### PR TITLE
Add unit test for setPinPowers and fix a bug.

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1806,7 +1806,9 @@ class HexBlock(Block):
             self.p.pinPowersNeutron = self.p.pinPowers
 
         if gamma:
-            self.p.pinPowers = self.p.pinPowersNeutron + self.p.pinPowersGamma
+            self.p.pinPowers = [
+                n + g for n, g in zip(self.p.pinPowersNeutron, self.p.pinPowersGamma)
+            ]
         else:
             self.p.pinPowers = self.p.pinPowersNeutron
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -38,6 +38,8 @@ from armi.reactor.tests.test_assemblies import makeTestAssembly
 from armi.tests import ISOAA_PATH
 from armi.nuclearDataIO.cccc import isotxs
 from armi.reactor import geometry
+from armi.physics.neutronics import NEUTRON
+from armi.physics.neutronics import GAMMA
 
 
 def buildSimpleFuelBlock():
@@ -1173,6 +1175,36 @@ class Block_TestCase(unittest.TestCase):
 
         emptyBlock = blocks.HexBlock("empty")
         self.assertEqual(emptyBlock.getNumPins(), 0)
+
+    def test_setPinPowers(self):
+
+        numPins = self.Block.getNumPins()
+        neutronPower = [10.0 * i for i in range(numPins)]
+        gammaPower = [1.0 * i for i in range(numPins)]
+        totalPower = [x + y for x, y in zip(neutronPower, gammaPower)]
+        imax = 9  # hexagonal rings of pins
+        jmax = [max(1, 6 * i) for i in range(imax)]  # pins in each hexagonal ring
+        self.Block.setPinPowers(
+            neutronPower,
+            numPins,
+            imax,
+            jmax,
+            gamma=False,
+            removeSixCornerPins=False,
+            powerKeySuffix=NEUTRON,
+        )
+        self.Block.setPinPowers(
+            gammaPower,
+            numPins,
+            imax,
+            jmax,
+            gamma=True,
+            removeSixCornerPins=False,
+            powerKeySuffix=GAMMA,
+        )
+        assert_allclose(self.Block.p.pinPowersNeutron, numpy.array(neutronPower))
+        assert_allclose(self.Block.p.pinPowersGamma, numpy.array(gammaPower))
+        assert_allclose(self.Block.p.pinPowers, numpy.array(totalPower))
 
     def test_getComponentAreaFrac(self):
         def calcFracManually(names):


### PR DESCRIPTION
setPinPowers has a boolean option gamma. If gamma == True, then it adds
the gamma pin power to the neutron pin power to get the total pin power,
and stores in in b.p.pinPowers. The old code used the following
notation:

self.p.pinPowers = self.p.pinPowersNeutron + self.p.pinPowersGamma

This would work for numpy arrays, but the pin powers are defined as
python lists in this method. As a result, python was concatenating a
list of the gamma powers onto the neutron pin power list instead of
computing an element-wise addition.