### PR TITLE
Add link to ARMI GUI user doc section from tutorial

### DIFF
--- a/doc/tutorials/walkthrough_inputs.rst
+++ b/doc/tutorials/walkthrough_inputs.rst
@@ -9,7 +9,7 @@ We will model the CR=1.0 sodium-cooled fast reactor documented in `ANL-AFCI-177
 <https://publications.anl.gov/anlpubs/2008/05/61507.pdf>`_. The full :doc:`documentation
 for input files is available here </user/inputs/index>`.
 
-.. tip:: The full inputs created in this tutorial are available for download at the bottom of 
+.. tip:: The full inputs created in this tutorial are available for download at the bottom of
 	this page.
 
 Setting up the blueprints
@@ -17,7 +17,7 @@ Setting up the blueprints
 First we'll set up the fuel assembly design in the blueprints input. Make a new
 file called ``anl-acfi-177-blueprints.yaml``. We'll be entering information
 based on Table 4.4 of the reference. To define the pin cell we need dimensions
-of the fuel pin, cladding, ducts, wire wrap, and so on. 
+of the fuel pin, cladding, ducts, wire wrap, and so on.
 
 The cladding dimensions are clear from the table. The outer diameter is given
 as the pin diameter, and the inner diameter is simply that minus twice the
@@ -38,9 +38,9 @@ assembly, we'll set the ``mult`` (short for *multiplicity*) to 271:
     pin level, and compositions are often quite spatially flat across an assembly.
     Thus we can often just copy a component using the ``mult`` input equal to the
     number of pins, and neutronic modeling is sufficient. For subchannel T/H, the
-    spatial details are of course much more important. 
+    spatial details are of course much more important.
 
-.. note:: The ``&block_fuel`` is a YAML anchor which will be discussed more below. 
+.. note:: The ``&block_fuel`` is a YAML anchor which will be discussed more below.
 
 Next, let's enter the wire wrap. This is a helical wire used in fast reactors
 to mix coolant and keep pins separate (used in lieu of a grid spacer). ARMI has
@@ -48,9 +48,9 @@ a special shape for this, called a ``Helix``. Helices are defined by their
 axial pitch (how much linear distance between two wrappings axially), the wire
 diameter, and the diameter of the pin they're wrapping around (called
 ``helixDiameter``).  Thus, we input the wire wrap into the blueprints as
-follows. 
+follows.
 
-.. note:: The wire axial pitch isn't specified in the table so we just use a typical value of 30 cm. 
+.. note:: The wire axial pitch isn't specified in the table so we just use a typical value of 30 cm.
 
 .. literalinclude:: ../../armi/tests/tutorials/anl-afci-177-blueprints.yaml
     :language: yaml
@@ -66,13 +66,13 @@ Now, it's time to do the fuel. This example reactor uses UZr metal fuel with a
 liquid sodium thermal bond in the large gap between the fuel and the cladding.
 The fraction of space inside the clad that is fuel is called the "smeared
 density", so we can figure out the actual fuel slug dimensions from the
-information in the table. 
+information in the table.
 
 Specifically, the smeared density is 75%, which means that 75% of the area
 inside the circle made by the inner diameter of the cladding (0.6962 cm) is
 fuel. Thus, the fuel outer diameter is given by solving:
 
-.. math:: 
+.. math::
        0.75 = \frac{\pi d^2}{\pi 0.6962^2}
 
 which gives :math:`d = 0.6029`, our fuel outer diameter. Now we can enter our
@@ -90,7 +90,7 @@ fuel slug component into blueprints:
 Let's enter a description of the thermal bond next. This is an annulus of
 sodium between the fuel and the cladding.  Since those dimensions are already
 set, we will use **linked dimensions**. Thus, no numbers (beyond temperatures)
-are needed! 
+are needed!
 
 
 .. literalinclude:: ../../armi/tests/tutorials/anl-afci-177-blueprints.yaml
@@ -150,7 +150,7 @@ just be full pins of HT9 steel with coolant around them, and shields will be
 unclad B4C in sodium. Normally the pin sizes would be different, but again for
 simplicity, we're just duplicating the pin dimensions.
 
-For brevity, we will simply provide the definitions as described. 
+For brevity, we will simply provide the definitions as described.
 
 Radial Shields
 ^^^^^^^^^^^^^^
@@ -198,13 +198,13 @@ material, which is just empty space:
     :end-before: end-block-plenum
 
 
-That should be enough to define the whole core. 
+That should be enough to define the whole core.
 
 Defining how the blocks are arranged into assemblies
 ----------------------------------------------------
 With block cross-sections defined, we now set their heights and stack them up
 into assemblies. While we're at it, we can conveniently adjust some
-frequently-modified material parameters, such as the uranium enrichment. 
+frequently-modified material parameters, such as the uranium enrichment.
 
 Defining the fuel assemblies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -270,7 +270,7 @@ calculations, which can require either more time or more processors:
 Same deal for the outer core.
 
 .. note:: The columnar form of YAML lists is very convenient when using text editors with column-edit capabilities. It
-        is highly recommended to make sure you know how to column edit. 
+        is highly recommended to make sure you know how to column edit.
 
 
 .. literalinclude:: ../../armi/tests/tutorials/anl-afci-177-blueprints.yaml
@@ -316,7 +316,7 @@ And that's it! All blueprints are now defined.
 
 Specifying the core map
 =======================
-With blueprints defined we can now arrange assemblies into the core. This is with the geometry input file. 
+With blueprints defined we can now arrange assemblies into the core. This is with the geometry input file.
 
 .. note:: There are GUI tools to help making the core map easy to set up.
 
@@ -342,21 +342,21 @@ And then, in the core map file (``anl-afci-177-coreMap.yaml``):
 
 
 .. note:: The two-letter values here can be any contiguous strings, and
-    correspond with the ``specifier`` field in the blueprints input. 
+    correspond with the ``specifier`` field in the blueprints input.
 
-.. note:: GUI utilities are also useful for building core maps like this. 
+.. note:: GUI utilities are also useful for building core maps like this.
 
 
 Specifying settings
 ===================
 Now we need to specify some **settings** that define fundamental reactor
 parameters, as well as modeling approximation options. For this, we make a
-**settings file**, called ``anl-acfi-177.yaml``. 
+**settings file**, called ``anl-acfi-177.yaml``.
 
 The thermal power in this reference is 1000 MWt. The thermal efficiency isn't
 specified, so let's assume 0.38. From Table 4.8, the cycle length is 370 EFPD.
 Let's also assume a 0.90 capacity factor which will gives full cycles of 411.1
-days. 
+days.
 
 .. literalinclude:: ../../armi/tests/tutorials/anl-afci-177.yaml
     :language: yaml
@@ -386,7 +386,7 @@ Set some physics kernel and environment options:
     :start-after: end-section-3
 
 
-.. note:: The ARMI GUI is simply an optional frontend to this settings file. Behind the scenes it just reads and writes
+.. note:: The :ref:`ARMI GUI <armi-gui>` is simply an optional frontend to this settings file. Behind the scenes it just reads and writes
         this. It is quite convenient for discovering important settings and describing what they do, however.
 
 Defining fuel management
@@ -394,18 +394,18 @@ Defining fuel management
 Finally, let's specify the fuel management file that we referred to above by
 creating the file ``anl-afci-177-fuelManagement.py``. Fuel management is very
 wide-open, so we use Python scripts to drive it. It's generally overly
-constraining to require any higher-level input for such a general problem. 
+constraining to require any higher-level input for such a general problem.
 
 In ANL-AFCI-177, section 2 says no shuffling was modeled, and that the core is
 in a batch shuffling mode, limited by a cladding fast fluence of 4.0e23 n/cm\
 :sup:`2`. Often, SFR studies use the REBUS code's implicit equilibrium fuel
 cycle mode. There is an ARMI equilibrium module at TerraPower that performs
 this useful calculation (with different inputs), but for this sample problem,
-we will simply model 10 cycles with explicit fuel management. 
+we will simply model 10 cycles with explicit fuel management.
 
 The shuffling algorithm we'll write will simply predict whether or not the
 stated fluence limit will be violated in the next cycle. If it will be, the
-fuel assembly will be replaced with a fresh one of the same kind. 
+fuel assembly will be replaced with a fresh one of the same kind.
 
 
 .. literalinclude:: ../../armi/tests/tutorials/anl-afci-177-fuelManagement.py
@@ -415,7 +415,7 @@ fuel assembly will be replaced with a fresh one of the same kind.
 There! You have now created all the ARMI inputs, from scratch, needed to
 perform a simplified reactor analysis of one of the SFRs in the ANL-AFCI-177
 document. The possibilities from here are only limited by your creativity, (and
-a few code limitations ;). 
+a few code limitations ;).
 
 As you load the inputs in ARMI it will provide some consistency checks and
 errors to help identify common mistakes.

--- a/doc/tutorials/walkthrough_inputs.rst
+++ b/doc/tutorials/walkthrough_inputs.rst
@@ -15,7 +15,7 @@ for input files is available here </user/inputs/index>`.
 Setting up the blueprints
 =========================
 First we'll set up the fuel assembly design in the blueprints input. Make a new
-file called ``anl-acfi-177-blueprints.yaml``. We'll be entering information
+file called ``anl-afci-177-blueprints.yaml``. We'll be entering information
 based on Table 4.4 of the reference. To define the pin cell we need dimensions
 of the fuel pin, cladding, ducts, wire wrap, and so on.
 
@@ -351,7 +351,7 @@ Specifying settings
 ===================
 Now we need to specify some **settings** that define fundamental reactor
 parameters, as well as modeling approximation options. For this, we make a
-**settings file**, called ``anl-acfi-177.yaml``.
+**settings file**, called ``anl-afci-177.yaml``.
 
 The thermal power in this reference is 1000 MWt. The thermal efficiency isn't
 specified, so let's assume 0.38. From Table 4.8, the cycle length is 370 EFPD.

--- a/doc/user/inputs/settings.rst
+++ b/doc/user/inputs/settings.rst
@@ -6,7 +6,7 @@ The **settings** input file defines a series of key/value pairs the define vario
 modeling as well as which modules to run and various modeling/approximation settings. For example, it includes:
 
 * The case title
-* The reactor power 
+* The reactor power
 * The number of cycles to run
 * Which physics solvers to activate
 * Whether or not to perform a critical control search
@@ -15,7 +15,7 @@ modeling as well as which modules to run and various modeling/approximation sett
 * Environment settings (paths to external codes)
 * How many CPUs to use on a computer cluster
 
-This file is a YAML file that you can edit manually with a text editor or with the ARMI GUI. 
+This file is a YAML file that you can edit manually with a text editor or with the ARMI GUI.
 
 Here is an excerpt from a settings file:
 
@@ -25,14 +25,16 @@ Here is an excerpt from a settings file:
 
 A full listing of settings may be found in the :doc:`Table of all global settings </user/inputs/settings_report>`.
 
-Many settings are provided by the ARMI Framework, and others are defined by various plugins. 
+Many settings are provided by the ARMI Framework, and others are defined by various plugins.
+
+.. _armi-gui:
 
 The ARMI GUI
 ============
 The ARMI GUI may be used to manipulate many common settings (though the GUI can't change all of the settings).  The GUI
 also enables the graphical manipulation of a reactor core map, and convenient automation of commands required to submit to a
 cluster.  The GUI is a front-end to
-these files. You can choose to use the GUI or not, ARMI doesn't know or care --- it just reads these files and runs them. 
+these files. You can choose to use the GUI or not, ARMI doesn't know or care --- it just reads these files and runs them.
 
 Note that one settings input file is required for each ARMI case, though many ARMI cases can refer to the same
 Blueprints, Core Map, and Fuel Management inputs.
@@ -75,9 +77,9 @@ often take longer, ARMI has a feature, called *detail assemblies* to help. Diffe
 may treat detail assemblies differently, so it's important to read the plugin documentation
 as well. For example, a depletion plugin may perform pin-level depletion and rotation analysis
 only on the detail assemblies. Or perhaps CFD thermal/hydraulics will be run on detail assemblies,
-while subchannel T/H is run on the others. 
+while subchannel T/H is run on the others.
 
-Detail assemblies are specified by the user in a variety of ways, 
+Detail assemblies are specified by the user in a variety of ways,
 through the GUI or the settings system.
 
 .. warning:: The Detail Assemblies mechanism has begun to be too broad of a brush
@@ -86,8 +88,8 @@ through the GUI or the settings system.
     surprising in the future.
 
 Detail Assembly Locations BOL
-    The ``detailAssemLocationsBOL`` setting is a list of assembly location strings 
-    (e.g. ``A4003`` for ring 4, position 3). Assemblies that are in these locations at the 
+    The ``detailAssemLocationsBOL`` setting is a list of assembly location strings
+    (e.g. ``A4003`` for ring 4, position 3). Assemblies that are in these locations at the
     beginning-of-life will be activated as detail assemblies.
 
 Detail assembly numbers


### PR DESCRIPTION
When going through tutorial on input files, I saw a mention of the ARMI GUI and then later realized (from the user doc section) that the GUI is not yet part of the open source release. In this PR, I've just added a hyperlink in the tutorial to the relevant user doc section so that it makes it easier to find further information about the GUI.

There are only two lines of actual changes -- the rest are just trailing whitespaces that got deleted.