### PR TITLE
Several documentation updates.

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -2,10 +2,11 @@ name: black
 
 on: [push, pull_request]
 
+# use workaround due to: https://github.com/psf/black/issues/2079#issuecomment-812359146
 jobs:
     check-formatting:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-python@v2
-            - uses: psf/black@stable
+            - uses: psf/black@20.8b1

--- a/armi/utils/dochelpers.py
+++ b/armi/utils/dochelpers.py
@@ -44,26 +44,28 @@ def create_table(rst_table, caption=None, align=None, widths=None, width=None):
 
     The ``rst_table``
     """
-    try:
-        rst = [".. table:: {}".format(caption or "")]
-        if align:
-            rst += ["    :align: {}".format(align)]
-        if width:
-            rst += ["    :width: {}".format(width)]
-        if widths:
-            rst += ["    :widths: {}".format(widths)]
-        rst += [""]
-        rst += ["    " + line for line in rst_table.split("\n")]
-        return "\n".join(rst)
-    except:
-        raise Exception("crap, crap crap!")
+    rst = [".. table:: {}".format(caption or "")]
+    if align:
+        rst += ["    :align: {}".format(align)]
+    if width:
+        rst += ["    :width: {}".format(width)]
+    if widths:
+        rst += ["    :widths: {}".format(widths)]
+    rst += [""]
+    rst += ["    " + line for line in rst_table.split("\n")]
+    return "\n".join(rst)
 
 
 class ExecDirective(Directive):
-    """Execute the specified python code and insert the output into the document.
+    """
+    Execute the specified python code and insert the output into the document.
 
     The code is used as the body of a method, and must return a ``str``. The string result is
     interpreted as reStructuredText.
+
+    Error handling informed by https://docutils.sourceforge.io/docs/howto/rst-directives.html#error-handling
+    The self.error function should both inform the documentation builder of the error and also
+    insert an error into the built documentation.
 
     .. warning:: This only works on a single node in the doctree, so the rendered code
         may not contain any new section names or labels. They will result in
@@ -84,7 +86,8 @@ class ExecDirective(Directive):
             result = locals()["usermethod"]()
 
             if result is None:
-                raise Exception(
+
+                raise self.error(
                     "Return value needed! The body of your `.. exec::` is used as a "
                     "function call that must return a value."
                 )
@@ -96,18 +99,11 @@ class ExecDirective(Directive):
             return [para]
         except Exception as e:
             docname = self.state.document.settings.env.docname
-            return [
-                nodes.error(
-                    None,
-                    nodes.paragraph(
-                        text="Unable to execute python code at {}:{} ... {}".format(
-                            docname, self.lineno, datetime.datetime.now()
-                        )
-                    ),
-                    nodes.paragraph(text=str(e)),
-                    nodes.literal_block(text=str(code)),
+            raise self.error(
+                "Unable to execute embedded doc code at {}:{} ... {}\n{}".format(
+                    docname, self.lineno, datetime.datetime.now(), str(e)
                 )
-            ]
+            )
 
 
 class PyReverse(Directive):
@@ -133,8 +129,6 @@ class PyReverse(Directive):
     }
 
     def run(self):
-        stdStreams = sys.stdout, sys.stderr
-        sys.stdout, sys.stderr = StringIO(), StringIO()
         try:
             args = list(self.arguments)
             args.append("--project")
@@ -188,21 +182,13 @@ class PyReverse(Directive):
             return [para]
         except Exception as e:
             docname = self.state.document.settings.env.docname
-            return [
-                nodes.error(
-                    None,
-                    nodes.paragraph(
-                        text="Unable to generate figure from {}:{} with command {} ... {}".format(
-                            docname, self.lineno, command, datetime.datetime.now()
-                        )
-                    ),
-                    nodes.paragraph(text=str(e)),
-                    nodes.literal_block(text=str(sys.stdout.getvalue())),
-                    nodes.literal_block(text=str(sys.stderr.getvalue())),
+            # add the error message directly to the built documentation and also tell the
+            # builder
+            raise self.error(
+                "Unable to execute embedded doc code at {}:{} ... {}\n{}".format(
+                    docname, self.lineno, datetime.datetime.now(), str(e)
                 )
-            ]
-        finally:
-            sys.stdout, sys.stderr = stdStreams
+            )
 
 
 def generateParamTable(klass, fwParams, app=None):

--- a/doc/user/inputs/settings.rst
+++ b/doc/user/inputs/settings.rst
@@ -19,7 +19,7 @@ This file is a YAML file that you can edit manually with a text editor or with t
 
 Here is an excerpt from a settings file:
 
-.. literalinclude:: ../../armi/tests/armiRun.yaml
+.. literalinclude:: ../../../armi/tests/armiRun.yaml
     :language: yaml
     :lines: 3-15
 

--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -13,12 +13,6 @@ You must have the following before proceeding:
 
 * `Python <https://www.python.org/downloads/>`_ version 3.6 or later (preferably 64-bit)
 
-  .. warning:: Python 3.9 was released in October 2020 and some of ARMI's
-      dependencies are non-trivial to build for it at the moment. Thus, the
-      installation process of ARMI will be easier if you have Python 3.6 -- Python
-      3.8 until the dependencies catch up.
-
-
   .. admonition:: The right Python command
 
      Python 2 and Python 3 often co-exist on the same system. Whether the

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,2 +1,6 @@
 numpy<1.19.4
+
+# docutils 0.17 introduced a bug that prevents bullets from rendering
+# see https://github.com/terrapower/armi/issues/274
+docutils <0.17
 -e .[memprof,dev]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,3 +1,4 @@
+--prefer-binary
 numpy<1.19.4
 
 # docutils 0.17 introduced a bug that prevents bullets from rendering

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # See the discussion in docs\developer\tooling
-
+--prefer-binary
 # see https://github.com/numpy/numpy/issues/17726
 # This is included in requirements.txt because it is not a semantic version
 # bound, but rather intended to avoid a bug in windows

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,14 @@ deps=
 setenv =
     PYTHONPATH = {toxinidir}
 commands =
-    pytest --prefer-binary --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
+    pytest --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
 
 [testenv:cov]
 deps=
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-testing.txt
 commands =
-    pytest --cov-config=.coveragerc --prefer-binary --cov=armi --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
+    pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
 
 [testenv:lint]
 ignore_errors = true

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,14 @@ deps=
 setenv =
     PYTHONPATH = {toxinidir}
 commands =
-    pytest --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
+    pytest --prefer-binary --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
 
 [testenv:cov]
 deps=
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-testing.txt
 commands =
-    pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
+    pytest --cov-config=.coveragerc --prefer-binary --cov=armi --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
 
 [testenv:lint]
 ignore_errors = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist = py36,py37,lint,cov
-
+# need pip at least with --prefer-binary
+requires = 
+	pip >= 20.2
+	
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}
 deps=


### PR DESCRIPTION
* Removed warning about Python 3.9 since the installation is fairly
  smooth by now (except wxpython on linux is still a pain, but that's an
  extra).

* Improved error handling for pylint errors, preferring to inform the
  person building the docs of errors more than the person reading them.

* Fixed a broken link to a settings snippet

* Pinned docutils at <0.17 to avoid bug