### PR TITLE
Add flag list setting class

### DIFF
--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -40,6 +40,7 @@ from typing import List, Optional, Tuple
 import voluptuous as vol
 
 from armi import runLog
+from armi.reactor.flags import Flags
 
 
 # Options are used to imbue existing settings with new Options. This allows a setting
@@ -78,7 +79,7 @@ class Setting:
         enforcedOptions=False,
         subLabels=None,
         isEnvironment=False,
-        oldNames: Optional[List[Tuple[str, Optional[datetime.date]]]] = None
+        oldNames: Optional[List[Tuple[str, Optional[datetime.date]]]] = None,
     ):
         """
         Initialize a Setting object.
@@ -312,3 +313,58 @@ class Setting:
             "type": type(self.default),
             "default": self.default,
         }
+
+
+class FlagListSetting(Setting):
+    """Subclass of :py:class:`Setting <armi.settings.Setting>` convert settings between flags and strings."""
+
+    def __init__(
+        self,
+        name,
+        default,
+        description=None,
+        label=None,
+        oldNames: Optional[List[Tuple[str, Optional[datetime.date]]]] = None,
+    ):
+        Setting.__init__(
+            self,
+            name=name,
+            default=default,
+            description=description,
+            label=label,
+            options=None,
+            schema=self.schema,
+            enforcedOptions=None,
+            subLabels=None,
+            isEnvironment=False,
+            oldNames=oldNames,
+        )
+
+    @staticmethod
+    def schema(val) -> List[Flags]:
+        """
+        Return a list of :py:class:`Flags <armi.reactor.flags.Flags`.
+        
+        Raises
+        ------
+        TypeError
+            When ``val`` is not a list.
+        ValueError
+            When ``val`` is not an instance of str or Flags.
+        """
+        if not isinstance(val, list):
+            raise TypeError(f"Expected `{val}` to be a list.")
+
+        flagVals = []
+        for v in val:
+            if isinstance(v, str):
+                flagVals.append(Flags.fromString(v))
+            elif isinstance(v, Flags):
+                flagVals.append(v)
+            else:
+                raise ValueError(f"Invalid flag input `{v}` in `{self}`")
+        return flagVals
+
+    def dump(self) -> List[str]:
+        """Return a list of strings converted from the flag values."""
+        return [Flags.toString(v) for v in self.value]

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -29,6 +29,7 @@ from armi.settings import setting
 from armi.operators import settingsValidation
 from armi import plugins
 from armi.utils import directoryChangers
+from armi.reactor.flags import Flags
 
 THIS_DIR = os.path.dirname(__file__)
 TEST_XML = os.path.join(THIS_DIR, "old_xml_settings_input.xml")
@@ -265,6 +266,30 @@ class TestSettingsUtils(unittest.TestCase):
     def test_prompt(self):
         selection = settings.promptForSettingsFile(1)
         self.assertEqual(selection, "settings1.yaml")
+
+
+class TestFlagListSetting(unittest.TestCase):
+    def test_flagListSetting(self):
+        """Test that a list of strings can be converted to a list of flags and back."""
+        flagsAsStringList = ["DUCT", "FUEL", "CLAD"]
+        flagsAsFlagList = [Flags.DUCT, Flags.FUEL, Flags.CLAD]
+
+        fs = setting.FlagListSetting(name="testFlagSetting", default=[])
+        # Set the value as a list of strings first
+        fs.value = flagsAsStringList
+        self.assertEqual(fs.value, flagsAsFlagList)
+        self.assertEqual(fs.dump(), flagsAsStringList)
+
+        # Set the value as a list of flags
+        fs.value = flagsAsFlagList
+        self.assertEqual(fs.value, flagsAsFlagList)
+        self.assertEqual(fs.dump(), flagsAsStringList)
+
+    def test_invalidFlagListTypeError(self):
+        """Test raising a TypeError when a list is not provided."""
+        fs = setting.FlagListSetting(name="testFlagSetting", default=[])
+        with self.assertRaises(TypeError):
+            fs.value = "DUCT"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding a subclass to Setting to handle flag inputs. This automatically converts a list of strings to a list of flags 
when applying the value to a setting. Additionally, this will convert back to a list of strings
when writing to the Settings YAML or XML file.