### PR TITLE
Add support for ex-core structures to VTK files

### DIFF
--- a/armi/bookkeeping/visualization/utils.py
+++ b/armi/bookkeeping/visualization/utils.py
@@ -124,7 +124,8 @@ class VtkMesh:
 
 def createReactorBlockMesh(r: reactors.Reactor) -> VtkMesh:
     mesh = VtkMesh.empty()
-    for b in r.core.getBlocks():
+    blks = r.getChildren(deep=True, predicate=lambda o: isinstance(o, blocks.Block))
+    for b in blks:
         mesh.append(createBlockMesh(b))
 
     return mesh
@@ -132,7 +133,10 @@ def createReactorBlockMesh(r: reactors.Reactor) -> VtkMesh:
 
 def createReactorAssemMesh(r: reactors.Reactor) -> VtkMesh:
     mesh = VtkMesh.empty()
-    for a in r.core.getAssemblies():
+    assems = r.getChildren(
+        deep=True, predicate=lambda o: isinstance(o, assemblies.Assembly)
+    )
+    for a in assems:
         mesh.append(createAssemMesh(a))
 
     return mesh

--- a/armi/bookkeeping/visualization/vtk.py
+++ b/armi/bookkeeping/visualization/vtk.py
@@ -34,6 +34,8 @@ import numpy
 from pyevtk.vtk import VtkGroup
 
 from armi import runLog
+from armi.reactor import assemblies
+from armi.reactor import blocks
 from armi.reactor import composites
 from armi.reactor import reactors
 from armi.reactor import parameters
@@ -94,9 +96,11 @@ class VtkDumper(dumper.VisFileDumper):
                 "includeParams and excludeParams can not both be used at the same time"
             )
 
-        # make the meshes
-        blks = r.core.getBlocks()
-        assems = r.core.getAssemblies()
+        blks = r.getChildren(deep=True, predicate=lambda o: isinstance(o, blocks.Block))
+        assems = r.getChildren(
+            deep=True, predicate=lambda o: isinstance(o, assemblies.Assembly)
+        )
+
         blockMesh = utils.createReactorBlockMesh(r)
         assemMesh = utils.createReactorAssemMesh(r)
 
@@ -175,7 +179,7 @@ def _collectObjectData(objs: List[composites.ArmiObject],
 
             try:
                 data = database3.replaceNonesWithNonsense(data, pDef.name, nones=nones)
-            except ValueError:
+            except (ValueError, TypeError):
                 # Looks like we have some weird data. We might be able to handle it
                 # with more massaging, but probably not visualizable anyhow
                 continue

--- a/armi/bookkeeping/visualization/xdmf.py
+++ b/armi/bookkeeping/visualization/xdmf.py
@@ -303,7 +303,9 @@ class XdmfDumper(dumper.VisFileDumper):
         blks = r.getChildren(deep=True, predicate=lambda o: isinstance(o, blocks.Block))
         blks = sorted(blks, key=lambda b: snToIdx[b.p.serialNum])
 
-        assems = r.core.getAssemblies()
+        assems = r.getChildren(
+            deep=True, predicate=lambda o: isinstance(o, assemblies.Assembly)
+        )
         assems = sorted(assems, key=lambda a: snToIdx[a.p.serialNum])
 
         blockGrid = self._makeBlockMesh(r, snToIdx)


### PR DESCRIPTION
Huzzah!

![image](https://user-images.githubusercontent.com/1179265/95144494-a51d0f80-072d-11eb-85b1-4807e6f307d5.png)

This used #165 to create the input database.