### PR TITLE
Add permissive option to armi.configure()

### DIFF
--- a/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
+++ b/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
@@ -16,7 +16,7 @@ from armi.utils.densityTools import formatMaterialCard
 from armi.nucDirectory import nuclideBases as nb
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 _o, r = test_reactors.loadTestReactor()
 

--- a/doc/gallery-src/analysis/run_hexBlockToRZConversion.py
+++ b/doc/gallery-src/analysis/run_hexBlockToRZConversion.py
@@ -34,7 +34,7 @@ from armi.reactor.flags import Flags
 from armi.reactor.converters import blockConverters
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 _o, r = test_reactors.loadTestReactor()
 

--- a/doc/gallery-src/analysis/run_hexReactorToRZ.py
+++ b/doc/gallery-src/analysis/run_hexReactorToRZ.py
@@ -23,7 +23,7 @@ from armi.reactor.converters import geometryConverters
 from armi.utils import plotting
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 o, r = test_reactors.loadTestReactor()
 kgFis = [a.getHMMass() for a in r.core]

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_blocks import buildSimpleFuelBlock

--- a/doc/gallery-src/framework/run_chartOfNuclides.py
+++ b/doc/gallery-src/framework/run_chartOfNuclides.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 from armi.nucDirectory import nuclideBases
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 xyc = []
 for name, base in nuclideBases.byName.items():

--- a/doc/gallery-src/framework/run_computeReactionRates.py
+++ b/doc/gallery-src/framework/run_computeReactionRates.py
@@ -36,7 +36,7 @@ from armi.materials import ht9
 from armi.materials import sodium
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 
 def _addFlux(b):

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -27,7 +27,7 @@ from armi.utils import plotting
 
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 o, reactor = test_reactors.loadTestReactor(inputFileName="refTestCartesian.yaml")
 

--- a/doc/gallery-src/framework/run_grids1_hex.py
+++ b/doc/gallery-src/framework/run_grids1_hex.py
@@ -17,7 +17,7 @@ from armi.reactor import grids
 
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 hexes = grids.HexGrid.fromPitch(1.0)
 

--- a/doc/gallery-src/framework/run_grids2_cartesian.py
+++ b/doc/gallery-src/framework/run_grids2_cartesian.py
@@ -15,7 +15,7 @@ from armi.reactor import grids
 
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 fig = plt.figure()
 zCoords = [1, 4, 8]

--- a/doc/gallery-src/framework/run_grids3_rzt.py
+++ b/doc/gallery-src/framework/run_grids3_rzt.py
@@ -16,7 +16,7 @@ from armi.reactor import grids
 
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 fig = plt.figure()
 theta = np.linspace(0, 2 * np.pi, 10)

--- a/doc/gallery-src/framework/run_isotxs.py
+++ b/doc/gallery-src/framework/run_isotxs.py
@@ -14,7 +14,7 @@ from armi.tests import ISOAA_PATH
 from armi.nuclearDataIO.cccc import isotxs
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 gs = energyGroups.getGroupStructure("ANL33")
 lib = isotxs.readBinary(ISOAA_PATH)

--- a/doc/gallery-src/framework/run_isotxs2_matrix.py
+++ b/doc/gallery-src/framework/run_isotxs2_matrix.py
@@ -19,7 +19,7 @@ from armi.nuclearDataIO import xsNuclides
 import armi
 
 
-armi.configure()
+armi.configure(permissive=True)
 
 lib = isotxs.readBinary(ISOAA_PATH)
 

--- a/doc/gallery-src/framework/run_materials.py
+++ b/doc/gallery-src/framework/run_materials.py
@@ -20,7 +20,7 @@ from armi.nucDirectory import nuclideBases
 
 MAX_Z = 96  # stop at Curium
 
-armi.configure()
+armi.configure(permissive=True)
 
 materialNames = []
 mats = list(materials.iterAllMaterialClassesInNamespace(materials))

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -9,7 +9,7 @@ from armi.reactor.tests import test_reactors
 from armi.utils import plotting
 import armi
 
-armi.configure()
+armi.configure(permissive=True)
 
 operator, reactor = test_reactors.loadTestReactor()
 reactor.core.growToFullCore(None)

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,9 @@ setup(
         "configparser",
         "coverage",
         "future",
-        "h5py",
+        # Newer h5py versions do strings differently, and we need to do some work to
+        # support it
+        "h5py<3.0",
         "matplotlib",
         # see https://github.com/numpy/numpy/issues/17726
         "numpy<1.19.4",


### PR DESCRIPTION
This was added to make it easier for tests and other demonstration
examples to run back-to-back without having to restart the python
interpreter.