### PR TITLE
Fixes to Circular Ring HEX to RZ Conversion and Preloading ISOTXS on Core

### DIFF
--- a/armi/physics/neutronics/__init__.py
+++ b/armi/physics/neutronics/__init__.py
@@ -55,10 +55,7 @@ class NeutronicsPlugin(plugins.ArmiPlugin):
         from armi.physics.neutronics.fissionProductModel import fissionProductModel
 
         interfaceInfo = []
-        for mod in (
-            crossSectionGroupManager,
-            fissionProductModel,
-        ):
+        for mod in (crossSectionGroupManager, fissionProductModel):
             interfaceInfo += plugins.collectInterfaceDescriptions(mod, cs)
 
         return interfaceInfo
@@ -172,11 +169,12 @@ REAL_CALC = "real"
 ADJREAL_CALC = "both"
 
 # Constants for boundary conditions
-INFINITE = (
-    "Infinite"  # All external boundary conditions are set to zero outward current
-)
 
-REFLECTIVE = "Reflective"  # "Planar" external boundaries conditions are set to zero outward current
+# All external boundary conditions are set to zero outward current
+INFINITE = "Infinite"
+
+# "Planar" external boundaries conditions are set to zero outward current
+REFLECTIVE = "Reflective"
 
 # Generalized boundary conditions D * PHI PRIME + A * PHI = 0 where A is user-specified constant,
 # D is the diffusion coefficient, PHI PRIME and PHI are the outward current and flux at the

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -88,7 +88,8 @@ def defineSettings():
             label="Multigroup Cross Sections Generation",
             description="Generate multigroup cross sections for the selected particle "
             "type(s) using the specified lattice physics kernel (see Lattice Physics "
-            "tab).",
+            "tab). When not set, the XS library will be auto-loaded from an existing ISOTXS "
+            "within then working directory and fail if the ISOTXS does not exist.",
             options=["", "Neutron", "Neutron and Gamma"],
         ),
         setting.Setting(
@@ -125,7 +126,7 @@ def defineSettings():
             default="DIF3D-Nodal",
             label="Neutronics Kernel",
             description="The neutronics / depletion solver for global flux solve.",
-            options=["DIF3D-Nodal", "DIF3D-FD", "VARIANT", "DIFNT",],  # lol
+            options=["DIF3D-Nodal", "DIF3D-FD", "VARIANT", "DIFNT"],
             enforcedOptions=True,
         ),
         setting.Setting(

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -535,14 +535,6 @@ class HexToRZThetaConverter(GeometryConverter):
 
         self._sourceReactor = r
         self._setupSourceReactorForConversion()
-        reactorConversionMethod = (
-            "hexagonal"
-            if self.converterSettings["hexRingGeometryConversion"]
-            else "circular"
-        )
-        runLog.extra(
-            "Converting reactor using {} rings".format(reactorConversionMethod)
-        )
         rztSpatialGrid = self._generateConvertedReactorMesh()
         runLog.info(rztSpatialGrid)
         self._setupConvertedReactor(rztSpatialGrid)
@@ -635,12 +627,9 @@ class HexToRZThetaConverter(GeometryConverter):
     def _getAssembliesInCurrentRadialZone(self, lowerRing, upperRing):
         ringAssems = []
         for ring in range(lowerRing, upperRing):
-            if self.converterSettings["hexRingGeometryConversion"]:
-                ringAssems.extend(
-                    self._sourceReactor.core.getAssembliesInSquareOrHexRing(ring)
-                )
-            else:
-                ringAssems.extend(self._sourceReactor.core.getAssembliesInRing(ring))
+            ringAssems.extend(
+                self._sourceReactor.core.getAssembliesInSquareOrHexRing(ring)
+            )
         return ringAssems
 
     def _setupSourceReactorForConversion(self):

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -126,7 +126,6 @@ class TestHexToRZConverter(unittest.TestCase):
             "thetaBins": 1,
             "axialMesh": [50, 100, 150, 175],
             "thetaMesh": [2 * math.pi],
-            "hexRingGeometryConversion": False,
         }
 
         expectedMassDict, expectedNuclideList = self._getExpectedData()

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -392,6 +392,9 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
             )
             # Now recalculate derived params with the mapped flux to minimize
             # potential numerical diffusion (e.g. control rod tip into large coolant)
+
+        if destReactor.core.lib is not None:
+            runLog.extra(f"Computing block-level reaction rates for {destReactor.core}")
             for b in aDest:
                 globalFluxInterface.calcReactionRates(
                     b, destReactor.core.p.keff, destReactor.core.lib

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -224,7 +224,7 @@ class Core(composites.Composite):
         self._circularRingPitch = cs["circularRingPitch"]
         self._automaticVariableMesh = cs["automaticVariableMesh"]
         self._minMeshSizeRatio = cs["minMeshSizeRatio"]
-        self._preloadCoreXS = cs["preloadCoreXS"]
+        self._preloadCoreXS = True if not cs["genXS"] else False
 
     def __getstate__(self):
         """Applies a settings and parent to the core and components. """
@@ -296,7 +296,10 @@ class Core(composites.Composite):
         if self._lib is None:
             if self._preloadCoreXS:
                 runLog.info(
-                    "Loading an existing ISOTXS microscopic cross section library"
+                    "A microscopic cross sections library is not already "
+                    f"provided on {self}. Because `genXS` is disabled, an "
+                    "existing `ISOTXS` microscopic cross section library "
+                    "within the working directory is being loaded instead."
                 )
                 self._lib = nuclearDataIO.ISOTXS()
             else:

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -293,9 +293,20 @@ class Core(composites.Composite):
     @property
     def lib(self):
         """"Get the microscopic cross section library."""
-        if self._lib is None and self._preloadCoreXS:
-            runLog.info(f"Loading existing ISOTXS microscopic cross section library")
-            self._lib = nuclearDataIO.ISOTXS()
+        if self._lib is None:
+            if self._preloadCoreXS:
+                runLog.info(
+                    "Loading an existing ISOTXS microscopic cross section library"
+                )
+                self._lib = nuclearDataIO.ISOTXS()
+            else:
+                raise ValueError(
+                    f"A microscopic cross section library has not been loaded onto {self}. "
+                    "Either enable an interface to create a cross section library or enable "
+                    "the `preloadCoreXS` setting and place an existing `ISOTXS` file in the "
+                    "working directory."
+                )
+
         return self._lib
 
     @lib.setter

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -293,8 +293,9 @@ class Core(composites.Composite):
     def lib(self):
         """"Get the microscopic cross section library."""
         if self._lib is None:
-            runLog.info("Loading microscopic cross section library ISOTXS")
-            self._lib = nuclearDataIO.ISOTXS()
+            runLog.warning(
+                f"A cross section library has not yet been assigned to {self}."
+            )
         return self._lib
 
     @lib.setter

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -32,8 +32,8 @@ import time
 import numpy
 
 import armi
-from armi import nuclearDataIO
 from armi import runLog
+from armi import nuclearDataIO
 from armi import settings
 from armi.reactor import assemblies
 from armi.reactor import assemblyLists
@@ -66,7 +66,6 @@ class Reactor(composites.Composite):
 
     def __init__(self, name, blueprints):
         composites.Composite.__init__(self, "R-{}".format(name))
-
         self.o = None
         self.spatialGrid = None
         self.spatialLocator = None
@@ -214,6 +213,7 @@ class Core(composites.Composite):
         self._circularRingPitch = 1.0
         self._automaticVariableMesh = False
         self._minMeshSizeRatio = 0.15
+        self._libPath = None
 
     def setOptionsFromCs(self, cs):
         # these are really "user modifiable modeling constants"
@@ -224,6 +224,7 @@ class Core(composites.Composite):
         self._circularRingPitch = cs["circularRingPitch"]
         self._automaticVariableMesh = cs["automaticVariableMesh"]
         self._minMeshSizeRatio = cs["minMeshSizeRatio"]
+        self._libPath = cs["initialXSFilePath"]
 
     def __getstate__(self):
         """Applies a settings and parent to the core and components. """
@@ -293,9 +294,10 @@ class Core(composites.Composite):
     def lib(self):
         """"Get the microscopic cross section library."""
         if self._lib is None:
-            runLog.warning(
-                f"A cross section library has not yet been assigned to {self}."
+            runLog.info(
+                f"Loading microscopic cross section library from {self._libPath}"
             )
+            self._lib = nuclearDataIO.ISOTXS(self._libPath)
         return self._lib
 
     @lib.setter

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -213,7 +213,7 @@ class Core(composites.Composite):
         self._circularRingPitch = 1.0
         self._automaticVariableMesh = False
         self._minMeshSizeRatio = 0.15
-        self._libPath = None
+        self._preloadCoreXS = False
 
     def setOptionsFromCs(self, cs):
         # these are really "user modifiable modeling constants"
@@ -224,7 +224,7 @@ class Core(composites.Composite):
         self._circularRingPitch = cs["circularRingPitch"]
         self._automaticVariableMesh = cs["automaticVariableMesh"]
         self._minMeshSizeRatio = cs["minMeshSizeRatio"]
-        self._libPath = cs["initialXSFilePath"]
+        self._preloadCoreXS = cs["preloadCoreXS"]
 
     def __getstate__(self):
         """Applies a settings and parent to the core and components. """
@@ -293,11 +293,9 @@ class Core(composites.Composite):
     @property
     def lib(self):
         """"Get the microscopic cross section library."""
-        if self._lib is None:
-            runLog.info(
-                f"Loading microscopic cross section library from {self._libPath}"
-            )
-            self._lib = nuclearDataIO.ISOTXS(self._libPath)
+        if self._lib is None and self._preloadCoreXS:
+            runLog.info(f"Loading existing ISOTXS microscopic cross section library")
+            self._lib = nuclearDataIO.ISOTXS()
         return self._lib
 
     @lib.setter

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -17,6 +17,7 @@ testing for reactors.py
 import copy
 import os
 import unittest
+import shutil
 
 from six.moves import cPickle
 from numpy.testing import assert_allclose, assert_equal
@@ -597,13 +598,14 @@ class HexReactorTests(_ReactorTests):
         # By default there should be no XS library
         # assigned to the core during initialization.
         o = buildOperatorOfEmptyHexBlocks()
-        with self.assertRaises(FileNotFoundError):
-            _lib = o.r.core.lib
+        self.assertIsNone(o.r.core.lib)
 
-        o = buildOperatorOfEmptyHexBlocks(
-            customSettings={"initialXSFilePath": ISOAA_PATH}
-        )
+        # Copy over an existing ISOTXS into the working directory to
+        # be preloaded onto the core.
+        shutil.copy(ISOAA_PATH, "ISOTXS")
+        o = buildOperatorOfEmptyHexBlocks(customSettings={"preloadCoreXS": True})
         self.assertTrue(isinstance(o.r.core.lib, xsLibraries.IsotxsLibrary))
+        os.remove("ISOTXS")
 
 
 class CartesianReactorTests(_ReactorTests):

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -598,7 +598,8 @@ class HexReactorTests(_ReactorTests):
         # By default there should be no XS library
         # assigned to the core during initialization.
         o = buildOperatorOfEmptyHexBlocks()
-        self.assertIsNone(o.r.core.lib)
+        with self.assertRaises(ValueError):
+            _lib = o.r.core.lib
 
         # Copy over an existing ISOTXS into the working directory to
         # be preloaded onto the core.

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -597,14 +597,14 @@ class HexReactorTests(_ReactorTests):
     def test_initializeCoreWithISOTXS(self):
         # By default there should be no XS library
         # assigned to the core during initialization.
-        o = buildOperatorOfEmptyHexBlocks()
+        o = buildOperatorOfEmptyHexBlocks(customSettings={"genXS": "neutron"})
         with self.assertRaises(ValueError):
             _lib = o.r.core.lib
 
         # Copy over an existing ISOTXS into the working directory to
         # be preloaded onto the core.
         shutil.copy(ISOAA_PATH, "ISOTXS")
-        o = buildOperatorOfEmptyHexBlocks(customSettings={"preloadCoreXS": True})
+        o = buildOperatorOfEmptyHexBlocks(customSettings={"genXS": ""})
         self.assertTrue(isinstance(o.r.core.lib, xsLibraries.IsotxsLibrary))
         os.remove("ISOTXS")
 

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -113,7 +113,6 @@ CONF_DEFERRED_INTERFACE_NAMES = "deferredInterfaceNames"
 CONF_OUTPUT_CACHE_LOCATION = "outputCacheLocation"
 CONF_MATERIAL_NAMESPACE_ORDER = "materialNamespaceOrder"
 CONF_DETAILED_AXIAL_EXPANSION = "detailedAxialExpansion"
-CONF_HEX_RING_GEOMETRY_CONVERSION = "hexRingGeometryConversion"
 
 
 def defineSettings() -> List[setting.Setting]:
@@ -713,12 +712,6 @@ def defineSettings() -> List[setting.Setting]:
                 "This allows users to specify to get materials out of a plugin rather "
                 "than from the framework."
             ),
-        ),
-        setting.Setting(
-            CONF_HEX_RING_GEOMETRY_CONVERSION,
-            default=False,
-            label="Convert Using Hexagonal Ring Zones",
-            description="Convert the core geometry model to RZ/RZT using hexagonal ring zones. Note: If this is disabled, circular ring zones will be used.",
         ),
     ]
     return settings

--- a/armi/settings/fwSettings/xsSettings.py
+++ b/armi/settings/fwSettings/xsSettings.py
@@ -18,7 +18,7 @@ from armi.settings import setting
 
 
 CONF_CLEAR_XS = "clearXS"
-CONF_INITIAL_XS_FILE_PATH = "initialXSFilePath"
+CONF_PRELOAD_CORE_XS = "preloadCoreXS"
 CONF_DPA_XS_DIRECTORY_PATH = "DPAXSDirectoryPath"
 CONF_MINIMUM_FISSILE_FRACTION = "minimumFissileFraction"
 CONF_MINIMUM_NUCLIDE_DENSITY = "minimumNuclideDensity"
@@ -43,12 +43,12 @@ def defineSettings():
             description="Delete all cross section libraries before regenerating them.",
         ),
         setting.Setting(
-            CONF_INITIAL_XS_FILE_PATH,
-            default="",
-            label="XS File Path",
+            CONF_PRELOAD_CORE_XS,
+            default=False,
+            label="Preload Core XS",
             description=(
-                "Path to a valid ISOTXS XS file to load onto the core library attribute during construction. "
-                "This is helpful for analyses where the lattice physics interface is not being run and XS are still needed."
+                "When enabled, the ISOTXS in the working directory will be loaded onto the core. "
+                "This is useful when a XS set is not being generated explicitly, but XS data is still needed for the analysis. "
             ),
         ),
         setting.Setting(

--- a/armi/settings/fwSettings/xsSettings.py
+++ b/armi/settings/fwSettings/xsSettings.py
@@ -18,7 +18,6 @@ from armi.settings import setting
 
 
 CONF_CLEAR_XS = "clearXS"
-CONF_PRELOAD_CORE_XS = "preloadCoreXS"
 CONF_DPA_XS_DIRECTORY_PATH = "DPAXSDirectoryPath"
 CONF_MINIMUM_FISSILE_FRACTION = "minimumFissileFraction"
 CONF_MINIMUM_NUCLIDE_DENSITY = "minimumNuclideDensity"
@@ -41,15 +40,6 @@ def defineSettings():
             default=False,
             label="Clear XS",
             description="Delete all cross section libraries before regenerating them.",
-        ),
-        setting.Setting(
-            CONF_PRELOAD_CORE_XS,
-            default=False,
-            label="Preload Core XS",
-            description=(
-                "When enabled, the ISOTXS in the working directory will be loaded onto the core. "
-                "This is useful when a XS set is not being generated explicitly, but XS data is still needed for the analysis. "
-            ),
         ),
         setting.Setting(
             CONF_DPA_XS_DIRECTORY_PATH,

--- a/armi/settings/fwSettings/xsSettings.py
+++ b/armi/settings/fwSettings/xsSettings.py
@@ -18,6 +18,7 @@ from armi.settings import setting
 
 
 CONF_CLEAR_XS = "clearXS"
+CONF_INITIAL_XS_FILE_PATH = "initialXSFilePath"
 CONF_DPA_XS_DIRECTORY_PATH = "DPAXSDirectoryPath"
 CONF_MINIMUM_FISSILE_FRACTION = "minimumFissileFraction"
 CONF_MINIMUM_NUCLIDE_DENSITY = "minimumNuclideDensity"
@@ -40,6 +41,15 @@ def defineSettings():
             default=False,
             label="Clear XS",
             description="Delete all cross section libraries before regenerating them.",
+        ),
+        setting.Setting(
+            CONF_INITIAL_XS_FILE_PATH,
+            default="",
+            label="XS File Path",
+            description=(
+                "Path to a valid ISOTXS XS file to load onto the core library attribute during construction. "
+                "This is helpful for analyses where the lattice physics interface is not being run and XS are still needed."
+            ),
         ),
         setting.Setting(
             CONF_DPA_XS_DIRECTORY_PATH,


### PR DESCRIPTION
A bug was found using the circular ring mode when converting between
the hex reactor to the rz reactor where total, fissile, and heavy metal
masses were not always being preserved. The circular ring mode conversions
were never used in practice, but having this available as an option could
lead to future issues for users.

Additionally, the `hexRingGeometryConversion` setting is being removed
since this is implied as the default behavior in `getAssembliesInRing`
on the core. This default is overwritten using the `circularRingMode`
setting.

Finally, the core.lib was assuming the existence of an `ISOTXS` file
in the working directory if it was not explicitly assigned. This is
generally not good practice as a cross section set from previous core
state could be accidently read in without the user realizing it. This is
being changed to happen explicitly only when `genXS` is not set versus
always implicitly being loaded. The library loading still occurs when `core.lib`
is called.