### PR TITLE
Add support for converting old database flags

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -82,9 +82,7 @@ from armi import apps
 from armi import pluginManager
 from armi import plugins
 from armi import runLog
-from armi import materials
 from armi.localization import exceptions
-from armi.reactor import composites
 from armi.reactor import flags
 from armi.reactor import parameters
 from armi.nucDirectory import nuclideBases

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -673,13 +673,23 @@ class Database3(database.Database):
 
         cs = settings.Settings()
         cs.caseTitle = os.path.splitext(os.path.basename(self.fileName))[0]
-        cs.loadFromString(self.h5db["inputs/settings"][()])
+        try:
+            cs.loadFromString(self.h5db["inputs/settings"][()])
+        except:
+            pass
+
         return cs
 
     def loadBlueprints(self):
         from armi.reactor import blueprints
 
-        bpString = self.h5db["inputs/blueprints"][()]
+        bpString = None
+
+        try:
+            bpString = self.h5db["inputs/blueprints"][()]
+        except:
+            pass
+
         if not bpString:
             # looks like no blueprints contents
             return None

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -675,7 +675,14 @@ class Database3(database.Database):
         cs.caseTitle = os.path.splitext(os.path.basename(self.fileName))[0]
         try:
             cs.loadFromString(self.h5db["inputs/settings"][()])
-        except:
+        except KeyError:
+            # not all paths to writing a database require inputs to be written to the
+            # database. Technically, settings do affect some of the behavior of database
+            # reading, so not having the settings that made the reactor that went into
+            # the database is not ideal. However, this isn't the right place to crash
+            # into it. Ideally, there would be not way to not have the settings in the
+            # database (force writing in writeToDB), or to make reading invariant to
+            # settings.
             pass
 
         return cs
@@ -687,7 +694,8 @@ class Database3(database.Database):
 
         try:
             bpString = self.h5db["inputs/blueprints"][()]
-        except:
+        except KeyError:
+            # not all reactors need to be created from blueprints, so they may not exist
             pass
 
         if not bpString:

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -19,6 +19,7 @@ import unittest
 from armi import runLog
 from armi import settings
 from armi.nucDirectory import nucDir, nuclideBases
+from armi import utils
 
 from armi.reactor import components
 from armi.reactor import composites
@@ -404,10 +405,23 @@ class TestCompositeTree(unittest.TestCase):
 
 
 class TestFlagSerializer(unittest.TestCase):
+    class TestFlagsA(utils.Flag):
+        A = utils.flags.auto()
+        B = utils.flags.auto()
+        C = utils.flags.auto()
+        D = utils.flags.auto()
+
+    class TestFlagsB(utils.Flag):
+        A = utils.flags.auto()
+        B = utils.flags.auto()
+        BPRIME = utils.flags.auto()
+        C = utils.flags.auto()
+        D = utils.flags.auto()
+
     def test_flagSerialization(self):
         data = [
             Flags.FUEL,
-            Flags.FUEL | Flags.DEPLETABLE,
+            Flags.FUEL | Flags.INNER,
             Flags.A | Flags.B | Flags.CONTROL,
         ]
 
@@ -422,19 +436,36 @@ class TestFlagSerializer(unittest.TestCase):
         with self.assertRaises(ValueError):
             data2 = composites.FlagSerializer.unpack(flagsArray, "0", attrs)
 
-        # wrong number of Flags
-        removedFlag = attrs["flag_order"].pop()
+        # missing flags in current version Flags
+        attrs["flag_order"].append("NONEXISTANTFLAG")
         with self.assertRaises(ValueError):
             data2 = composites.FlagSerializer.unpack(
                 flagsArray, composites.FlagSerializer.version, attrs
             )
 
-        # Flags order doesn't match anymore
-        attrs["flag_order"].insert(0, removedFlag)
-        with self.assertRaises(ValueError):
-            data2 = composites.FlagSerializer.unpack(
-                flagsArray, composites.FlagSerializer.version, attrs
-            )
+    def test_flagConversion(self):
+        data = [
+            self.TestFlagsA.A,
+            self.TestFlagsA.A | self.TestFlagsA.C,
+            self.TestFlagsA.A | self.TestFlagsA.C | self.TestFlagsA.D,
+        ]
+
+        for f in data:
+            print(int(f))
+
+        serialized, attrs = composites.FlagSerializer._packImpl(data, self.TestFlagsA)
+
+        data2 = composites.FlagSerializer._unpackImpl(
+            serialized, composites.FlagSerializer.version, attrs, self.TestFlagsB
+        )
+        for f in data2:
+            print(int(f))
+
+        expected = [
+            self.TestFlagsB.A,
+            self.TestFlagsB.A | self.TestFlagsB.C,
+            self.TestFlagsB.A | self.TestFlagsB.C | self.TestFlagsB.D,
+        ]
 
 
 class TestMiscMethods(unittest.TestCase):

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -450,22 +450,19 @@ class TestFlagSerializer(unittest.TestCase):
             self.TestFlagsA.A | self.TestFlagsA.C | self.TestFlagsA.D,
         ]
 
-        for f in data:
-            print(int(f))
-
         serialized, attrs = composites.FlagSerializer._packImpl(data, self.TestFlagsA)
 
         data2 = composites.FlagSerializer._unpackImpl(
             serialized, composites.FlagSerializer.version, attrs, self.TestFlagsB
         )
-        for f in data2:
-            print(int(f))
 
         expected = [
             self.TestFlagsB.A,
             self.TestFlagsB.A | self.TestFlagsB.C,
             self.TestFlagsB.A | self.TestFlagsB.C | self.TestFlagsB.D,
         ]
+
+        self.assertEqual(data2, expected)
 
 
 class TestMiscMethods(unittest.TestCase):

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -43,6 +43,7 @@ from armi.utils import iterables
 from armi.localization import strings
 from armi.localization import warnings
 from armi.localization import exceptions
+from armi.utils.flags import Flag
 
 # Read in file 1 MB at a time to reduce memory burden of reading entire file at once
 _HASH_BUFFER_SIZE = 1024 * 1024

--- a/doc/release/0.1.rst
+++ b/doc/release/0.1.rst
@@ -148,3 +148,7 @@ Release Date: TBD
   by features of Database, version 3. Database 3 supports history tracking from the
   database file, and whole reactor models can be loaded for any stored time step,
   obviating the need for special logic in snapshots.
+
+* Added capability to map flags to current meaning when loading from database.
+  Previously, loading would fail if the meanings of written and current flags did not
+  match exactly.


### PR DESCRIPTION
Before this, if flags are added to an application, databases from a
previous version would be unreadable, because the Flags serializer makes
sure that the meaning of all flags is the same between the reading app,
and the app that wrote the database. Now, it will only check that all
old flags still exist, but permit converting to the new Flag numeric
values.