### PR TITLE
Add `doTH` T/H activation setting.

### DIFF
--- a/armi/physics/thermalHydraulics/settings.py
+++ b/armi/physics/thermalHydraulics/settings.py
@@ -17,10 +17,19 @@
 from armi.settings import setting
 from armi.operators.settingsValidation import Query
 
+CONF_DO_TH = "doTH"
+
 
 def defineSettings():
     """Define generic thermal/hydraulic settings."""
-    settings = []
+    settings = [
+        setting.Setting(
+            CONF_DO_TH,
+            default=False,
+            label="Run Thermal Hydraulics",
+            description="Run thermal hydraulics",
+        ),
+    ]
     return settings
 
 

--- a/armi/physics/thermalHydraulics/settings.py
+++ b/armi/physics/thermalHydraulics/settings.py
@@ -15,9 +15,9 @@
 """Settings related to Thermal Hydraulics"""
 
 from armi.settings import setting
-from armi.operators.settingsValidation import Query
 
 CONF_DO_TH = "doTH"
+CONF_TH_KERNEL = "thKernel"
 
 
 def defineSettings():
@@ -27,7 +27,16 @@ def defineSettings():
             CONF_DO_TH,
             default=False,
             label="Run Thermal Hydraulics",
-            description="Run thermal hydraulics",
+            description=(
+                f"Activate thermal hydraulics calculations using the physics module defined in "
+                f"`{CONF_TH_KERNEL}`"
+            ),
+        ),
+        setting.Setting(
+            CONF_TH_KERNEL,
+            default=False,
+            label="Thermal Hydraulics Kernel",
+            description="Name of primary T/H solver in this run",
         ),
     ]
     return settings


### PR DESCRIPTION
This setting can be used to activate any thermal/hydraulics plugin that
is incorporated into an ARMI app. It is being promoted from internal
plugins to a framework setting so that it can be shared across various
T/H plugins without coupling to any particular one.