### PR TITLE
Loading Unstable Nuclides from the RIPL-3 Database using the ARMI_RIPL_PATH Environment Variable

### DIFF
--- a/armi/nuclearDataIO/ripl.py
+++ b/armi/nuclearDataIO/ripl.py
@@ -30,7 +30,7 @@ from armi.utils import units
 from armi.settings.caseSettings import Settings
 
 DECAY_CONSTANTS = {}
-MINIMUM_HALFLIFE = 1.0e-06
+MINIMUM_HALFLIFE = 2.8e-7
 STABLE_FLAG = -1
 UNKNOWN_HALFLIFE = -2
 EXIT_DATA_FILE = -3
@@ -96,10 +96,6 @@ def getNuclideDecayConstants(fileName):
                         m += 1
 
                     else:
-                        msg = "metastable state for {}m{} greater than 1 -- skipping".format(
-                            symb, m
-                        )
-                        runLog.warning(msg)
                         level += numLevels + 1
 
                 elif halflife < MINIMUM_HALFLIFE or halflife == UNKNOWN_HALFLIFE:

--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -99,3 +99,21 @@ If it worked, you should see the (classic) ARMI splash screen and no errors::
 
 
 If it works, congrats! So far so good.
+
+Optional Setup
+--------------
+This subsection provides setup information for optional external data packages.
+
+RIPL-3 Nuclide Decay Database
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The RIPL-3 decay files (``levels.zip``) can be downloaded from `<https://www-nds.iaea.org/RIPL-3/levels/>`_.
+
+By default, nuclides within :py:mod:`armi.nucDirectory.nuclideBases` are initialized from 
+a subset of the RIPL-3 database, which ships with ARMI. The base data set contains 2339 
+nuclides and RIPL-3 decay data set increases this to 4379 nuclides. The RIPL-3 decay data 
+files mainly add metastable nuclides and other exotic nuclides that could be important for 
+detailed depletion/decay models or activation analyses.
+
+Once the ``levels.zip`` file is downloaded and unzipped, an environment variable :envvar:`ARMI_RIPL_PATH` 
+should be created and set to the directory containing the ``z*.dat`` files.
+


### PR DESCRIPTION
Adding an `ARMI_RIPL_PATH` environment variable to determine if
nuclide bases should read in unstable nuclide data from the RIPL-3
data files during the `factory` function call. These data files are not 
distributed with the framework, so a user will have to download them 
separately from `https://www-nds.iaea.org/RIPL-3/levels/`. 