### PR TITLE
GAMISO/PMATRX merging treatment with voided cross section sets

### DIFF
--- a/armi/nuclearDataIO/__init__.py
+++ b/armi/nuclearDataIO/__init__.py
@@ -173,7 +173,9 @@ def _getGammaKeywords(cycle, suffix, xsID):
         elif xsID is not None:
             keywords = [xsID]
             if suffix not in [None, ""]:
-                keywords.append("-" + suffix)
+                if not suffix.startswith("-"):
+                    suffix = "-" + suffix
+                keywords.append(suffix)
         else:
             raise ValueError("The cycle or XS ID must be specified.")
         keywords.append(".")

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -200,8 +200,22 @@ def mergeXSLibrariesInWorkingDirectory(lib, xsLibrarySuffix="", mergeGammaLibs=F
                 for nuc in neutronLibrary.nuclides
                 if isinstance(nuc._base, nuclideBases.DummyNuclideBase)
             ]
+
+            gamisoLibraryPath = nuclearDataIO.getExpectedGAMISOFileName(suffix=xsLibrarySuffix, xsID=xsID)
+            pmatrxLibraryPath = nuclearDataIO.getExpectedPMATRXFileName(suffix=xsLibrarySuffix, xsID=xsID)
+
+            # Check if the gamiso and pmatrx data paths exist with the xs library suffix so that
+            # these are merged in. If they don't both exist then that is OK and we can just
+            # revert back to expecting the files just based on the XS ID.
+            if not (os.path.exists(gamisoLibraryPath) and os.path.exists(pmatrxLibraryPath)):
+                runLog.warning(f"One of GAMISO or PMATRX data exist for "
+                               f"XS ID {xsID} with suffix {xsLibrarySuffix}. "
+                               f"Attempting to find GAMISO/PMATRX data with "
+                               f"only XS ID {xsID} instead.")
+                gamisoLibraryPath = nuclearDataIO.getExpectedGAMISOFileName(xsID=xsID)
+                pmatrxLibraryPath = nuclearDataIO.getExpectedPMATRXFileName(xsID=xsID)
+
             # GAMISO data
-            gamisoLibraryPath = nuclearDataIO.getExpectedGAMISOFileName(xsID=xsID)
             gammaLibrary = gamiso.readBinary(gamisoLibraryPath)
             addedDummyData = gamiso.addDummyNuclidesToLibrary(
                 gammaLibrary, dummyNuclides
@@ -215,8 +229,8 @@ def mergeXSLibrariesInWorkingDirectory(lib, xsLibrarySuffix="", mergeGammaLibs=F
                 librariesToMerge.append(gammaLibraryDummyData)
             else:
                 librariesToMerge.append(gammaLibrary)
+
             # PMATRX data
-            pmatrxLibraryPath = nuclearDataIO.getExpectedPMATRXFileName(xsID=xsID)
             pmatrxLibrary = pmatrx.readBinary(pmatrxLibraryPath)
             addedDummyData = pmatrx.addDummyNuclidesToLibrary(
                 pmatrxLibrary, dummyNuclides


### PR DESCRIPTION
Updating the merging of GAMISO and PMATRX files when both gamma transport
and reactivity coefficients are enabled within the same run. This is
needed when considering a reactivity coefficient like Voided Doppler where
some cross section groups are updated to have a cross section library
suffix and others do not. This mirrors the behavior of the ISOTXS file
treatment.