### PR TITLE
Add unit tests for Material.

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -585,6 +585,7 @@ class Material(composites.Leaf):
         if not "Rincu" in self.modelConst:
             msg = "Material missing incubation dose"
             runLog.warning(msg, single=True, label="Missing incubation dose")
+            return False
         else:
             if totalDPA > self.modelConst["Rincu"]:
                 return True

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -582,13 +582,14 @@ class Material(composites.Leaf):
 
         """
 
-        if not self.modelConst["Rincu"]:
+        if not "Rincu" in self.modelConst:
             msg = "Material missing incubation dose"
             runLog.warning(msg, single=True, label="Missing incubation dose")
-        elif totalDPA > self.modelConst["Rincu"]:
-            return True
         else:
-            return False
+            if totalDPA > self.modelConst["Rincu"]:
+                return True
+            else:
+                return False
 
     def updateDeltaDPApastIncubation(self, totalDPA, deltaDPA):
         r"""
@@ -610,15 +611,18 @@ class Material(composites.Leaf):
         deltaDPA past the incubation dose of the material.
 
         """
-        if not self.modelConst["Rincu"]:
+
+        if not "Rincu" in self.modelConst:
             msg = "Material missing incubation dose"
             runLog.warning(msg, single=True, label="Missing incubation dose")
-        elif (totalDPA > self.modelConst["Rincu"]) and (
-            (totalDPA - self.modelConst["Rincu"]) < deltaDPA
-        ):
-            return totalDPA - self.modelConst["Rincu"]
-        else:
             return deltaDPA
+        else:
+            if (totalDPA > self.modelConst["Rincu"]) and (
+                (totalDPA - self.modelConst["Rincu"]) < deltaDPA
+            ):
+                return totalDPA - self.modelConst["Rincu"]
+            else:
+                return deltaDPA
 
     def densityTimesHeatCapacity(self, Tk=None, Tc=None):
         r"""
@@ -650,8 +654,8 @@ class Material(composites.Leaf):
     def getTempChangeForDensityChange(self, Tc, densityFrac, quiet=True):
         """Return a temperature difference for a given density perturbation."""
         linearExpansion = self.linearExpansion(Tc=Tc)
-        volFrac = densityFrac ** (-1.0 / 3.0) - 1.0
-        deltaT = volFrac / linearExpansion
+        linearChange = densityFrac ** (-1.0 / 3.0) - 1.0
+        deltaT = linearChange / linearExpansion
         if not quiet:
             runLog.info(
                 "The linear expansion for {} at initial temperature of {} C is {}.\nA change in density of {} "

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -615,12 +615,7 @@ class Material(composites.Leaf):
             runLog.warning(msg, single=True, label="Missing incubation dose")
             return deltaDPA
         else:
-            if (totalDPA > self.modelConst["Rincu"]) and (
-                (totalDPA - self.modelConst["Rincu"]) < deltaDPA
-            ):
-                return totalDPA - self.modelConst["Rincu"]
-            else:
-                return deltaDPA
+            return min(totalDPA - self.modelConst["Rincu"], deltaDPA)
 
     def densityTimesHeatCapacity(self, Tk=None, Tc=None):
         r"""

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -587,10 +587,7 @@ class Material(composites.Leaf):
             runLog.warning(msg, single=True, label="Missing incubation dose")
             return False
         else:
-            if totalDPA > self.modelConst["Rincu"]:
-                return True
-            else:
-                return False
+            return totalDPA > self.modelConst["Rincu"]
 
     def updateDeltaDPApastIncubation(self, totalDPA, deltaDPA):
         r"""

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -238,12 +238,19 @@ class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
         self.assertAlmostEqual(2.0, self.mat.updateDeltaDPApastIncubation(8.0, 2.0))
 
     def test_densityTimesHeatCapactiy(self):
-        rhoCp = 3278155.7491839416
-        self.assertAlmostEqual(rhoCp, self.mat.densityTimesHeatCapacity(Tc=500))
+        Tc = 500.0
+        expectedRhoCp = self.mat.density(Tc=Tc) * 1000.0 * self.mat.heatCapacity(Tc=Tc)
+        self.assertAlmostEqual(expectedRhoCp, self.mat.densityTimesHeatCapacity(Tc=Tc))
 
     def test_getTempChangeForDensityChange(self):
-        expectedDeltaT = -33.77346947512134
-        actualDeltaT = self.mat.getTempChangeForDensityChange(500.0, 1.001, quiet=False)
+        Tc = 500.0
+        linearExpansion = self.mat.linearExpansion(Tc=Tc)
+        densityFrac = 1.001
+        linearChange = densityFrac ** (-1.0 / 3.0) - 1.0
+        expectedDeltaT = linearChange / linearExpansion
+        actualDeltaT = self.mat.getTempChangeForDensityChange(
+            Tc, densityFrac, quiet=False
+        )
         self.assertAlmostEqual(expectedDeltaT, actualDeltaT)
 
     def test_duplicate(self):
@@ -429,8 +436,15 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
     def test_getTempChangeForDensityChange(self):
-        expectedDeltaT = -7.310047340585811
-        actualDeltaT = self.mat.getTempChangeForDensityChange(800.0, 1.001, quiet=False)
+        Tc = 800.0
+        densityFrac = 1.001
+        currentDensity = self.mat.density(Tc=Tc)
+        perturbedDensity = currentDensity * densityFrac
+        tAtPerturbedDensity = self.mat.getTemperatureAtDensity(perturbedDensity, Tc)
+        expectedDeltaT = tAtPerturbedDensity - Tc
+        actualDeltaT = self.mat.getTempChangeForDensityChange(
+            Tc, densityFrac, quiet=False
+        )
         self.assertAlmostEqual(expectedDeltaT, actualDeltaT)
 
 

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -43,7 +43,7 @@ class _Material_Test(object):
         )
 
 
-class MaterialConstructionTestss(unittest.TestCase):
+class MaterialConstructionTests(unittest.TestCase):
     def test_material_initialization(self):
         """Make sure all materials can be instantiated without error."""
         for matClass in materials.iterAllMaterialClassesInNamespace(materials):
@@ -211,6 +211,52 @@ class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
         self.assertAlmostEqual(self.mat.heatCapacity(300), 230.0, delta=20)
         self.assertAlmostEqual(self.mat.heatCapacity(1000), 320.0, delta=20)
         self.assertAlmostEqual(self.mat.heatCapacity(2000), 380.0, delta=20)
+
+    def test_getTemperatureAtDensity(self):
+        expectedTemperature = 100.0
+        tAtTargetDensity = self.mat.getTemperatureAtDensity(
+            self.mat.density(Tc=expectedTemperature), 30.0
+        )
+        self.assertAlmostEqual(expectedTemperature, tAtTargetDensity)
+
+    def test_getDensityExpansion3D(self):
+        expectedTemperature = 100.0
+        self.mat.p.refDens = 10.9
+        density3D = self.mat.density3KgM3(Tc=expectedTemperature)
+        self.assertAlmostEqual(10.86792660463439e3, density3D)
+
+    def test_removeNucMassFrac(self):
+        self.mat.removeNucMassFrac("O")
+        massFracs = [str(k) for k in self.mat.p.massFrac.keys()]
+        self.assertListEqual(["U235", "U238"], massFracs)
+
+    def test_isBeyondIncubationDose(self):
+        self.mat.modelConst["Rincu"] = 5.0
+        self.assertTrue(self.mat.isBeyondIncubationDose(10.0))
+        self.assertFalse(self.mat.isBeyondIncubationDose(1.0))
+        self.assertAlmostEqual(1.0, self.mat.updateDeltaDPApastIncubation(6.0, 2.0))
+        self.assertAlmostEqual(2.0, self.mat.updateDeltaDPApastIncubation(8.0, 2.0))
+
+    def test_densityTimesHeatCapactiy(self):
+        rhoCp = 3278155.7491839416
+        self.assertAlmostEqual(rhoCp, self.mat.densityTimesHeatCapacity(Tc=500))
+
+    def test_getTempChangeForDensityChange(self):
+        expectedDeltaT = -33.77346947512134
+        actualDeltaT = self.mat.getTempChangeForDensityChange(500.0, 1.001, quiet=False)
+        self.assertAlmostEqual(expectedDeltaT, actualDeltaT)
+
+    def test_duplicate(self):
+        duplicateU = self.mat.duplicate()
+        for key in self.mat.p:
+            self.assertEqual(duplicateU.p[key], self.mat.p[key])
+
+        for key in self.mat.p.massFrac:
+            self.assertEqual(duplicateU.p.massFrac[key], self.mat.p.massFrac[key])
+
+        duplicateMassFrac = self.mat.getMassFracCopy()
+        for key in self.mat.p.massFrac.keys():
+            self.assertEqual(duplicateMassFrac[key], self.mat.p.massFrac[key])
 
 
 class Thorium_TestCase(_Material_Test, unittest.TestCase):
@@ -381,6 +427,11 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
         ref = 141.7968
         delta = ref * 0.05
         self.assertAlmostEqual(cur, ref, delta=delta)
+
+    def test_getTempChangeForDensityChange(self):
+        expectedDeltaT = -7.310047340585811
+        actualDeltaT = self.mat.getTempChangeForDensityChange(800.0, 1.001, quiet=False)
+        self.assertAlmostEqual(expectedDeltaT, actualDeltaT)
 
 
 class Sulfur_TestCase(_Material_Test, unittest.TestCase):


### PR DESCRIPTION
Needed more test coverage for material.py. Identified one issue, with
the implementation of isBeyondIncubationDose and
updateDeltaDPApastIncubation. The logic tries to evaluate the result
of self.modelConst["Rincu"] as a boolean. If "Rincu" is not in modelConst, 
it will not return False, but rather throw a KeyError. First, we need to check
whether it is in the dict, then we can proceed.