### PR TITLE
Make psutil dependency optional

### DIFF
--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -47,18 +47,23 @@ import logging
 import tabulate
 from typing import Optional
 
-try:
-    import psutil
-
-    _havePsutil = True
-except ImportError:
-    _havePsutil = False
-
 import armi
 from armi import interfaces
 from armi import mpiActions
 from armi import runLog
 from armi.reactor.composites import ArmiObject
+
+try:
+    import psutil
+
+    # psutil is an optional requirement, since it doesnt support MacOS very well
+    _havePsutil = True
+except ImportError:
+    runLog.warning(
+        "Failed to import psutil; MemoryProfiler will not provide meaningful data."
+    )
+    _havePsutil = False
+
 
 # disable the import warnings (Issue #88)
 logging.disable(logging.CRITICAL)
@@ -509,6 +514,9 @@ class ProfileMemoryUsageAction(mpiActions.MpiAction):
 class SystemAndProcessMemoryUsage(object):
     def __init__(self):
         self.nodeName = armi.MPI_NODENAME
+        # no psutil, no memory diagnostics. TODO: Ideally, we could just cut
+        # MemoryProfiler out entirely, but it is referred to directly by the standard
+        # operator and reports, so easier said than done.
         self.percentNodeRamUsed: Optional[float] = None
         self.processMemoryInMB: Optional[float] = None
         if _havePsutil:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ ordered-set
 pluggy
 pyyaml>=5.1
 pyevtk
-psutil
 xlrd
 pillow
 future
@@ -16,3 +15,5 @@ configparser
 voluptuous
 pympler
 coverage
+
+psutil[memprof]

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
         "ordered-set",
         "pillow",
         "pluggy",
-        "psutil",
         "pyevtk",
         "pympler",
         "pyyaml>=5.1",
@@ -71,7 +70,7 @@ setup(
         "xlrd",
         "yamlize",
     ],
-    extras_require={"mpi": ["mpi4py"], "grids": ["wxpython"]},
+    extras_require={"mpi": ["mpi4py"], "grids": ["wxpython"], "memprof": ["psutil"]},
     tests_require=["nbconvert", "jupyter_client", "ipykernel"],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
MacOS users have trouble getting psutil to work, and it is only needed
to do memory profiling, which is not a necessity. This makes the psutil
package optional, and hobbles most of the MemoryProfiler functionality
if it isn't found. Removing the MemoryProfiler entirely in the absence
of psutil might be a better long-term goal, but it is rather intertwined
with reports and the standard operator and difficult to remove.