### PR TITLE
Change access of FAST_PATH to a callable for safety at runtime

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -57,7 +57,6 @@ import warnings
 # necessarily safe to import the rest of the ARMI system. Things like:
 # - configure the MPI environment
 # - detect the nature of interaction with the user (terminal UI, GUI, unsupervized, etc)
-# - define the FAST_PATH
 # - Initialize the nuclide database
 import armi._bootstrap
 from armi import context

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -549,7 +549,7 @@ class Database3(database.Database):
 
         if self._permission == "w":
             # assume fast path!
-            filePath = os.path.join(context.FAST_PATH, filePath)
+            filePath = os.path.join(context.getFastPath(), filePath)
             self._fullPath = os.path.abspath(filePath)
 
         else:

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -70,8 +70,8 @@ def bootstrapArmiTestEnv():
     # responsible for making FAST_PATH, so we make it here.
     # It will be deleted by the atexit hook.
     context.activateLocalFastPath()
-    if not os.path.exists(context.FAST_PATH):
-        os.makedirs(context.FAST_PATH)
+    if not os.path.exists(context.getFastPath()):
+        os.makedirs(context.getFastPath())
 
     # some tests need to find the TEST_ROOT via an env variable when they're
     # filling in templates with ``$ARMITESTBASE`` in them or opening

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -127,14 +127,14 @@ class Operator:  # pylint: disable=too-many-public-methods
         """
         context.activateLocalFastPath()
         try:
-            os.makedirs(context.FAST_PATH)
+            os.makedirs(context.getFastPath())
         except OSError:
             # If FAST_PATH exists already that generally should be an error because
             # different processes will be stepping on each other.
             # The exception to this rule is in cases that instantiate multiple operators in one
             # process (e.g. unit tests that loadTestReactor). Since the FAST_PATH is set at
             # import, these will use the same path multiple times. We pass here for that reason.
-            if not os.path.exists(context.FAST_PATH):
+            if not os.path.exists(context.getFastPath()):
                 # if it actually doesn't exist, that's an actual error. Raise
                 raise
 

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -9,7 +9,7 @@ import os
 
 from armi.utils import directoryChangers
 from armi import runLog
-from armi.context import FAST_PATH, MPI_RANK
+from armi.context import getFastPath, MPI_RANK
 
 
 class ExecutionOptions:
@@ -79,7 +79,9 @@ class ExecutionOptions:
         use this, you will get a relatively consistent naming convention
         for your fast-past folders.
         """
-        self.runDir = os.path.join(FAST_PATH, f"{caseTitle}-{self.label}-{MPI_RANK}")
+        self.runDir = os.path.join(
+            getFastPath(), f"{caseTitle}-{self.label}-{MPI_RANK}"
+        )
 
     def describe(self):
         """Make a string summary of all options."""
@@ -107,11 +109,11 @@ class Executer:
 
     def run(self):
         """
-        Run the executer steps. 
+        Run the executer steps.
 
         This should use the current state of the reactor as input,
         perform some kind of calculation, and update the reactor
-        with the output. 
+        with the output.
         """
         raise NotImplementedError()
 
@@ -120,7 +122,7 @@ class DefaultExecuter(Executer):
     """
     An Executer that uses a common run sequence.
 
-    This sequence has been found to be relatively common in many 
+    This sequence has been found to be relatively common in many
     externally-executed physics codes. It is here for convenience
     but is not required. The sequence look like:
 
@@ -147,7 +149,7 @@ class DefaultExecuter(Executer):
                 do not update this method with new complexity! Instead, simply make your own
                 run sequence and/or class. This pattern is useful only in that it is fairly simple.
                 By all means, do use ``DirectoryChanger`` and ``ExecuterOptions``
-                and other utilities. 
+                and other utilities.
         """
         self.options.resolveDerivedOptions()
         runLog.debug(self.options.describe())

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -134,7 +134,7 @@ class DirectoryChanger:
     def _transferFiles(initialPath, destinationPath, fileList):
         """
         Transfer files into or out of the directory.
-        
+
         Parameters
         ----------
         initialPath : str
@@ -142,7 +142,7 @@ class DirectoryChanger:
         destinationPath: str
             Path to the folder to move file to.
         fileList : list of str or list of tuple
-            File names to move from initial to destination. If this is a 
+            File names to move from initial to destination. If this is a
             simple list of strings, the files will be transferred. Alternatively
             tuples of (initialName, finalName) are allowed if you want the file
             renamed during transit. In the non-tuple option, globs/wildcards
@@ -187,7 +187,7 @@ class TemporaryDirectoryChanger(DirectoryChanger):
     temporary directory will be deleted.
     """
 
-    _home = armi.context.FAST_PATH
+    _home = armi.context.getFastPath()
 
     def __init__(
         self, root=None, filesToMove=None, filesToRetrieve=None, dumpOnException=True


### PR DESCRIPTION
Actually works when FAST_PATH changes between import and runtime. 