### PR TITLE
Grammar and Language improvements in the docs

### DIFF
--- a/armi/tests/tutorials/data_model.ipynb
+++ b/armi/tests/tutorials/data_model.ipynb
@@ -81,8 +81,8 @@
     "* :py:mod:`Reactors <armi.reactor.reactors>`, often named ``reactor`` or ``r`` contain a Core and possibly other equipment. They represent collections of assemblies. \n",
     "* :py:mod:`Assemblies <armi.reactor.assemblies>`, often named ``assembly`` or ``a``, are individual pieces that collect into a System.\n",
     "* :py:mod:`Blocks <armi.reactor.blocks>`, often called ``block`` or ``b`` are divisions of the assemblies into sections one on top of the other.\n",
-    "* :py:mod:`Components <armi.reactor.components>` The geometrically defined objects (Circles, Hexagons, Helices, Dodecagons) and their dimensions\n",
-    "* :py:mod:`Materials <armi.materials>` are objects which have material properties like linear expansion coefficients, thermal conductivities, isotopic mass fractions, and densities\n",
+    "* :py:mod:`Components <armi.reactor.components>` The geometrically defined objects (Circles, Hexagons, Helices, Dodecagons) and their dimensions.\n",
+    "* :py:mod:`Materials <armi.materials>` are objects which have material properties like linear expansion coefficients, thermal conductivities, isotopic mass fractions, and densities.\n",
     "\n",
     "Each of these objects house more than the listed objects, they also are responsible for a variety of state information\n",
     "like the reactor's overall keff, flux, height, temperature, etc. In this section, we will explore these objects,\n",
@@ -494,7 +494,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Having Reactor object by itself can be very useful for all sorts of post-processing tasks. However, sometimes we may wish initialize more ARMI components to do more advanced tasks and interactive follow-on analysis.  Lucky for us, the database stores the settings that were used to run the case in the first place. We can get them like this:"
+    "Having a Reactor object by itself can be very useful for all sorts of post-processing tasks. However, sometimes we may wish initialize more ARMI components to do more advanced tasks and interactive follow-on analysis.  Lucky for us, the database stores the settings that were used to run the case in the first place. We can get them like this:"
    ]
   },
   {

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -24,7 +24,7 @@ for all dependencies.
 
 A common source of concern is that the list of dependencies would be duplicated between
 ``setup.py`` and ``requirements.txt``. In our particular case, ARMI does not benefit
-from pointing to special package indices, and most version bounds are semanic. We
+from pointing to special package indices, and most version bounds are semantic. We
 therefore follow the recommendation in the above article of including in
 ``requirements.txt`` a simple ``-e .``. This tells pip to install ``armi`` itself,
 deferring to ``setup.py`` for a list of requiremed dependencies. Non-semantic version

--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -85,7 +85,7 @@ These files are:
   application.
 
 * :file:`README.md` and :file:`LICENSE.md` are an optional description and license of your
-  application that would be prominently featured, e.g. in a github repo, if you were to
+  application that would be prominently featured, e.g. in a GitHub repo, if you were to
   put it there.
 
 * :file:`doc/` is an optional folder where your application documentation source may go.

--- a/doc/tutorials/nuclide_demo.ipynb
+++ b/doc/tutorials/nuclide_demo.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Nuclides and ARMI\n",
-    "For starters, we will explore some features of ARMI related to nuclides (recall: a *nuclide* is some isotope of an element. Iron-56, Uranium-238, and Boron-10 are all nuclides). Everyone needs information about nuclides: atomic weights, natural isotopics, number of protons, etc. ARMI comes with some features that can help you in this respect. \n",
+    "For starters, we will explore some features of ARMI related to nuclides (recall: a *nuclide* is a particular isotope of an element. Iron-56, Uranium-238, and Boron-10 are all nuclides). Everyone needs information about nuclides: atomic weights, natural isotopics, number of protons, etc. ARMI comes with some features that can help you in this respect. \n",
     "\n",
     "Fire up a Python interpreter, either by running `$ python` or (preferred) `$ ipython`, and let's dive in by importing some modules from the `nucDirectory` package.\n",
     "\n",

--- a/doc/tutorials/walkthrough_lwr_inputs.rst
+++ b/doc/tutorials/walkthrough_lwr_inputs.rst
@@ -20,7 +20,7 @@ in `NEA/NSC/DOC(2003)16 <https://www.oecd-nea.org/science/docs/2003/nsc-doc2003-
     new developments. We are excited to expand ARMI scope fully
     into LWR relevant analysis.
 
-    In particular the handling of detailed locations within a block is
+    In particular, the handling of detailed locations within a block is
     relatively experimental (fast reactors usually just smear it out).
 
 Setting up the blueprints


### PR DESCRIPTION
While working through the tutorials and developer docs I found a few grammatical/spelling errors. They are all, obviously, unimportant and low-risk. On the hand, they were also easy to fix.

The Changes:

* **tooling.rst** - "semantic" was misspelled "semanic"
* **walkthrough_lwr_inputs.rst** - Grammatical error: missing comma
* **data_model.ipynb** - Some sentences in the list have periods, some didn't. I made them uniform.
* **making_your_first_app.rst** - "GitHub" is capitalized elsewhere but this one time in the documentation it is all lowercase.
* **nuclide_demo.ipynb** - This is my most ambiguous change. It was not grammatically wrong before. But I had to read the sentence like three times to figure out what it meant. I have provided a small change that makes it a lot more clear to *me*. Feel free to tell me "no".

I will happily alter this commit/PR if, for instance:

1. You would like to remove one or more of the changes.
2. This commit does not conform to your group's standards/practices. (I tried to look at past commits for examples.)