### PR TITLE
Add full-core asciimap read/write capability from ascii or data

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -339,7 +339,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
 
 class GlobalFluxExecuter(executers.DefaultExecuter):
     """
-    A short-lived object that  coordinates the prep, execution, and processing of a flux solve
+    A short-lived object that coordinates the prep, execution, and processing of a flux solve.
 
     There are many forms of global flux solves:
 

--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -123,7 +123,7 @@ assemblies:
         xs types: [A, A]
 grids:
     fuelgrid:
-       geom: hex
+       geom: hex_corners_up
        symmetry: full
        lattice map: |
          - - -  1 1 1 1

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -24,7 +24,7 @@ from armi.reactor import geometry
 
 LATTICE_BLUEPRINT = """
 control:
-    geom: hex
+    geom: hex_corners_up
     symmetry: full
     lattice map: |
        - - - - - - - - - 1 1 1 1 1 1 1 1 1 4

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -116,6 +116,7 @@ SYSTEMS = "systems"
 VERSION = "version"
 
 HEX = "hex"
+HEX_CORNERS_UP = "hex_corners_up"
 RZT = "thetarz"
 RZ = "rz"
 CARTESIAN = "cartesian"
@@ -126,7 +127,7 @@ HEX_PRISM = "HexPrism"
 CONCENTRIC_CYLINDER = "ConcentricCylinder"
 ANNULUS_SECTOR_PRISM = "AnnulusSectorPrism"
 
-VALID_GEOMETRY_TYPE = {HEX, RZT, RZ, CARTESIAN}
+VALID_GEOMETRY_TYPE = {HEX, HEX_CORNERS_UP, RZT, RZ, CARTESIAN}
 
 FULL_CORE = "full"
 THIRD_CORE = "third "
@@ -450,9 +451,9 @@ class SystemLayoutInput:
         """Read a ascii map string into this object."""
         mapTxt = system[INP_LATTICE]
         if self.geomType == HEX and THIRD_CORE in self.symmetry:
-            geomMap = asciimaps.AsciiMapHexThird()
-            geomMap.readMap(mapTxt)
-            for (i, j), spec in geomMap.lattice.items():
+            asciimap = asciimaps.AsciiMapHexThirdFlatsUp()
+            asciimap.readAscii(mapTxt)
+            for (i, j), spec in asciimap.items():
                 if spec == "-":
                     # skip whitespace placeholders
                     continue
@@ -583,8 +584,10 @@ class SystemLayoutInput:
             i, j = grids.HexGrid.getIndicesFromRingAndPos(ring, pos)
             lattice[i, j] = specifier
 
-        geomMap = asciimaps.AsciiMapHexThird(lattice)
-        geomMap.writeMap(sys.stdout)
+        geomMap = asciimaps.AsciiMapHexThirdFlatsUp()
+        geomMap.asciiLabelByIndices = lattice
+        geomMap.gridContentsToAscii()
+        geomMap.writeAscii(sys.stdout)
 
     def growToFullCore(self):
         """
@@ -614,7 +617,9 @@ class SystemLayoutInput:
         for (ring, pos), specifierID in list(self.assemTypeByIndices.items()):
             indices = grids.HexGrid.getIndicesFromRingAndPos(ring, pos)
             for symmetricI, symmetricJ in grid.getSymmetricEquivalents(indices):
-                symmetricRingPos = grids.HexGrid.indicesToRingPos(symmetricI, symmetricJ)
+                symmetricRingPos = grids.HexGrid.indicesToRingPos(
+                    symmetricI, symmetricJ
+                )
                 self.assemTypeByIndices[symmetricRingPos] = specifierID
 
         self.symmetry = FULL_CORE

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -983,7 +983,7 @@ class CartesianGrid(Grid):
         ----------
         width : float
             Width of the unit rectangle
-        width : float
+        height : float
             Height of the unit rectangle
         numRings : int
             Number of rings that the grid should span

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -1427,30 +1427,30 @@ class GridBlueprintControl(wx.Panel):
         bp = copy.deepcopy(self.bp)
 
         for gridDesignType, gridDesign in bp.gridDesigns.items():
-
             # The core equilibrium path should be put into the
-            # grid contents rather than a lattice map. Skip
+            # grid contents rather than a lattice map until we write
+            # a string-> tuple parser for reading it back in. Skip
             # this type of grid.
             if gridDesignType == "coreEqPath":
                 continue
-
             _filterOutsideDomain(gridDesign)
             if gridDesign.gridContents:
 
                 try:
                     aMap = asciimaps.asciiMapFromGeomAndSym(
                         self.grid.geomType, self.grid.symmetry
-                    )(lattice=gridDesign.gridContents)
+                    )()
+                    aMap.asciiLabelByIndices = gridDesign.gridContents
+                    aMap.gridContentsToAscii()
                 except:
-                    aMap = None
-
-                if type(aMap) == asciimaps.AsciiMapHexFullTipsUp:
-                    # This appears broken for full-core cases; stick to `grid contents`
+                    runLog.warning(
+                        "Cannot write geometry with asciimap. Defaulting to dict."
+                    )
                     aMap = None
 
                 if aMap is not None:
                     mapString = io.StringIO()
-                    aMap.writeMap(mapString)
+                    aMap.writeAscii(mapString)
                     # deep ruamel.yaml magic
                     formattedStr = scalarstring.LiteralScalarString(
                         mapString.getvalue()

--- a/armi/utils/tests/test_asciimaps.py
+++ b/armi/utils/tests/test_asciimaps.py
@@ -11,13 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""Test ASCII maps."""
 import unittest
 import io
-import sys
 
 from armi.utils import asciimaps
+
 
 CARTESIAN_MAP = """2 2 2 2 2
 2 1 1 1 2
@@ -68,26 +66,104 @@ HEX_THIRD_MAP_2 = """-   -   SH  SH
           EX  IC  IC  PC  OC
 """
 
-HEX_FULL_MAP = """
-       - - - - - - - - - 1 1 1 1 1 1 1 1 1 4
-        - - - - - - - - 1 1 1 1 1 1 1 1 1 1 1
-         - - - - - - - 1 8 1 1 1 1 1 1 1 1 1 1
-          - - - - - - 1 1 1 1 1 1 1 1 1 1 1 1 1
-           - - - - - 1 1 1 1 1 1 1 1 1 1 1 1 1 1
-            - - - - 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
-             - - - 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
-              - - 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
-               - 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
-                7 1 1 1 1 1 1 1 1 0 1 1 1 1 1 1 1 1 1
-                 1 1 1 1 1 1 1 1 2 1 1 1 1 1 1 1 1 1
-                  1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
-                   1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
-                    1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
-                     1 1 1 1 1 1 1 1 1 1 1 1 1 1
-                      1 1 1 1 1 1 1 1 1 3 1 1 1
-                       1 1 1 1 1 1 1 1 1 1 1 1
-                        1 6 1 1 1 1 1 1 1 1 1
-                         1 1 1 1 1 1 1 1 1 1
+HEX_THIRD_MAP_WITH_HOLES = """-   -   SH  SH
+  -   SH  SH  SH
+    SH  OC  OC  SH
+  SH  OC  OC  OC  SH
+    OC  EX  EX  OC  SH
+      EX  EX  EX  OC  SH
+    EX  MC  MC  EX  OC  SH
+      MC  HX  MC  EX  OC  SH
+        MC  -   PC  EX  OC
+      MC  IC  MC  MC  EX  SH
+        IC  IC  MC  MC  OC  SH
+          PC  IC  MC  EX  OC
+        FA  FA  IC  TG  EX  SH
+          IC  FA  IC  -   OC
+            -   US  MC  EX  SH
+          EX  IC  IC  MC  OC
+            EX  FA  MC  EX  SH
+          EX  IC  IC  PC  OC
+"""
+
+HEX_THIRD_MAP_WITH_EMPTY_ROW = """-   -   SH  SH
+  -   SH  SH  SH
+    SH  OC  OC  SH
+  SH  OC  OC  OC  SH
+    OC  EX  EX  OC  SH
+      EX  EX  EX  OC  SH
+    EX  MC  MC  EX  OC  SH
+      MC  HX  MC  EX  OC  SH
+        MC  -   PC  EX  OC
+      MC  IC  MC  MC  EX  SH
+        IC  IC  MC  MC  OC  SH
+          -   -   -   -   - 
+        FA  FA  IC  TG  EX  SH
+          IC  FA  IC  -   OC
+            -   US  MC  EX  SH
+          EX  IC  IC  MC  OC
+            EX  FA  MC  EX  SH
+          EX  IC  IC  PC  OC
+"""
+
+HEX_FULL_MAP = """- - - - - - - - - 1 1 1 1 1 1 1 1 1 4
+ - - - - - - - - 1 1 1 1 1 1 1 1 1 1 1
+  - - - - - - - 1 8 1 1 1 1 1 1 1 1 1 1
+   - - - - - - 1 1 1 1 1 1 1 1 1 1 1 1 1
+    - - - - - 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+     - - - - 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+      - - - 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+       - - 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+        - 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+         7 1 1 1 1 1 1 1 1 0 1 1 1 1 1 1 1 1 1
+          1 1 1 1 1 1 1 1 2 1 1 1 1 1 1 1 1 1
+           1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+            1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+             1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+              1 1 1 1 1 1 1 1 1 1 1 1 1 1
+               1 1 1 1 1 1 1 1 1 3 1 1 1
+                1 1 1 1 1 1 1 1 1 1 1 1
+                 1 6 1 1 1 1 1 1 1 1 1
+                  1 1 1 1 1 1 1 1 1 1
+"""
+
+HEX_FULL_MAP_FLAT = """-       -       -       -       ORS     ORS     ORS 
+    -       -       -       ORS     ORS     ORS     ORS 
+-       -       -       ORS     IRS     IRS     IRS     ORS 
+    -       -       ORS     IRS     IRS     IRS     IRS     ORS 
+-       -       ORS     IRS     RR89    RR89    RR89    IRS     ORS 
+    -       ORS     IRS     RR89    RR89    RR89    RR89    IRS     ORS 
+-       ORS     IRS     RR89    RR89    RR7     RR89    RR89    IRS     ORS 
+    -       IRS     RR89    RR89    RR7     RR7     RR89    RR89    IRS 
+-       ORS     RR89    RR89    RR7     OC      RR7     RR89    RR89    ORS 
+    ORS     IRS     RR89    RR7     OC      OC      RR7     RR89    IRS     ORS 
+-       IRS     RR89    RR7     OC      OC      FS      RR7     RR89    IRS 
+    ORS     RR89    RR7     OC      OC      OC      OC      RR7     RR89    ORS 
+ORS     IRS     RR7     OC      OC      IC      OC      OC      RR7     IRS     ORS 
+    IRS     RR89    OC      SC      ICS     IC      SC      OC      RR89    IRS 
+ORS     RR89    RR7     OC      IC      IC      IC      OC      RR7     RR89    ORS 
+    IRS     RR89    OC      IC      IC      IC      IC      OC      RR89    IRS 
+ORS     RR89    RR7     SC      PC      ICS     PC      SC      RR7     RR89    ORS 
+    IRS     RR89    OC      IC      IC      IC      IC      OC      RR89    IRS 
+ORS     RR89    RR7     OC      IC      IC      IC      OC      RR7     RR89    ORS 
+    IRS     RR89    VOTA    ICS     IC      IRT     ICS     OC      RR89    IRS 
+ORS     RR89    RR7     OC      IC      IC      IC      OC      RR7     RR89    ORS 
+    IRS     RR89    OC      IC      IC      IC      IC      OC      RR89    IRS 
+ORS     RR89    FS      OC      ICS     PC      ICS     OC      RR7     RR89    ORS 
+    IRS     RR89    OC      OC      IC      IC      OC      OC      RR89    IRS 
+ORS     IRS     RR7     OC      OC      IC      OC      OC      RR7     IRS     ORS 
+    ORS     RR89    RR7     OC      SC      SC      OC      FS      RR89    ORS 
+-       IRS     RR89    RR7     OC      OC      OC      RR7     RR89    IRS 
+    ORS     IRS     RR89    RR7     OC      OC      RR7     RR89    IRS     ORS 
+-       ORS     RR89    RR89    RR7     OC      RR7     RR89    RR89    ORS 
+    -       IRS     RR89    RR89    RR7     RR7     RR89    RR89    IRS 
+        ORS     IRS     RR89    RR89    RR7     RR89    RR89    IRS     ORS 
+            ORS     IRS     RR89    RR89    RR89    RR89    IRS     ORS 
+                ORS     IRS     RR89    RR89    RR89    IRS     ORS 
+                    ORS     IRS     IRS     IRS     IRS     ORS 
+                        ORS     IRS     IRS     IRS     ORS 
+                            ORS     ORS     ORS     ORS 
+                                ORS     ORS     ORS 
 """
 
 
@@ -96,62 +172,171 @@ class TestAsciiMaps(unittest.TestCase):
 
     def test_cartesian(self):
         """Make sure we can read Cartesian maps."""
-        reader = asciimaps.AsciiMapCartesian()
-        lattice = reader.readMap(CARTESIAN_MAP)
-        self.assertEqual(lattice[0, 0], "2")
-        self.assertEqual(lattice[1, 1], "3")
-        self.assertEqual(lattice[2, 2], "3")
-        self.assertEqual(lattice[3, 3], "1")
-        with self.assertRaises(KeyError):
-            lattice[5, 2]  # pylint: disable=pointless-statement
+        asciimap = asciimaps.AsciiMapCartesian()
+        with io.StringIO() as stream:
+            stream.write(CARTESIAN_MAP)
+            stream.seek(0)
+            asciimap.readAscii(stream.read())
 
         with io.StringIO() as stream:
-            reader.writeMap(stream)
+            asciimap.writeAscii(stream)
             stream.seek(0)
             output = stream.read()
             self.assertEqual(output, CARTESIAN_MAP)
 
-    def test_hexThird(self):
-        """Check some third-symmetry maps against known answers."""
-        reader = asciimaps.AsciiMapHexThird()
-        lattice = reader.readMap(HEX_THIRD_MAP)
-        self.assertEqual(lattice[7, 0], "2")
-        self.assertEqual(lattice[8, 0], "3")
-        self.assertEqual(lattice[8, -4], "2")
-        self.assertEqual(lattice[0, 8], "3")
-        self.assertEqual(lattice[0, 0], "1")
+        self.assertEqual(asciimap[0, 0], "2")
+        self.assertEqual(asciimap[1, 1], "3")
+        self.assertEqual(asciimap[2, 2], "3")
+        self.assertEqual(asciimap[3, 3], "1")
         with self.assertRaises(KeyError):
-            lattice[10, 0]  # pylint: disable=pointless-statement
+            asciimap[5, 2]  # pylint: disable=pointless-statement
+
+    def test_hexThird(self):
+        """Read 1/3 core flats-up maps."""
+        asciimap = asciimaps.AsciiMapHexThirdFlatsUp()
+        with io.StringIO() as stream:
+            stream.write(HEX_THIRD_MAP)
+            stream.seek(0)
+            asciimap.readAscii(stream.read())
 
         with io.StringIO() as stream:
-            reader.writeMap(stream)
+            asciimap.writeAscii(stream)
             stream.seek(0)
             output = stream.read()
             self.assertEqual(output, HEX_THIRD_MAP)
 
-    def test_troublesomeHexThird(self):
-        reader = asciimaps.AsciiMapHexThird()
-        lattice = reader.readMap(HEX_THIRD_MAP_2)
-        writer = asciimaps.AsciiMapHexThird(lattice)
+        self.assertEqual(asciimap[7, 0], "2")
+        self.assertEqual(asciimap[8, 0], "3")
+        self.assertEqual(asciimap[8, -4], "2")
+        self.assertEqual(asciimap[0, 8], "3")
+        self.assertEqual(asciimap[0, 0], "1")
+        with self.assertRaises(KeyError):
+            asciimap[10, 0]  # pylint: disable=pointless-statement
+
+    def test_hexWithHoles(self):
+        """Read 1/3 core flats-up maps with holes."""
+        asciimap = asciimaps.AsciiMapHexThirdFlatsUp()
         with io.StringIO() as stream:
-            writer.writeMap(stream)
-            asStr = stream.getvalue()
-            self.assertEqual(asStr, HEX_THIRD_MAP_2)
+            stream.write(HEX_THIRD_MAP_WITH_HOLES)
+            stream.seek(0)
+            asciimap.readAscii(stream.read())
+
+        with io.StringIO() as stream:
+            asciimap.writeAscii(stream)
+            stream.seek(0)
+            output = stream.read()
+            self.assertEqual(output, HEX_THIRD_MAP_WITH_HOLES)
+
+        self.assertEqual(asciimap[1, 1], asciimaps.PLACEHOLDER)
+        self.assertEqual(asciimap[5, 0], "TG")
+        with self.assertRaises(KeyError):
+            asciimap[10, 0]  # pylint: disable=pointless-statement
+
+        # also test writing from pure data (vs. reading) gives the exact same map :o
+        with io.StringIO() as stream:
+            asciimap2 = asciimaps.AsciiMapHexThirdFlatsUp()
+            asciimap2.asciiLabelByIndices = asciimap.asciiLabelByIndices
+            asciimap2.gridContentsToAscii()
+            asciimap2.writeAscii(stream)
+            stream.seek(0)
+            output = stream.read()
+            self.assertEqual(output, HEX_THIRD_MAP_WITH_HOLES)
+
+    def test_hexWithEmptyRow(self):
+        """Read 1/3 core flats-up maps with one entirely empty row."""
+        asciimap = asciimaps.AsciiMapHexThirdFlatsUp()
+        with io.StringIO() as stream:
+            stream.write(HEX_THIRD_MAP_WITH_EMPTY_ROW)
+            stream.seek(0)
+            asciimap.readAscii(stream.read())
+
+        with io.StringIO() as stream:
+            asciimap.writeAscii(stream)
+            stream.seek(0)
+            output = stream.read()
+            self.assertEqual(output, HEX_THIRD_MAP_WITH_EMPTY_ROW)
+
+        self.assertEqual(asciimap[1, 1], asciimaps.PLACEHOLDER)
+        self.assertEqual(asciimap[6, 0], asciimaps.PLACEHOLDER)
+        self.assertEqual(asciimap[5, 0], "TG")
+        with self.assertRaises(KeyError):
+            asciimap[10, 0]  # pylint: disable=pointless-statement
+
+    def test_troublesomeHexThird(self):
+        asciimap = asciimaps.AsciiMapHexThirdFlatsUp()
+        with io.StringIO() as stream:
+            stream.write(HEX_THIRD_MAP_2)
+            stream.seek(0)
+            asciimap.readAscii(stream.read())
+
+        with io.StringIO() as stream:
+            asciimap.writeAscii(stream)
+            stream.seek(0)
+            output = stream.read()
+            self.assertEqual(output, HEX_THIRD_MAP_2)
+
+        self.assertEqual(asciimap[5, 0], "TG")
 
     def test_hexFull(self):
         """Test sample full hex map against known answers."""
         # hex map is 19 rows tall, so it should go from -9 to 9
-        reader = asciimaps.AsciiMapHexFullTipsUp()
-        lattice = reader.readMap(HEX_FULL_MAP)
-        self.assertEqual(lattice[0, 0], "0")
-        self.assertEqual(lattice[0, -1], "2")
-        self.assertEqual(lattice[0, -8], "6")
-        self.assertEqual(lattice[0, 9], "4")
-        self.assertEqual(lattice[-9, 0], "7")
-        self.assertEqual(lattice[-8, 7], "8")
-        self.assertEqual(lattice[6, -6], "3")
+        asciimap = asciimaps.AsciiMapHexFullTipsUp()
+        with io.StringIO() as stream:
+            stream.write(HEX_FULL_MAP)
+            stream.seek(0)
+            asciimap.readAscii(stream.read())
 
+        with io.StringIO() as stream:
+            asciimap.writeAscii(stream)
+            stream.seek(0)
+            output = stream.read()
+            self.assertEqual(output, HEX_FULL_MAP)
+        self.assertEqual(asciimap[0, 0], "0")
+        self.assertEqual(asciimap[0, -1], "2")
+        self.assertEqual(asciimap[0, -8], "6")
+        self.assertEqual(asciimap[0, 9], "4")
+        self.assertEqual(asciimap[-9, 0], "7")
+        self.assertEqual(asciimap[-8, 7], "8")
+        self.assertEqual(asciimap[6, -6], "3")
 
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()
+    def test_hexFullFlat(self):
+        """Test sample full hex map against known answers."""
+        # hex map is 19 rows tall, so it should go from -9 to 9
+        asciimap = asciimaps.AsciiMapHexFullFlatsUp()
+        with io.StringIO() as stream:
+            stream.write(HEX_FULL_MAP_FLAT)
+            stream.seek(0)
+            asciimap.readAscii(stream.read())
+
+        with io.StringIO() as stream:
+            asciimap.writeAscii(stream)
+            stream.seek(0)
+            output = stream.read()
+            self.assertEqual(output, HEX_FULL_MAP_FLAT)
+
+        self.assertEqual(asciimap[0, 0], "IC")
+        self.assertEqual(asciimap[-5, 2], "VOTA")
+        self.assertEqual(asciimap[2, 3], "FS")
+
+        # also test writing from pure data (vs. reading) gives the exact same map :o
+        with io.StringIO() as stream:
+            asciimap2 = asciimaps.AsciiMapHexFullFlatsUp()
+            asciimap2.asciiLabelByIndices = asciimap.asciiLabelByIndices
+            asciimap2.gridContentsToAscii()
+            asciimap2.writeAscii(stream)
+            stream.seek(0)
+            output = stream.read()
+            self.assertEqual(output, HEX_FULL_MAP_FLAT)
+
+    def test_flatHexBases(self):
+        """For the full core with 2 lines chopped, get the first 3 bases"""
+        asciimap = asciimaps.AsciiMapHexFullFlatsUp()
+        with io.StringIO() as stream:
+            stream.write(HEX_FULL_MAP_FLAT)
+            stream.seek(0)
+            asciimap.readAscii(stream.read())
+        bases = []
+        for li in range(3):
+            bases.append(asciimap._getIJBaseByAsciiLine(li))
+        # self.assertEqual(bases, [(0, -10), (-1, -9), (-2, -8)]) # unchopped
+        self.assertEqual(bases, [(-2, -8), (-3, -7), (-4, -6)])  # chopped


### PR DESCRIPTION
This is a full rewrite of the asciimap utility, for better or worse. 

The primary motivation was to get full core coremaps working. This also fixes some
open bugs related to the grids editor. It can now safe full-core geometries in
asciimap format. 

The asciimap functionality is inherently complex so the re-write isn't all that much
better than the original. 