### PR TITLE
Ensure that Cases do not consider themselves to be their own dependency

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -192,6 +192,8 @@ class Case:
                     r"^(?P<dirName>.*[\/\\])?(?P<title>[^\/\\]+)-SHUFFLES\.txt$",
                 )
             )
+        # ensure that a case doesn't appear to be its own dependency
+        dependencies.remove(self)
 
         return dependencies
 
@@ -282,6 +284,12 @@ class Case:
         Set the task dependence based on the :code:`dependencies`.
 
         This accounts for whether or not the dependency is enabled.
+
+        Note
+        ----
+        This is a leftover from before the release of the ARMI framework. The API of the
+        proprietary cluster communication library is being used here. This should either
+        be moved out into the cluster plugin, or the library should be made available.
         """
         if not self.enabled:
             return

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -193,7 +193,7 @@ class Case:
                 )
             )
         # ensure that a case doesn't appear to be its own dependency
-        dependencies.remove(self)
+        dependencies.discard(self)
 
         return dependencies
 


### PR DESCRIPTION
This makes sure that self is not contained in a Case's set of
dependencies. This can happen sometimes when a plugin is infering a Case
dependency based on a referenced input file name. If that name maps back
to the current case, it would errantly flag the current Case as its own
dependency.