### PR TITLE
Create a generic fuel performance plugin

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -71,6 +71,7 @@ class App:
         from armi import cli
         from armi import bookkeeping
         from armi.physics import fuelCycle
+        from armi.physics import fuelPerformance
         from armi.physics import neutronics
         from armi.physics import safety
         from armi import reactor
@@ -80,6 +81,7 @@ class App:
             cli.EntryPointsPlugin,
             bookkeeping.BookkeepingPlugin,
             fuelCycle.FuelHandlerPlugin,
+            fuelPerformance.FuelPerformancePlugin,
             neutronics.NeutronicsPlugin,
             safety.SafetyPlugin,
             reactor.ReactorPlugin,

--- a/armi/physics/fuelPerformance/__init__.py
+++ b/armi/physics/fuelPerformance/__init__.py
@@ -1,21 +1,44 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Generic fuel performance plugin package.
 
-Fuel performance deals with how nuclear fuel evolves chemically and mechanically with burnup.
-It is often a key performance limiter in nuclear reactor design.
+Fuel performance deals with addressing fuel system limits and predicting
+behaviors that are coupled to other physics within the reactor. Often
+fuel performance models address chemical, thermal and mechanical behaviors
+of the fuel system.
 
-The following general phenomena fall into the fuel performance category of physics:
+The following general phenomena fall into the fuel performance category 
+of physics for solid fuel (e.g., SFR, LWR, TRISO):
 
-* the fission gas pressure build-up in a solid fuel pin
-* the fuel-clad chemical interaction (FCCI) on the inside of fuel cladding
-* the fuel-clad mechanical interaction (FCMI)
+* chemical degradation on the inside of fuel cladding such as
+  fuel-clad chemical interaction (FCCI)
+* corrosion or erosion processes on the outside of the fuel cladding
+* the fuel-clad mechanical interaction (FCMI) resulting in cladding stress 
+  and strain
+* pressurization of the fuel pin due to released fission gases
+* high temperatures of the fuel which affect material properties and feedback
+  during accident scenarios
 
-Fuel performance is always coupled with thermal analysis because the thermal
-properties of the fuel change with burnup.
+Fuel performance is typically coupled with thermal analysis because the thermal
+conditions of the fuel affects the performance and properties of the fuel
+change with temperature and burnup.
 
 In many cases, fuel performance is coupled with neutronic analysis as well,
 because the fission gases are strong neutron absorbers. In some reactors,
 significant composition changes during irradiation can influence neutronics
-as well (e.g. sodium thermal bond being squeezed out of pins.
+as well (e.g. sodium thermal bond being squeezed out of pins). Finally, 
+fuel temperatures impact the Doppler reactivity coefficient.
 """
 from .plugin import FuelPerformancePlugin

--- a/armi/physics/fuelPerformance/__init__.py
+++ b/armi/physics/fuelPerformance/__init__.py
@@ -1,0 +1,21 @@
+"""
+Generic fuel performance plugin package.
+
+Fuel performance deals with how nuclear fuel evolves chemically and mechanically with burnup.
+It is often a key performance limiter in nuclear reactor design.
+
+The following general phenomena fall into the fuel performance category of physics:
+
+* the fission gas pressure build-up in a solid fuel pin
+* the fuel-clad chemical interaction (FCCI) on the inside of fuel cladding
+* the fuel-clad mechanical interaction (FCMI)
+
+Fuel performance is always coupled with thermal analysis because the thermal
+properties of the fuel change with burnup.
+
+In many cases, fuel performance is coupled with neutronic analysis as well,
+because the fission gases are strong neutron absorbers. In some reactors,
+significant composition changes during irradiation can influence neutronics
+as well (e.g. sodium thermal bond being squeezed out of pins.
+"""
+from .plugin import FuelPerformancePlugin

--- a/armi/physics/fuelPerformance/parameters.py
+++ b/armi/physics/fuelPerformance/parameters.py
@@ -1,0 +1,82 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parameter definitions for fuel performance plugins."""
+from armi.reactor import parameters
+from armi.reactor.parameters import ParamLocation
+from armi.reactor.blocks import Block
+from armi.utils import units
+
+
+def getFuelPerformanceParameterDefinitions():
+    """Return ParameterDefinitionCollections for each appropriate ArmiObject."""
+    return {Block: _getFuelPerformanceBlockParams()}
+
+
+def _getFuelPerformanceBlockParams():
+    pDefs = parameters.ParameterDefinitionCollection()
+    with pDefs.createBuilder(default=0.0, location=ParamLocation.AVERAGE) as pb:
+
+        pb.defParam(
+            "gasReleaseFraction",
+            units="fraction",
+            description="Fraction of generated fission gas that no longer exists in the block."
+            " Should be between 0 and 1, inclusive.",
+            categories=["eq cumulative shift"],
+        )
+
+        pb.defParam(
+            "bondRemoved",
+            units="fraction",
+            description="Fraction of thermal bond between fuel and clad that has been pushed out. "
+            "Should be between 0 and 1, inclusive.",
+            categories=["eq cumulative shift"],
+        )
+
+        pb.defParam(
+            "cladWastage",
+            units=units.MICRONS,
+            description="Total cladding wastage from inner and outer surfaces.",
+            location=ParamLocation.AVERAGE,
+            categories=["eq cumulative shift"],
+        )
+
+        pb.defParam(
+            "totalCladStrain",
+            units="%",
+            description="Total diametral clad strain.",
+            categories=["eq cumulative shift"],
+        )
+
+        pb.defParam(
+            "axialGrowthPct",
+            units="%",
+            description="Axial growth percentage",
+            categories=["eq cumulative shift"],
+        )
+
+        pb.defParam(
+            "fpPeakFuelTemp",
+            units="C",
+            description="Fuel performance calculated peak fuel temperature.",
+            location=ParamLocation.AVERAGE,
+        )
+
+        pb.defParam(
+            "fpAveFuelTemp",
+            units="C",
+            description="Fuel performance calculated average fuel temperature.",
+            location=ParamLocation.AVERAGE,
+        )
+
+    return pDefs

--- a/armi/physics/fuelPerformance/plugin.py
+++ b/armi/physics/fuelPerformance/plugin.py
@@ -1,0 +1,105 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Generic Fuel Performance Plugin
+"""
+
+import tabulate
+
+from armi import plugins
+from armi import interfaces
+from armi import runLog
+from armi.reactor.flags import Flags
+from armi.physics.fuelPerformance import settings
+
+
+ORDER = interfaces.STACK_ORDER.CROSS_SECTIONS
+
+
+class FuelPerformancePlugin(plugins.ArmiPlugin):
+    """Plugin for fuel performance."""
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def exposeInterfaces(cs):
+        """Expose the fuel performance interfaces."""
+        return []
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineSettings():
+        """Define settings for fuel performance."""
+        return settings.defineSettings()
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineSettingsValidators(inspector):
+        """Define settings inspections for fuel performance."""
+        return settings.defineValidators(inspector)
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineParameters():
+        from armi.physics.fuelPerformance import parameters
+
+        return parameters.getFuelPerformanceParameterDefinitions()
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def afterConstructionOfAssemblies(assemblies, cs):
+        """After new assemblies are built, set some state information."""
+        _setBOLBond(assemblies)
+
+
+def _setBOLBond(assemblies):
+    """Set initial bond fractions for each block in the core."""
+    assemsWithoutMatchingBond = set()
+    for a in assemblies:
+        for b in a:
+            coolant = b.getComponent(Flags.COOLANT, quiet=True)
+            bond = b.getComponent(Flags.BOND, quiet=True)
+            if not bond:
+                b.p.bondBOL = 0.0
+                continue
+            b.p.bondBOL = sum(
+                [bond.getNumberDensity(nuc) for nuc in bond.getNuclides()]
+            )
+
+            if not isinstance(bond.material, coolant.material.__class__):
+                assemsWithoutMatchingBond.add(
+                    (
+                        a.getType(),
+                        b.getType(),
+                        bond.material.getName(),
+                        coolant.material.getName(),
+                    )
+                )
+
+    if assemsWithoutMatchingBond:
+        runLog.warning(
+            "The following have mismatching `{}` and `{}` materials:\n".format(
+                Flags.BOND, Flags.COOLANT
+            )
+            + tabulate.tabulate(
+                list(assemsWithoutMatchingBond),
+                headers=[
+                    "Assembly Type",
+                    "Block Type",
+                    "Bond Material",
+                    "Coolant Material",
+                ],
+                tablefmt="armi",
+            )
+        )

--- a/armi/physics/fuelPerformance/settings.py
+++ b/armi/physics/fuelPerformance/settings.py
@@ -1,0 +1,105 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Settings related to fuel performance."""
+
+from armi.settings import setting2 as setting
+from armi.operators.settingsValidation import Query
+
+
+CONF_FUEL_PERFORMANCE_ENGINE = "fuelPerformanceEngine"
+CONF_AXIAL_EXPANSION = "axialExpansion"
+CONF_BOND_REMOVAL = "bondRemoval"
+CONF_FGR_REMOVAL = "fgRemoval"
+CONF_CLADDING_WASTAGE = "claddingWastage"
+CONF_CLADDING_STRAIN = "claddingStrain"
+
+
+def defineSettings():
+    """Define generic fuel performance settings."""
+    settings = [
+        setting.Setting(
+            CONF_FUEL_PERFORMANCE_ENGINE,
+            default="",
+            label="Fuel Performance Engine",
+            description=(
+                "Fuel performance engine that determines fission gas removal, bond removal,"
+                " axial growth, wastage, and cladding strain."
+            ),
+            options=[""],
+        ),
+        setting.Setting(
+            CONF_AXIAL_EXPANSION,
+            default=False,
+            label="Fuel Axial Expansion",
+            description="Perform axial fuel expansion. This will adjust fuel block lengths.",
+        ),
+        setting.Setting(
+            CONF_BOND_REMOVAL,
+            default=False,
+            label="Thermal Bond Removal",
+            description="Toggles fuel performance bond removal. This will remove thermal bond from the fuel.",
+        ),
+        setting.Setting(
+            CONF_FGR_REMOVAL,
+            default=False,
+            label="Fission Gas Removal",
+            description="Toggles fuel performance fission gas removal.  This will remove fission gas from the fuel.",
+        ),
+        setting.Setting(
+            CONF_CLADDING_WASTAGE,
+            default=False,
+            label="Cladding Wastage",
+            description="Evaluate cladding wastage. ",
+        ),
+        setting.Setting(
+            CONF_CLADDING_STRAIN,
+            default=False,
+            label="Cladding Strain",
+            description="Evaluate cladding strain. ",
+        ),
+    ]
+    return settings
+
+
+def defineValidators(inspector):
+    return [
+        Query(
+            lambda: (
+                inspector.cs["axialExpansion"]
+                or inspector.cs["bondRemoval"]
+                or inspector.cs["fgRemoval"]
+                or inspector.cs["claddingWastage"]
+                or inspector.cs["claddingStrain"]
+            )
+            and inspector.cs["fuelPerformanceEngine"] == "",
+            "A fuel performance behavior has been selected but no fuel performance engine is selected.",
+            "",
+            inspector.NO_ACTION,
+        ),
+        Query(
+            lambda: (
+                inspector.cs["axialExpansion"]
+                or inspector.cs["bondRemoval"]
+                or inspector.cs["fgRemoval"]
+                or inspector.cs["claddingWastage"]
+                or inspector.cs["claddingStrain"]
+            )
+            and not inspector.cs["doTH"],
+            "A fuel performance behavior has been selected which may require thermal-hydraulics.",
+            "Would you like to turn the TH option on?",
+            # pylint: disable=protected-access
+            lambda: inspector._assignCS("doTH", True),
+        ),
+    ]

--- a/armi/physics/fuelPerformance/tests/__init__.py
+++ b/armi/physics/fuelPerformance/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
+++ b/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
@@ -1,3 +1,16 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Tests for generic fuel performance plugin.
 """

--- a/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
+++ b/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
@@ -1,0 +1,15 @@
+"""
+Tests for generic fuel performance plugin.
+"""
+import unittest
+
+from armi.tests.test_plugins import TestPlugin
+from armi.physics.fuelPerformance.plugin import FuelPerformancePlugin
+
+
+class TestFuelPerformancePlugin(TestPlugin):
+    plugin = FuelPerformancePlugin
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -1014,20 +1014,6 @@ def getBlockParameterDefinitions():
 
         pb.defParam("bu", units="", description="?")
 
-        pb.defParam(
-            "gasReleaseFraction",
-            units="",
-            description="Fraction of fission gas to remove",
-            categories=["eq cumulative shift"],
-        )
-
-        pb.defParam(
-            "bondRemoved",
-            units="fraction",
-            description="Fraction of thermal bond between fuel and clad that has been pushed out.",
-            categories=["eq cumulative shift"],
-        )
-
         def buGroup(self, buGroupChar):  # pylint: disable=method-hidden
             if isinstance(buGroupChar, (int, float)):
                 intValue = int(buGroupChar)

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -211,8 +211,6 @@ class ArmiTestHelper(unittest.TestCase):
         Rebaselining the reference files upon large, expected, hand-verified changes is accomodated by
         :py:meth:`rebaselineTextComparisons`.
 
-
-
         Parameters
         ----------
         expectedFilePath: str
@@ -248,11 +246,11 @@ class ArmiTestHelper(unittest.TestCase):
                         for line in (actualLine, expectedLine)
                     ):
                         continue
-                    else:
-                        msg = "\nThe files: \n{} and \n{} \nwere not the same.".format(
-                            expectedFilePath, os.path.abspath(actualFilePath)
-                        )
-                        raise AssertionError(msg) from er
+
+                    msg = "\nThe files: \n{} and \n{} \nwere not the same.".format(
+                        expectedFilePath, os.path.abspath(actualFilePath)
+                    )
+                    raise AssertionError(msg) from er
         os.remove(actualFilePath)
 
 


### PR DESCRIPTION
Similar to the other generic plugins, this will be a central place
to put settings, parameters, executers, etc. that are expected to
be shared across a variety of fuel performance plugins.