### PR TITLE
Improve installation instruction

### DIFF
--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -13,6 +13,21 @@ You must have the following before proceeding:
 
 * `Python <https://www.python.org/downloads/>`_ version 3.6 or later (preferably 64-bit)
 
+  .. warning:: Python 3.9 was released in October 2020 and some of ARMI's
+      dependencies are non-trivial to build for it at the moment. Thus, the
+      installation process of ARMI will be easier if you have Python 3.6 -- Python
+      3.8 until the dependencies catch up.
+
+
+  .. admonition:: The right Python command
+
+     Python 2 and Python 3 often co-exist on the same system. Whether the
+     ``python`` command refers to Python 2 or 3 depends on operating system and
+     configuration. Under some circumstances ``python3`` or ``pip3`` will need
+     to be used in place of ``python`` or ``pip`` to target the correct
+     version. You can verify your version by running ``python -VV``.  You can
+     also refer to the Python executable with a full path.
+
 You also likely need the following for interacting with the source code repository:
 
 * `Git <https://git-scm.com/>`_
@@ -30,7 +45,7 @@ step.
 Start a terminal and navigate to the directory you'd like to install ARMI into. 
 To create a new virtual environment, use a command like:: 
 
-    $ python3 -m venv armi-venv
+    $ python -m venv armi-venv
 
 The result is a folder named ``armi-venv``, which contains a minimal set of Python
 packages, and a set of scripts for activating and deactivating that environment.
@@ -51,12 +66,20 @@ library. On Linux, doing so will require some MPI development libraries
 
 Getting the code
 ----------------
-If you plan on running ARMI without viewing or modifying source code, you 
-may install it with ``pip``, which will automatically discover and install the dependencies::
+Choose one of the following two installation methods depending on your needs.
 
-   	(armi-venv) $ pip3 install https://github.com/terrapower/armi/archive/master.zip
+Option 1: Install as a library
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you plan on running ARMI without viewing or modifying source code, you may
+install it with ``pip``, which will automatically discover and install the
+dependencies. This is useful for quick evaluations or to use it as a dependency
+in another project::
 
-On the other hand, if you'd like to view or change the ARMI source code (common!), you need to
+   	(armi-venv) $ pip install https://github.com/terrapower/armi/archive/master.zip
+
+Option 2: Install as a repository (for developers)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you'd like to view or change the ARMI source code (common!), you need to
 clone the ARMI source and then install its dependencies. Clone the ARMI source code from
 the git repository with::
 
@@ -68,11 +91,11 @@ the git repository with::
 Now install the ARMI dependencies::
 
     (armi-venv) $ cd armi
-    (armi-venv) $ pip3 install -r requirements.txt
+    (armi-venv) $ pip install -r requirements.txt
 
 Then, install ARMI into your venv with::
 
-	(armi-venv) $ python3 setup.py install 
+	(armi-venv) $ pip install -e .
 
 .. tip:: If you don't want to install ARMI into your venv, you will need to add the ARMI source 
 	location to your system's ``PYTHONPATH`` environment variable so that
@@ -81,9 +104,16 @@ Then, install ARMI into your venv with::
 	In Windows, click *Start* and type ``Edit Environmental Variable`` to adjust ``PYTHONPATH``. 
 	In Linux, add ``export PYTHONPATH=/path/to/armi/source`` in a  user profile script (like ``.bashrc``).
 
-To see if it worked, run::
 
-    (armi-venv) $ python3 -m armi
+Verifying installation
+^^^^^^^^^^^^^^^^^^^^^^
+Check the installation status by running::
+
+    (armi-venv) $ armi
+
+or, equivalently:: 
+    
+    (armi-venv) $ python -m armi
 
 If it worked, you should see the ARMI splash screen and no errors::
 
@@ -99,12 +129,6 @@ If it worked, you should see the ARMI splash screen and no errors::
 
 If it works, congrats! So far so good.
 
-.. admonition:: Shortcut
-
-    You can also try the launcher script as a shortcut to ``python3 -m armi``::
-
-        (armi-venv) $ armi
-
 
 Optional Setup
 --------------
@@ -117,7 +141,7 @@ To use the :py:mod:`graphical core-map editor <armi.utils.gridEditor>` you will 
 by default during armi installation because it can cause installation complexities on some platforms.
 In many cases, a ``pip install`` should suffice::
 
-    (armi-venv) $ pip3 install wxpython
+    (armi-venv) $ pip install wxpython
 
 .. warning:: On some platforms, ``pip`` may try to compile wxpython from 
     source which can take a long time and require additional dependencies.


### PR DESCRIPTION
* Drop python3 and pip3 since they are not universal and added a blurb
  explaining the situation.

* Make the installation options more obviously a fork so people don't do
  both.

* Switch dev install to use pip install -e rather than setup.py install
  because it works better (e.g. on MacOS where package data is left out)

* Add a warning about Python 3.9 which we will remove soonish.