### PR TITLE
Replace parameters.RENAMES with plugin hook

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -310,6 +310,11 @@ def getPluginManagerOrFail() -> pluggy.PluginManager:
     return _app.pluginManager
 
 
+def getApp() -> Optional[apps.App]:
+    global _app
+    return _app
+
+
 def _cleanupOnCancel(signum, _frame):
     """Helper function to clean up upon cancellation."""
     print(

--- a/armi/bookkeeping/db/xtviewDB.py
+++ b/armi/bookkeeping/db/xtviewDB.py
@@ -30,6 +30,7 @@ import traceback
 
 import numpy
 
+import armi
 from armi import runLog
 from armi import settings
 from armi import utils
@@ -1087,8 +1088,14 @@ def setParameterWithRenaming(obj, parameter, value):
     This allows older databases to work with newer ARMI versions if the parameter renames are
     properly recorded.
     """
+    # Watch out, this might be slow if it isn't cached by the App
+    renames = armi.getApp().getParamRenames()
+    name = parameter
+
+    while name in renames:
+        name = renames[name]
+
     try:
-        name = parameters.RENAMES.get(parameter, parameter)
         obj.p[name] = value
     except parameters.UnknownParameterError:
         runLog.warning(

--- a/armi/reactor/parameters/__init__.py
+++ b/armi/reactor/parameters/__init__.py
@@ -236,17 +236,3 @@ def reset():
     """
     for pd in ALL_DEFINITIONS:
         pd.assigned = NEVER
-
-
-# Note this should only have to be used as a setitem from stale databases. DON'T USE
-# ELSEWHERE!
-RENAMES = {
-    "SC0SigmaCladIDT": "TH0SigmaCladIDT",
-    "SC0SigmaCladODT": "TH0SigmaCladODT",
-    "SC2SigmaCladIDT": "TH2SigmaCladIDT",
-    "SC2SigmaCladODT": "TH2SigmaCladODT",
-    "SC2SigmaFuelCenterlineT": "TH2SigmaFuelCenterlineT",
-    "SC2SigmaOutletT": "TH2SigmaOutletT",
-    "SC3SigmaOutletT": "TH3SigmaOutletT",
-    "THmassFlow": "THmassFlowRate",
-}

--- a/armi/scripts/migration/migrate_inputs.py
+++ b/armi/scripts/migration/migrate_inputs.py
@@ -108,6 +108,7 @@ def migrate_database(database_path):
 
 
 def _copyValidDatasets(newDB, typeNames, name, dataset):
+    renames = armi.getApp().getParamRenames()
     if isinstance(dataset, h5py.Group):
         runLog.important("Skipping Group {}".format(dataset))
         return
@@ -127,13 +128,14 @@ def _copyValidDatasets(newDB, typeNames, name, dataset):
                 "Unexpected entry in database `{}` being copied.".format(name)
             )
 
-        elif paramName in parameters.RENAMES:
-            runLog.important(
-                "Renaming `{}` -> `{}`.".format(
-                    paramName, parameters.RENAMES[paramName]
+        elif paramName in renames:
+            while paramName in renames:
+                runLog.important(
+                    "Renaming `{}` -> `{}`.".format(
+                        paramName, renames[paramName]
+                    )
                 )
-            )
-            paramName = parameters.RENAMES[paramName]
+                paramName = renames[paramName]
 
         elif paramName in {"typeNumBlock"}:
             newName = "type"

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -1,0 +1,103 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the App class.
+"""
+
+import copy
+import unittest
+
+import armi
+from armi import plugins
+
+
+class TestPlugin1(plugins.ArmiPlugin):
+    """This should be fine on its own"""
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineParameterRenames():
+        return {"oldType": "type"}
+
+
+class TestPlugin2(plugins.ArmiPlugin):
+    """
+    This should lead to an error if it coexists with Plugin1.
+    """
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineParameterRenames():
+        return {"oldType": "type"}
+
+
+class TestPlugin3(plugins.ArmiPlugin):
+    """This should lead to errors, since it collides with the framework `type` param."""
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineParameterRenames():
+        return {"type": "newType"}
+
+
+class TestPlugin4(plugins.ArmiPlugin):
+    """This should be fine on its own, and safe to merge with TestPlugin1. And would
+    make for a pretty good rename IRL."""
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineParameterRenames():
+        return {"arealPD": "arealPowerDensity"}
+
+
+class TestApps(unittest.TestCase):
+    """
+    Test the base apps.App interfaces.
+    """
+
+    def setUp(self):
+        """Manipulate the standard App. We can't just configure our own, since the
+        pytest environment bleeds between tests :("""
+        self._backupApp = copy.deepcopy(armi._app)
+
+    def tearDown(self):
+        """Restore the App to its original state"""
+        armi._app = self._backupApp
+
+    def test_getParamRenames(self):
+        app = armi.getApp()
+        app.pluginManager.register(TestPlugin1)
+        app.pluginManager.register(TestPlugin4)
+
+        renames = app.getParamRenames()
+        self.assertIn("oldType", renames)
+        self.assertEqual(renames["oldType"], "type")
+
+        self.assertIn("arealPD", renames)
+        self.assertEqual(renames["arealPD"], "arealPowerDensity")
+
+        app.pluginManager.register(TestPlugin2)
+        with self.assertRaisesRegex(
+            plugins.PluginError,
+            ".*parameter renames are already defined by another plugin.*",
+        ):
+            app.getParamRenames()
+        app.pluginManager.unregister(TestPlugin2)
+
+        app.pluginManager.register(TestPlugin3)
+        with self.assertRaisesRegexp(
+            plugins.PluginError, ".*currently-defined parameters.*"
+        ):
+            app.getParamRenames()

--- a/doc/developer/guide.rst
+++ b/doc/developer/guide.rst
@@ -226,12 +226,13 @@ When using the Operators that come with ARMI, Interfaces are discovered using th
 
 How interfaces get called
 -------------------------
+
 The hooks of interfaces are called during the main loop in
-:py:meth:`armi.operators.Operator.mainOperate`. There are a few special operator calls in there to
-methods like :py:meth:`armi.operators.Operator.interactAllBOL` that loop through the interface stack
-and call each enabled interface's ``interactBOL()`` method. If you override ``mainOperate`` in a
-custom operator, you will need to add these calls as deemed necessary to have the interfaces work
-properly.
+:py:meth:`armi.operators.Operator.mainOperate`. There are a few special operator calls
+in there to methods like :py:meth:`armi.operators.Operator.interactAllBOL` that loop
+through the interface stack and call each enabled interface's ``interactBOL()`` method.
+If you override ``mainOperate`` in a custom operator, you will need to add these calls
+as deemed necessary to have the interfaces work properly.
 
 To use interfaces in parallel, please refer to :py:mod:`armi.mpiActions`.
 
@@ -239,8 +240,10 @@ To use interfaces in parallel, please refer to :py:mod:`armi.mpiActions`.
 -------
 Plugins
 -------
-Plugins are higher-level objects that can bring in one or more Interfaces, settings definitions, 
-parameters, validations, etc. They are documented in :doc:/doc/developer/making_armi_based_apps`.
+
+Plugins are higher-level objects that can bring in one or more Interfaces, settings
+definitions, parameters, validations, etc. They are documented in
+:doc:`/developer/making_armi_based_apps` and :py:mod:`armi.plugins`.
 
 
 Entry Points
@@ -262,14 +265,19 @@ Finding assemblies
 ------------------
 There are a few ways to get the assemblies you're interested in.
 
-    * `r.whichAssembyIsIn(ring,position)` returns whichever assembly is in (ring,position)
-    * `r.getLocationContents(locList)` returns the assemblies or blocks that correspond to
-      the location list. This can be much faster that `whichAssemblyIsIn` if you need many assemblies
-    * `r.getAssemblies()` loops through all assemblies in the core for when you need to do something to all
-      assemblies
-    * `hist.getDetailAssemblies()` use the `HistoryInterface` to find the assemblies that the user has
-      specifically designated "detail assemblies", meaning assemblies that will receive special analysis. This
-      is useful for doing limiting analyses that would be too time consuming or otherwise wasteful
-      to apply to all assemblies.
+    * `r.whichAssembyIsIn(ring,position)` returns whichever assembly is in
+      (ring,position)
+
+    * `r.getLocationContents(locList)` returns the assemblies or blocks that correspond
+      to the location list. This can be much faster that `whichAssemblyIsIn` if you need
+      many assemblies
+
+    * `r.getAssemblies()` loops through all assemblies in the core for when you need to
+      do something to all assemblies
+
+    * `hist.getDetailAssemblies()` use the `HistoryInterface` to find the assemblies
+      that the user has specifically designated "detail assemblies", meaning assemblies
+      that will receive special analysis. This is useful for doing limiting analyses
+      that would be too time consuming or otherwise wasteful to apply to all assemblies.
 
 


### PR DESCRIPTION
Plugins can now define parameter renames for their own parameters. The
old RENAMES were also not even being applied in the new database
implementation, which is also fixed.