### PR TITLE
Fix bug when specifying GRID_PLATE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ dist/
 dist-*/
 doc/*.png
 doc/_build
+doc/user/tutorials/anl-afci-177*
+doc/user/tutorials/case-suite
 .apidocs/
 
 # No workspace crumbs.

--- a/armi/bookkeeping/tests/_constants.py
+++ b/armi/bookkeeping/tests/_constants.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Bookkeeping test package.
+Plain old data for the bookkeeping tests.
 
-This may seem a little bit over-engineered, but the jupyter notebooks that get run by
-the test_historyTracker are also used in the documentation system, so providing a list
-of related files from this package is useful. Also, these are organized like this to
-prevent having to import the world just to get something like a list of strings.
+These are stored here so that they can be accessed from within this test package, but
+also re-exported by `__init__.py`, so that other things (like the documentation system)
+can use it without having to import the rest of ARMI.
 """
 
-from ._constants import *
+# These files are needed to run the data_model ipython notebook, which is done in
+# test_historyTracker, and when building the docs.
+TUTORIAL_FILES = [
+    "anl-afci-177-blueprints.yaml",
+    "anl-afci-177-coreMap.yaml",
+    "anl-afci-177-fuelManagement.py",
+    "anl-afci-177.yaml",
+    "data_model.ipynb",
+]

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -80,7 +80,8 @@ True
 [<component fuel1>, <component fuel2>, ...]
 
 """
-from typing import Optional, Sequence, Union
+import re
+from typing import Any, Dict, Optional, Sequence, Union
 
 from armi.utils.flags import Flag, auto
 
@@ -95,10 +96,11 @@ def __fromStringGeneral(cls, typeSpec, updateMethod):
     """Helper method to minimize code repeat in other fromString methods."""
     result = cls(0)
     typeSpec = typeSpec.upper()
-    for conversion in CONVERSIONS:
-        if conversion in typeSpec:
-            typeSpec = typeSpec.replace(conversion, "")
-            result |= CONVERSIONS[conversion]
+    for conversion in _CONVERSIONS:
+        m = conversion.search(typeSpec)
+        if m:
+            typeSpec = re.sub(conversion, "", typeSpec)
+            result |= _CONVERSIONS[conversion]
 
     for name in typeSpec.split():
         # ignore numbers so we don't have to define flags up to 217+ (number of pins/assem)
@@ -292,24 +294,24 @@ def registerPluginFlags(pm):
 
 
 # string conversions for multiple-word flags
-CONVERSIONS = {
-    "GRID PLATE": Flags.GRID_PLATE,
-    "GRID": Flags.GRID_PLATE,  # often used as component in "grid plate" block
-    "INLET NOZZLE": Flags.INLET_NOZZLE,
-    "NOZZLE": Flags.INLET_NOZZLE,
-    "HANDLING SOCKET": Flags.HANDLING_SOCKET,
-    "GUIDE TUBE": Flags.GUIDE_TUBE,
-    "FISSION CHAMBER": Flags.FISSION_CHAMBER,
-    "SOCKET": Flags.HANDLING_SOCKET,
-    "SHIELD BLOCK": Flags.SHIELD_BLOCK,
-    "SHIELDBLOCK": Flags.SHIELD_BLOCK,
-    "CORE BARREL": Flags.CORE_BARREL,
-    "INNERDUCT": Flags.INNER | Flags.DUCT,
-    "GAP1": Flags.GAP | Flags.A,
-    "GAP2": Flags.GAP | Flags.B,
-    "GAP3": Flags.GAP | Flags.C,
-    "GAP4": Flags.GAP | Flags.D,
-    "GAP5": Flags.GAP | Flags.E,
-    "LINER1": Flags.LINER | Flags.A,
-    "LINER2": Flags.LINER | Flags.B,
+_CONVERSIONS = {
+    re.compile(r"GRID\s+PLATE"): Flags.GRID_PLATE,
+    re.compile(r"\bGRID\b"): Flags.GRID_PLATE,  # often used as component in "grid plate" block
+    re.compile(r"INLET\s+NOZZLE"): Flags.INLET_NOZZLE,
+    re.compile("NOZZLE"): Flags.INLET_NOZZLE,
+    re.compile(r"HANDLING\s+SOCKET"): Flags.HANDLING_SOCKET,
+    re.compile(r"GUIDE\s+TUBE"): Flags.GUIDE_TUBE,
+    re.compile(r"FISSION\s+CHAMBER"): Flags.FISSION_CHAMBER,
+    re.compile("SOCKET"): Flags.HANDLING_SOCKET,
+    re.compile(r"SHIELD\s+BLOCK"): Flags.SHIELD_BLOCK,
+    re.compile("SHIELDBLOCK"): Flags.SHIELD_BLOCK,
+    re.compile(r"CORE\s+BARREL"): Flags.CORE_BARREL,
+    re.compile("INNERDUCT"): Flags.INNER | Flags.DUCT,
+    re.compile("GAP1"): Flags.GAP | Flags.A,
+    re.compile("GAP2"): Flags.GAP | Flags.B,
+    re.compile("GAP3"): Flags.GAP | Flags.C,
+    re.compile("GAP4"): Flags.GAP | Flags.D,
+    re.compile("GAP5"): Flags.GAP | Flags.E,
+    re.compile("LINER1"): Flags.LINER | Flags.A,
+    re.compile("LINER2"): Flags.LINER | Flags.B,
 }

--- a/armi/tests/tutorials/data_model.ipynb
+++ b/armi/tests/tutorials/data_model.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "o=armi.init(fName=\"../../../armi/tests/tutorials/anl-afci-177.yaml\");"
+    "o=armi.init(fName=\"anl-afci-177.yaml\");"
    ]
   },
   {

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -31,7 +31,7 @@ def _changeDirectory(destination):
         )
 
 
-class DirectoryChanger(object):
+class DirectoryChanger:
     """
     Utility to change directory.
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,6 +28,7 @@
 
 import datetime
 import os
+import pathlib
 import sys
 import subprocess
 import shutil
@@ -40,6 +41,7 @@ from docutils import nodes, statemachine
 
 import armi
 from armi import apps
+from armi.bookkeeping import tests as bookkeepingTests
 
 # Configure the baseline framework "App" for framework doc building
 armi.configure(apps.App())
@@ -226,12 +228,21 @@ class PyReverse(Directive):
 APIDOC_REL = ".apidocs"
 SOURCE_DIR = os.path.join("..", "armi")
 APIDOC_DIR = APIDOC_REL
+_TUTORIAL_FILES = [pathlib.Path(SOURCE_DIR) / "tests" / "tutorials" / fName for
+        fName in bookkeepingTests.TUTORIAL_FILES if "ipynb" not in fName]
 
 
 def setup(app):
     """Method to make `python setup.py build_sphinx` generate api documentation"""
     app.add_directive("exec", ExecDirective)
     app.add_directive("pyreverse", PyReverse)
+
+    # copy resources needed to build the tutorial notebooks. nbsphinx_link is slick, but
+    # the working directory for running the notebooks is the directory of the link
+    # itself, so relative paths don't work.
+    for path in _TUTORIAL_FILES:
+        shutil.copy(path, pathlib.Path("user") / "tutorials")
+
 
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
This fixes a bug preventing users from specifying `grid_plate` in blueprints. The implicit conversion would turn "grid" into "grid_plate", leaving "grid_plate_plate", which then fails. Using regular expressions to be more precise in the conversions resolves this