### PR TITLE
Partially revert "Fixes to Circular Ring HEX to RZ Conversion and Pre…

### DIFF
--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -392,9 +392,6 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
             )
             # Now recalculate derived params with the mapped flux to minimize
             # potential numerical diffusion (e.g. control rod tip into large coolant)
-
-        if destReactor.core.lib is not None:
-            runLog.extra(f"Computing block-level reaction rates for {destReactor.core}")
             for b in aDest:
                 globalFluxInterface.calcReactionRates(
                     b, destReactor.core.p.keff, destReactor.core.lib

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -213,7 +213,6 @@ class Core(composites.Composite):
         self._circularRingPitch = 1.0
         self._automaticVariableMesh = False
         self._minMeshSizeRatio = 0.15
-        self._preloadCoreXS = False
 
     def setOptionsFromCs(self, cs):
         # these are really "user modifiable modeling constants"
@@ -224,7 +223,6 @@ class Core(composites.Composite):
         self._circularRingPitch = cs["circularRingPitch"]
         self._automaticVariableMesh = cs["automaticVariableMesh"]
         self._minMeshSizeRatio = cs["minMeshSizeRatio"]
-        self._preloadCoreXS = True if not cs["genXS"] else False
 
     def __getstate__(self):
         """Applies a settings and parent to the core and components. """
@@ -294,22 +292,8 @@ class Core(composites.Composite):
     def lib(self):
         """"Get the microscopic cross section library."""
         if self._lib is None:
-            if self._preloadCoreXS:
-                runLog.info(
-                    "A microscopic cross sections library is not already "
-                    f"provided on {self}. Because `genXS` is disabled, an "
-                    "existing `ISOTXS` microscopic cross section library "
-                    "within the working directory is being loaded instead."
-                )
-                self._lib = nuclearDataIO.ISOTXS()
-            else:
-                raise ValueError(
-                    f"A microscopic cross section library has not been loaded onto {self}. "
-                    "Either enable an interface to create a cross section library or enable "
-                    "the `preloadCoreXS` setting and place an existing `ISOTXS` file in the "
-                    "working directory."
-                )
-
+            runLog.info("Loading microscopic cross section library ISOTXS")
+            self._lib = nuclearDataIO.ISOTXS()
         return self._lib
 
     @lib.setter

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -17,7 +17,6 @@ testing for reactors.py
 import copy
 import os
 import unittest
-import shutil
 
 from six.moves import cPickle
 from numpy.testing import assert_allclose, assert_equal
@@ -29,7 +28,6 @@ from armi import operators
 from armi import runLog
 from armi import settings
 from armi import tests
-from armi.tests import ISOAA_PATH
 from armi.reactor.flags import Flags
 from armi.reactor import assemblies
 from armi.reactor import blocks
@@ -41,7 +39,6 @@ from armi.reactor.converters import geometryConverters
 from armi.tests import TEST_ROOT, ARMI_RUN_PATH
 from armi.utils import directoryChangers
 from armi.physics.neutronics import isotopicDepletion
-from armi.nuclearDataIO import xsLibraries
 
 TEST_REACTOR = None  # pickled string of test reactor (for fast caching)
 
@@ -593,20 +590,6 @@ class HexReactorTests(_ReactorTests):
             aNew3.getFirstBlock(Flags.FUEL).getUraniumMassEnrich(), 0.195
         )
         self.assertAlmostEqual(aNew3.getMass(), bol.getMass() / 3.0)
-
-    def test_initializeCoreWithISOTXS(self):
-        # By default there should be no XS library
-        # assigned to the core during initialization.
-        o = buildOperatorOfEmptyHexBlocks(customSettings={"genXS": "neutron"})
-        with self.assertRaises(ValueError):
-            _lib = o.r.core.lib
-
-        # Copy over an existing ISOTXS into the working directory to
-        # be preloaded onto the core.
-        shutil.copy(ISOAA_PATH, "ISOTXS")
-        o = buildOperatorOfEmptyHexBlocks(customSettings={"genXS": ""})
-        self.assertTrue(isinstance(o.r.core.lib, xsLibraries.IsotxsLibrary))
-        os.remove("ISOTXS")
 
 
 class CartesianReactorTests(_ReactorTests):


### PR DESCRIPTION
…loading ISOTXS on Core (#79)"

This reverts the parts of commit
8be2e6f9bc7f10d070e9e90ce0547b10eb61f729 related to handling reactor
ISOTXS objects. This change caused more knock-on effects than
anticipated, and introduced some bugs. Need to rethink. Also,
specifically introduced an indentation-related bug ca. line 395 of
uniformMesh.py.