### PR TITLE
Fix issues with restart runs

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -806,7 +806,7 @@ class Database3(database.Database):
         for comps in groupedComps.values():
             self._writeParams(h5group, comps)
 
-    def load(self, cycle, node, cs=None, bp=None):
+    def load(self, cycle, node, cs=None, bp=None, statePointName=None):
         """Load a new reactor from (cycle, node).
 
         Case settings, blueprints, and geom can be provided by the client, or read from
@@ -838,7 +838,7 @@ class Database3(database.Database):
         settings.setMasterCs(cs)
         bp = bp or self.loadBlueprints()
 
-        h5group = self.h5db[getH5GroupName(cycle, node)]
+        h5group = self.h5db[getH5GroupName(cycle, node, statePointName)]
 
         layout = Layout(h5group=h5group)
         comps, groupedComps = layout._initComps(cs, bp)

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -45,7 +45,10 @@ class GlobalFluxInterface(interfaces.Interface):
     r"""
     A general abstract interface for global flux calculating modules.
 
-    Should be subclassed
+    Should be subclassed by more specific implementations. This class currently serves
+    as a common ancestor to a handful of DIF3D/REBUS-based neutronics interfaces, and
+    therefore is not as general as it should be. Future revisions will be generalized to
+    support other families of codes.
     """
 
     name = None  # make sure to set this in subclasses

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -35,6 +35,14 @@ def _getNeutronicsBlockParams():
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder() as pb:
 
+        pb.defParam(
+            "axMesh",
+            units="",
+            description="number of neutronics axial mesh points in this block",
+            default=None,
+            categories=[parameters.Category.retainOnReplacement],
+        )
+
         def mgFlux(self, value):
             self._p_mgFlux = (
                 value

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -168,7 +168,7 @@ class ArmiPlugin:
 
         - Verify that all assemblies satisfy constraints imposed by active interfaces
           and plugins
-        - Apply modifications to Assemblies based on modeling opetions and active
+        - Apply modifications to Assemblies based on modeling options and active
           interfaces
 
         Implementers may alter the state of the passed Assembly objects.

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -1312,14 +1312,6 @@ def getBlockParameterDefinitions():
             categories=[parameters.Category.retainOnReplacement],
         )
 
-        pb.defParam(
-            "axMesh",
-            units="",
-            description="number of neutronics axial mesh points in this block",
-            default=None,
-            categories=[parameters.Category.retainOnReplacement],
-        )
-
         def xsType(self, value):  # pylint: disable=method-hidden
             self._p_xsType = value  # pylint: disable=attribute-defined-outside-init
             self._p_xsTypeNum = crossSectionGroupManager.getXSTypeNumberFromLabel(

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -347,10 +347,10 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
         self.elementsToExpand = []
         for nucFlag in self.nuclideFlags:
+            # this returns any nuclides that are flagged specifically for expansion by input
             expandedElements = nucFlag.fileAsActiveOrInert(
                 actives, inerts, undefBurnChainActiveNuclides
             )
-            # this returns any nuclides that are flagged specifically for expansion by input
             self.elementsToExpand.extend(expandedElements)
 
         inerts -= actives

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -969,7 +969,8 @@ def defineCoreParameters():
         pb.defParam(
             "power",
             units="W",
-            description="Rated thermal power of the reactor core. Corresponds to the nuclear power generated in the core.",
+            description="Rated thermal power of the reactor core. Corresponds to the "
+            "nuclear power generated in the core.",
         )
 
         pb.defParam(

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -998,7 +998,7 @@ class Core(composites.Composite):
         exact=False,
     ):
         """
-        Return an list of all the assemblies in the reactor.
+        Return a list of all the assemblies in the reactor.
 
         Assemblies from the Core itself are sorted based on the Assemblies' comparison
         operators (location-based). This is done so that two reactors with physically


### PR DESCRIPTION
This mainly propagates the `statePointName` kwarg through the database load functions. Before, the argument wasn't being honored, so it was hard to load from named state points. Also fixes some documentation/typos and moves the axial mesh parameter to the neutronics plugin.