### PR TITLE
Add version bound to h5py requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 scipy
 yamlize
 matplotlib
-h5py
+h5py<3.0
 tabulate
 ordered-set
 pluggy


### PR DESCRIPTION
The newer version of h5py has breaking changes that we do not want to
deal with quite yet. Need to update how we read/write string data to
HDF5 files.