### PR TITLE
Boost global flux interface testing coverage

### DIFF
--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -268,16 +268,6 @@ class Interface(object):
     def getInterface(self, *args, **kwargs):
         return self.o.getInterface(*args, **kwargs) if self.o else None
 
-    def updateAssemblyLevelParams(
-        self, a, excludedBlockTypes=None
-    ):  # pylint-disable=no-self-use
-        """
-        Called during loads from snapshots.
-
-        Allows block params to go derive the assembly-level params (such as massFlow).
-        """
-        pass
-
     def interactInit(self):
         """
         Interacts immediately after the interfaces are created.

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -317,8 +317,6 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         self.runDir = os.path.join(
             armi.FAST_PATH, f"{cs.caseTitle}-{self.label}-{armi.context.MPI_RANK}"
         )
-        if cs["restartNeutronics"]:
-            self.isRestart = True
         self.isRestart = cs["restartNeutronics"]
         self.adjoint = neutronics.adjointCalculationRequested(cs)
         self.real = neutronics.realCalculationRequested(cs)
@@ -506,11 +504,11 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
         --------
         getTotalEnergyGenerationConstants
         """
-        # The multi-group flux is volume integrated, so J/cm * n-cm/s gives units of Watts
         # update the block power param here as well so
         # the ratio/multiplications below are consistent
         currentCorePower = 0.0
         for b in self.r.core.getBlocks():
+            # The multi-group flux is volume integrated, so J/cm * n-cm/s gives units of Watts
             b.p.power = numpy.dot(
                 b.getTotalEnergyGenerationConstants(), b.getIntegratedMgFlux()
             )

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -547,6 +547,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
                 b.p.arealPd = b.p.power / area * conversion
             a.p.arealPd = a.calcTotalParam("arealPd")
         self.r.core.p.maxPD = self.r.core.getMaxParam("arealPd")
+        self._updateAssemblyLevelParams()
 
     def updateDpaRate(self, blockList=None):
         """
@@ -596,15 +597,11 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
         maxGridDose = self.r.core.getMaxBlockParam("detailedDpaPeak", Flags.GRID_PLATE)
         self.r.core.p.maxGridDpa = maxGridDose
 
-    def updateAssemblyLevelParams(self, excludedBlockTypes=None):
+    def _updateAssemblyLevelParams(self):
         for a in self.r.core.getAssemblies():
-            if excludedBlockTypes is None:
-                excludedBlockTypes = []
             totalAbs = 0.0  # for calculating assembly average k-inf
             totalSrc = 0.0
             for b in a:
-                if b.getType() in excludedBlockTypes:
-                    continue
                 totalAbs += b.p.rateAbs
                 totalSrc += b.p.rateProdNet
 

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -1,0 +1,150 @@
+"""
+Tests for generic global flux interface.
+"""
+import unittest
+
+import numpy
+
+from armi import settings
+from armi.reactor import reactors
+
+from armi.physics.neutronics.globalFlux import globalFluxInterface as gi
+from armi.reactor.tests import test_reactors
+from armi.tests import ISOAA_PATH
+from armi.nuclearDataIO import isotxs
+
+
+class MockParams:
+    pass
+
+
+class MockCore:
+    def __init__(self):
+        self.geomType = "spiral"
+        self.symmetry = "full"
+        self.p = MockParams()
+
+
+class MockReactor:
+    def __init__(self):
+        self.core = MockCore()
+        self.o = None
+
+
+class MockGlobalFluxInterface(gi.GlobalFluxInterface):
+    """
+    Add fake keff calc to a the general gf interface.
+    
+    This simulates a 1000 pcm keff increase over 1 step.
+    """
+
+    def interactBOC(self, cycle=None):
+        gi.GlobalFluxInterface.interactBOC(self, cycle=cycle)
+        self.r.core.p.keff = 1.00
+
+    def interactEveryNode(self, cycle, node):
+        gi.GlobalFluxInterface.interactEveryNode(self, cycle, node)
+        self.r.core.p.keff = 1.01
+
+
+class MockGlobalFluxWithExecuters(gi.GlobalFluxInterfaceUsingExecuters):
+    def getExecuterCls(self):
+        return MockGlobalFluxExecuter
+
+
+class MockGlobalFluxExecuter(gi.GlobalFluxExecuter):
+    def _readOutput(self):
+        class MockOutputReader:
+            def apply(self, r):
+                r.core.p.keff += 0.01
+
+        return MockOutputReader()
+
+
+class TestGlobalFluxOptions(unittest.TestCase):
+    def test_readFromSettings(self):
+        cs = settings.Settings()
+        opts = gi.GlobalFluxOptions("neutronics-run")
+        opts.fromUserSettings(cs)
+        self.assertFalse(opts.adjoint)
+
+    def test_readFromReactors(self):
+        reactor = MockReactor()
+        opts = gi.GlobalFluxOptions("neutronics-run")
+        opts.fromReactor(reactor)
+        self.assertEqual(opts.geomType, "spiral")
+
+
+class TestGlobalFluxInterface(unittest.TestCase):
+    def test_interaction(self):
+        """
+        Ensure the basic interaction hooks work
+
+        Check that a 1000 pcm rx swing is observed due to the mock.
+        """
+        cs = settings.Settings()
+        o, r = test_reactors.loadTestReactor()
+        gfi = MockGlobalFluxInterface(r, cs)
+        gfi.interactBOC()
+        gfi.interactEveryNode(0, 0)
+        gfi.interactEOC()
+        self.assertAlmostEqual(r.core.p.rxSwing, 1000)
+
+    def test_getIOFileNames(self):
+        cs = settings.Settings()
+        gfi = MockGlobalFluxInterface(MockReactor(), cs)
+        inf, _outf, _stdname = gfi.getIOFileNames(1, 2, 1)
+        self.assertEqual(inf, "armi001_2_001.GlobalFlux.inp")
+
+
+class TestGlobalFluxInterfaceWithExecuters(unittest.TestCase):
+    """Tests for the default global flux execution."""
+
+    def test_executerInteraction(self):
+        cs = settings.Settings()
+        _o, r = test_reactors.loadTestReactor()
+        r.core.p.keff = 1.0
+        gfi = MockGlobalFluxWithExecuters(r, cs)
+        gfi.interactBOC()
+        gfi.interactEveryNode(0, 0)
+        r.p.timeNode += 1
+        gfi.interactEveryNode(0, 1)
+        gfi.interactEOC()
+        self.assertAlmostEqual(r.core.p.rxSwing, (1.02 - 1.01) / 1.01 * 1e5)
+
+
+class TestGlobalFluxResultMapper(unittest.TestCase):
+    def test_mapper(self):
+        MCC2_SETTINGS = {"xsKernel": "MC2v2"}  # compat with ISOAA test lib
+        _o, r = test_reactors.loadTestReactor(customSettings=MCC2_SETTINGS)
+        applyDummyFlux(r)
+        r.core.lib = isotxs.readBinary(ISOAA_PATH)
+        mapper = gi.GlobalFluxResultMapper()
+        mapper.r = r
+        mapper._renormalizeNeutronFluxByBlock(100)
+        self.assertAlmostEqual(r.core.calcTotalParam("power", generationNum=2), 100)
+
+        mapper._updateDerivedParams()
+        self.assertGreater(r.core.p.maxPD, 0.0)
+        self.assertGreater(r.core.p.maxFlux, 0.0)
+
+        mapper.updateDpaRate()
+        self.assertGreater(r.core.getFirstBlock().p.detailedDpaRate, 0)
+
+        self.assertEqual(r.core.getFirstBlock().p.detailedDpa, 0)
+        opts = gi.GlobalFluxOptions("test")
+        dosemapper = gi.DoseResultsMapper(1000, opts)
+        dosemapper.apply(r)
+        self.assertGreater(r.core.getFirstBlock().p.detailedDpa, 0)
+
+
+def applyDummyFlux(r, ng=33):
+    """Set arbitrary flux distribution on reactor."""
+    for b in r.core.getBlocks():
+        b.p.power = 1.0
+        b.p.mgFlux = numpy.arange(ng, dtype=numpy.float64)
+
+
+if __name__ == "__main__":
+    # import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -176,7 +176,11 @@ def defineSettings():
             CONF_LOAD_PAD_ELEVATION,
             default=0.0,
             label="Load pad elevation (cm)",
-            description="The elevation of the bottom of the above-core load pad (ACLP) in cm from the bottom of the upper grid plate. Used for calculating the load pad dose",
+            description=(
+                "The elevation of the bottom of the above-core load pad (ACLP) in cm "
+                "from the bottom of the upper grid plate. Used for calculating the load "
+                "pad dose"
+            ),
         ),
         setting.Setting(
             CONF_LOAD_PAD_LENGTH,
@@ -188,7 +192,7 @@ def defineSettings():
             CONF_ACLP_DOSE_LIMIT,
             default=80.0,
             label="ALCP dose limit",
-            description="Dose limit in dpa used to position the ACLP",
+            description="Dose limit in dpa used to position the above-core load pad (if one exists)",
         ),
         setting.Setting(
             CONF_RESTART_NEUTRONICS,
@@ -200,7 +204,10 @@ def defineSettings():
             CONF_GRID_PLATE_DPA_XS_SET,
             default="dpa_EBRII_HT9",
             label="Grid plate DPA XS",
-            description="The cross sections to use for grid plate blocks DPA when computing displacements per atom.",
+            description=(
+                "The cross sections to use for grid plate blocks DPA when computing "
+                "displacements per atom."
+            ),
             options=CONF_OPT_DPA,
         ),
         setting.Setting(

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -28,14 +28,28 @@ CONF_GROUP_STRUCTURE = "groupStructure"
 CONF_EIGEN_PROB = "eigenProb"
 CONF_EXISTING_FIXED_SOURCE = "existingFixedSource"
 CONF_NUMBER_MESH_PER_EDGE = "numberMeshPerEdge"
+CONF_RESTART_NEUTRONICS = "restartNeutronics"
 
 CONF_EPS_EIG = "epsEig"
 CONF_EPS_FSAVG = "epsFSAvg"
 CONF_EPS_FSPOINT = "epsFSPoint"
 
-# used for dpa/dose analysis
+# used for dpa/dose analysis. These should be relocated to more
+# design-specific places
 CONF_LOAD_PAD_ELEVATION = "loadPadElevation"
 CONF_LOAD_PAD_LENGTH = "loadPadLength"
+CONF_ACLP_DOSE_LIMIT = "aclpDoseLimit"
+CONF_DPA_XS_SET = "dpaXsSet"
+CONF_GRID_PLATE_DPA_XS_SET = "gridPlateDpaXsSet"
+
+CONF_OPT_DPA = [
+    "",
+    "dpa_EBRII_INC600",
+    "dpa_EBRII_INCX750",
+    "dpa_EBRII_HT9",
+    "dpa_EBRII_PE16",
+    "dpa_EBRII_INC625",
+]
 
 
 def defineSettings():
@@ -169,6 +183,32 @@ def defineSettings():
             default=0.0,
             label="Load pad length (cm)",
             description="The length of the load pad. Used to compute average and peak dose.",
+        ),
+        setting.Setting(
+            CONF_ACLP_DOSE_LIMIT,
+            default=80.0,
+            label="ALCP dose limit",
+            description="Dose limit in dpa used to position the ACLP",
+        ),
+        setting.Setting(
+            CONF_RESTART_NEUTRONICS,
+            default=False,
+            label="Restart neutronics",
+            description="Restart global flux case using outputs from last time as a guess",
+        ),
+        setting.Setting(
+            CONF_GRID_PLATE_DPA_XS_SET,
+            default="dpa_EBRII_HT9",
+            label="Grid plate DPA XS",
+            description="The cross sections to use for grid plate blocks DPA when computing displacements per atom.",
+            options=CONF_OPT_DPA,
+        ),
+        setting.Setting(
+            CONF_DPA_XS_SET,
+            default="dpa_EBRII_HT9",
+            label="DPA Cross Sections",
+            description="The cross sections to use when computing displacements per atom.",
+            options=CONF_OPT_DPA,
         ),
     ]
 

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -164,7 +164,7 @@ class Settings:
 
     @property
     def caseTitle(self):
-        if self.path is None:
+        if not self.path:
             return self.defaultCaseTitle
         else:
             return os.path.splitext(os.path.basename(self.path))[0]

--- a/armi/tests/armiRun.yaml
+++ b/armi/tests/armiRun.yaml
@@ -42,7 +42,7 @@ settings:
   geomFile: geom.xml
   jumpRingNum: 9
   loadingFile: refSmallReactor.yaml
-  loadNode: 1
+  startNode: 1
   loadPadElevation: 200.0
   max2SigmaCladIDT: 630.0
   maxFlowZones: 12

--- a/armi/tests/partisnTestReactor.yaml
+++ b/armi/tests/partisnTestReactor.yaml
@@ -27,7 +27,7 @@ settings:
   geomFile: partisnReactorGeom.xml
   jumpRingNum: 9
   loadingFile: refSmallReactor.yaml
-  loadNode: 1
+  startNode: 1
   loadPadElevation: 200.0
   max2SigmaCladIDT: 630.0
   maxFlowZones: 12

--- a/armi/tests/refTestCartesian.yaml
+++ b/armi/tests/refTestCartesian.yaml
@@ -20,7 +20,7 @@ settings:
   geomFile: cartesian-geom.xml
   jumpRingNum: 9
   loadingFile: refSmallCartesian.yaml
-  loadNode: 1
+  startNode: 1
   loadPadElevation: 200.0
   max2SigmaCladIDT: 630.0
   maxFlowZones: 12

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -221,7 +221,7 @@ class ForcedCreationDirectoryChanger(DirectoryChanger):
         clean=False,
     ):
         if not destination:
-            raise ValueError("Non-empty destination directory must be provided.")
+            raise ValueError("A destination directory must be provided.")
         DirectoryChanger.__init__(
             self, destination, filesToMove, filesToRetrieve, dumpOnException
         )

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -220,6 +220,8 @@ class ForcedCreationDirectoryChanger(DirectoryChanger):
         dumpOnException=True,
         clean=False,
     ):
+        if not destination:
+            raise ValueError("Non-empty destination directory must be provided.")
         DirectoryChanger.__init__(
             self, destination, filesToMove, filesToRetrieve, dumpOnException
         )


### PR DESCRIPTION
The generic standalone global flux interface didn't have any
tests. This code has historically been covered by plugin tests
that are not in the framework repo. As part of testing it, a
few minor changes were made and adjustments to methodology.

* Basic unit tests that run the majority of the globalFluxInterface.py
  were added. Mostly they just make sure it runs.

* Some dpa-related settings are used in the framework that were
  not defined in the framework. Though they are a bit design-specific, I
  decided to bring the settings into the framework for now. The framework
  code otherwise simply cannot run.

* The neutronics restart setting is now in the framework

* The power normalization was assuming that powers/flux ratios
  were reasonable. In the dummy tests I made this was certainly
  not the case. I decided that this method should snap the power
  to something consistent with the flux because it has all the
  information needed anyway.