### PR TITLE
Fix bug in HT9

### DIFF
--- a/armi/materials/ht9.py
+++ b/armi/materials/ht9.py
@@ -75,6 +75,7 @@ class HT9(materials.Material):
 
         .. tip:: This can probably be sped up with a polynomial evaluator.
         """
+        Tk = units.getTk(Tc, Tk)
         return (
             29.65
             - 6.668e-2 * Tk


### PR DESCRIPTION
The temperature was not being converted to Kelvin before evaluating the
fit.