### PR TITLE
Pin numpy version to 1.19.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy
+# see https://github.com/numpy/numpy/issues/17726
+numpy==1.19.3
 scipy
 yamlize
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
         "future",
         "h5py",
         "matplotlib",
-        "numpy",
+        # see https://github.com/numpy/numpy/issues/17726
+        "numpy==1.19.3",
         "ordered-set",
         "pillow",
         "pluggy",


### PR DESCRIPTION
The latest numpy version, 1.19.4 is bugged in Windows.