### PR TITLE
Remove one level of the call stack for ndens.

### DIFF
--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -594,7 +594,7 @@ class Component(composites.Composite, metaclass=ComponentType):
 
     def getNuclideNumberDensities(self, nucNames):
         """Return a list of number densities for the nuc names requested."""
-        return [self.getNumberDensity(nucName) for nucName in nucNames]
+        return [self.p.numberDensities.get(nucName, 0.0) for nucName in nucNames]
 
     def _getNdensHelper(self):
         return dict(self.p.numberDensities)


### PR DESCRIPTION
Getting number densities is a performance-critical activity. This small
change just accesses the number density params directly rather than
using the method call just above. This won't change things by much but
just acknowledges that performance really matters in these methods.