### PR TITLE
Improve standardization in global flux calculations

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1489,9 +1489,9 @@ class Layout(object):
             Klass = ArmiObject.TYPES[compType]
 
             if issubclass(Klass, Reactor):
-                comp = Klass(cs, bp)
+                comp = Klass(cs.caseTitle, bp)
             elif issubclass(Klass, Core):
-                comp = Klass(name, cs)
+                comp = Klass(name)
             elif issubclass(Klass, Component):
                 # XXX: initialize all dimensions to 0, they will be loaded and assigned
                 # after load

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -425,11 +425,11 @@ class Interface(object):
 
     def writeInput(self, inName):
         """Write input file(s)."""
-        pass
+        raise NotImplementedError()
 
     def readOutput(self, outName):
         """Read output file(s)."""
-        pass
+        raise NotImplementedError()
 
     @staticmethod
     def specifyInputs(cs) -> Dict[str, List[str]]:  # pylint: disable=unused-argument
@@ -482,7 +482,21 @@ class InputWriter(object):
 
 
 class OutputReader(object):
-    """Read output files from external codes."""
+    """
+    A generic representation of a particular module's output.
+    
+    Attributes
+    ----------
+    success : bool
+        False by default, set to True if the run is considered
+        to have completed without error.
+        
+    Notes
+    -----
+    Should ideally not require r, eci, and fname arguments
+    and would rather just have an apply(reactor) method.
+    
+    """
 
     def __init__(self, r=None, externalCodeInterface=None, fName=None):
         self.externalCodeInterface = externalCodeInterface
@@ -494,6 +508,7 @@ class OutputReader(object):
         else:
             self.output = None
         self.fName = fName
+        self.success = False
 
     def getInterface(self, name):
         """Get another interface by name."""
@@ -504,6 +519,17 @@ class OutputReader(object):
     def read(self, fileName):
         """Read the output file."""
         raise NotImplementedError
+
+    def apply(self, reactor):
+        """
+        Apply the output back to a reactor state.
+        
+        This provides a generic interface for the output data of anything
+        to be applied to a reactor state. The application could involve
+        reading text or binary output or simply parameters to appropriate
+        values in some other data structure.
+        """
+        raise NotImplementedError()
 
 
 def getActiveInterfaceInfo(cs):

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -704,7 +704,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         """
         return self.interfaces[:]
 
-    def reattach(self, r, cs):
+    def reattach(self, r, cs=None):
         """Add links to globally-shared objects to this operator and all interfaces.
 
         Notes
@@ -713,11 +713,13 @@ class Operator:  # pylint: disable=too-many-public-methods
         """
         self.r = r
         self.r.o = self
-        self.cs = cs
+        if cs is not None:
+            self.cs = cs
         for i in self.interfaces:
             i.r = r
             i.o = self
-            i.cs = cs
+            if cs is not None:
+                i.cs = cs
 
     def detach(self):
         """
@@ -875,18 +877,6 @@ class Operator:  # pylint: disable=too-many-public-methods
             )
         else:
             os.mkdir(newFolder)
-
-        inf = "{0}{1:03d}{2:03d}.inp".format(self.cs.caseTitle, cycle, node)
-        writer = self.getInterface("dif3d")
-
-        if not writer:
-            writer = self.getInterface("rebus")
-        if not writer:
-            runLog.warning(
-                "There are no interface attached that can write a snapshot input"
-            )
-        else:
-            writer.writeInput(os.path.join(newFolder, inf))
 
         # copy the cross section inputs
         for fileName in os.listdir("."):

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -195,8 +195,8 @@ class OperatorMPI(Operator):
                 bp = self.r.blueprints
                 spatialGrid = self.r.core.spatialGrid
                 self.detach()
-                self.r = reactors.Reactor(cs, bp)
-                core = reactors.Core("Core", cs)
+                self.r = reactors.Reactor(cs.caseTitle, bp)
+                core = reactors.Core("Core")
                 self.r.add(core)
                 core.spatialGrid = spatialGrid
                 self.reattach(self.r, cs)

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -1,0 +1,177 @@
+"""
+Executors are useful for having a standard way to run physics calculations.
+
+They may involve external codes (with inputs/execution/output) or in-memory
+data pathways.
+"""
+
+import os
+
+from armi.utils import directoryChangers
+from armi import runLog
+
+
+class ExecutionOptions:
+    """
+    A data structure representing all options needed for a physics kernel.
+
+    Attributes
+    ----------
+    inputFile : str
+        Name of main input file. Often passed to stdin of external code.
+    outputFile : str
+        Name of main output file. Often the stdout of external code.
+    extraInputFiles : list of tuples
+        (sourceName, destName) pairs of file names that will be brought from the
+        working dir into the runDir. Allows renames while in transit.
+    extraOutputFiles : list of tuples
+        (sourceName, destName) pairs of file names that will be extracted from the
+        runDir to the working dir
+    executablePath : str
+        Path to external executable to run (if external code is used)
+    runDir : str
+        Path on running system where the run will take place. This is often used
+        to ensure external codes that use hard-drive disk space run on a local disk
+        rather than a shared network drive
+    workingDir : str
+        Path on system where results will be placed after the run. This is often
+        a shared network location. Auto-applied during execution by default.
+    label : str
+        A name for the run that may be used as a prefix for input/output files generated.
+    applyResultsToReactor : bool
+        Update the in-memory reactor model with results upon completion. Set to False
+        when information from a run is needed for auxiliary purposes rather than progressing
+        the reactor model.
+    """
+
+    def __init__(self, label=None):
+        self.inputFile = None
+        self.outputFile = None
+        self.extraInputFiles = []
+        self.extraOutputFiles = []
+        self.executablePath = None
+        self.runDir = None
+        self.workingDir = None
+        self.label = label
+        self.applyResultsToReactor = True
+        self.paramsToScaleSubset = None
+
+    def fromUserSettings(self, cs):
+        """Set options from a particular CaseSettings object."""
+        raise NotImplementedError()
+
+    def fromReactor(self, reactor):
+        """Set options from a particular reactor object."""
+        raise NotImplementedError()
+
+    def resolveDerivedOptions(self):
+        """Called by executers right before executing."""
+
+    def describe(self):
+        """Make a string summary of all options."""
+        lines = ["Options summary:", "----------------"]
+        for key, val in self.__dict__.items():
+            if not key.startswith("_"):
+                lines.append(f"  {key:40s}{str(val)[:80]:80s}")
+        return "\n".join(lines)
+
+
+class Executer:
+    """
+    Coordinates the execution of some calculation.
+
+    This is a semi-generic way to run some kind of calculation based on experience
+    of running many related calculations. It may
+    be an external code execution but could also be some internal calculation.
+    The generic characteristics of a execution are some optional subset of the following:
+
+    * Choose modeling options (either from the global run settings input or dictated programmatically)
+    * Apply geometry transformations to the ARMI Reactor as needed
+    * Build run-specific working directory
+    * Write input file(s)
+    * Put specific input files and libs in run directory
+    * Run the analysis (external execution, or not)
+    * Process output while still in run directory
+    * Check error conditions
+    * Move desired output files back to main working directory
+    * Clean up run directory
+    * Un-apply geometry transformations as needed
+    * Update ARMI data model as desired
+
+    Notes
+    -----
+    This is deliberately **not** a :py:class:`~mpiActions.MpiAction`. Thus, Executers can run as
+    potentially multiple steps in a parent (parallelizable ) MpiAction or in other flexible
+    ways. This is intended to maximize reusability.
+    """
+
+    def __init__(self, options, reactor):
+        self.options = options
+        self.r = reactor
+
+    def run(self):
+        """
+        Run the executer steps. 
+        
+        .. warning::
+            If a calculation requires anything different from what this method does,
+            do not update this method with new complexity! Instead, simply make your own
+            run sequence and/or class. This pattern is useful only in that it is fairly simple.
+            By all means, do use ``DirectoryChanger`` and ``ExecuterOptions``
+            and other utilities. 
+        """
+        self.options.resolveDerivedOptions()
+        runLog.debug(self.options.describe())
+        if self.options.executablePath and not os.path.exists(
+            self.options.executablePath
+        ):
+            raise IOError(
+                f"Required executable `{self.options.executablePath}` not found for {self}"
+            )
+        self._performGeometryTransformations()
+        inputs, outputs = self._collectInputsAndOutputs()
+        # must either write input to CWD for analysis and then copy to runDir
+        # or not list it in inputs (for optimization)
+        self.writeInput()
+        with directoryChangers.ForcedCreationDirectoryChanger(
+            self.options.runDir, filesToMove=inputs, filesToRetrieve=outputs
+        ) as dc:
+            self.options.workingDir = dc.initial
+            self._execute()
+            output = self._readOutput()
+            if self.options.applyResultsToReactor:
+                output.apply(self.r)
+        self._undoGeometryTransformations()
+        return output
+
+    def _execute(self):
+        runLog.extra(
+            f"Executing {self.options.executablePath}\n"
+            f"\tInput: {self.options.inputFile}\n"
+            f"\tOutput: {self.options.outputFile}\n"
+            f"\tWorking dir: {self.options.runDir}"
+        )
+        return True
+
+    def _collectInputsAndOutputs(self):
+        """Get total lists of input and output files."""
+        inputs = [self.options.inputFile] if self.options.inputFile else []
+        inputs.extend(self.options.extraInputFiles)
+        outputs = [self.options.outputFile] if self.options.outputFile else []
+        outputs.extend(self.options.extraOutputFiles)
+        return inputs, outputs
+
+    def writeInput(self):
+        pass
+
+    def _readOutput(self):
+        raise NotImplementedError()
+
+    def _applyOutputToDataModel(self, output):
+        pass
+
+    def _performGeometryTransformations(self):
+        pass
+
+    def _undoGeometryTransformations(self):
+        pass

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -57,9 +57,7 @@ class SystemBlueprint(yamlize.Object):
     gridName = yamlize.Attribute(key="grid name", type=str)
     origin = yamlize.Attribute(key="origin", type=Triplet, default=None)
 
-    def __init__(
-        self, name=None, gridName=None, origin=None,
-    ):
+    def __init__(self, name=None, gridName=None, origin=None):
         """
         A Reactor Level Structure like a core or SFP.
 
@@ -82,7 +80,8 @@ class SystemBlueprint(yamlize.Object):
         else:
             gridDesign = bp.gridDesigns[self.gridName]
         spatialGrid = gridDesign.construct()
-        container = reactors.Core(self.name, cs)
+        container = reactors.Core(self.name)
+        container.setOptionsFromCs(cs)
         container.spatialGrid = spatialGrid
         container.spatialGrid.armiObject = container
         reactor.add(container)  # need parent before loading assemblies
@@ -114,9 +113,7 @@ class SystemBlueprint(yamlize.Object):
             loc = container.spatialGrid[i, j, 0]
             if (
                 container.symmetry == geometry.THIRD_CORE + geometry.PERIODIC
-                and not container.spatialGrid.isInFirstThird(
-                    loc, includeTopEdge=True
-                )
+                and not container.spatialGrid.isInFirstThird(loc, includeTopEdge=True)
             ):
                 badLocations.add(loc)
             container.add(newAssembly, loc)

--- a/armi/reactor/blueprints/tests/test_reactorBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_reactorBlueprints.py
@@ -88,7 +88,7 @@ class TestReactorBlueprints(unittest.TestCase):
         )
         bp.systemDesigns = self.systemDesigns
         bp.gridDesigns = self.gridDesigns
-        reactor = reactors.Reactor(cs, bp)
+        reactor = reactors.Reactor(cs.caseTitle, bp)
         core = bp.systemDesigns["core"].construct(cs, bp, reactor)
         sfp = bp.systemDesigns["sfp"].construct(cs, bp, reactor)
         for fn in fnames:

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -107,9 +107,9 @@ class TestGeometryConverters(unittest.TestCase):
 
 class TestHexToRZConverter(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = loadTestReactor(TEST_ROOT, {"circularRingMode": True})
+        self.o, self.r = loadTestReactor(TEST_ROOT)
         self.cs = settings.getMasterCs()
-        runLog.setVerbosity("info")
+        runLog.setVerbosity("extra")
         self._expandReactor = False
         self._massScaleFactor = 1.0
         if not self._expandReactor:
@@ -128,6 +128,7 @@ class TestHexToRZConverter(unittest.TestCase):
             "thetaBins": 1,
             "axialMesh": [50, 100, 150, 175],
             "thetaMesh": [2 * math.pi],
+            "hexRingGeometryConversion": False,
         }
 
         expectedMassDict, expectedNuclideList = self._getExpectedData()
@@ -178,7 +179,7 @@ class TestHexToRZConverter(unittest.TestCase):
             expectedMass = expectedMassDict[nuclide]
             actualMass = newR.core.getMass(nuclide) / self._massScaleFactor
             if round(abs(expectedMass - actualMass), 7) != 0.0:
-                runLog.warning(
+                print(
                     "{:6s} {:10.2f} {:10.2f}".format(nuclide, expectedMass, actualMass)
                 )
                 massMismatchCount += 1
@@ -293,6 +294,8 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
 
 if __name__ == "__main__":
     import sys
+    import armi
 
+    armi.configure()
     # sys.argv = ["", "TestEdgeAssemblyChanger"]
     unittest.main()

--- a/armi/reactor/converters/tests/test_meshConverters.py
+++ b/armi/reactor/converters/tests/test_meshConverters.py
@@ -42,9 +42,9 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         expectedThetaMesh = [2 * math.pi]
 
         meshConvert = meshConverters.RZThetaReactorMeshConverterByRingCompositionAxialBins(
-            self.o.cs
+            self._converterSettings
         )
-        meshConvert.generateMesh(self.r, self._converterSettings)
+        meshConvert.generateMesh(self.r)
 
         self.assertListEqual(meshConvert.radialMesh, expectedRadialMesh)
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
@@ -56,9 +56,9 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         expectedThetaMesh = [2 * math.pi]
 
         meshConvert = meshConverters.RZThetaReactorMeshConverterByRingCompositionAxialCoordinates(
-            self.o.cs
+            self._converterSettings
         )
-        meshConvert.generateMesh(self.r, self._converterSettings)
+        meshConvert.generateMesh(self.r)
 
         self.assertListEqual(meshConvert.radialMesh, expectedRadialMesh)
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
@@ -84,9 +84,9 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         expectedThetaMesh = [2 * math.pi]
 
         meshConvert = meshConverters.RZThetaReactorMeshConverterByRingCompositionAxialBins(
-            self.o.cs
+            self._converterSettingsLargerCore
         )
-        meshConvert.generateMesh(self.r, self._converterSettingsLargerCore)
+        meshConvert.generateMesh(self.r)
 
         self.assertListEqual(meshConvert.radialMesh, expectedRadialMesh)
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
@@ -99,9 +99,9 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         expectedThetaMesh = [2 * math.pi]
 
         meshConvert = meshConverters.RZThetaReactorMeshConverterByRingCompositionAxialCoordinates(
-            self.o.cs
+            self._converterSettingsLargerCore
         )
-        meshConvert.generateMesh(self.r, self._converterSettingsLargerCore)
+        meshConvert.generateMesh(self.r)
 
         self.assertListEqual(meshConvert.radialMesh, expectedRadialMesh)
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -190,7 +190,7 @@ class Assembly_TestCase(unittest.TestCase):
             "error"
         )  # Print nothing to the screen that would normally go to the log.
 
-        self.r = tests.getEmptyHexReactor(self.cs)
+        self.r = tests.getEmptyHexReactor()
         self.r.core.symmetry = "third periodic"
 
         self.Assembly = makeTestAssembly(NUM_BLOCKS, self.assemNum, r=self.r)

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1448,8 +1448,8 @@ class AnnularFuelTestCase(unittest.TestCase):
         self.cs["xsKernel"] = "MC2v2"  # don't try to expand elementals
         settings.setMasterCs(self.cs)
         bp = blueprints.Blueprints()
-        self.r = reactors.Reactor(self.cs, bp)
-        self.r.add(reactors.Core("Core", self.cs))
+        self.r = reactors.Reactor("test", bp)
+        self.r.add(reactors.Core("Core"))
 
         inputStr = """blocks:
     ann fuel: &block_ann_fuel

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -45,7 +45,7 @@ def loadTestBlock(cold=True):
     settings.setMasterCs(caseSetting)
     runLog.setVerbosity("error")
     caseSetting["nCycles"] = 1
-    r = tests.getEmptyHexReactor(caseSetting)
+    r = tests.getEmptyHexReactor()
 
     assemNum = 3
     block = blocks.HexBlock("TestHexBlock")
@@ -1448,7 +1448,7 @@ class HexBlock_TestCase(unittest.TestCase):
         self.HexBlock.addComponent(
             components.DerivedShape("coolant", "Sodium", Tinput=273.0, Thot=273.0)
         )
-        r = tests.getEmptyHexReactor(caseSetting)
+        r = tests.getEmptyHexReactor()
         a = makeTestAssembly(1, 1)
         a.add(self.HexBlock)
         loc1 = r.core.spatialGrid[0, 1, 0]

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -92,7 +92,7 @@ def loadTestReactor(
     o : Operator
     r : Reactor
     """
-    #TODO: it would be nice to have this be more stream-oriented. Juggling files is
+    # TODO: it would be nice to have this be more stream-oriented. Juggling files is
     # devilishly difficult.
     global TEST_REACTOR
     isotopicDepletion.applyDefaultBurnChain()

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -35,8 +35,8 @@ THIS_DIR = pathTools.armiAbsDirFromName(__name__)
 class Zone_TestCase(unittest.TestCase):
     def setUp(self):
         bp = blueprints.Blueprints()
-        r = reactors.Reactor(settings.getMasterCs(), bp)
-        r.add(reactors.Core("Core", settings.getMasterCs()))
+        r = reactors.Reactor("zonetest", bp)
+        r.add(reactors.Core("Core"))
         r.core.spatialGrid = grids.hexGridFromPitch(1.0)
         r.core.spatialGrid.symmetry = geometry.THIRD_CORE + geometry.PERIODIC
         r.core.spatialGrid.geomType = geometry.HEX

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -36,11 +36,10 @@ ISOAA_PATH = os.path.join(TEST_ROOT, "ISOAA")
 COMPXS_PATH = os.path.join(TEST_ROOT, "COMPXS.ascii")
 
 
-def getEmptyHexReactor(cs=None):
+def getEmptyHexReactor():
     """Make an empty hex reactor used in some tests."""
     from armi.reactor import blueprints
 
-    cs = cs or settings.getMasterCs()
     bp = blueprints.Blueprints()
     reactor = reactors.Reactor("Reactor", bp)
     reactor.add(reactors.Core("Core"))

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -42,8 +42,8 @@ def getEmptyHexReactor(cs=None):
 
     cs = cs or settings.getMasterCs()
     bp = blueprints.Blueprints()
-    reactor = reactors.Reactor(cs, bp)
-    reactor.add(reactors.Core("Core", cs))
+    reactor = reactors.Reactor("Reactor", bp)
+    reactor.add(reactors.Core("Core"))
     reactor.core.spatialGrid = grids.hexGridFromPitch(1.0)
     reactor.core.spatialGrid.symmetry = geometry.THIRD_CORE + geometry.PERIODIC
     reactor.core.spatialGrid.geomType = geometry.HEX

--- a/armi/tests/test_fuelHandlers.py
+++ b/armi/tests/test_fuelHandlers.py
@@ -41,7 +41,9 @@ class TestFuelHandler(ArmiTestHelper):
     def setUpClass(cls):
         # prepare the input files. This is important so the unit tests run from wherever
         # they need to run from.
-        cls.directoryChanger = directoryChangers.DirectoryChanger(TEST_ROOT)
+        cls.directoryChanger = directoryChangers.DirectoryChanger(
+            TEST_ROOT, dumpOnException=False
+        )
         cls.directoryChanger.open()
 
     @classmethod
@@ -277,7 +279,8 @@ class TestFuelHandler(ArmiTestHelper):
     def runShuffling(self, fh):
         """Shuffle fuel and write out a SHUFFLES.txt file."""
         fh.attachReactor(self.o, self.r)
-        self.o.cs.caseTitle = "armiRun2"  # so we don't overwrite the version-controlled armiRun-SHUFFLES.txt
+        # so we don't overwrite the version-controlled armiRun-SHUFFLES.txt
+        self.o.cs.caseTitle = "armiRun2"
         fh.interactBOL()
 
         for cycle in range(3):
@@ -357,13 +360,17 @@ class TestFuelHandler(ArmiTestHelper):
         for a in self.r.core.sfp.getChildren():
             self.assertEqual(a.getLocation(), "SFP")
 
-        os.remove("armiRun2-SHUFFLES.txt")
+        if os.path.exists("armiRun2-SHUFFLES.txt"):
+            # sometimes pytest runs two of these at once.
+            os.remove("armiRun2-SHUFFLES.txt")
 
         restartFileName = "armiRun2.restart.dat"
         if os.path.exists(restartFileName):
             os.remove(restartFileName)
         for i in range(3):
-            os.remove("armiRun2.shuffles_{}.png".format(i))
+            fname = f"armiRun2.shuffles_{i}.png"
+            if os.path.exists(fname):
+                os.remove(fname)
 
     def test_readMoves(self):
         """


### PR DESCRIPTION
Many global flux plugins had a similar run sequence.
This combines them into one to allow better inter-operability.

Also:
- Add better error handling to directory changers
- Add better testing for directory changers
- Remove some DIF3D-specific auxiliary code
- Defer error handling to the directory changer
- Improve debug statements in directorychangers
- Reduce parallel test collisions
- Remove complex cs dependency as much as possible.