### PR TITLE
Change block names during blueprint construction

### DIFF
--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -151,7 +151,7 @@ class HistoryTrackerInterface(interfaces.Interface):
         """
         if self.cs["detailAssemLocationsBOL"]:
             for locLabel in self.cs["detailAssemLocationsBOL"]:
-                ring, pos, _axial = grids.ringPosFromRingLabel(locLabel)
+                ring, pos, _axial = grids.locatorLabelToIndices(locLabel)
                 i, j = self.r.core.spatialGrid.getIndicesFromRingAndPos(ring, pos)
                 aLoc = self.r.core.spatialGrid[i, j, 0]
                 try:

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -76,7 +76,7 @@ class TestHistoryTracker(ArmiTestHelper):
         reloadCs["reloadDBName"] = pathlib.Path(f"{CASE_TITLE}.h5").absolute()
         reloadCs["runType"] = "Snapshots"
         reloadCs["loadStyle"] = "fromDB"
-        reloadCs["detailAssemLocationsBOL"] = ["A1001"]
+        reloadCs["detailAssemLocationsBOL"] = ["001-001"]
         o = armi.init(cs=reloadCs)
         cls.o = o
 
@@ -89,7 +89,7 @@ class TestHistoryTracker(ArmiTestHelper):
         cs["db"] = True
         cs["reloadDBName"] = pathlib.Path(f"{CASE_TITLE}.h5").absolute()
         cs["loadStyle"] = "fromDB"
-        cs["detailAssemLocationsBOL"] = ["A1001"]
+        cs["detailAssemLocationsBOL"] = ["001-001"]
         cs["startNode"] = 1
 
         self.td = directoryChangers.TemporaryDirectoryChanger()

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -1590,7 +1590,7 @@ class FuelHandler:
             elif "assembly" in line:
                 # this is the new load style where an actual assembly type is written to the shuffle logic
                 # due to legacy reasons, the assembly type will be put into group 4
-                pat = r"([A-Za-z0-9!]+) moved to ([A-Za-z0-9!]+) with assembly type ([A-Za-z0-9!\s]+)\s*(ANAME=\S+)?\s*with enrich list: (.+)"
+                pat = r"([A-Za-z0-9!\-]+) moved to ([A-Za-z0-9!\-]+) with assembly type ([A-Za-z0-9!\s]+)\s*(ANAME=\S+)?\s*with enrich list: (.+)"
                 m = re.search(pat, line)
                 if not m:
                     raise InputError(

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -206,13 +206,18 @@ class Block(composites.Composite):
 
         This also sets the block-level assembly-num param.
 
+        Once, we used a axial-character suffix to represent the axial
+        index, but this is inherently limited so we switched to a numerical
+        name. The axial suffix needs can be brought in in plugins that require
+        them.
+
         Examples
         --------
         >>> makeName(120, 5)
-        'B0120E'
+        'B0120-005'
         """
         self.p.assemNum = assemNum
-        return "B{0:04d}{1}".format(assemNum, grids.AXIAL_CHARS[axialIndex])
+        return "B{0:04d}-{1:03d}".format(assemNum, axialIndex)
 
     def makeUnique(self):
         """

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -129,7 +129,8 @@ class BlockBlueprint(yamlize.KeyedList):
             c._resolveLinkedDims(components)
 
         boundingComp = sorted(components.values())[-1]
-        b = self._getBlockClass(boundingComp)("Bxxx-{0:03d}".format(axialIndex))
+        # give a temporary name (will be updated by b.makeName as real blocks populate systems)
+        b = self._getBlockClass(boundingComp)(name=f"block-bol-{axialIndex:03d}")
 
         for paramDef in b.p.paramDefs.inCategory(
             parameters.Category.assignInBlueprints

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -129,9 +129,7 @@ class BlockBlueprint(yamlize.KeyedList):
             c._resolveLinkedDims(components)
 
         boundingComp = sorted(components.values())[-1]
-        b = self._getBlockClass(boundingComp)(
-            "Bxxx{0}".format(grids.AXIAL_CHARS[axialIndex])
-        )
+        b = self._getBlockClass(boundingComp)("Bxxx-{0:03d}".format(axialIndex))
 
         for paramDef in b.p.paramDefs.inCategory(
             parameters.Category.assignInBlueprints

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -50,7 +50,8 @@ class TestGeometryConverters(unittest.TestCase):
         self.assertEqual(
             numAssems, 13
         )  # should wind up with 6 reflector assemblies per 1/3rd core
-        shieldtype = self.r.core.getAssemblyWithStringLocation("A4001").getType()
+        locator = self.r.core.spatialGrid.getLocatorFromRingAndPos(4, 1)
+        shieldtype = self.r.core.childrenByLocator[locator].getType()
         self.assertEqual(
             shieldtype, "radial shield"
         )  # check that the right thing was added
@@ -79,20 +80,24 @@ class TestGeometryConverters(unittest.TestCase):
         self.assertEqual(numFuelAssems, 60)
 
         # checks that existing fuel assemblies are preserved
-        fueltype = self.r.core.getAssemblyWithStringLocation("A1001").getType()
+        locator = self.r.core.spatialGrid.getLocatorFromRingAndPos(1, 1)
+        fueltype = self.r.core.childrenByLocator[locator].getType()
         self.assertEqual(fueltype, "igniter fuel")
 
         # checks that existing control rods are preserved
-        controltype = self.r.core.getAssemblyWithStringLocation("A5001").getType()
+        locator = self.r.core.spatialGrid.getLocatorFromRingAndPos(5, 1)
+        controltype = self.r.core.childrenByLocator[locator].getType()
         self.assertEqual(controltype, "primary control")
 
         # checks that existing reflectors are overwritten with feed fuel
-        oldshieldtype = self.r.core.getAssemblyWithStringLocation("A9005").getType()
+        locator = self.r.core.spatialGrid.getLocatorFromRingAndPos(9, 5)
+        oldshieldtype = self.r.core.childrenByLocator[locator].getType()
         self.assertEqual(oldshieldtype, "feed fuel")
 
         # checks that outer assemblies are removed
-        outerassem = self.r.core.getAssemblyWithStringLocation("A9001")
-        self.assertEqual(outerassem, None)
+        locator = self.r.core.spatialGrid.getLocatorFromRingAndPos(9, 1)
+        with self.assertRaises(KeyError):
+            loc = self.r.core.childrenByLocator[locator]
 
         # tests ability to remove fuel assemblies
         converter.numFuelAssems = 20

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -1392,7 +1392,13 @@ class HexGrid(Grid):
         ]
 
     def getLabel(self, indices):
-        """Hex labels start at 1, and are ring/position based."""
+        """
+        Hex labels start at 1, and are ring/position based rather than i,j.
+
+        This difference is partially because ring/pos is easier to understand in hex
+        geometry, and partially because it is used in some codes ARMI originally was focused
+        on.
+        """
         ring, pos = self.getRingPos(indices)
         if len(indices) == 2:
             return Grid.getLabel(self, (ring, pos))

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -923,7 +923,7 @@ class Core(composites.Composite):
         runLog.extra(
             "Building a circular ring dictionary with ring pitch {}".format(ringPitch)
         )
-        referenceAssembly = self.getAssemblyWithStringLocation("A1001")
+        referenceAssembly = self.getAssemblyWithStringLocation("001-001")
         refLocation = referenceAssembly.spatialLocator
         pitchFactor = ringPitch / self.spatialGrid.pitch
 
@@ -1513,7 +1513,7 @@ class Core(composites.Composite):
         """
         Returns an assembly or none if given a location string like 'B0014'.
         """
-        ring, pos, _ = grids.ringPosFromRingLabel(locationString)
+        ring, pos, _ = grids.locatorLabelToIndices(locationString)
         loc = self.spatialGrid.getLocatorFromRingAndPos(ring, pos)
         assem = self.childrenByLocator.get(loc)
         return assem

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -923,7 +923,7 @@ class Core(composites.Composite):
         runLog.extra(
             "Building a circular ring dictionary with ring pitch {}".format(ringPitch)
         )
-        referenceAssembly = self.getAssemblyWithStringLocation("001-001")
+        referenceAssembly = self.childrenByLocator[self.spatialGrid[0, 0, 0]]
         refLocation = referenceAssembly.spatialLocator
         pitchFactor = ringPitch / self.spatialGrid.pitch
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -745,7 +745,7 @@ class Block_TestCase(unittest.TestCase):
         # a bit obvious, but location is a property now...
         i, j = grids.HexGrid.getIndicesFromRingAndPos(2, 3)
         b.spatialLocator = b.core.spatialGrid[i, j, 0]
-        self.assertEqual(b.getLocation(), "A2003A")
+        self.assertEqual(b.getLocation(), "002-003-000")
         self.assertEqual(0, b.spatialLocator.k)
         self.assertEqual(b.getSymmetryFactor(), 1.0)
 

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -158,7 +158,7 @@ class TestGrid(unittest.TestCase):
 
     def testLabel(self):
         grid = grids.Grid(unitSteps=((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)))
-        self.assertEqual(grid.getLabel((1, 1, 2)), "A1001C")
+        self.assertEqual(grid.getLabel((1, 1, 2)), "001-001-002")
 
     def test_isAxialOnly(self):
         grid = grids.HexGrid.fromPitch(1.0, numRings=3)
@@ -232,8 +232,13 @@ class TestHexGrid(unittest.TestCase):
     def testLabel(self):
         grid = grids.HexGrid.fromPitch(1.0)
         indices = grid.getIndicesFromRingAndPos(12, 5)
-        self.assertEqual(grid.getLabel(indices), "B2005")
-        self.assertEqual(grid.getLabel(indices + (5,)), "B2005F")
+        label1 = grid.getLabel(indices)
+        self.assertEqual(label1, "012-005")
+        self.assertEqual(grids.locatorLabelToIndices(label1), (12, 5, None))
+
+        label2 = grid.getLabel(indices + (5,))
+        self.assertEqual(label2, "012-005-005")
+        self.assertEqual(grids.locatorLabelToIndices(label2), (12, 5, 5))
 
     def test_overlapsWhichSymmetryLine(self):
         grid = grids.HexGrid.fromPitch(1.0)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -275,19 +275,19 @@ class HexReactorTests(ReactorTests):
         neighbs = self.r.core.findNeighbors(
             a, duplicateAssembliesOnReflectiveBoundary=True
         )
-        locs = [a.getLocation() for a in neighbs]
+        locs = [a.spatialLocator.getRingPos() for a in neighbs]
         self.assertEqual(len(neighbs), 6)
-        self.assertIn("A2001", locs)
-        self.assertIn("A2002", locs)
-        self.assertEqual(locs.count("A2001"), 3)
+        self.assertIn((2, 1), locs)
+        self.assertIn((2, 2), locs)
+        self.assertEqual(locs.count((2, 1)), 3)
 
         loc = self.r.core.spatialGrid.getLocatorFromRingAndPos(1, 1)
         a = self.r.core.childrenByLocator[loc]
         neighbs = self.r.core.findNeighbors(
             a, duplicateAssembliesOnReflectiveBoundary=True
         )
-        locs = [a.getLocation() for a in neighbs]
-        self.assertEqual(locs, ["A2001", "A2002"] * 3, 6)
+        locs = [a.spatialLocator.getRingPos() for a in neighbs]
+        self.assertEqual(locs, [(2, 1), (2, 2)] * 3, 6)
 
         loc = self.r.core.spatialGrid.getLocatorFromRingAndPos(2, 2)
         a = self.r.core.childrenByLocator[loc]
@@ -295,9 +295,9 @@ class HexReactorTests(ReactorTests):
         neighbs = self.r.core.findNeighbors(
             a, duplicateAssembliesOnReflectiveBoundary=True
         )
-        locs = [a.getLocation() for a in neighbs]
+        locs = [a.spatialLocator.getRingPos() for a in neighbs]
         self.assertEqual(len(neighbs), 6)
-        self.assertEqual(locs, ["A3002", "A3003", "A3012", "A2001", "A1001", "A2001"])
+        self.assertEqual(locs, [(3, 2), (3, 3), (3, 12), (2, 1), (1, 1), (2, 1)])
 
         # try with edge assemblies
         # With edges, the neighbor is the one that's actually next to it.
@@ -308,10 +308,10 @@ class HexReactorTests(ReactorTests):
         neighbs = self.r.core.findNeighbors(
             a, duplicateAssembliesOnReflectiveBoundary=True
         )
-        locs = [a.getLocation() for a in neighbs]
+        locs = [a.spatialLocator.getRingPos() for a in neighbs]
         self.assertEqual(len(neighbs), 6)
         # in this case no locations that aren't actually in the core should be returned
-        self.assertEqual(locs, ["A3002", "A3003", "A3004", "A2001", "A1001", "A2001"])
+        self.assertEqual(locs, [(3, 2), (3, 3), (3, 4), (2, 1), (1, 1), (2, 1)])
         converter.removeEdgeAssemblies(self.r.core)
 
         # try with full core
@@ -320,15 +320,15 @@ class HexReactorTests(ReactorTests):
         a = self.r.core.childrenByLocator[loc]
         neighbs = self.r.core.findNeighbors(a)
         self.assertEqual(len(neighbs), 6)
-        locs = [a.getLocation() for a in neighbs]
-        for loc in ["A2002", "A2003", "A3003", "A3005", "A4005", "A4006"]:
+        locs = [a.spatialLocator.getRingPos() for a in neighbs]
+        for loc in [(2, 2), (2, 3), (3, 3), (3, 5), (4, 5), (4, 6)]:
             self.assertIn(loc, locs)
 
         loc = self.r.core.spatialGrid.getLocatorFromRingAndPos(2, 2)
         a = self.r.core.childrenByLocator[loc]
         neighbs = self.r.core.findNeighbors(a)
-        locs = [a.getLocation() for a in neighbs]
-        for loc in ["A1001", "A2001", "A2003", "A3002", "A3003", "A3004"]:
+        locs = [a.spatialLocator.getRingPos() for a in neighbs]
+        for loc in [(1, 1), (2, 1), (2, 3), (3, 2), (3, 3), (3, 4)]:
             self.assertIn(loc, locs)
 
         # Try the duplicate option in full core as well
@@ -337,9 +337,9 @@ class HexReactorTests(ReactorTests):
         neighbs = self.r.core.findNeighbors(
             a, duplicateAssembliesOnReflectiveBoundary=True
         )
-        locs = [a.getLocation() for a in neighbs]
+        locs = [a.spatialLocator.getRingPos() for a in neighbs]
         self.assertEqual(len(neighbs), 6)
-        self.assertEqual(locs, ["A3002", "A3003", "A3004", "A2003", "A1001", "A2001"])
+        self.assertEqual(locs, [(3, 2), (3, 3), (3, 4), (2, 3), (1, 1), (2, 1)])
 
     def test_getAssembliesInCircularRing(self):
         expectedAssemsInRing = [5, 6, 8, 10, 12, 16, 14, 2]
@@ -471,8 +471,8 @@ class HexReactorTests(ReactorTests):
         assert_allclose(a.spatialLocator.indices, [1, 1, 0])
         for bi, b in enumerate(a):
             assert_allclose(b.spatialLocator.getCompleteIndices(), [1, 1, bi])
-        self.assertEqual(a.getLocation(), "A3002")
-        self.assertEqual(a[0].getLocation(), "A3002A")
+        self.assertEqual(a.getLocation(), "003-002")
+        self.assertEqual(a[0].getLocation(), "003-002-000")
 
     def test_getMass(self):
         # If these are not in agreement check on block symmetry factor being applied to volumes

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -69,14 +69,14 @@ class Zone_TestCase(unittest.TestCase):
     def test_addRing(self):
         zone = zones.Zone("TestZone")
         zone.addRing(5)
-        self.assertIn("A5003", zone)
-        self.assertNotIn("A6002", zone)
+        self.assertIn("005-003", zone)
+        self.assertNotIn("006-002", zone)
 
         zone.addRing(6, 3, 9)
-        self.assertIn("A6003", zone)
-        self.assertIn("A6009", zone)
-        self.assertNotIn("A6002", zone)
-        self.assertNotIn("A6010", zone)
+        self.assertIn("006-003", zone)
+        self.assertIn("006-009", zone)
+        self.assertNotIn("006-002", zone)
+        self.assertNotIn("006-010", zone)
 
 
 class Zones_InReactor(unittest.TestCase):

--- a/armi/scripts/migration/__init__.py
+++ b/armi/scripts/migration/__init__.py
@@ -37,6 +37,7 @@ from . import (
     m0_1_3,
     m0_1_0_newDbFormat,
     crossSectionBlueprintsToSettings,
+    m0_1_6_locationLabels,
 )
 
 ACTIVE_MIGRATIONS = [
@@ -45,4 +46,5 @@ ACTIVE_MIGRATIONS = [
     m0_1_3.RemoveCentersFromBlueprints,
     m0_1_3.UpdateElementalNuclides,
     crossSectionBlueprintsToSettings.MoveCrossSectionsFromBlueprints,
+    m0_1_6_locationLabels.ConvertAlphanumLocationSettingsToNum,
 ]

--- a/armi/scripts/migration/m0_1_6_locationLabels.py
+++ b/armi/scripts/migration/m0_1_6_locationLabels.py
@@ -1,0 +1,98 @@
+# Copyright 2021 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Migrate ARMI settings that have alphanumeric location labels to new numeric mode."""
+import io
+import re
+
+from armi import runLog
+from armi.settings import caseSettings
+from armi.scripts.migration.base import SettingsMigration
+from armi.settings import settingsIO
+from armi.utils.units import ASCII_LETTER_A, ASCII_ZERO
+
+AXIAL_CHARS = [
+    chr(asciiCode)
+    for asciiCode in (
+        list(range(ASCII_LETTER_A, ASCII_LETTER_A + 26))
+        + list(range(ASCII_ZERO, ASCII_ZERO + 10))
+        + list(range(ASCII_LETTER_A + 26, ASCII_LETTER_A + 32 + 26))
+    )
+]
+
+
+class ConvertAlphanumLocationSettingsToNum(SettingsMigration):
+    """Convert old location label values to new style"""
+
+    fromVersion = "0.1.6"
+    toVersion = "0.1.7"
+
+    def _applyToStream(self):
+        cs = caseSettings.Settings()
+        reader = settingsIO.SettingsReader(cs)
+        reader.readFromStream(self.stream)
+
+        if reader.invalidSettings:
+            runLog.info(
+                "The following deprecated settings will be deleted:\n  * {}"
+                "".format("\n  * ".join(list(reader.invalidSettings)))
+            )
+
+        _modify_settings(cs)
+        writer = settingsIO.SettingsWriter(cs)
+        newStream = io.StringIO()
+        writer.writeYaml(newStream)
+        newStream.seek(0)
+        return newStream
+
+
+def _modify_settings(cs):
+    if cs["detailAssemLocationsBOL"]:
+        newLocs = []
+        for loc in cs["detailAssemLocationsBOL"]:
+            if "-" not in loc:
+                # assume it is old style assem location.
+                i, j, _k = getIndicesFromDIF3DStyleLocatorLabel(loc)
+                newLoc = f"{i:03d}-{j:03d}"
+                runLog.info(
+                    f"Converting old-style location label `{loc}` to `{newLoc}`, assuming hex geom"
+                )
+                loc = newLoc
+            newLocs.append(loc)
+
+        cs["detailAssemLocationsBOL"] = newLocs
+
+
+def getIndicesFromDIF3DStyleLocatorLabel(label):
+    """Convert a ring-based label like A2003B into 1-based ring, location indices."""
+    locMatch = re.search(r"([A-Z]\d)(\d\d\d)([A-Z]?)", label)
+    if locMatch:
+        # we have a valid location label. Process it and set parameters
+        # convert A4 to 04, B2 to 12, etc.
+        ring = locMatch.group(1)
+        posLabel = locMatch.group(2)
+        axLabel = locMatch.group(3)
+        firstDigit = ord(ring[0]) - ASCII_LETTER_A
+        if firstDigit < 10:
+            i = int("{0}{1}".format(firstDigit, ring[1]))
+        else:
+            raise RuntimeError(
+                "invalid label {0}. 1st character too large.".format(label)
+            )
+        j = int(posLabel)
+        if axLabel:
+            k = AXIAL_CHARS.index(axLabel)
+        else:
+            k = None
+        return i, j, k

--- a/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
+++ b/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
@@ -1,0 +1,30 @@
+"""Test Locationlabel migration"""
+import unittest
+import io
+
+from armi.settings import caseSettings
+from armi.scripts.migration.m0_1_6_locationLabels import (
+    ConvertAlphanumLocationSettingsToNum,
+)
+from armi.settings.settingsIO import SettingsWriter, SettingsReader
+
+
+class TestMigration(unittest.TestCase):
+    def testLocationLabelMigration(self):
+        """Make a setting with an old value and make sure it migrates to expected new value."""
+        cs = caseSettings.Settings()
+        cs["detailAssemLocationsBOL"] = ["B1012"]
+        writer = SettingsWriter(cs)
+        stream = io.StringIO()
+        writer.writeYaml(stream)
+        stream.seek(0)
+
+        converter = ConvertAlphanumLocationSettingsToNum(stream=stream)
+        newCs = caseSettings.Settings()
+        reader = SettingsReader(newCs)
+        reader.readFromStream(converter.apply())
+        self.assertEqual(newCs["detailAssemLocationsBOL"][0], "011-012")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/armi/settings/settingsRules.py
+++ b/armi/settings/settingsRules.py
@@ -21,9 +21,10 @@ The ``settingsRules`` system was developed before the pluginification of ARMI, a
 doesn't play very nicely with the post-plugin world. This is mainly because
 registration of new rules happens at import time of the rule itself, which is
 unreliable and difficult to control, and even sort of implicit and sneaky. They are
-also somewhate redundant with the
+also somewhat redundant with the
 :py:class:`armi.operators.settingsValidation.Query`/:py:class:`armi.operators.settingsValidation.Inspector`
-system. It is not recommended for plugins to define settings rules using the mechanism
+system and the ``scripts.migration`` package.. It is not recommended for plugins to define 
+settings rules using the mechanism
 in this module, which may be removed in the future.
 """
 import re

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -269,6 +269,12 @@ class ArmiTestHelper(unittest.TestCase):
                         expectedFilePath, os.path.abspath(actualFilePath)
                     )
                     raise AssertionError(msg) from er
+            # ensure we're also at the end of the actual file
+            # readline is unambiuous about reaching the end of a file.
+            self.assertFalse(
+                actual.readline(),
+                msg="The test-generated file is longer than the reference file.",
+            )
         os.remove(actualFilePath)
 
 

--- a/armi/tests/armiRun-SHUFFLES.txt
+++ b/armi/tests/armiRun-SHUFFLES.txt
@@ -25,3 +25,4 @@ Before cycle 3:
 LoadQueue moved to 006-007 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 SFP moved to 005-004 with assembly type feed fuel ANAME=A0086 with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 005-004 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+

--- a/armi/tests/armiRun-SHUFFLES.txt
+++ b/armi/tests/armiRun-SHUFFLES.txt
@@ -1,28 +1,27 @@
 Before cycle 1:
-A2001 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A3003 moved to A2001 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A4002 moved to A3003 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A5001 moved to A4002 with assembly type primary control with enrich list: 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000
-A6007 moved to A5001 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-LoadQueue moved to A6007 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+002-001 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+003-003 moved to 002-001 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+004-002 moved to 003-003 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+005-001 moved to 004-002 with assembly type primary control with enrich list: 0.00000000 0.00000000 0.00000000 0.00000000 0.00000000
+006-007 moved to 005-001 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+LoadQueue moved to 006-007 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 
 Before cycle 2:
-A2002 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A3002 moved to A2002 with assembly type lta fuel with enrich list: 0.00000000 0.20000000 0.20000000 0.20000000 0.00000000
-A4001 moved to A3002 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A5004 moved to A4001 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A6004 moved to A5004 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-LoadQueue moved to A6004 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-SFP moved to A5003 with assembly type feed fuel ANAME=A0085 with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A5003 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+002-002 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+003-002 moved to 002-002 with assembly type lta fuel with enrich list: 0.00000000 0.20000000 0.20000000 0.20000000 0.00000000
+004-001 moved to 003-002 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+005-004 moved to 004-001 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+006-004 moved to 005-004 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+LoadQueue moved to 006-004 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+SFP moved to 005-003 with assembly type feed fuel ANAME=A0085 with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+005-003 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 
 Before cycle 3:
-A2001 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A3001 moved to A2001 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A4003 moved to A3001 with assembly type lta fuel b with enrich list: 0.00000000 0.20000000 0.20000000 0.20000000 0.00000000
-A5002 moved to A4003 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A6007 moved to A5002 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-LoadQueue moved to A6007 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-SFP moved to A5004 with assembly type feed fuel ANAME=A0086 with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-A5004 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-
+002-001 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+003-001 moved to 002-001 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+004-003 moved to 003-001 with assembly type lta fuel b with enrich list: 0.00000000 0.20000000 0.20000000 0.20000000 0.00000000
+005-002 moved to 004-003 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+006-007 moved to 005-002 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+LoadQueue moved to 006-007 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+SFP moved to 005-004 with assembly type feed fuel ANAME=A0086 with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+005-004 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000

--- a/armi/tests/armiRun.yaml
+++ b/armi/tests/armiRun.yaml
@@ -29,7 +29,7 @@ settings:
   cycleLength: 2000.0
   db: false
   detailAssemLocationsBOL:
-    - A2001
+    - 002-001
   economics: false
   epsBurnTime: 0.001
   epsFSAvg: 1e-06

--- a/armi/tests/test_fuelHandlers.py
+++ b/armi/tests/test_fuelHandlers.py
@@ -431,7 +431,7 @@ class TestFuelHandler(ArmiTestHelper):
         moves = fh.readMoves("armiRun-SHUFFLES.txt")
         self.assertEqual(len(moves), 3)
         firstMove = moves[1][0]
-        self.assertEqual(firstMove[0], "A2001")
+        self.assertEqual(firstMove[0], "002-001")
         self.assertEqual(firstMove[1], "SFP")
         self.assertEqual(len(firstMove[2]), numblocks)
         self.assertEqual(firstMove[3], "igniter fuel")
@@ -440,7 +440,7 @@ class TestFuelHandler(ArmiTestHelper):
         # check the move that came back out of the SFP
         sfpMove = moves[2][-2]
         self.assertEqual(sfpMove[0], "SFP")
-        self.assertEqual(sfpMove[1], "A5003")
+        self.assertEqual(sfpMove[1], "005-003")
         self.assertEqual(sfpMove[4], "A0085")  # name of assem in SFP
 
     def test_processMoveList(self):
@@ -511,7 +511,7 @@ class TestFuelHandler(ArmiTestHelper):
     def test_buildEqRingSchedule(self):
         fh = fuelHandlers.FuelHandler(self.o)
         locSchedule = fh.buildEqRingSchedule([2, 1])
-        self.assertEqual(locSchedule, ["A2001", "A2002", "A1001"])
+        self.assertEqual(locSchedule, ["002-001", "002-002", "001-001"])
 
 
 class TestFuelPlugin(unittest.TestCase):

--- a/doc/release/0.1.rst
+++ b/doc/release/0.1.rst
@@ -203,4 +203,10 @@ API changes
   input migrations.
 
 * Changed block default names so that they are no longer constrained by axial characters. 
-  They now are named ``B{assemNum}-{axialIndex}`` to allow arbitrary numbers of blocks.
+  They now are named ``B{assemNum}-{axialIndex}`` to allow arbitrary numbers of blocks. This
+  will invalidate any user setting that includes a block name (e.g. detail assemblies)
+
+* Changed location string labels to be numerical (``001-002-005``) rather than alphanumeric
+  to eliminate a limitation on how many i-indices and k-indices were allowed. This will
+  invalidate any user setting value that includes a location label (e.g. in 
+  ``detailAssemsByBOLLocation``). A migration script may be used to assist in migration.

--- a/doc/release/0.1.rst
+++ b/doc/release/0.1.rst
@@ -201,3 +201,6 @@ API changes
   signatures. These will be removed soon, as grids now serve this purpose, and ``geom``
   objects are largely vestigial. ``SystemLayoutInput`` will be retained to facilitate
   input migrations.
+
+* Changed block default names so that they are no longer constrained by axial characters. 
+  They now are named ``B{assemNum}-{axialIndex}`` to allow arbitrary numbers of blocks.

--- a/doc/user/inputs/settings.rst
+++ b/doc/user/inputs/settings.rst
@@ -89,7 +89,7 @@ through the GUI or the settings system.
 
 Detail Assembly Locations BOL
     The ``detailAssemLocationsBOL`` setting is a list of assembly location strings
-    (e.g. ``A4003`` for ring 4, position 3). Assemblies that are in these locations at the
+    (e.g. ``004-003`` for ring 4, position 3). Assemblies that are in these locations at the
     beginning-of-life will be activated as detail assemblies.
 
 Detail assembly numbers


### PR DESCRIPTION
The blocks used to have an axial character indicating axial height,
but this is inherently limited. That behavior is now delegated
to the plugins that need it so that more general inputs can be created.

Fixes #233.