### PR TITLE
Add tests for lumpedFissionProducts.

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 jobs:
     check-formatting:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-python@v2
-            - uses: psf/black@stable
+            - uses: psf/black@20.8b1

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -259,10 +259,10 @@ class LumpedFissionProduct(object):
 
     def printDensities(self, lfpDens):
         """Print densities of nuclides given a LFP density. """
-        nucs = self.keys()
+        nucs = list(self.keys())
         nucs.sort()
         for n in nucs:
-            runLog.info("{0:6s} {1:.7E}".format(n, lfpDens * self[n]))
+            runLog.info("{0:6s} {1:.7E}".format(n.name, lfpDens * self[n]))
 
 
 class LumpedFissionProductCollection(dict):

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -147,7 +147,7 @@ class LumpedFissionProduct(object):
 
     def getMassFracs(self):
         """
-        Return a dictionary of mass fractions indexed by nuclide names.
+        Return a dictionary of mass fractions indexed by nuclide.
 
         Returns
         -------
@@ -162,18 +162,18 @@ class LumpedFissionProduct(object):
 
     def getNumberFracs(self):
         """
-        Return a dictionary of number fractions indexed by nuclide names.
+        Return a dictionary of number fractions indexed by nuclide.
 
         Returns
         -------
         numberFracs : dict
-            number fractions (floats) of fission products indexed by nuclide names (e.g. 'XE135')
+            number fractions (floats) of fission products indexed by nuclide.
         """
 
         numberFracs = {}
         totalNumber = sum(self.yld.values())
-        for nucName, yld in self.yld.items():
-            numberFracs[nucName] = yld / totalNumber
+        for nuc, yld in self.yld.items():
+            numberFracs[nuc] = yld / totalNumber
         return numberFracs
 
     def getMassFrac(

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -349,7 +349,7 @@ class LumpedFissionProductCollection(dict):
 
         for lfpName, lfp in self.items():
             lfpMFrac = oldMassFrac[lfpName]
-            for nuc, mFrac in lfp.getMassFracs():
+            for nuc, mFrac in lfp.getMassFracs().items():
                 try:
                     massFrac[nuc] += lfpMFrac * mFrac
                 except KeyError:

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -259,9 +259,7 @@ class LumpedFissionProduct(object):
 
     def printDensities(self, lfpDens):
         """Print densities of nuclides given a LFP density. """
-        nucs = list(self.keys())
-        nucs.sort()
-        for n in nucs:
+        for n in sorted(self.keys()):
             runLog.info("{0:6s} {1:.7E}".format(n.name, lfpDens * self[n]))
 
 

--- a/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
@@ -125,6 +125,18 @@ class TestLumpedFissionProductCollection(unittest.TestCase):
         self.assertIn("XE135", names)
         self.assertIn("KR85", names)
 
+    def test_getAllFissionProductNuclideBases(self):
+        """ Test to ensure the fission product nuclide bases are present """
+        clideBases = self.lfps.getAllFissionProductNuclideBases()
+        xe135 = nuclideBases.fromName("XE135")
+        kr85 = nuclideBases.fromName("KR85")
+        self.assertIn(xe135, clideBases)
+        self.assertIn(kr85, clideBases)
+
+    def test_getGasRemovedFrac(self):
+        val = self.lfps.getGasRemovedFrac()
+        self.assertEqual(val, 0.0)
+
     def test_duplicate(self):
         """ Test to ensure that when we duplicate, we don't adjust the original file """
         newLfps = self.lfps.duplicate()

--- a/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
@@ -86,12 +86,23 @@ class TestLumpedFissionProduct(unittest.TestCase):
         numberFracs = lfp.getNumberFracs()
         self.assertEqual(numberFracs.get(xe135), 1.0)
 
+    def test_getExpandedMass(self):
+        xe135 = nuclideBases.fromName("XE135")
+        lfp = self.fpd.createSingleLFPFromFile("LFP38")
+        massVector = lfp.getExpandedMass(mass=0.99)
+        self.assertEqual(massVector.get(xe135), 0.99)
+
     def test_getGasFraction(self):
         """ Test of the get gas removal fraction """
         lfp = self.fpd.createSingleLFPFromFile("LFP35")
         frac = lfp.getGasFraction()
         self.assertGreater(frac, 0.0)
         self.assertLess(frac, 1.0)
+
+    def test_printDensities(self):
+        xe135 = nuclideBases.fromName("XE135")
+        lfp = self.fpd.createSingleLFPFromFile("LFP38")
+        lfp.printDensities(10.0)
 
     def test_getLanthanideFraction(self):
         """ Test of the lanthanide fraction function """

--- a/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
@@ -80,6 +80,12 @@ class TestLumpedFissionProduct(unittest.TestCase):
         self.assertEqual(val3, 3)
         self.assertIsNone(lfp[5])
 
+    def test_getNumberFracs(self):
+        xe135 = nuclideBases.fromName("XE135")
+        lfp = self.fpd.createSingleLFPFromFile("LFP38")
+        numberFracs = lfp.getNumberFracs()
+        self.assertEqual(numberFracs.get(xe135), 1.0)
+
     def test_getGasFraction(self):
         """ Test of the get gas removal fraction """
         lfp = self.fpd.createSingleLFPFromFile("LFP35")


### PR DESCRIPTION
Improve the test coverage for lumped fission products. Fixed one bug in iterating through the directory returned by `LumpedFissionProductCollection.getMassFracs()`.

LumpedFissionProduct and LumpedFissionProductCollection have methods to create dictionaries of number fractions or mass fractions. The code creates these dictionaries with `nuclideBase` objects as keys, but in some places the key was used as if the code expects it to be a `str` type name. These commits change the usage of the dictionary to consistently handle these dictionary keys as `nuclideBase` objects.