### PR TITLE
Add auto-generated tables of Parameter docs

### DIFF
--- a/doc/user/assembly_parameters_report.rst
+++ b/doc/user/assembly_parameters_report.rst
@@ -1,0 +1,15 @@
+Assembly Parameters
+===================
+This document lists all of the Assembly Parameters that are provided by the ARMI
+Framework and included plugins.
+
+.. exec::
+   from armi.reactor import assemblies
+   from armi.reactor import assemblyParameters
+   from armi.reactor import parameters
+
+   return parameters.generateTable(
+       assemblies.Assembly, assemblyParameters.getAssemblyParameterDefinitions()
+   )
+
+

--- a/doc/user/block_parameters_report.rst
+++ b/doc/user/block_parameters_report.rst
@@ -1,0 +1,15 @@
+Block Parameters
+================
+This document lists all of the Block Parameters that are provided by the ARMI
+Framework and included plugins.
+
+.. exec::
+   from armi.reactor import blocks
+   from armi.reactor import blockParameters
+   from armi.reactor import parameters
+
+   return parameters.generateTable(
+       blocks.Block, blockParameters.getBlockParameterDefinitions()
+   )
+
+

--- a/doc/user/core_parameters_report.rst
+++ b/doc/user/core_parameters_report.rst
@@ -1,0 +1,14 @@
+Core Parameters
+===============
+This document lists all of the Core Parameters that are provided by the ARMI
+Framework and included plugins.
+
+.. exec::
+   from armi.reactor import reactors
+   from armi.reactor import reactorParameters
+   from armi.reactor import parameters
+
+   return parameters.generateTable(
+       reactors.Core, reactorParameters.defineCoreParameters()
+   )
+

--- a/doc/user/index.rst
+++ b/doc/user/index.rst
@@ -17,4 +17,8 @@ analyzing ARMI output files,
    inputs/index
    outputs/index
    manual_data_access
+   reactor_parameters_report
+   core_parameters_report
+   assembly_parameters_report
+   block_parameters_report
    assorted_guide

--- a/doc/user/reactor_parameters_report.rst
+++ b/doc/user/reactor_parameters_report.rst
@@ -1,0 +1,14 @@
+Reactor Parameters
+==================
+This document lists all of the Reactor Parameters that are provided by the ARMI
+Framework and included plugins.
+
+.. exec::
+   from armi.reactor import reactors
+   from armi.reactor import reactorParameters
+   from armi.reactor import parameters
+
+   return parameters.generateTable(
+       reactors.Reactor, reactorParameters.defineReactorParameters()
+   )
+


### PR DESCRIPTION
This will take some tweaking to make them more pretty, but this gets us started.
There is now a function in the parameters package that generates text for a rst
list-table for each Plugin and and the passed ArmiObject subclass. Tables are
generated for all Plugins that are registered with the passed App. Then, this
function is used to generate tables for Reactor, Core, Assembly, and Block.
