### PR TITLE
Fill in some blanks in the buRate definition.

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -345,7 +345,7 @@ class DatabaseInterface(interfaces.Interface):
                     )
                 )
             raise RuntimeError(
-                "Cannot load state @ {}".format(
+                "Cannot load state from <unspecified file> @ {}".format(
                     getH5GroupName(cycle, timeNode, timeStepName)
                 )
             )

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -1075,7 +1075,15 @@ def getBlockParameterDefinitions():
             setter=buGroupNum,
         )
 
-        pb.defParam("buRate", units="", description="?")
+        pb.defParam(
+            "buRate",
+            units="%FIMA/day",
+            # This is very related to power, but normalized to %FIMA.
+            description=(
+                "Current rate of burnup accumulation. Useful for estimating times when "
+                "burnup limits may be exceeded."
+            ),
+        )
 
         pb.defParam(
             "detailedDpa",


### PR DESCRIPTION
Also adds a slight hint in an error message for when you're loading from
a snapshot without specifying a file to load from.