### PR TITLE
Avoid plotting empty vectors in keffVsTime

### DIFF
--- a/armi/bookkeeping/plotting.py
+++ b/armi/bookkeeping/plotting.py
@@ -156,14 +156,14 @@ def keffVsTime(reactor, time, keff, keffUnc=None, ymin=None):
         Minimum y-axis value to target.
     """
     plt.figure()
-    if keffUnc:
+    if any(keffUnc):
         label1 = "Controlled k-eff"
         label2 = "Uncontrolled k-eff"
     else:
         label1 = None
 
     plt.plot(time, keff, ".-", label=label1)
-    if keffUnc:
+    if any(keffUnc):
         plt.plot(time, keffUnc, ".-", label=label2)
         plt.legend()
     plt.xlabel("Time (yr)")


### PR DESCRIPTION
Sometimes a database will be populated with an empty vector for the
uncontrolled multiplication factor. I believe this happens if the
value of keffUnc is not updated during an ARMI run. This leads to a
list of zeros being passed to the bookkeeping keffVsTime graph which
_technically_ evaluates to `True` and gets plotted. Using `any` for
the conditional check skips plotting empty lists and `None`s.

Signed-off-by: Andrew Johnson <drewejohnson@users.noreply.github.com>