### PR TITLE
Minor optimization and doc cleanup

### DIFF
--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -286,8 +286,14 @@ class IndexLocation(LocationBase):
         a reactor, then the ``parentLocation`` is the spatialLocator of the reactor, which
         will often be a ``CoordinateLocation``.
         """
-        if self.grid and self.grid.armiObject and self.grid.armiObject.parent:
-            return self.grid.armiObject.spatialLocator
+        grid = self.grid  # performance matters a lot here so we remove a dot
+        # check for None rather than __nonzero__ for speed (otherwise it checks the length)
+        if (
+            grid is not None
+            and grid.armiObject is not None
+            and grid.armiObject.parent is not None
+        ):
+            return grid.armiObject.spatialLocator
         return None
 
     @property
@@ -328,8 +334,10 @@ class IndexLocation(LocationBase):
         """
         parentLocation = self.parentLocation  # to avoid evaluating property if's twice
         indices = self.indices
-        if parentLocation:
-            if parentLocation.grid and addingIsValid(self.grid, parentLocation.grid):
+        if parentLocation is not None:
+            if parentLocation.grid is not None and addingIsValid(
+                self.grid, parentLocation.grid
+            ):
                 indices += parentLocation.indices
         return tuple(indices)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -217,7 +217,7 @@ wiki = {"phabricator": ("https://ubuntuprod.tp.int" + "%s", None)}
 pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-# modindex_common_prefix = []
+modindex_common_prefix = ["armi."]
 
 
 # -- Options for HTML output ---------------------------------------------------


### PR DESCRIPTION
This speeds up some very frequently called indexing operations on grids

Also adds a doc configuration to clean up the module index so they
don't all start with `a` for `armi`. 