### PR TITLE
Clean test crumb and fix/expand isotxs examples

### DIFF
--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -26,12 +26,15 @@ ISOTXS file format, consistent with [CCCC-IV]_.
 
 Examples
 --------
->>> myLib = armi.nuclearDataIO.ISOTXS('ISOTXS-ref')
->>> nuc = myLib.nuclides['U235AA']
+>>> from armi.nuclearDataIO.cccc import isotxs
+>>> myLib = isotxs.readBinary('ISOTXS-ref')
+>>> nuc = myLib.getNuclide('U235','AA')
 >>> fis5 = nuc.micros.fission[5]
 >>> scat = nuc.micros.scatter[(0, 5, 6, 1)] # 1st order elastic scatter from group 5->6
 >>> nuc.micros.fission[7] = fis5*1.01       # you can modify the isotxs too.
->>> armi.nuclearDataIO.isotxs.writeBinary(myLib, 'ISOTXS-modified')
+>>> captureEnergy = nuc.isotxsMetadata["ecapt"]
+>>> isotxs.writeBinary(myLib, 'ISOTXS-modified')
+
 """
 
 import traceback

--- a/armi/nuclearDataIO/cccc/tests/test_rzflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_rzflux.py
@@ -35,6 +35,7 @@ class TestRzflux(unittest.TestCase):
         flux2 = rzflux.readBinary("RZFLUX3")
         self.assertAlmostEqual(flux2.groupFluxes[12, 1], flux.groupFluxes[12, 1])
         os.remove("RZFLUX2")
+        os.remove("RZFLUX3")
 
     def test_rwAscii(self):
         """Ensure that we can read/write in ascii format."""


### PR DESCRIPTION
This cleans up new `RZFLUX3` files leftover from tests and fixes/enhances examples in isotoxs