### PR TITLE
Add optional syncDbAfterWrite behavior and setting

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -206,6 +206,8 @@ class DatabaseInterface(interfaces.Interface):
                 time.time() - self.r.core.timeOfStart
             ) / 60.0
             self._db.writeToDB(self.r)
+            if self.cs["syncDbAfterWrite"]:
+                self._db.syncToSharedFolder()
 
     def interactEOC(self, cycle=None):
         """In case anything changed since last cycle (e.g. rxSwing), update DB. """
@@ -239,6 +241,20 @@ class DatabaseInterface(interfaces.Interface):
             self._db.close(False)
         except:  # pylint: disable=bare-except; we're already responding to an error
             pass
+
+    def interactDistributeState(self):
+        """
+        Reconnect to pre-existing database.
+
+        DB is created and managed by the master node only but we can still connect to it
+        from workers to enable things like history tracking.
+        """
+        if armi.MPI_RANK > 0:
+            dbPath = self.cs.caseTitle + ".h5"
+            # DB may not exist if distribute state is called early.
+            if os.path.exists(dbPath):
+                self._db = Database3(dbPath, "r")
+                self._db.open()
 
     def distributable(self):
         return self.Distribute.SKIP
@@ -825,6 +841,23 @@ class Database3(database.Database):
 
         for comps in groupedComps.values():
             self._writeParams(h5group, comps)
+
+    def syncToSharedFolder(self):
+        """
+        Copy DB to run working directory.
+
+        Needed when multiple MPI processes need to read the same db, for example
+        when a history is needed from independent runs (e.g. for fuel performance on
+        a variety of assemblies).
+
+        Notes
+        -----
+        At some future point, we may implement a client-server like DB system which
+        would render this kind of operation unnecessary.
+        """
+        runLog.extra("Copying DB to shared working directory.")
+        self.h5db.flush()
+        shutil.copy(self._fullPath, self._fileName)
 
     def load(self, cycle, node, cs=None, bp=None, statePointName=None):
         """Load a new reactor from (cycle, node).

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -91,6 +91,8 @@ from armi.bookkeeping.db import database
 from armi.reactor import geometry
 from armi.utils.textProcessors import resolveMarkupInclusions
 
+from armi.settings.fwSettings.databaseSettings import CONF_SYNC_AFTER_WRITE
+
 ORDER = interfaces.STACK_ORDER.BOOKKEEPING
 DB_MAJOR = 3
 DB_MINOR = 3
@@ -206,7 +208,7 @@ class DatabaseInterface(interfaces.Interface):
                 time.time() - self.r.core.timeOfStart
             ) / 60.0
             self._db.writeToDB(self.r)
-            if self.cs["syncDbAfterWrite"]:
+            if self.cs[CONF_SYNC_AFTER_WRITE]:
                 self._db.syncToSharedFolder()
 
     def interactEOC(self, cycle=None):

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -9,6 +9,7 @@ import os
 
 from armi.utils import directoryChangers
 from armi import runLog
+from armi.context import FAST_PATH, MPI_RANK
 
 
 class ExecutionOptions:
@@ -56,6 +57,9 @@ class ExecutionOptions:
         self.applyResultsToReactor = True
         self.paramsToScaleSubset = None
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__}: {self.label}>"
+
     def fromUserSettings(self, cs):
         """Set options from a particular CaseSettings object."""
         raise NotImplementedError()
@@ -66,6 +70,16 @@ class ExecutionOptions:
 
     def resolveDerivedOptions(self):
         """Called by executers right before executing."""
+
+    def setRunDirFromCaseTitle(self, caseTitle):
+        """
+        Set run directory derived from case title and label.
+
+        This is optional (you can set runDir to whatever you want). If you
+        use this, you will get a relatively consistent naming convention
+        for your fast-past folders.
+        """
+        self.runDir = os.path.join(FAST_PATH, f"{caseTitle}-{self.label}-{MPI_RANK}")
 
     def describe(self):
         """Make a string summary of all options."""

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -314,9 +314,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         This is not required; these options can alternatively be set programmatically.
         """
         self.kernelName = cs["neutronicsKernel"]
-        self.runDir = os.path.join(
-            armi.FAST_PATH, f"{cs.caseTitle}-{self.label}-{armi.context.MPI_RANK}"
-        )
+        self.setRunDirFromCaseTitle(cs.caseTitle)
         self.isRestart = cs["restartNeutronics"]
         self.adjoint = neutronics.adjointCalculationRequested(cs)
         self.real = neutronics.realCalculationRequested(cs)

--- a/armi/settings/fwSettings/databaseSettings.py
+++ b/armi/settings/fwSettings/databaseSettings.py
@@ -34,6 +34,7 @@ CONF_UPDATE_INDIVIDUAL_ASSEMBLY_NUMBERS_ON_DB_LOAD = (
 )
 CONF_DB_STORAGE_AFTER_CYCLE = "dbStorageAfterCycle"
 CONF_ZERO_OUT_NUCLIDES_NOT_IN_DB = "zeroOutNuclidesNotInDB"
+CONF_SYNC_AFTER_WRITE = "syncDbAfterWrite"
 
 
 def defineSettings():
@@ -98,6 +99,15 @@ def defineSettings():
             default=True,
             label="Load Nuclides not in Database",
             description="If a nuclide was added to the problem after a previous case was run, deactivate this to let it survive in a restart run",
+        ),
+        setting.Setting(
+            CONF_SYNC_AFTER_WRITE,
+            default=False,
+            label="Sync DB after write",
+            description=(
+                "Copy the output DB from the fast scratch space to the shared network drive "
+                "after each write."
+            ),
         ),
     ]
     return settings


### PR DESCRIPTION
The ARMI output database is created by the master node in parallel cases
and is actually written on a local scratch space during the run (for i/o
performance in large sweeps). There are some scenarios, however, where a
DB is needed by other MPI processes as they're doing their work (for
example, if a DB-derived history is needed). This feature just copies
the whole database from the local drive into the run's working directory
(often on a shared network drive) after every write.

This feature can be activted by setting the new syncDbAfterWrite user
setting to `true`.

Relatedly, MPI worker nodes now open the database with read-only
permissions after every DistributeState. This allows them to perform
DB-reading tasks during a run, now that the DB is available to them.

Also added optional Executer-level way to set a runPath.