### PR TITLE
Remove Duplicate Time Reporting on Case Initialization

### DIFF
--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -68,7 +68,6 @@ def writeWelcomeHeaders(o, cs):
             (strings.Operator_PythonInterperter, sys.version),
             (strings.Operator_MasterMachine, os.environ.get("COMPUTERNAME", "?")),
             (strings.Operator_NumProcessors, armi.MPI_SIZE),
-            (strings.Operator_Date, time.ctime()),
             (strings.Operator_Date, armi.START_TIME),
         ]
 


### PR DESCRIPTION
An extra date/time message was being printed within the `writeWelcomeHeaders`
function and reporting two different times. The first time reflected the
time that the function was called, whereas the second time reflected the
start time for ARMI. The first time was removed.