### PR TITLE
Fix multi-index location unpacking in db3

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1788,10 +1788,12 @@ def _unpackLocationsV2(locationTypes, locData):
         elif lt.startswith(LOC_MULTI):
             # extract number of sublocations from e.g. "M:345" string.
             numSubLocs = int(lt.split(":")[1])
+            multiLocs = []
             for _ in range(numSubLocs):
                 subLoc = next(locsIter)
                 # All multiindexes sublocs are index locs
-                unpackedLocs.append(tuple(int(i) for i in subLoc))
+                multiLocs.append(tuple(int(i) for i in subLoc))
+            unpackedLocs.append(multiLocs)
         else:
             raise ValueError(f"Read unknown location type {lt}. Invalid DB.")
 
@@ -1842,6 +1844,14 @@ class Layout:
         self.indexInData: List[int] = []
         self.numChildren: List[int] = []
         self.locationType: List[str] = []
+        # There is a minor asymmetry here in that before writing to the DB, this is
+        # truly a flat list of tuples. However when reading, this may contain lists of
+        # tuples, which represent MI locations. This comes from the fact that we map the
+        # tuples to Location objects in Database3._compose, but map from Locations to
+        # tuples in Layout._createLayout. Ideally we would handle both directions in the
+        # same place so this can be less surprising. Resolving this would require
+        # changing the interface of the various pack/unpack functions, which have
+        # multiple versions, so the update would need to be done with care.
         self.location: List[Tuple[int, int, int]] = []
         self.gridIndex: List[int] = []
         self.temperatures: List[float] = []

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -321,7 +321,7 @@ class Test_LocationPacking(unittest.TestCase):
 
         self.assertEqual(unpackedData[0], (1, 2, 3))
         self.assertEqual(unpackedData[1], (4.0, 5.0, 6.0))
-        self.assertEqual(unpackedData[2], (7, 8, 9))
+        self.assertEqual(unpackedData[2], [(7, 8, 9), (10, 11, 12)])
 
 
 if __name__ == "__main__":

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -731,9 +731,19 @@ class Grid:
         for _indices, locator in self.items():
             locator._grid = self
 
-    def __getitem__(self, ijk):
+    def __getitem__(self, ijk: Union[Tuple[int, int, int], List[Tuple[int, int, int]]]):
         """
         Get a location by (i, j, k) indices. If it does not exist, create a new one and return it.
+
+        Parameters
+        ----------
+
+        ijk : tuple of indices or list of the same
+            If provided a tuple, an IndexLocation will be created (if necessary) and
+            returned. If provided a list, each element will create a new IndexLocation
+            (if necessary), and a MultiIndexLocation containing all of the passed
+            indices will be returned.
+
 
         Notes
         -----

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -745,11 +745,18 @@ class Grid:
         """
         try:
             return self._locations[ijk]
-        except KeyError:
+        except (KeyError, TypeError):
+            pass
+
+        if isinstance(ijk, tuple):
             i, j, k = ijk
             val = IndexLocation(i, j, k, self)
             self._locations[ijk] = val
-            return val
+        elif isinstance(ijk, list):
+            val = MultiIndexLocation(self)
+            locators = [self[idx] for idx in ijk]
+            val.extend(locators)
+        return val
 
     def __len__(self):
         return len(self._locations)

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -184,12 +184,12 @@ class TestGrid(unittest.TestCase):
         """
         grid = grids.HexGrid.fromPitch(1.0, numRings=0)
         self.assertNotIn((0, 0, 0), grid._locations)
-        loc = grid[0,0,0]
+        loc = grid[0, 0, 0]
         self.assertIn((0, 0, 0), grid._locations)
 
-        multiLoc = grid[[(0,0,0), (1,0,0), (0,1,0)]]
+        multiLoc = grid[[(0, 0, 0), (1, 0, 0), (0, 1, 0)]]
         self.assertIsInstance(multiLoc, grids.MultiIndexLocation)
-        self.assertIn((1,0,0), grid._locations)
+        self.assertIn((1, 0, 0), grid._locations)
 
 
 class TestHexGrid(unittest.TestCase):

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -177,6 +177,20 @@ class TestGrid(unittest.TestCase):
         reduction = grid.reduce()
         self.assertAlmostEqual(reduction[0][1][1], 1.0)
 
+    def test_getitem(self):
+        """
+        Test that locations are created on demand, and the multi-index locations are
+        returned when necessary.
+        """
+        grid = grids.HexGrid.fromPitch(1.0, numRings=0)
+        self.assertNotIn((0, 0, 0), grid._locations)
+        loc = grid[0,0,0]
+        self.assertIn((0, 0, 0), grid._locations)
+
+        multiLoc = grid[[(0,0,0), (1,0,0), (0,1,0)]]
+        self.assertIsInstance(multiLoc, grids.MultiIndexLocation)
+        self.assertIn((1,0,0), grid._locations)
+
 
 class TestHexGrid(unittest.TestCase):
     def testPositions(self):

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -15,6 +15,8 @@
 import unittest
 import os
 
+import numpy
+
 from armi.utils import directoryChangers
 from armi.tests import TEST_ROOT
 from armi.reactor.flags import Flags
@@ -39,7 +41,7 @@ class C5G7ReactorTests(unittest.TestCase):
 
     def test_loadC5G7(self):
         """
-        Load the C5G7 case and check basic counts.
+        Load the C5G7 case from input and check basic counts.
         """
         o = armi.init(fName=TEST_INPUT_TITLE + ".yaml")
         b = o.r.core.getFirstBlock(Flags.MOX)
@@ -50,10 +52,25 @@ class C5G7ReactorTests(unittest.TestCase):
         gt = b.getComponent(Flags.GUIDE_TUBE)
         self.assertEqual(gt.getDimension("mult"), 24)
 
-    def test_runC5G7(self):
+    def test_runAndLoadC5G7(self):
         """
-        Run C5G7 in basic no-op app and load from the result.
+        Run C5G7 in basic no-op app and load from the result from DB.
+
+        This ensures that these kinds of cases can be read from DB.
         """
+
+        def _loadLocs(o, locs):
+            for b in o.r.core.getBlocks():
+                indices = b.spatialLocator.getCompleteIndices()
+                locs[indices] = b.spatialLocator.getGlobalCoordinates()
+
         o = armi.init(fName=TEST_INPUT_TITLE + ".yaml")
+        locsInput, locsDB = {}, {}
+        _loadLocs(o, locsInput)
         o.operate()
         o2 = db.loadOperator(TEST_INPUT_TITLE + ".h5", 0, 0)
+        _loadLocs(o2, locsDB)
+
+        for indices, coordsInput in sorted(locsInput.items()):
+            coordsDB = locsDB[indices]
+            self.assertTrue(numpy.allclose(coordsInput, coordsDB))

--- a/doc/release/0.1.rst
+++ b/doc/release/0.1.rst
@@ -202,11 +202,16 @@ API changes
   objects are largely vestigial. ``SystemLayoutInput`` will be retained to facilitate
   input migrations.
 
-* Changed block default names so that they are no longer constrained by axial characters. 
+* Changed block default names so that they are no longer constrained by axial characters.
   They now are named ``B{assemNum}-{axialIndex}`` to allow arbitrary numbers of blocks. This
   will invalidate any user setting that includes a block name (e.g. detail assemblies)
 
 * Changed location string labels to be numerical (``001-002-005``) rather than alphanumeric
   to eliminate a limitation on how many i-indices and k-indices were allowed. This will
-  invalidate any user setting value that includes a location label (e.g. in 
+  invalidate any user setting value that includes a location label (e.g. in
   ``detailAssemsByBOLLocation``). A migration script may be used to assist in migration.
+
+Bug fixes
+---------
+
+ * Fix bug in loading from databases when multi-index locations are used.

--- a/doc/user/outputs/database.rst
+++ b/doc/user/outputs/database.rst
@@ -117,42 +117,42 @@ documentation of the database modules.
 
        Also, it is important to note that all components are flattened and then grouped
        by type.
-   * - ``/c{CC}n{NN}/hierarchy/``
+   * - ``/c{CC}n{NN}/layout/``
      - H5Group
      - A group that contains  a description of the ARMI model within this timenode
-   * - ``/c{CC}n{NN}/hierarchy/name``
+   * - ``/c{CC}n{NN}/layout/name``
      - list of strings
      - ``comp.name``
-   * - ``/c{CC}n{NN}/hierarchy/type``
+   * - ``/c{CC}n{NN}/layout/type``
      - list of strings
      - ``type(comp).__name__`` -- The name of the component type. We can use this to
        construct a new object when reading. You could also use it to filter down to data
        that you care about using hdf5 directly.
-   * - ``/c{CC}n{NN}/hierarchy/serialNum``
+   * - ``/c{CC}n{NN}/layout/serialNum``
      - list of int
      - ``comp.p.serialNum`` -- Serial number of the component. This number is unique
        within a component type.
-   * - ``/c{CC}n{NN}/hierarchy/location``
+   * - ``/c{CC}n{NN}/layout/location``
      - list of 3-tuple floats
      - ``tuple(comp.spatialLocator) or (0, 0, 0)`` -- Gives the location indices for a
        given component. Note these are relative, so there are duplicates.
-   * - ``/c{CC}n{NN}/hierarchy/locationType``
+   * - ``/c{CC}n{NN}/layout/locationType``
      - list of strings
      - ``type(comp.spatialLocator).__name__ or "None"`` -- The type name of the
        location.
-   * - ``/c{CC}n{NN}/hierarchy/indexInData``
+   * - ``/c{CC}n{NN}/layout/indexInData``
      - list of int
      - The components are grouped by ``type(comp).__name__``. The integers are a mapping
        between the component and its index in the ``/c{CC}n{NN}/{COMP_TYPE}/`` group.
-   * - ``/c{CC}n{NN}/hierarchy/numChildren``
+   * - ``/c{CC}n{NN}/layout/numChildren``
      - list of int
      - ``len(comp)`` -- The number of direct child composites this composite has.
        Notably, this is not a summation of all the children.
-   * - ``/c{CC}n{NN}/hierarchy/temperatures``
+   * - ``/c{CC}n{NN}/layout/temperatures``
      - list of 2-tuple floats
      - ``(comp.InputTemperatureInC, comp.TemperatureInC) or (-900, -900)`` --
        Temperatures in for Component objects.
-   * - ``/c{CC}n{NN}/hierarchy/material``
+   * - ``/c{CC}n{NN}/layout/material``
      - list of string
      - ``type(comp.material).__name__ or ""`` -- Name of the associated material for an
        Component.
@@ -165,7 +165,7 @@ documentation of the database modules.
    * - ``/c{CC}n{NN}/{COMP_TYPE}/{PARAMETER}``
      - list of inferred data
      - Values for all parameters for a specific component type, in the order defined by
-       the ``/c{CC}n{NN}/hierarchy/``. See the next table to see a description of the
+       the ``/c{CC}n{NN}/layout/``. See the next table to see a description of the
        attributes.
 
 


### PR DESCRIPTION
Multi-index locations were not being unpacked in a manner that was
detectable when composing the reactor model on load. The solution was to
unpack multi-index locations into a list of tuples, and to teach the
Grids how to return one when presented with such a list in __getitem__().

Fixes #251 