### PR TITLE
Defer fast path resolution

### DIFF
--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -187,15 +187,13 @@ class TemporaryDirectoryChanger(DirectoryChanger):
     temporary directory will be deleted.
     """
 
-    _home = armi.context.getFastPath()
-
     def __init__(
         self, root=None, filesToMove=None, filesToRetrieve=None, dumpOnException=True
     ):
         DirectoryChanger.__init__(
             self, root, filesToMove, filesToRetrieve, dumpOnException
         )
-        root = root or TemporaryDirectoryChanger._home
+        root = root or armi.context.getFastPath()
         if not os.path.exists(root):
             os.makedirs(root)
         self.initial = os.path.abspath(os.getcwd())


### PR DESCRIPTION
Though we moved fast path resolution to a function to prevent
import-time execution of it, this one case still ran at import time
because it was in a class definition. As a result, any client of the
TemporaryDirectoryChanger would be using the CWD as the fast path rather
than some probably-better local fast path. In cases on clusters where
cwd is a shared network drive, this could really lower performance.