### PR TITLE
Move the isDepletable function off of the composite structure

### DIFF
--- a/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
+++ b/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
@@ -23,6 +23,44 @@ from armi.nuclearDataIO import xsLibraries
 from armi.physics.neutronics.isotopicDepletion.crossSectionTable import (
     CrossSectionTable,
 )
+from armi.reactor import composites
+from armi.reactor.flags import Flags
+
+
+def isDepletable(obj: composites.ArmiObject):
+    """
+    Return True if obj or any child is flagged as DEPLETABLE.
+
+    The DEPLETABLE flag is automatically set to true if any composition contains
+    nuclides that are in the active nuclides list, unless flags are specifically
+    set and DEPLETABLE is left out.
+
+    This is often interpreted by depletion plugins as indicating which parts of the
+    problem to apply depletion to. Analysts may want to turn on and off depletion
+    in certain problems.
+
+    For example, sometimes they want the control rods to deplete
+    to figure out how often to replace them. But in conceptual design, they may want to just
+    leave them as they are as an approximation.
+
+    .. warning:: The ``DEPLETABLE`` flag is automatically added to compositions that have
+        active nuclides. If you explicitly define any flags at all, you must also
+        manually include ``DEPLETABLE`` or else the objects will silently not deplete.
+
+    Notes
+    -----
+    The auto-flagging of ``DEPLETABLE`` happens in the construction of blueprints
+    rather than in a plugin hook because the reactor is not available at the time
+    the plugin hook runs.
+
+    See Also
+    --------
+    armi.reactor.blueprints.componentBlueprint._insertDepletableNuclideKeys
+    """
+
+    return obj.hasFlags(Flags.DEPLETABLE) or obj.containsAtLeastOneChildWithFlags(
+        Flags.DEPLETABLE
+    )
 
 
 class AbstractIsotopicDepleter:

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2005,18 +2005,6 @@ class ArmiObject(metaclass=CompositeModelType):
             nucs.update(child.getNuclides())
         return nucs
 
-    def isDepletable(self):
-        """
-        Return True if itself or any child is depletable.
-
-        See Also
-        --------
-        armi.reactor.blueprints.componentBlueprint._insertDepletableNuclideKeys: sets this flag
-        """
-        return self.hasFlags(Flags.DEPLETABLE) or self.containsAtLeastOneChildWithFlags(
-            Flags.DEPLETABLE
-        )
-
     def getFissileMass(self):
         """Returns fissile mass in grams."""
         return self.getMass(nuclideBases.NuclideBase.fissile)

--- a/armi/tests/refSmallReactorBase.yaml
+++ b/armi/tests/refSmallReactorBase.yaml
@@ -306,7 +306,7 @@ blocks:
             id: 0.600
             mult: 169.0
             od: 0.878
-            flags: annular fuel
+            flags: annular fuel depletable
         gap2:
             shape: Circle
             material: Void

--- a/armi/tests/refSmallReactorBase.yaml
+++ b/armi/tests/refSmallReactorBase.yaml
@@ -306,6 +306,7 @@ blocks:
             id: 0.600
             mult: 169.0
             od: 0.878
+            flags: annular fuel
         gap2:
             shape: Circle
             material: Void


### PR DESCRIPTION
This moves isDepletable off of the composite and into the framework neutronics plugin. This is part of the overall push to keep the composite structure cleaner. 

Additionally, a situation was discovered and fixed where if the flags were set explicitly, including a depletable flag, the burn chain nuclides were not expanded properly on the composite. This would have been an error condition to any user who attempted it before. 

The annular and depletable flags were explicitly set on a test input to cover situations with annular fuel that is also depletable. 