### PR TITLE
Adding block volume fractions gallery example

### DIFF
--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -40,6 +40,39 @@ from armi.nuclearDataIO import isotxs
 from armi.reactor import geometry
 
 
+def buildSimpleFuelBlock():
+    """Return a simple block containing fuel, clad, duct, and coolant."""
+    b = blocks.HexBlock("fuel", height=10.0)
+
+    fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
+    cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.77, "mult": 127.0}
+    ductDims = {"Tinput": 25.0, "Thot": 400, "op": 16, "ip": 15.3, "mult": 1.0}
+    intercoolantDims = {
+        "Tinput": 400,
+        "Thot": 400,
+        "op": 17.0,
+        "ip": ductDims["op"],
+        "mult": 1.0,
+    }
+    coolDims = {"Tinput": 25.0, "Thot": 400}
+
+    fuel = components.Circle("fuel", "UZr", **fuelDims)
+    clad = components.Circle("clad", "HT9", **cladDims)
+    duct = components.Hexagon("duct", "HT9", **ductDims)
+    coolant = components.DerivedShape("coolant", "Sodium", **coolDims)
+    intercoolant = components.Hexagon("intercoolant", "Sodium", **intercoolantDims)
+
+    b.addComponent(fuel)
+    b.addComponent(clad)
+    b.addComponent(duct)
+    b.addComponent(coolant)
+    b.addComponent(intercoolant)
+
+    b.getVolumeFractions()  # TODO: remove, should be no-op when removed self.cached
+
+    return b
+
+
 def loadTestBlock(cold=True):
     """Build an annular test block for evaluating unit tests."""
     caseSetting = settings.Settings()
@@ -1694,25 +1727,7 @@ class MassConservationTests(unittest.TestCase):
     """
 
     def setUp(self):
-        # build a block that has some basic components in it.
-        self.b = blocks.HexBlock("fuel", height=10.0)
-
-        fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
-        cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.77, "mult": 127.0}
-        ductDims = {"Tinput": 25.0, "Thot": 400, "op": 16, "ip": 15.3, "mult": 1.0}
-        coolDims = {"Tinput": 25.0, "Thot": 400}
-
-        fuel = components.Circle("fuel", "UZr", **fuelDims)
-        clad = components.Circle("clad", "HT9", **cladDims)
-        duct = components.Hexagon("duct", "HT9", **ductDims)
-        coolant = components.DerivedShape("coolant", "Sodium", **coolDims)
-
-        self.b.addComponent(fuel)
-        self.b.addComponent(clad)
-        self.b.addComponent(duct)
-        self.b.addComponent(coolant)
-
-        self.b.getVolumeFractions()  # TODO: remove, should be no-op when removed self.cached
+        self.b = buildSimpleFuelBlock()
 
     def test_adjustSmearDensity(self):
         r"""

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -3,9 +3,9 @@ Computing Component Volume Fractions on a Block
 ===============================================
 
 Given an :py:mod:`Block <armi.reactor.blocks.Block>`, compute
-the component volume fractions. Re-assess these fractions 
-as the temperatures of the fuel and structure components are 
-increased uniformly.
+the component volume fractions. Assess the change in volume
+of these components within the block as the temperatures of 
+the fuel and structure components are increased uniformly.
 """
 
 import collections
@@ -14,54 +14,61 @@ import tabulate
 import matplotlib.pyplot as plt
 
 import armi
+
 armi.configure()
 
-from armi import runLog
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_blocks import buildSimpleFuelBlock
 
 
 def writeInitialVolumeFractions(b):
     """Write out the initial temperatures and component volume fractions."""
-    runLog.info(f"Volume fractions of {len(b)} components within {b}:")
     headers = ["Component", "Temperature (C)", "Volume Fraction"]
     data = [(c, c.temperatureInC, volFrac) for c, volFrac in b.getVolumeFractions()]
-    runLog.info(tabulate.tabulate(tabular_data=data, headers=headers))
+    print(tabulate.tabulate(tabular_data=data, headers=headers) + "\n")
+
 
 def plotVolFracsWithComponentTemps(b, uniformTemps):
     """Plot the percent change in vol. fractions as fuel/structure temperatures are uniformly increased."""
     # Perform uniform temperature modifications of the fuel and structural
     # components.
     componentsToModify = b.getComponents([Flags.FUEL, Flags.CLAD, Flags.DUCT])
-    
-    initialVolFracs = {}
-    relativeVolFracs = collections.defaultdict(list)
+
+    initialVols = {}
+    relativeVols = collections.defaultdict(list)
     for temp in uniformTemps:
-    
+
+        print(f"Updating fuel/structure components to {temp} C")
         # Modify the fuel/structure components to the
         # same uniform temperature
         for c in componentsToModify:
             c.setTemperature(temp)
-    
+
+        writeInitialVolumeFractions(b)
+
         # Iterate over all components and calculate the mass
         # and volume fractions
         for c in b:
             # Set the initial volume fractions at the first uniform temperature
             if temp == uniformTemps[0]:
-                initialVolFracs[c] = c.getVolume()/b.getVolume()
-            relativeVolFracs[c].append((c.getVolume()/b.getVolume() - initialVolFracs[c])/initialVolFracs[c] * 100.0)
-            
+                initialVols[c] = c.getVolume()
+
+            relativeVols[c].append(
+                (c.getVolume() - initialVols[c]) / initialVols[c] * 100.0
+            )
+
     fig, ax = plt.subplots()
-    
+
     for c in b.getComponents():
-        ax.plot(uniformTemps, relativeVolFracs[c], label=c.name)
-    
-    ax.set_ylabel(f"% Change in Vol. Fraction from {uniformTemps[0]} C")
+        ax.plot(uniformTemps, relativeVols[c], label=c.name)
+
+    ax.set_ylabel(f"% Change in Volume from {uniformTemps[0]} C")
     ax.set_xlabel("Uniform Fuel/Structure Temperature, C")
     ax.legend()
     ax.grid()
-    
+
     fig.show()
+
 
 uniformTemps = [400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1200.0]
 b = buildSimpleFuelBlock()

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -1,0 +1,70 @@
+"""
+Computing Component Volume Fractions on a Block
+===============================================
+
+Given an :py:mod:`Block <armi.reactor.blocks.Block>`, compute
+the component volume fractions. Re-assess these fractions 
+as the temperatures of the fuel and structure components are 
+increased uniformly.
+"""
+
+import collections
+
+import tabulate
+import matplotlib.pyplot as plt
+
+import armi
+armi.configure()
+
+from armi import runLog
+from armi.reactor.flags import Flags
+from armi.reactor.tests.test_blocks import buildSimpleFuelBlock
+
+
+def writeInitialVolumeFractions(b):
+    """Write out the initial temperatures and component volume fractions."""
+    runLog.info(f"Volume fractions of {len(b)} components within {b}:")
+    headers = ["Component", "Temperature (C)", "Volume Fraction"]
+    data = [(c, c.temperatureInC, volFrac) for c, volFrac in b.getVolumeFractions()]
+    runLog.info(tabulate.tabulate(tabular_data=data, headers=headers))
+
+def plotVolFracsWithComponentTemps(b, uniformTemps):
+    """Plot the percent change in vol. fractions as fuel/structure temperatures are uniformly increased."""
+    # Perform uniform temperature modifications of the fuel and structural
+    # components.
+    componentsToModify = b.getComponents([Flags.FUEL, Flags.CLAD, Flags.DUCT])
+    
+    initialVolFracs = {}
+    relativeVolFracs = collections.defaultdict(list)
+    for temp in uniformTemps:
+    
+        # Modify the fuel/structure components to the
+        # same uniform temperature
+        for c in componentsToModify:
+            c.setTemperature(temp)
+    
+        # Iterate over all components and calculate the mass
+        # and volume fractions
+        for c in b:
+            # Set the initial volume fractions at the first uniform temperature
+            if temp == uniformTemps[0]:
+                initialVolFracs[c] = c.getVolume()/b.getVolume()
+            relativeVolFracs[c].append((c.getVolume()/b.getVolume() - initialVolFracs[c])/initialVolFracs[c] * 100.0)
+            
+    fig, ax = plt.subplots()
+    
+    for c in b.getComponents():
+        ax.plot(uniformTemps, relativeVolFracs[c], label=c.name)
+    
+    ax.set_ylabel(f"% Change in Vol. Fraction from {uniformTemps[0]} C")
+    ax.set_xlabel("Uniform Fuel/Structure Temperature, C")
+    ax.legend()
+    ax.grid()
+    
+    fig.show()
+
+uniformTemps = [400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1200.0]
+b = buildSimpleFuelBlock()
+
+writeInitialVolumeFractions(b)
+plotVolFracsWithComponentTemps(b, uniformTemps)

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -1,11 +1,15 @@
+# -*- coding: utf-8 -*-
 """
-Computing Component Volume Fractions on a Block
-===============================================
+Computing Component Volume Fractions on a Block with Automatic Thermal Expansion
+================================================================================
 
 Given an :py:mod:`Block <armi.reactor.blocks.Block>`, compute
 the component volume fractions. Assess the change in volume
 of these components within the block as the temperatures of 
-the fuel and structure components are increased uniformly.
+the fuel and structure components are uniformly increased.
+
+Note: Thermal expansion is automatically considered with
+material data defined within :py:mod:`materials <armi.materials>`.
 """
 
 import collections
@@ -23,7 +27,7 @@ from armi.reactor.tests.test_blocks import buildSimpleFuelBlock
 
 def writeInitialVolumeFractions(b):
     """Write out the initial temperatures and component volume fractions."""
-    headers = ["Component", "Temperature (C)", "Volume Fraction"]
+    headers = ["Component", "Temperature, °C", "Volume Fraction"]
     data = [(c, c.temperatureInC, volFrac) for c, volFrac in b.getVolumeFractions()]
     print(tabulate.tabulate(tabular_data=data, headers=headers) + "\n")
 
@@ -36,13 +40,13 @@ def plotVolFracsWithComponentTemps(b, uniformTemps):
 
     initialVols = {}
     relativeVols = collections.defaultdict(list)
-    for temp in uniformTemps:
+    for tempInC in uniformTemps:
 
-        print(f"Updating fuel/structure components to {temp} C")
+        print(f"Updating fuel/structure components to {tempInC} °C")
         # Modify the fuel/structure components to the
         # same uniform temperature
         for c in componentsToModify:
-            c.setTemperature(temp)
+            c.setTemperature(tempInC)
 
         writeInitialVolumeFractions(b)
 
@@ -50,7 +54,7 @@ def plotVolFracsWithComponentTemps(b, uniformTemps):
         # and volume fractions
         for c in b:
             # Set the initial volume fractions at the first uniform temperature
-            if temp == uniformTemps[0]:
+            if tempInC == uniformTempsInC[0]:
                 initialVols[c] = c.getVolume()
 
             relativeVols[c].append(
@@ -60,18 +64,19 @@ def plotVolFracsWithComponentTemps(b, uniformTemps):
     fig, ax = plt.subplots()
 
     for c in b.getComponents():
-        ax.plot(uniformTemps, relativeVols[c], label=c.name)
+        ax.plot(uniformTempsInC, relativeVols[c], label=c.name)
 
-    ax.set_ylabel(f"% Change in Volume from {uniformTemps[0]} C")
-    ax.set_xlabel("Uniform Fuel/Structure Temperature, C")
+    ax.set_title("Component Volume Fractions with Automatic Thermal Expansion")
+    ax.set_ylabel(f"% Change in Volume from {uniformTempsInC[0]} °C")
+    ax.set_xlabel("Uniform Fuel/Structure Temperature, °C")
     ax.legend()
     ax.grid()
 
-    fig.show()
+    plt.show()
 
 
-uniformTemps = [400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1200.0]
+uniformTempsInC = [400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1200.0]
 b = buildSimpleFuelBlock()
 
 writeInitialVolumeFractions(b)
-plotVolFracsWithComponentTemps(b, uniformTemps)
+plotVolFracsWithComponentTemps(b, uniformTempsInC)


### PR DESCRIPTION
Adding an example to demonstrate computing component volume fractions on a block as a function 
of thermal expansion when uniformly adjusting component temperatures.