### PR TITLE
Add Thermal Scattering information

### DIFF
--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -32,8 +32,13 @@ from armi.settings import caseSettings
 def pytest_sessionstart(session):
     import armi
     from armi import apps
+    from armi.nucDirectory import nuclideBases
 
     print("Initializing generic ARMI Framework application")
     armi.configure(apps.App())
     cs = caseSettings.Settings()
     settings.setMasterCs(cs)
+    # Need to init burnChain.
+    # see armi.cases.case.Case._initBurnChain
+    with open(cs["burnChainFileName"]) as burnChainStream:
+        nuclideBases.imposeBurnChain(burnChainStream)

--- a/armi/materials/__init__.py
+++ b/armi/materials/__init__.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 """
-The material package defines compositions and temperature-dependent thermo-mechanical properties.
+The material package defines compositions and material-specific properties.
+
+Properties in scope include temperature dependent thermo/mechanical properties 
+(like heat capacity, linear expansion coefficients, viscosity, density),
+and material-specific nuclear properties that can't exist at the nuclide level 
+alone (like :py:mod:`thermal scattering laws <armi.nucDirectory.thermalScattering>`).
 
 As the fundamental macroscopic building blocks of any physical object,
 these are highly important to reactor analysis.

--- a/armi/materials/be9.py
+++ b/armi/materials/be9.py
@@ -20,12 +20,15 @@ It has a nice (n,2n) reaction and is an inhalation hazard.
 
 from armi.utils.units import getTk
 from armi.materials.material import Material
+from armi.nucDirectory import thermalScattering as tsl
+from armi.nucDirectory import nuclideBases as nb
 
 
 class Be9(Material):
     """Beryllium."""
 
     name = "Be-9"
+    thermalScatteringLaws = (tsl.byNbAndCompound[nb.byName["BE"], tsl.BE_METAL],)
 
     def setDefaultMassFracs(self):
         self.setMassFrac("BE9", 1.0)

--- a/armi/materials/graphite.py
+++ b/armi/materials/graphite.py
@@ -19,6 +19,8 @@ Graphite is often used as a moderator in gas-cooled nuclear reactors.
 
 from armi.materials.material import Material
 from armi.utils import units
+from armi.nucDirectory import thermalScattering as tsl
+from armi.nucDirectory import nuclideBases as nb
 
 
 class Graphite(Material):
@@ -31,6 +33,7 @@ class Graphite(Material):
     """
 
     name = "Graphite"
+    thermalScatteringLaws = (tsl.byNbAndCompound[nb.byName["C"], tsl.GRAPHITE_10P],)
 
     def setDefaultMassFracs(self):
         """
@@ -48,4 +51,4 @@ class Graphite(Material):
         From  [INL-EXT-16-38241]_, page 4.
         """
         Tc = units.getTc(Tc, Tk)
-        return 100*(-1.454e-4 + 4.812e-6 * Tc + 1.145e-9 * Tc ** 2)
+        return 100 * (-1.454e-4 + 4.812e-6 * Tc + 1.145e-9 * Tc ** 2)

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -17,7 +17,7 @@ Base Material classes.
 
 All temperatures are in K, but Tc can be specified and the functions will convert for you.
 
-.. Caution:: ARMI uses these objects for all material properties. Under the hood,
+.. warning:: ARMI uses these objects for all material properties. Under the hood,
      A system called MAT_PROPS is in charge of several material properties. It
      is a more industrial-strength material property system that is currently
      a TerraPower proprietary system. You will see references to it in this module.
@@ -41,37 +41,30 @@ FAIL_ON_RANGE = False
 
 
 class Material(composites.Leaf):
-    r"""
-    A material is made up of elements or isotopes. It has bulk properties like mass density.
-
-    Attributes
-    ----------
-    params : dict
-        scalar parameters.
-
-    massFrac : dict
-        The mass fractions of each nuclide in this material. These will not always sum to 1.0 after
-        situations like axial expansion.
-
-    massFracNorm : float
-        The sum of massFrac, tracked by the setters so it doesn't have to be added up a lot.
-
-    cache : dict
-        Fast storage for commonly computed values.
-
-    reference : str
-        The literature reference.
-
     """
+    A material is made up of elements or isotopes. It has bulk properties like mass density.
+    """
+
     pDefs = materialParameters.getMaterialParameterDefinitions()
+    """State parameter definitions"""
 
     DATA_SOURCE = "ARMI"
+    """Indication of where the material is loaded from (may be plugin name)"""
 
     name = "Material"
     references = {}  # property : citation
+    """The literature references."""
+
     enrichedNuclide = None
+    """Name of enriched nuclide to be interpreted by enrichment modification methods"""
     correctDensityAfterApplyInputParams = True
+
     modelConst = {}
+    """Constants that may be used in intepolation functions for property lookups"""
+
+    thermalScatteringLaws = ()
+    """A tuple of :py:class:`~armi.nucDirectory.thermalScattering.ThermalScattering` instances 
+    with information about thermal scattering."""
 
     def __init__(self):
         composites.Leaf.__init__(self, self.__class__.name)
@@ -82,7 +75,7 @@ class Material(composites.Leaf):
 
         # so it doesn't have to be summed each time ( O(1) vs. O(N))
         self.p.atomFracDenom = 0.0
-        self.references = {}  # reference dictionary for each method
+
         self.p.refDens = 0.0
 
         # call subclass implementations

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -20,6 +20,8 @@ import math
 
 from armi.utils.units import getTc
 from armi.materials.material import Material
+from armi.nucDirectory import thermalScattering as tsl
+from armi.nucDirectory import nuclideBases as nb
 
 
 class SiC(Material):
@@ -27,6 +29,10 @@ class SiC(Material):
 
     """
     name = "Silicon Carbide"
+    thermalScatteringLaws = (
+        tsl.byNbAndCompound[nb.byName["C"], tsl.SIC],
+        tsl.byNbAndCompound[nb.byName["SI"], tsl.SIC],
+    )
     references = {
         "heat capacity": [
             "Munro, Material Properties of a-SiC, J. Phys. Chem. Ref. Data, Vol. 26, No. 5, 1997"

--- a/armi/materials/tests/test_graphite.py
+++ b/armi/materials/tests/test_graphite.py
@@ -1,0 +1,16 @@
+"""
+Tests for graphite material
+"""
+import unittest
+
+
+from armi.materials.graphite import Graphite
+from armi.materials.tests import test_materials
+
+
+class Graphite_TestCase(test_materials._Material_Test, unittest.TestCase):
+    MAT_CLASS = Graphite
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/armi/materials/tests/test_sic.py
+++ b/armi/materials/tests/test_sic.py
@@ -1,0 +1,21 @@
+"""Test for SiC"""
+import unittest
+
+from armi.materials.siC import SiC
+from armi.materials.tests import test_materials
+
+
+class Test_SiC(test_materials._Material_Test, unittest.TestCase):
+    """SiC tests"""
+
+    MAT_CLASS = SiC
+
+    def test_density(self):
+        cur = self.mat.density(Tc=25)
+        ref = 3.159
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -27,10 +27,12 @@ import collections
 
 from numpy import interp
 
-from armi.nucDirectory import nuclideBases
 from armi.utils.units import getTk
 from armi.materials import material
 from armi import runLog
+from armi.nucDirectory import thermalScattering as tsl
+from armi.nucDirectory import nuclideBases as nb
+
 
 HeatCapacityConstants = collections.namedtuple(
     "HeatCapacityConstants", ["c1", "c2", "c3", "theta", "Ea"]
@@ -39,6 +41,10 @@ HeatCapacityConstants = collections.namedtuple(
 
 class UraniumOxide(material.FuelMaterial):
     name = "Uranium Oxide"
+    thermalScatteringLaws = (
+        tsl.byNbAndCompound[nb.byName["U"], tsl.UO2],
+        tsl.byNbAndCompound[nb.byName["O"], tsl.UO2],
+    )
     references = {
         "thermal conductivity": "Thermal conductivity of uranium dioxide by nonequilibrium molecular dynamics simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999",
         "linear expansion": "Thermophysical Properties of MOX and UO2 Fuels Including the Effects of Irradiation. S.G. Popov, et.al. Oak Ridge National Laboratory. ORNL/TM-2000/351",
@@ -110,9 +116,9 @@ class UraniumOxide(material.FuelMaterial):
         r"""
         UO2 mass fractions. Using Natural Uranium without U234
         """
-        u235 = nuclideBases.byName["U235"]
-        u238 = nuclideBases.byName["U238"]
-        oxygen = nuclideBases.byName["O"]
+        u235 = nb.byName["U235"]
+        u238 = nb.byName["U238"]
+        oxygen = nb.byName["O"]
 
         u238Abundance = (
             1.0 - u235.abundance

--- a/armi/materials/water.py
+++ b/armi/materials/water.py
@@ -19,6 +19,8 @@ from armi.utils.units import getTk
 from armi.nucDirectory import elements
 from armi.materials.material import Fluid
 from armi.utils import units
+from armi.nucDirectory import thermalScattering as tsl
+from armi.nucDirectory import nuclideBases as nb
 
 
 class Water(Fluid):
@@ -40,7 +42,7 @@ class Water(Fluid):
     """
 
     name = "Water"
-
+    thermalScatteringLaws = (tsl.byNbAndCompound[nb.byName["H"], tsl.H2O],)
     references = {
         "vapor pressure": "IAPWS SR1-86 Revised Supplementary Release on Saturation Properties of Ordinary Water and Steam",
         "enthalpy (saturated water)": "IAPWS SR1-86 Revised Supplementary Release on Saturation Properties of Ordinary Water and Steam",

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -193,7 +193,7 @@ def getSymbol(z=None, name=None):
         element = byZ[z]
     else:
         element = byName[name.lower()]
-    return element.name
+    return element.symbol
 
 
 def getElementZ(symbol=None, name=None):

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -112,7 +112,6 @@ from armi.utils.units import HEAVY_METAL_CUTOFF_Z
 # unphysically. This is a bit of a crutch for the global state that is the nuclide
 # directory.
 _burnChainImposed = False
-_burnChainHash = None
 
 instances = []
 
@@ -373,34 +372,30 @@ def imposeBurnChain(burnChainStream):
     """
     Apply transmutation and decay information to each nuclide.
 
+    Notes
+    -----
+    You cannot impose a burn chain twice. Doing so would require that you clean out the
+    transmutations and decays from all the module-level nuclide bases, which generally
+    requires that you rebuild them. But rebuilding those is not an option because some
+    of them get set as class-level attributes and would be orphaned. If a need to change
+    burn chains mid-run re-arises, then a better nuclideBase-level burnchain cleanup
+    should be implemented so the objects don't have to change identity.
+
+    Notes
+    -----
+    We believe the transmutation information would probably be better stored on a
+    less fundamental place (e.g. not on the NuclideBase).
+
     See Also
     --------
     armi.nucDirectory.transmutations : describes file format
     """
     global _burnChainImposed  # pylint: disable=global-statement
-    global _burnChainHash  # pylint: disable=global-statement
     if _burnChainImposed:
-
-        # Check that the hash of the burnChain is the same or
-        # different. If different then re-init the nuclides.
-        # The burn chain should really only be changing for
-        # special cases (e.g., unit testing). Note: after
-        # hashing is performed, the stream location has to
-        # be reset.
-        streamHash = zlib.crc32(burnChainStream.read().encode())
-        burnChainStream.seek(0)
-        if _burnChainHash is not None:
-            if streamHash != _burnChainHash:
-                # We cannot apply more than one burn chain at a time, as this would lead to
-                # unphysical traits in the nuclide directory (e.g., duplicate decays and
-                # transmutations)
-                runLog.warning(
-                    "Applying a burn chain when one has already been applied; "
-                    "resetting the nuclide directory to it's default state first."
-                )
-                factory(True)
-        _burnChainHash = streamHash
-
+        # the only time this should happen is if in a unit test that has already
+        # processed conftest.py and is now building a Case that also imposes this.
+        runLog.warning("Burn chain already imposed. Skipping reimposition.")
+        return
     _burnChainImposed = True
     burnData = yaml.load(burnChainStream, Loader=yaml.FullLoader)
     for nucName, burnInfo in burnData.items():
@@ -409,8 +404,9 @@ def imposeBurnChain(burnChainStream):
         nuclide._processBurnData(burnInfo)  # pylint: disable=protected-access
 
 
-def factory(force=False):
-    r"""Reads data files to instantiate the :py:class:`INuclides <INuclide>`.
+def factory():
+    """
+    Reads data files to instantiate the :py:class:`INuclides <INuclide>`.
 
     Reads NIST, MC**2 and burn chain data files to instantiate the :py:class:`INuclides <INuclide>`.
     Also clears and fills in the
@@ -423,22 +419,17 @@ def factory(force=False):
 
     Notes
     -----
+    This may cannot be run more than once. NuclideBase instances are used throughout the ARMI
+    ecosystem and are even class attributes in some cases. Re-instantiating them would orphan
+    any existing ones and break everything.
+
     Nuclide labels from MC2-2, MC2-3, and MCNP are currently handled directly.
     Moving forward, we plan to implement a more generic labeling system so that
     plugins can provide code-specific nuclide labels in a more extensible fashion.
-
-    Attributes
-    ----------
-    force: bool, optional
-        If True, forces the reinstantiation of all :py:class:`INuclides`.
-        Any :py:class:`Nuclides <armi.nucDirectory.nuclide.Nuclde>` objects referring to the
-        original :py:class:`INuclide` will not update their references, and will probably fail.
     """
     # this intentionally clears and reinstantiates all nuclideBases
     global instances  # pylint: disable=global-statement
-    global _burnChainImposed  # pylint: disable=global-statement
-    if force or len(instances) == 0:
-        _burnChainImposed = False
+    if len(instances) == 0:
         # make sure the elements actually exist...
         elements.factory()
         del instances[:]  # there is no .clear() for a list
@@ -455,6 +446,11 @@ def factory(force=False):
         _completeNaturalNuclideBases()
         elements.deriveNaturalWeights()
         __readRiplDecayData()
+        # reload the thermal scattering library with the new nuclideBases too
+        # pylint: disable=import-outside-toplevel; cyclic import
+        from . import thermalScattering
+
+        thermalScattering.factory()
 
 
 def __readRiplDecayData():

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -21,8 +21,6 @@ import re
 
 from armi.nucDirectory import nuclideBases
 from armi.nucDirectory import elements
-from armi.tests import mockRunLogs
-from armi.physics.neutronics import isotopicDepletion
 
 from armi.nucDirectory.tests import NUCDIRECTORY_TESTS_DEFAULT_DIR_PATH
 
@@ -30,14 +28,7 @@ from armi.nucDirectory.tests import NUCDIRECTORY_TESTS_DEFAULT_DIR_PATH
 class TestNuclide(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        isotopicDepletion.applyDefaultBurnChain()
         cls.nucDirectoryTestsPath = NUCDIRECTORY_TESTS_DEFAULT_DIR_PATH
-
-    def test_nucBases_factoryIsFast(self):
-        with mockRunLogs.BufferLog():
-            nuclideBases.factory(True)
-        # If we don't re-apply the default burn chain, subsequent tests will fail
-        isotopicDepletion.applyDefaultBurnChain()
 
     def test_nucBases_fromNameBadNameRaisesException(self):
         with self.assertRaises(KeyError):

--- a/armi/nucDirectory/tests/test_thermalScattering.py
+++ b/armi/nucDirectory/tests/test_thermalScattering.py
@@ -1,0 +1,154 @@
+"""Tests for thermal scattering metadata"""
+# pylint: disable=protected-access
+
+import unittest
+
+from armi.reactor import blocks
+from armi.reactor import components
+
+from .. import thermalScattering as ts
+from .. import nuclideBases as nb
+
+
+def buildBlockWithTSL():
+    """Return a simple block containing something with a TSL (graphite)."""
+    b = blocks.HexBlock("fuel", height=10.0)
+
+    fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
+    cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.77, "mult": 127.0}
+    coolDims = {"Tinput": 25.0, "Thot": 400}
+
+    fuel = components.Circle("fuel", "UZr", **fuelDims)
+    clad = components.Circle("clad", "Graphite", **cladDims)
+    coolant = components.DerivedShape("coolant", "Sodium", **coolDims)
+
+    b.add(fuel)
+    b.add(clad)
+    b.add(coolant)
+
+    return b
+
+
+class TestThermalScattering(unittest.TestCase):
+    """Tests for thermal scattering on the reactor model"""
+
+    def test_graphiteOnReactor(self):
+        b = buildBlockWithTSL()
+        tsl = getNuclideThermalScatteringData(b)
+        carbon = nb.byName["C"]
+        carbon12 = nb.byName["C12"]
+        self.assertIn(carbon, tsl)
+        self.assertNotIn(carbon12, tsl)
+
+        b.expandElementalToIsotopics(carbon)
+
+        tsl = getNuclideThermalScatteringData(b)
+        self.assertNotIn(carbon, tsl)
+        self.assertIn(carbon12, tsl)
+
+        self.assertIs(tsl[carbon12], ts.byNbAndCompound[carbon, ts.GRAPHITE_10P])
+
+    def testEndf8Compound(self):
+        si = nb.byName["SI"]
+        o = nb.byName["O"]
+        sio2 = ts.ThermalScattering((si, o), "SiO2-alpha")
+        self.assertEqual(sio2._genENDFB8Label(), "tsl-SiO2-alpha.endf")
+
+    def testEndf8ElementInCompound(self):
+        hyd = nb.byName["H"]
+        hInH2O = ts.ThermalScattering(hyd, "H2O")
+        self.assertEqual(hInH2O._genENDFB8Label(), "tsl-HinH2O.endf")
+
+    def testEndf8Isotope(self):
+        fe56 = nb.byName["FE56"]
+        fe56tsl = ts.ThermalScattering(fe56)
+        self.assertEqual(fe56tsl._genENDFB8Label(), "tsl-026_Fe_056.endf")
+
+    def testACECompound(self):
+        si = nb.byName["SI"]
+        o = nb.byName["O"]
+        sio2 = ts.ThermalScattering((si, o), "SiO2-alpha")
+        self.assertEqual(sio2._genACELabel(), "sio2")
+
+    def testACEElementInCompound(self):
+        hyd = nb.byName["H"]
+        hInH2O = ts.ThermalScattering(hyd, "H2O")
+        self.assertEqual(hInH2O._genACELabel(), "h-h2o")
+
+    def testACEIsotope(self):
+        fe56 = nb.byName["FE56"]
+        fe56tsl = ts.ThermalScattering(fe56)
+        self.assertEqual(fe56tsl._genACELabel(), "fe-56")
+
+    def test_failOnMultiple(self):
+        """HT9 has carbon in it with no TSL, while graphite has C with TSL. This should crash"""
+        b = buildBlockWithTSL()
+        cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.79, "mult": 127.0}
+        clad2 = components.Circle("clad", "HT9", **cladDims)
+        b.add(clad2)
+        with self.assertRaises(RuntimeError):
+            getNuclideThermalScatteringData(b)
+
+
+def getNuclideThermalScatteringData(armiObj):
+    """
+    Make a mapping between nuclideBases in an armiObj and relevant thermal scattering laws.
+
+    In some cases, a nuclide will be present both with a TSL and without (e.g. hydrogen in water
+    and hydrogen in concrete in the same armiObj). While this could conceptually be handled
+    somehow, we simply error out at this time.
+
+    Notes
+    -----
+    Clients can use code like this to access TSL data. This is not an official framework
+    method because it's not general enough to cover all use cases in all reactors.
+
+    Returns
+    -------
+    tslByNuclideBase : dict
+        A dictionary with NuclideBase keys and ThermalScattering values
+
+    Raises
+    ------
+    RuntimeError
+        When a armiObj has nuclides subject to more than one TSL, or subject to a TLS
+        in one case and no TSL in another.
+
+    Examples
+    --------
+    >>> tslInfo = getNuclideThermalScatteringData(armiObj)
+    >>> if nucBase in tslInfo:
+    >>>     aceLabel = tslInfo[nucBase].aceLabel
+    """
+    tslByNuclideBase = {}
+    freeNuclideBases = set()
+    for c in armiObj.iterComponents():
+        nucs = {nb.byName[nn] for nn in c.getNuclides()}
+        freeNucsHere = set()
+        freeNucsHere.update(nucs)
+        for tsl in c.material.thermalScatteringLaws:
+            for subjectNb in tsl.getSubjectNuclideBases():
+                if subjectNb in nucs:
+                    if (
+                        subjectNb in tslByNuclideBase
+                        and tslByNuclideBase[subjectNb] is not tsl
+                    ):
+                        raise RuntimeError(
+                            f"{subjectNb} in {armiObj} is subject to more than 1 different TSL: "
+                            f"{tsl} and {tslByNuclideBase[subjectNb]}"
+                        )
+                    tslByNuclideBase[subjectNb] = tsl
+                    freeNucsHere.remove(subjectNb)
+        freeNuclideBases.update(freeNucsHere)
+
+    freeAndBound = freeNuclideBases.intersection(set(tslByNuclideBase.keys()))
+    if freeAndBound:
+        raise RuntimeError(
+            f"{freeAndBound} is/are present in both bound and free forms in {armiObj}"
+        )
+
+    return tslByNuclideBase
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/armi/nucDirectory/thermalScattering.py
+++ b/armi/nucDirectory/thermalScattering.py
@@ -1,0 +1,245 @@
+"""
+Handle awareness of Thermal Scattering Laws.
+
+Scattering characteristics of thermal neutrons are often significantly different 
+between a free atom and one bound in a particular molecule. Nuclear data libraries
+often have special tables to account for the bound states. 
+These data are commonly represented as S(alpha, beta) tables. 
+
+Here we provide objects representing the thermal scattering law (TSL) information.
+We expect them to be most useful as class attributes on :py:class:`~armi.materials.material.Material` subclasses
+to inform physics solvers that support thermal scattering of the TSLs. See
+:py:class:`~armi.materials.graphite.Graphite` for an example.
+
+We do not provide special versions of various NuclideBases like C12 because of
+potential errors in choosing one over the other
+
+The information contained in here is based on Parsons, LA-UR-18-25096, 
+https://mcnp.lanl.gov/pdf_files/la-ur-18-25096.pdf
+
+Scattering law data are currently available for a variety of classifications:
+
+* Element in Compound (H in H2O, Be in BeO)
+* Element in structure (C in Graphite, Be in metal)
+
+    * Can be separated as crystalline, 30% porous, 10% porous, etc.
+
+* Element in spin isomer (para H, ortho H, para D, ortho D, etc.)
+* Compound in phase (solid CH4, liquid CH4, SiO2-alpha, SiO2-beta). 
+* Just compound (benzene)
+* Just isotope (Fe56, Al27)
+
+The labels for these vary across evaluations (e.g. ENDF/B-VII, ENDF/B-VIII, etc.). We provide
+ENDF/B-III.0 and ACE labels. Other physics kernels will have to derive their own labels
+as appropriate in client code.
+
+Like NuclideBase and Element, we want to have only one ThermalScattering instance
+for each TSL, so we use a module-level directory called ``byNbAndCompound``. This improves
+efficiency and allows better cross-referencing when thousands of material instances
+would otherwise have identical instances of these.
+
+Thus, in practice, users should rarely instantiate these on their own.
+"""
+from typing import Tuple, Union
+
+from . import nuclideBases as nb
+from . import elements
+
+
+BE_METAL = "Be-metal"
+BEO = "BeO"
+SIC = "SiC"
+D2O = "D2O"
+H2O = "H2O"
+UN = "UN"
+UO2 = "UO2"
+ZRH = "ZrH"
+CRYSTALLINE_GRAPHITE = "crystalline-graphite"
+GRAPHITE_10P = "reactor-graphite-10P"
+GRAPHITE_30P = "reactor-graphite-30P"
+
+
+byNbAndCompound = {}
+
+
+class ThermalScattering:
+    """
+    Thermal Scattering data.
+
+    Parameters
+    ----------
+    nuclideBases : INuclide or tuple of INuclide
+        One or more nuclide bases whose existence would trigger the inclusion of the TSL.
+        Generally items here will be a NaturalNuclideBase like ``nb.byName["C"]`` for Carbon
+        but it is a tuple to capture, e.g. the C and H in *methane*. 
+    compoundName : str, optional
+        Label indicating what the subjects are in (e.g. ``"Graphite"`` or ``"H2O"``.
+        Can be left off for, e.g. Fe56.
+    endf8Label : str, optional
+        Label for endf8 evaluation
+    aceLabel: str, optional
+        ace label
+    """
+
+    def __init__(
+        self,
+        nuclideBases: Union[nb.INuclide, Tuple[nb.INuclide]],
+        compoundName: str = None,
+        endf8Label: str = None,
+        aceLabel: str = None,
+    ):
+        if isinstance(nuclideBases, nb.INuclide):
+            # handle common single entry for convenience
+            nuclideBases = [nuclideBases]
+        self.nbs = nuclideBases
+        self.compoundName = compoundName
+        self.endf8Label = endf8Label or self._genENDFB8Label()
+        self.aceLabel = aceLabel or self._genACELabel()
+
+    def getSubjectNuclideBases(self):
+        """
+        Return all nuclide bases that could be subject to this law.
+
+        In cases where the law is defined by a NaturalNuclideBase, all potential
+        isotopes of the element as well as the element it self should trigger it.
+        This helps handle cases where, for example, C or C12 is present.
+        """
+        subjectNbs = []
+        for nbi in self.nbs:
+            if isinstance(nbi, nb.NaturalNuclideBase):
+                subjectNbs.extend(nbi.element.nuclideBases)
+            else:
+                subjectNbs.append(nbi)
+        return subjectNbs
+
+    def _genENDFB8Label(self):
+        """
+        Generate the ENDF/B-VIII.0 label.
+
+        Several ad-hoc assumptions are made in converting this object to a ENDF/B-VIII label
+        which may not apply in all cases.
+
+        It is believed that these rules cover most ENDF TSLs listed in 
+        Parsons, LA-UR-18-25096, https://mcnp.lanl.gov/pdf_files/la-ur-18-25096.pdf
+
+        Unfortunately, the ace labels are not as easily derived.
+
+        * If nuclideBases is length one and contains a ``NaturalNuclideBase``, then the
+          name will be assumed to be ``Element_in_compoundName``
+        * If nuclideBases is length one and is a NuclideBase, it is assumed to be an isotope
+          like Fe-56 and  the label will be (for example) 026_Fe_056
+        * If nuclideBases has length greater than one, the compoundName will form the 
+          entire of the label. So, if Si and O are in the bases, the compoundName must
+          be ``SiO2-alpha`` in order to get ``tsl-SiO2-alpha.endf`` as a endf8 label.
+        """
+        first = next(iter(self.nbs))
+        if len(self.nbs) > 1:
+            # just compound (like SiO2)
+            label = f"tsl-{self.compoundName}.endf"
+        elif isinstance(first, nb.NaturalNuclideBase):
+            # element in compound
+            label = f"tsl-{first.element.symbol}in{self.compoundName}.endf"
+        elif isinstance(first, nb.NuclideBase):
+            # just isotope
+            element = elements.byZ[first.z]
+            label = (
+                f"tsl-{first.z:03d}_{element.symbol.capitalize()}_{first.a:03d}.endf"
+            )
+        else:
+            raise ValueError(f"{self} label cannot be generated")
+        return label
+
+    def _genACELabel(self):
+        """
+        Attempt to derive the ACE label of a TSL.
+
+        There are certain exceptions that cannot be derived and must be provided
+        by the user upon instantiation, for example:
+
+        * ``grph10``
+        * ``grph30``
+        * ``grph``
+
+        """
+        first = next(iter(self.nbs))
+        if len(self.nbs) > 1:
+            # just compound (like SiO2)
+            label = f"{self.compoundName[:4].lower()}"
+        elif isinstance(first, nb.NaturalNuclideBase):
+            # element in compound
+            label = f"{first.element.symbol.lower()}-{self.compoundName.lower()}"
+        elif isinstance(first, nb.NuclideBase):
+            # just isotope
+            element = elements.byZ[first.z]
+            label = f"{element.symbol.lower()}-{first.a:d}"
+        else:
+            raise ValueError(f"{self} label cannot be generated")
+        return label
+
+
+def factory():
+    """
+    Generate the :class:`ThermalScattering` instances.
+
+    The logic for these is a bit complex so we skip reading a text file and code
+    it up here. 
+
+    This is called by the nuclideBases factory since it must ALWAYS be re-run when
+    the nuclideBases are rebuilt.
+
+    See Also
+    --------
+    armi.nucDirectory.nuclideBases.factory
+        Calls this during ARMI initialization.
+
+
+    .. warning::
+        This gets called automatically during init, so don't call it
+        unless you know what you're doing.
+    """
+    # pylint: disable=invalid-name)
+    global byNbAndCompound  # pylint: disable=global-statement
+    byNbAndCompound.clear()
+
+    al27 = nb.byName["AL27"]
+    fe56 = nb.byName["FE56"]
+    be = nb.byName["BE"]
+    c = nb.byName["C"]
+    d = nb.byName["H2"]
+    n = nb.byName["N"]
+    o = nb.byName["O"]
+    h = nb.byName["H"]
+    u = nb.byName["U"]
+    zr = nb.byName["ZR"]
+    si = nb.byName["SI"]
+
+    for isotope in [al27, fe56]:
+        byNbAndCompound[isotope, None] = ThermalScattering(isotope)
+
+    byNbAndCompound[be, BE_METAL] = ThermalScattering(
+        be, BE_METAL, endf8Label=f"tsl-{BE_METAL}.endf", aceLabel="be-met"
+    )
+    byNbAndCompound[be, BEO] = ThermalScattering(
+        be, BEO, endf8Label=BEO, aceLabel="be-beo"
+    )
+    byNbAndCompound[c, SIC] = ThermalScattering(c, SIC)
+    byNbAndCompound[d, D2O] = ThermalScattering(d, D2O, f"tsl-Din{D2O}.endf", "d-d2o")
+    byNbAndCompound[h, H2O] = ThermalScattering(h, H2O)
+    byNbAndCompound[h, ZRH] = ThermalScattering(h, ZRH)
+    byNbAndCompound[n, UN] = ThermalScattering(n, UN)
+    byNbAndCompound[o, BEO] = ThermalScattering(o, BEO)
+    byNbAndCompound[o, D2O] = ThermalScattering(o, D2O, f"tsl-Oin{D2O}.endf", "o-d2o")
+    byNbAndCompound[o, UO2] = ThermalScattering(o, UO2)
+    byNbAndCompound[u, UO2] = ThermalScattering(u, UO2)
+    byNbAndCompound[u, UN] = ThermalScattering(u, UN)
+    byNbAndCompound[zr, ZRH] = ThermalScattering(zr, ZRH)
+    byNbAndCompound[si, SIC] = ThermalScattering(si, SIC)
+    byNbAndCompound[c, CRYSTALLINE_GRAPHITE] = ThermalScattering(
+        c, CRYSTALLINE_GRAPHITE, f"tsl-{CRYSTALLINE_GRAPHITE}.endf", "grph"
+    )
+    byNbAndCompound[c, GRAPHITE_10P] = ThermalScattering(
+        c, GRAPHITE_10P, f"tsl-{GRAPHITE_10P}.endf", "grph10"
+    )
+    byNbAndCompound[c, GRAPHITE_30P] = ThermalScattering(
+        c, GRAPHITE_30P, f"tsl-{GRAPHITE_30P}.endf", "grph30"
+    )

--- a/armi/nuclearDataIO/tests/test_isotxs.py
+++ b/armi/nuclearDataIO/tests/test_isotxs.py
@@ -36,11 +36,6 @@ class TestIsotxs(unittest.TestCase):
         # be a small library with LFPs, Actinides, structure, and coolant
         cls.lib = isotxs.readBinary(ISOAA_PATH)
 
-    @classmethod
-    def tearDownClass(cls):
-        # reset the labels
-        nuclideBases.factory(True)
-
     def test_isotxsGeneralData(self):
         nucs = self.lib.nuclides
         self.assertTrue(nucs)

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -32,11 +32,6 @@ class NuclideTests(unittest.TestCase):
     def setUpClass(cls):
         cls.lib = nuclearDataIO.ISOTXS(ISOAA_PATH)
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.lib = None
-        nuclideBases.factory(True)
-
     def test_nuclide_createFromLabelFailsOnBadName(self):
         nuc = xsNuclides.XSNuclide(None, "BACONAA")
         nuc.isotxsMetadata["nuclideId"] = "BACN87"
@@ -65,6 +60,7 @@ class NuclideTests(unittest.TestCase):
         self.assertEqual("whatever", nuc.trans[-1])
         self.assertEqual("whatever", nrAA.trans[-1])
         # I've modified the underlying nuclide... need to reset.
+        nuc.trans.pop()
 
     def test_nuclide_newLabelsDontCauseWarnings(self):
         with mockRunLogs.BufferLog() as logCapture:

--- a/armi/nuclearDataIO/xsNuclides.py
+++ b/armi/nuclearDataIO/xsNuclides.py
@@ -63,7 +63,8 @@ class XSNuclide(nuclideBases.NuclideWrapper):
         XSNuclide._ensuredBurnInfo = False
 
     def updateBaseNuclide(self):
-        """Update the nuclide base for this :py:class:`~armi.nucDirectory.nuclide.XSNuclide`.
+        """
+        Update which nuclide base this :py:class:`XSNuclide` points to.
 
         Notes
         -----

--- a/armi/physics/neutronics/isotopicDepletion/__init__.py
+++ b/armi/physics/neutronics/isotopicDepletion/__init__.py
@@ -22,9 +22,3 @@ from armi.nucDirectory import nuclideBases
 from armi import interfaces
 
 ORDER = interfaces.STACK_ORDER.DEPLETION
-
-
-def applyDefaultBurnChain():
-    """The framework has a default transmutation chain that many users will want to override."""
-    with open(os.path.join(RES, "burn-chain.yaml")) as stream:
-        nuclideBases.imposeBurnChain(stream)

--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -17,7 +17,6 @@ import io
 
 from armi.reactor import blueprints
 from armi import settings
-from armi.physics.neutronics import isotopicDepletion
 from armi.reactor.flags import Flags
 
 FULL_BP = """
@@ -142,7 +141,6 @@ class TestGriddedBlock(unittest.TestCase):
 
     def setUp(self):
         self.cs = settings.Settings()
-        isotopicDepletion.applyDefaultBurnChain()
 
         with io.StringIO(FULL_BP) as stream:
             self.blueprints = blueprints.Blueprints.load(stream)

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -29,7 +29,6 @@ from armi.utils import directoryChangers
 from armi.utils import textProcessors
 from armi.reactor.blueprints.isotopicOptions import NuclideFlags, CustomIsotopics
 from armi.reactor.blueprints.componentBlueprint import ComponentBlueprint
-from armi.physics.neutronics import isotopicDepletion
 
 
 class TestBlueprints(unittest.TestCase):
@@ -54,7 +53,6 @@ class TestBlueprints(unittest.TestCase):
         cls.cs = settings.Settings()
         cls.directoryChanger = directoryChangers.DirectoryChanger(TEST_ROOT)
         cls.directoryChanger.open()
-        isotopicDepletion.applyDefaultBurnChain()
 
         y = textProcessors.resolveMarkupInclusions(
             pathlib.Path(os.getcwd()) / "refSmallReactor.yaml"
@@ -98,6 +96,7 @@ class TestBlueprints(unittest.TestCase):
         self.assertAlmostEqual(fuel.getDimension("mult"), 169)
 
     def test_traceNuclides(self):
+        """Ensure that armi.reactor.blueprints.componentBlueprint._insertDepletableNuclideKeys runs."""
         fuel = (
             self.blueprints.constructAssem("hex", self.cs, "igniter fuel")
             .getFirstBlock(Flags.FUEL)

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -22,7 +22,6 @@ import unittest
 from armi import settings
 from armi.reactor import blueprints
 from armi.reactor.flags import Flags
-from armi.nucDirectory import nuclideBases
 
 
 class TestComponentBlueprint(unittest.TestCase):
@@ -48,14 +47,6 @@ assemblies:
         axial mesh points: [1]
         xs types: [A]
 """
-
-    @classmethod
-    def setUpClass(cls):
-        cs = settings.Settings()
-        # Need to init burnChain first.
-        # see armi.cases.case.Case._initBurnChain
-        with open(cs["burnChainFileName"]) as burnChainStream:
-            nuclideBases.imposeBurnChain(burnChainStream)
 
     def test_componentInitializationIncompleteBurnChain(self):
         nuclideFlagsFuelWithBurn = (

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -188,10 +188,6 @@ assemblies:
     @classmethod
     def setUpClass(cls):
         cs = settings.Settings()
-        # Need to init burnChain first.
-        # see armi.cases.case.Case._initBurnChain
-        with open(cs["burnChainFileName"]) as burnChainStream:
-            nuclideBases.imposeBurnChain(burnChainStream)
         cs["xsKernel"] = "MC2v2"
         cls.bp = blueprints.Blueprints.load(cls.yamlString)
         cls.a = cls.bp.constructAssem("hex", cs, name="fuel a")

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -143,7 +143,6 @@ def loadTestReactor(
     # TODO: it would be nice to have this be more stream-oriented. Juggling files is
     # devilishly difficult.
     global TEST_REACTOR
-    isotopicDepletion.applyDefaultBurnChain()
     fName = os.path.join(inputFilePath, inputFileName)
     customSettings = customSettings or {}
     isPickeledReactor = fName == ARMI_RUN_PATH and customSettings == {}

--- a/doc/user/tutorials/making_your_first_app.rst
+++ b/doc/user/tutorials/making_your_first_app.rst
@@ -419,6 +419,7 @@ your new material in a new module called :file:`myapp/materials.py`:
             # not even temperature dependent for now
             return 1.252
 
+
 But wait! Now there are **two** materials with the name *Sodium* in ARMI. Which will be
 chosen? ARMI uses a namespace order controlled by
 :py:func:`armi.materials.setMaterialNamespaceOrder` which can be set either


### PR DESCRIPTION
Thermal scattering laws are important nearly all thermal reactors. This
change adds a class to the nucDirectory package to represent these laws,
and populates a module-level lookup table with some common ones. A class
attribute on Material is also added so that Material designers can
activate certain TSLs. Given this information, physics kernel authors
can detect the need for TSL treatment and implement it as necessary.