### PR TITLE
Reduce Database Overwriting 

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -175,13 +175,14 @@ class DatabaseInterface(interfaces.Interface):
         interface stack (so that all the parameters have been updated) while the Main
         Interface interacts first.
         """
-        if self.cs["reloadDBName"].lower() == (self.cs.caseTitle + ".h5").lower():
+        databaseName = self.cs.caseTitle + ".h5"
+        if os.path.exists(os.path.abspath(databaseName)):
             raise ValueError(
-                "It appears that reloadDBName is the same as the case "
-                "title. This could lead to data loss! Rename the reload DB or the "
-                "case."
+                "There is already a database file {}.\nIt would be overwritten. "
+                "Please rename your case (settings file) to a name that does not yet "
+                "have a database.".format(os.path.abspath(databaseName))
             )
-        self._db = Database3(self.cs.caseTitle + ".h5", "w")
+        self._db = Database3(databaseName, "w")
         self._db.open()
 
         # Grab geomString here because the DB-level has no access to the reactor or

--- a/armi/bookkeeping/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/tests/test_databaseInterface.py
@@ -332,12 +332,14 @@ class TestDatabaseReading(unittest.TestCase):
 class TestBadName(unittest.TestCase):
     def test_badDBName(self):
         cs = settings.Settings(os.path.join(TEST_ROOT, "armiRun.yaml"))
-        cs["reloadDBName"] = "aRmIRuN.h5"  # weird casing to confirm robust checking
         dbi = DatabaseInterface(None, cs)
+        with open("aRmIRuN.h5", "w"):  # check case insensitive
+            pass  # just make file, don't do anything with it
         with self.assertRaises(ValueError):
             # an error should be raised when the database loaded from
             # has the same name as the run to avoid overwriting.
             dbi.initDB()
+        os.remove("aRmIRuN.h5")
 
 
 class TestStandardFollowOn(unittest.TestCase):


### PR DESCRIPTION
DatabaseInterface now checks if the database file that it is
creating already exists and raises an error if it does. This
change is to prevent unfortunate overwrite of an old database.