### PR TITLE
Separate type and flags Parameter assignments

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1081,10 +1081,9 @@ class Database3(database.Database):
                 assert dataSet.attrs[_SERIALIZER_NAME] == pDef.serializer.__name__
                 assert _SERIALIZER_VERSION in dataSet.attrs
 
-                data = pDef.serializer.unpack(
+                data = numpy.array(pDef.serializer.unpack(
                     data, dataSet.attrs[_SERIALIZER_VERSION], attrs
-                )
-                continue
+                ))
 
             if data.dtype.type is numpy.string_:
                 data = numpy.char.decode(data)

--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -242,11 +242,6 @@ def getAssemblyParameterDefinitions():
 
     with pDefs.createBuilder() as pb:
 
-        def typeSetter(self, value):
-            """Always set flags when type changes."""
-            self._p_type = value
-            self._p_flags = Flags.fromStringIgnoreErrors(value)
-
         pb.defParam(
             "type",
             units="?",
@@ -254,7 +249,6 @@ def getAssemblyParameterDefinitions():
             location="?",
             default="defaultAssemType",
             saveToDB=True,
-            setter=typeSetter,
         )
 
     with pDefs.createBuilder(default=0.0) as pb:

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -1345,20 +1345,12 @@ def getBlockParameterDefinitions():
             setter=xsTypeNum,
         )
 
-        def type(self, value):  # pylint: disable=method-hidden
-            """Always set flags when type changes."""
-            self._p_type = value  # pylint: disable=attribute-defined-outside-init
-            self._p_flags = Flags.fromStringIgnoreErrors(
-                value
-            )  # pylint: disable=attribute-defined-outside-init
-
         pb.defParam(
             "type",
             units="N/A",
             description="string name of the input block",
             default="defaultType",
             saveToDB=True,
-            setter=type,
         )
 
         pb.defParam(

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1140,7 +1140,7 @@ class Block(composites.Composite):
     def replaceBlockWithBlock(self, bReplacement):
         """
         Replace the current block with the replacementBlock.
-        
+
         Typically used in the insertion of control rods.
         """
         paramsToSkip = set(

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -15,10 +15,12 @@
 """
 This module defines the blueprints input object for assemblies.
 
-In addition to defining the input format, the ``AssemblyBlueprint`` class is responsible for constructing ``Assembly``
-objects. An attempt has been made to decouple ``Assembly`` construction from the rest of ARMI as much as possible. For
-example, an assembly does not require a reactor to be constructed, or a geometry file (but uses ``geomType`` string as a
-surrogate).
+In addition to defining the input format, the ``AssemblyBlueprint`` class is responsible
+for constructing ``Assembly`` objects. An attempt has been made to decouple ``Assembly``
+construction from the rest of ARMI as much as possible. For example, an assembly does
+not require a reactor to be constructed, or a geometry file (but uses ``geomType``
+string as a surrogate).
+
 """
 import yamlize
 

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -158,9 +158,9 @@ class BlockBlueprint(yamlize.KeyedList):
     def _getGridDesign(self, blueprint):
         """
         Get the appropriate grid design
-        
-        This happens when a lattice input is provided on the block. Otherwise
-        all components are ambiguously defined in the block. 
+
+        This happens when a lattice input is provided on the block. Otherwise all
+        components are ambiguously defined in the block.
         """
         if self.gridName:
             if self.gridName not in blueprint.gridDesigns:

--- a/armi/reactor/components/componentParameters.py
+++ b/armi/reactor/components/componentParameters.py
@@ -46,18 +46,10 @@ def getComponentParameterDefinitions():
             description="Label of other component to merge with",
         )
 
-        def type(self, value):  # pylint: disable=method-hidden
-            """Always set flags when type changes."""
-            self._p_type = value  # pylint: disable=attribute-defined-outside-init
-            self._p_flags = Flags.fromStringIgnoreErrors(
-                value
-            )  # pylint: disable=attribute-defined-outside-init
-
         pb.defParam(
             "type",
             units="",
             description="The name of this object as input on the blueprints",
-            setter=type,
         )
 
         pb.defParam(

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -639,9 +639,10 @@ class ArmiObject(metaclass=CompositeModelType):
         """Return the object type."""
         return self.p.type
 
-    def setType(self, typeSpec):
+    def setType(self, newType):
         """Set the object type."""
-        self.p.type = typeSpec
+        self.p.flags = Flags.fromStringIgnoreErrors(newType)
+        self.p.type = newType
 
     def getVolume(self):
         return sum(child.getVolume() for child in self)
@@ -2815,7 +2816,7 @@ class Leaf(Composite):
         return []
 
 
-class StateRetainer(object):
+class StateRetainer:
     """
     Retains state during some operations.
 

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -29,7 +29,7 @@ armi.reactor.parameters
 import enum
 import re
 import functools
-from typing import Callable, Dict, Optional, Sequence, Tuple, Type
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type
 
 import numpy
 
@@ -164,9 +164,9 @@ class Serializer:
         """
         raise NotImplementedError()
 
-    @staticmethod
+    @classmethod
     def unpack(
-        data: numpy.ndarray, version: any, attrs: Dict[str, any]
+        cls, data: numpy.ndarray, version: Any, attrs: Dict[str, any]
     ) -> Sequence[any]:
         """Given packed data and attributes, return the unpacked data."""
         raise NotImplementedError()

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -98,7 +98,7 @@ def buildTestAssemblies():
 
     block = blocks.HexBlock("fuel", caseSetting)
     block2 = blocks.HexBlock("fuel", caseSetting)
-    block.p.type = "fuel"
+    block.setType("fuel")
     block.setHeight(10.0)
     block.addComponent(fuelUZr)
     block.addComponent(fuelUTh)
@@ -108,7 +108,7 @@ def buildTestAssemblies():
     block.p.molesHmBOL = 1.0
     block.p.molesHmNow = 1.0
 
-    block2.p.type = "fuel"
+    block2.setType("fuel")
     block2.setHeight(10.0)
     block2.addComponent(fuelUThZr)
     block2.addComponent(clad)

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1505,9 +1505,9 @@ class HexBlock_TestCase(unittest.TestCase):
     def test_retainState(self):
         """Ensure retainState restores params and spatialGrids."""
         self.HexBlock.spatialGrid = grids.hexGridFromPitch(1.0)
-        self.HexBlock.p.type = "intercoolant"
+        self.HexBlock.setType("intercoolant")
         with self.HexBlock.retainState():
-            self.HexBlock.p.type = "fuel"
+            self.HexBlock.setType("fuel")
             self.HexBlock.spatialGrid.changePitch(2.0)
         self.assertEqual(self.HexBlock.spatialGrid.pitch, 1.0)
         self.assertTrue(self.HexBlock.hasFlags(Flags.INTERCOOLANT))

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -55,11 +55,7 @@ def getDummyParamDefs():
     dummyDefs = parameters.ParameterDefinitionCollection()
     with dummyDefs.createBuilder() as pb:
 
-        def type(self, value):
-            self._p_type = value
-            self._p_flags = Flags.fromStringIgnoreErrors(value)
-
-        pb.defParam("type", units="none", description="Fake type", setter=type)
+        pb.defParam("type", units="none", description="Fake type")
     return dummyDefs
 
 
@@ -164,23 +160,23 @@ class TestCompositePattern(unittest.TestCase):
         )
 
     def test_hasFlags(self):
-        self.container.p.type = "fuel"
+        self.container.setType("fuel")
         self.assertFalse(self.container.hasFlags(Flags.SHIELD | Flags.FUEL, exact=True))
         self.assertTrue(self.container.hasFlags(Flags.FUEL))
         self.assertTrue(self.container.hasFlags(None))
 
     def test_hasFlagsSubstring(self):
         """Make sure typespecs with the same word in them no longer match."""
-        self.container.p.type = "intercoolant"
+        self.container.setType("intercoolant")
         self.assertFalse(self.container.hasFlags(Flags.COOLANT))
         self.assertFalse(self.container.hasFlags(Flags.COOLANT, exact=True))
         self.assertTrue(self.container.hasFlags(Flags.INTERCOOLANT, exact=True))
 
-        self.container.p.type = "innerduct"
+        self.container.setType("innerduct")
         self.assertFalse(self.container.hasFlags(Flags.DUCT, exact=True))
 
     def test_hasFlagsNoTypeSpecified(self):
-        self.container.p.type = "fuel"
+        self.container.setType("fuel")
         types = [None, [], [None]]
         for t in types:
             self.assertTrue(self.container.hasFlags(t))

--- a/armi/tests/test_fuelHandlers.py
+++ b/armi/tests/test_fuelHandlers.py
@@ -80,7 +80,7 @@ class TestFuelHandler(ArmiTestHelper):
 
         # generate a block
         self.block = blocks.HexBlock("TestHexBlock", self.o.cs)
-        self.block.p.type = "fuel"
+        self.block.setType("fuel")
         self.block.setHeight(10.0)
         self.block.addComponent(fuel)
         self.block.addComponent(clad)


### PR DESCRIPTION
This finishes the implementation of storing/loading flags from the
database by removing the `type` Parameter setter (which used to also set
flags through string conversion). Instead, flags are set when calling
setType().