### PR TITLE
Improve coverage tracking behavior

### DIFF
--- a/armi/resources/coveragerc
+++ b/armi/resources/coveragerc
@@ -1,7 +1,6 @@
 # coveragerc to control coverage.py
 [run]
 branch = True
-parallel = True
 omit =
     */tests/*
 # change default .coverage file to something that doesn't have a dot

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -52,18 +52,25 @@ _HASH_BUFFER_SIZE = (
 
 def coverageReportHelper(config, dataPaths):
     """
-    Small utility function to generate converage reports.
+    Small utility function to generate coverage reports.
 
     This was created to side-step the difficulties in submitting multi-line python
     commands on-the-fly.
+
+    This combines data paths and then makes html and xml reports for the
+    fully-combined result.
     """
     from coverage import Coverage
     import coverage
 
     try:
         cov = Coverage(config_file=config)
-        cov.combine(data_paths=dataPaths)
-        cov.save()
+        if dataPaths:
+            # fun fact: if you combine when there's only one file, it gets deleted.
+            cov.combine(data_paths=dataPaths)
+            cov.save()
+        else:
+            cov.load()
         cov.html_report()
         cov.xml_report()
     except PermissionError:


### PR DESCRIPTION
If you have just one coverage results file
in a folder and you call cov.combine(), the one
file gets deleted. This prevents this from happening
in most cases used in ARMI testing.