### PR TITLE
Uniform mesh conversion fixes

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -395,7 +395,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
         if self.options.detailedAxialExpansion:
             converter = self.geomConverters.get("axial")
             if not converter:
-                converter = uniformMesh.UniformMeshGeometryConverter(None)
+                converter = uniformMesh.NeutronicsUniformMeshConverter(None)
                 neutronicsReactor = converter.convert(self.r)
                 if makePlots:
                     converter.plotConvertedReactor()

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -112,13 +112,266 @@ def _getNeutronicsBlockParams():
             categories=[parameters.Category.multiGroupQuantities],
             default=None,
         )
+
+    with pDefs.createBuilder(
+        default=0.0,
+        location=ParamLocation.AVERAGE,
+        categories=[parameters.Category.detailedAxialExpansion],
+    ) as pb:
+        # Neutronics reaction rate params
+        pb.defParam(
+            "rateAbs",
+            units="1/cm^3/s",
+            description="Total absorption rate in this block (fisson + capture).",
+        )
+
+        pb.defParam(
+            "rateCap",
+            units="1/cm^3/s",
+            description="Parasitic capture rate in this block.",
+        )
+
+        pb.defParam(
+            "rateFis", units="1/cm^3/s", description="Fission rate in this block."
+        )
+
+        pb.defParam(
+            "rateProdFis",
+            units="1/cm^3/s",
+            description="Production rate of neutrons from fission reactions (nu * fission source / k-eff)",
+        )
+
+        pb.defParam(
+            "rateProdN2n",
+            units="1/cm^3/s",
+            description="Production rate of neutrons from n2n reactions.",
+        )
+
+        pb.defParam(
+            "rateBalance",
+            units="1/cm^3/s",
+            description="Numerical balance between particle production and destruction (should be small)",
+        )
+
+        pb.defParam(
+            "rateExtSrc",
+            units="1/cm^3/s",
+            description="Rate of production of neutrons from an external source.",
+        )
+
+        pb.defParam(
+            "rateFisAbs",
+            units="1/cm^3/s",
+            description="Neutron abs. rate in fissile material",
+        )
+
+        pb.defParam(
+            "rateFisSrc",
+            units="1/cm^3/s",
+            description="Fission source rate. This is related to production rate in fissile by a factor of keff",
+        )
+
+        pb.defParam(
+            "rateLeak",
+            units="1/cm^3/s",
+            description="Rate that neutrons leak out of this block.",
+        )
+
+        pb.defParam(
+            "rateParasAbs",
+            units="1/cm^3/s",
+            description="Rate of parasitic absorption (absorption in non-fertile/fissionable material)",
+        )
+
+        pb.defParam(
+            "rateProdNet",
+            units="1/cm^3/s",
+            description="Net production rate of neutrons",
+        )
+
+        pb.defParam(
+            "rateScatIn",
+            units="1/cm^3/s",
+            description="Rate neutrons in-scatter in this block",
+        )
+
+        pb.defParam(
+            "rateScatOut",
+            units="1/cm^3/s",
+            description="Rate that neutrons out-scatter in this block (removal - absorption)",
+        )
+
+        pb.defParam(
+            "capturePowerFrac",
+            units=None,
+            description="Fraction of the power produced through capture in a block.",
+            saveToDB="True",
+        )
+
+        pb.defParam(
+            "fastFluence",
+            units="#/cm^2",
+            description="Fast spectrum fluence",
+            categories=["cumulative"],
+        )
+
+        pb.defParam(
+            "fastFluencePeak",
+            units="#/cm^2",
+            description="Fast spectrum fluence with a peaking factor",
+        )
+
+        pb.defParam(
+            "fluence", units="#/cm^2", description="Fluence", categories=["cumulative"]
+        )
+
+        pb.defParam(
+            "flux",
+            units="n/cm^2/s",
+            description="neutron flux",
+            categories=[
+                parameters.Category.retainOnReplacement,
+                parameters.Category.fluxQuantities,
+            ],
+        )
+
+        pb.defParam(
+            "fluxAdj", units="", description="Adjoint flux"  # adjoint flux is unitless
+        )
+
+        pb.defParam(
+            "pdens", units="W/cm$^3$", description="Average volumetric power density"
+        )
+
+        pb.defParam(
+            "pdensDecay",
+            units="W/cm$^3$",
+            description="Decay power density from decaying radionuclides",
+        )
+
+        pb.defParam("arealPd", units="MW/m^2", description="Power divided by XY area")
+
+        pb.defParam(
+            "arealPdGamma", units="MW/m^2", description="Areal gamma power density"
+        )
+
+        pb.defParam("fertileBonus", units=None, description="The fertile bonus")
+
+        pb.defParam(
+            "fisDens",
+            units="fissions/cm^3/s",
+            description="Fission density in a pin (scaled up from homogeneous)",
+        )
+
+        pb.defParam(
+            "fisDensHom", units="1/cm^3/s", description="Homogenized fissile density"
+        )
+
+        pb.defParam(
+            "fluxDeltaFromRef",
+            units="None",
+            description="Relative difference between the current flux and the directly-computed perturbed flux.",
+        )
+
+        pb.defParam(
+            "fluxDirect",
+            units="n/cm^2/s",
+            description="Flux is computed with a direct method",
+        )
+
+        pb.defParam(
+            "fluxGamma",
+            units="g/cm^2/s",
+            description="Gamma scalar flux",
+            categories=[
+                parameters.Category.retainOnReplacement,
+                parameters.Category.fluxQuantities,
+            ],
+        )
+
+        pb.defParam(
+            "fluxPeak",
+            units="n/cm^2/s",
+            description="Peak neutron flux calculated within the mesh",
+        )
+
+        pb.defParam(
+            "fluxPertDeltaFromDirect",
+            units="None",
+            description="Relative difference between the perturbed flux and the directly-computed perturbed flux",
+        )
+
+        pb.defParam(
+            "fluxPertDeltaFromDirectfluxRefWeighted", units="None", description=""
+        )
+
+        pb.defParam(
+            "fluxPerturbed", units="1/cm^2/s", description="Flux is computed by MEPT"
+        )
+
+        pb.defParam("fluxRef", units="1/cm^2/s", description="Reference flux")
+
+        pb.defParam(
+            "kInf",
+            units="None",
+            description="Neutron production rate in this block/neutron absorption rate in this block. Not truly kinf but a reasonable approximation of reactivity.",
+        )
+
+        pb.defParam(
+            "medAbsE", units="eV", description="Median neutron absorption energy"
+        )
+
+        pb.defParam(
+            "medFisE",
+            units="eV",
+            description="Median energy of neutron causing fission",
+        )
+
+        pb.defParam("medFlxE", units="eV", description="Median neutron flux energy")
+
+        pb.defParam(
+            "pdensGamma",
+            units="W/cm^3",
+            description="Average volumetric gamma power density",
+        )
+
+        pb.defParam(
+            "pdensNeutron",
+            units="W/cm^3",
+            description="Average volumetric neutron power density",
+        )
+
+        pb.defParam("ppdens", units="W/cm^3", description="Peak power density")
+
+        pb.defParam("ppdensGamma", units="W/cm^3", description="Peak gamma density")
+
+    with pDefs.createBuilder(
+        default=0.0,
+        location=ParamLocation.VOLUME_INTEGRATED,
+        categories=[parameters.Category.detailedAxialExpansion],
+    ) as pb:
+
+        pb.defParam(
+            "powerGenerated",
+            units=" W",
+            description="Generated power. Different than b.p.power only when gamma transport is activated.",
+        )
+
+        pb.defParam("power", units="W", description="Total power")
+
+        pb.defParam("powerDecay", units="W", description="Total decay power")
+
+        pb.defParam("powerGamma", units="W", description="Total gamma power")
+
+        pb.defParam("powerNeutron", units="W", description="Total neutron power")
+
     return pDefs
 
 
 def _getNeutronicsCoreParams():
     pDefs = parameters.ParameterDefinitionCollection()
 
-    with pDefs.createBuilder(categories=["neutronics"]) as pb:
+    with pDefs.createBuilder(categories=[parameters.Category.neutronics]) as pb:
         pb.defParam(
             "eigenvalues",
             units=None,

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -1111,70 +1111,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "fastFluence",
-            units="#/cm^2",
-            description="Fast spectrum fluence",
-            categories=["cumulative"],
-        )
-
-        pb.defParam(
-            "fastFluencePeak",
-            units="#/cm^2",
-            description="Fast spectrum fluence with a peaking factor",
-            categories=["detailedAxialExpansion"],
-        )
-
-        pb.defParam(
-            "fluence", units="#/cm^2", description="Fluence", categories=["cumulative"]
-        )
-
-        pb.defParam(
-            "flux",
-            units="n/cm^2/s",
-            description="neutron flux",
-            categories=[
-                "detailedAxialExpansion",
-                parameters.Category.retainOnReplacement,
-                parameters.Category.fluxQuantities,
-            ],
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fluxAdj", units="", description="Adjoint flux"  # adjoint flux is unitless
-        )
-
-        pb.defParam(
-            "pdens",
-            units="W/cm$^3$",
-            description="Average volumetric power density",
-            categories=["detailedAxialExpansion"],
-        )
-
-        pb.defParam(
-            "pdensDecay",
-            units="W/cm$^3$",
-            description="Decay power density from decaying radionuclides",
-            categories=["detailedAxialExpansion"],
-        )
-
-        pb.defParam(
-            "power",
-            units="W",
-            description="Total power",
-            location=ParamLocation.VOLUME_INTEGRATED,
-            categories=["detailedAxialExpansion"],
-        )
-
-        pb.defParam(
-            "powerDecay",
-            units="W",
-            description="Total decay power",
-            location=ParamLocation.VOLUME_INTEGRATED,
-            categories=["detailedAxialExpansion"],
-        )
-
-        pb.defParam(
             "powerRx", units="W/cm$^3$", description="?", location=ParamLocation.AVERAGE
         )
 
@@ -1187,34 +1123,6 @@ def getBlockParameterDefinitions():
             units="He/s/cm$^3$",
             description="?",
             location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "rateAbs",
-            units="1/cm^3/s",
-            description="Total absorption rate in this block (fisson + capture).",
-        )
-
-        pb.defParam(
-            "rateCap",
-            units="1/cm^3/s",
-            description="Parasitic capture rate in this block.",
-        )
-
-        pb.defParam(
-            "rateFis", units="1/cm^3/s", description="Fission rate in this block."
-        )
-
-        pb.defParam(
-            "rateProdFis",
-            units="1/cm^3/s",
-            description="Production rate of neutrons from fission reactions (nu * fission source / k-eff)",
-        )
-
-        pb.defParam(
-            "rateProdN2n",
-            units="1/cm^3/s",
-            description="Production rate of neutrons from n2n reactions.",
         )
 
         pb.defParam(
@@ -1776,20 +1684,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "arealPd",
-            units="MW/m^2",
-            description="Power divided by XY area",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "arealPdGamma",
-            units="MW/m^2",
-            description="Areal gamma power density",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "assemNum",
             units="None",
             description="Index that refers, nominally, to the assemNum parameter of "
@@ -2104,88 +1998,6 @@ def getBlockParameterDefinitions():
             saveToDB=False,
         )
 
-        pb.defParam("fertileBonus", units=None, description="The fertile bonus")
-
-        pb.defParam(
-            "fisDens",
-            units="fissions/cm^3/s",
-            description="Fission density in a pin (scaled up from homogeneous)",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fisDensHom", units="1/cm^3/s", description="Homogenized fissile density"
-        )
-
-        pb.defParam(
-            "fluxDeltaFromRef",
-            units="None",
-            description="Relative difference between the current flux and the directly-computed perturbed flux.",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fluxDif3d",
-            units="1/cm^2/s",
-            description="Average scalar neutron flux before gamma step",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fluxDirect",
-            units="n/cm^2/s",
-            description="Flux is computed with a direct method",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fluxGamma",
-            units="g/cm^2/s",
-            description="Gamma scalar flux",
-            categories=[
-                "detailedAxialExpansion",
-                parameters.Category.retainOnReplacement,
-                parameters.Category.fluxQuantities,
-            ],
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fluxPeak",
-            units="n/cm^2/s",
-            description="Peak neutron flux calculated within the mesh",
-            location=ParamLocation.AVERAGE,
-            categories=["detailedAxialExpansion"],
-        )
-
-        pb.defParam(
-            "fluxPertDeltaFromDirect",
-            units="None",
-            description="Relative difference between the perturbed flux and the directly-computed perturbed flux",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fluxPertDeltaFromDirectfluxRefWeighted",
-            units="None",
-            description="",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fluxPerturbed",
-            units="1/cm^2/s",
-            description="Flux is computed by MEPT",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fluxRef",
-            units="1/cm^2/s",
-            description="Reference flux",
-            location=ParamLocation.AVERAGE,
-        )
-
         pb.defParam(
             "heightBOL",
             units="cm",
@@ -2205,13 +2017,6 @@ def getBlockParameterDefinitions():
             "intrinsicSourceDecayed",
             units="?",
             description="Intrinsic source from spontaneous fissions after a decay period",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "kInf",
-            units="None",
-            description="Neutron production rate in this block/neutron absorption rate in this block. Not truly kinf but a reasonable approximation of reactivity.",
             location=ParamLocation.AVERAGE,
         )
 
@@ -2237,18 +2042,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "medAbsE", units="eV", description="Median neutron absorption energy"
-        )
-
-        pb.defParam(
-            "medFisE",
-            units="eV",
-            description="Median energy of neutron causing fission",
-        )
-
-        pb.defParam("medFlxE", units="eV", description="Median neutron flux energy")
-
-        pb.defParam(
             "mreg",
             units="None",
             description="SASSYS/DIF3D-K radial region index assignment",
@@ -2272,45 +2065,10 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "pdensGamma",
-            units="W/cm^3",
-            description="Average volumetric gamma power density",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "pdensNeutron",
-            units="W/cm^3",
-            description="Average volumetric neutron power density",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "percentBuPeak",
             units="%FIMA",
             description="Peak percentage of the initial heavy metal atoms that have been fissioned",
             location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "powerGenerated",
-            units=" W",
-            description="Generated power. Different than b.p.power only when gamma transport is activated.",
-            location=ParamLocation.VOLUME_INTEGRATED,
-        )
-
-        pb.defParam(
-            "powerGamma",
-            units="W",
-            description="Total gamma power",
-            location=ParamLocation.VOLUME_INTEGRATED,
-        )
-
-        pb.defParam(
-            "powerNeutron",
-            units="W",
-            description="Total neutron power",
-            location=ParamLocation.VOLUME_INTEGRATED,
         )
 
         pb.defParam(
@@ -2328,94 +2086,9 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "ppdens",
-            units="W/cm^3",
-            description="Peak power density",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "ppdensGamma",
-            units="W/cm^3",
-            description="Peak gamma density",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "puFrac",
             units="None",
             description="Current Pu number density relative to HM at BOL",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "rateBalance",
-            units="1/cm^3/s",
-            description="Numerical balance between particle production and destruction (should be small)",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "rateExtSrc",
-            units="1/cm^3/s",
-            description="Rate of production of neutrons from an external source.",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "rateFisAbs",
-            units="1/cm^3/s",
-            description="Neutron abs. rate in fissile material",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "capturePowerFrac",
-            units=None,
-            description="Fraction of the power produced through capture in a block.",
-            location=ParamLocation.AVERAGE,
-            saveToDB="True",
-        )
-
-        pb.defParam(
-            "rateFisSrc",
-            units="1/cm^3/s",
-            description="Fission source rate. This is related to production rate in fissile by a factor of keff",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "rateLeak",
-            units="1/cm^3/s",
-            description="Rate that neutrons leak out of this block.",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "rateParasAbs",
-            units="1/cm^3/s",
-            description="Rate of parasitic absorption (absorption in non-fertile/fissionable material)",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "rateProdNet",
-            units="1/cm^3/s",
-            description="Net production rate of neutrons",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "rateScatIn",
-            units="1/cm^3/s",
-            description="Rate neutrons in-scatter in this block",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "rateScatOut",
-            units="1/cm^3/s",
-            description="Rate that neutrons out-scatter in this block (removal - absorption)",
             location=ParamLocation.AVERAGE,
         )
 

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -43,7 +43,7 @@ class TestUniformMeshComponents(unittest.TestCase):
         a[2].setHeight(a[2].getHeight() * 1.05)
 
     def setUp(self):
-        self.converter = uniformMesh.UniformMeshGeometryConverter()
+        self.converter = uniformMesh.NeutronicsUniformMeshConverter()
         self.converter._sourceReactor = self.r
 
     def test_computeAverageAxialMesh(self):
@@ -88,7 +88,7 @@ class TestUniformMesh(unittest.TestCase):
 
     def setUp(self):
         self.o, self.r = test_reactors.loadTestReactor(TEST_ROOT)
-        self.converter = uniformMesh.UniformMeshGeometryConverter()
+        self.converter = uniformMesh.NeutronicsUniformMeshConverter()
 
     def test_convertNumberDensities(self):
         refMass = self.r.core.getMass("U235")
@@ -168,7 +168,7 @@ class TestParamConversion(unittest.TestCase):
         self.destinationAssem[0].setHeight(self.height1 + self.height2)
         self.destinationAssem.calculateZCoords()
 
-        self.converter = uniformMesh.UniformMeshGeometryConverter()
+        self.converter = uniformMesh.NeutronicsUniformMeshConverter()
 
     def test_setStateFromOverlaps(self):
         """

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -61,21 +61,54 @@ class UniformMeshGeometryConverter(GeometryConverter):
     def __init__(self, cs=None):
         GeometryConverter.__init__(self, cs)
         self._uniformMesh = None
+        self.blockParamNames = []
+        self.reactorParamNames = []
 
     def convert(self, r=None):
+        """Create a new reactor with a uniform mesh."""
         runLog.extra("Building copy of {} with a uniform axial mesh".format(r))
         self._sourceReactor = r
         self.convReactor = self.initNewReactor(r)
+        self._setParamsToUpdate()
         self._computeAverageAxialMesh()
-        self._convertNumberDensities()
+        self._buildAllUniformAssemblies()
+        self._clearStateOnReactor(self.convReactor)
+        self._mapStateFromReactorToOther(self._sourceReactor, self.convReactor)
+        self.convReactor.core.updateAxialMesh()
+        self._checkConversion()
         return self.convReactor
+
+    def _checkConversion(self):
+        """
+        Make sure both reactors have the same power and that it's equal to user-input.
+
+        On the initial neutronics run, of course source power will be zero.
+        """
+        sourcePow = self._sourceReactor.core.getTotalBlockParam("power")
+        convPow = self.convReactor.core.getTotalBlockParam("power")
+        expectedPow = (
+            self._sourceReactor.core.p.power / self._sourceReactor.core.powerMultiplier
+        )
+        if abs(sourcePow - convPow) / sourcePow > 1e-5:
+            runLog.info(
+                f"Source reactor power ({sourcePow}) is too different from "
+                f"converted power ({convPow})."
+            )
+        if sourcePow and abs(sourcePow - expectedPow) / sourcePow > 1e-5:
+            raise ValueError(
+                f"Source reactor power ({sourcePow}) is too different from "
+                f"user-input power ({expectedPow})."
+            )
 
     @staticmethod
     def initNewReactor(sourceReactor):
         """
-        Set up the new reactor
+        Built an empty version of the new reactor.
         """
-        newReactor = copy.deepcopy(sourceReactor)  # XXX: very wasteful
+        # XXX: this deepcopy is extremely wasteful because the assemblies copied
+        # are immediately removed. It's just laziness of getting the same class
+        # of reactor set up.
+        newReactor = copy.deepcopy(sourceReactor)
         newReactor.core.removeAllAssemblies()
         newReactor.core.regenAssemblyLists()
         return newReactor
@@ -105,7 +138,20 @@ class UniformMeshGeometryConverter(GeometryConverter):
         return a
 
     @staticmethod
-    def applyUniformMesh(sourceAssem, newMesh):
+    def makeAssemWithUniformMesh(sourceAssem, newMesh):
+        """
+        Build new assembly based on a source assembly but apply the uniform mesh.
+
+        The new assemblies must have appropriately mapped number densities as
+        input for a neutronics solve. They must also have other relevant
+        neutronics parameters for follow-on neutronics steps (e.g. a fixed
+        source gamma transport step that needs appropriate fission rates).
+        Thus, this maps many parameters from the ARMI mesh to the uniform mesh.
+
+        See Also
+        --------
+        applyStateToOriginal : basically the reverse on the way out.
+        """
         newAssem = UniformMeshGeometryConverter._createNewAssembly(sourceAssem)
         bottom = 0.0
         for topMeshPoint in newMesh:
@@ -160,7 +206,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         newAssem.calculateZCoords()
         return newAssem
 
-    def _convertNumberDensities(self):
+    def _buildAllUniformAssemblies(self):
         """
         Loop through each new block for each mesh point and apply conservation of atoms.
 
@@ -169,7 +215,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         into plenum).
         """
         for sourceAssem in self._sourceReactor.core:
-            newAssem = self.applyUniformMesh(sourceAssem, self._uniformMesh)
+            newAssem = self.makeAssemWithUniformMesh(sourceAssem, self._uniformMesh)
             newAssem.r = self.convReactor
             # would be nicer if this happened in add but there's  complication between
             # moveTo and add precedence and location-already-filled-issues.
@@ -177,8 +223,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
             src = sourceAssem.spatialLocator
             newLoc = self.convReactor.core.spatialGrid[src.i, src.j, 0]
             self.convReactor.core.add(newAssem, newLoc)
-
-        self.convReactor.core.updateAxialMesh()
 
     def plotConvertedReactor(self):
         assemsToPlot = self.convReactor.core[:12]
@@ -188,11 +232,14 @@ class UniformMeshGeometryConverter(GeometryConverter):
             )
 
     def _setParamsToUpdate(self):
+        """Gather a list of parameters that will be mapped between reactors."""
         b = self._sourceReactor.core.getFirstBlock()
 
-        self.blockParamNames = b.p.paramDefs.inCategory("detailedAxialExpansion").names
+        self.blockParamNames = b.p.paramDefs.inCategory(
+            parameters.Category.detailedAxialExpansion
+        ).names
         self.reactorParamNames = self._sourceReactor.core.p.paramDefs.inCategory(
-            "neutronics"
+            parameters.Category.neutronics
         ).names
 
         runLog.debug(
@@ -206,13 +253,17 @@ class UniformMeshGeometryConverter(GeometryConverter):
             )
         )
 
-    def _clearStateOnSourceReactor(self):
-        """Delete existing state that will be updated so they don't increment."""
+    def _clearStateOnReactor(self, reactor):
+        """
+        Delete existing state that will be updated so they don't increment.
+        
+        The summations should start at zero but will happen for all overlaps.
+        """
         runLog.debug("Clearing params from source reactor that will be converted.")
         for rp in self.reactorParamNames:
-            self._sourceReactor.core.p[rp] = 0.0
+            reactor.core.p[rp] = 0.0
 
-        for b in self._sourceReactor.core.getBlocks():
+        for b in reactor.core.getBlocks():
             b.p.mgFlux = []
             b.p.adjMgFlux = []
             for bp in self.blockParamNames:
@@ -229,8 +280,16 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 self.convReactor, self._sourceReactor
             )
         )
-        self._setParamsToUpdate()
-        self._clearStateOnSourceReactor()
+        self._clearStateOnReactor(self._sourceReactor)
+        self._mapStateFromReactorToOther(self.convReactor, self._sourceReactor)
+
+    def _mapStateFromReactorToOther(self, sourceReactor, destReactor):
+        """
+        Map parameters from one reactor to another.
+
+        Used for preparing and uniform reactor as well as for mapping its results
+        back to the original reactor.
+        """
 
         def paramSetter(armiObject, vals, paramNames):
             for paramName, val in zip(paramNames, vals):
@@ -265,16 +324,16 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 return numpy.array(val)
 
         for paramName in self.reactorParamNames:
-            self._sourceReactor.core.p[paramName] = self.convReactor.core.p[paramName]
+            destReactor.core.p[paramName] = sourceReactor.core.p[paramName]
 
-        for aUniform in self.convReactor.core:
-            aReal = self._sourceReactor.core.getAssemblyByName(aUniform.getName())
+        for aSource in sourceReactor.core:
+            aDest = destReactor.core.getAssemblyByName(aSource.getName())
             _setStateFromOverlaps(
-                aUniform, aReal, paramSetter, paramGetter, self.blockParamNames
+                aSource, aDest, paramSetter, paramGetter, self.blockParamNames
             )
-            _setStateFromOverlaps(aUniform, aReal, fluxSetter, fluxGetter, ["mgFlux"])
+            _setStateFromOverlaps(aSource, aDest, fluxSetter, fluxGetter, ["mgFlux"])
             _setStateFromOverlaps(
-                aUniform, aReal, adjointFluxSetter, adjointFluxGetter, ["adjMgFlux"]
+                aSource, aDest, adjointFluxSetter, adjointFluxGetter, ["adjMgFlux"]
             )
 
 

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -72,6 +72,10 @@ class Category:
 
     multiGroupQuantities = "multi-group quantities"
 
+    detailedAxialExpansion = "detailedAxialExpansion"
+
+    neutronics = "neutronics"
+
 
 class ParamLocation(enum.Flag):
     """Represents point which a parameter is physically meaningful."""


### PR DESCRIPTION
Fixes issues where multiple uniform mesh conversions happen in the same timestep (e.g. gamma-transport corrected global flux calculations with detailed axial expansion and critical control rod insertion). 