### PR TITLE
Fix incorrect mult for non-grid block components

### DIFF
--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -111,19 +111,25 @@ class BlockBlueprint(yamlize.KeyedList):
             c = componentDesign.construct(blueprint, materialInput)
             components[c.name] = c
             if spatialGrid:
-                c.spatialLocator = gridDesign.getMultiLocator(
+                componentLocators = gridDesign.getMultiLocator(
                     spatialGrid, componentDesign.latticeIDs
                 )
-                mult = c.getDimension("mult")
-                if mult and mult != 1.0 and mult != len(c.spatialLocator):
-                    raise ValueError(
-                        f"Conflicting ``mult`` input ({mult}) and number of "
-                        f"lattice positions ({len(c.spatialLocator)}) for {c}. "
-                        "Recommend leaving off ``mult`` input when using grids."
-                    )
-                elif not mult or mult == 1.0:
-                    # learn mult from grid definition
-                    c.setDimension("mult", len(c.spatialLocator))
+                if componentLocators:
+                    # this component is defined in the block grid
+                    # We can infer the multiplicity from the grid.
+                    # Otherwise it's a component that is in a block
+                    # with grids but that's not in the grid itself.
+                    c.spatialLocator = componentLocators
+                    mult = c.getDimension("mult")
+                    if mult and mult != 1.0 and mult != len(c.spatialLocator):
+                        raise ValueError(
+                            f"Conflicting ``mult`` input ({mult}) and number of "
+                            f"lattice positions ({len(c.spatialLocator)}) for {c}. "
+                            "Recommend leaving off ``mult`` input when using grids."
+                        )
+                    elif not mult or mult == 1.0:
+                        # learn mult from grid definition
+                        c.setDimension("mult", len(c.spatialLocator))
 
         for c in components.values():
             c._resolveLinkedDims(components)

--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -174,6 +174,14 @@ class TestGriddedBlock(unittest.TestCase):
                 seen = True
         self.assertTrue(seen)
 
+    def test_nonLatticeComponentHasRightMult(self):
+        """Make sure non-grid components in blocks with grids get the right multiplicity"""
+        aDesign = self.blueprints.assemDesigns.bySpecifier["IC"]
+        a = aDesign.construct(self.cs, self.blueprints)
+        fuelBlock = a.getFirstBlock(Flags.FUEL)
+        duct = fuelBlock.getComponent(Flags.DUCT)
+        self.assertEqual(duct.getDimension("mult"), 1.0)
+
     def test_explicitFlags(self):
         a1 = self.blueprints.assemDesigns.bySpecifier["IC"].construct(
             self.cs, self.blueprints


### PR DESCRIPTION
All components in blueprints-defined blocks that had grids assigned but
were not themselves in the grid got a multiplicity of zero, which made
the volume fractions (and therefore everything else) wrong. This fix
detects when a component is not represented in the grid and just leaves
the user-input multiplicity. A unit test covering the situation was also
added.

Fixes #254.