### PR TITLE
Remove isBeyondInucbationDose and updateDeltaDPApastIncubation

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -565,58 +565,6 @@ class Material(composites.Leaf):
                     label="T out of bounds for {} {}".format(self.name, label),
                 )
 
-    def isBeyondIncubationDose(self, totalDPA):
-        r"""
-        Checks if the materials is beyond is incubation dose. Passes if the material
-        does not have an incubation dose assigned (self.modelConst['Rincu']
-
-        Parameters
-        ----------
-
-        totalDPA : float
-            Total DPA accumulated in the material
-
-        Returns
-        -------
-        Bool indicating whether the material is beyond its incubation dose or not.
-
-        """
-
-        if not "Rincu" in self.modelConst:
-            msg = "Material missing incubation dose"
-            runLog.warning(msg, single=True, label="Missing incubation dose")
-            return False
-        else:
-            return totalDPA > self.modelConst["Rincu"]
-
-    def updateDeltaDPApastIncubation(self, totalDPA, deltaDPA):
-        r"""
-        If a material has passed its incubation dose, this method updates deltaDPA. The concern
-        here is when a step in DPA crosses the incubation threshold, the amount of DPA input into a
-        calculation is more than is actually contributing to deformation.
-
-        Parameters
-        ----------
-
-        totalDPA : float
-            Total DPA accumulated in the material.
-
-        deltaDPA : float
-            Change in DPA over a time step.
-
-        Returns
-        -------
-        deltaDPA past the incubation dose of the material.
-
-        """
-
-        if not "Rincu" in self.modelConst:
-            msg = "Material missing incubation dose"
-            runLog.warning(msg, single=True, label="Missing incubation dose")
-            return deltaDPA
-        else:
-            return min(totalDPA - self.modelConst["Rincu"], deltaDPA)
-
     def densityTimesHeatCapacity(self, Tk=None, Tc=None):
         r"""
         Return heat capacity * density at a temperature

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -230,13 +230,6 @@ class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
         massFracs = [str(k) for k in self.mat.p.massFrac.keys()]
         self.assertListEqual(["U235", "U238"], massFracs)
 
-    def test_isBeyondIncubationDose(self):
-        self.mat.modelConst["Rincu"] = 5.0
-        self.assertTrue(self.mat.isBeyondIncubationDose(10.0))
-        self.assertFalse(self.mat.isBeyondIncubationDose(1.0))
-        self.assertAlmostEqual(1.0, self.mat.updateDeltaDPApastIncubation(6.0, 2.0))
-        self.assertAlmostEqual(2.0, self.mat.updateDeltaDPApastIncubation(8.0, 2.0))
-
     def test_densityTimesHeatCapactiy(self):
         Tc = 500.0
         expectedRhoCp = self.mat.density(Tc=Tc) * 1000.0 * self.mat.heatCapacity(Tc=Tc)


### PR DESCRIPTION
…lt plugin.

isBeyondIncubationDose and updateDPABeyondIncubationDose are
highly specific functions that don't belong in the base Material
class. These functions were moved to the oxbowlt plugin, where they
are used.