### PR TITLE
Pack and unpack MultiIndexLocations in DB.

### DIFF
--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -22,8 +22,8 @@ import glob
 import os
 import subprocess
 import re
-
-from six.moves import zip_longest
+import shutil
+import itertools
 
 from armi import interfaces
 from armi import runLog
@@ -122,7 +122,7 @@ class MainInterface(interfaces.Interface):
             # if any files to copy, then use the first as the default, i.e. len() == 1,
             # otherwise assume '.'
             default = copyFilesTo[0] if any(copyFilesTo) else "."
-            for filename, dest in zip_longest(
+            for filename, dest in itertools.zip_longest(
                 copyFilesFrom, copyFilesTo, fillvalue=default
             ):
                 pathTools.copyOrWarn("copyFilesFrom", filename, dest)
@@ -165,6 +165,8 @@ class MainInterface(interfaces.Interface):
 
     def updateClusterProgress(self):
         """Updates the status window on the Windows HPC client."""
+        if not shutil.which("job"):
+            return
         totalSteps = max(
             (self.cs["burnSteps"] + 1) * self.cs["nCycles"] - 1, 1
         )  # 0 through 5 if 2 cycles

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -26,16 +26,17 @@ All other modules can just assume there's a LFP collection and use it as needed.
 Examples
 --------
 
-from armi.physics.neutronics.fissionProductModel import fissionProductModel
-fpInterface = fissionProductModel.FissionProductModel()
-lfp = fpInterface.getGlobalLumpedFissionProducts()
-lfp['LFP35']
-lfp35 = lfp['LFP35']
-lfp35.printDensities(0.05)
-lfp35.values()
-allFPs = [(fpY, fpNuc) for (fpNuc,fpY) in lfp35.items()]
-allFPs.sort()
-lfp35.keys()
+    from armi.physics.neutronics.fissionProductModel import fissionProductModel
+    fpInterface = fissionProductModel.FissionProductModel()
+    lfp = fpInterface.getGlobalLumpedFissionProducts()
+    lfp['LFP35']
+    lfp35 = lfp['LFP35']
+    lfp35.printDensities(0.05)
+    lfp35.values()
+    allFPs = [(fpY, fpNuc) for (fpNuc,fpY) in lfp35.items()]
+    allFPs.sort()
+    lfp35.keys()
+
 """
 
 from armi import runLog

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -429,6 +429,10 @@ class MultiIndexLocation(IndexLocation):
     def pop(self, location: IndexLocation):
         self._locations.pop(location)
 
+    @property
+    def indices(self):
+        raise NotImplementedError
+
 
 class CoordinateLocation(IndexLocation):
     """

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -19,6 +19,9 @@ from armi.utils import directoryChangers
 from armi.tests import TEST_ROOT
 from armi.reactor.flags import Flags
 import armi
+from armi.bookkeeping import db
+
+TEST_INPUT_TITLE = "c5g7-settings"
 
 
 class C5G7ReactorTests(unittest.TestCase):
@@ -38,7 +41,7 @@ class C5G7ReactorTests(unittest.TestCase):
         """
         Load the C5G7 case and check basic counts.
         """
-        o = armi.init(fName="c5g7-settings.yaml")
+        o = armi.init(fName=TEST_INPUT_TITLE + ".yaml")
         b = o.r.core.getFirstBlock(Flags.MOX)
         # there are 100 of each high, medium, and low MOX pins
         fuelPinsHigh = b.getComponent(Flags.HIGH | Flags.MOX)
@@ -46,3 +49,11 @@ class C5G7ReactorTests(unittest.TestCase):
 
         gt = b.getComponent(Flags.GUIDE_TUBE)
         self.assertEqual(gt.getDimension("mult"), 24)
+
+    def test_runC5G7(self):
+        """
+        Run C5G7 in basic no-op app and load from the result.
+        """
+        o = armi.init(fName=TEST_INPUT_TITLE + ".yaml")
+        o.operate()
+        o2 = db.loadOperator(TEST_INPUT_TITLE + ".h5", 0, 0)

--- a/armi/tests/tutorials/c5g7-settings.yaml
+++ b/armi/tests/tutorials/c5g7-settings.yaml
@@ -12,3 +12,4 @@ settings:
   comment: C5G7 LWR Benchmark inputs
   genXS: Neutron
   numProcessors: 1
+  genReports: false

--- a/doc/user/tutorials/walkthrough_lwr_inputs.rst
+++ b/doc/user/tutorials/walkthrough_lwr_inputs.rst
@@ -11,6 +11,15 @@ in `NEA/NSC/DOC(2003)16 <https://www.oecd-nea.org/science/docs/2003/nsc-doc2003-
 .. tip:: The full inputs created in this tutorial are available for download at the bottom of
 	this page.
 
+.. warning:: ARMI was historically developed in support of fast reactors and most
+    features have been used and tested in fast reactor contexts. This
+    tutorial shows that simple LWR cases can be defined in input,
+    but there is still a lot of work to make sure all ARMI capabilities
+    are operational in this context. Thus, be warned that
+    as of 2020, doing LWR analysis with ARMI will certainly require
+    new developments. We are excited to expand ARMI scope fully
+    into LWR relevant analysis.
+
 Setting up the blueprints
 =========================
 This tutorial is shorter than the previous, focusing mostly on the new information.

--- a/doc/user/tutorials/walkthrough_lwr_inputs.rst
+++ b/doc/user/tutorials/walkthrough_lwr_inputs.rst
@@ -20,6 +20,9 @@ in `NEA/NSC/DOC(2003)16 <https://www.oecd-nea.org/science/docs/2003/nsc-doc2003-
     new developments. We are excited to expand ARMI scope fully
     into LWR relevant analysis.
 
+    In particular the handling of detailed locations within a block is
+    relatively experimental (fast reactors usually just smear it out).
+
 Setting up the blueprints
 =========================
 This tutorial is shorter than the previous, focusing mostly on the new information.


### PR DESCRIPTION
This writes location information for all components that are positioned
using a sub-block grid (e.g. pins in a LWR lattice).

Fixes #53.