### PR TITLE
Add support for supplying explicit flags in blueprints

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -97,11 +97,11 @@ class Assembly(composites.Composite):
         if ringDum % 2
     ]
 
-    def __init__(self, designName, assemNum=None):
+    def __init__(self, typ, assemNum=None):
         """
         Parameters
         ----------
-        designName : str
+        typ : str
             Name of assembly design (e.g. the name from the blueprints input file).
 
         assemNum : int, optional
@@ -113,7 +113,7 @@ class Assembly(composites.Composite):
         name = self.makeNameFromAssemNum(assemNum)
         composites.Composite.__init__(self, name)
         self.p.assemNum = assemNum
-        self.setType(designName)
+        self.setType(typ)
         self._current = 0  # for iterating
         self.p.buLimit = self.getMaxParam("buLimit")
         self.pinPeakingFactors = []  # assembly-averaged pin power peaking factors

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -27,8 +27,7 @@ import yamlize
 import armi
 from armi import runLog
 from armi.reactor import assemblies
-
-# justification=required to populate assembly parameter definitions
+from armi.reactor.flags import Flags
 from armi.reactor import parameters
 from armi.reactor.blueprints import blockBlueprint
 from armi.reactor import grids
@@ -58,6 +57,7 @@ class AssemblyBlueprint(yamlize.Object):
     """
 
     name = yamlize.Attribute(type=str)
+    flags = yamlize.Attribute(type=str, default=None)
     specifier = yamlize.Attribute(type=str)
     blocks = yamlize.Attribute(type=blockBlueprint.BlockList)
     height = yamlize.Attribute(type=yamlize.FloatList)
@@ -120,6 +120,11 @@ class AssemblyBlueprint(yamlize.Object):
 
         assemblyClass = self.getAssemClass(blocks)
         a = assemblyClass(self.name)
+        flags = None
+        if self.flags is not None:
+            flags = Flags.fromString(self.flags)
+            a.p.flags = flags
+
         # set a basic grid with the right number of blocks with bounds to be adjusted.
         a.spatialGrid = grids.axialUnitGrid(len(blocks))
         a.spatialGrid.armiObject = a

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -23,6 +23,7 @@ import armi
 from armi import runLog
 from armi.reactor import blocks
 from armi.reactor import parameters
+from armi.reactor.flags import Flags
 from armi.reactor.blueprints import componentBlueprint
 from armi.reactor.converters import blockConverters
 from armi.reactor.locations import AXIAL_CHARS
@@ -46,6 +47,7 @@ class BlockBlueprint(yamlize.KeyedList):
     key_attr = componentBlueprint.ComponentBlueprint.name
     name = yamlize.Attribute(key="name", type=str)
     gridName = yamlize.Attribute(key="grid name", type=str, default=None)
+    flags = yamlize.Attribute(type=str, default=None)
     _geomOptions = _configureGeomOptions()
 
     def _getBlockClass(self, outerComponent):
@@ -137,7 +139,11 @@ class BlockBlueprint(yamlize.KeyedList):
             if val is not None:
                 b.p[paramDef.name] = val
 
-        b.setType(self.name)
+        flags = None
+        if self.flags is not None:
+            flags = Flags.fromString(self.flags)
+
+        b.setType(self.name, flags)
         for c in components.values():
             b.addComponent(c)
         b.p.nPins = b.getNumPins()

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -121,6 +121,7 @@ class ComponentBlueprint(yamlize.Object):
     """
 
     name = yamlize.Attribute(type=str)
+    flags = yamlize.Attribute(type=str, default=None)
 
     @name.validator
     def name(self, name):  # pylint: disable=no-self-use; reason=yamlize requirement
@@ -150,6 +151,8 @@ class ComponentBlueprint(yamlize.Object):
         runLog.debug("Constructing component {}".format(self.name))
         kwargs = self._conformKwargs(blueprint, matMods)
         component = components.factory(self.shape.strip().lower(), [], kwargs)
+        if self.flags is not None:
+            component.p.flags = Flags.fromString(self.flags)
         _insertDepletableNuclideKeys(component, blueprint)
         return component
 
@@ -168,6 +171,10 @@ class ComponentBlueprint(yamlize.Object):
             elif attr.name == "latticeIDs":
                 # Don't pass latticeIDs on to the component constructor.
                 # They're applied during block construction.
+                continue
+            elif attr.name == "flags":
+                # Don't pass these to the component constructor. These are used to
+                # override the flags derived from the type, if present.
                 continue
             else:
                 value = attr.get_value(self)

--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -61,10 +61,60 @@ blocks:
             ip: duct.op
             mult: 1.0
             op: 16.75
+    other fuel: &block_fuel_other
+        grid name: fuelgrid
+        flags: fuel test
+        fuel:
+            shape: Circle
+            material: UZr
+            Tinput: 25.0
+            Thot: 600.0
+            id: 0.0
+            od: 0.86602
+            latticeIDs: [1]
+        clad:
+            shape: Circle
+            material: HT9
+            Tinput: 25.0
+            Thot: 470.0
+            id: 1.0
+            od: 1.09
+            latticeIDs: [1,2]
+        coolant:
+            shape: DerivedShape
+            material: Sodium
+            Tinput: 450.0
+            Thot: 450.0
+        duct:
+            shape: Hexagon
+            material: HT9
+            Tinput: 25.0
+            Thot: 450.0
+            ip: 16.0
+            mult: 1.0
+            op: 16.6
+        intercoolant:
+            shape: Hexagon
+            material: Sodium
+            Tinput: 450.0
+            Thot: 450.0
+            ip: duct.op
+            mult: 1.0
+            op: 16.75
 assemblies:
     fuel:
         specifier: IC
-        blocks:  [*block_fuel, *block_fuel]
+        blocks:  [*block_fuel, *block_fuel_other]
+        height: [25.0, 25.0]
+        axial mesh points:  [1, 1]
+        material modifications:
+            U235_wt_frac: [0.11, 0.11]
+            ZR_wt_frac:  [0.06, 0.06]
+        xs types: [A, A]
+    fuel other:
+        flags: fuel test
+        specifier: ID
+        blocks:  [*block_fuel, *block_fuel_other]
         height: [25.0, 25.0]
         axial mesh points:  [1, 1]
         material modifications:
@@ -125,6 +175,24 @@ class TestGriddedBlock(unittest.TestCase):
             if locator == (1, 0, 0):
                 seen = True
         self.assertTrue(seen)
+
+    def test_explicitFlags(self):
+        a1 = self.blueprints.assemDesigns.bySpecifier["IC"].construct(
+            self.cs, self.blueprints
+        )
+        b1 = a1[0]
+        b2 = a1[1]
+
+        a2 = self.blueprints.assemDesigns.bySpecifier["ID"].construct(
+            self.cs, self.blueprints
+        )
+
+        self.assertTrue(b1.hasFlags(Flags.FUEL, exact=True))
+        self.assertTrue(b2.hasFlags(Flags.FUEL | Flags.TEST, exact=True))
+
+        self.assertEqual(a1.p.flags, Flags.FUEL)
+        self.assertTrue(a1.hasFlags(Flags.FUEL, exact=True))
+        self.assertTrue(a2.hasFlags(Flags.FUEL | Flags.TEST, exact=True))
 
 
 if __name__ == "__main__":

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -21,6 +21,7 @@ import unittest
 
 from armi import settings
 from armi.reactor import blueprints
+from armi.reactor.flags import Flags
 from armi.nucDirectory import nuclideBases
 
 
@@ -30,6 +31,7 @@ class TestComponentBlueprint(unittest.TestCase):
 blocks:
     block: &block
         component:
+            flags: fuel test
             shape: Hexagon
             material: {material} # This is being used to format a string to allow for different materials to be added
             {isotopics} # This is being used to format a string to allow for different isotopics to be added
@@ -109,6 +111,12 @@ assemblies:
             self.assertIn(nuc, a[0][0].getNuclides())
         for nuc in unexpectedNuclides:
             self.assertNotIn(nuc, a[0][0].getNuclides())
+
+        c = a[0][0]
+        # Watch out, depletion is adding DEPLETABLE, so this can be a bit brittle
+        self.assertEqual(c.p.flags, Flags.FUEL|Flags.DEPLETABLE|Flags.TEST)
+        # More robust test, but worse unittest.py output when it fails
+        self.assertTrue(c.hasFlags(Flags.FUEL|Flags.TEST))
 
     def test_componentInitializationAmericiumCustomIsotopics(self):
         nuclideFlags = (

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -647,10 +647,15 @@ class ArmiObject(metaclass=CompositeModelType):
         """Return the object type."""
         return self.p.type
 
-    def setType(self, newType):
-        """Set the object type."""
-        self.p.flags = Flags.fromStringIgnoreErrors(newType)
-        self.p.type = newType
+    def setType(self, typ, flags: Optional[Flags] = None):
+        """
+        Set the object type.
+
+        If Flags are provided, use them directly. Otherwise, attempt to derive flags
+        from the passed type.
+        """
+        self.p.flags = flags or Flags.fromStringIgnoreErrors(typ)
+        self.p.type = typ
 
     def getVolume(self):
         return sum(child.getVolume() for child in self)

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -651,8 +651,27 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         Set the object type.
 
-        If Flags are provided, use them directly. Otherwise, attempt to derive flags
-        from the passed type.
+        Parameters
+        ----------
+        typ : str
+            The desired "type" for the object. Type describes the general class of the
+            object, and typically corresponds to the name of the blueprint that created
+            it.
+
+        flags : Flags, optional
+            The set of Flags to apply to the object. If these are omitted, then Flags
+            will be derived from the ``typ``.
+
+        Warning
+        -------
+        We are in the process of developing more robust definitions for things like
+        "name" and "type". "type" will generally refer to the name of the blueprint that
+        created a particular object. When present, a "name" will refer to a specific
+        instance of an object of a particular "type". Think unique names for each
+        assembly in a core, even if they are all created from the same blueprint and
+        therefore have the same "type". When this work is complete, it will be strongly
+        discouraged, or even disallowed to change the type of an object after it has
+        been created, and ``setType()`` may be removed entirely.
         """
         self.p.flags = flags or Flags.fromStringIgnoreErrors(typ)
         self.p.type = typ

--- a/doc/user/inputs/blueprints.rst
+++ b/doc/user/inputs/blueprints.rst
@@ -230,6 +230,7 @@ cladding as the fuel pins. ::
         fuel: &block_fuel
             grid name: fuelgrid
             fuel:
+                flags: fuel test
                 shape: Circle
                 material: UZr
                 Tinput: 25.0
@@ -253,23 +254,29 @@ cladding as the fuel pins. ::
 
 .. _naming-flags:
 
-About naming
-============
+Flags and naming
+================
 
-The treatment of components, blocks, and assemblies by various physics kernels
-often depend on the user supplied name.  The name is a way to indicate how a
-specific component, block, or assembly should be treated by the various physics
-packages.
+All objects in the ARMI Reactor Model possess a set of
+:py:class:`armi.reactor.flags.Flags`, which affect the way that the various physics
+kernels treat each object. For instance, an object with the ``DEPLETABLE`` flag set will
+participate in isotopic depletion analysis, whereas objects without the ``DEPLETION``
+flag set will not. Some parts of the ARMI ecosystem use the flags like ``FUEL``,
+``CLAD``, or ``WIRE`` to guess at an object's function.
 
-Note that the user supplied names themselves can be whatever the user would like. However, some
-words (space separated) have special meaning in the physics packages.
+The set of specific flags that should be set on an object can be specified in one of two
+ways for each object defined in the blueprints. The most precise way is to use include a
+``flags:`` entry for the object blueprint in question. In the example above, the
+``fuel`` component sets the ``FUEL`` and ``TEST`` flags. When specifying flags in this
+way, the value specified must be completely and unambiguously convertible into valid
+Flags. If it cannot, it will lead to an error when constructing the object.
 
-For example, if the word "fuel" is in the block name, a lattice physics module
-(provided by the user) may use this block to generate cross sections.  If
-"fuel" is omitted, the module will not know that there is fissile material and
-will use a different block to generate cross sections.
+If ``flags:`` is empty, or not specified, then the name of the object blueprint will be
+used to infer as many flags as possible. In the above example, the ``clad`` component
+will get the ``CLAD`` flag from its name.
 
-The following special names should be used in the **blueprints** input to achieve specific behavior.
+The following special names should be used in the **blueprints** input to achieve
+specific behavior.
 
 .. exec::
     from armi.reactor.flags import Flags


### PR DESCRIPTION
This adds a `flags:` attribute to Assembly, Block, and Component
blueprints, allowing users to override the flags that would otherwise be
inferred from the blueprint `type`.