### PR TITLE
Allow setting block heights to zero with DerivedShape components

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -498,7 +498,7 @@ class Block(composites.Composite):
         assemblies.Assembly.calculateZCoords : Recalculates z-coords, automatically called by this.
         """
         originalHeight = self.getHeight()  # get before modifying
-        if modifiedHeight <= 0.0:
+        if modifiedHeight < 0.0:
             raise ValueError(
                 "Cannot set height of block {} to height of {} cm".format(
                     self, modifiedHeight

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -310,7 +310,7 @@ class DerivedShape(UnshapedComponent):
 
     def computeVolume(self):
         """Cannot compute volume until it is derived."""
-        return self.parent._deriveUndefinedVolume()  # pylint: disable=protected-access
+        return self.parent._deriveUndefinedVolumeAndArea()  # pylint: disable=protected-access
 
     def getVolume(self):
         """

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -519,16 +519,15 @@ class Component(composites.Composite, metaclass=ComponentType):
         return self.p.volume
 
     def setVolume(self, volume):
+        self.p.volume = volume
         if not self.is3D:
             try:
                 self.setArea(volume / self.parent.getHeight())
             except ZeroDivisionError:
-                runLog.error(
-                    "The parent object {0} of {1} has no height. Cannot compute volume."
-                    "Check input.".format(self.parent, self)
-                )
-                raise
-        self.p.volume = volume
+                msg = (f"The parent object {self.parent} of {self} has no defined height and "
+                       f"therefore the area cannot be computed during the volume assignment. "
+                       f"The assigned volume is {volume} cc.")
+                raise ZeroDivisionError(msg)
 
     def setArea(self, val):
         raise NotImplementedError

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -521,13 +521,13 @@ class Component(composites.Composite, metaclass=ComponentType):
     def setVolume(self, volume):
         self.p.volume = volume
         if not self.is3D:
-            try:
-                self.setArea(volume / self.parent.getHeight())
-            except ZeroDivisionError:
+            if not self.parent.getHeight():
                 msg = (f"The parent object {self.parent} of {self} has no defined height and "
                        f"therefore the area cannot be computed during the volume assignment. "
                        f"The assigned volume is {volume} cc.")
-                raise ZeroDivisionError(msg)
+                raise ValueError(msg)
+            self.setArea(volume / self.parent.getHeight())
+
 
     def setArea(self, val):
         raise NotImplementedError

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -404,12 +404,15 @@ class Component(composites.Composite, metaclass=ComponentType):
 
     def getVolume(self):
         """
-        Return volume in cm**3.
-
-        Returns
-        -------
-        volume : float
-            volume in cm3
+        Return the volume [cm^3] of the component.
+        
+        Notes
+        -----
+        ``self.p.volume`` is not set until this method is called,
+        so under most circumstances it is probably not safe to
+        access ``self.p.volume`` directly. This is because not
+        all components (e.g., ``DerivedShape``) can compute
+        their volume during initialization.
         """
         if self.p.volume is None:
             self._updateVolume()
@@ -518,17 +521,9 @@ class Component(composites.Composite, metaclass=ComponentType):
     def getComponentVolume(self):
         return self.p.volume
 
-    def setVolume(self, volume):
-        self.p.volume = volume
-        if not self.is3D:
-            if not self.parent.getHeight():
-                msg = (f"The parent object {self.parent} of {self} has no defined height and "
-                       f"therefore the area cannot be computed during the volume assignment. "
-                       f"The assigned volume is {volume} cc.")
-                raise ValueError(msg)
-            self.setArea(volume / self.parent.getHeight())
-
-
+    def setVolume(self, val):
+        raise NotImplementedError
+    
     def setArea(self, val):
         raise NotImplementedError
 

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -58,7 +58,6 @@ class Sphere(ShapedComponent):
         self._linkAndStoreDimensions(
             components, od=od, id=id, mult=mult, modArea=modArea
         )
-        self.setVolume(self.getVolume())
 
     def getComponentArea(self, cold=False):
         raise NotImplementedError("Cannot compute area of a sphere component.")
@@ -122,7 +121,6 @@ class Cube(ShapedComponent):
             mult=mult,
             modArea=modArea,
         )
-        self.setVolume(self.getVolume())
 
     def getComponentArea(self, cold=False):
         raise NotImplementedError("Cannot compute area of a cube component.")
@@ -371,7 +369,6 @@ class RadialSegment(ShapedComponent):
             inner_theta=inner_theta,
             outer_theta=outer_theta,
         )
-        self.setVolume(self.getVolume())
 
     def getComponentArea(self, refVolume=None, refHeight=None, cold=False):
         if refHeight:
@@ -476,7 +473,7 @@ class DifferentialRadialSegment(RadialSegment):
             azimuthal_differential=azimuthal_differential,
             mult=mult,
         )
-        self.setVolume(self.getVolume())
+        self.updateDims()
 
     def updateDims(self, key="", val=None):
         """

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -758,9 +758,9 @@ class ArmiObject(metaclass=CompositeModelType):
             if child is self:
                 return frac
 
-    def _deriveUndefinedVolume(self):
+    def _deriveUndefinedVolumeAndArea(self):
         """
-        Determine the volume of any DerivedShapes (e.g. coolant components).
+        Determine the volume and area of any DerivedShapes (e.g. coolant components).
 
         When a coolant component first gets loaded, it has no area. But after that, it
         does have area so we must detect purely derived components by the fact that they
@@ -771,66 +771,80 @@ class ArmiObject(metaclass=CompositeModelType):
         then the area should not update. HOWEVER, if it was specified by a previous
         leftover computation, then we should re-compute.  That's why we store the area
         on the dims.
-
         """
         from armi.reactor import components  # avoid circular import
 
-        leftover = []
-        processed = []  # for input debugging
-        totalVolume = 0.0
-        for child in self.getChildren():
-            # so far, only coolants do this. ThRZBlock's with these must have
-            # area set specifically by input.
-            if child.__class__ is components.DerivedShape:
-                leftover.append(child)
-            else:
-                totalVolume += child.getVolume()
-                processed.append(child)
-        derivedVolume = 0.0
-        if len(leftover) == 1:
-            left = leftover[0]
-            derivedVolume = self.getMaxVolume() - totalVolume
-            if derivedVolume < 0:
-                runLog.error(
-                    "Negative remaining volume of {0} cm^3 for {1} in {2}. "
-                    "Check geometry (is pitch correct?). \nMax volume in this object is {3}\n"
-                    "Total of others is {4}\n"
-                    "Processed children include:\n{5}"
-                    "".format(
-                        derivedVolume,
-                        left,
-                        self,
-                        self.getMaxVolume(),
-                        totalVolume,
-                        "\n".join(
-                            [
-                                f"{child:40s}, {child.getArea():.5e}"
-                                for child in processed
-                            ]
-                        ),
-                    )
-                )
-                raise RuntimeError(
-                    "Negative remaining volume ({}) in {}".format(derivedVolume, self)
-                )
-            left.setVolume(derivedVolume)
-            totalVolume += derivedVolume
-        elif leftover:
-            runLog.warning(
-                "Gluttony Error incoming, total components {}"
-                "".format(self.getChildren())
-            )
-            for c in self.getChildren():
-                runLog.warning(
-                    "volume {} params {} for component {}"
-                    "".format(c.getVolume(), c.p, c.getName())
-                )
-            runLog.error(
-                "These are leftovers: {0}\n"
-                " Cannot deduce area of more than one component".format(leftover)
-            )
-            raise RuntimeError("Gluttony Error too many leftovers.")
-        return derivedVolume
+        # Determine the number of `DerivedShape` components and non-derived shape components
+        derivedShapeComps = [c for c in self.getChildren() if isinstance(c.__class__, components.DerivedShape)]
+        otherComps = [c for c in self.getChildren() if c not in derivedShapeComps]
+
+        otherCompAreas = sum([c.getArea() for c in otherComps])
+        otherCompVolumes = sum([c.getVolume() for c in otherComps])
+
+        remainingArea = self.getMaxArea() - otherCompAreas
+        remainingVolume = self.getMaxVolume() - otherCompVolumes
+
+        geometryError = False
+        # Check for negative area
+        if remainingArea < 0:
+            geometryError = True
+            componentAreas = "\n".join(
+            [
+                f"{c:40s}, {c.getArea():.5e} cm^2"
+                for c in otherComps
+            ])
+            msg = (f"The component areas in {self} exceed the maximum "
+                   f"allowable area based on the geometry. Check that the "
+                   f"geometry is defined correctly.\n"
+                   f"Maximum allowable area: {self.getMaxArea()} cm^2\n"
+                   f"Area of all defined components: {otherCompAreas} cm^2\n"
+                   f"Breakdown: {componentAreas}")
+            runLog.error(msg)
+
+        # Check for negative volume
+        if remainingVolume < 0:
+            geometryError = True
+            componentVols = "\n".join(
+            [
+                f"{c:40s}, {c.getVolume():.5e} cc"
+                for c in otherComps
+            ])
+            msg = (f"The component volumes in {self} exceed the maximum "
+                   f"allowable volume based on the geometry. Check that the "
+                   f"geometry is defined correctly.\n"
+                   f"Maximum allowable volume: {self.getMaxVolume()} cc\n"
+                   f"Volume of all defined components: {otherCompVolumes} cc\n"
+                   f"Breakdown: {componentVols}")
+            runLog.error(msg)
+
+        if geometryError:
+            raise ValueError(f"Negative area/volume errors occurred for {self}. "
+                             "Check log for errors.")
+
+        if len(derivedShapeComps) == 1:
+            c = derivedShapeComps[0]
+
+            # A ZeroDivisonError can occur when the height of the component's
+            # parent is zero, thus the volume may be set within `setVolume`
+            # (using the derived volume calculated here), but the component's
+            # area cannot be determined by directly using this volume. In this
+            # case, the area can be computed by subtracting the area of all
+            # other components from the parent's maximum area.
+            try:
+                c.setVolume(remainingVolume)
+            except ZeroDivisionError:
+                c.setArea(remainingArea)
+
+        elif derivedShapeComps > 1:
+            msg = (f"The number of `DerivedShape` children exceeds 1 in {self} "
+                   f"and it is not possible to set the volume/area of these children.\n"
+                   f"Remove the multiple instances of these components to fully define the "
+                   f"geometry.\n"
+                   f"Derived shapes: {derivedShapeComps}")
+            runLog.error(msg)
+            raise ValueError(f"Multiple `DerivedShape` children exceed in {self}. Check log for errors.")
+
+        return remainingVolume
 
     def getMaxArea(self):
         """ "

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -775,7 +775,7 @@ class ArmiObject(metaclass=CompositeModelType):
         from armi.reactor import components  # avoid circular import
 
         # Determine the number of `DerivedShape` components and non-derived shape components
-        derivedShapeComps = [c for c in self.getChildren() if isinstance(c.__class__, components.DerivedShape)]
+        derivedShapeComps = [c for c in self.getChildren() if c.__class__ is components.DerivedShape]
         otherComps = [c for c in self.getChildren() if c not in derivedShapeComps]
 
         otherCompAreas = sum([c.getArea() for c in otherComps])

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -725,7 +725,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def getVolumeFractions(self):
         """
-        Return volume  fractions of each child.
+        Return volume fractions of each child.
 
         Sets volume or area of missing piece (like coolant) if it exists.  Caching would
         be nice here.
@@ -750,10 +750,17 @@ class ArmiObject(metaclass=CompositeModelType):
         children = self.getChildren()
         volumes = [c.getVolume() for c in children]
         vol = sum(volumes)
-        return [(ci, vi / vol) for ci, vi in zip(children, volumes)]
+        if vol > 0.0:
+            volFracs = [(ci, vi / vol) for ci, vi in zip(children, volumes)]
+        else:
+            volFracs = [(ci, 0.0) for ci in children]
+        return volFracs
 
     def getVolumeFraction(self):
         """Return the volume fraction that this object takes up in its parent."""
+        if self.parent is None:
+            return 0.0
+
         for child, frac in self.parent.getVolumeFractions():
             if child is self:
                 return frac
@@ -832,7 +839,7 @@ class ArmiObject(metaclass=CompositeModelType):
             # other components from the parent's maximum area.
             try:
                 c.setVolume(remainingVolume)
-            except ZeroDivisionError:
+            except ValueError:
                 c.setArea(remainingArea)
 
         elif derivedShapeComps > 1:

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -485,6 +485,7 @@ class Block_TestCase(unittest.TestCase):
 
         # Check for a DerivedShape component
         self.assertEqual(len([c for c in b if c.__class__ is components.DerivedShape]), 1)
+        m1 = b.getMass()
         v1 = b.getVolume()
         a1 = b.getArea()
         nd1 = copy.deepcopy(b.getNumberDensities())
@@ -493,11 +494,13 @@ class Block_TestCase(unittest.TestCase):
 
         # Set height to 0.0
         b.setHeight(0.0)
+        m2 = b.getMass()
         v2 = b.getVolume()
         a2 = b.getArea()
         nd2 = copy.deepcopy(b.getNumberDensities())
         h2 = b.getHeight()
 
+        self.assertEqual(m2, 0.0)
         self.assertEqual(v2, 0.0)
         self.assertEqual(h2, 0.0)
         self.assertAlmostEqual(a2, a1)
@@ -507,11 +510,13 @@ class Block_TestCase(unittest.TestCase):
 
         # Set height back to the original height
         b.setHeight(h1)
+        m3 = b.getMass()
         v3 = b.getVolume()
         a3 = b.getArea()
         nd3 = copy.deepcopy(b.getNumberDensities())
         h3 = b.getHeight()
 
+        self.assertAlmostEqual(m3, m1)
         self.assertAlmostEqual(v3, v1)
         self.assertAlmostEqual(a3, a1)
         self.assertEqual(h3, h1)
@@ -519,6 +524,38 @@ class Block_TestCase(unittest.TestCase):
         for nuc in nd3.keys():
             self.assertAlmostEqual(nd3[nuc], nd1[nuc])
 
+    def test_getVolumeFractionsWithZeroHeight(self):
+        """Tests that the volume fractions of components in a block are zero."""
+        b = buildSimpleFuelBlock()
+
+        # Check that the component volume fractions are not
+        # zero to begin with.
+        h1 = b.getHeight()
+        originalVolFracs = b.getVolumeFractions()
+        for _c, vf in originalVolFracs:
+            self.assertNotEqual(vf, 0.0)
+
+        # Check that the component volume fractions are
+        # now zero after setting the block height to
+        # zero.
+        b.setHeight(0.0)
+        volFracs = b.getVolumeFractions()
+        for _c, vf in volFracs:
+            self.assertEqual(vf, 0.0)
+
+        # Check that the component volume fractions are
+        # back to the same values once the height is
+        # returned.
+        b.setHeight(h1)
+        volFracs = b.getVolumeFractions()
+        for (_c, vf1), (_c, vf2) in zip(volFracs, originalVolFracs):
+            self.assertAlmostEqual(vf1, vf2)
+
+    def test_getVolumeFractionWithoutParent(self):
+        """Tests that the volume fraction of a block with no parent is zero."""
+        b = buildSimpleFuelBlock()
+        self.assertIsNone(b.parent)
+        self.assertEqual(b.getVolumeFraction(), 0.0)
 
     def test_clearDensity(self):
         self.Block.clearNumberDensities()

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -525,27 +525,19 @@ class Block_TestCase(unittest.TestCase):
             self.assertAlmostEqual(nd3[nuc], nd1[nuc])
 
     def test_getVolumeFractionsWithZeroHeight(self):
-        """Tests that the volume fractions of components in a block are zero."""
+        """Tests that the component fractions are the same with a zero height block."""
         b = buildSimpleFuelBlock()
 
-        # Check that the component volume fractions are not
-        # zero to begin with.
         h1 = b.getHeight()
         originalVolFracs = b.getVolumeFractions()
         for _c, vf in originalVolFracs:
             self.assertNotEqual(vf, 0.0)
 
-        # Check that the component volume fractions are
-        # now zero after setting the block height to
-        # zero.
         b.setHeight(0.0)
         volFracs = b.getVolumeFractions()
-        for _c, vf in volFracs:
-            self.assertEqual(vf, 0.0)
+        for (_c, vf1), (_c, vf2) in zip(volFracs, originalVolFracs):
+            self.assertAlmostEqual(vf1, vf2)
 
-        # Check that the component volume fractions are
-        # back to the same values once the height is
-        # returned.
         b.setHeight(h1)
         volFracs = b.getVolumeFractions()
         for (_c, vf1), (_c, vf2) in zip(volFracs, originalVolFracs):
@@ -555,7 +547,8 @@ class Block_TestCase(unittest.TestCase):
         """Tests that the volume fraction of a block with no parent is zero."""
         b = buildSimpleFuelBlock()
         self.assertIsNone(b.parent)
-        self.assertEqual(b.getVolumeFraction(), 0.0)
+        with self.assertRaises(ValueError):
+            b.getVolumeFraction()
 
     def test_clearDensity(self):
         self.Block.clearNumberDensities()

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -479,6 +479,46 @@ class Block_TestCase(unittest.TestCase):
         ref = chr(typeNumber + 65)
         self.assertEqual(cur, ref)
 
+    def test_setZeroHeight(self):
+        """Test that demonstrates that a block's height can be set to zero."""
+        b = buildSimpleFuelBlock()
+
+        # Check for a DerivedShape component
+        self.assertEqual(len([c for c in b if c.__class__ is components.DerivedShape]), 1)
+        v1 = b.getVolume()
+        a1 = b.getArea()
+        nd1 = copy.deepcopy(b.getNumberDensities())
+        h1 = b.getHeight()
+        self.assertNotEqual(h1, 0.0)
+
+        # Set height to 0.0
+        b.setHeight(0.0)
+        v2 = b.getVolume()
+        a2 = b.getArea()
+        nd2 = copy.deepcopy(b.getNumberDensities())
+        h2 = b.getHeight()
+
+        self.assertEqual(v2, 0.0)
+        self.assertEqual(h2, 0.0)
+        self.assertEqual(a2, a1)
+        for nuc, ndens in nd2.items():
+            self.assertEqual(ndens, 0.0, msg=(f"Number density of {nuc} is "
+                                              "expected to be zero."))
+
+        # Set height back to the original height
+        b.setHeight(h1)
+        v3 = b.getVolume()
+        a3 = b.getArea()
+        nd3 = copy.deepcopy(b.getNumberDensities())
+        h3 = b.getHeight()
+
+        self.assertEqual(v3, v1)
+        self.assertEqual(a3, a1)
+        self.assertEqual(h3, h1)
+        for nuc in nd3.items():
+            self.assertAlmostEqual(nd3[nuc], nd1[nuc])
+
+
     def test_clearDensity(self):
         self.Block.clearNumberDensities()
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -515,7 +515,8 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(v3, v1)
         self.assertAlmostEqual(a3, a1)
         self.assertEqual(h3, h1)
-        for nuc in nd3.items():
+
+        for nuc in nd3.keys():
             self.assertAlmostEqual(nd3[nuc], nd1[nuc])
 
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -500,7 +500,7 @@ class Block_TestCase(unittest.TestCase):
 
         self.assertEqual(v2, 0.0)
         self.assertEqual(h2, 0.0)
-        self.assertEqual(a2, a1)
+        self.assertAlmostEqual(a2, a1)
         for nuc, ndens in nd2.items():
             self.assertEqual(ndens, 0.0, msg=(f"Number density of {nuc} is "
                                               "expected to be zero."))
@@ -512,8 +512,8 @@ class Block_TestCase(unittest.TestCase):
         nd3 = copy.deepcopy(b.getNumberDensities())
         h3 = b.getHeight()
 
-        self.assertEqual(v3, v1)
-        self.assertEqual(a3, a1)
+        self.assertAlmostEqual(v3, v1)
+        self.assertAlmostEqual(a3, a1)
         self.assertEqual(h3, h1)
         for nuc in nd3.items():
             self.assertAlmostEqual(nd3[nuc], nd1[nuc])

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -621,6 +621,7 @@ class TestCube(TestShapedComponent):
         self.assertAlmostEqual(negativeCube.getVolume(), refVolume)
         with self.assertRaises(exceptions.NegativeComponentVolume):
             negativeCube = Cube("test", "UZr", **dims)
+            negativeCube.getVolume()
 
     def test_getVolume(self):
         lengthO = self.component.getDimension("lengthOuter")


### PR DESCRIPTION
A zero block height is supported in the framework when it is assigned in the blueprints and when there are no `DerivedShape`
components defined within the block. This aims to fix this issue to allow a user to specify a zero height block within an assembly even with a `DerivedShape` being used.

Additionally, there was an issue where while the blueprints could support adding a zero height block to an assembly, the `setHeight` method on blocks would not allow this. 

* The `setHeight` method on blocks now allows the user to set a zero height block and then return it to a non-zero height later on. 
* A unit test was added to check that setting a non-zero height block to zero and then back to the original height preserves the volume, area, number densities, and height.

The assignment of the `DerivedShape` component area was determined based on the computed volume and the height of the parent block. When the height was set to zero, this resulted in a `ZeroDivisionError`. Now, this exception is caught and the area of the `DerivedShape` component is instead set directly.