### PR TITLE
Add error check that ARMI is not being re-configured

### DIFF
--- a/armi/localization/exceptions.py
+++ b/armi/localization/exceptions.py
@@ -63,6 +63,17 @@ class CcccRecordError(Exception):
     pass
 
 
+class OverConfiguredError(RuntimeError):
+    """An error that occurs when ARMI is configure()'d more than once."""
+
+    def __init__(self, context):
+        RuntimeError.__init__(
+            self,
+            "Multiple calls to armi.configure() are not allowed. "
+            "Previous call from:\n{}".format(context),
+        )
+
+
 class ReactivityCoefficientNonExistentComponentsInRepresentativeBlock(Exception):
     """
     An error that can occur when getting Doppler or Temperature reactivity coefficients within the core.

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -21,6 +21,7 @@ import unittest
 
 import armi
 from armi import plugins
+from armi.localization import exceptions
 
 
 class TestPlugin1(plugins.ArmiPlugin):
@@ -118,3 +119,7 @@ class TestArmi(unittest.TestCase):
 
         self.assertTrue(pm is not pm2)
         self.assertIn(cli.EntryPointsPlugin, pm.get_plugins())
+
+    def test_overConfigured(self):
+        with self.assertRaises(exceptions.OverConfiguredError):
+            armi.configure()


### PR DESCRIPTION
This produces a far more useful error message when armi.configure() is being called more than once.