### PR TITLE
Bump h5py version

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -674,7 +674,7 @@ class Database3(database.Database):
         cs = settings.Settings()
         cs.caseTitle = os.path.splitext(os.path.basename(self.fileName))[0]
         try:
-            cs.loadFromString(self.h5db["inputs/settings"][()])
+            cs.loadFromString(self.h5db["inputs/settings"].asstr()[()])
         except KeyError:
             # not all paths to writing a database require inputs to be written to the
             # database. Technically, settings do affect some of the behavior of database
@@ -693,7 +693,7 @@ class Database3(database.Database):
         bpString = None
 
         try:
-            bpString = self.h5db["inputs/blueprints"][()]
+            bpString = self.h5db["inputs/blueprints"].asstr()[()]
         except KeyError:
             # not all reactors need to be created from blueprints, so they may not exist
             pass
@@ -710,7 +710,7 @@ class Database3(database.Database):
 
     def loadGeometry(self):
         geom = systemLayoutInput.SystemLayoutInput()
-        geom.readGeomFromStream(io.StringIO(self.h5db["inputs/geomFile"][()]))
+        geom.readGeomFromStream(io.StringIO(self.h5db["inputs/geomFile"].asstr()[()]))
         return geom
 
     def writeInputsToDB(self, cs, csString=None, geomString=None, bpString=None):
@@ -758,9 +758,9 @@ class Database3(database.Database):
 
     def readInputsFromDB(self):
         return (
-            self.h5db["inputs/settings"][()],
-            self.h5db["inputs/geomFile"][()],
-            self.h5db["inputs/blueprints"][()],
+            self.h5db["inputs/settings"].asstr()[()],
+            self.h5db["inputs/geomFile"].asstr()[()],
+            self.h5db["inputs/blueprints"].asstr()[()],
         )
 
     def mergeHistory(self, inputDB, startCycle, startNode):
@@ -1976,10 +1976,10 @@ class Layout:
                 unitStepLimits = thisGroup["unitStepLimits"][:]
                 offset = thisGroup["offset"][:] if thisGroup.attrs["offset"] else None
                 geomType = (
-                    thisGroup["geomType"][()] if "geomType" in thisGroup else None
+                    thisGroup["geomType"].asstr()[()] if "geomType" in thisGroup else None
                 )
                 symmetry = (
-                    thisGroup["symmetry"][()] if "symmetry" in thisGroup else None
+                    thisGroup["symmetry"].asstr()[()] if "symmetry" in thisGroup else None
                 )
 
                 self.gridParams.append(
@@ -2468,7 +2468,7 @@ def unpackSpecialData(data: numpy.ndarray, attrs, paramName: str) -> numpy.ndarr
         for i in attrs["noneLocations"]:
             unpackedJaggedData[i] = None
 
-        return numpy.array(unpackedJaggedData)
+        return numpy.array(unpackedJaggedData, dtype=object)
     if attrs.get("dict", False):
         keys = numpy.char.decode(attrs["keys"])
         unpackedData = []

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1976,10 +1976,14 @@ class Layout:
                 unitStepLimits = thisGroup["unitStepLimits"][:]
                 offset = thisGroup["offset"][:] if thisGroup.attrs["offset"] else None
                 geomType = (
-                    thisGroup["geomType"].asstr()[()] if "geomType" in thisGroup else None
+                    thisGroup["geomType"].asstr()[()]
+                    if "geomType" in thisGroup
+                    else None
                 )
                 symmetry = (
-                    thisGroup["symmetry"].asstr()[()] if "symmetry" in thisGroup else None
+                    thisGroup["symmetry"].asstr()[()]
+                    if "symmetry" in thisGroup
+                    else None
                 )
 
                 self.gridParams.append(

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -228,10 +228,15 @@ class TestDatabase3(unittest.TestCase):
         data1 = numpy.array([1, 2, 3, 4, 5, 6, 7, 8])
         data1iNones = numpy.array([1, 2, None, 5, 6])
         data1fNones = numpy.array([None, 2.0, None, 5.0, 6.0])
-        data2fNones = numpy.array([None, [[1.0, 2.0, 6.0], [2.0, 3.0, 4.0]]])
-        dataJag = numpy.array([[[1, 2], [3, 4]], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]])
+        data2fNones = numpy.array(
+            [None, [[1.0, 2.0, 6.0], [2.0, 3.0, 4.0]]], dtype=object
+        )
+        dataJag = numpy.array(
+            [[[1, 2], [3, 4]], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]], dtype=object
+        )
         dataJagNones = numpy.array(
-            [[[1, 2], [3, 4]], [[1], [1]], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]]
+            [[[1, 2], [3, 4]], [[1], [1]], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]],
+            dtype=object,
         )
         dataDict = numpy.array(
             [{"bar": 2, "baz": 3}, {"foo": 4, "baz": 6}, {"foo": 7, "bar": 8}]

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
+r"""
 Contains classes that build case suites from perturbing inputs.
 
 The general use case is to create a :py:class:`~SuiteBuilder` with a base

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -35,6 +35,11 @@ from armi import settings
 from armi.settings import caseSettings
 from armi import context
 
+# For some reason, it is important that h5py be imported here. If it is not, something
+# happens in pytest where regardless of the outcome of the tests themselves, it exits
+# with an access violation error code (on Windows, anyways). More investigation is
+# needed into why this is occuring.
+import h5py
 
 def pytest_sessionstart(session):
 

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -41,6 +41,7 @@ from armi import context
 # needed into why this is occuring.
 import h5py
 
+
 def pytest_sessionstart(session):
 
     print("Initializing generic ARMI Framework application")

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -312,7 +312,7 @@ def readEndfMatNumIndex(path):
     endfMatNumbers = {}
 
     for line in endfReferenceFile:
-        if not re.search("^\s+\d+\)", line):
+        if not re.search(r"^\s+\d+\)", line):
             continue
         data = line.split()
         _rowNum, matNum, nuclide = data[:3]

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -167,7 +167,7 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         self.assertGreater(block.p.detailedDpa, 0)
 
         mapper.clearFlux()
-        self.assertFalse(block.p.mgFlux)
+        self.assertTrue(len(block.p.mgFlux) == 0)
 
 
 class TestGlobalFluxUtils(unittest.TestCase):

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
+r"""
 Plugins allow various built-in or external functionality to be brought into the ARMI ecosystem.
 
 This module defines the hooks that may be defined within plugins. Plugins are ultimately
@@ -401,7 +401,7 @@ class ArmiPlugin:
     @staticmethod
     @HOOKSPEC
     def defineCaseDependencies(case, suite):
-        """
+        r"""
         Function for defining case dependencies.
 
         Some Cases depend on the results of other ``Case``\ s in the same ``CaseSuite``.

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -95,6 +95,7 @@ class TestUniformMesh(unittest.TestCase):
             TEST_ROOT, customSettings={"xsKernel": "MC2v2"}
         )
         self.r.core.lib = isotxs.readBinary(ISOAA_PATH)
+        self.r.core.p.keff = 1.0
         self.converter = uniformMesh.NeutronicsUniformMeshConverter()
 
     def test_convertNumberDensities(self):

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -311,7 +311,8 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
         convPow = self.convReactor.core.getTotalBlockParam("power")
         if sourcePow > 0.0 and convPow > 0.0:
             expectedPow = (
-                self._sourceReactor.core.p.power / self._sourceReactor.core.powerMultiplier
+                self._sourceReactor.core.p.power
+                / self._sourceReactor.core.powerMultiplier
             )
             if abs(sourcePow - convPow) / sourcePow > 1e-5:
                 runLog.info(

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -309,19 +309,20 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
         UniformMeshGeometryConverter._checkConversion(self)
         sourcePow = self._sourceReactor.core.getTotalBlockParam("power")
         convPow = self.convReactor.core.getTotalBlockParam("power")
-        expectedPow = (
-            self._sourceReactor.core.p.power / self._sourceReactor.core.powerMultiplier
-        )
-        if abs(sourcePow - convPow) / sourcePow > 1e-5:
-            runLog.info(
-                f"Source reactor power ({sourcePow}) is too different from "
-                f"converted power ({convPow})."
+        if sourcePow > 0.0 and convPow > 0.0:
+            expectedPow = (
+                self._sourceReactor.core.p.power / self._sourceReactor.core.powerMultiplier
             )
-        if sourcePow and abs(sourcePow - expectedPow) / sourcePow > 1e-5:
-            raise ValueError(
-                f"Source reactor power ({sourcePow}) is too different from "
-                f"user-input power ({expectedPow})."
-            )
+            if abs(sourcePow - convPow) / sourcePow > 1e-5:
+                runLog.info(
+                    f"Source reactor power ({sourcePow}) is too different from "
+                    f"converted power ({convPow})."
+                )
+            if sourcePow and abs(sourcePow - expectedPow) / sourcePow > 1e-5:
+                raise ValueError(
+                    f"Source reactor power ({sourcePow}) is too different from "
+                    f"user-input power ({expectedPow})."
+                )
 
     def _setParamsToUpdate(self):
         """Activate conversion of various neutronics paramters."""

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
+r"""
 This contains structured meshes in multiple geometries and spatial locators (i.e. locations).
 
 :py:class:`Grids <Grid>` are objects that map indices (i, j, k) to spatial locations

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -108,7 +108,7 @@ class _Undefined:
 
 
 class Serializer:
-    """
+    r"""
     Abstract class describing serialize/deserialize operations for Parameter data.
 
     Parameters need to be stored to and read from database files. This currently
@@ -122,7 +122,7 @@ class Serializer:
     The ``Database3`` already knows how to handle certain cases where the data are not
     straightforward to get into a numpy array, such as when:
 
-      - There are ``None`` s.
+      - There are ``None``\ s.
 
       - The dimensions of the values stored on each object are inconsistent (e.g.,
         "jagged" arrays)

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -22,7 +22,7 @@ from six.moves import cPickle
 
 from armi.reactor import grids
 from armi.reactor import geometry
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 
 
 class MockLocator(grids.IndexLocation):

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -283,7 +283,7 @@ class ArmiTestHelper(unittest.TestCase):
         os.remove(actualFilePath)
 
     @staticmethod
-    def compareLines(actual: str, expected: str, eps: Optional[float]=None):
+    def compareLines(actual: str, expected: str, eps: Optional[float] = None):
         """
         Impl of line comparison for compareFilesLineByLine.
 
@@ -320,7 +320,7 @@ class ArmiTestHelper(unittest.TestCase):
 
             if actualVal is not None:
                 # we have two floats and can compare them
-                if abs(actualVal - expectedVal)/expectedVal > eps:
+                if abs(actualVal - expectedVal) / expectedVal > eps:
                     return False
             else:
                 # strings, compare directly

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 TerraPower, LLC
+# Copyright 2021 TerraPower, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
 import os
 import datetime
 import inspect
+import itertools
 import timeit
 import unittest
 import re
 import shutil
+from typing import Optional
 
 import armi
 from armi import runLog
@@ -210,7 +212,7 @@ class ArmiTestHelper(unittest.TestCase):
     """Class containing common testing methods shared by many tests."""
 
     def compareFilesLineByLine(
-        self, expectedFilePath, actualFilePath, falseNegList=None
+        self, expectedFilePath, actualFilePath, falseNegList=None, eps=None
     ):
         """
         Compare the contents of two files line by line.
@@ -238,7 +240,12 @@ class ArmiTestHelper(unittest.TestCase):
         falseNegList: None or Iterable
             Optional argument. If two lines are not equal, then check if any values
             from ``falseNegList`` are in this line. If so, do not fail the test.
+        eps: float, optional
+            If provided, try to determine if the only difference between compared lines
+            is in the value of something that can be parsed into a float, and the
+            relative difference between the two floats is below the passed epsilon.
         """
+
         if falseNegList is None:
             falseNegList = []
         elif isinstance(falseNegList, str):
@@ -247,35 +254,89 @@ class ArmiTestHelper(unittest.TestCase):
         with open(expectedFilePath, "r") as expected, open(
             actualFilePath, "r"
         ) as actual:
-            for lineIndex, expectedLine in enumerate(expected):
-                actualLine = actual.readline()
-                try:
-                    self.assertEqual(
-                        expectedLine.rstrip(),
-                        actualLine.rstrip(),
-                        "Error on line {}:\nE>{}\nA<{}".format(
-                            lineIndex, expectedLine.rstrip(), actualLine.rstrip()
-                        ),
+            for lineIndex, (expectedLine, actualLine) in enumerate(
+                itertools.zip_longest(expected, actual)
+            ):
+                if expectedLine is None:
+                    raise AssertionError(
+                        "The test-generated file is longer than expected file"
                     )
-                except AssertionError as er:
+                if actualLine is None:
+                    raise AssertionError(
+                        "The test-generated file is shorter than expected file"
+                    )
+
+                if not self.compareLines(actualLine, expectedLine, eps):
                     if any(
                         falseNeg in line
                         for falseNeg in falseNegList
                         for line in (actualLine, expectedLine)
                     ):
-                        continue
+                        pass
+                    else:
+                        raise AssertionError(
+                            "Error on line {}:\nE>{}\nA<{}".format(
+                                lineIndex, expectedLine.rstrip(), actualLine.rstrip()
+                            )
+                        )
 
-                    msg = "\nThe files: \n{} and \n{} \nwere not the same.".format(
-                        expectedFilePath, os.path.abspath(actualFilePath)
-                    )
-                    raise AssertionError(msg) from er
-            # ensure we're also at the end of the actual file
-            # readline is unambiuous about reaching the end of a file.
-            self.assertFalse(
-                actual.readline(),
-                msg="The test-generated file is longer than the reference file.",
-            )
         os.remove(actualFilePath)
+
+    @staticmethod
+    def compareLines(actual: str, expected: str, eps: Optional[float]=None):
+        """
+        Impl of line comparison for compareFilesLineByLine.
+
+        if rstripped lines are equal -> Good. Otherwise, split on whitespace and try to
+        parse element pairs as floats. if they are both parsable, compare with relative
+        eps, if provided. A side effect of the epsilon comparison is that differing
+        whitespace **between** words is treated as irrelevant.
+        """
+        actual = actual.rstrip()
+        expected = expected.rstrip()
+
+        if actual == expected:
+            return True
+
+        if eps is None:
+            # no more in-depth comparison is allowed
+            return False
+
+        actualWords = actual.split()
+        expectedWords = expected.split()
+
+        if len(actualWords) != len(expectedWords):
+            # different number of words cant possibly be the same enough
+            return False
+
+        for actualWord, expectedWord in zip(actualWords, expectedWords):
+            actualVal = _tryFloat(actualWord)
+            expectedVal = _tryFloat(expectedWord)
+
+            if (actualVal is None) ^ (expectedVal is None):
+                # could not coerce both words into a float, so they cannot possibly
+                # match
+                return False
+
+            if actualVal is not None:
+                # we have two floats and can compare them
+                if abs(actualVal - expectedVal)/expectedVal > eps:
+                    return False
+            else:
+                # strings, compare directly
+                if actualWord != expectedWord:
+                    return False
+
+        # if we got to the end without pitching a fit, the lines should match
+        return True
+
+
+def _tryFloat(val: str) -> Optional[float]:
+    try:
+        return float(val)
+
+    except ValueError:
+        return None
 
 
 def rebaselineTextComparisons(root):

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -101,7 +101,7 @@ class TestApps(unittest.TestCase):
         app.pluginManager.unregister(TestPlugin2)
 
         app.pluginManager.register(TestPlugin3)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             plugins.PluginError, ".*currently-defined parameters.*"
         ):
             app.getParamRenames()

--- a/armi/tests/test_tests.py
+++ b/armi/tests/test_tests.py
@@ -1,0 +1,40 @@
+# Copyright 2021 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the test helpers.
+"""
+
+import unittest
+
+from armi import tests
+
+
+class Test_CompareFiles(unittest.TestCase):
+    def test_compareFileLine(self):
+        expected = "oh look, a number! 3.14 and some text and another number 1.5"
+
+        self.assertTrue(tests.ArmiTestHelper.compareLines(expected, expected))
+        self.assertTrue(tests.ArmiTestHelper.compareLines(expected, expected, eps=0.01))
+
+        actual = "oh look, a number! 3.15 and some text and another number 1.6  "
+        self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))
+        self.assertTrue(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.07))
+
+        actual = "oh look, a number! 3.15 and some text and another number 1.6 extra"
+        self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))
+
+        actual = "oh look, a number! notANumber and some text and another number 1.5"
+        self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))
+

--- a/armi/tests/test_tests.py
+++ b/armi/tests/test_tests.py
@@ -37,4 +37,3 @@ class Test_CompareFiles(unittest.TestCase):
 
         actual = "oh look, a number! notANumber and some text and another number 1.5"
         self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))
-

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -17,7 +17,6 @@ This module contains methods for adding properties with custom behaviors to clas
 """
 
 import numpy
-import six
 
 
 def areEqual(val1, val2, relativeTolerance=0.0):
@@ -30,16 +29,16 @@ def areEqual(val1, val2, relativeTolerance=0.0):
 
 
 def numpyHackForEqual(val1, val2):
-    r""" "
+    r"""
     checks lots of types for equality like strings and dicts
     """
     # when doing this with numpy arrays you get an array of booleans which causes the value error
     notEqual = val1 != val2
+
     try:  # should work for everything but numpy arrays
-        if six.PY3:
-            return not notEqual.__bool__()
-        else:
-            return not notEqual.__nonzero__()
+        if isinstance(notEqual, numpy.ndarray) and notEqual.size == 0:
+            return True
+        return not notEqual.__bool__()
     except (AttributeError, ValueError):  # from comparing 2 numpy arrays
         return not notEqual.any()
 

--- a/armi/utils/tests/test_directoryChangers.py
+++ b/armi/utils/tests/test_directoryChangers.py
@@ -22,7 +22,7 @@ from armi.utils import directoryChangers
 from armi.utils import directoryChangersMpi
 
 
-class TestException(Exception):
+class ExpectedException(Exception):
     pass
 
 
@@ -64,8 +64,8 @@ class TestDirectoryChangers(unittest.TestCase):
             with directoryChangers.ForcedCreationDirectoryChanger(self.temp_directory):
                 Path("file1.txt").touch()
                 Path("file2.txt").touch()
-                raise TestException("Ooops")
-        except TestException:
+                raise ExpectedException("Ooops")
+        except ExpectedException:
             pass
 
         retrievedFolder = f"dump-{self.temp_directory}"
@@ -81,8 +81,8 @@ class TestDirectoryChangers(unittest.TestCase):
             ):
                 Path("file1.txt").touch()
                 Path("file2.txt").touch()
-                raise TestException("Ooops")
-        except TestException:
+                raise ExpectedException("Ooops")
+        except ExpectedException:
             pass
 
         self.assertFalse(

--- a/armi/utils/textProcessors.py
+++ b/armi/utils/textProcessors.py
@@ -483,7 +483,7 @@ class SequentialStringIOReader(SequentialReader):
     ...     data = []
     ...     while sr.searchForText('start of data chunk'):
     ...         # this needs to repeat for as many chunks as there are.
-    ...         if sr.searchForPatternOnNextLine('some-(?P<data>\w+)-pattern'):
+    ...         if sr.searchForPatternOnNextLine('some-(?P<data>\\w+)-pattern'):
     ...             data.append(sr.match['data'])
     """
 

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,7 @@ setup(
         "configparser",
         "coverage",
         "future",
-        # This is a semantic version bound, because newer h5py versions handle strings
-        # differently, and we would need to do some work to support it
-        "h5py<3.0",
+        "h5py>=3.0",
         "matplotlib",
         "numpy",
         "ordered-set",


### PR DESCRIPTION
h5py changed the manner in which they handle strings, requireing some
modifications to the database3 implementation. These were relatively
straightforward, but the new h5py required a newer version of numpy,
which unerthed some new warnings and issues in the tests. This addresses
all of those as well.

Of particular note is the addition of floating-point epsilon-aware
line-by-line file comparisons. This is needed, since newer numpy
versions produce slightly different results in certain scenarios, and we
want to make the tests a little less sensitive to minor differences
between numpy versions. The approach is to (in the event that string
comparison of two lines fails) split each line into words along
whitespace. For each pair of words, attempt parsing them as floats. If
they can both be parsed into floats, do a relative epsilon comparison.
Any trouble in this process and it will declare the strings non-equal.