### PR TITLE
Add run-suite entry point for local param sweeps

### DIFF
--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -155,6 +155,7 @@ class SuiteBuilder(object):
                     )
 
                 previousMods.append(type(mod))
+                case.bp._prepConstruction(case.cs)
                 mod(case.cs, case.bp, case.geom)
                 case.independentVariables.update(mod.independentVariable)
 

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -64,6 +64,7 @@ class EntryPointsPlugin(plugins.ArmiPlugin):
             backupDatabases,
             cleanTemps,
             database,
+            runSuite,
         )
 
         entryPoints = []
@@ -76,6 +77,7 @@ class EntryPointsPlugin(plugins.ArmiPlugin):
         entryPoints.append(migrateInputs.MigrateInputs)
         entryPoints.append(modify.ModifyCaseSettingsCommand)
         entryPoints.append(run.RunEntryPoint)
+        entryPoints.append(runSuite.RunSuiteCommand)
 
         # testing
         entryPoints.append(backupDatabases.BackUpInUseTestDabases)

--- a/armi/cli/run.py
+++ b/armi/cli/run.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 """Run ARMI."""
-import six
-
 import armi
 from armi.cli.entryPoint import EntryPoint
 

--- a/armi/cli/runSuite.py
+++ b/armi/cli/runSuite.py
@@ -1,0 +1,98 @@
+# Copyright 2020 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run multiple ARMI cases one after the other on the local machine."""
+import os
+
+import tabulate
+
+from armi.cli.run import RunEntryPoint
+from armi import cases
+from armi.utils import directoryChangers
+from armi import runLog
+from armi import settings
+
+
+class RunSuiteCommand(RunEntryPoint):
+    """
+    Recursively run all the cases in a suite one after the other on the local machine.
+
+    Invoke with ``mpirun`` or ``mpiexec`` to activate parallelism within each individual case.
+    """
+
+    name = "run-suite"
+
+    def addOptions(self):
+        RunEntryPoint.addOptions(self)
+        self.parser.add_argument(
+            "patterns",
+            nargs="*",
+            type=str,
+            default=["*.yaml"],
+            help="Pattern to use while searching for ARMI settings files.",
+        )
+        self.parser.add_argument(
+            "--ignore",
+            "-i",
+            nargs="+",
+            type=str,
+            default=[],
+            help="Pattern to search for inputs to ignore.",
+        )
+        self.parser.add_argument(
+            "--list",
+            "-l",
+            action="store_true",
+            default=False,
+            help="Just list the settings files found, don't actually submit them.",
+        )
+        self.parser.add_argument(
+            "--suiteDir",
+            type=str,
+            default=os.getcwd(),
+            help=(
+                "The path containing the case suite to submit. Default current "
+                "working directory."
+            ),
+        )
+
+    def invoke(self):
+        with directoryChangers.DirectoryChanger(
+            self.args.suiteDir, dumpOnException=False
+        ):
+            suite = cases.CaseSuite(self.cs)
+            suite.discover(patterns=self.args.patterns, ignorePatterns=self.args.ignore)
+            if self.args.list:
+                runLog.important("Found the following settings ")
+                tableData = []
+                for case in suite:
+                    tableData.append(
+                        (
+                            case.title,
+                            case.cs.path,
+                            ",".join(pp.title for pp in case.dependencies),
+                        )
+                    )
+                runLog.important(
+                    tabulate.tabulate(
+                        tableData,
+                        headers=["Case title", "Settings path", "Parent tasks"],
+                    )
+                )
+            else:
+                for ci, case in enumerate(suite):
+                    runLog.important(f"Running case {ci+1}/{len(suite)}: {case}")
+                    with directoryChangers.DirectoryChanger(case.directory):
+                        settings.setMasterCs(case.cs)
+                        case.run()

--- a/armi/cli/runSuite.py
+++ b/armi/cli/runSuite.py
@@ -55,14 +55,14 @@ class RunSuiteCommand(RunEntryPoint):
             "-l",
             action="store_true",
             default=False,
-            help="Just list the settings files found, don't actually submit them.",
+            help="Just list the settings files found, don't actually run them.",
         )
         self.parser.add_argument(
             "--suiteDir",
             type=str,
             default=os.getcwd(),
             help=(
-                "The path containing the case suite to submit. Default current "
+                "The path containing the case suite to run. Default current "
                 "working directory."
             ),
         )
@@ -74,22 +74,7 @@ class RunSuiteCommand(RunEntryPoint):
             suite = cases.CaseSuite(self.cs)
             suite.discover(patterns=self.args.patterns, ignorePatterns=self.args.ignore)
             if self.args.list:
-                runLog.important("Found the following settings ")
-                tableData = []
-                for case in suite:
-                    tableData.append(
-                        (
-                            case.title,
-                            case.cs.path,
-                            ",".join(pp.title for pp in case.dependencies),
-                        )
-                    )
-                runLog.important(
-                    tabulate.tabulate(
-                        tableData,
-                        headers=["Case title", "Settings path", "Parent tasks"],
-                    )
-                )
+                suite.echoConfiguration()
             else:
                 for ci, case in enumerate(suite):
                     runLog.important(f"Running case {ci+1}/{len(suite)}: {case}")

--- a/armi/cli/tests/testRunSuite.py
+++ b/armi/cli/tests/testRunSuite.py
@@ -1,0 +1,29 @@
+"""
+Test for runsuite cli entry point
+"""
+import unittest
+
+import sys
+import io
+
+
+class TestRunSuiteSuite(unittest.TestCase):
+    def testListCommand(self):
+        """Ensure run-suite entry point is registered."""
+        from armi import cli
+
+        cli = cli.ArmiCLI()
+
+        origout = sys.stdout
+        try:
+            out = io.StringIO()
+            sys.stdout = out
+            cli.listCommands()
+        finally:
+            sys.stdout = origout
+        self.assertIn("run-suite", out.getvalue())
+
+
+if __name__ == "__main__":
+    # import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/armi/cli/tests/test_runSuite.py
+++ b/armi/cli/tests/test_runSuite.py
@@ -8,7 +8,7 @@ import io
 
 
 class TestRunSuiteSuite(unittest.TestCase):
-    def testListCommand(self):
+    def test_listCommand(self):
         """Ensure run-suite entry point is registered."""
         from armi import cli
 


### PR DESCRIPTION
A run-suite entry point is now provided, similar to the submit-suite
entry point available in some apps. This entry point runs all cases of a
suite one after the other, on the local machine. It is useful for
situations where a HPC is not available but a big workstation is.

Relatedly, some issues with paths in the parameter sweep system were
dealt with by allowing plugins to provide relative glob patterns that
are expanded at a higher level. This simplifies some plugin code (e.g.
when lattice physics specifies ISOTXS files) and makes the param sweep
system more capable.