### PR TITLE
Remove armiAbsPath utility

### DIFF
--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -28,14 +28,13 @@ from armi import utils
 from armi.bookkeeping import historyTracker
 from armi.reactor import blocks
 from armi.reactor.flags import Flags
-from armi.utils import pathTools
 from armi import settings
 from armi.utils import directoryChangers
 from armi.reactor import grids
 from armi.cases import case
 from armi.tests import ArmiTestHelper
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)  # b/c tests don't run in this folder
+THIS_DIR = os.path.dirname(__file__)  # b/c tests don't run in this folder
 TUTORIAL_DIR = os.path.join(armi.context.ROOT, "tests", "tutorials")
 CASE_TITLE = "anl-afci-177"
 

--- a/armi/nuclearDataIO/tests/test_labels.py
+++ b/armi/nuclearDataIO/tests/test_labels.py
@@ -19,9 +19,8 @@ import unittest
 import os
 
 from armi.nuclearDataIO import labels
-from armi.utils import pathTools
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)
+THIS_DIR = os.path.dirname(__file__)
 
 
 class TestLabels(unittest.TestCase):

--- a/armi/nuclearDataIO/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/tests/test_nhflux.py
@@ -23,10 +23,9 @@ import numpy
 
 from armi import settings
 from armi.nuclearDataIO import NHFLUX
-from armi.utils import pathTools
 
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)
+THIS_DIR = os.path.dirname(__file__)
 
 SIMPLE_HEXZ_INP = os.path.join(THIS_DIR, "simple_hexz.inp")
 SIMPLE_HEXZ_NHFLUX = os.path.join(THIS_DIR, "fixtures", "simple_hexz.nhflux")

--- a/armi/nuclearDataIO/tests/test_ripl.py
+++ b/armi/nuclearDataIO/tests/test_ripl.py
@@ -21,11 +21,10 @@ import math
 import six
 
 from armi.nuclearDataIO import ripl
-from armi.utils import pathTools
 from armi.nucDirectory import nuclideBases
 from armi.utils.units import SECONDS_PER_HOUR
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)
+THIS_DIR = os.path.dirname(__file__)
 SAMPLE_RIPL_MASS = """#
 #  Z   A s fl     Mexp      Err       Mth      Emic    beta2   beta3   beta4   beta6
 #                [MeV]     [MeV]     [MeV]     [MeV]

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -32,12 +32,11 @@ from armi.nuclearDataIO import isotxs
 from armi.nuclearDataIO import pmatrx
 from armi.nuclearDataIO import gamiso
 from armi.nuclearDataIO import xsLibraries
-from armi.utils import pathTools
 from armi.utils import directoryChangers
 from armi.utils import properties
 from armi.utils import outputCache
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)
+THIS_DIR = os.path.dirname(__file__)
 RUN_DIR = os.path.join(THIS_DIR, "library-file-generation")
 FIXTURE_DIR = os.path.join(THIS_DIR, "fixtures")
 

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -19,18 +19,16 @@ import unittest
 
 from armi import runLog
 from armi import settings
-from armi.utils import pathTools
 from armi.reactor import blocks
 from armi.reactor import geometry
 from armi.tests import TEST_ROOT
-from armi.nucDirectory import nuclideBases
 from armi.reactor.converters import geometryConverters
 from armi.reactor.tests.test_reactors import loadTestReactor
 from armi.reactor.flags import Flags
 from armi.reactor import locations
 
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)
+THIS_DIR = os.path.dirname(__file__)
 
 
 class TestGeometryConverters(unittest.TestCase):

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -15,9 +15,9 @@
 """Test for Zones"""
 import copy
 import unittest
+import os
 
 import armi
-from armi import settings
 from armi.reactor import assemblies
 from armi.reactor import blueprints
 from armi.reactor import geometry
@@ -26,10 +26,9 @@ from armi.reactor import reactors
 from armi.reactor import zones
 from armi.reactor.flags import Flags
 from armi.reactor.tests import test_reactors
-from armi.utils import pathTools
 from armi.settings.fwSettings import globalSettings
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)
+THIS_DIR = os.path.dirname(__file__)
 
 
 class Zone_TestCase(unittest.TestCase):

--- a/armi/tests/test_armiTestHelper.py
+++ b/armi/tests/test_armiTestHelper.py
@@ -17,9 +17,8 @@ import os
 import unittest
 
 from armi.tests import ArmiTestHelper
-from armi.utils import pathTools
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)
+THIS_DIR = os.path.dirname(__file__)
 
 
 class TestArmiTestHelper(ArmiTestHelper):

--- a/armi/utils/dynamicImporter.py
+++ b/armi/utils/dynamicImporter.py
@@ -52,7 +52,7 @@ def importModule(fullyQualifiedModule):
 def importEntirePackage(module):
     """Load every module in a package"""
     # TODO: this method may only work for a flat directory?
-    modules = glob.glob(pathTools.armiAbsDirFromName(module.__name__) + "/*.py")
+    modules = glob.glob(os.path.dirname(module.__file__) + "/*.py")
     names = [os.path.basename(f)[:-3] for f in modules]
     for name in names:
         import_module(module.__package__ + "." + name)

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -99,27 +99,9 @@ def copyOrWarn(fileDescription, sourcePath, destinationPath):
     except Exception as e:
         runLog.warning(
             "Could not copy {} from {} to {}\nError was: {}".format(
-                fileDescription, sourcePath, destinationPath, e)
+                fileDescription, sourcePath, destinationPath, e
+            )
         )
-
-
-def armiAbsDirFromName(modName):
-    """
-    Convert a module name to a path.
-
-    Notes
-    -----
-    This is often required in a Cython'd pyd extension where ``__file__`` is otherwise invalid.
-    """
-    if modName == "__main__":
-        # allows it to work when a file is called directly (Python only, not cython).
-        # But this fails when running via the Pydev debugger because the stack's non-standard
-        # so we loop until we find a non-debugger file.
-        for item in reversed(inspect.stack()):
-            fname = inspect.getfile(item[0])
-            if "pydevd" not in fname:
-                return os.path.abspath(os.path.dirname(fname))
-    return os.path.join(*([ROOT] + modName.split(".")[1:-1]))
 
 
 def isFilePathNewer(path1, path2):

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -16,14 +16,14 @@
 Unit tests for pathTools.
 """
 import unittest
-from os import path
+import os
 import types
 
 from armi.utils import pathTools
 from armi.utils import directoryChangers
 from armi import ROOT
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)
+THIS_DIR = os.path.dirname(__file__)
 
 
 class PathToolsTests(unittest.TestCase):
@@ -38,14 +38,6 @@ class PathToolsTests(unittest.TestCase):
                 pathTools.getFullFileNames(recursive=True),
                 pathTools.getFullFileNames(THIS_DIR, recursive=True),
             )
-
-    def test_armiAbsDir(self):
-        result = pathTools.armiAbsDirFromName("armi.utils.tests.test1")
-        self.assertEqual(result, path.join(ROOT, "utils", "tests"))
-
-    def test_armiAbsDir_name(self):
-        result = pathTools.armiAbsDirFromName(__name__)
-        self.assertEqual(result, path.join(ROOT, "utils", "tests"))
 
     def test_separateModuleAndAttribute(self):
         self.assertRaises(
@@ -69,14 +61,14 @@ class PathToolsTests(unittest.TestCase):
 
     def test_importCustomModule(self):
         """Test that importCustomPyModule is usable just like any other module."""
-        module = pathTools.importCustomPyModule(path.join(THIS_DIR, __file__))
+        module = pathTools.importCustomPyModule(os.path.join(THIS_DIR, __file__))
         self.assertIsInstance(module, types.ModuleType)
         self.assertIn("THIS_DIR", module.__dict__)
         # test that this class is present in the import
         self.assertIn(self.__class__.__name__, module.__dict__)
 
     def test_moduleAndAttributeExist(self):
-        """Test that determination of existance of module attribute works."""
+        """Test that determination of existence of module attribute works."""
 
         # test that no `:` doesn't raise an exception
         self.assertFalse(pathTools.moduleAndAttributeExist(r"path/that/not/exist.py"))
@@ -84,7 +76,7 @@ class PathToolsTests(unittest.TestCase):
         self.assertFalse(
             pathTools.moduleAndAttributeExist(r"c:/path/that/not/exist.py:MyClass")
         )
-        thisFile = path.join(THIS_DIR, __file__)
+        thisFile = os.path.join(THIS_DIR, __file__)
         # no module attribute specified
         self.assertFalse(pathTools.moduleAndAttributeExist(thisFile))
         self.assertFalse(pathTools.moduleAndAttributeExist(thisFile + ":doesntExist"))

--- a/armi/utils/tests/test_textProcessors.py
+++ b/armi/utils/tests/test_textProcessors.py
@@ -20,12 +20,10 @@ import pathlib
 import unittest
 
 import ruamel
-from ruamel import yaml
 
 from armi.utils import textProcessors
-from armi.utils import pathTools
 
-THIS_DIR = pathTools.armiAbsDirFromName(__name__)
+THIS_DIR = os.path.dirname(__file__)
 RES_DIR = os.path.join(THIS_DIR, "resources")
 
 
@@ -70,7 +68,7 @@ class YamlIncludeTest(unittest.TestCase):
             pathlib.Path(RES_DIR) / "root.yaml"
         )
         for i, _mark in includes:
-            self.assertTrue((RES_DIR/i).exists())
+            self.assertTrue((RES_DIR / i).exists())
 
         self.assertEqual(len(includes), 2)
 


### PR DESCRIPTION
This utility had been made for rare scenarios where __file__ was not
available (specifically when the modules were compiled with cython). We
have moved away from cythoning the ARMI framework and no longer neat
this capability. The utility has thus been removed and all instances
replaced with the original __file__ based code.