### PR TITLE
Re-implement the 1/3 hex asciimap reader

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -426,7 +426,7 @@ class Case:
         bool
             True if the inputs are all good, False otherwise
         """
-        with DirectoryChanger(self.cs.inputDirectory):
+        with DirectoryChanger(self.cs.inputDirectory, dumpOnException=False):
             operatorClass = operators.getOperatorClassFromSettings(self.cs)
             inspector = operatorClass.inspector(self.cs)
             inspectorIssues = [query for query in inspector.queries if query]

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -33,6 +33,9 @@ armi.reactor.geometry : a specific usage of lattices, for core maps
 import itertools
 
 
+PLACEHOLDER = "-"
+
+
 class AsciiMap(object):
     """
     Base class for maps.
@@ -71,7 +74,7 @@ class AsciiMap(object):
                 i, j = self._getIndices(base, col)
                 self.lattice[i, j] = char
 
-        self.lattice = {k: v for k, v in self.lattice.items() if v != "-"}
+        self.lattice = {k: v for k, v in self.lattice.items() if v != PLACEHOLDER}
         return self.lattice
 
     def writeMap(self, stream):
@@ -82,7 +85,7 @@ class AsciiMap(object):
             if line and i == 0:
                 stream.write(" ".join(line) + "\n")
                 line = []
-            line.append(f"{self.lattice.get((i,j),'-')}")
+            line.append(f"{self.lattice.get((i,j), PLACEHOLDER)}")
         stream.write(" ".join(line) + "\n")
 
     @staticmethod
@@ -214,7 +217,7 @@ class AsciiMapHexThird(AsciiMap):
                     # of our otherwise infinite loop
                     break
                 if contents is None:
-                    contents = '-'
+                    contents = PLACEHOLDER
                 elif not foundContents:
                     foundContents = True
 

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -30,6 +30,7 @@ armi.reactor.blueprints.latticeBlueprint : user input of generic lattices
 armi.reactor.geometry : a specific usage of lattices, for core maps
 
 """
+import itertools
 
 
 class AsciiMap(object):
@@ -69,6 +70,8 @@ class AsciiMap(object):
             for col, char in enumerate(line.split()):
                 i, j = self._getIndices(base, col)
                 self.lattice[i, j] = char
+
+        self.lattice = {k: v for k, v in self.lattice.items() if v != "-"}
         return self.lattice
 
     def writeMap(self, stream):
@@ -180,22 +183,44 @@ class AsciiMapHexThird(AsciiMap):
         return iBase + col * 2, jBase - col
 
     def writeMap(self, stream):
-        """Writing this is easiest if we just make a big ascii map and fill it in."""
+        """Write the lattice to a text stream"""
         grid = {}
+        # The length of the largest string contents. Useful for spacing everything out
+        # nicely
+        maxSize = len(str(next(iter(self.lattice.values()))))
         for (i, j), val in self.lattice.items():
+            maxSize = max(len(str(val)), maxSize)
             x = i * 2
             y = j * 2 + i
             grid[x, y] = val
 
-        allI, allJ = zip(*grid.keys())
+        nRows = max(y for _x, y in grid)
+        minX = min(self._getRowBase(row)[0] for row in range(nRows+1))
 
-        lines = []
-        for y in reversed(range(min(allJ) - 1, max(allJ) + 1)):
-            line = []
-            for x in range(min(allI) - 1, max(allI) + 1):
-                line.append(f"{grid.get((x,y),' ')}")
-            lines.append("".join(line).rstrip())
-        stream.write("\n".join(lines))
+        spacer = " "*maxSize
+
+        for row in reversed(range(nRows+1)):
+            base = self._getRowBase(row)
+            foundContents = False
+
+            padding = self._getIndices(base, 0)[0] - minX
+            rowContents = []
+            for col in itertools.count(0):
+                i, j = self._getIndices(base, col)
+
+                contents = self.lattice.get((i, j), None)
+                if contents is None and foundContents:
+                    # we have gotten to the end of the contents for this row; break out
+                    # of our otherwise infinite loop
+                    break
+                if contents is None:
+                    contents = '-'
+                elif not foundContents:
+                    foundContents = True
+
+                rowContents.append(contents.center(maxSize))
+
+            stream.write(" "*padding*maxSize + spacer.join(rowContents) + "\n")
 
 
 class AsciiMapHexFullTipsUp(AsciiMap):

--- a/armi/utils/tests/test_asciimaps.py
+++ b/armi/utils/tests/test_asciimaps.py
@@ -15,6 +15,7 @@
 """Test ASCII maps."""
 import unittest
 import io
+import sys
 
 from armi.utils import asciimaps
 
@@ -25,24 +26,46 @@ CARTESIAN_MAP = """2 2 2 2 2
 2 2 2 2 2
 """
 
-HEX_THIRD_MAP = """ -   -   3   3
-   -   3   3   3
-     3   2   2   3
-   3   2   2   2   3
-     2   1   1   2   3
-       1   1   1   2   3
-     1   1   1   1   2   3
-       1   1   1   1   2   3
-         1   1   1   1   2
-       1   1   1   1   1   3
-         1   1   1   1   2   3
-           1   1   1   1   2
-         1   1   1   1   1   3
-           1   1   1   1   2
-             1   1   1   1   3
-           1   1   1   1   2
-             1   1   1   1   3
-           1   1   1   1   2
+HEX_THIRD_MAP = """- - 3 3
+ - 3 3 3
+  3 2 2 3
+ 3 2 2 2 3
+  2 1 1 2 3
+   1 1 1 2 3
+  1 1 1 1 2 3
+   1 1 1 1 2 3
+    1 1 1 1 2
+   1 1 1 1 1 3
+    1 1 1 1 2 3
+     1 1 1 1 2
+    1 1 1 1 1 3
+     1 1 1 1 2
+      1 1 1 1 3
+     1 1 1 1 2
+      1 1 1 1 3
+     1 1 1 1 2
+"""
+
+# This core map is from refTestBase, and exhibited some issues when trying to read with
+# an older implementation of the 1/3 hex lattice reader.
+HEX_THIRD_MAP_2 = """-   -   SH  SH
+  -   SH  SH  SH
+    SH  OC  OC  SH
+  SH  OC  OC  OC  SH
+    OC  EX  EX  OC  SH
+      EX  EX  EX  OC  SH
+    EX  MC  MC  EX  OC  SH
+      MC  HX  MC  EX  OC  SH
+        MC  MC  PC  EX  OC
+      MC  IC  MC  MC  EX  SH
+        IC  IC  MC  MC  OC  SH
+          PC  IC  MC  EX  OC
+        FA  FA  IC  TG  EX  SH
+          IC  FA  IC  MC  OC
+            IC  US  MC  EX  SH
+          EX  IC  IC  MC  OC
+            EX  FA  MC  EX  SH
+          EX  IC  IC  PC  OC
 """
 
 HEX_FULL_MAP = """
@@ -105,6 +128,15 @@ class TestAsciiMaps(unittest.TestCase):
             stream.seek(0)
             output = stream.read()
             self.assertEqual(output, HEX_THIRD_MAP)
+
+    def test_troublesomeHexThird(self):
+        reader = asciimaps.AsciiMapHexThird()
+        lattice = reader.readMap(HEX_THIRD_MAP_2)
+        writer = asciimaps.AsciiMapHexThird(lattice)
+        with io.StringIO() as stream:
+            writer.writeMap(stream)
+            asStr = stream.getvalue()
+            self.assertEqual(asStr, HEX_THIRD_MAP_2)
 
     def test_hexFull(self):
         """Test sample full hex map against known answers."""


### PR DESCRIPTION
The old one was not interpreting the leading hyphens properly. The new
ones is a more reliable inversion of the writing process, and handles
spacing between elements better.