### PR TITLE
Adding several unit tests to improve coverage.

### DIFF
--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -142,6 +142,9 @@ class TestHistoryTracker(ArmiTestHelper):
         mgFluence = None
         for ts, years in enumerate(timesInYears):
             cycle, node = utils.getCycleNode(ts, self.o.cs)
+            # get coverage for getTimeStepNum by checking against getcycleNode
+            testTS = utils.getTimeStepNum(cycle, node, self.o.cs)
+            self.assertEqual(ts, testTS)
             mgFlux = (
                 hti.getBlockHistoryVal(bName, "mgFlux", (cycle, node)) / bVolume
             )  #  b.p.mgFlux is vol integrated

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2216,7 +2216,7 @@ class ThRZBlock(Block):
     def thetaOuter(self):
         """Return a largest theta of all the components."""
         outerTheta = self.getDimensions("outer_theta")
-        largestOuter = min(outerTheta) if outerTheta else None
+        largestOuter = max(outerTheta) if outerTheta else None
         return largestOuter
 
     def axialInner(self):

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -159,7 +159,7 @@ class BlockNumberModifier(GeometryChanger):
                     self.setNumberOfBlocks(a)
                 else:
                     # non-fuel. Control?
-                    self.setNumberOfBlocks(a, blockType=a[fuelI].getType())
+                    self.setNumberOfBlocks(a, blockFlags=a[fuelI].p.flags)
             else:
                 # radial shields, etc. go here.
                 pass
@@ -173,7 +173,7 @@ class BlockNumberModifier(GeometryChanger):
         # update bookkeeping.
         r.core.regenAssemblyLists()
 
-    def setNumberOfBlocks(self, assem, blockType=Flags.FUEL):
+    def setNumberOfBlocks(self, assem, blockFlags=Flags.FUEL):
         r"""
         Change the region to have a certain number of blocks with uniform height
 
@@ -184,9 +184,9 @@ class BlockNumberModifier(GeometryChanger):
         assem : Assembly
             The assembly to modify
 
-        blockType : str, optional
-            Type of block to change. Default: Fuel. Allows control
-            assemblies, etc. to modified just like fuel assemblies.
+        blockFlags : Flags, optional
+            Type of block to change. Default: Flags.FUEL. Allows control
+            assemblies, etc. to be modified just like fuel assemblies.
 
         Notes
         -----
@@ -198,9 +198,9 @@ class BlockNumberModifier(GeometryChanger):
         if you're tracking history.
 
         """
-        fuelHeight = assem.getTotalHeight(blockType)
+        fuelHeight = assem.getTotalHeight(blockFlags)
         blockHeight = fuelHeight / self.numToAdd
-        fuelBlocks = set(assem.getBlocks(blockType))
+        fuelBlocks = set(assem.getBlocks(blockFlags))
         newBlockStack = []
         numFuelBlocksAdded = 0
         # make a tracker flag that tells us if we're below or above fuel.

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -599,7 +599,7 @@ def _buildAssemTypeZones(core, cs, typeSpec=None):
         try:
             zone = zones[zoneName]
         except KeyError:
-            zone = Zone(a.name)
+            zone = Zone(zoneName)
             zones.add(zone)
         zone.append(a.getLocation())
     return zones

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -612,7 +612,7 @@ def classesInHierarchy(obj, classCounts, visited=None):
 def slantSplit(val, ratio, nodes, order="low first"):
 
     r"""
-    Returns a list of values who's sum is equal to the value specified.
+    Returns a list of values whose sum is equal to the value specified.
     The ratio between the highest and lowest value is equal to the specified ratio,
     and the middle values trend linearly between them.
 

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -258,13 +258,11 @@ class Utils_TestCase(unittest.TestCase):
         matrix[1, 1] = 4
         xtick = ([0, 1], ["1", "2"])
         ytick = ([0, 1], ["1", "2"])
-        dc = directoryChangers.TemporaryDirectoryChanger()
-        dc.__enter__()
         fname = "test_plotMatrix_testfile"
-        utils.plotMatrix(matrix, fname, show=True, title="plot")
-        utils.plotMatrix(matrix, fname, minV=0, maxV=5, figsize=[3, 4])
-        utils.plotMatrix(matrix, fname, xticks=xtick, yticks=ytick)
-        dc.__exit__(None, None, None)
+        with directoryChangers.TemporaryDirectoryChanger():
+            utils.plotMatrix(matrix, fname, show=True, title="plot")
+            utils.plotMatrix(matrix, fname, minV=0, maxV=5, figsize=[3, 4])
+            utils.plotMatrix(matrix, fname, xticks=xtick, yticks=ytick)
 
     def test_getStepsFromValues(self):
         steps = utils.getStepsFromValues([1.0, 3.0, 6.0, 10.0], prevValue=0.0)

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -18,7 +18,10 @@ r"""
 import unittest
 import math
 
+import numpy as np
+
 from armi.utils import units
+from armi.utils import directoryChangers
 import armi.utils as utils
 
 
@@ -35,6 +38,9 @@ class Utils_TestCase(unittest.TestCase):
         self.assertEqual(a, 1.0)
         self.assertEqual(b, 0.0)
         self.assertEqual(c, 1.0)
+
+        with self.assertRaises(Exception):
+            a, b, c = utils.parabolaFromPoints((0, 1), (0, 1), (-1, 2))
 
     def test_findClosest(self):
         l1 = range(10)
@@ -53,6 +59,22 @@ class Utils_TestCase(unittest.TestCase):
 
         self.assertEqual(x, 20.0)
         self.assertEqual(x2, 50.0)
+
+        with self.assertRaises(ZeroDivisionError):
+            error = utils.linearInterpolation(1.0, 1.0, 1.0, 2.0)
+
+    def test_parabolicInterpolation(self):
+        realRoots = utils.parabolicInterpolation(2.0e-6, -5.0e-4, 1.02, 1.0)
+        self.assertAlmostEqual(realRoots[0][0], 200.0)
+        self.assertAlmostEqual(realRoots[0][1], 3.0e-4)
+        self.assertAlmostEqual(realRoots[1][0], 50.0)
+        self.assertAlmostEqual(realRoots[1][1], -3.0e-4)
+        noRoots = utils.parabolicInterpolation(2.0e-6, -4.0e-4, 1.03, 1.0)
+        self.assertAlmostEqual(noRoots[0][0], -100.0)
+        self.assertAlmostEqual(noRoots[0][1], 0.0)
+        # 3. run time error
+        with self.assertRaises(RuntimeError):
+            error = utils.parabolicInterpolation(2.0e-6, 4.0e-4, 1.02, 1.0)
 
     def test_rotateXY(self):
         x = [1.0, -1.0]
@@ -110,6 +132,13 @@ class Utils_TestCase(unittest.TestCase):
         )
         self.assertEqual(outputStr, "hello, world, 1,\n2, 3,\n4, 5\n")
 
+        outputStr = utils.createFormattedStrWithDelimiter(
+            dataList=dataList,
+            maxNumberOfValuesBeforeDelimiter=0,
+            delimiter=delimiter,
+        )
+        self.assertEqual(outputStr, "hello, world, 1, 2, 3, 4, 5\n")
+
         # test with an empty list
         dataList = []
         outputStr = utils.createFormattedStrWithDelimiter(
@@ -137,6 +166,8 @@ class Utils_TestCase(unittest.TestCase):
         self.assertEqual("pot...", str1)
         str1 = utils.capStrLen("rubidium", 7)
         self.assertEqual("rubi...", str1)
+        with self.assertRaises(Exception):
+            str1 = utils.capStrLen("sodium", 2)
 
     def test_list2str(self):
         # Test with list of strings
@@ -160,6 +191,84 @@ class Utils_TestCase(unittest.TestCase):
         str1 = "OneTwoThreeFourT...FourThreeFour T... Four "
         str2 = utils.list2str(list2, 4, list1, 5)
         self.assertEqual(str1, str2)
+
+    def test_getFloat(self):
+        self.assertEqual(utils.getFloat(1.0), 1.0)
+        self.assertEqual(utils.getFloat("1.0"), 1.0)
+        self.assertIsNone(utils.getFloat("word"))
+
+    def test_relErr(self):
+        self.assertAlmostEqual(utils.relErr(1.00, 1.01), 0.01)
+        self.assertAlmostEqual(utils.relErr(100.0, 97.0), -0.03)
+        self.assertAlmostEqual(utils.relErr(0.00, 1.00), -1e99)
+
+    def test_efmt(self):
+        self.assertAlmostEqual(utils.efmt("1.0e+001"), "1.0E+01")
+        self.assertAlmostEqual(utils.efmt("1.0E+01"), "1.0E+01")
+
+    def test_slantSplit(self):
+        x1 = utils.slantSplit(10.0, 4.0, 4)
+        x2 = utils.slantSplit(10.0, 4.0, 4, order="high first")
+        self.assertListEqual(x1, [1.0, 2.0, 3.0, 4.0])
+        self.assertListEqual(x2, [4.0, 3.0, 2.0, 1.0])
+
+    def test_newtonsMethod(self):
+        f = lambda x: (x + 2) * (x - 1)
+        root = utils.newtonsMethod(f, 0.0, 5.0, maxIterations=10, positiveGuesses=True)
+        self.assertAlmostEqual(root, 1.0, places=3)
+        root = utils.newtonsMethod(f, 0.0, -10.0, maxIterations=10)
+        self.assertAlmostEqual(root, -2.0, places=3)
+
+    def test_minimizeScalarFunc(self):
+        f = lambda x: (x + 1) ** 2
+        minimum = utils.minimizeScalarFunc(f, -3.0, 10.0, maxIterations=10)
+        self.assertAlmostEqual(minimum, -1.0, places=3)
+        minimum = utils.minimizeScalarFunc(
+            f, -3.0, 10.0, maxIterations=10, positiveGuesses=True
+        )
+        self.assertAlmostEqual(minimum, 0.0, places=3)
+
+    def test_prependToList(self):
+        a = ["hello", "world"]
+        b = [1, 2, 3]
+        utils.prependToList(a, b)
+        self.assertListEqual(a, [1, 2, 3, "hello", "world"])
+
+    def test_convertToSlice(self):
+        slice1 = utils.convertToSlice(2)
+        self.assertEqual(slice1, slice(2, 3, None))
+        slice1 = utils.convertToSlice(2.0, increment=-1)
+        self.assertEqual(slice1, slice(1, 2, None))
+        slice1 = utils.convertToSlice(None)
+        self.assertEqual(slice1, slice(None, None, None))
+        slice1 = utils.convertToSlice([1, 2, 3])
+        self.assertTrue(np.allclose(slice1, np.array([1, 2, 3])))
+        slice1 = utils.convertToSlice(slice(2, 3, None))
+        self.assertEqual(slice1, slice(2, 3, None))
+        slice1 = utils.convertToSlice(np.array([1, 2, 3]))
+        self.assertTrue(np.allclose(slice1, np.array([1, 2, 3])))
+        with self.assertRaises(Exception):
+            slice1 = utils.convertToSlice("slice")
+
+    def test_plotMatrix(self):
+        matrix = np.zeros([2, 2], dtype=float)
+        matrix[0, 0] = 1
+        matrix[0, 1] = 2
+        matrix[1, 0] = 3
+        matrix[1, 1] = 4
+        xtick = ([0, 1], ["1", "2"])
+        ytick = ([0, 1], ["1", "2"])
+        dc = directoryChangers.TemporaryDirectoryChanger()
+        dc.__enter__()
+        fname = "test_plotMatrix_testfile"
+        utils.plotMatrix(matrix, fname, show=True, title="plot")
+        utils.plotMatrix(matrix, fname, minV=0, maxV=5, figsize=[3, 4])
+        utils.plotMatrix(matrix, fname, xticks=xtick, yticks=ytick)
+        dc.__exit__(None, None, None)
+
+    def test_getStepsFromValues(self):
+        steps = utils.getStepsFromValues([1.0, 3.0, 6.0, 10.0], prevValue=0.0)
+        self.assertListEqual(steps, [1.0, 2.0, 3.0, 4.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I selected files currently in the top 20 of missed lines on coveralls and skimmed through them to determine which had low-hanging fruit for improving test coverage statistics. I added unit tests to the following files:

armi/utils/tests/test_utils.py
armi/reactor/tests/test_reactors.py
armi/reactor/tests/test_blocks.py
armi/reactor/tests/test_zones.py

I tended towards smaller bites: unit tests for small functions with only a couple of relevant lines that could be easily implemented giving the existing test infrastructure and example objects that were already set up for other tests. I considered writing tests for more complicated functions that would have likely required setting up new data (e.g., burnup/power/flux summary functions that require spatial distributions) but generally stayed away from those.

I fixed three small bugs that I discovered while writing the tests:

1) armi/reactor/blocks.py: In the class ThRZBlock, the thetaOuter() method returned the min() of the "outer_theta" dimensions, but it seems like it should return the max() based on the name and comments.
2) armi/reactor/zones.py: The Zones method _buildAssemTypeZones() is supposed to create and name zones based on the assembly type (i.e., "igniter fuel", "lta fuel", etc.) but it was instead using the assembly name attribute, derived from the location ("A0010", "A0016", etc.). As a result, the assemblies were not correctly grouped into zones based on type.
3) armi/reactor/converters/geometryConverters.py: In the class BlockNumberModifier, the convert() method calls SetNumberOfBlocks, and passed it a string blockType (e.g., "clad") where it expects a flag (e.g., "Flags.CLAD"). Fixed with a call to Flags.fromString().

P.S. This is my first pull request. I used black and tried to keep naming and style in line with the surrounding code, but I wouldn't be surprised if I missed some subtleties (or even some not-so-subtleties). The commits are pretty atomic, so I'm hoping it will be easy to go back and revise them as necessary.