### PR TITLE
Stabilize "refAssem"

### DIFF
--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -148,9 +148,8 @@ class BlockNumberModifier(GeometryChanger):
         """
         refAssem = r.core.refAssem
         fuelI = refAssem.getBlocks().index(refAssem.getFirstBlock(Flags.FUEL))
-        origRefBlocks = len(
-            refAssem
-        )  # store this b/c the ref assem length will change.
+        # store this b/c the ref assem length will change.
+        origRefBlocks = len(refAssem)
 
         for a in r.core.getAssemblies(includeBolAssems=True):
             if len(a) == origRefBlocks:
@@ -1134,7 +1133,7 @@ class HexToRZThetaConverter(GeometryConverter):
                     innerAxial = outerAxial
                 innerRadius = outerRadius
             ax.set_title(
-                    "{} Core Map from {} to {:.4f} revolutions".format(
+                "{} Core Map from {} to {:.4f} revolutions".format(
                     self.convReactor.core.geomType.upper(),
                     innerTheta * units.RAD_TO_REV,
                     outerTheta * units.RAD_TO_REV,
@@ -1159,7 +1158,7 @@ class HexToRZThetaConverter(GeometryConverter):
             ax.set_xlabel("Radial Mesh (cm)".upper(), labelpad=20)
             ax.set_ylabel("Axial Mesh (cm)".upper(), labelpad=20)
             if fNameBase:
-                root, ext  = os.path.splitext(fNameBase)
+                root, ext = os.path.splitext(fNameBase)
                 fName = root + f"{i}" + ext
                 plt.savefig(fName)
                 plt.close()

--- a/armi/reactor/converters/meshConverters.py
+++ b/armi/reactor/converters/meshConverters.py
@@ -451,7 +451,7 @@ class AxialExpansionModifier(MeshConverter):
 
         if not self._converterSettings["detailedAxialExpansion"]:
             # loop through again now that the reference is adjusted and adjust the non-fuel assemblies.
-            refAssem = r.core.getFirstAssembly(Flags.FUEL) or r.core.getFirstAssembly()
+            refAssem = r.core.refAssem
             axMesh = refAssem.getAxialMesh()
             for a in r.core.getAssemblies(includeBolAssems=True):
                 # See ARMI Ticket #112 for explanation of the commented out code

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -115,7 +115,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         Computes an average axial mesh based on the first fuel assembly
         """
         src = self._sourceReactor
-        refAssem = src.core.getFirstAssembly(Flags.FUEL)
+        refAssem = src.core.refAssem
         refNumPoints = (
             len(src.core.findAllAxialMeshPoints([refAssem], applySubMesh=True)) - 1
         )  # pop off zero

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -324,9 +324,9 @@ class Core(composites.Composite):
         not particularly representative of the state of the core as a whole.
         """
         key = lambda a: a.spatialLocator.getRingPos()
-        assems = self.getAssemblies(Flags.FUEL, key=key)
+        assems = self.getAssemblies(Flags.FUEL, sortKey=key)
         if not assems:
-            assems = self.getAssemblies(key=key)
+            assems = self.getAssemblies(sortKey=key)
 
         return assems[0]
 
@@ -1004,7 +1004,7 @@ class Core(composites.Composite):
     def getAssemblies(
         self,
         typeSpec=None,
-        key=None,
+        sortKey=None,
         includeBolAssems=False,
         includeSFP=False,
         includeCFP=False,

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1027,7 +1027,7 @@ class Core(composites.Composite):
         typeSpec : Flags or iterable of Flags, optional
             List of assembly types that will be returned
 
-        key : callable, optional
+        sortKey : callable, optional
             Sort predicate to use when sorting the assemblies.
 
         includeBolAssems : bool, optional
@@ -1063,7 +1063,7 @@ class Core(composites.Composite):
             and self.parent.blueprints is not None
         ):
             assems.extend(self.parent.blueprints.assemblies.values())
-        assems.extend(a for a in sorted(self, key=key))
+        assems.extend(a for a in sorted(self, key=sortKey))
 
         if includeSFP:
             assems.extend(self.sfp.getChildren())


### PR DESCRIPTION
This explicitly defines the Core's "refAssem" to be the center-most FUEL
assembly, if there are fueled assemblies, or the center-most assembly if
there are not. It also bends some code that was doing essentially the
same thing towards using `core.refAssem` so that their behavior is at
least consistent.

In support of this, an optional `key=` argument was added to the
`getAssemblies()` method to inject a sorting key. This allows client
code to sort assemblies however they wish, without having to resort
re-sorting the already-sorted Assemblies.