### PR TITLE
Consolidate getDominantMaterial methods into one

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -532,7 +532,7 @@ class SlabComponentsAverageBlockCollection(BlockCollection):
         - This component does not serve any purpose for XS generation as it contains void material with zero area.
         - Removing this component does not modify the blocks within the reactor.
         """
-        for c in repBlock.getComponents():
+        for c in repBlock.iterComponents():
             if c.isLatticeComponent():
                 repBlock.remove(c)
         return repBlock

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1358,53 +1358,6 @@ class Assembly(composites.Composite):
         # return none if there is nothing to return
         return None
 
-    def getDominantMaterial(self, typeSpec=None, blockList=None):
-        """
-        Returns the most common material in the compositions of the blocks.
-
-        If you pass ['clad','duct'], you might get HT9, for example.  This allows
-        generality in reading material properties on groups of blocks.  Dominant is
-        defined by most volume. This version is assembly-level.
-
-        Parameters
-        ----------
-        typeSpec : Flags or list of Flags, optional
-            Specification of the type of components to pull the dominant materials from.
-
-        blockList : list of block objects
-            A list of blocks to look at in this assembly.
-
-        Returns
-        -------
-        samples[maxMat] : Material object
-            The material that has the most volume within this assembly within the given
-            typeSpec and blockList.
-
-        """
-        mats = {}
-        samples = {}
-
-        if not blockList:
-            blockList = self.getBlocks()
-        for b in blockList:
-            bmats, bsamples = b.getDominantMaterial(typeSpec)
-            for matName, blockVol in bmats.items():
-                mats[matName] = mats.get(matName, 0.0) + blockVol
-            samples.update(bsamples)
-
-        # find max volume
-        maxVol = 0.0
-        maxMat = None
-        for mName, vol in mats.items():
-            if vol > maxVol:
-                maxVol = vol
-                maxMat = mName
-        if maxMat:
-            # return a copy of this material. Note that if this material
-            # has properties like Zr-frac, enrichment, etc. then this will
-            # just return one in the batch, not an average.
-            return samples[maxMat]
-
     def getSymmetryFactor(self):
         """Return the symmetry factor of this assembly."""
         return self[0].getSymmetryFactor()

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1137,7 +1137,7 @@ class Block(composites.Composite):
             A list of (components,dimName) that are linked to this component, dim.
         """
         linked = []
-        for c in self.getComponents():
+        for c in self.iterComponents():
             for dimName, val in c.p.items():
                 if c.dimensionIsLinked(dimName):
                     requiredComponent = val[0]
@@ -1338,7 +1338,7 @@ class Block(composites.Composite):
 
     def getPlenumPin(self):
         """Return the plenum pin if it exists."""
-        for c in self.getComponents(Flags.GAP):
+        for c in self.iterComponents(Flags.GAP):
             if self.isPlenumPin(c):
                 return c
         return None
@@ -1436,7 +1436,7 @@ class Block(composites.Composite):
         """
         maxDim = -float("inf")
         largestComponent = None
-        for c in self.getComponents():
+        for c in self.iterComponents():
             try:
                 dimVal = c.getDimension(dimension)
             except parameters.ParameterError:

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1085,38 +1085,6 @@ class Block(composites.Composite):
         if recomputeAreaFractions:
             self.getVolumeFractions()
 
-    def getDominantMaterial(self, typeSpec):
-        """
-        compute the total volume of each distinct material type in this object.
-
-        Parameters
-        ----------
-        typeSpec : Flags or iterable of Flags
-            The types of components to consider (e.g. [Flags.FUEL, Flags.CONTROL])
-
-        Returns
-        -------
-        mats : dict
-            keys are material names, values are the total volume of this material in cm*2
-        samples : dict
-            keys are material names, values are Material objects
-
-        See Also
-        --------
-        getComponentsOfMaterial : gets components made of a particular material
-        getComponent : get component of a particular type (e.g. Flags.COOLANT)
-        getNuclides : list all nuclides in a block or component
-        armi.reactor.reactors.Core.getDominantMaterial : gets dominant material in core
-        """
-        mats = {}
-        samples = {}
-        for c in self.iterComponents(typeSpec):
-            vol = c.getVolume()
-            matName = c.material.getName()
-            mats[matName] = mats.get(matName, 0.0) + vol
-            samples[matName] = c.material
-        return mats, samples
-
     def getComponentsThatAreLinkedTo(self, comp, dim):
         """
         Determine which dimensions of which components are linked to a specific dimension of a particular component.

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -180,13 +180,12 @@ def summarizeMaterialData(container):
     )
     materialNames = set()
     materialData = []
-    for b in container.getBlocks():
-        for c in b:
-            if c.material.name in materialNames:
-                continue
-            sourceLocation, wasModified = _getMaterialSourceData(c.material)
-            materialData.append((c.material.name, sourceLocation, wasModified))
-            materialNames.add(c.material.name)
+    for c in container.iterComponents():
+        if c.material.name in materialNames:
+            continue
+        sourceLocation, wasModified = _getMaterialSourceData(c.material)
+        materialData.append((c.material.name, sourceLocation, wasModified))
+        materialNames.add(c.material.name)
     materialData = sorted(materialData)
     runLog.info(
         tabulate.tabulate(

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -3224,7 +3224,7 @@ def gatherMaterialsByVolume(
             volumes[matName] = volumes.get(matName, 0.0) + vol
             if matName not in samples:
                 samples[matName] = c.material
-        return volumes, samples
+    return volumes, samples
 
 
 def getDominantMaterial(

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -249,7 +249,6 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def __init__(self, name):
         self.name = name
-        self._children = []
         self.parent = None
         self.cached = {}
         self._backupCache = None
@@ -259,10 +258,8 @@ class ArmiObject(metaclass=CompositeModelType):
         # way to either represent them in parameters, or otherwise reliably
         # recover them.
         self._lumpedFissionProducts = None
-
         self.spatialGrid = None
         self.spatialLocator = grids.CoordinateLocation(0.0, 0.0, 0.0, None)
-        self.childrenByLocator = {}
 
     def __lt__(self, other):
         """
@@ -2640,6 +2637,11 @@ class Composite(ArmiObject):
     reactors.
 
     """
+
+    def __init__(self, name):
+        ArmiObject.__init__(self, name)
+        self.childrenByLocator = {}
+        self._children = []
 
     def __getitem__(self, index):
         return self._children[index]

--- a/armi/reactor/converters/meshConverters.py
+++ b/armi/reactor/converters/meshConverters.py
@@ -486,10 +486,7 @@ def getAxialExpansionNuclideAdjustList(r, componentFlags: TypeSpec = None):
         componentFlags = [Flags.FUEL]
 
     adjustSet = {
-        nuc
-        for b in r.core.getBlocks()
-        for c in b.getComponents(componentFlags)
-        for nuc in c.getNuclides()
+        nuc for c in r.core.iterComponents(componentFlags) for nuc in c.getNuclides()
     }
 
     return list(adjustSet)

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1892,18 +1892,6 @@ class Core(composites.Composite):
         assembliesOnLine.sort(key=lambda a: a.spatialLocator.getRingPos())
         return assembliesOnLine
 
-    def _addBlockToXsIndex(self, block):
-        """
-        Build cross section index as required by subdivide.
-        """
-        volumes, _samples = composites.gatherMaterialsByVolume([block])
-        mTuple = ("", 0)
-        blockVol = block.getVolume()
-        for matName, volume in volumes.items():
-            if volume > mTuple[1]:
-                mTuple = (matName, volume / blockVol, False)
-        self.xsIndex[block.p.xsType] = mTuple
-
     def buildZones(self, cs):
         """Update the zones on the reactor."""
         self.zones = zones.buildZones(self, cs)

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1257,14 +1257,13 @@ class Core(composites.Composite):
             coolantNuclides = set()
             fuelNuclides = set()
             structureNuclides = set()
-            for b in self.getBlocks():
-                for c in b:
-                    if c.getName() == "coolant":
-                        coolantNuclides.update(c.getNuclides())
-                    elif "fuel" in c.getName():
-                        fuelNuclides.update(c.getNuclides())
-                    else:
-                        structureNuclides.update(c.getNuclides())
+            for c in self.iterComponents():
+                if c.getName() == "coolant":
+                    coolantNuclides.update(c.getNuclides())
+                elif "fuel" in c.getName():
+                    fuelNuclides.update(c.getNuclides())
+                else:
+                    structureNuclides.update(c.getNuclides())
             structureNuclides -= coolantNuclides
             structureNuclides -= fuelNuclides
             remainingNuclides = (
@@ -2254,7 +2253,7 @@ class Core(composites.Composite):
                 weight = b.p.flux ** 2.0
             else:
                 weight = 1.0
-            for c in b.getComponents(typeSpec):
+            for c in b.iterComponents(typeSpec):
                 vol = c.getVolume()
                 num += c.temperatureInC * vol * weight
                 denom += vol * weight
@@ -2347,10 +2346,9 @@ class Core(composites.Composite):
             mats = [mats]
         names = set(m.name for m in mats)
         allNucNames = set()
-        for b in self.getBlocks():
-            for c in b.getComponents():
-                if c.material.name in names:
-                    allNucNames.update(c.getNuclides())
+        for c in self.iterComponents():
+            if c.material.name in names:
+                allNucNames.update(c.getNuclides())
         return list(allNucNames)
 
     def growToFullCore(self, cs):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1166,7 +1166,7 @@ class Block_TestCase(unittest.TestCase):
         cur = self.Block.getVolumeFractions()
         tot = 0.0
         areas = []
-        for c in self.Block.getComponents():
+        for c in self.Block.iterComponents():
             a = c.getArea()
             tot += a
             areas.append((c, a))


### PR DESCRIPTION
There were quasi-independent implementations of getDominantMaterial
on three separate objects. Now they are all unified into the same
implementation. The special needs of various clients have been handled
by refactoring the functionality into two functions at the composite
module level. A warning was added indicating the high likelihood of these
functions being moved to something more topical of composition in the
near future.

In addition, several calls to `getComponents` were changed to `iterComponents`
mostly as an indication of where it's appropriate to use one over the other.
The performance enhancement of this is not expected to be large.