### PR TITLE
Minor reorg and fixes to docs

### DIFF
--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -65,15 +65,7 @@ Now you can do a few things, such as::
 
 Specifying blocks and assemblies to track
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The History Tracker stores history only for certain blocks and assemblies (known as detail assemblies or blocks).
-These can be input by the user in a variety of ways, through the GUI or the settings system.
-
-    * Detail Assembly Locations BOL (`detailAssemLocationsBOL`) can be specified on the GUI. This is a list of
-      assembly location strings (e.g. ``A4003`` for ring 4, position3).
-      Assemblies in these locations at beginning-of-life will be activated as detail assemblies.
-    * Detail assembly numbers (``detailAssemNums``) are ``assemNum`` params similar to block IDs.
-
-Finally, you can activate the ``detailAllAssems`` option to specify all assemblies in the problem as detail assemblies.
+See :ref:`detail-assems`.
 
 """
 import re

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -21,7 +21,7 @@ be used to collect a series of cases
 and submit them to a cluster for execution. Furthermore, a ``CaseSuite`` can be used to gather
 executed cases for post-analysis.
 
-``CaseSuite``s should allow ``Cases`` to be added from totally separate directories.
+``CaseSuite``\ s should allow ``Cases`` to be added from totally separate directories.
 This is useful for plugin-informed in-use testing as well as other things.
 
 See Also

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -23,7 +23,7 @@ the standard ``CaseSuite`` objects.
 
 This module contains a variety of ``InputModifier`` objects as well, which are examples
 of how you can modify inputs for parameter sweeping. Power-users will generally make
-their own ``Modifier``s that are design-specific.
+their own ``Modifier``\ s that are design-specific.
 
 """
 import copy

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -85,7 +85,7 @@ considerably). Examples:
 Plugins are stateless. They do not have ``__init__()`` methods, and when they are
 registered with the PluginMagager, the PluginManager gets the Plugin's class object
 rather than an instance of that class. Also notice that all of the hooks are
-``@staticmethod``s. As a result, they can be called directly off of the class object,
+``@staticmethod``\ s. As a result, they can be called directly off of the class object,
 and only have access to the state passed into them to perform their function. This is a
 deliberate design choice to keep the plugin system simple and to preclude a large class
 of potential bugs. At some point it may make sense to revisit this.
@@ -367,7 +367,7 @@ class ArmiPlugin:
         """
         Function for defining case dependencies.
 
-        Some Cases depend on the results of other ``Case``s in the same ``CaseSuite``.
+        Some Cases depend on the results of other ``Case``\ s in the same ``CaseSuite``.
         Which dependencies exist, and how they are discovered depends entirely on the
         type of analysis and active interfaces, etc. This function allows a plugin to
         inspect settings and declare dependencies between the passed ``case`` and any

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -25,12 +25,12 @@ This contains structured meshes in multiple geometries and spatial locators (i.e
 Fast reactors often use a hexagonal grid, while other reactors may be better suited for
 Cartesian or RZT grids. This module contains representations of all these.
 
-``Grid``s can be defined by any arbitrary combination of absolute grid boundaries and
+``Grid``\ s can be defined by any arbitrary combination of absolute grid boundaries and
 unit step directions.
 
 Associated with grids are :py:class:`IndexLocations <IndexLocation>`. Each of these maps
 to a single cell in a grid, or to an arbitrary point in the continuous space represented
-by a grid. When a `Grid`` is built, it builds a collection of ``IndexLocation``s, one
+by a grid. When a `Grid`` is built, it builds a collection of ``IndexLocation``\ s, one
 for each cell.
 
 In the ARMI :py:mod:`armi.reactor` module, each object is assigned a locator either from

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -15,7 +15,7 @@
 r"""
 This module contains the code necessary to represent parameter definitions.
 
-``ParameterDefinition``s are the metadata that describe specific parameters, and aid in
+``ParameterDefinition``\ s are the metadata that describe specific parameters, and aid in
 enforcing certain rules upon the parameters themselves and the parameter collections
 that contain them.
 
@@ -109,7 +109,7 @@ class Serializer:
     requires that the Parameter data be converted to a numpy array of a datatype
     supported by the ``h5py`` package. Some parameters may contain data that are not
     trivially representable in numpy/HDF5, and need special treatment. Subclassing
-    ``Serializer`` and setting it as a ``Parameter``s ``serializer`` allows for special
+    ``Serializer`` and setting it as a ``Parameter``\ s ``serializer`` allows for special
     operations to be performed on the parameter values as they are stored to the
     database or read back in.
 
@@ -673,7 +673,7 @@ class ParameterBuilder(object):
             default=default if default is not NoDefault else self._defaultValue,
             setter=setter,
             categories=set(categories or []).union(self._defaultCategories),
-            serializer=serializer
+            serializer=serializer,
         )
 
         if self._paramDefs is not None:

--- a/doc/.static/theme_fixes.css
+++ b/doc/.static/theme_fixes.css
@@ -1,0 +1,11 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -450,9 +450,7 @@ html_last_updated_fmt = "%Y-%m-%d"
 htmlhelp_basename = "ARMIdoc"
 
 html_context = {
-    "css_files": [
-        "_static/theme_overrides.css"  # overrides for wide tables in RTD theme
-    ]
+    "css_files": ["_static/theme_fixes.css"]  # overrides for wide tables in RTD theme
 }
 
 # -- Options for LaTeX output --------------------------------------------------

--- a/doc/developer/documenting.rst
+++ b/doc/developer/documenting.rst
@@ -38,14 +38,15 @@ all output cells in the notebook web interface itself before committing the file
 
 Documentation for ARMI plugins
 ------------------------------
+The following subsections apply to documentation for ARMI plugins.
 
 Linking to ARMI documentation from plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ARMI plugin documentation can feature rich hyperlinks to the ARMI API documentation 
-with the help of the 
-`intersphinx plugin <http://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_.
-The plugin documentation config file simply should add ``"sphinx.ext.intersphinx",`` to
-its active plugin list, and change the default config to read::
+with the help of the
+`intersphinx Sphinx plugin <http://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_.
+The ARMI plugin documentation config file should add ``"sphinx.ext.intersphinx",`` to
+its active Sphinx plugin list, and change the default config to read::
 
     intersphinx_mapping = {
         "python": ("https://docs.python.org/3", None),
@@ -60,8 +61,9 @@ Now you can link to the ARMI documentation with links like::
 
 Automatically building apidocs of namespace packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Activating the ``"sphinxcontrib.apidoc",`` `plugin <https://github.com/sphinx-contrib/apidoc>`_
-enables plugin API documentation to be built with the standard ``make html`` sphinx workflow. If 
-your plugin is a namespace package, the following extra config is required::
+Activating the ``"sphinxcontrib.apidoc",`` 
+`Sphinx plugin <https://github.com/sphinx-contrib/apidoc>`_
+enables plugin API documentation to be built with the standard ``make html`` Sphinx workflow. If 
+your ARMI plugin is a namespace package, the following extra config is required::
 
     apidoc_extra_args = ["--implicit-namespaces"]

--- a/doc/developer/documenting.rst
+++ b/doc/developer/documenting.rst
@@ -35,3 +35,33 @@ documentation is built. To do this, you can clean the output with::
 
 This should clear the output and overwrite the file. If this doesn't work, you can clear
 all output cells in the notebook web interface itself before committing the file.
+
+Documentation for ARMI plugins
+------------------------------
+
+Linking to ARMI documentation from plugins
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ARMI plugin documentation can feature rich hyperlinks to the ARMI API documentation 
+with the help of the 
+`intersphinx plugin <http://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_.
+The plugin documentation config file simply should add ``"sphinx.ext.intersphinx",`` to
+its active plugin list, and change the default config to read::
+
+    intersphinx_mapping = {
+        "python": ("https://docs.python.org/3", None),
+        "armi": ("https://terrapower.github.io/armi/", None),
+    }
+
+Now you can link to the ARMI documentation with links like::
+
+    :doc:`armi:developer/documenting`
+    :py:mod:`armi.physics.executers`
+
+
+Automatically building apidocs of namespace packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Activating the ``"sphinxcontrib.apidoc",`` `plugin <https://github.com/sphinx-contrib/apidoc>`_
+enables plugin API documentation to be built with the standard ``make html`` sphinx workflow. If 
+your plugin is a namespace package, the following extra config is required::
+
+    apidoc_extra_args = ["--implicit-namespaces"]

--- a/doc/user/inputs/settings.rst
+++ b/doc/user/inputs/settings.rst
@@ -61,3 +61,34 @@ to update this setting.
 
 Other settings on this tab may need to be updated depending on your computational environment.
 Talk to your system admins to determine which settings are best.
+
+Some special settings
+=====================
+A few settings warrant additional discussion.
+
+.. _detail-assems:
+
+Detail assemblies
+-----------------
+Many plugins perform more detailed analysis on certain regions of the reactor. Since the analyses
+often take longer, ARMI has a feature, called *detail assemblies* to help. Different plugins
+may treat detail assemblies differently, so it's important to read the plugin documentation
+as well. For example, a depletion plugin may perform pin-level depletion and rotation analysis
+only on the detail assemblies. Or perhaps CFD thermal/hydraulics will be run on detail assemblies,
+while subchannel T/H is run on the others. 
+
+Detail assemblies are specified by the user in a variety of ways, 
+through the GUI or the settings system.
+
+Detail Assembly Locations BOL
+    The ``detailAssemLocationsBOL`` setting is a list of assembly location strings 
+    (e.g. ``A4003`` for ring 4, position3). Assemblies that are in these locations at the 
+    beginning-of-life will be activated as detail assemblies.
+
+Detail assembly numbers
+    The ``detailAssemNums`` setting is a list of``assemNum``s that can be inferred from a previous
+    case and specified, regardless of when the assemblies enter the core. This is useful for
+    activating detailed treatment of assemblies that enter the core at a later cycle.
+
+Detail all assemblies
+    The ``detailAllAssems`` setting makes all assemblies in the problem detail assemblies

--- a/doc/user/inputs/settings.rst
+++ b/doc/user/inputs/settings.rst
@@ -31,7 +31,7 @@ The ARMI GUI
 ============
 The ARMI GUI may be used to manipulate many common settings (though the GUI can't change all of the settings).  The GUI
 also enables the graphical manipulation of a reactor core map, and convenient automation of commands required to submit to a
-cluster.  The GUI is simply a front-end to
+cluster.  The GUI is a front-end to
 these files. You can choose to use the GUI or not, ARMI doesn't know or care --- it just reads these files and runs them. 
 
 Note that one settings input file is required for each ARMI case, though many ARMI cases can refer to the same
@@ -80,13 +80,18 @@ while subchannel T/H is run on the others.
 Detail assemblies are specified by the user in a variety of ways, 
 through the GUI or the settings system.
 
+.. warning:: The Detail Assemblies mechanism has begun to be too broad of a brush
+    for serious multiphysics calculations with each plugin treating them differently.
+    It is likely that this feature will be extended to be more flexible and less
+    surprising in the future.
+
 Detail Assembly Locations BOL
     The ``detailAssemLocationsBOL`` setting is a list of assembly location strings 
-    (e.g. ``A4003`` for ring 4, position3). Assemblies that are in these locations at the 
+    (e.g. ``A4003`` for ring 4, position 3). Assemblies that are in these locations at the 
     beginning-of-life will be activated as detail assemblies.
 
 Detail assembly numbers
-    The ``detailAssemNums`` setting is a list of``assemNum``s that can be inferred from a previous
+    The ``detailAssemNums`` setting is a list of ``assemNum``\ s that can be inferred from a previous
     case and specified, regardless of when the assemblies enter the core. This is useful for
     activating detailed treatment of assemblies that enter the core at a later cycle.
 

--- a/doc/user/inputs/settings_report.rst
+++ b/doc/user/inputs/settings_report.rst
@@ -15,14 +15,13 @@ through the :py:class:`armi.settings.caseSettings.Settings` object, which is typ
     cs = settings.Settings()
     # User textwrap to split up long words that mess up the table.
     wrapper = textwrap.TextWrapper(width=25, subsequent_indent='')
-    content = '\n.. list-table:: ARMI Settings\n   :header-rows: 1\n   :widths: 30 40 20 10\n    \n'
-    content += '   * - Name\n     - Description\n     - Default\n     - Units\n'
+    content = '\n.. list-table:: ARMI Settings\n   :header-rows: 1\n   :widths: 30 40 30\n    \n'
+    content += '   * - Name\n     - Description\n     - Default\n'
 
     for setting in sorted(cs.settings.values(), key=lambda s: s.name):
         content += '   * - {}\n'.format(' '.join(wrapper.wrap(setting.name)))
         content += '     - {}\n'.format(' '.join(wrapper.wrap(setting.description or '')))
         content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper.wrap(str(getattr(setting,'default','') or ''))]))
-        content += '     - {}\n'.format(' '.join(wrapper.wrap(str(getattr(setting,'units','') or ''))))
 
     content += '\n'
 


### PR DESCRIPTION
* This makes a new section describing the detail assembly settings.
  It was moved with an anchor so plugins that use it can easily
  reference it.

* Bug in RTD theme related to table widths was fixed. Now the
  table of all settings renders in a readable way.

* Empty units column of settings table removed