### PR TITLE
Change assembly ordering to be i,j based instead of ring,pos

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -153,7 +153,9 @@ class App:
                         defaultsCache[pluginSetting.settingName] = pluginSetting
                 else:
                     raise TypeError(
-                        f"Invalid setting definition found: {pluginSetting}"
+                        "Invalid setting definition found: {} ({})".format(
+                            pluginSetting, type(pluginSetting)
+                        )
                     )
 
         if optionsCache:

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -129,12 +129,21 @@ class Assembly(composites.Composite):
         """
         Compare two assemblies by location.
 
-        This allows for consistent sorting of assemblies based on location. If either
-        assembly is not in the core (or more accurately a container), returns False.
-        This behavior may lead to some strange sorting behavior when two or more
-        Assemblies are being compared that do not live in the same grid. It may be
-        beneficial in the future to maintain the more strict behavior of ArmiObject's
-        ``__lt__`` implementation.
+        Notes
+        -----
+        As with other ArmiObjects, Assemblies are sorted based on location. Assemblies
+        are more permissive in the grid consistency checks to accomodate situations
+        where assemblies might be children of the same Core, but not in the same grid as
+        each other (as can be the case in the spent fuel or charge fuel pools). In these
+        situations, the operator returns ``False``.  This behavior may lead to some
+        strange sorting behavior when two or more Assemblies are being compared that do
+        not live in the same grid. It may be beneficial in the future to maintain the
+        more strict behavior of ArmiObject's ``__lt__`` implementation once the SFP/CFP
+        situation is cleared up.
+
+        See also
+        --------
+        armi.reactor.composites.ArmiObject.__lt__
         """
         try:
             return composites.ArmiObject.__lt__(self, other)
@@ -207,6 +216,8 @@ class Assembly(composites.Composite):
         """
         Get string label representing this object's location.
 
+        Notes
+        -----
         This function (and its friends) were created before the advent of both the
         grid/spatialLocator system and the ability to represent things like the SFP as
         siblings of a Core. In future, this will likely be re-implemented in terms of

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -129,12 +129,16 @@ class Assembly(composites.Composite):
         """
         Compare two assemblies by location.
 
-        This allow consistent sorting of assemblies based on location. If either
+        This allows for consistent sorting of assemblies based on location. If either
         assembly is not in the core (or more accurately a container), returns False.
+        This behavior may lead to some strange sorting behavior when two or more
+        Assemblies are being compared that do not live in the same grid. It may be
+        beneficial in the future to maintain the more strict behavior of ArmiObject's
+        ``__lt__`` implementation.
         """
         try:
-            return self.spatialLocator.getRingPos() < other.spatialLocator.getRingPos()
-        except:
+            return composites.ArmiObject.__lt__(self, other)
+        except ValueError:
             return False
 
     def makeUnique(self):
@@ -200,7 +204,14 @@ class Assembly(composites.Composite):
         return int(self.p.assemNum)
 
     def getLocation(self):
-        """Get string label representing this object's location."""
+        """
+        Get string label representing this object's location.
+
+        This function (and its friends) were created before the advent of both the
+        grid/spatialLocator system and the ability to represent things like the SFP as
+        siblings of a Core. In future, this will likely be re-implemented in terms of
+        just spatialLocator objects.
+        """
         # just use ring and position, not axial (which is 0)
         if not self.parent:
             return self.LOAD_QUEUE

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2631,9 +2631,10 @@ class HexBlock(Block):
         If this block is not in any grid at all, then there can be no symmetry so return 1.
         """
         if (
-            self.core is not None
-            and self.spatialLocator.grid
-            and self.core.symmetry == geometry.THIRD_CORE + geometry.PERIODIC
+            self.parent is not None
+            and self.parent.spatialLocator.grid is not None
+            and self.parent.spatialLocator.grid.symmetry
+            == geometry.THIRD_CORE + geometry.PERIODIC
         ):
             indices = self.spatialLocator.getCompleteIndices()
             if indices[0] == 0 and indices[1] == 0:

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -278,6 +278,11 @@ class ArmiObject(metaclass=CompositeModelType):
         restrictive, it can probably be relaxed or overridden on specific classes.
 
         """
+
+        if self.spatialLocator is None or other.spatialLocator is None:
+            runLog.error("could not compare {} and {}".format(self, other))
+            raise ValueError("One or more of the compared objects have no spatialLocator")
+
         if self.spatialLocator.grid is not other.spatialLocator.grid:
             runLog.error("could not compare {} and {}".format(self, other))
             raise ValueError(

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -939,6 +939,17 @@ class Grid:
 
         A tuple is returned so that it is easy to compare pairs of indices.
         """
+        # Regular grids dont really know about ring and position. We can try to see if
+        # their parent does!
+        if (
+            self.armiObject is not None
+            and self.armiObject.parent is not None
+            and self.armiObject.parent.spatialGrid is not None
+        ):
+            return self.armiObject.parent.spatialGrid.getRingPos(indices)
+
+        # For compatibility's sake, return __something__. TODO: We may want to just
+        # throw here, to be honest.
         return tuple(indices[:2])
 
     def changePitch(self, xw, yw):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1160,6 +1160,15 @@ class Core(composites.Composite):
         """
         Gets the first assembly in the reactor.
 
+        Warning
+        -------
+        This function should be used with great care. There are **very** few
+        circumstances in which one wants the "first" of a given sort of assembly,
+        `whichever that may happen to be`. Precisely which assembly is returned is
+        sensitive to all sorts of implementation details in Grids, etc., which make the
+        concept of "first" rather slippery. Prefer using some sort of precise logic to
+        pick a specific assembly from the Core.
+
         Parameters
         ----------
         typeSpec : Flags or iterable of Flags, optional
@@ -1769,6 +1778,15 @@ class Core(composites.Composite):
         -------
         a : Assembly
             A new assembly
+
+        Notes
+        -----
+        This and similar fuel shuffle-enabling functionality on the Core are responsible
+        for coupling between the Core and Blueprints. Technically, it should not be
+        required to involve Blueprints at all in the construction of a Reactor model.
+        Therefore in some circumstances, this function will not work. Ultimately, this
+        should be purely the domain of blueprints themselves, and may be migrated out of
+        Core in the future.
 
         See Also
         --------

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1160,8 +1160,8 @@ class Core(composites.Composite):
         """
         Gets the first assembly in the reactor.
 
-        Warning
-        -------
+        Warnings
+        --------
         This function should be used with great care. There are **very** few
         circumstances in which one wants the "first" of a given sort of assembly,
         `whichever that may happen to be`. Precisely which assembly is returned is

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1805,7 +1805,7 @@ class Core(composites.Composite):
                 enrichList = itertools.cycle([enrichList])
             elif len(a) != len(enrichList):
                 raise RuntimeError(
-                    "{0} and enrichment list do not have the same number of blocks. Check repeat shuffles file".format(
+                    "{0} and enrichment list do not have the same number of blocks.".format(
                         a
                     )
                 )

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -589,7 +589,7 @@ class HexReactorTests(ReactorTests):
         self.assertAlmostEqual(
             aNew3.getFirstBlock(Flags.FUEL).getUraniumMassEnrich(), 0.195
         )
-        self.assertAlmostEqual(aNew3.getMass(), bol.getMass() / 3.0)
+        self.assertAlmostEqual(aNew3.getMass(), bol.getMass())
 
 
 class CartesianReactorTests(ReactorTests):

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -203,7 +203,11 @@ class Zones_InRZReactor(unittest.TestCase):
         # Create a single assembly zone to verify that it will not create a hot zone
         single = zones.Zone("single")
         daZones.add(single)
-        aLoc = r.core.getFirstAssembly(Flags.FUEL).getLocation()
+        aLoc = next(
+            a
+            for a in r.core.getAssemblies(Flags.FUEL)
+            if a.spatialLocator.getRingPos() == (1, 1)
+        ).getLocation()
         single.append(aLoc)
 
         # Set power and flow.


### PR DESCRIPTION
Ring and position are not always available, and therefore aren't a good
candidate about which to build fundamental concepts like object
ordering. This will unfortunately break unit tests and other code that
are sensitive to assembly (and therefore Block) ordering within a
reactor model.
