### PR TITLE
Add .txt files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tags
 *.ppm
 *.mp4
 *.h5
+*.txt
 
 # vis files
 *.vtu


### PR DESCRIPTION
It is rare enough that we want to track one and common enough to make
one when running tests/tutorials, so might be best to just ignore them.
If someone needs to, they can still add with `git add -f`.