### PR TITLE
Define and implement plugin hook to handle MPI resets

### DIFF
--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -188,7 +188,8 @@ class OperatorMPI(Operator):
                     )
             pm = armi.getPluginManager()
             resetFlags = pm.hook.mpiActionRequiresReset(cmd=cmd)
-            if any(resetFlags):
+            # if any of the plugins vote to NOT reset, then we don't reset.
+            if not all(resetFlags):
                 self._resetWorker()
 
             # might be an mpi action which has a reactor and everything, preventing

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -188,8 +188,8 @@ class OperatorMPI(Operator):
                     )
             pm = armi.getPluginManager()
             resetFlags = pm.hook.mpiActionRequiresReset(cmd=cmd)
-            # if any of the plugins vote to NOT reset, then we don't reset.
-            if not all(resetFlags):
+            # only reset if all the plugins agree to reset
+            if all(resetFlags):
                 self._resetWorker()
 
             # might be an mpi action which has a reactor and everything, preventing
@@ -228,9 +228,8 @@ class OperatorMPI(Operator):
     def workerQuit():
         runLog.debug("Worker ending")
         runLog.LOG.close()  # no more messages.
-        armi.MPI_COMM.bcast(
-            "finished", root=0
-        )  # wait until all workers are closed so we can delete them.
+        # wait until all workers are closed so we can delete them.
+        armi.MPI_COMM.bcast("finished", root=0)
 
     def collapseAllStderrs(self):
         """Takes all the individual stderr files from each processor and arranges them nicely into one file"""

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -475,6 +475,31 @@ class ArmiPlugin:
                     "oldParam": "currentParam"}
         """
 
+    @staticmethod
+    @HOOKSPEC
+    def mpiActionRequiresReset(cmd) -> bool:
+        """
+        Flag indicating when a reactor reset is required.
+
+        Commands are sent through operators either as strings (old) or as MpiActions (newer).
+        After some are sent, the reactor must be reset. This hook says when to reset. The
+        reset operation is a (arguably suboptimal) response to some memory issues in
+        very large and long-running cases.
+
+        Parameters
+        ----------
+        cmd :  str or MpiAction
+            The ARMI mpi command being sent
+
+        Returns
+        -------
+        bool
+
+        See Also
+        --------
+        armi.operators.operatorMPI.OperatorMPI.workerOperate : Handles these flags
+        """
+
 
 def getNewPluginManager() -> pluginManager.ArmiPluginManager:
     """


### PR DESCRIPTION
For ARMI runs in parallel over MPI, several internal plugins were
imported, causing ImportErrors. The rectify this, we define here
a new plugin hook, mpiActionRequiresReset, and implement it
as appropriate on the framework and in other plugins.

Along the way, it was noticed that if a worker MPI node fails
in this way, the traceback was not available. So we added an
additional traceback printout to help aid in debugging. Still
not quite right is the fact that the run hangs in this situation.

Sidenote: No one is too happy with the MPI resetting operation
in general. It is a remnant of challenging memory issues related
to gigantic long-running cases.