### PR TITLE
Fix some clashes between new and old symmetry.

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -474,8 +474,8 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
         """
         return (
             "FD" in self.options.kernelName
-            and self.options.symmetry.domain == geometry.THIRD_CORE
-            and self.options.symmetry.boundary == geometry.PERIODIC
+            and self.options.symmetry.domain == geometry.DomainType.THIRD_CORE
+            and self.options.symmetry.boundary == geometry.BoundaryType.PERIODIC
             and self.options.geomType == geometry.GeomType.HEX
         )
 

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -474,7 +474,8 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
         """
         return (
             "FD" in self.options.kernelName
-            and self.options.symmetry == geometry.THIRD_CORE + geometry.PERIODIC
+            and self.options.symmetry.domain == geometry.THIRD_CORE
+            and self.options.symmetry.boundary == geometry.PERIODIC
             and self.options.geomType == geometry.GeomType.HEX
         )
 

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -197,8 +197,10 @@ class GridBlueprint(yamlize.Object):
         name=None,
         geom=geometry.HEX,
         latticeMap=None,
-        symmetry=geometry.SymmetryType(
-            geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC
+        symmetry=str(
+            geometry.SymmetryType(
+                geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC
+            )
         ),
         gridContents=None,
         gridBounds=None,

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -358,8 +358,9 @@ class SymmetryType:
     @classmethod
     def fromStr(cls, symmetryString: str) -> "SymmetryType":
         """Construct a SymmetryType object from a valid string"""
-        isThroughCenter = cls._checkIfThroughCenter(symmetryString)
-        coreString = symmetryString.replace(THROUGH_CENTER_ASSEMBLY, "").strip()
+        canonical = symmetryString.lower().strip()
+        isThroughCenter = cls._checkIfThroughCenter(canonical)
+        coreString = canonical.replace(THROUGH_CENTER_ASSEMBLY, "").strip()
         trimmedString = coreString.replace("core", "").strip()
         pieces = trimmedString.split()
         domain = DomainType.fromStr(pieces[0])

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -1767,31 +1767,33 @@ class NewGridBlueprintDialog(wx.Dialog):
         geom = self._geomFromIdx[self.geomType.GetSelection()]
 
         if self.domainFull.GetValue():
-            domain = geometry.FULL_CORE
+            domain = geometry.DomainType.FULL_CORE
         elif self.domain3.GetValue():
-            domain = geometry.THIRD_CORE
+            domain = geometry.DomainType.THIRD_CORE
         elif self.domain4.GetValue():
-            domain = geometry.QUARTER_CORE
+            domain = geometry.DomainType.QUARTER_CORE
         else:
             raise ValueError("Couldn't map selection to supported fractional domain")
 
         if self.periodic.GetValue():
-            bc = geometry.PERIODIC
+            bc = geometry.BoundaryType.PERIODIC
         elif self.reflective.GetValue():
-            bc = geometry.REFLECTIVE
+            bc = geometry.BoundaryType.REFLECTIVE
         else:
-            bc = ""
+            bc = geometry.BoundaryType.NO_SYMMETRY
 
         if self.throughCenter.GetValue():
             through = geometry.THROUGH_CENTER_ASSEMBLY
         else:
             through = ""
 
-        symmetry = domain + bc + through
+        symmetry = geometry.SymmetryType.fromStr(
+            domain, bc, self.throughCenter.GetValue()
+        )
 
-        assert symmetry in geometry.VALID_SYMMETRY, symmetry
+        assert symmetry.checkValidSymmetry()
 
-        bp = GridBlueprint(name=name, geom=str(geom), symmetry=symmetry)
+        bp = GridBlueprint(name=name, geom=str(geom), symmetry=str(symmetry))
 
         return bp
 

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -1787,9 +1787,7 @@ class NewGridBlueprintDialog(wx.Dialog):
         else:
             through = ""
 
-        symmetry = geometry.SymmetryType.fromStr(
-            domain, bc, self.throughCenter.GetValue()
-        )
+        symmetry = geometry.SymmetryType(domain, bc, self.throughCenter.GetValue())
 
         assert symmetry.checkValidSymmetry()
 

--- a/doc/gallery-src/framework/run_computeReactionRates.py
+++ b/doc/gallery-src/framework/run_computeReactionRates.py
@@ -65,8 +65,10 @@ def createDummyReactor():
     r = reactors.Reactor("Reactor", bp)
     r.add(reactors.Core("Core"))
     r.core.spatialGrid = grids.HexGrid.fromPitch(1.0)
-    r.core.spatialGrid.symmetry = " ".join([geometry.THIRD_CORE, geometry.PERIODIC])
-    r.core.spatialGrid.geomType = geometry.HEX
+    r.core.spatialGrid.symmetry = geometry.SymmetryType(
+        geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC
+    )
+    r.core.spatialGrid.geomType = geometry.GeomType.HEX
     r.core.spatialGrid.armiObject = r.core
     r.core.setOptionsFromCs(cs)
 


### PR DESCRIPTION
#276 updated the representation of symmetry from plain strings to an enumeration. The intent was that the new SymmetryType class could handle string or enumeration representations seamlessly to minimize breakage of old code that used the string representations.

While the strings still worked with little to no modification in most places, some pieces of code with the older format flew under the radar because the problems weren't caught by the unit tests. Also, the `.lower()` was misplaced in the `fromStr()` constructor for `SymmetryType` in a way that would break case insensitivity.
