### PR TITLE
Add ARMITESTBASE env to test environment

### DIFF
--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -73,5 +73,8 @@ def bootstrapArmiTestEnv():
     if not os.path.exists(context.FAST_PATH):
         os.makedirs(context.FAST_PATH)
 
-    # for any tests that want to find the ARMI test root via env variable.
+    # some tests need to find the TEST_ROOT via an env variable when they're
+    # filling in templates with ``$ARMITESTBASE`` in them or opening
+    # input files use the variable in an `!include` tag. Thus
+    # we provide it here.
     os.environ["ARMITESTBASE"] = TEST_ROOT

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -29,6 +29,7 @@ import os
 import matplotlib
 
 import armi
+from armi.tests import TEST_ROOT
 from armi import apps
 from armi import settings
 from armi.settings import caseSettings
@@ -71,3 +72,6 @@ def bootstrapArmiTestEnv():
     context.activateLocalFastPath()
     if not os.path.exists(context.FAST_PATH):
         os.makedirs(context.FAST_PATH)
+
+    # for any tests that want to find the ARMI test root via env variable.
+    os.environ["ARMITESTBASE"] = TEST_ROOT


### PR DESCRIPTION
This makes it easier for ARMI-based apps to find the ARMI
framework's `TEST_BASE` in case they want to use some 
of the test fixtures in there.