### PR TITLE
Add linPow parameter to the detailed axial expansion treatment category

### DIFF
--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -355,9 +355,10 @@ def getBlockParameterDefinitions():
         pb.defParam(
             "linPow",
             units="W/m",
-            description="Linear heat generation rate",
+            description="Pin-averaged linear heat generation rate",
             location=ParamLocation.AVERAGE,
             default=0.0,
+            categories=[parameters.Category.detailedAxialExpansion],
         )
 
         pb.defParam(


### PR DESCRIPTION
Updating the Pin-average linear heat generation rate to be in 
the `detailedAxialExpansion` category so that the pin powers
are remapped from a uniform mesh to a detailed axial mesh
after the global flux calculation is completed.