### PR TITLE
Move fuel perf utils from blocks to physics

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -397,7 +397,7 @@ class DatabaseInterface(interfaces.Interface):
         """
         Get historical parameter values for one or more objects.
 
-        This is mostly a wrapper around the same fumction on the ``Database3`` class,
+        This is mostly a wrapper around the same function on the ``Database3`` class,
         but knows how to return the current value as well.
 
         See Also

--- a/armi/bookkeeping/db/xtviewDB.py
+++ b/armi/bookkeeping/db/xtviewDB.py
@@ -21,7 +21,6 @@ maintained to allow conversions between database formats and visualization.
 # pylint: disable=too-many-public-methods
 
 import copy
-import math
 import io
 import os
 import re
@@ -30,24 +29,23 @@ import traceback
 import itertools
 
 import numpy
+import h5py
 
 import armi
 from armi import runLog
 from armi import settings
 from armi import utils
-from armi.bookkeeping import db
 from armi.nucDirectory import nucDir
 from armi.nucDirectory import nuclideBases
 from armi.reactor import reactors
 from armi.reactor import blocks
-from armi.reactor import assemblies
 from armi.reactor import locations
 from armi.reactor import parameters
 from armi.reactor import geometry
 from armi.reactor.flags import Flags
 from armi.utils import exceptions
 
-import h5py
+import armi.physics.fuelPerformance.utils as fuelUtils
 
 
 class XTViewDatabase:
@@ -603,7 +601,7 @@ class XTViewDatabase:
         according to the bondRemoved param.
         """
         for b in reactor.core.getBlocks(Flags.FUEL):
-            b.enforceBondRemovalFraction(b.p.bondRemoved)
+            fuelUtils.enforceBondRemovalFraction(b, b.p.bondRemoved)
 
     def lookupGeometry(self):
         """

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -137,6 +137,8 @@ class HistoryTrackerInterface(interfaces.Interface):
     def interactBOC(self, cycle=None):
         """Look for any new assemblies that are asked for and add them to tracking."""
         self.addDetailAssemsByAssemNums()
+        if self.cs["detailAllAssems"]:
+            self.addAllFuelAssems()
 
     def interactEOL(self):
         """Generate the history reports."""
@@ -164,13 +166,17 @@ class HistoryTrackerInterface(interfaces.Interface):
                 self.addDetailAssembly(a)
 
         if self.cs["detailAllAssems"]:
-            for a in self.r.getAssemblies():
-                if a.hasFlags(Flags.FUEL):
-                    self.addDetailAssembly(a)
+            self.addAllFuelAssems()
 
         # This also gets called at BOC but we still
         # do it here for operators that do not call BOC.
         self.addDetailAssemsByAssemNums()
+
+    def addAllFuelAssems(self):
+        """Add all fuel assems as detail assems."""
+        for a in self.r.core:
+            if a.hasFlags(Flags.FUEL):
+                self.addDetailAssembly(a)
 
     def addDetailAssemsByAssemNums(self):
         """
@@ -230,8 +236,10 @@ class HistoryTrackerInterface(interfaces.Interface):
         return sorted(trackedParams)
 
     def addDetailAssembly(self, a):
-        """Track the name of all assemblies flagged for detailed treatment."""
-        self.detailAssemblyNames.append(a.getName())
+        """Track the name of assemblies that are flagged for detailed treatment."""
+        aName = a.getName()
+        if aName not in self.detailAssemblyNames:
+            self.detailAssemblyNames.append(aName)
 
     def getDetailAssemblies(self):
         r"""returns the assemblies that have been signaled as detail assemblies."""

--- a/armi/physics/fuelPerformance/parameters.py
+++ b/armi/physics/fuelPerformance/parameters.py
@@ -79,4 +79,25 @@ def _getFuelPerformanceBlockParams():
             location=ParamLocation.AVERAGE,
         )
 
+        pb.defParam(
+            "gasPorosity",
+            units="",
+            description="Fraction of fuel volume that is occupied by gas pores",
+            default=0.0,
+            categories=["eq cumulative shift"],
+        )
+
+        pb.defParam(
+            "liquidPorosity",
+            units="",
+            description="Fraction of fuel volume that is occupied by liquid filled pores",
+            default=0.0,
+        )
+
+        pb.defParam(
+            "fuelRadialDisplacement",
+            units="cm",
+            description="Radial fuel displacement from irradiation",
+        )
+
     return pDefs

--- a/armi/physics/fuelPerformance/tests/test_fuelPerformanceUtils.py
+++ b/armi/physics/fuelPerformance/tests/test_fuelPerformanceUtils.py
@@ -1,0 +1,36 @@
+"""
+Tests for fuel performance utilities.
+"""
+
+import unittest
+
+from armi.physics.fuelPerformance import utils
+from armi.reactor.flags import Flags
+from armi.reactor.tests import test_blocks
+
+
+class TestFuelPerformanceUtils(unittest.TestCase):
+    def test_enforceBondRemovalFraction(self):
+        b = test_blocks.loadTestBlock()
+        bond = b.getComponent(Flags.BOND)
+        bondRemovalFrac = 0.705
+        ndensBefore = b.getNumberDensity("NA")
+        bondNdensBefore = bond.getNumberDensity("NA")
+        b.p.bondBOL = bondNdensBefore
+        utils.enforceBondRemovalFraction(b, bondRemovalFrac)
+        bondNdensAfter = bond.getNumberDensity("NA")
+        ndensAfter = b.getNumberDensity("NA")
+
+        self.assertAlmostEqual(
+            bondNdensAfter / bondNdensBefore, (1.0 - bondRemovalFrac)
+        )
+        self.assertAlmostEqual(ndensBefore, ndensAfter)
+
+        # make sure it doesn't change if you run it twice
+        utils.enforceBondRemovalFraction(b, bondRemovalFrac)
+        bondNdensAfter = bond.getNumberDensity("NA")
+        ndensAfter = b.getNumberDensity("NA")
+        self.assertAlmostEqual(
+            bondNdensAfter / bondNdensBefore, (1.0 - bondRemovalFrac)
+        )
+        self.assertAlmostEqual(ndensBefore, ndensAfter)

--- a/armi/physics/fuelPerformance/tests/test_fuelPerformanceUtils.py
+++ b/armi/physics/fuelPerformance/tests/test_fuelPerformanceUtils.py
@@ -11,6 +11,11 @@ from armi.reactor.tests import test_blocks
 
 class TestFuelPerformanceUtils(unittest.TestCase):
     def test_enforceBondRemovalFraction(self):
+        """
+        Tests that the bond sodium is removed from the `bond` component in a block
+        and the mass is then evenly distributed across all other sodium containing components 
+        (e.g., coolant, intercoolant).
+        """
         b = test_blocks.loadTestBlock()
         bond = b.getComponent(Flags.BOND)
         bondRemovalFrac = 0.705
@@ -34,3 +39,13 @@ class TestFuelPerformanceUtils(unittest.TestCase):
             bondNdensAfter / bondNdensBefore, (1.0 - bondRemovalFrac)
         )
         self.assertAlmostEqual(ndensBefore, ndensAfter)
+
+    def test_applyFuelDisplacement(self):
+        displacement = 0.01
+        block = test_blocks.loadTestBlock()
+        fuel = block.getComponent(Flags.FUEL)
+        originalHotODInCm = fuel.getDimension("od")
+        utils.applyFuelDisplacement(block, displacement)
+        finalHotODInCm = fuel.getDimension("od")
+
+        self.assertAlmostEqual(finalHotODInCm, originalHotODInCm + 2 * displacement)

--- a/armi/physics/fuelPerformance/utils.py
+++ b/armi/physics/fuelPerformance/utils.py
@@ -98,4 +98,4 @@ def applyFuelDisplacement(block, displacementInCm):
     fuel.setDimension("od", newHotODInCm, retainLink=True, cold=False)
     # reduce number density of fuel to conserve number of atoms (and mass)
     fuel.changeNDensByFactor(originalHotODInCm ** 2 / newHotODInCm ** 2)
-    block.updateAllNumberDensityParams()
+    block.buildNumberDensityParams()

--- a/armi/physics/fuelPerformance/utils.py
+++ b/armi/physics/fuelPerformance/utils.py
@@ -72,13 +72,16 @@ def enforceBondRemovalFraction(block, bondRemovedFrac):
 
 def applyFuelDisplacement(block, displacementInCm):
     r"""
-    Expands the fuel in a pin. 
+    Expands the fuel radius in a pin by a number of cm.
 
     Assumes there's thermal bond in it to displace.
     This adjusts the dimension of the fuel while conserving its mass.
 
     The bond mass is not conserved; it is assumed to be pushed up into the plenum
     but the modeling of this is not done yet by this method.
+    
+    .. warning:: A 0.5% buffer is included to avoid overlaps. This should be analyzed
+        in detail as a methodology before using in any particular analysis.
 
     .. math::
 

--- a/armi/physics/fuelPerformance/utils.py
+++ b/armi/physics/fuelPerformance/utils.py
@@ -1,0 +1,98 @@
+"""
+Fuel performance utilities.
+"""
+
+from armi.reactor.flags import Flags
+
+
+def enforceBondRemovalFraction(block, bondRemovedFrac):
+    r"""
+    Update the distribution of coolant in this block to agree with a fraction
+
+    This pulls coolant material out of the bond component and adds it to the other
+    coolant-containing components while conserving mass.
+
+    Useful after db load with sodium bond. See armi.bookkeeping.db.database.updateFromDB
+
+    :math:`N_{hom} = \sum_{i} a_i N_i`
+
+    We want :math:`f = \frac{a_{bond} N_{bond}}{N_{hom}}`
+    So we can solve this for :math:`N_{bond}` and reduce the other
+    number densities accordingly.
+
+    Should work for coolants with more than 1 nuclide (e.g. H2O, Pb-Bi, NaK,...)
+
+    Parameters
+    ----------
+    bondRemovedFrac : float
+        Fraction of the bond that has been removed.
+
+    See Also
+    --------
+    armi.reactor.assemblies.Assembly.applyBondRemovalFractions : does this in the original case
+    """
+
+    bond = block.getComponent(Flags.BOND, quiet=True)
+    if not bond or not bondRemovedFrac:
+        return
+    volFracs = block.getVolumeFractions()
+    vBond = block.getComponentAreaFrac(Flags.BOND)
+    nuclides = bond.getNuclides()
+    # reduce to components of the same material.
+    coolantFracs = []
+
+    totalCoolantFrac = 0.0
+    for comp, vFrac in volFracs:
+        if comp.getProperties().getName() == bond.getProperties().getName():
+            coolantFracs.append((comp, vFrac))
+            totalCoolantFrac += vFrac
+
+    ndensHomog = []
+    for nuc in nuclides:
+        nh = 0.0  # homogenized number density of bond material (e.g. sodium)
+        for comp, vFrac in coolantFracs:
+            nh += comp.getNumberDensity(nuc) * vFrac
+        ndensHomog.append(nh)
+
+    # adjust bond values Nb'=(1-f)*Nb_bol
+    newBondNdens = []
+    for nuc, nh in zip(nuclides, ndensHomog):
+        ni = block.p.bondBOL * (1.0 - bondRemovedFrac)
+        newBondNdens.append(ni)
+        bond.setNumberDensity(nuc, ni)
+
+    # adjust values of other components (e.g. coolant, interCoolant)
+    for nuc, nh, nbNew in zip(nuclides, ndensHomog, newBondNdens):
+        newOtherDens = (nh - nbNew * vBond) / (totalCoolantFrac - vBond)
+        for comp, vFrac in coolantFracs:
+            if comp is bond:
+                continue
+            comp.setNumberDensity(nuc, newOtherDens)
+
+
+def applyFuelDisplacement(block, displacementInCm):
+    r"""
+    Expands the fuel in a pin. 
+
+    Assumes there's thermal bond in it to displace.
+    This adjusts the dimension of the fuel while conserving its mass.
+
+    The bond mass is not conserved; it is assumed to be pushed up into the plenum
+    but the modeling of this is not done yet by this method.
+
+    .. math::
+
+        n V = n\prime V\prime
+        n\prime = \frac{V}{V\prime} n
+
+    """
+    clad = block.getComponent(Flags.CLAD)
+    fuel = block.getComponent(Flags.FUEL)
+    originalHotODInCm = fuel.getDimension("od")
+    cladID = clad.getDimension("id")
+    # do not swell past cladding ID! (actually leave 0.5% buffer for thermal expansion)
+    newHotODInCm = min(cladID * 0.995, originalHotODInCm + displacementInCm * 2)
+    fuel.setDimension("od", newHotODInCm, retainLink=True, cold=False)
+    # reduce number density of fuel to conserve number of atoms (and mass)
+    fuel.changeNDensByFactor(originalHotODInCm ** 2 / newHotODInCm ** 2)
+    block.updateAllNumberDensityParams()

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -612,6 +612,11 @@ class Block(composites.Composite):
         for nucName, ndens in numberDensities.items():
             self.setNDensParam(nucName, ndens)
 
+    def updateAllNumberDensityParams(self):
+        """Update all block-level ndens params for visualization."""
+        for nucName, ndens in self.getNumberDensities().items():
+            self.setNDensParam(nucName, ndens)
+
     def setNDensParam(self, nucName, ndens):
         """
         Set a block-level param with the homog. number density of a nuclide.
@@ -2053,70 +2058,6 @@ class Block(composites.Composite):
             del self.p[elementalNuclide.getDatabaseName()]
         except KeyError:
             pass
-
-    def enforceBondRemovalFraction(self, bondRemovedFrac):
-        r"""
-        Update the distribution of coolant in this block to agree with a fraction
-
-        This pulls coolant material out of the bond component and adds it to the other
-        coolant-containing components while conserving mass.
-
-        Useful after db load with sodium bond. See armi.bookkeeping.db.database.updateFromDB
-
-        :math:`N_{hom} = \sum_{i} a_i N_i`
-
-        We want :math:`f = \frac{a_{bond} N_{bond}}{N_{hom}}`
-        So we can solve this for :math:`N_{bond}` and reduce the other
-        number densities accordingly.
-
-        Should work for coolants with more than 1 nuclide (e.g. H2O, Pb-Bi, NaK,...)
-
-        Parameters
-        ----------
-        bondRemovedFrac : float
-            Fraction of the bond that has been removed.
-
-        See Also
-        --------
-        armi.reactor.assemblies.Assembly.applyBondRemovalFractions : does this in the original case
-        """
-
-        bond = self.getComponent(Flags.BOND, quiet=True)
-        if not bond or not bondRemovedFrac:
-            return
-        volFracs = self.getVolumeFractions()
-        vBond = self.getComponentAreaFrac(Flags.BOND)
-        nuclides = bond.getNuclides()
-        # reduce to components of the same material.
-        coolantFracs = []
-
-        totalCoolantFrac = 0.0
-        for comp, vFrac in volFracs:
-            if comp.getProperties().getName() == bond.getProperties().getName():
-                coolantFracs.append((comp, vFrac))
-                totalCoolantFrac += vFrac
-
-        ndensHomog = []
-        for nuc in nuclides:
-            nh = 0.0  # homogenized number density of bond material (e.g. sodium)
-            for comp, vFrac in coolantFracs:
-                nh += comp.getNumberDensity(nuc) * vFrac
-            ndensHomog.append(nh)
-
-        # adjust bond values Nb'=(1-f)*Nb_bol
-        newBondNdens = []
-        for nuc, nh in zip(nuclides, ndensHomog):
-            ni = self.p.bondBOL * (1.0 - bondRemovedFrac)
-            newBondNdens.append(ni)
-            bond.setNumberDensity(nuc, ni)
-
-        # adjust values of other components (e.g. coolant, interCoolant)
-        for nuc, nh, nbNew in zip(nuclides, ndensHomog, newBondNdens):
-            newOtherDens = (nh - nbNew * vBond) / (totalCoolantFrac - vBond)
-            for comp, vFrac in coolantFracs:
-                if comp is bond:
-                    continue
-                comp.setNumberDensity(nuc, newOtherDens)
 
     def getBurnupPeakingFactor(self):
         """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -613,7 +613,15 @@ class Block(composites.Composite):
             self.setNDensParam(nucName, ndens)
 
     def updateAllNumberDensityParams(self):
-        """Update all block-level ndens params for visualization."""
+        """
+        Update all block-level ndens params.
+        Notes
+        -----
+        Recall that actual number densities are not the same as the number
+        density params (they're really stored on the components). These
+        params are still useful for plotting block-level number density
+        information in database viewers, etc.
+        """
         for nucName, ndens in self.getNumberDensities().items():
             self.setNDensParam(nucName, ndens)
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -612,9 +612,10 @@ class Block(composites.Composite):
         for nucName, ndens in numberDensities.items():
             self.setNDensParam(nucName, ndens)
 
-    def updateAllNumberDensityParams(self):
+    def buildNumberDensityParams(self, nucNames=None):
         """
-        Update all block-level ndens params.
+        Copy homogenized density onto self.p for storing in the DB.
+
         Notes
         -----
         Recall that actual number densities are not the same as the number
@@ -622,8 +623,12 @@ class Block(composites.Composite):
         params are still useful for plotting block-level number density
         information in database viewers, etc.
         """
-        for nucName, ndens in self.getNumberDensities().items():
-            self.setNDensParam(nucName, ndens)
+        if nucNames is None:
+            nucNames = self.getNuclides()
+        nucBases = [nuclideBases.byName[nn] for nn in nucNames]
+        nucDensities = self.getNuclideNumberDensities(nucNames)
+        for nb, ndens in zip(nucBases, nucDensities):
+            self.p[nb.getDatabaseName()] = ndens
 
     def setNDensParam(self, nucName, ndens):
         """
@@ -2021,15 +2026,6 @@ class Block(composites.Composite):
         for nucName, nucDens in numberDensities.items():
             lines.append("{0:6s} {1:.7E}".format(nucName, nucDens))
         return lines
-
-    def buildNumberDensityParams(self, nucNames=None):
-        """Copy homogenized density onto self.p for storing in the DB."""
-        if nucNames is None:
-            nucNames = self.getNuclides()
-        nucBases = [nuclideBases.byName[nn] for nn in nucNames]
-        nucDensities = self.getNuclideNumberDensities(nucNames)
-        for nb, ndens in zip(nucBases, nucDensities):
-            self.p[nb.getDatabaseName()] = ndens
 
     def expandAllElementalsToIsotopics(self):
         reactorNucs = self.getNuclides()

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -737,10 +737,11 @@ class Component(composites.Composite, metaclass=ComponentType):
         val : float
             The value to set on the dimension
         retainLink : bool, optional
-            If True, the val will be applied to the dimension of linked component which indirectly
-            changes this component's dimensions.
+            If True, the val will be applied to the dimension of linked 
+            component which indirectly changes this component's dimensions.
         cold : book, optional
-            If True sets the component to the dimension that would cause the hot dimension to be the specified value.
+            If True sets the component to the dimension that would cause 
+            the hot dimension to be the specified value.
         """
         if not key:
             return
@@ -801,9 +802,8 @@ class Component(composites.Composite, metaclass=ComponentType):
         """Clear this cache and any other dependent volumes."""
         self.clearCache()
         if self.parent:  # pylint: disable=no-member
-            self.parent.cached = (
-                {}
-            )  # changes in dimensions can affect cached variables such as pitch
+            # changes in dimensions can affect cached variables such as pitch
+            self.parent.cached = {}
             for c in self.getLinkedComponents():
                 # no clearCache since parent already updated derivedMustUpdate in self.clearCache()
                 c.p.volume = None

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -440,6 +440,8 @@ class ParameterDefinitionCollection(object):
             self._representedTypes
         )
         assert self is not other
+        if other is None:
+            raise ValueError(f"Cannot extend {self} with `None`.")
         for pd in other:
             self.add(pd)
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1265,31 +1265,6 @@ class Block_TestCase(unittest.TestCase):
         moles3 = b.p.molesHmBOL
         self.assertAlmostEqual(moles2, moles3)
 
-    def test_enforceBondRemovalFraction(self):
-        b = self.Block
-        bond = b.getComponent(Flags.BOND)
-        bondRemovalFrac = 0.705
-        ndensBefore = b.getNumberDensity("NA")
-        bondNdensBefore = bond.getNumberDensity("NA")
-        b.p.bondBOL = bondNdensBefore
-        b.enforceBondRemovalFraction(bondRemovalFrac)
-        bondNdensAfter = bond.getNumberDensity("NA")
-        ndensAfter = b.getNumberDensity("NA")
-
-        self.assertAlmostEqual(
-            bondNdensAfter / bondNdensBefore, (1.0 - bondRemovalFrac)
-        )
-        self.assertAlmostEqual(ndensBefore, ndensAfter)
-
-        # make sure it doesn't change if you run it twice
-        b.enforceBondRemovalFraction(bondRemovalFrac)
-        bondNdensAfter = bond.getNumberDensity("NA")
-        ndensAfter = b.getNumberDensity("NA")
-        self.assertAlmostEqual(
-            bondNdensAfter / bondNdensBefore, (1.0 - bondRemovalFrac)
-        )
-        self.assertAlmostEqual(ndensBefore, ndensAfter)
-
     def test_getMfp(self):
         """Test mean free path."""
         applyDummyData(self.Block)


### PR DESCRIPTION
Some fuel performance utilities and tests were on the blocks.py
framework-level module. Since they're very physics specific, I moved
them to the built-in fuel performance plugin.

I also fixed an issue with specifying all assemblies as detailAssems.