### PR TITLE
Removing Outdated Database Settings

### DIFF
--- a/armi/settings/fwSettings/databaseSettings.py
+++ b/armi/settings/fwSettings/databaseSettings.py
@@ -20,18 +20,7 @@ from armi.settings import setting
 CONF_DB = "db"
 CONF_DEBUG_DB = "debugDB"
 CONF_RELOAD_DB_NAME = "reloadDBName"
-CONF_BLOCK_TYPES_TO_IGNORE_ON_DB_LOADING = "blockTypesToIgnoreOnDBLoading"
-CONF_BLOCK_PARAMETER_NAMES_TO_IGNORE_ON_DB_LOADING = (
-    "blockParameterNamesToIgnoreOnDBLoading"
-)
-CONF_BLOCK_PARAMETER_NAMES_TO_INCLUDE_ON_DB_LOADING = (
-    "blockParameterNamesToIncludeOnDBLoading"
-)
-CONF_UPDATE_MASS_FRACTIONS_FROM_DB = "updateMassFractionsFromDB"
 CONF_LOAD_FROM_DB_EVERY_NODE = "loadFromDBEveryNode"
-CONF_UPDATE_INDIVIDUAL_ASSEMBLY_NUMBERS_ON_DB_LOAD = (
-    "updateIndividualAssemblyNumbersOnDbLoad"
-)
 CONF_DB_STORAGE_AFTER_CYCLE = "dbStorageAfterCycle"
 CONF_ZERO_OUT_NUCLIDES_NOT_IN_DB = "zeroOutNuclidesNotInDB"
 CONF_SYNC_AFTER_WRITE = "syncDbAfterWrite"
@@ -53,40 +42,10 @@ def defineSettings():
             description="Name of the database file to load initial conditions from",
         ),
         setting.Setting(
-            CONF_BLOCK_TYPES_TO_IGNORE_ON_DB_LOADING,
-            default=[],
-            label="Excluded Block Types",
-            description="Block types to exclude when loading the database",
-        ),
-        setting.Setting(
-            CONF_BLOCK_PARAMETER_NAMES_TO_IGNORE_ON_DB_LOADING,
-            default=[],
-            label="Excluded Block Parameters",
-            description="Block parameter data (names) to exclude when loading from the database",
-        ),
-        setting.Setting(
-            CONF_BLOCK_PARAMETER_NAMES_TO_INCLUDE_ON_DB_LOADING,
-            default=[],
-            label="Exclusive Block Parameters",
-            description="Block parameter data (names) to load from the database",
-        ),
-        setting.Setting(
-            CONF_UPDATE_MASS_FRACTIONS_FROM_DB,
-            default=True,
-            label="Update Mass Fractions on Load",
-            description="Update the mass fractions when loading from the database",
-        ),
-        setting.Setting(
             CONF_LOAD_FROM_DB_EVERY_NODE,
             default=False,
             label="Load Database at EveryNode",
             description="Every node loaded from reference database",
-        ),
-        setting.Setting(
-            CONF_UPDATE_INDIVIDUAL_ASSEMBLY_NUMBERS_ON_DB_LOAD,
-            default=True,
-            label="Update Assembly Numbers on Load",
-            description="When a DB is loaded, this will update assembly numbers as well as other state",
         ),
         setting.Setting(
             CONF_DB_STORAGE_AFTER_CYCLE,


### PR DESCRIPTION
Several database settings are no longer in use due to the transition to the new database format and are being removed.