### PR TITLE
Fix bug related to database file path

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -275,7 +275,7 @@ class DatabaseInterface(interfaces.Interface):
         """
         if armi.MPI_RANK > 0:
             # DB may not exist if distribute state is called early.
-            if os.path.exists(self._dbPath):
+            if self._dbPath is not None and os.path.exists(self._dbPath):
                 self._db = Database3(self._dbPath, "r")
                 self._db.open()
 


### PR DESCRIPTION
The path is not guaranteed to be set when interactDistributeState is
called, so it is important to check that there is a non-None path before
asking if the file exists.