### PR TITLE
Add early import of h5py in __init__

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -87,26 +87,6 @@ from armi.reactor import flags
 from armi.reactor import parameters
 from armi.nucDirectory import nuclideBases
 
-# h5py needs to be imported here, so that the disconnectAllHdfDBs() call that gets bound
-# to atexit below doesn't lead to a segfault on python exit. The Database3 module is
-# imported at call time, since it itself needs stuff that is initialized in this module
-# to import properly.  However, if that import leads to the first time that h5py is
-# imported in this process, doing so will cause a segfault. The theory here is that this
-# happens because the h5py extension module is not safe to import (for whatever reason)
-# when the python interpreter is in whatever state it's in when the atexit callbacks are
-# being invoked.  Importing early avoids this.
-#
-# Minimal code to reproduce the issue:
-#
-# >>> import atexit
-#
-# >>> def boom():
-# >>>     import h5py
-#
-# >>> atexit.register(boom)
-
-import h5py
-
 # ARMI does not configure its own application by default. This is mostly to catch issues
 # involving calling code that requires the framework to be configured before that has
 # explicitly taken place. An application should call `configure()` with its App class in

--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -87,6 +87,25 @@ from armi.reactor import flags
 from armi.reactor import parameters
 from armi.nucDirectory import nuclideBases
 
+# h5py needs to be imported here, so that the disconnectAllHdfDBs() call that gets bound
+# to atexit below doesn't lead to a segfault on python exit. The Database3 module is
+# imported at call time, since it itself needs stuff that is initialized in this module
+# to import properly.  However, if that import leads to the first time that h5py is
+# imported in this process, doing so will cause a segfault. The theory here is that this
+# happens because the h5py extension module is not safe to import (for whatever reason)
+# when the python interpreter is in whatever state it's in when the atexit callbacks are
+# being invoked.  Importing early avoids this.
+#
+# Minimal code to reproduce the issue:
+#
+# >>> import atexit
+#
+# >>> def boom():
+# >>>     import h5py
+#
+# >>> atexit.register(boom)
+
+import h5py
 
 # ARMI does not configure its own application by default. This is mostly to catch issues
 # involving calling code that requires the framework to be configured before that has

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -35,12 +35,6 @@ from armi import settings
 from armi.settings import caseSettings
 from armi import context
 
-# For some reason, it is important that h5py be imported here. If it is not, something
-# happens in pytest where regardless of the outcome of the tests themselves, it exits
-# with an access violation error code (on Windows, anyways). More investigation is
-# needed into why this is occuring.
-import h5py
-
 
 def pytest_sessionstart(session):
 

--- a/armi/context.py
+++ b/armi/context.py
@@ -29,6 +29,27 @@ import enum
 import shutil
 import gc
 
+# h5py needs to be imported here, so that the disconnectAllHdfDBs() call that gets bound
+# to atexit below doesn't lead to a segfault on python exit. The Database3 module is
+# imported at call time, since it itself needs stuff that is initialized in this module
+# to import properly.  However, if that import leads to the first time that h5py is
+# imported in this process, doing so will cause a segfault. The theory here is that this
+# happens because the h5py extension module is not safe to import (for whatever reason)
+# when the python interpreter is in whatever state it's in when the atexit callbacks are
+# being invoked.  Importing early avoids this.
+#
+# Minimal code to reproduce the issue:
+#
+# >>> import atexit
+#
+# >>> def willSegFault():
+# >>>     import h5py
+#
+# >>> atexit.register(willSegFault)
+
+import h5py
+
+
 BLUEPRINTS_IMPORTED = False
 BLUEPRINTS_IMPORT_CONTEXT = ""
 


### PR DESCRIPTION
This is needed to avoid the possibility of the first import of `h5py`
occurring in the cleanup function that gets called by `atexit`.
Importing `h5py` from that context leads to segfaults.