### PR TITLE
Add FlagType type alas

### DIFF
--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -83,13 +83,13 @@ True
 import re
 from typing import Any, Dict, Optional, Sequence, Union
 
-from armi.utils.flags import Flag, auto
+from armi.utils.flags import Flag, FlagType, auto
 
 
 # Type alias used for passing type specifications to many of the composite methods. See
 # Composite::hasFlags() to understand the semantics for how TypeSpecs are interpreted.
 # Anything that interprets a TypeSpec should apply the same semantics.
-TypeSpec = Optional[Union[Flag, Sequence[Flag]]]
+TypeSpec = Optional[Union[FlagType, Sequence[FlagType]]]
 
 
 def __fromStringGeneral(cls, typeSpec, updateMethod):

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -312,3 +312,9 @@ class Flag(metaclass=_FlagMeta):
 
     def __hash__(self):
         return hash(self._value)
+
+# Type alias to reliably check for a proper Flag type. This cannot just be `Flag`, since
+# mypy gets confused by `auto` because it doesn't go to the trouble of resolving them in
+# the metaclass.
+FlagType = Union[Flag, auto]
+


### PR DESCRIPTION
This helps with mypy type checking to consider the `flags.auto` class as
counting as a Flag.