### PR TITLE
No longer automatically use or clean FAST_PATH in interactive sessions

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -76,6 +76,8 @@ from armi.context import (
     MPI_SIZE,
     APP_DATA,
 )
+from armi.context import Mode
+
 from armi.meta import __version__
 from armi import apps
 from armi import pluginManager

--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -44,10 +44,8 @@ If using the ``run`` entry point, additional work is done:
 """
 import atexit
 import datetime
-import gc
 import importlib
 import os
-import shutil
 import signal
 import subprocess
 import sys
@@ -62,7 +60,7 @@ import warnings
 # - define the FAST_PATH
 # - Initialize the nuclide database
 import armi._bootstrap
-import armi.context
+from armi import context
 from armi.context import (
     ROOT,
     RES,
@@ -78,7 +76,6 @@ from armi.context import (
     MPI_SIZE,
     APP_DATA,
 )
-from armi.context import Mode
 from armi.meta import __version__
 from armi import apps
 from armi import pluginManager
@@ -88,7 +85,6 @@ from armi import materials
 from armi.localization import exceptions
 from armi.reactor import composites
 from armi.reactor import flags
-from armi.bookkeeping.db import Database3
 from armi.reactor import parameters
 from armi.nucDirectory import nuclideBases
 
@@ -132,97 +128,6 @@ def _registerUserPlugin(plugManager, userPluginName):
             "This constant is required in user plugins. Please adjust plugin."
         )
         raise
-
-
-def disconnectAllHdfDBs():
-    """
-    Forcibly disconnect all instances of HdfDB objects
-
-    Notes
-    -----
-    This is a hack to help ARMI exit gracefully when the garbage collector and h5py have
-    issues destroying objects. After lots of investigation, the root cause for why this
-    was having issues was never identified. It appears that when several HDF5 files are
-    open in the same run (e.g.  when calling armi.init() multiple times from a
-    post-processing script), when these h5py File objects were closed, the garbage
-    collector would raise an exception related to the repr'ing the object. We
-    get around this by using the garbage collector to manually disconnect all open HdfDB
-    objects.
-    """
-    h5dbs = [db for db in gc.get_objects() if isinstance(db, Database3)]
-    for db in h5dbs:
-        db.close()
-
-
-def cleanTempDirs(olderThanDays=None):
-    """
-    Clean up temporary files after a run.
-
-    The Windows HPC system sends a SIGBREAK signal when the user cancels a job, which
-    is NOT handled by ``atexit``. Notably SIGBREAK doesn't exist off Windows.
-    For the SIGBREAK signal to work with a Microsoft HPC, the ``TaskCancelGracePeriod``
-    option must be configured to be non-zero. This sets the period between SIGBREAK
-    and SIGTERM/SIGINT. To do cleanups in this case, we must use the ``signal`` module.
-    Actually, even then it does not work because MS ``mpiexec`` does not pass signals
-    through.
-
-    Parameters
-    ----------
-    olderThanDays: int, optional
-        If provided, deletes other ARMI directories if they are older than the requested
-        time.
-    """
-    disconnectAllHdfDBs()
-    if armi.context.CURRENT_MODE == armi.context.Mode.INTERACTIVE:
-        # assume no temporary directory was needed in interactive mode.
-        # This can help prevent surprises e.g. when a interactive task is running
-        # and is cancelled by the user but they just want to adjust something and
-        # rerun without losing all their working files.
-        return
-    if armi.context.APP_DATA not in armi.context.FAST_PATH:
-        # safety mechanism to ensure people's working dirs never get deleted automatically
-        # Warn here to indicate the near miss, which should really never happen.
-        runLog.warning(
-            f"Skipping deletion of non-appdata FAST_PATH in {armi.context.FAST_PATH}"
-        )
-        return
-    if os.path.exists(armi.context.FAST_PATH):
-        if runLog.getVerbosity() <= runLog.getLogVerbosityRank("extra"):
-            print(
-                "Cleaning up temporary files in: {}".format(armi.context.FAST_PATH),
-                file=sys.stdout,
-            )
-        try:
-            shutil.rmtree(armi.context.FAST_PATH)
-        except Exception as error:  # pylint: disable=broad-except
-            for outputStream in (sys.stderr, sys.stdout):
-                print(
-                    "Failed to delete temporary files in: {}\n"
-                    "    error: {}".format(armi.context.FAST_PATH, error),
-                    file=outputStream,
-                )
-
-    # Also delete anything still here after `olderThanDays` days (in case this failed on
-    # earlier runs)
-    if olderThanDays is not None:
-        gracePeriod = datetime.timedelta(days=olderThanDays)
-        now = datetime.datetime.now()
-        thisRunFolder = os.path.basename(armi.context.FAST_PATH)
-
-        for dirname in os.listdir(APP_DATA):
-            dirPath = os.path.join(APP_DATA, dirname)
-            if not os.path.isdir(dirPath):
-                continue
-            try:
-                fromThisRun = dirname == thisRunFolder  # second chance to delete
-                _rank, dateString = dirname.split("-")
-                dateOfFolder = datetime.datetime.strptime(dateString, "%Y%m%d%H%M%S%f")
-                runIsOldAndLikleyComplete = (now - dateOfFolder) > gracePeriod
-                if runIsOldAndLikleyComplete or fromThisRun:
-                    # Delete old files
-                    shutil.rmtree(dirPath)
-            except:  # pylint: disable=bare-except
-                pass
 
 
 def init(choice=None, fName=None, cs=None):
@@ -350,7 +255,7 @@ def _cleanupOnCancel(signum, _frame):
         "".format(signum),
         file=sys.stderr,
     )
-    cleanTempDirs()
+    context.cleanTempDirs()
     sys.stdout.flush()
     sys.stderr.flush()
     sys.exit(1)  # since we're handling the signal we have to cancel
@@ -390,11 +295,9 @@ def configure(app: Optional[apps.App] = None):
         # ARMI cannot be reconfigured!
         raise exceptions.OverConfiguredError(_ARMI_CONFIGURE_CONTEXT)
 
-    assert not armi.context.BLUEPRINTS_IMPORTED, (
+    assert not context.BLUEPRINTS_IMPORTED, (
         "ARMI can no longer be configured after blueprints have been imported. "
-        "Blueprints were imported from:\n{}".format(
-            armi.context.BLUEPRINTS_IMPORT_CONTEXT
-        )
+        "Blueprints were imported from:\n{}".format(context.BLUEPRINTS_IMPORT_CONTEXT)
     )
 
     _ARMI_CONFIGURE_CONTEXT = "".join(traceback.format_stack())
@@ -404,7 +307,7 @@ def configure(app: Optional[apps.App] = None):
     _app = app
 
     pm = app.pluginManager
-    armi.context.APP_NAME = app.name
+    context.APP_NAME = app.name
     parameters.collectPluginParameters(pm)
     parameters.applyAllParameters()
     flags.registerPluginFlags(pm)
@@ -433,7 +336,7 @@ def applyAsyncioWindowsWorkaround():
 applyAsyncioWindowsWorkaround()
 
 # The ``atexit`` handler is like putting it in a finally after everything.
-atexit.register(cleanTempDirs, olderThanDays=14)
+atexit.register(context.cleanTempDirs, olderThanDays=14)
 
 # register cleanups upon HPC cancellations. Linux clusters will send a different signal.
 # SIGBREAK doesn't exist on non-windows

--- a/armi/_bootstrap.py
+++ b/armi/_bootstrap.py
@@ -59,20 +59,6 @@ def _addCustomTabulateTables():
 _addCustomTabulateTables()
 
 
-# Creating the FAST_PATH here so that parts of ARMI that dont necessarily create an
-# Operator can use it. Main example is the Database funtionality
-try:
-    os.makedirs(context.FAST_PATH)
-except OSError:
-    # If FAST_PATH exists already that generally should be an error because
-    # different processes will be stepping on each other.
-    # The exception to this rule is in cases that instantiate multiple operators in one
-    # process (e.g. unit tests that loadTestReactor). Since the FAST_PATH is set at
-    # import, these will use the same path multiple times. We pass here for that reason.
-    if not os.path.exists(context.FAST_PATH):
-        # if it actually doesn't exist, that's an actual error. Raise
-        raise
-
 from armi import runLog
 
 from armi.nucDirectory import nuclideBases

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -82,6 +82,7 @@ import numpy
 import h5py
 
 import armi
+from armi import context
 from armi import interfaces
 from armi import runLog
 from armi import settings
@@ -548,7 +549,7 @@ class Database3(database.Database):
 
         if self._permission == "w":
             # assume fast path!
-            filePath = os.path.join(armi.FAST_PATH, filePath)
+            filePath = os.path.join(context.FAST_PATH, filePath)
             self._fullPath = os.path.abspath(filePath)
 
         else:

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -431,7 +431,7 @@ class Case:
             operatorClass = operators.getOperatorClassFromSettings(self.cs)
             inspector = operatorClass.inspector(self.cs)
             inspectorIssues = [query for query in inspector.queries if query]
-            if armi.CURRENT_MODE == armi.Mode.Interactive:
+            if armi.CURRENT_MODE == armi.Mode.INTERACTIVE:
                 # if interactive, ask user to deal with settings issues
                 inspector.run()
             else:
@@ -717,7 +717,5 @@ def copyInterfaceInputs(cs, destination: str, sourceDir: Optional[str] = None):
                         continue
                     _sourceDir, sourceName = os.path.split(sourceFullPath)
                     pathTools.copyOrWarn(
-                        label,
-                        sourceFullPath,
-                        os.path.join(destination, sourceName),
+                        label, sourceFullPath, os.path.join(destination, sourceName)
                     )

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -190,7 +190,7 @@ class ArmiCLI:
         cmd.parse(args)
 
         if cmd.args.batch:
-            armi.Mode.setMode(armi.Mode.Batch)
+            armi.Mode.setMode(armi.Mode.BATCH)
         elif cmd.mode is not None:
             armi.Mode.setMode(cmd.mode)
 

--- a/armi/cli/database.py
+++ b/armi/cli/database.py
@@ -27,7 +27,7 @@ class ConvertDB(EntryPoint):
     """Convert databases between different versions"""
 
     name = "convert-db"
-    mode = armi.Mode.Batch
+    mode = armi.Mode.BATCH
 
     def addOptions(self):
         self.parser.add_argument("h5db", help="Input database path", type=str)
@@ -91,7 +91,7 @@ class ExtractInputs(EntryPoint):
     """
 
     name = "extract-inputs"
-    mode = armi.Mode.Batch
+    mode = armi.Mode.BATCH
 
     def addOptions(self):
         self.parser.add_argument("h5db", help="Path to input database", type=str)
@@ -157,7 +157,7 @@ class InjectInputs(EntryPoint):
     """
 
     name = "inject-inputs"
-    mode = armi.Mode.Batch
+    mode = armi.Mode.BATCH
 
     def addOptions(self):
         self.parser.add_argument("h5db", help="Path to affected database", type=str)

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -78,8 +78,8 @@ class EntryPoint:
     then it is an optional positional argument. Finally, if settingsArgument is
     None, then no settings file argument is added."""
 
-    #: One of {armi.Mode.Batch, armi.Mode.Interactive, armi.Mode.Gui}, optional.
-    #: Specifies the ARMI mode in which the command is run. Default is armi.Mode.Batch.
+    #: One of {armi.Mode.BATCH, armi.Mode.INTERACTIVE, armi.Mode.GUI}, optional.
+    #: Specifies the ARMI mode in which the command is run. Default is armi.Mode.BATCH.
     mode: Optional[int] = None
 
     def __init__(self):

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -53,7 +53,7 @@ def bootstrapArmiTestEnv():
 
     cs = caseSettings.Settings()
 
-    armi.Mode.setMode(armi.Mode.BATCH)
+    context.Mode.setMode(context.Mode.BATCH)
     settings.setMasterCs(cs)
     # Need to init burnChain.
     # see armi.cases.case.Case._initBurnChain

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -28,19 +28,32 @@ import os
 
 import matplotlib
 
+import armi
+from armi import apps
 from armi import settings
 from armi.settings import caseSettings
+from armi import context
 
 
 def pytest_sessionstart(session):
-    import armi
-    from armi import apps
-    from armi import context
-    from armi.nucDirectory import nuclideBases
 
     print("Initializing generic ARMI Framework application")
     armi.configure(apps.App())
+    bootstrapArmiTestEnv()
+
+
+def bootstrapArmiTestEnv():
+    """
+    Perform ARMI config appropriate for running unit tests
+
+    .. tip:: This can be imported and run from other ARMI applications
+        for test support.
+    """
+    from armi.nucDirectory import nuclideBases
+
     cs = caseSettings.Settings()
+
+    armi.Mode.setMode(armi.Mode.BATCH)
     settings.setMasterCs(cs)
     # Need to init burnChain.
     # see armi.cases.case.Case._initBurnChain

--- a/armi/context.py
+++ b/armi/context.py
@@ -29,9 +29,6 @@ import enum
 import shutil
 import gc
 
-from armi import runLog
-from armi.bookkeeping.db import Database3
-
 BLUEPRINTS_IMPORTED = False
 BLUEPRINTS_IMPORT_CONTEXT = ""
 
@@ -181,6 +178,10 @@ def cleanTempDirs(olderThanDays=None):
         If provided, deletes other ARMI directories if they are older than the requested
         time.
     """
+    from armi import (
+        runLog,
+    )  # pylint: disable=import-outside-toplevel # avoid cyclic import
+
     disconnectAllHdfDBs()
 
     if _FAST_PATH_IS_TEMPORARY and os.path.exists(FAST_PATH):
@@ -237,6 +238,9 @@ def disconnectAllHdfDBs():
     get around this by using the garbage collector to manually disconnect all open HdfDB
     objects.
     """
+
+    from armi.bookkeeping.db import Database3  # pylint: disable=import-outside-toplevel
+
     h5dbs = [db for db in gc.get_objects() if isinstance(db, Database3)]
     for db in h5dbs:
         db.close()

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -112,7 +112,7 @@ class Operator:  # pylint: disable=too-many-public-methods
 
     def _initFastPath(self):
         """
-        Create the FAST_PATH directory for fast local operations if it's in APP_DATA
+        Create the FAST_PATH directory for fast local operations
 
         Notes
         -----
@@ -121,6 +121,9 @@ class Operator:  # pylint: disable=too-many-public-methods
         to leave FAST_PATH as the CWD in INTERACTIVE mode, so this should not
         be a problem anymore, and we can safely move FAST_PATH creation
         back into the Operator.
+
+        If the operator is being used interactively (e.g. at a prompt) we will still
+        use a temporary local fast path (in case the user is working on a slow network path).
         """
         context.activateLocalFastPath()
         try:

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -386,9 +386,9 @@ def prompt(statement, question, *options):
     """"Prompt the user for some information."""
     from armi.localization import exceptions
 
-    if context.CURRENT_MODE == Mode.Gui:
+    if context.CURRENT_MODE == Mode.GUI:
         # avoid hard dependency on wx
-        import wx # pylint: disable=import-error
+        import wx  # pylint: disable=import-error
 
         msg = statement + "\n\n\n" + question
         if len(msg) < 300:
@@ -408,7 +408,7 @@ def prompt(statement, question, *options):
             raise exceptions.RunLogPromptCancel("Manual cancellation of GUI prompt")
         return response in [wx.ID_OK, wx.ID_YES]
 
-    elif context.CURRENT_MODE == Mode.Interactive:
+    elif context.CURRENT_MODE == Mode.INTERACTIVE:
         response = ""
         responses = [
             opt for opt in options if opt in ["YES_NO", "YES", "NO", "CANCEL", "OK"]


### PR DESCRIPTION
When ARMI is run in INTERACTIVE mode, the FAST_PATH is no longer
set to somewhere in APP_DATA, nor is it cleaned on cancel or
exit. Also defers creation of FAST_PATH back to Operator rather
than at import. During unit tests, conftest.py makes the FAST_PATH
folder.

Fixes #180.

* Made the Mode enum an actual Enum for clarity

* Importing FAST_PATH into armi duplicated the string and decoupled them
  which can lead to confusion when you change it at runtime. Now it is
  only stored in armi.context.

* Switch matplotlib to agg backend in testing to reduce spontaneous Tkl
  errors