### PR TITLE
Improve setting rename/migration functionality

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -54,8 +54,6 @@ import sys
 from typing import Optional, List, Type
 import warnings
 
-import pluggy
-
 # The _bootstrap module performs operations that may need to occur before it is
 # necessarily safe to import the rest of the ARMI system. Things like:
 # - configure the MPI environment
@@ -83,6 +81,7 @@ from armi.context import (
 from armi.context import Mode
 from armi.meta import __version__
 from armi import apps
+from armi import pluginManager
 from armi import plugins
 from armi import runLog
 from armi import materials
@@ -275,7 +274,7 @@ def getDefaultPlugins() -> List[Type[plugins.ArmiPlugin]]:
     return defaultPlugins
 
 
-def getDefaultPluginManager() -> pluggy.PluginManager:
+def getDefaultPluginManager() -> pluginManager.ArmiPluginManager:
     """
     Return a plugin manager containing the default set of ARMI Framework plugins.
 
@@ -296,7 +295,7 @@ def isConfigured():
     return _app is not None
 
 
-def getPluginManager() -> Optional[pluggy.PluginManager]:
+def getPluginManager() -> Optional[pluginManager.ArmiPluginManager]:
     """
     Return the plugin manager, if there is one.
     """
@@ -306,7 +305,7 @@ def getPluginManager() -> Optional[pluggy.PluginManager]:
     return _app.pluginManager
 
 
-def getPluginManagerOrFail() -> pluggy.PluginManager:
+def getPluginManagerOrFail() -> pluginManager.ArmiPluginManager:
     """
     Return the plugin manager. Raise an error if there is none.
     """

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -177,7 +177,10 @@ class App:
         Return the parameter renames from all registered plugins.
 
         This renders a merged dictionary containing all parameter renames from all of
-        the registered plugins. It also performs simple error checking.
+        the registered plugins. It also performs simple error checking. The result of
+        this operation is cached, since it is somewhat expensive to perform. If the App
+        detects that its plugin manager's set of registered plugins has changed, the
+        cache will be invalidated and recomputed.
         """
         cacheInvalid = False
         if self._paramRenames is not None:

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -153,7 +153,9 @@ def defineSettings():
             CONF_NUMBER_MESH_PER_EDGE,
             default=1,
             label="Number of Mesh per Edge",
-            description="Number of mesh per block edge for finite-difference planar mesh refinement.",
+            description="Number of mesh per block edge for finite-difference planar "
+            "mesh refinement.",
+            oldNames=[("hexSideSubdivisions", None)],
         ),
         setting.Setting(
             CONF_EPS_EIG,

--- a/armi/pluginManager.py
+++ b/armi/pluginManager.py
@@ -1,0 +1,34 @@
+"""
+Slightly customized version of the stock pluggy ``PluginManager``.
+"""
+
+import pluggy
+
+class ArmiPluginManager(pluggy.PluginManager):
+    """
+    PluginManager implementation with ARMI-specific features.
+
+    The main point of this subclass is to make it possible to detect when the plugin
+    manager has been mutated, allowing for safe cacheing of expensive results derived
+    from the set of registered plugins. This is done by exposing a counter that is
+    incremented any time the set of registered plugins is modified. If a client caches
+    any results derived from calling plugin hooks, caching this counter along with that
+    data allows for cheaply testing that the cached results are still valid.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pluggy.PluginManager.__init__(self, *args,  **kwargs)
+
+        self._counter = 0
+
+    @property
+    def counter(self):
+        return self._counter
+
+    def register(self, *args, **kwargs):
+        self._counter += 1
+        pluggy.PluginManager.register(self, *args, **kwargs)
+
+    def unregister(self, *args, **kwargs):
+        self._counter += 1
+        pluggy.PluginManager.unregister(self, *args, **kwargs)

--- a/armi/pluginManager.py
+++ b/armi/pluginManager.py
@@ -9,7 +9,7 @@ class ArmiPluginManager(pluggy.PluginManager):
     PluginManager implementation with ARMI-specific features.
 
     The main point of this subclass is to make it possible to detect when the plugin
-    manager has been mutated, allowing for safe cacheing of expensive results derived
+    manager has been mutated, allowing for safe caching of expensive results derived
     from the set of registered plugins. This is done by exposing a counter that is
     incremented any time the set of registered plugins is modified. If a client caches
     any results derived from calling plugin hooks, caching this counter along with that

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -16,13 +16,13 @@
 Plugins allow various built-in or external functionality to be brought into the ARMI ecosystem.
 
 This module defines the hooks that may be defined within plugins. Plugins are ultimately
-incorporated into a ``PluginManager``, which live inside of a :py:class:`armi.apps.App`
-object.
+incorporated into a :py:class:`armi.pluginManager.ArmiPluginManager`, which live inside
+of a :py:class:`armi.apps.App` object.
 
-The ``PluginManager`` is a class provided by the ``pluggy`` package, which provides a
-registry of known plugins. Rather than create one directly, we use the
-:py:func:`armi.plugins.getNewPluginManager()` function, which handles some of the setup
-for us.
+The ``ArmiPluginManager`` is derived from the ``PluginManager`` class provided by the
+``pluggy`` package, which provides a registry of known plugins. Rather than create one
+directly, we use the :py:func:`armi.plugins.getNewPluginManager()` function, which
+handles some of the setup for us.
 
 From a high-altitude perspective, the plugins provide numerous "hooks", which allow for
 ARMI to be extended in various ways. Some of these extensions are subtle and play a part
@@ -82,7 +82,7 @@ considerably). Examples:
     much of the class's behavior through metaclassing. Therefore, we need to be able
     to import all plugins *before* importing blueprints.
 
-Plugins are stateless. They do not have ``__init__()`` methods, and when they are
+Plugins are currently stateless. They do not have ``__init__()`` methods, and when they are
 registered with the PluginMagager, the PluginManager gets the Plugin's class object
 rather than an instance of that class. Also notice that all of the hooks are
 ``@staticmethod``\ s. As a result, they can be called directly off of the class object,
@@ -94,6 +94,7 @@ from typing import Dict, Union
 
 import pluggy
 
+from armi import pluginManager
 from armi.utils import flags
 
 HOOKSPEC = pluggy.HookspecMarker("armi")
@@ -475,11 +476,11 @@ class ArmiPlugin:
         """
 
 
-def getNewPluginManager() -> pluggy.PluginManager:
+def getNewPluginManager() -> pluginManager.ArmiPluginManager:
     """
     Return a new plugin manager with all of the hookspecs pre-registered.
     """
-    pm = pluggy.PluginManager("armi")
+    pm = pluginManager.ArmiPluginManager("armi")
     pm.add_hookspecs(ArmiPlugin)
     return pm
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -534,7 +534,7 @@ class Core(composites.Composite):
             )
 
         if spatialLocator is not None:
-            # transfer spatialLocator to reactor one
+            # transfer spatialLocator to Core one
             spatialLocator = self.spatialGrid[tuple(spatialLocator.indices)]
             a.moveTo(spatialLocator)
 

--- a/armi/settings/__init__.py
+++ b/armi/settings/__init__.py
@@ -35,6 +35,9 @@ from armi.settings.caseSettings import Settings
 from armi.utils import pathTools
 
 from armi.settings.setting import Setting
+from armi.settings.setting import Option
+from armi.settings.setting import Default
+
 
 NOT_ENABLED = ""  # An empty setting value implies that the feature
 

--- a/armi/settings/fwSettings/databaseSettings.py
+++ b/armi/settings/fwSettings/databaseSettings.py
@@ -40,6 +40,7 @@ def defineSettings():
             default="",
             label="Database Input File",
             description="Name of the database file to load initial conditions from",
+            oldNames=[("snapShotDB", None)]
         ),
         setting.Setting(
             CONF_LOAD_FROM_DB_EVERY_NODE,

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -189,6 +189,7 @@ def defineSettings() -> List[setting.Setting]:
             description="Turn on the profiler for the submitted case. The profiler "
             "results will not include all import times.",
             isEnvironment=True,
+            oldNames=[("turnOnProfiler", None),],
         ),
         setting.Setting(
             CONF_COVERAGE,
@@ -212,6 +213,7 @@ def defineSettings() -> List[setting.Setting]:
             description="Duration of one single cycle. If availability factor is below "
             "1, the reactor will be at power less than this. If variable, use "
             "cycleLengths setting.",
+            oldNames=[("burnTime", None),],
         ),
         setting.Setting(
             CONF_CYCLE_LENGTHS,
@@ -230,6 +232,7 @@ def defineSettings() -> List[setting.Setting]:
             description="Availability factor of the plant. This is the fraction of the "
             "time that the plant is operating. If variable, use availabilityFactors "
             "setting.",
+            oldNames=[("capacityFactor", None),],
         ),
         setting.Setting(
             CONF_AVAILABILITY_FACTORS,
@@ -268,6 +271,7 @@ def defineSettings() -> List[setting.Setting]:
             schema=vol.Any(
                 [float], None, float, msg="Expected NoneType, float, or list of floats."
             ),
+            oldNames=[("betaComponents", None),],
         ),
         setting.Setting(
             CONF_DECAY_CONSTANTS,
@@ -457,6 +461,7 @@ def defineSettings() -> List[setting.Setting]:
             label="Start Cycle",
             description="Cycle number to continue calculation from. Database will "
             "load from the time step just before. For snapshots use `dumpSnapshot`",
+            oldNames=[("loadCycle", None),],
         ),
         setting.Setting(
             CONF_LOADING_FILE,
@@ -471,6 +476,7 @@ def defineSettings() -> List[setting.Setting]:
             label="StartNode",
             description="Timenode number (0 for BOC, etc.) to continue calulation from. "
             "Database will load from the time step just before.",
+            oldNames=[("loadNode", None),],
         ),
         setting.Setting(
             CONF_LOAD_STYLE,
@@ -565,6 +571,7 @@ def defineSettings() -> List[setting.Setting]:
             label="Browse for shuffle history to repeat",
             description="Path to file that contains a detailed shuffling history that "
             "is to be repeated exactly.",
+            oldNames=[("movesFile", None), ("shuffleFileName", None)],
         ),
         setting.Setting(
             CONF_SKIP_CYCLES,

--- a/armi/settings/fwSettings/reportSettings.py
+++ b/armi/settings/fwSettings/reportSettings.py
@@ -30,13 +30,16 @@ def defineSettings():
             CONF_GEN_REPORTS,
             default=True,
             label="Enable Reports",
-            description="Employ the use of the reporting utility for ARMI, generating HTML and ASCII summaries of the run",
+            description="Employ the use of the reporting utility for ARMI, generating "
+            "HTML and ASCII summaries of the run",
+            oldNames=[("summarizer", None)]
         ),
         setting.Setting(
             CONF_ASSEM_POW_SUMMARY,
             default=False,
             label="Summarize Assembly Power",
-            description="Print out a summary of how much power is in each assembly type at every timenode.",
+            description="Print out a summary of how much power is in each assembly "
+            "type at every timenode.",
         ),
         setting.Setting(
             CONF_ZONE_FLOW_SUMMARY,
@@ -54,7 +57,8 @@ def defineSettings():
             CONF_TIMELINE_INCLUSION_CUTOFF,
             default=0.03,
             label="Timer Cutoff",
-            description="Timers who are not active for this percent of the run will not be presented in the timeline graphic.",
+            description="Timers who are not active for this percent of the run will "
+            "not be presented in the timeline graphic.",
         ),
     ]
     return settings

--- a/armi/settings/fwSettings/xsSettings.py
+++ b/armi/settings/fwSettings/xsSettings.py
@@ -55,6 +55,7 @@ def defineSettings():
             default=0.045,
             label="Minimum Fissile Fraction",
             description="Minimum fissile fraction (fissile number densities / heavy metal number densities).",
+            oldNames=[("mc2.minimumFissileFraction", None)],
         ),
         setting.Setting(
             CONF_MINIMUM_NUCLIDE_DENSITY,
@@ -110,6 +111,10 @@ def defineSettings():
             default=1e-05,
             label="Buckling Convergence Criteria",
             description="The convergence criteria for the buckling iteration if it is available in the lattice physics solver",
+            oldNames=[
+                ("mc2BucklingConvergence", None),
+                ("bucklingConvergence", None),
+            ],
         ),
         setting.Setting(
             CONF_XS_EIGENVALUE_CONVERGENCE,

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -34,7 +34,8 @@ code-based re-implementation.
 
 import copy
 from collections import namedtuple
-from typing import List
+import datetime
+from typing import List, Optional, Tuple
 
 import voluptuous as vol
 
@@ -77,6 +78,7 @@ class Setting:
         enforcedOptions=False,
         subLabels=None,
         isEnvironment=False,
+        oldNames: Optional[List[Tuple[str, Optional[datetime.date]]]] = None
     ):
         """
         Initialize a Setting object.
@@ -110,7 +112,11 @@ class Setting:
             Whether this should be considered an "environment" setting. These can be
             used by the Case system to propagate environment options through
             command-line flags.
-
+        oldNames : list of tuple, optional
+            List of previous names that this setting used to have, along with optional
+            expiration dates. These can aid in automatic migration of old inputs. When
+            provided, if it is appears that the expiration date has passed, old names
+            will result in errors.
         """
         self.name = name
         self.description = description or name
@@ -119,6 +125,7 @@ class Setting:
         self.enforcedOptions = enforcedOptions
         self.subLabels = subLabels
         self.isEnvironment = isEnvironment
+        self.oldNames: List[Tuple[str, Optional[datetime.date]]] = oldNames or []
 
         self._default = default
         # Retain the passed schema so that we don't accidentally stomp on it in

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -116,7 +116,8 @@ class Setting:
             List of previous names that this setting used to have, along with optional
             expiration dates. These can aid in automatic migration of old inputs. When
             provided, if it is appears that the expiration date has passed, old names
-            will result in errors.
+            will result in errors, requiring to user to update their input by hand to
+            use more current settings.
         """
         self.name = name
         self.description = description or name

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -89,7 +89,7 @@ class SettingRenamer:
          - If the ``name`` does not correspond to a current setting name, but is one of
            the active renames, return the corresponding active rename.
          - If the ``name`` does not correspond to a current setting name, but is one of
-           the expired renamse, produce a warning and do not rename it.
+           the expired renames, produce a warning and do not rename it.
 
         Parameters
         ----------

--- a/armi/settings/settingsRules.py
+++ b/armi/settings/settingsRules.py
@@ -12,7 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This module contains rules supporting custom actions taken on the reading of setting inputs"""
+"""
+This module contains rules supporting custom actions taken on the reading of setting inputs
+
+Note
+----
+The ``settingsRules`` system was developed before the pluginification of ARMI, and
+doesn't play very nicely with the post-plugin world. This is mainly because
+registration of new rules happens at import time of the rule itself, which is
+unreliable and difficult to control, and even sort of implicit and sneaky. They are
+also somewhate redundant with the
+:py:class:`armi.operators.settingsValidation.Query`/:py:class:`armi.operators.settingsValidation.Inspector`
+system. It is not recommended for plugins to define settings rules using the mechanism
+in this module, which may be removed in the future.
+"""
 import re
 
 from armi import runLog
@@ -27,138 +40,6 @@ OLD_TAGS = {
     "boolean": "bool",
     "string": "str",
     "list": "list",
-}
-
-# old : new
-RENAMES = {
-    "hexSideSubdivisions": "numberMeshPerEdge",
-    "generateFluxReconImagePlots": "plotReconAxialPower",
-    "snapShotDB": "reloadDBName",
-    "summarizer": "genReports",
-    "asymtoticExtrapolationPowerIters": "asymptoticExtrapolationPowerIters",
-    "old1PhaseHTC": "SinglePhaseHTC",
-    "1PhaseHTC": "SinglePhaseHTC",
-    "movesFile": "explicitRepeatShuffles",
-    "shuffleFileName": "explicitRepeatShuffles",
-    "intrinsicsourceDecayTime": "intrinsicSourceDecayTime",
-    "handlingSocketLength": "HandlingSocketLength",
-    "VoidWorth": "voidWorth",
-    # start of SASSYS settings rename
-    "useFileforGenericUncertainty": "useFileForGenericUncertainty",
-    "VoideddopplerCoeff": "voidedDopplerCoeff",
-    "structDensityCoeff": "structureDensityCoeff",
-    "cladaxialparams": "cladAxialParams",
-    "cladaxialParams": "cladAxialParams",
-    "cladaxialdistrib": "cladAxialDistrib",
-    "cladaxialDistrib": "cladAxialDistrib",
-    "structureaxialParams": "structureAxialParams",
-    "structureaxialDistrib": "structureAxialDistrib",
-    "fuelaxialparams": "fuelAxialParams",
-    "fuelaxialParams": "fuelAxialParams",
-    "fuelaxialdistrib": "fuelAxialDistrib",
-    "fuelaxialDistrib": "fuelAxialDistrib",
-    "cladaxialdistrib": "cladaxialDistrib",
-    "coolantparams": "coolantParams",
-    "coolantdistrib": "coolantDistrib",
-    "crdlparams": "crdlParams",
-    "crdldistrib": "crdlDistrib",
-    "dopplerparams": "dopplerParams",
-    "dopplerdistrib": "dopplerDistrib",
-    "fuelaxialparams": "fuelaxialParams",
-    "fuelaxialdistrib": "fuelaxialDistrib",
-    "radialparams": "radialParams",
-    "radialdistrib": "radialDistrib",
-    "ACRDEX": "acrDex",
-    "BCRDEX": "bcrDex",
-    "CPfe": "cpFe",
-    "CRWorthFile": "crWorthFile",
-    "numberofCases": "numberOfCases",
-    "numCaseforSassysSensitivity": "numCaseForSassysSensitivity",
-    "PowerFlowUncerCases": "powerFlowUncerCases",
-    "PowertoFlowRatioList": "powerToFlowRatioList",
-    "reCRDL": "reCrdl",
-    "sascases": "sasCases",
-    "TinFactor": "tinFactor",
-    "UTOPreactivity": "utopReactivity",
-    "Param10blockstartlocation": "param10BlockStartLocation",
-    "Param10Distrib": "param10Distrib",
-    "Param10name": "param10Name",
-    "Param10nominalvalue": "param10NominalValue",
-    "Param10Params": "param10Params",
-    "Param1blockstartlocation": "param1BlockStartLocation",
-    "Param1Distrib": "param1Distrib",
-    "Param1name": "param1Name",
-    "Param1nominalvalue": "param1NominalValue",
-    "Param1Params": "param1Params",
-    "Param2blockstartlocation": "param2BlockStartLocation",
-    "Param2Distrib": "param2Distrib",
-    "Param2name": "param2Name",
-    "Param2nominalvalue": "param2NominalValue",
-    "Param2Params": "param2Params",
-    "Param3blockstartlocation": "param3BlockStartLocation",
-    "Param3Distrib": "param3Distrib",
-    "Param3name": "param3Name",
-    "Param3nominalvalue": "param3NominalValue",
-    "Param3Params": "param3Params",
-    "Param4blockstartlocation": "param4BlockStartLocation",
-    "Param4Distrib": "param4Distrib",
-    "Param4name": "param4Name",
-    "Param4nominalvalue": "param4NominalValue",
-    "Param4Params": "param4Params",
-    "Param5blockstartlocation": "param5BlockStartLocation",
-    "Param5Distrib": "param5Distrib",
-    "Param5name": "param5Name",
-    "Param5nominalvalue": "param5NominalValue",
-    "Param5Params": "param5Params",
-    "Param6blockstartlocation": "param6BlockStartLocation",
-    "Param6Distrib": "param6Distrib",
-    "Param6name": "param6Name",
-    "Param6nominalvalue": "param6NominalValue",
-    "Param6Params": "param6Params",
-    "Param7blockstartlocation": "param7BlockStartLocation",
-    "Param7Distrib": "param7Distrib",
-    "Param7name": "param7Name",
-    "Param7nominalvalue": "param7NominalValue",
-    "Param7Params": "param7Params",
-    "Param8Distrib": "param8Distrib",
-    "Param8name": "param8Name",
-    "Param8nominalvalue": "param8NominalValue",
-    "Param8Params": "param8Params",
-    "Param9blockstartlocation": "param9BlockStartLocation",
-    "Param9Distrib": "param9Distrib",
-    "Param9name": "param9Name",
-    "Param9nominalvalue": "param9NominalValue",
-    "Param9Params": "param9Params",
-    "steadystate.txt": "steadyState.txt",
-    "lockrotor.txt": "lockRotor.txt",
-    "powerdefect.txt": "powerDefect.txt",
-    "control0name": "control0Name",
-    "control0location": "control0Location",
-    "control0value": "control0Value",
-    "control1name": "control1Name",
-    "control1location": "control1Location",
-    "control1value": "control1Value",
-    "control2name": "control2Name",
-    "control2location": "control2Location",
-    "control2value": "control2Value",
-    "SASdensityCoeff": "calcSpatialRxCoeffs",
-    # end of sassys setting rename
-    "turnOnProfiler": "profile",
-    "mc2.path": "mc2v3.path",
-    "mc2.minimumFissileFraction": "minimumFissileFraction",
-    "DLAYXSFilePath": "mc2DLAYXSFilePath",
-    "mc2BucklingConvergence": "bucklingConvergence",
-    "inactiveCycles": "mcnpInactiveCycles",
-    "mcnpBurnsPerAssem": "mcnpBurnRegionsPerBlock",
-    "particlesPerCycle": "mcnpParticlesPerCycle",
-    "mcnpCycles": "mcnpTotalCycles",
-    "burnTime": "cycleLength",
-    "capacityFactor": "availabilityFactor",
-    "covarianceFileName": "covariancePath",
-    "cinderdat": "mcnpBurnxDepLib",
-    "loadCycle": "startCycle",
-    "loadNode": "startNode",
-    "betaComponents": "beta",
 }
 
 TARGETED_CONVERSIONS = {}
@@ -196,13 +77,14 @@ def include_as_rule(*args):
 
 
 @include_as_rule
-def rename(_cs, name, value):
-    if name in RENAMES:
-        runLog.warning(
-            "Invalid setting {} found. Renaming to {}.".format(name, RENAMES[name])
-        )
-        name = RENAMES[name]
+def nullRule(_cs, name, value):
+    """
+    Pass setting values through.
 
+    All settings are passed through these settings rules when being read, with the
+    filtered results actually being used. Therefore, settings that aren't manipulated
+    need to be returned by something.
+    """
     return {name: value}
 
 


### PR DESCRIPTION
The previous mechanism for implicitly renaming old setting names to new
ones lived in settingsRules, which are difficult to extend from plugins.
As a result there were still a bunch of RENAMES for settings that have
since been removed from ARMI altogether. This includes a handful of
changes that allow these renames to live closer to the Settings to which
they apply, and therefore accessible to plugins. Changes include:

 - Introduce ArmiPluginManager. This is a subclass of the pluggy
 version, which adds a counter that is incremented any time the set of
 registered plugins changes. This allows clients to safely cache things
 derived from the plugins, and invalidate those caches as necessary. We
 may instead want to go the route of simply locking the plugin manager
 and preventing future modification, but this should work well for now,
 and is more flexible.

 - Add getSettings() method to the App class. The corresponding logic
 used to be called through the Settings.__init__() method, which was
 pretty odd.

 - Add the oldNames instance attribute to the Setting class. This is
 used to handle setting renames in lieu of settingsRules.RENAMES.

 - Add the SettingRenamer class to settingsIO, which distills the
 oldNames from the Setting instances and helps settingsIO perform
 migrations.

 - Merge the protected and public sections of SettingsReader. This was a
 holdover from when the SettingsReader doubled as a setting definition
 reader as well, and now only served to complicate matters.

 - Migrate the contents of RENAMES to their respective settings.