### PR TITLE
Consolidating Delayed Neutron Fraction Settings

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -338,7 +338,7 @@ def _cleanupOnCancel(signum, _frame):
     sys.exit(1)  # since we're handling the signal we have to cancel
 
 
-def configure(app: Optional[apps.App]=None):
+def configure(app: Optional[apps.App] = None):
     """
     Set the plugin manager for the Framework and configure internals to those plugins.
 

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1602,7 +1602,7 @@ def _packLocations(
 
 
 def _packLocationsV1(
-    locations: List[grids.LocationBase]
+    locations: List[grids.LocationBase],
 ) -> Tuple[List[str], List[Tuple[int, int, int]]]:
     """Delete when reading v <=3.2 DB's no longer wanted."""
     locTypes = []
@@ -1624,7 +1624,7 @@ def _packLocationsV1(
 
 
 def _packLocationsV2(
-    locations: List[grids.LocationBase]
+    locations: List[grids.LocationBase],
 ) -> Tuple[List[str], List[Tuple[int, int, int]]]:
     """
     Location packing implementation for minor version 3. See release notes above.
@@ -1653,7 +1653,7 @@ def _packLocationsV2(
 
 
 def _packLocationsV3(
-    locations: List[grids.LocationBase]
+    locations: List[grids.LocationBase],
 ) -> Tuple[List[str], List[Tuple[int, int, int]]]:
     """
     Location packing implementation for minor version 4. See release notes above.

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -217,12 +217,10 @@ class TestDatabase3(unittest.TestCase):
 
         # if requested time step isnt written, return no content
         hist = self.dbi.getHistory(
-            self.r.core[0],
-            params=["chargeTime", "serialNum"],
-            byLocation=True
+            self.r.core[0], params=["chargeTime", "serialNum"], byLocation=True
         )
-        self.assertIn((3,0), hist["chargeTime"].keys())
-        self.assertEqual(hist["chargeTime"][(3,0)], 3)
+        self.assertIn((3, 0), hist["chargeTime"].keys())
+        self.assertEqual(hist["chargeTime"][(3, 0)], 3)
 
     def test_replaceNones(self):
         """

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -54,7 +54,7 @@ class EntryPoint:
     """
 
     # The <command-name> that is used to call the command from the command line
-    name : Optional[str] = None
+    name: Optional[str] = None
 
     # A string summarizing the command's actions. This is summary that is printed when
     # you run `python -m armi --list-commands` or `python -m armi <command-name>
@@ -62,7 +62,7 @@ class EntryPoint:
     # instead. In general, the docstring is probably sufficient but this argument allows
     # you to provide a short description of the command while retaining a long and
     # detailed docstring.
-    description : Optional[str] = None
+    description: Optional[str] = None
 
     # One of {'optional', 'required', None}, or unspecified.
     # Specifies whether a settings file argument is to be added to the
@@ -70,11 +70,11 @@ class EntryPoint:
     # file is a required positional argument. If settingsArgument == 'optional',
     # then it is an optional positional argument. Finally, if settingsArgument is
     # None, then no settings file argument is added.
-    settingsArgument : Union[str, None] = None
+    settingsArgument: Union[str, None] = None
 
     # One of {armi.Mode.Batch, armi.Mode.Interactive, armi.Mode.Gui}, optional.
     # Specifies the ARMI mode in which the command is run. Default is armi.Mode.Batch.
-    mode : Optional[int] = None
+    mode: Optional[int] = None
 
     def __init__(self):
         if self.name is None:

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -722,6 +722,7 @@ class FuelMaterial(Material):
 
     All this really does is enable the special class 1/class 2 isotopics input option.
     """
+
     pDefs = materialParameters.getFuelMaterialParameterDefinitions()
 
     def applyInputParams(

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -134,4 +134,3 @@ class Sodium(material.Fluid):
             124.67 - 0.11381 * Tk + 5.5226e-5 * Tk ** 2 - 1.1842e-8 * Tk ** 3
         )
         return thermalConductivity
-

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -535,7 +535,7 @@ class Inconel_TestCase(_Material_Test, unittest.TestCase):
 
     def test_density(self):
         self.assertEqual(self.Inconel.density(), 8.3600)
-        self.assertEqual(self.Inconel800.density(Tc=21.), 7.94)
+        self.assertEqual(self.Inconel800.density(Tc=21.0), 7.94)
         self.assertEqual(self.InconelPE16.density(), 8.00)
 
     def test_Iconel800_linearExpansion(self):
@@ -860,9 +860,10 @@ class Alloy200_TestCase(unittest.TestCase):
 
         self.assertGreater(Alloy200().p.massFrac["NI"], 0.99)
 
+
 class HastelloyN_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.HastelloyN
-    
+
     def test_thermalConductivity(self):
         TcList = [100, 200, 300, 400, 500, 600, 700, 800]
         refList = [
@@ -903,7 +904,6 @@ class HastelloyN_TestCase(_Material_Test, unittest.TestCase):
                 cur, ref
             )
             self.assertAlmostEqual(cur, ref, delta=10e-7, msg=errorMsg)
-
 
     def test_linearExpansionPercent(self):
         TcList = [100, 200, 300, 400, 500, 600, 700, 800]

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -331,6 +331,20 @@ class Inspector:
             "",
             self.NO_ACTION,
         )
+        self.addQuery(
+            lambda: (
+                (
+                    self.cs["beta"]
+                    and isinstance(self.cs["beta"], list)
+                    and not self.cs["decayConstants"]
+                )
+                or (self.cs["decayConstants"] and not self.cs["beta"])
+            ),
+            "Both beta components and decay constants should be provided if either are "
+            "being supplied.",
+            "",
+            self.NO_ACTION,
+        ),
 
         self.addQuery(
             lambda: self.cs["skipCycles"] > 0 and not self.cs["reloadDBName"],

--- a/armi/physics/fuelCycle/__init__.py
+++ b/armi/physics/fuelCycle/__init__.py
@@ -174,15 +174,17 @@ class FuelHandlerPlugin(plugins.ArmiPlugin):
         """
         queries = []
 
-        queries.append(settingsValidation.Query(
-                lambda: bool(inspector.cs["shuffleLogic"]) ^
-                bool(inspector.cs["fuelHandlerName"]),
+        queries.append(
+            settingsValidation.Query(
+                lambda: bool(inspector.cs["shuffleLogic"])
+                ^ bool(inspector.cs["fuelHandlerName"]),
                 "A value was provided for `fuelHandlerName` or `shuffleLogic`, but not "
                 "the other. Either both `fuelHandlerName` and `shuffleLogic` should be "
                 "defined, or neither of them.",
                 "",
                 inspector.NO_ACTION,
-            ))
+            )
+        )
 
         # Check for code fixes for input code on the fuel shuffling outside the version control of ARMI
         # These are basically auto-migrations for untracked code using

--- a/armi/physics/safety/settings.py
+++ b/armi/physics/safety/settings.py
@@ -15,23 +15,6 @@
 from armi.settings import setting
 
 
-CONF_BETA_COMPONENTS = "betaComponents"
-CONF_DECAY_CONSTANTS = "decayConstants"
-
-
 def defineSettings():
-    settings = [
-        setting.Setting(
-            CONF_BETA_COMPONENTS,
-            default=[],
-            label="Beta Components",
-            description="Manually set individual precursor group delayed neutron fractions",
-        ),
-        setting.Setting(
-            CONF_DECAY_CONSTANTS,
-            default=[],
-            label="Decay Constants",
-            description="Manually set individual precursor group delayed neutron decay constants",
-        ),
-    ]
+    settings = []
     return settings

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -385,9 +385,7 @@ class Assembly(composites.Composite):
                     abs(heightChopped - heightToChop) > 1e-5
                 ):  # stop when they are equal. floating point.
                     # update which ref block we're on (does nothing on the first pass)
-                    refB = refA[
-                        i + newBlocks
-                    ]
+                    refB = refA[i + newBlocks]
                     newB = copy.deepcopy(b)
                     newB.setHeight(refB.getHeight())  # make block match ref mesh
                     newBlockStack.append(newB)

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -511,7 +511,6 @@ def getBlockParameterDefinitions():
         )
     )
 
-
     with pDefs.createBuilder(default=0.0, location=ParamLocation.AVERAGE) as pb:
 
         pb.defParam("bu", units="", description="?")

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -101,8 +101,9 @@ assemblies:
         )
         bp = blueprints.Blueprints.load(
             nuclideFlags
-            + self.componentString.format(material="Custom", isotopics="isotopics: B4C",
-                flags="")
+            + self.componentString.format(
+                material="Custom", isotopics="isotopics: B4C", flags=""
+            )
         )
         cs = settings.Settings()
         a = bp.constructAssem("hex", cs, "assembly")
@@ -131,8 +132,9 @@ assemblies:
         )
         bp = blueprints.Blueprints.load(
             nuclideFlags
-            + self.componentString.format(material="Custom", isotopics="isotopics: B4C",
-                flags="")
+            + self.componentString.format(
+                material="Custom", isotopics="isotopics: B4C", flags=""
+            )
         )
         cs = settings.Settings()
         a = bp.constructAssem("hex", cs, "assembly")
@@ -151,21 +153,21 @@ assemblies:
         # More robust test, but worse unittest.py output when it fails
         self.assertTrue(c.hasFlags(Flags.DEPLETABLE))
 
-
         # repeat the process with some flags set explicitly
         bp = blueprints.Blueprints.load(
             nuclideFlags
-            + self.componentString.format(material="Custom", isotopics="isotopics: B4C",
-                flags="fuel test")
+            + self.componentString.format(
+                material="Custom", isotopics="isotopics: B4C", flags="fuel test"
+            )
         )
         cs = settings.Settings()
         a = bp.constructAssem("hex", cs, "assembly")
         c = a[0][0]
 
         # Since we supplied flags, we should NOT get the DEPLETABLE flag added
-        self.assertEqual(c.p.flags, Flags.FUEL|Flags.TEST)
+        self.assertEqual(c.p.flags, Flags.FUEL | Flags.TEST)
         # More robust test, but worse unittest.py output when it fails
-        self.assertTrue(c.hasFlags(Flags.FUEL|Flags.TEST))
+        self.assertTrue(c.hasFlags(Flags.FUEL | Flags.TEST))
 
     def test_componentInitializationAmericiumCustomIsotopics(self):
         nuclideFlags = (
@@ -218,8 +220,9 @@ assemblies:
         )
         bp = blueprints.Blueprints.load(
             nuclideFlags
-            + self.componentString.format(material="Custom", isotopics="isotopics: AM",
-                flags="")
+            + self.componentString.format(
+                material="Custom", isotopics="isotopics: AM", flags=""
+            )
         )
         cs = settings.Settings()
         a = bp.constructAssem("hex", cs, "assembly")

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2544,7 +2544,6 @@ class Composite(ArmiObject):
         """
         return (c for child in self for c in child.iterComponents(typeSpec, exact))
 
-
     def syncMpiState(self):
         """
         Synchronize all parameters of this object and all children to all worker nodes

--- a/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
+++ b/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
@@ -41,7 +41,7 @@ class SettingsModifier(ParameterSweepConverter):
     def convert(self, r=None):
         ParameterSweepConverter.convert(self, r)
         sType = self._cs.settings[self.modifier].underlyingType
-        if sType is not None:
+        if sType is not type(None):
             # NOTE: this won't work with "new-style" settings related to the plugin system.
             # Using the type of the setting._default may be more appropriate if there are issues.
             self._cs[self.modifier] = sType(self._parameter)

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -296,7 +296,9 @@ def registerPluginFlags(pm):
 # string conversions for multiple-word flags
 _CONVERSIONS = {
     re.compile(r"GRID\s+PLATE"): Flags.GRID_PLATE,
-    re.compile(r"\bGRID\b"): Flags.GRID_PLATE,  # often used as component in "grid plate" block
+    re.compile(
+        r"\bGRID\b"
+    ): Flags.GRID_PLATE,  # often used as component in "grid plate" block
     re.compile(r"INLET\s+NOZZLE"): Flags.INLET_NOZZLE,
     re.compile("NOZZLE"): Flags.INLET_NOZZLE,
     re.compile(r"HANDLING\s+SOCKET"): Flags.HANDLING_SOCKET,

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -905,7 +905,7 @@ class Grid:
         return tuple(indexBounds)
 
     def getBounds(
-        self
+        self,
     ) -> Tuple[
         Optional[Sequence[float]], Optional[Sequence[float]], Optional[Sequence[float]]
     ]:

--- a/armi/reactor/parameters/__init__.py
+++ b/armi/reactor/parameters/__init__.py
@@ -238,7 +238,8 @@ def reset():
     for pd in ALL_DEFINITIONS:
         pd.assigned = NEVER
 
-def generateTable(klass, fwParams, app = None):
+
+def generateTable(klass, fwParams, app=None):
     """
     Return a string containing one or more restructured text list tables containing
     parameter descriptions for the passed ArmiObject class.
@@ -279,7 +280,9 @@ def generateTable(klass, fwParams, app = None):
        * - Name
          - Description
          - Units
-    """.format(klass.__name__)
+    """.format(
+        klass.__name__
+    )
 
     content = ""
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -706,20 +706,23 @@ def defineCoreParameters():
     ) as pb:
 
         pb.defParam(
-            "beta", units=None, description="Effective delayed neutron fraction"
+            "beta",
+            units=None,
+            description="Effective delayed neutron fraction",
+            default=None,
         )
 
         pb.defParam(
             "betaComponents",
             units=None,
-            description="Group-wise delayed neutron component",
+            description="Group-wise delayed neutron fractions.",
             default=None,
         )
 
         pb.defParam(
             "betaDecayConstants",
             units="1/s",
-            description="Group-wise decay constant for precursor",
+            description="Group-wise precursor decay constants",
             default=None,
         )
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -225,53 +225,14 @@ class Core(composites.Composite):
     def _setupEffectiveDelayedNeutronFraction(self, cs):
         """Process the settings for the delayed neutron fraction and precursor decay constants."""
         # Verify and set the core beta parameters based on the user-supplied settings
-
-        def _betaValidator(value):
-            """
-            Validate the input for beta.
-            
-            Notes
-            -----
-            Beta can either be provided as a float or list of floats.
-            If the list has a single value or is a float, this is 
-            interpreted as the total delayed neutron fraction. Otherwise,
-            the value is interpreted as the group-wise delayed neutron
-            fractions.
-            """
-            if value is None:
-                return None
-
-            if isinstance(value, list):
-                return [float(val) for val in value]
-            elif isinstance(value, float):
-                return value
-            else:
-                raise ValueError(
-                    "`beta` must be set as a float or a list of floats. "
-                    f"Attempted to assign {value}."
-                )
-
-        def _decayConstantsValidator(value):
-            """Validate the input for precursor decay constants."""
-            if value is None:
-                return None
-
-            if isinstance(value, list):
-                return [float(val) for val in value]
-            else:
-                raise ValueError(
-                    "`decayConstants` must be set as a list of floats. "
-                    f"Attempted to assign {value}."
-                )
-
         runLog.info(
             "Checking for user-supplied `beta` and `decayConstants` settings and attempting to "
             f"apply them to state of {self}."
         )
-        beta = _betaValidator(cs["beta"])
-        decayConstants = _decayConstantsValidator(cs["decayConstants"])
+        beta = cs["beta"]
+        decayConstants = cs["decayConstants"]
 
-        # If beta is interpreted as a single float value, then assign it to
+        # If beta is interpreted as a float, then assign it to
         # the total delayed neutron fraction parameter. Otherwise, setup the
         # group-wise delayed neutron fractions and precursor decay constants.
         reportTableData = []
@@ -303,15 +264,14 @@ class Core(composites.Composite):
             runLog.warning(
                 f"Delayed neutron fraction(s) - {beta} and decay constants - {decayConstants} have not been applied."
             )
-            return
-
-        runLog.info(
-            tabulate.tabulate(
-                tabular_data=reportTableData,
-                headers=["Component", "Value"],
-                tablefmt="armi",
+        else:
+            runLog.info(
+                tabulate.tabulate(
+                    tabular_data=reportTableData,
+                    headers=["Component", "Value"],
+                    tablefmt="armi",
+                )
             )
-        )
 
     def __getstate__(self):
         """Applies a settings and parent to the core and components. """

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -73,7 +73,9 @@ class TestSpatialLocator(unittest.TestCase):
         # build meshes just like how they're used on a regular system.
         coreGrid = grids.Grid.fromRectangle(1.0, 1.0, armiObject=core)  # 2-D grid
         # 1-D z-mesh
-        assemblyGrid = grids.Grid(bounds=(None, None, numpy.arange(5)), armiObject=assem)
+        assemblyGrid = grids.Grid(
+            bounds=(None, None, numpy.arange(5)), armiObject=assem
+        )
         # pins sit in this 2-D grid.
         blockGrid = grids.Grid.fromRectangle(0.1, 0.1, armiObject=block)
 
@@ -114,7 +116,9 @@ class TestSpatialLocator(unittest.TestCase):
         # 2-D grid
         coreGrid = grids.Grid.fromRectangle(1.0, 1.0, armiObject=core)
         # 1-D z-mesh
-        assemblyGrid = grids.Grid(bounds=(None, None, numpy.arange(5)), armiObject=assem)
+        assemblyGrid = grids.Grid(
+            bounds=(None, None, numpy.arange(5)), armiObject=assem
+        )
         # pins sit in this 2-D grid.
         blockGrid = grids.Grid.fromRectangle(0.1, 0.1, armiObject=block)
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -18,6 +18,7 @@ import copy
 import os
 import unittest
 
+import voluptuous as vol
 from six.moves import cPickle
 from numpy.testing import assert_allclose, assert_equal
 import armi
@@ -188,7 +189,7 @@ def loadTestReactor(
     return o, o.r
 
 
-class _ReactorTests(unittest.TestCase):
+class ReactorTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # prepare the input files. This is important so the unit tests run from wherever
@@ -200,8 +201,106 @@ class _ReactorTests(unittest.TestCase):
     def tearDownClass(cls):
         cls.directoryChanger.close()
 
+    def test_kineticsParameterAssignment(self):
+        """Test that the delayed neutron fraction and precursor decay constants are applied from settings."""
+        o = buildOperatorOfEmptyHexBlocks()
+        self.assertIsNone(o.r.core.p.beta)
+        self.assertIsNone(o.r.core.p.betaComponents)
+        self.assertIsNone(o.r.core.p.betaDecayConstants)
 
-class HexReactorTests(_ReactorTests):
+        # Test that the group-wise beta and decay constants are assigned
+        # together given that they are the same length.
+        o = buildOperatorOfEmptyHexBlocks(
+            customSettings={"beta": [0.0] * 6, "decayConstants": [0.0] * 6,},
+        )
+        self.assertEqual(o.r.core.p.beta, sum(o.cs["beta"]))
+        self.assertListEqual(list(o.r.core.p.betaComponents), o.cs["beta"])
+        self.assertListEqual(
+            list(o.r.core.p.betaDecayConstants), o.cs["decayConstants"]
+        )
+
+        # Test the assignment of total beta as a float
+        o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": 0.00670},)
+        self.assertEqual(o.r.core.p.beta, o.cs["beta"])
+        self.assertIsNone(o.r.core.p.betaComponents)
+        self.assertIsNone(o.r.core.p.betaDecayConstants)
+
+        # Test that nothing is assigned if the beta is specified as a list
+        # without a corresponding decay constants list.
+        o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": [0.0] * 6,},)
+        self.assertIsNone(o.r.core.p.beta)
+        self.assertIsNone(o.r.core.p.betaComponents)
+        self.assertIsNone(o.r.core.p.betaDecayConstants)
+
+        # Test that 1 group beta components and decay constants can be assigned.
+        # Since beta is a list, ensure that it's assigned to the `betaComponents`
+        # parameter.
+        o = buildOperatorOfEmptyHexBlocks(
+            customSettings={"beta": [0.0], "decayConstants": [0.0]},
+        )
+        self.assertEqual(o.r.core.p.beta, sum(o.cs["beta"]))
+        self.assertListEqual(list(o.r.core.p.betaComponents), o.cs["beta"])
+        self.assertListEqual(
+            list(o.r.core.p.betaDecayConstants), o.cs["decayConstants"]
+        )
+
+        # Test that decay constants are not assigned without a corresponding
+        # group-wise beta input.
+        o = buildOperatorOfEmptyHexBlocks(customSettings={"decayConstants": [0.0] * 6},)
+        self.assertIsNone(o.r.core.p.beta)
+        self.assertIsNone(o.r.core.p.betaComponents)
+        self.assertIsNone(o.r.core.p.betaDecayConstants)
+
+        # Test that decay constants are not assigned without a corresponding
+        # group-wise beta input. This also demonstrates that the total beta
+        # is still assigned.
+        o = buildOperatorOfEmptyHexBlocks(
+            customSettings={"decayConstants": [0.0] * 6, "beta": 0.0},
+        )
+        self.assertEqual(o.r.core.p.beta, o.cs["beta"])
+        self.assertIsNone(o.r.core.p.betaComponents)
+        self.assertIsNone(o.r.core.p.betaDecayConstants)
+
+        # Test the demonstrates that None values are acceptable
+        # and that nothing is assigned.
+        o = buildOperatorOfEmptyHexBlocks(
+            customSettings={"decayConstants": None, "beta": None},
+        )
+        self.assertEqual(o.r.core.p.beta, o.cs["beta"])
+        self.assertIsNone(o.r.core.p.betaComponents)
+        self.assertIsNone(o.r.core.p.betaDecayConstants)
+
+        # Test that an error is raised if the decay constants
+        # and group-wise beta are inconsistent sizes
+        with self.assertRaises(ValueError):
+            o = buildOperatorOfEmptyHexBlocks(
+                customSettings={"decayConstants": [0.0] * 6, "beta": [0.0]},
+            )
+
+        # Test that an error is raised if the decay constants
+        # and group-wise beta are inconsistent sizes
+        with self.assertRaises(ValueError):
+            o = buildOperatorOfEmptyHexBlocks(
+                customSettings={"decayConstants": [0.0] * 6, "beta": [0.0] * 5},
+            )
+
+        # The following tests check the voluptuous schema definition. This
+        # ensures that anything except NoneType, [float], float are not valid
+        # inputs.
+        with self.assertRaises(vol.AnyInvalid):
+            o = buildOperatorOfEmptyHexBlocks(customSettings={"decayConstants": [1]},)
+
+        with self.assertRaises(vol.AnyInvalid):
+            o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": [1]},)
+
+        with self.assertRaises(vol.AnyInvalid):
+            o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": 1},)
+
+        with self.assertRaises(vol.AnyInvalid):
+            o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": (1, 2, 3)},)
+
+
+class HexReactorTests(ReactorTests):
     def setUp(self):
         self.o, self.r = loadTestReactor(self.directoryChanger.destination)
 
@@ -592,7 +691,7 @@ class HexReactorTests(_ReactorTests):
         self.assertAlmostEqual(aNew3.getMass(), bol.getMass() / 3.0)
 
 
-class CartesianReactorTests(_ReactorTests):
+class CartesianReactorTests(ReactorTests):
     def setUp(self):
         self.o = buildOperatorOfEmptyCartesianBlocks()
         self.r = self.o.r

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -203,101 +203,130 @@ class ReactorTests(unittest.TestCase):
 
     def test_kineticsParameterAssignment(self):
         """Test that the delayed neutron fraction and precursor decay constants are applied from settings."""
-        o = buildOperatorOfEmptyHexBlocks()
-        self.assertIsNone(o.r.core.p.beta)
-        self.assertIsNone(o.r.core.p.betaComponents)
-        self.assertIsNone(o.r.core.p.betaDecayConstants)
+
+        def _getModifiedSettings(customSettings):
+            cs = settings.Settings()
+            for key, val in customSettings.items():
+                cs[key] = val
+            return cs
+
+        r = tests.getEmptyHexReactor()
+        self.assertIsNone(r.core.p.beta)
+        self.assertIsNone(r.core.p.betaComponents)
+        self.assertIsNone(r.core.p.betaDecayConstants)
 
         # Test that the group-wise beta and decay constants are assigned
         # together given that they are the same length.
-        o = buildOperatorOfEmptyHexBlocks(
-            customSettings={"beta": [0.0] * 6, "decayConstants": [0.0] * 6,},
+        r = tests.getEmptyHexReactor()
+        cs = _getModifiedSettings(
+            customSettings={"beta": [0.0] * 6, "decayConstants": [0.0] * 6,}
         )
-        self.assertEqual(o.r.core.p.beta, sum(o.cs["beta"]))
-        self.assertListEqual(list(o.r.core.p.betaComponents), o.cs["beta"])
-        self.assertListEqual(
-            list(o.r.core.p.betaDecayConstants), o.cs["decayConstants"]
-        )
+        r.core.setOptionsFromCs(cs)
+        self.assertEqual(r.core.p.beta, sum(cs["beta"]))
+        self.assertListEqual(list(r.core.p.betaComponents), cs["beta"])
+        self.assertListEqual(list(r.core.p.betaDecayConstants), cs["decayConstants"])
 
         # Test the assignment of total beta as a float
-        o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": 0.00670},)
-        self.assertEqual(o.r.core.p.beta, o.cs["beta"])
-        self.assertIsNone(o.r.core.p.betaComponents)
-        self.assertIsNone(o.r.core.p.betaDecayConstants)
+        r = tests.getEmptyHexReactor()
+        cs = _getModifiedSettings(customSettings={"beta": 0.00670},)
+        r.core.setOptionsFromCs(cs)
+        self.assertEqual(r.core.p.beta, cs["beta"])
+        self.assertIsNone(r.core.p.betaComponents)
+        self.assertIsNone(r.core.p.betaDecayConstants)
 
         # Test that nothing is assigned if the beta is specified as a list
         # without a corresponding decay constants list.
-        o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": [0.0] * 6,},)
-        self.assertIsNone(o.r.core.p.beta)
-        self.assertIsNone(o.r.core.p.betaComponents)
-        self.assertIsNone(o.r.core.p.betaDecayConstants)
+        r = tests.getEmptyHexReactor()
+        cs = _getModifiedSettings(customSettings={"beta": [0.0] * 6,},)
+        r.core.setOptionsFromCs(cs)
+        self.assertIsNone(r.core.p.beta)
+        self.assertIsNone(r.core.p.betaComponents)
+        self.assertIsNone(r.core.p.betaDecayConstants)
 
         # Test that 1 group beta components and decay constants can be assigned.
         # Since beta is a list, ensure that it's assigned to the `betaComponents`
         # parameter.
-        o = buildOperatorOfEmptyHexBlocks(
+        r = tests.getEmptyHexReactor()
+        cs = _getModifiedSettings(
             customSettings={"beta": [0.0], "decayConstants": [0.0]},
         )
-        self.assertEqual(o.r.core.p.beta, sum(o.cs["beta"]))
-        self.assertListEqual(list(o.r.core.p.betaComponents), o.cs["beta"])
-        self.assertListEqual(
-            list(o.r.core.p.betaDecayConstants), o.cs["decayConstants"]
-        )
+        r.core.setOptionsFromCs(cs)
+        self.assertEqual(r.core.p.beta, sum(cs["beta"]))
+        self.assertListEqual(list(r.core.p.betaComponents), cs["beta"])
+        self.assertListEqual(list(r.core.p.betaDecayConstants), cs["decayConstants"])
 
         # Test that decay constants are not assigned without a corresponding
         # group-wise beta input.
-        o = buildOperatorOfEmptyHexBlocks(customSettings={"decayConstants": [0.0] * 6},)
-        self.assertIsNone(o.r.core.p.beta)
-        self.assertIsNone(o.r.core.p.betaComponents)
-        self.assertIsNone(o.r.core.p.betaDecayConstants)
+        r = tests.getEmptyHexReactor()
+        cs = _getModifiedSettings(customSettings={"decayConstants": [0.0] * 6},)
+        r.core.setOptionsFromCs(cs)
+        self.assertIsNone(r.core.p.beta)
+        self.assertIsNone(r.core.p.betaComponents)
+        self.assertIsNone(r.core.p.betaDecayConstants)
 
         # Test that decay constants are not assigned without a corresponding
         # group-wise beta input. This also demonstrates that the total beta
         # is still assigned.
-        o = buildOperatorOfEmptyHexBlocks(
+        r = tests.getEmptyHexReactor()
+        cs = _getModifiedSettings(
             customSettings={"decayConstants": [0.0] * 6, "beta": 0.0},
         )
-        self.assertEqual(o.r.core.p.beta, o.cs["beta"])
-        self.assertIsNone(o.r.core.p.betaComponents)
-        self.assertIsNone(o.r.core.p.betaDecayConstants)
+        r.core.setOptionsFromCs(cs)
+        self.assertEqual(r.core.p.beta, cs["beta"])
+        self.assertIsNone(r.core.p.betaComponents)
+        self.assertIsNone(r.core.p.betaDecayConstants)
 
         # Test the demonstrates that None values are acceptable
         # and that nothing is assigned.
-        o = buildOperatorOfEmptyHexBlocks(
+        r = tests.getEmptyHexReactor()
+        cs = _getModifiedSettings(
             customSettings={"decayConstants": None, "beta": None},
         )
-        self.assertEqual(o.r.core.p.beta, o.cs["beta"])
-        self.assertIsNone(o.r.core.p.betaComponents)
-        self.assertIsNone(o.r.core.p.betaDecayConstants)
+        r.core.setOptionsFromCs(cs)
+        self.assertEqual(r.core.p.beta, cs["beta"])
+        self.assertIsNone(r.core.p.betaComponents)
+        self.assertIsNone(r.core.p.betaDecayConstants)
 
         # Test that an error is raised if the decay constants
         # and group-wise beta are inconsistent sizes
         with self.assertRaises(ValueError):
-            o = buildOperatorOfEmptyHexBlocks(
+            r = tests.getEmptyHexReactor()
+            cs = _getModifiedSettings(
                 customSettings={"decayConstants": [0.0] * 6, "beta": [0.0]},
             )
+            r.core.setOptionsFromCs(cs)
 
         # Test that an error is raised if the decay constants
         # and group-wise beta are inconsistent sizes
         with self.assertRaises(ValueError):
-            o = buildOperatorOfEmptyHexBlocks(
+            r = tests.getEmptyHexReactor()
+            cs = _getModifiedSettings(
                 customSettings={"decayConstants": [0.0] * 6, "beta": [0.0] * 5},
             )
+            r.core.setOptionsFromCs(cs)
 
         # The following tests check the voluptuous schema definition. This
         # ensures that anything except NoneType, [float], float are not valid
         # inputs.
         with self.assertRaises(vol.AnyInvalid):
-            o = buildOperatorOfEmptyHexBlocks(customSettings={"decayConstants": [1]},)
+            r = tests.getEmptyHexReactor()
+            cs = _getModifiedSettings(customSettings={"decayConstants": [1]},)
+            r.core.setOptionsFromCs(cs)
 
         with self.assertRaises(vol.AnyInvalid):
-            o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": [1]},)
+            r = tests.getEmptyHexReactor()
+            cs = _getModifiedSettings(customSettings={"beta": [1]},)
+            r.core.setOptionsFromCs(cs)
 
         with self.assertRaises(vol.AnyInvalid):
-            o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": 1},)
+            r = tests.getEmptyHexReactor()
+            cs = _getModifiedSettings(customSettings={"beta": 1},)
+            r.core.setOptionsFromCs(cs)
 
         with self.assertRaises(vol.AnyInvalid):
-            o = buildOperatorOfEmptyHexBlocks(customSettings={"beta": (1, 2, 3)},)
+            r = tests.getEmptyHexReactor()
+            cs = _getModifiedSettings(customSettings={"beta": (1, 2, 3)},)
+            r.core.setOptionsFromCs(cs)
 
 
 class HexReactorTests(ReactorTests):

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -48,6 +48,7 @@ CONF_AVAILABILITY_FACTORS = "availabilityFactors"
 CONF_POWER_FRACTIONS = "powerFractions"
 CONF_BURN_STEPS = "burnSteps"
 CONF_BETA = "beta"
+CONF_DECAY_CONSTANTS = "decayConstants"
 CONF_BRANCH_VERBOSITY = "branchVerbosity"
 CONF_BU_GROUPS = "buGroups"
 CONF_BURNUP_PEAKING_FACTOR = "burnupPeakingFactor"
@@ -261,10 +262,21 @@ def defineSettings() -> List[setting.Setting]:
         ),
         setting.Setting(
             CONF_BETA,
-            default=0.0,
-            label="Effective delayed neutron fraction",
-            description="Effective delayed neutron fraction. You may need to enter the "
-            "precursor groups in detail elsewhere to do kinetics.",
+            default=None,
+            label="Delayed neutron fraction",
+            description="Set individual precursor group delayed neutron fractions.",
+            schema=vol.Any(
+                [float], None, float, msg="Expected NoneType, float, or list of floats."
+            ),
+        ),
+        setting.Setting(
+            CONF_DECAY_CONSTANTS,
+            default=None,
+            label="Decay Constants",
+            description="Set individual precursor group delayed neutron decay constants.",
+            schema=vol.Any(
+                [float], None, float, msg="Expected NoneType, float, or list of floats."
+            ),
         ),
         setting.Setting(
             CONF_BRANCH_VERBOSITY,

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -166,6 +166,7 @@ class _SettingsReader(object):
         This is intended to replace the XML stuff as we converge on consistent input formats.
         """
         from armi.physics.thermalHydraulics import const  # avoid circular import
+
         yaml = YAML()
         tree = yaml.load(stream)
         if "settings" not in tree:

--- a/armi/settings/settingsRules.py
+++ b/armi/settings/settingsRules.py
@@ -158,6 +158,7 @@ RENAMES = {
     "cinderdat": "mcnpBurnxDepLib",
     "loadCycle": "startCycle",
     "loadNode": "startNode",
+    "betaComponents": "beta",
 }
 
 TARGETED_CONVERSIONS = {}

--- a/armi/settings/tests/old_xml_settings_input.xml
+++ b/armi/settings/tests/old_xml_settings_input.xml
@@ -4,7 +4,6 @@
 	<aclpMaterial value="SS316" />
 	<armiLocation value="\\albert\apps\dev\armi\master" />
 	<axialExpansion value="True" />
-	<beta value="-1.0" />
 	<bondRemoval value="True" />
 	<branchVerbosity value="extra" />
 	<buGroups value="[3, 10, 20, 100]" />

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -236,8 +236,7 @@ class TestSettingsUtils(unittest.TestCase):
         cs.writeToYamlFile("settings1.yaml")
         cs.writeToYamlFile("settings2.yaml")
         with open("notSettings.yaml", "w") as f:
-            f.write("some: other\n"
-                    "yaml: file\n")
+            f.write("some: other\n" "yaml: file\n")
         os.mkdir("subdir")
         cs.writeToYamlFile("subdir/settings3.yaml")
         cs.writeToYamlFile("subdir/skipSettings.yaml")

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -80,7 +80,7 @@ class TestApps(unittest.TestCase):
         app = armi.getApp()
         app.pluginManager.register(TestPlugin1)
         app.pluginManager.register(TestPlugin4)
-        app._paramRenames = None # need to implement better cache invalidation rules
+        app._paramRenames = None  # need to implement better cache invalidation rules
 
         renames = app.getParamRenames()
         self.assertIn("oldType", renames)
@@ -90,7 +90,7 @@ class TestApps(unittest.TestCase):
         self.assertEqual(renames["arealPD"], "arealPowerDensity")
 
         app.pluginManager.register(TestPlugin2)
-        app._paramRenames = None # need to implement better cache invalidation rules
+        app._paramRenames = None  # need to implement better cache invalidation rules
         with self.assertRaisesRegex(
             plugins.PluginError,
             ".*parameter renames are already defined by another plugin.*",

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -198,11 +198,11 @@ class AsciiMapHexThird(AsciiMap):
             grid[x, y] = val
 
         nRows = max(y for _x, y in grid)
-        minX = min(self._getRowBase(row)[0] for row in range(nRows+1))
+        minX = min(self._getRowBase(row)[0] for row in range(nRows + 1))
 
-        spacer = " "*maxSize
+        spacer = " " * maxSize
 
-        for row in reversed(range(nRows+1)):
+        for row in reversed(range(nRows + 1)):
             base = self._getRowBase(row)
             foundContents = False
 
@@ -223,7 +223,7 @@ class AsciiMapHexThird(AsciiMap):
 
                 rowContents.append(contents.center(maxSize))
 
-            stream.write(" "*padding*maxSize + spacer.join(rowContents) + "\n")
+            stream.write(" " * padding * maxSize + spacer.join(rowContents) + "\n")
 
 
 class AsciiMapHexFullTipsUp(AsciiMap):

--- a/armi/utils/densityTools.py
+++ b/armi/utils/densityTools.py
@@ -376,9 +376,9 @@ def getChemicals(nuclideInventory):
     return chemicals
 
 
-def applyIsotopicsMix(material,
-                      enrichedMassFracs : Dict[str, float],
-                      fertileMassFracs: Dict[str, float]):
+def applyIsotopicsMix(
+    material, enrichedMassFracs: Dict[str, float], fertileMassFracs: Dict[str, float]
+):
     """
     Update material heavy metal mass fractions based on its enrichment and two nuclide feeds.
 

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -213,7 +213,9 @@ class Flag(metaclass=_FlagMeta):
         """
         Return a list of all field names, sorted by increasing integer value.
         """
-        return [i[0] for i in sorted(cls._nameToValue.items(), key=lambda item: item[1])]
+        return [
+            i[0] for i in sorted(cls._nameToValue.items(), key=lambda item: item[1])
+        ]
 
     @classmethod
     def extend(cls, fields: Dict[str, Union[int, auto]]):
@@ -324,8 +326,8 @@ class Flag(metaclass=_FlagMeta):
     def __hash__(self):
         return hash(self._value)
 
+
 # Type alias to reliably check for a proper Flag type. This cannot just be `Flag`, since
 # mypy gets confused by `auto` because it doesn't go to the trouble of resolving them in
 # the metaclass.
 FlagType = Union[Flag, auto]
-

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -52,8 +52,10 @@ class auto:
         FlagTypes in them, since these can normally be iterated over, but mypy doesn't
         know that the metaclass consumes the autos.
         """
-        raise NotImplementedError("__iter__() is not actually implemented on "
-                "{}; it is only defined to appease mypy.".format(type(self)))
+        raise NotImplementedError(
+            "__iter__() is not actually implemented on "
+            "{}; it is only defined to appease mypy.".format(type(self))
+        )
 
 
 class _FlagMeta(type):

--- a/armi/utils/tests/test_densityTools.py
+++ b/armi/utils/tests/test_densityTools.py
@@ -83,18 +83,22 @@ class Test_densityTools(unittest.TestCase):
         # expect some small difference due to renormalization
         self.assertNotAlmostEqual(m1["O17"], m2["O17"])
         self.assertAlmostEqual(m1["O17"], m2["O17"], delta=1e-5)
-        
+
     def test_applyIsotopicsMix(self):
         """Ensure isotopc classes get mixed properly."""
         uo2 = UO2()
         massFracO = uo2.p.massFrac["O"]
         uo2.p.class1_wt_frac = 0.2
-        enrichedMassFracs = {"U235":0.3, "U234":0.1, "PU239":0.6}
-        fertileMassFracs = {"U238":0.3, "PU240":0.7}
+        enrichedMassFracs = {"U235": 0.3, "U234": 0.1, "PU239": 0.6}
+        fertileMassFracs = {"U238": 0.3, "PU240": 0.7}
         densityTools.applyIsotopicsMix(uo2, enrichedMassFracs, fertileMassFracs)
 
-        self.assertAlmostEqual(uo2.p.massFrac["U234"], (1 - massFracO) * 0.2 * 0.1)  # HM blended
-        self.assertAlmostEqual(uo2.p.massFrac["U238"], (1 - massFracO) * 0.8 * 0.3)  # HM blended
+        self.assertAlmostEqual(
+            uo2.p.massFrac["U234"], (1 - massFracO) * 0.2 * 0.1
+        )  # HM blended
+        self.assertAlmostEqual(
+            uo2.p.massFrac["U238"], (1 - massFracO) * 0.8 * 0.3
+        )  # HM blended
         self.assertAlmostEqual(uo2.p.massFrac["O"], massFracO)  # non-HM stays unchanged
 
 

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -130,16 +130,16 @@ class Utils_TestCase(unittest.TestCase):
         self.assertEqual(-2.4594981981654e-101, fixed)
 
     def test_capStrLen(self):
-        #Test with strings
-        str1 = utils.capStrLen('sodium', 5)
-        self.assertEqual('so...', str1)
+        # Test with strings
+        str1 = utils.capStrLen("sodium", 5)
+        self.assertEqual("so...", str1)
         str1 = utils.capStrLen("potassium", 6)
-        self.assertEqual('pot...', str1)
-        str1 = utils.capStrLen('rubidium', 7)
-        self.assertEqual('rubi...', str1)
-		
+        self.assertEqual("pot...", str1)
+        str1 = utils.capStrLen("rubidium", 7)
+        self.assertEqual("rubi...", str1)
+
     def test_list2str(self):
-        #Test with list of strings
+        # Test with list of strings
         list1 = ["One", "Two"]
         list2 = ["Three", "Four"]
         str1 = "OneTwo"
@@ -160,6 +160,7 @@ class Utils_TestCase(unittest.TestCase):
         str1 = "OneTwoThreeFourT...FourThreeFour T... Four "
         str2 = utils.list2str(list2, 4, list1, 5)
         self.assertEqual(str1, str2)
+
 
 class TestUnits(unittest.TestCase):
     def setUp(self):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,8 +51,11 @@ armi.configure(apps.App())
 APIDOC_REL = ".apidocs"
 SOURCE_DIR = os.path.join("..", "armi")
 APIDOC_DIR = APIDOC_REL
-_TUTORIAL_FILES = [pathlib.Path(SOURCE_DIR) / "tests" / "tutorials" / fName for
-        fName in bookkeepingTests.TUTORIAL_FILES if "ipynb" not in fName]
+_TUTORIAL_FILES = [
+    pathlib.Path(SOURCE_DIR) / "tests" / "tutorials" / fName
+    for fName in bookkeepingTests.TUTORIAL_FILES
+    if "ipynb" not in fName
+]
 
 
 def setup(app):
@@ -65,7 +68,6 @@ def setup(app):
     # itself, so relative paths don't work.
     for path in _TUTORIAL_FILES:
         shutil.copy(path, pathlib.Path("user") / "tutorials")
-
 
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -172,7 +174,12 @@ release = armi.__version__
 'library/xml*' – ignores all files and directories starting with library/xml
 '**/.svn' – ignores all .svn directories (replaces entry in exclude_dirnames)
 """
-exclude_patterns = ["**/Python27*", "**/ccl*", "**.ipynb_checkpoints", "_build"]  # , '**/tests*']
+exclude_patterns = [
+    "**/Python27*",
+    "**/ccl*",
+    "**.ipynb_checkpoints",
+    "_build",
+]  # , '**/tests*']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None

--- a/doc/user/inputs/settings.rst
+++ b/doc/user/inputs/settings.rst
@@ -97,3 +97,39 @@ Detail assembly numbers
 
 Detail all assemblies
     The ``detailAllAssems`` setting makes all assemblies in the problem detail assemblies
+
+.. _kinetics-settings:
+
+Kinetics settings
+-----------------
+In reactor physics analyses it is standard practice to represent reactivity
+in either absolute units (i.e., dk/kk' or pcm) or in dollars or cents. To
+support this functionality, the framework supplies the ``beta`` and
+``decayConstants`` settings to apply the delayed neutron fraction and
+precursor decay constants to the Core parameters during initialization.
+
+These settings come with a few caveats:
+
+    1. The ``beta`` setting supports two different meanings depending on
+       the type that is provided. If a float is given, then this setting
+       is interpreted as the effective delayed neutron fraction for the
+       system and is applied to the Core's ``beta`` parameter. If a list
+       of floats is provided, then this setting is interpreted as the
+       group-wise (precursor family) delayed neutron fractions (useful for
+       reactor kinetics simulations). In this case, the values
+       will be stored on the Core's ``betaComponents`` parameter.
+
+    2. The ``decayConstants`` setting is used to define the precursor
+       decay constants for each group (family). When set, it must be
+       provided with a corresponding ``beta`` parameter that has the
+       same number of groups. For example, if six-group delayed neutron
+       fractions are provided, the decay constants must also be provided
+       in the same six-group structure. This setting is applied to Core's
+       ``betaDecayConstants`` parameter. If instead ``beta`` is interpreted
+       as the effective delayed neutron fraction, the ``betaDecayConstants``
+       parameter will not be set.
+
+    3. If both the group-wise ``beta`` and ``decayConstants`` are consistent,
+       then the effective delayed neutron fraction for the system is calculated
+       as the summation of the group-wise delayed neutron fractions and also
+       stored on the Core's ``beta`` parameter.

--- a/doc/user/inputs/settings.rst
+++ b/doc/user/inputs/settings.rst
@@ -111,25 +111,23 @@ precursor decay constants to the Core parameters during initialization.
 These settings come with a few caveats:
 
     1. The ``beta`` setting supports two different meanings depending on
-       the type that is provided. If a float is given, then this setting
+       the type that is provided. If a single value is given, then this setting
        is interpreted as the effective delayed neutron fraction for the
-       system and is applied to the Core's ``beta`` parameter. If a list
-       of floats is provided, then this setting is interpreted as the
-       group-wise (precursor family) delayed neutron fractions (useful for
-       reactor kinetics simulations). In this case, the values
-       will be stored on the Core's ``betaComponents`` parameter.
+       system. If a list of values is provided, then this setting is interpreted
+       as the group-wise (precursor family) delayed neutron fractions (useful for
+       reactor kinetics simulations).
 
     2. The ``decayConstants`` setting is used to define the precursor
-       decay constants for each group (family). When set, it must be
-       provided with a corresponding ``beta`` parameter that has the
+       decay constants for each group. When set, it must be
+       provided with a corresponding ``beta`` setting that has the
        same number of groups. For example, if six-group delayed neutron
        fractions are provided, the decay constants must also be provided
-       in the same six-group structure. This setting is applied to Core's
-       ``betaDecayConstants`` parameter. If instead ``beta`` is interpreted
-       as the effective delayed neutron fraction, the ``betaDecayConstants``
-       parameter will not be set.
+       in the same six-group structure.
 
-    3. If both the group-wise ``beta`` and ``decayConstants`` are consistent,
-       then the effective delayed neutron fraction for the system is calculated
-       as the summation of the group-wise delayed neutron fractions and also
-       stored on the Core's ``beta`` parameter.
+    3. If ``beta`` is interpreted as the effective delayed neutron fraction for
+       the system, then the ``decayConstants`` setting will not be utilized.
+
+    4. If both the group-wise ``beta`` and ``decayConstants`` are provided
+       and their number of groups are consistent, then the effective delayed
+       neutron fraction for the system is calculated as the summation of the
+       group-wise delayed neutron fractions.


### PR DESCRIPTION
Adding the functionality for the effective delayed neutron fraction, group-wise delayed neutron fraction, and group-wise precursor decay constants to be initialized on the `Core` using the `beta` and `decayConstants` settings. This is useful for supporting plugins that need access to delayed neutron data for reactor kinetics evaluations or representing absolute reactivity (dk/kk' or pcm) in dollars or cents (i.e., shutdown margin, control rod worth, excess reactivity, etc.)