### PR TITLE
Blueprint migration bug fix.

### DIFF
--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -554,7 +554,7 @@ def migrate(bp: Blueprints, cs):
         )
     bp.systemDesigns["core"] = SystemBlueprint("core", "core", Triplet())
 
-    if geom.geomType in (geometry.RZT, geometry.RZ):
+    if geom.geomType in (geometry.GeomType.RZT, geometry.GeomType.RZ):
         aziMeshes = {indices[4] for indices, _ in geom.assemTypeByIndices.items()}
         radMeshes = {indices[5] for indices, _ in geom.assemTypeByIndices.items()}
 

--- a/armi/reactor/tests/test_rz_reactors.py
+++ b/armi/reactor/tests/test_rz_reactors.py
@@ -35,7 +35,9 @@ class Test_RZT_Reactor(unittest.TestCase):
     def test_loadRZT(self):
         self.assertEqual(len(self.r.core), 14)
         radMeshes = [a.p.RadMesh for a in self.r.core]
-        self.assertTrue(all(radMesh == 4 for radMesh in radMeshes))
+        aziMeshes = [a.p.AziMesh for a in self.r.core]
+        self.assertTrue(all(radMesh == 6 for radMesh in radMeshes))
+        self.assertTrue(all(aziMesh == 8 for aziMesh in aziMeshes))
 
     def test_findAllMeshPoints(self):
         i, j, k = self.r.core.findAllMeshPoints()

--- a/armi/tests/ThRZGeom.xml
+++ b/armi/tests/ThRZGeom.xml
@@ -2,18 +2,18 @@
 <!--
 -->
 <reactor geom="ThetaRZ" symmetry="full core">
-	<assembly azimuthalMesh="4" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="4" theta1="0.0" theta2="0.11556368446681414" />
-	<assembly azimuthalMesh="4" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="4" theta1="0.11556368446681414" theta2="0.23112736893432645" />
-	<assembly azimuthalMesh="4" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="4" theta1="0.23112736893432645" theta2="0.34669105340061696" />
-	<assembly azimuthalMesh="4" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="4" theta1="0.34669105340061696" theta2="0.43870710999683127" />
-	<assembly azimuthalMesh="4" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="4" theta1="0.43870710999683127" theta2="0.5542707944631219" />
-	<assembly azimuthalMesh="4" name="MC" rad1="0.0" rad2="14.2857142857" radialMesh="4" theta1="0.5542707944631219" theta2="0.6698344789311578" />
-	<assembly azimuthalMesh="4" name="MC" rad1="0.0" rad2="14.2857142857" radialMesh="4" theta1="0.6698344789311578" theta2="0.7853981633974483" />
-	<assembly azimuthalMesh="4" name="MC" rad1="14.2857142857" rad2="28.5714285714" radialMesh="4" theta1="0.0" theta2="0.11556368446681414" />
-	<assembly azimuthalMesh="4" name="MC" rad1="14.2857142857" rad2="28.5714285714" radialMesh="4" theta1="0.11556368446681414" theta2="0.23112736893432645" />
-	<assembly azimuthalMesh="4" name="MC" rad1="14.2857142857" rad2="28.5714285714" radialMesh="4" theta1="0.23112736893432645" theta2="0.34669105340061696" />
-	<assembly azimuthalMesh="4" name="RR" rad1="14.2857142857" rad2="28.5714285714" radialMesh="4" theta1="0.34669105340061696" theta2="0.43870710999683127" />
-	<assembly azimuthalMesh="4" name="RR" rad1="14.2857142857" rad2="28.5714285714" radialMesh="4" theta1="0.43870710999683127" theta2="0.5542707944631219" />
-	<assembly azimuthalMesh="4" name="RR" rad1="14.2857142857" rad2="28.5714285714" radialMesh="4" theta1="0.5542707944631219" theta2="0.6698344789311578" />
-	<assembly azimuthalMesh="4" name="RR" rad1="14.2857142857" rad2="28.5714285714" radialMesh="4" theta1="0.6698344789311578" theta2="0.7853981633974483" />
+	<assembly azimuthalMesh="8" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="6" theta1="0.0" theta2="0.11556368446681414" />
+	<assembly azimuthalMesh="8" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="6" theta1="0.11556368446681414" theta2="0.23112736893432645" />
+	<assembly azimuthalMesh="8" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="6" theta1="0.23112736893432645" theta2="0.34669105340061696" />
+	<assembly azimuthalMesh="8" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="6" theta1="0.34669105340061696" theta2="0.43870710999683127" />
+	<assembly azimuthalMesh="8" name="IC" rad1="0.0" rad2="14.2857142857" radialMesh="6" theta1="0.43870710999683127" theta2="0.5542707944631219" />
+	<assembly azimuthalMesh="8" name="MC" rad1="0.0" rad2="14.2857142857" radialMesh="6" theta1="0.5542707944631219" theta2="0.6698344789311578" />
+	<assembly azimuthalMesh="8" name="MC" rad1="0.0" rad2="14.2857142857" radialMesh="6" theta1="0.6698344789311578" theta2="0.7853981633974483" />
+	<assembly azimuthalMesh="8" name="MC" rad1="14.2857142857" rad2="28.5714285714" radialMesh="6" theta1="0.0" theta2="0.11556368446681414" />
+	<assembly azimuthalMesh="8" name="MC" rad1="14.2857142857" rad2="28.5714285714" radialMesh="6" theta1="0.11556368446681414" theta2="0.23112736893432645" />
+	<assembly azimuthalMesh="8" name="MC" rad1="14.2857142857" rad2="28.5714285714" radialMesh="6" theta1="0.23112736893432645" theta2="0.34669105340061696" />
+	<assembly azimuthalMesh="8" name="RR" rad1="14.2857142857" rad2="28.5714285714" radialMesh="6" theta1="0.34669105340061696" theta2="0.43870710999683127" />
+	<assembly azimuthalMesh="8" name="RR" rad1="14.2857142857" rad2="28.5714285714" radialMesh="6" theta1="0.43870710999683127" theta2="0.5542707944631219" />
+	<assembly azimuthalMesh="8" name="RR" rad1="14.2857142857" rad2="28.5714285714" radialMesh="6" theta1="0.5542707944631219" theta2="0.6698344789311578" />
+	<assembly azimuthalMesh="8" name="RR" rad1="14.2857142857" rad2="28.5714285714" radialMesh="6" theta1="0.6698344789311578" theta2="0.7853981633974483" />
 </reactor>


### PR DESCRIPTION
Use GeomType enumeration instead of string.

This was missed in #276 and #278 because the unit test that covers this if statement will pass regardless of how the if statement evaluates. It's covered by `test_rz_reactors.py`.

I changed the azimuthal and radial mesh in `ThRzGeom.yaml`, so that `test_rz_reactors.py` will only pass if this bug in `migrate()` is fixed.