### PR TITLE
Clean up Block.plotFlux and move it to utils.plotting.

### DIFF
--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1441,33 +1441,6 @@ class Block_TestCase(unittest.TestCase):
         self.Block.breakFuelComponentsIntoIndividuals()
         self.assertEqual(fuel.getDimension("mult"), 1.0)
 
-    def test_plotFlux(self):
-        try:
-            xslib = isotxs.readBinary(ISOAA_PATH)
-            self.Block.r.core.lib = xslib
-            self.Block.p.mgFlux = range(33)
-            self.Block.plotFlux(self.Block.r.core, fName="flux.png", bList=[self.Block])
-            self.assertTrue(os.path.exists("flux.png"))
-            self.Block.plotFlux(
-                self.Block.r.core, fName="peak.png", bList=[self.Block], peak=True
-            )
-            self.assertTrue(os.path.exists("peak.png"))
-            self.Block.plotFlux(
-                self.Block.r.core,
-                fName="bList2.png",
-                bList=[self.Block],
-                bList2=[self.Block],
-            )
-            self.assertTrue(os.path.exists("bList2.png"))
-            # can't test adjoint at the moment, testBlock doesn't like to .getMgFlux(adjoint=True)
-        finally:
-            os.remove("flux.txt")  # secondarily created during the call.
-            os.remove("flux.png")  # created during the call.
-            os.remove("peak.txt")  # csecondarily reated during the call.
-            os.remove("peak.png")  # created during the call.
-            os.remove("bList2.txt")  # secondarily created during the call.
-            os.remove("bList2.png")  # created during the call.
-
     def test_pinMgFluxes(self):
         """
         Test setting/getting of pin-wise fluxes.

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1448,9 +1448,25 @@ class Block_TestCase(unittest.TestCase):
             self.Block.p.mgFlux = range(33)
             self.Block.plotFlux(self.Block.r.core, fName="flux.png", bList=[self.Block])
             self.assertTrue(os.path.exists("flux.png"))
+            self.Block.plotFlux(
+                self.Block.r.core, fName="peak.png", bList=[self.Block], peak=True
+            )
+            self.assertTrue(os.path.exists("peak.png"))
+            self.Block.plotFlux(
+                self.Block.r.core,
+                fName="bList2.png",
+                bList=[self.Block],
+                bList2=[self.Block],
+            )
+            self.assertTrue(os.path.exists("bList2.png"))
+            # can't test adjoint at the moment, testBlock doesn't like to .getMgFlux(adjoint=True)
         finally:
             os.remove("flux.txt")  # secondarily created during the call.
             os.remove("flux.png")  # created during the call.
+            os.remove("peak.txt")  # csecondarily reated during the call.
+            os.remove("peak.png")  # created during the call.
+            os.remove("bList2.txt")  # secondarily created during the call.
+            os.remove("bList2.png")  # created during the call.
 
     def test_pinMgFluxes(self):
         """

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -31,6 +31,7 @@ import matplotlib.colors as mcolors
 from armi import runLog
 from armi.reactor.flags import Flags
 from armi.reactor import grids
+from armi.bookkeeping import report
 
 
 def colorGenerator(skippedColors=10):
@@ -831,6 +832,162 @@ def _plotBlocksInAssembly(
             )
 
     return xBlockLoc, yBlockHeights, yBlockAxMesh
+
+
+def plotBlockFlux(core, fName=None, bList=None, peak=False, adjoint=False, bList2=[]):
+    """
+    Produce energy spectrum plot of real and/or adjoint flux in one or more blocks.
+
+    Parameters
+    ----------
+    core : Core
+        Core object
+    fName : str, optional
+        the name of the plot file to produce. If none, plot will be shown. A text file with
+        the flux values will also be generated if this is non-empty.
+    bList : iterable, optional
+        is a single block or a list of blocks to average over. If no bList, full core is assumed.
+    peak : bool, optional
+        a flag that will produce the peak as well as the average on the plot.
+    adjoint : bool, optional
+        plot the adjoint as well.
+    bList2 :
+        a separate list of blocks that will also be plotted on a separate axis on the same plot.
+        This is useful for comparing flux in some blocks with flux in some other blocks.
+
+    Notes
+    -----
+    This is not a great method. It should be cleand up and migrated into ``utils.plotting``.
+    """
+
+    class BlockListFlux(object):
+        def __init__(
+            self, nGroup, blockList=[], adjoint=False, peak=False, primary=False
+        ):
+            if blockList:
+                self.blockList = blockList
+                self.nGroup = nGroup
+                self.avgFlux = numpy.zeros(self.nGroup)
+                self.peakFlux = numpy.zeros(self.nGroup)
+                self.peak = peak
+                self.adjoint = adjoint
+                if self.adjoint:
+                    self.labelAvg = "Average Adjoint Flux"
+                    self.labelPeak = "Peak Adjoint Flux"
+                else:
+                    self.labelAvg = "Average Flux"
+                    self.labelPeak = "Peak Flux"
+                if primary:
+                    self.lineAvg = "-"
+                    self.linePeak = "-"
+                else:
+                    self.lineAvg = "r--"
+                    self.linePeak = "k--"
+
+        def calcAverage(self):
+            for b in self.blockList:
+                thisFlux = numpy.array(b.getMgFlux(adjoint=self.adjoint))
+                self.avgFlux += numpy.array(thisFlux)
+                if sum(thisFlux) > sum(self.peakFlux):
+                    self.peakFlux = thisFlux
+            self.avgFlux = self.avgFlux / len(bList)
+
+        def setEnergyStructure(self, upperEnergyBounds):
+            self.E = [eMax / 1e6 for eMax in upperEnergyBounds]
+
+        def makePlotHistograms(self):
+            self.eHistogram, self.avgHistogram = makeHistogram(self.E, self.avgFlux)
+            if self.peak:
+                _, self.peakHistogram = makeHistogram(self.E, self.peakFlux)
+
+        def checkSize(self):
+            if not len(self.E) == len(self.avgFlux):
+                runLog.error(self.avgFlux)
+                raise
+
+        def getTable(self):
+            return enumerate(zip(self.E, self.avgFlux, self.peakFlux))
+
+    if bList is None:
+        bList = core.getBlocks()
+    bList = list(bList)
+    if adjoint and bList2:
+        runLog.warning("Cannot plot adjoint flux with bList2 argument")
+        return
+    elif adjoint:
+        bList2 = bList
+    try:
+        G = len(core.lib.neutronEnergyUpperBounds)
+    except:
+        runLog.warning("No ISOTXS library attached so no flux plots.")
+        return
+
+    BlockListFluxes = set()
+    bf1 = BlockListFlux(G, blockList=bList, peak=peak, primary=True)
+    BlockListFluxes.add(bf1)
+    if bList2:
+        bf2 = BlockListFlux(G, blockList=bList2, adjoint=adjoint, peak=peak)
+        BlockListFluxes.add(bf2)
+
+    for bf in BlockListFluxes:
+        bf.calcAverage()
+        bf.setEnergyStructure(core.lib.neutronEnergyUpperBounds)
+        bf.checkSize()
+        bf.makePlotHistograms()
+
+    if fName:
+        # write a little flux text file.
+        txtFileName = os.path.splitext(fName)[0] + ".txt"
+        with open(txtFileName, "w") as f:
+            f.write(
+                "{0:16s} {1:16s} {2:16s}\n".format(
+                    "Energy_Group", "Average_Flux", "Peak_Flux"
+                )
+            )
+            for g, (eMax, avgFlux, peakFlux) in bf1.getTable():
+                f.write("{0:12E} {1:12E} {2:12E}\n".format(eMax, avgFlux, peakFlux))
+
+    if max(bf1.avgFlux) <= 0.0:
+        runLog.warning(
+            "Cannot plot flux with maxval=={0} in {1}".format(maxVal, bList[0])
+        )
+        return
+
+    plt.figure()
+    plt.plot(bf1.eHistogram, bf1.avgHistogram, bf1.lineAvg, label=bf1.labelAvg)
+    if peak:
+        plt.plot(bf1.eHistogram, bf1.peakHistogram, bf1.linePeak, label=bf1.labelPeak)
+    ax = plt.gca()
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    plt.xlabel("Energy (MeV)")
+    plt.ylabel("Flux (n/cm$^2$/s)")
+    if peak or bList2:
+        plt.legend(loc="lower right")
+    plt.grid(color="0.70")
+    if bList2:
+        if adjoint:
+            plt.twinx()
+            plt.ylabel("Adjoint Flux (n/cm$^2$/s)", rotation=270)
+            ax2 = plt.gca()
+            ax2.set_yscale("log")
+        plt.plot(bf2.eHistogram, bf2.avgHistogram, bf2.lineAvg, label=bf2.labelAvg)
+        if peak and not adjoint:
+            plt.plot(
+                bf2.eHistogram, bf2.peakHistogram, bf2.linePeak, label=bf2.labelPeak
+            )
+        plt.legend(loc="lower left")
+    plt.title("Group flux")
+
+    if fName:
+        plt.savefig(fName)
+        report.setData(
+            "Flux Plot {}".format(os.path.split(fName)[1]),
+            os.path.abspath(fName),
+            report.FLUX_PLOT,
+        )
+    else:
+        plt.show()
 
 
 def makeHistogram(x, y):

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -831,3 +831,27 @@ def _plotBlocksInAssembly(
             )
 
     return xBlockLoc, yBlockHeights, yBlockAxMesh
+
+
+def makeHistogram(x, y):
+    """
+    Take a list of x and y values, and return a histogram-ified version
+    Good for plotting multigroup flux spectrum or cross sections
+    """
+    if not len(x) == len(y):
+        raise ValueError(
+            "Cannot make a histogram unless the x and y lists are the same size."
+            + "len(x) == {} and len(y) == {}".format(len(x), len(y))
+        )
+    n = len(x)
+    xHistogram = numpy.zeros(2 * n)
+    yHistogram = numpy.zeros(2 * n)
+    for i in range(n):
+        lower = 2 * i
+        upper = 2 * i + 1
+        xHistogram[lower] = x[i - 1]
+        xHistogram[upper] = x[i]
+        yHistogram[lower] = y[i]
+        yHistogram[upper] = y[i]
+    xHistogram[0] = x[0] / 2.0
+    return xHistogram, yHistogram

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -18,8 +18,10 @@ Tests for functions in util.plotting.py
 import os
 import unittest
 
+from armi.nuclearDataIO.cccc import isotxs
 from armi.utils import plotting
 from armi.reactor.tests import test_reactors
+from armi.tests import ISOAA_PATH
 
 
 class TestPlotting(unittest.TestCase):
@@ -54,6 +56,37 @@ class TestPlotting(unittest.TestCase):
             self.r.core.parent.blueprints, "coreAssemblyTypes1.png"
         )
         self._checkExists("coreAssemblyTypes1.png")
+
+    def test_plotBlockFlux(self):
+        try:
+            xslib = isotxs.readBinary(ISOAA_PATH)
+            self.r.core.lib = xslib
+
+            blockList = self.r.core.getBlocks()
+            for i, b in enumerate(blockList):
+                b.p.mgFlux = range(33)
+
+            plotting.plotBlockFlux(self.r.core, fName="flux.png", bList=blockList)
+            self.assertTrue(os.path.exists("flux.png"))
+            plotting.plotBlockFlux(
+                self.r.core, fName="peak.png", bList=blockList, peak=True
+            )
+            self.assertTrue(os.path.exists("peak.png"))
+            plotting.plotBlockFlux(
+                self.r.core,
+                fName="bList2.png",
+                bList=blockList,
+                bList2=blockList,
+            )
+            self.assertTrue(os.path.exists("bList2.png"))
+            # can't test adjoint at the moment, testBlock doesn't like to .getMgFlux(adjoint=True)
+        finally:
+            os.remove("flux.txt")  # secondarily created during the call.
+            os.remove("flux.png")  # created during the call.
+            os.remove("peak.txt")  # csecondarily reated during the call.
+            os.remove("peak.png")  # created during the call.
+            os.remove("bList2.txt")  # secondarily created during the call.
+            os.remove("bList2.png")  # created during the call.
 
     def _checkExists(self, fName):
         self.assertTrue(os.path.exists(fName))


### PR DESCRIPTION
I'm creating this PR in relation to issue #104. The issue recommends changing all of the plotting utilities to return figures or patches, instead of directly creating and saving/showing the plots. I'm not trying to tackle that part, since it's a pretty big scope that would touch a lot of other code that calls on the plotting utilties.

This change is being proposed just to complete the first task on the list of 4 in #104: moving plotFlux from blocks.py to utils.plotting. It also fits nicely into the current desire to pare down loose-fitting functions in blocks.py.

I kept a "pass-through" function in blocks.py so that any plugins that call it don't have to be changed yet. My thinking was that we can go back and delete it later once all of the calls to plotFlux have been updated.