### PR TITLE
Fix outdated gallery example.

### DIFF
--- a/doc/gallery-src/framework/run_computeReactionRates.py
+++ b/doc/gallery-src/framework/run_computeReactionRates.py
@@ -65,7 +65,7 @@ def createDummyReactor():
     r = reactors.Reactor("Reactor", bp)
     r.add(reactors.Core("Core"))
     r.core.spatialGrid = grids.HexGrid.fromPitch(1.0)
-    r.core.spatialGrid.symmetry = geometry.THIRD_CORE + geometry.PERIODIC
+    r.core.spatialGrid.symmetry = " ".join([geometry.THIRD_CORE, geometry.PERIODIC])
     r.core.spatialGrid.geomType = geometry.HEX
     r.core.spatialGrid.armiObject = r.core
     r.core.setOptionsFromCs(cs)


### PR DESCRIPTION
The old code was invalidated by the recent change in enumerations so
this was failing when it was run. Just adding a space fixes it.