### PR TITLE
Broaden setting parsing error checking

### DIFF
--- a/armi/cli/migrateInputs.py
+++ b/armi/cli/migrateInputs.py
@@ -48,7 +48,7 @@ class MigrateInputs(EntryPoint):
         """
         if self.args.settings_path:
             path, _fname = os.path.split(self.args.settings_path)
-            with directoryChangers.DirectoryChanger(path):
+            with directoryChangers.DirectoryChanger(path, dumpOnException=False):
                 self._migrate(self.args.settings_path, self.args.database_path)
         else:
             self._migrate(self.args.settings_path, self.args.database_path)

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -209,7 +209,7 @@ class Setting:
         """
         try:
             val = self.schema(val)
-        except vol.error.MultipleInvalid:
+        except vol.error.Invalid:
             runLog.error(f"Error in setting {self.name}, val: {val}.")
             raise
 


### PR DESCRIPTION
Loading a settings file that had a setting with an invalid value was not
getting caught here because it was just a single invalid. This broadens
the exception catching to capture any related validation error.

Additionally the directory changer was changed to not make a separate
error folder since most of the time migration type errors will be found
in a local setting rather than while running on HPC.