### PR TITLE
Fix to timesteps list changing in database interface

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -370,6 +370,8 @@ class DatabaseInterface(interfaces.Interface):
         """
         now = (self.r.p.cycle, self.r.p.timeNode)
         nowRequested = timeSteps is None
+        if timeSteps is not None:
+            timeSteps = copy.copy(timeSteps)
         if timeSteps is not None and now in timeSteps:
             nowRequested = True
             timeSteps.remove(now)


### PR DESCRIPTION
When database interface removes the `now` timestep, it would alter the list that was passed in from the caller's scope. Bad manners.