### PR TITLE
Improve tox/travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"
-      env: TOXENV=py37
-    - python: "3.7"
       env: TOXENV=lint
     - python: "3.7"
       env: TOXENV=cov,report

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,lint,cov,report
+envlist = py36,py37,lint,cov
 
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
 - Remove redundant py3.7 tests; coverage does these
 - Remove report env from envlist in tox.ini