### PR TITLE
Add location-based history tracking on Database3

### DIFF
--- a/armi/bookkeeping/db/__init__.py
+++ b/armi/bookkeeping/db/__init__.py
@@ -45,10 +45,12 @@ fix bugs.
 
 Being a serialization format, the code associated with reading and writing database
 files may not benefit from Don't Repeat Yourself (DRY) practices in the same way as
-other code. Therefore, we do not share much code between different major versions of the
-databases. Minor revisions (e.g. M.(N+1)) to the database structure should be simple
-enough that specialized logic can be used to support all minor versions without posing a
-maintenance burden. A detailed change log should be maintained of each minor revision.
+other code. Therefore, we do not share much, if any, code between different major
+versions of the databases. As such, new major-versioned database implementations should
+exist in their own modules. Minor revisions (e.g. M.(N+1)) to the database structure
+should be simple enough that specialized logic can be used to support all minor versions
+without posing a maintenance burden. A detailed change log should be maintained of each
+minor revision.
 """
 import os
 from typing import Optional, List, Tuple

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1262,7 +1262,7 @@ class Database3(database.Database):
         # All locations must have the same parent and bear the same relationship to the
         # anchor object
         anchors = {
-            obj.getAncestorWithDistance(lambda a: isinstance(a, Core)) for obj in comps
+            obj.getAncestorAndDistance(lambda a: isinstance(a, Core)) for obj in comps
         }
 
         if len(anchors) != 1:

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1256,7 +1256,6 @@ class Database3(database.Database):
             )
         anchor, anchorDistance = anchors.pop()
         anchorSerialNum = anchor.p.serialNum
-        print(anchor, anchorSerialNum)
 
         # All objects of the same type
         objectTypes = {type(obj) for obj in comps}

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -207,8 +207,6 @@ class TestDatabase3(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.db.getHistoriesByLocation([testAssem, testBlock], params=["serialNum"])
 
-        raise Exception("wrench")
-
     def test_replaceNones(self):
         """
         This definitely needs some work.

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -74,7 +74,6 @@ class TestDatabase3(unittest.TestCase):
             a2.moveTo(olda1Loc)
             c = self.r.core.childrenByLocator[grid[0, 0, 0]]
             self.centralAssemSerialNums.append(c.p.serialNum)
-            print(type(c), type(c[-1]))
             self.centralTopBlockSerialNums.append(c[-1].p.serialNum)
 
             for node in range(3):
@@ -85,8 +84,6 @@ class TestDatabase3(unittest.TestCase):
                 self.r.p.cycleLength = cycle
 
                 self.db.writeToDB(self.r)
-        print(self.centralAssemSerialNums)
-        print(self.centralTopBlockSerialNums)
 
     def _compareArrays(self, ref, src):
         """
@@ -189,7 +186,6 @@ class TestDatabase3(unittest.TestCase):
         grid = self.r.core.spatialGrid
         testAssem = self.r.core.childrenByLocator[grid[0, 0, 0]]
         testBlock = testAssem[-1]
-        print(testBlock.p.serialNum)
 
         # Test assem
         hist = self.db.getHistoryByLocation(
@@ -210,12 +206,6 @@ class TestDatabase3(unittest.TestCase):
         # cant mix blocks and assems, since they are different distance from core
         with self.assertRaises(ValueError):
             self.db.getHistoriesByLocation([testAssem, testBlock], params=["serialNum"])
-
-        import pprint
-
-        pp = pprint.PrettyPrinter(indent=2, width=1000)
-        pp.pprint(hist)
-        pp.pprint(hists)
 
         raise Exception("wrench")
 

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -17,7 +17,8 @@ import unittest
 import numpy
 import h5py
 
-from armi.bookkeeping.db import database3 as database
+from armi.bookkeeping import db
+from armi.bookkeeping.db import database3
 from armi.reactor import grids
 from armi.reactor.tests import test_reactors
 
@@ -27,9 +28,13 @@ from armi.tests import TEST_ROOT
 class TestDatabase3(unittest.TestCase):
     def setUp(self):
         self.o, self.r = test_reactors.loadTestReactor(TEST_ROOT)
-        self.db = database.Database3(self._testMethodName + ".h5", "w")
+        self.db: db.Database3 = db.Database3(self._testMethodName + ".h5", "w")
         self.db.open()
         self.stateRetainer = self.r.retainState().__enter__()
+
+        # used to test location-based history. see details below
+        self.centralAssemSerialNums = []
+        self.centralTopBlockSerialNums = []
 
     def tearDown(self):
         self.db.close()
@@ -47,6 +52,41 @@ class TestDatabase3(unittest.TestCase):
             self.r.p.cycleLength = cycle
 
             self.db.writeToDB(self.r)
+
+    def makeShuffleHistory(self):
+        """
+        Walk the reactor through a few time steps with some shuffling.
+        """
+        # Serial numbers *are not stable* (i.e., they can be different between test runs
+        # due to parallelism and test run order). However, they are the simplest way to
+        # check correctness of location-based history tracking. So we stash the serial
+        # numbers at the location of interest so that we can use them later to check our
+        # work.
+        self.centralAssemSerialNums = []
+        self.centralTopBlockSerialNums = []
+
+        grid = self.r.core.spatialGrid
+        for cycle in range(3):
+            a1 = self.r.core.childrenByLocator[grid[cycle, 0, 0]]
+            a2 = self.r.core.childrenByLocator[grid[0, 0, 0]]
+            olda1Loc = a1.spatialLocator
+            a1.moveTo(a2.spatialLocator)
+            a2.moveTo(olda1Loc)
+            c = self.r.core.childrenByLocator[grid[0, 0, 0]]
+            self.centralAssemSerialNums.append(c.p.serialNum)
+            print(type(c), type(c[-1]))
+            self.centralTopBlockSerialNums.append(c[-1].p.serialNum)
+
+            for node in range(3):
+                self.r.p.cycle = cycle
+                self.r.p.timeNode = node
+                # something that splitDatabase won't change, so that we can make sure
+                # that the right data went to the right new groups/cycles
+                self.r.p.cycleLength = cycle
+
+                self.db.writeToDB(self.r)
+        print(self.centralAssemSerialNums)
+        print(self.centralTopBlockSerialNums)
 
     def _compareArrays(self, ref, src):
         """
@@ -73,9 +113,111 @@ class TestDatabase3(unittest.TestCase):
         """
         Make sure that data is unchanged by packing/unpacking.
         """
-        packed, attrs = database.packSpecialData(data, "testing")
-        roundTrip = database.unpackSpecialData(packed, attrs, "testing")
+        packed, attrs = database3.packSpecialData(data, "testing")
+        roundTrip = database3.unpackSpecialData(packed, attrs, "testing")
         self._compareArrays(data, roundTrip)
+
+    def test_computeParents(self):
+        # The below arrays represent a tree structure like this:
+        #                 71 -----------------------.
+        #                 |                          \
+        #                12--.-----.------.          72
+        #               / |  \      \      \
+        #             22 30  4---.   6      18-.
+        #            / |  |  | \  \        / |  \
+        #           8 17  2 32 52 62      1  9  10
+        #
+        # This should cover a handful of corner cases
+        numChildren = [2, 5, 2, 0, 0, 1, 0, 3, 0, 0, 0, 0, 3, 0, 0, 0, 0]
+        serialNums = [71, 12, 22, 8, 17, 30, 2, 4, 32, 53, 62, 6, 18, 1, 9, 10, 72]
+
+        expected_1 = [None, 71, 12, 22, 22, 12, 30, 12, 4, 4, 4, 12, 12, 18, 18, 18, 71]
+        expected_2 = [
+            None,
+            None,
+            71,
+            12,
+            12,
+            71,
+            12,
+            71,
+            12,
+            12,
+            12,
+            71,
+            71,
+            12,
+            12,
+            12,
+            None,
+        ]
+        expected_3 = [
+            None,
+            None,
+            None,
+            71,
+            71,
+            None,
+            71,
+            None,
+            71,
+            71,
+            71,
+            None,
+            None,
+            71,
+            71,
+            71,
+            None,
+        ]
+
+        self.assertEqual(
+            database3.Layout.computeAncestors(serialNums, numChildren), expected_1
+        )
+        self.assertEqual(
+            database3.Layout.computeAncestors(serialNums, numChildren, 2), expected_2
+        )
+        self.assertEqual(
+            database3.Layout.computeAncestors(serialNums, numChildren, 3), expected_3
+        )
+
+    def test_locationHistory(self) -> None:
+        self.makeShuffleHistory()
+
+        pLoc = self.r.core[0][0].spatialLocator.parentLocation
+        pLoc = self.r.core[0].spatialLocator.parentLocation
+        grid = self.r.core.spatialGrid
+        testAssem = self.r.core.childrenByLocator[grid[0, 0, 0]]
+        testBlock = testAssem[-1]
+        print(testBlock.p.serialNum)
+
+        # Test assem
+        hist = self.db.getHistoryByLocation(
+            testAssem, params=["chargeTime", "serialNum"]
+        )
+        expectedSn = {
+            (c, n): self.centralAssemSerialNums[c] for c in range(3) for n in range(3)
+        }
+        self.assertEqual(expectedSn, hist["serialNum"])
+
+        # test block
+        hists = self.db.getHistoriesByLocation(
+            [testBlock], params=["serialNum"], timeSteps=[(0, 0), (1, 0), (2, 0)]
+        )
+        expectedSn = {(c, 0): self.centralTopBlockSerialNums[c] for c in range(3)}
+        self.assertEqual(expectedSn, hists[testBlock]["serialNum"])
+
+        # cant mix blocks and assems, since they are different distance from core
+        with self.assertRaises(ValueError):
+            self.db.getHistoriesByLocation([testAssem, testBlock], params=["serialNum"])
+
+        import pprint
+
+        pp = pprint.PrettyPrinter(indent=2, width=1000)
+        pp.pprint(hist)
+        pp.pprint(hists)
+
+        raise Exception("wrench")
 
     def test_replaceNones(self):
         """
@@ -110,7 +252,7 @@ class TestDatabase3(unittest.TestCase):
         self.r.p.cycle = 1
         self.r.p.timeNode = 0
         tnGroup = self.db.getH5Group(self.r)
-        database._writeAttrs(
+        database3._writeAttrs(
             tnGroup["layout/serialNum"],
             tnGroup,
             {
@@ -119,7 +261,7 @@ class TestDatabase3(unittest.TestCase):
             },
         )
 
-        db2 = database.Database3("restartDB.h5", "w")
+        db2 = database3.Database3("restartDB.h5", "w")
         with db2:
             db2.mergeHistory(self.db, 2, 2)
             self.r.p.cycle = 1
@@ -133,7 +275,7 @@ class TestDatabase3(unittest.TestCase):
             )
 
             # actually exercise the _resolveAttrs function
-            attrs = database._resolveAttrs(tnGroup["layout/serialNum"].attrs, tnGroup)
+            attrs = database3._resolveAttrs(tnGroup["layout/serialNum"].attrs, tnGroup)
             self.assertTrue(numpy.array_equal(attrs["fakeBigData"], numpy.eye(6400)))
 
     def test_splitDatabase(self):
@@ -150,7 +292,7 @@ class TestDatabase3(unittest.TestCase):
             self.assertTrue(newDb["c00n00/Reactor/cycle"][()] == 0)
             self.assertTrue(newDb["c00n00/Reactor/cycleLength"][()] == 1)
             self.assertTrue("c02n00" not in newDb)
-            self.assertTrue(newDb.attrs["databaseVersion"] == database.DB_VERSION)
+            self.assertTrue(newDb.attrs["databaseVersion"] == database3.DB_VERSION)
 
 
 class Test_LocationPacking(unittest.TestCase):
@@ -162,20 +304,18 @@ class Test_LocationPacking(unittest.TestCase):
         loc3.append(grids.IndexLocation(7, 8, 9, None))
         loc3.append(grids.IndexLocation(10, 11, 12, None))
 
-        tp, data = database._packLocation(loc1)
-        self.assertEqual(tp, database.LOC_INDEX)
-        unpacked = database._unpackLocation([tp], data)
-        self.assertEqual(unpacked[0], (1, 2, 3))
+        locs = [loc1, loc2, loc3]
+        tp, data = database3._packLocations(locs)
 
-        tp, data = database._packLocation(loc2)
-        self.assertEqual(tp, database.LOC_COORD)
-        unpacked = database._unpackLocation([tp], data)
-        self.assertEqual(unpacked[0], (4.0, 5.0, 6.0))
+        self.assertEqual(tp[0], database3.LOC_INDEX)
+        self.assertEqual(tp[1], database3.LOC_COORD)
+        self.assertEqual(tp[2], database3.LOC_MULTI + "2")
 
-        tp, data = database._packLocation(loc3)
-        self.assertEqual(tp, database.LOC_MULTI + "2")
-        unpacked = database._unpackLocation([tp], data)
-        self.assertEqual(unpacked[0], (7, 8, 9))
+        unpackedData = database3._unpackLocations(tp, data)
+
+        self.assertEqual(unpackedData[0], (1, 2, 3))
+        self.assertEqual(unpackedData[1], (4.0, 5.0, 6.0))
+        self.assertEqual(unpackedData[2], (7, 8, 9))
 
 
 if __name__ == "__main__":

--- a/armi/bookkeeping/db/types.py
+++ b/armi/bookkeeping/db/types.py
@@ -15,9 +15,11 @@
 from typing import Dict, Tuple, Any
 
 from armi.reactor.composites import ArmiObject
+from armi.reactor.grids import LocationBase
 
 
 # Return type for the getHistories() method
 #              param       time node      value
 History = Dict[str, Dict[Tuple[int, int], Any]]
 Histories = Dict[ArmiObject, History]
+LocationHistories = Dict[LocationBase, History]

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1392,7 +1392,7 @@ class ArmiObject(metaclass=CompositeModelType):
         else:
             return self.parent.getAncestor(fn)
 
-    def getAncestorWithDistance(
+    def getAncestorAndDistance(
         self, fn, _distance=0
     ) -> Optional[Tuple["ArmiObject", int]]:
         """
@@ -1410,7 +1410,7 @@ class ArmiObject(metaclass=CompositeModelType):
         if self.parent is None:
             return None
         else:
-            return self.parent.getAncestorWithDistance(fn, _distance + 1)
+            return self.parent.getAncestorAndDistance(fn, _distance + 1)
 
     def getAncestorWithFlags(self, typeSpec: TypeSpec, exactMatch=False):
         """

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -152,7 +152,7 @@ class Serializer:
     # This will accompany the packed data as an attribute when written, and will be
     # provided to the unpack() method when reading. If the underlying format of the data
     # changes, make sure to change this.
-    version = None
+    version: Optional[str] = None
 
     @staticmethod
     def pack(data: Sequence[any]) -> Tuple[numpy.ndarray, Dict[str, any]]:

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -44,6 +44,17 @@ class auto:
     specified as well.
     """
 
+    def __iter__(self):
+        """
+        Dummy __iter__ implementation
+
+        This is only needed to make mypy happy when it type checks things that have
+        FlagTypes in them, since these can normally be iterated over, but mypy doesn't
+        know that the metaclass consumes the autos.
+        """
+        raise NotImplementedError("__iter__() is not actually implemented on "
+                "{}; it is only defined to appease mypy.".format(type(self)))
+
 
 class _FlagMeta(type):
     """


### PR DESCRIPTION
This adds the `getHistoryByLocation()` and `getHistoriesByLocation()`
methods to the Database3 class. These are quite similar to their
non-location based siblings, but rather than following an ArmiObject in
the database by serialNum, it does a little extra work to figure out
each object's location, then pull data from the object that is actually
at that location for each time node requested. Other changes:
 - Added some type annotation stuff
 - Added `computeParents()` classmethod to Layout to help make sense of
 the hierarchy without having to fully reconstruct.
 - Added a `getAncestorWithDistance()` method to ArmiObject. This is
 useful for determining not only the ancestor object, but how many
 layers above it happens to be.
 - Moved some methods that should obviously be Composite methods out of
 ArmiObject. There are plenty more that are miscategorized and still
 need moved, but that should be its own thing.