### PR TITLE
Several fixes to the CCCC reader/writers

### DIFF
--- a/armi/nuclearDataIO/cccc.py
+++ b/armi/nuclearDataIO/cccc.py
@@ -356,6 +356,12 @@ class IORecord(object):
         """
         return self._rwMatrix(contents, self.rwDouble, *shape)
 
+    def rwIntMatrix(self, contents, *shape):
+        """
+        Read or write a matrix of int values.
+        """
+        return self._rwMatrix(contents, self.rwInt, *shape)
+
     def _rwMatrix(self, contents, func, *shape):
         fortranShape = list(reversed(shape))
         if contents is None or contents.size == 0:

--- a/armi/nuclearDataIO/cccc.py
+++ b/armi/nuclearDataIO/cccc.py
@@ -362,7 +362,17 @@ class IORecord(object):
         """
         return self._rwMatrix(contents, self.rwInt, *shape)
 
-    def _rwMatrix(self, contents, func, *shape):
+    @staticmethod
+    def _rwMatrix(contents, func, *shape):
+        """
+        Read/write a matrix.
+
+        Notes
+        -----
+        This can be important for performance when reading large matrices (e.g. scatter
+        matrices). It may be worth investigating ``numpy.frombuffer`` on read and
+        something similar on write.
+        """
         fortranShape = list(reversed(shape))
         if contents is None or contents.size == 0:
             contents = numpy.empty(fortranShape)

--- a/armi/nuclearDataIO/gamiso.py
+++ b/armi/nuclearDataIO/gamiso.py
@@ -137,12 +137,6 @@ class _GamisoIO(isotxs._IsotxsIO):  # pylint: disable=protected-access,abstract-
             self._lib.gammaEnergyUpperBounds, self._metadata["numGroups"]
         )
 
-    @classmethod
-    def _readWrite(cls, lib, fileName, fileMode, getNuclideFunc):
-        with _GamisoIO(fileName, lib, fileMode, getNuclideFunc) as rw:
-            rw.readWrite()
-        return lib
-
 
 readBinary = _GamisoIO.readBinary
 readAscii = _GamisoIO.readAscii

--- a/armi/nuclearDataIO/geodst.py
+++ b/armi/nuclearDataIO/geodst.py
@@ -134,7 +134,7 @@ class GeodstStream(cccc.Stream):
 
     @classmethod
     def _readWrite(cls, geom: GeodstData, fileName: str, fileMode: str) -> GeodstData:
-        with GeodstStream(geom, fileName, fileMode) as rw:
+        with cls(geom, fileName, fileMode) as rw:
             rw.readWrite()
         return geom
 

--- a/armi/nuclearDataIO/geodst.py
+++ b/armi/nuclearDataIO/geodst.py
@@ -264,12 +264,10 @@ class GeodstStream(cccc.Stream):
             )
         for ki in range(self._metadata["NCINTK"]):
             with self.createRecord() as record:
-                # pylint: disable=protected-access
-                self._geom.coarseMeshRegions[:, :, ki] = record._rwMatrix(
+                self._geom.coarseMeshRegions[:, :, ki] = record.rwIntMatrix(
                     self._geom.coarseMeshRegions[:, :, ki],
-                    record.rwInt,
-                    self._metadata["NCINTI"],
                     self._metadata["NCINTJ"],
+                    self._metadata["NCINTI"],
                 )
 
     def _rw7DRecord(self):
@@ -287,12 +285,10 @@ class GeodstStream(cccc.Stream):
             )
         for ki in range(self._metadata["NINTK"]):
             with self.createRecord() as record:
-                # pylint: disable=protected-access
-                self._geom.fineMeshRegions[:, :, ki] = record._rwMatrix(
+                self._geom.fineMeshRegions[:, :, ki] = record.rwIntMatrix(
                     self._geom.fineMeshRegions[:, :, ki],
-                    record.rwInt,
-                    self._metadata["NINTI"],
                     self._metadata["NINTJ"],
+                    self._metadata["NINTI"],
                 )
 
 

--- a/armi/nuclearDataIO/isotxs.py
+++ b/armi/nuclearDataIO/isotxs.py
@@ -175,7 +175,7 @@ class _IsotxsIO(cccc.Stream):
 
     @classmethod
     def _readWrite(cls, lib, fileName, fileMode, getNuclideFunc):
-        with _IsotxsIO(fileName, lib, fileMode, getNuclideFunc) as rw:
+        with cls(fileName, lib, fileMode, getNuclideFunc) as rw:
             rw.readWrite()
         return lib
 

--- a/armi/nuclearDataIO/labels.py
+++ b/armi/nuclearDataIO/labels.py
@@ -136,7 +136,7 @@ class LabelsStream(cccc.Stream):
 
     @classmethod
     def _readWrite(cls, labels, fileName: str, fileMode: str) -> LabelsData:
-        with LabelsStream(labels, fileName, fileMode) as rw:
+        with cls(labels, fileName, fileMode) as rw:
             rw.readWrite()
         return labels
 

--- a/armi/nuclearDataIO/pwdint.py
+++ b/armi/nuclearDataIO/pwdint.py
@@ -133,10 +133,8 @@ class PwdintStream(cccc.Stream):
             for bi in range(nblck):
                 jL, jU = cccc.getBlockBandwidth(bi + 1, jmax, nblck)
                 with self.createRecord() as record:
-                    # pylint: disable=protected-access
-                    self._power.powerDensity[:, jL : jU + 1, ki] = record._rwMatrix(
+                    self._power.powerDensity[:, jL : jU + 1, ki] = record.rwMatrix(
                         self._power.powerDensity[:, jL : jU + 1, ki],
-                        record.rwFloat,
                         jU - jL + 1,
                         imax,
                     )

--- a/armi/nuclearDataIO/rtflux.py
+++ b/armi/nuclearDataIO/rtflux.py
@@ -117,7 +117,7 @@ class RtfluxStream(cccc.Stream):
 
     @classmethod
     def _readWrite(cls, flux: RtfluxData, fileName: str, fileMode: str) -> RtfluxData:
-        with RtfluxStream(flux, fileName, fileMode) as rw:
+        with cls(flux, fileName, fileMode) as rw:
             rw.readWrite()
         return flux
 
@@ -202,6 +202,8 @@ class RtfluxStream(cccc.Stream):
         r"""
         Real fluxes stored in RTFLUX have "normal" (or "forward") energy groups.
         Also see the subclass method ATFLUX.getEnergyGroupIndex().
+
+        0 based, so if NG=33 and you want the third group, this return 2.
         """
         return g
 
@@ -215,6 +217,8 @@ class AtfluxStream(RtfluxStream):
     def getEnergyGroupIndex(self, g):
         r"""
         Adjoint fluxes stored in ATFLUX have "reversed" (or "backward") energy groups.
+
+        0 based, so if NG=33 and you want the third group (g=2), this returns 30.
         """
 
         ng = self._metadata["NGROUP"]

--- a/armi/nuclearDataIO/rtflux.py
+++ b/armi/nuclearDataIO/rtflux.py
@@ -190,12 +190,10 @@ class RtfluxStream(cccc.Stream):
                     numZonesInBlock = jUp - jLow + 1
                     with self.createRecord() as record:
                         # pass in shape in fortran (read) order
-                        # pylint: disable=protected-access
                         self._flux.groupFluxes[
                             :, jLow : jUp + 1, k, gEff
-                        ] = record._rwMatrix(
+                        ] = record.rwDoubleMatrix(
                             self._flux.groupFluxes[:, jLow : jUp + 1, k, gEff],
-                            record.rwDouble,
                             numZonesInBlock,
                             imax,
                         )

--- a/armi/nuclearDataIO/rzflux.py
+++ b/armi/nuclearDataIO/rzflux.py
@@ -146,7 +146,7 @@ class RzfluxStream(cccc.Stream):
         Zones are blocked into multiple records so we have to block or unblock
         them.
 
-        _rwMatrix reverses the indices into FORTRAN data order so be
+        rwMatrix reverses the indices into FORTRAN data order so be
         very careful with the indices.
         """
         nz = self._metadata["NZONE"]
@@ -164,10 +164,8 @@ class RzfluxStream(cccc.Stream):
             numZonesInBlock = jUp - jLow + 1
             with self.createRecord() as record:
                 # pass in shape in fortran (read) order
-                # pylint: disable=protected-access
-                self._flux.groupFluxes[:, jLow : jUp + 1] = record._rwMatrix(
+                self._flux.groupFluxes[:, jLow : jUp + 1] = record.rwMatrix(
                     self._flux.groupFluxes[:, jLow : jUp + 1],
-                    record.rwFloat,
                     numZonesInBlock,
                     ng,
                 )

--- a/armi/nuclearDataIO/rzflux.py
+++ b/armi/nuclearDataIO/rzflux.py
@@ -100,7 +100,7 @@ class RzfluxStream(cccc.Stream):
 
     @classmethod
     def _readWrite(cls, flux: RzfluxData, fileName: str, fileMode: str) -> RzfluxData:
-        with RzfluxStream(flux, fileName, fileMode) as rw:
+        with cls(flux, fileName, fileMode) as rw:
             rw.readWrite()
         return flux
 

--- a/armi/nuclearDataIO/tests/test_rtflux.py
+++ b/armi/nuclearDataIO/tests/test_rtflux.py
@@ -49,3 +49,16 @@ class Testrtflux(unittest.TestCase):
         flux2 = rtflux.RtfluxStream.readAscii("rtflux.ascii")
         self.assertTrue((flux2.groupFluxes == flux.groupFluxes).all())
         os.remove("rtflux.ascii")
+
+    def test_adjoint(self):
+        """Ensure adjoint reads energy groups differently."""
+        real = rtflux.RtfluxStream.readBinary(SIMPLE_RTFLUX)
+        adjoint = rtflux.AtfluxStream.readBinary(SIMPLE_RTFLUX)
+        self.assertFalse((real.groupFluxes == adjoint.groupFluxes).all())
+        g = 3
+        self.assertTrue(
+            (
+                real.groupFluxes[:, :, :, g]
+                == adjoint.groupFluxes[:, :, :, real.metadata["NGROUP"] - g - 1]
+            ).all()
+        )


### PR DESCRIPTION
This fixes some issues related to the recent upgrades/changes to the CCCC reader/writers

* Fixes a class inheritance propagation bug affecting the new adjoint RTFLUX reader/writer
* Propagates that fix to other related classes in case they get subclassed later
* Fixes an i/j order bug on the new GEODST reader
* Implements a rwIntMatrix method and applies use of the related public methods 
   rather than the private _rwMatrix
* Adds new tests covering these bugs