### PR TITLE
Adding forensic information to the Database metadata

### DIFF
--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+r""" Tests for the Database3 class
+"""
+
 import unittest
 
 import numpy
@@ -20,12 +23,16 @@ import h5py
 from armi.bookkeeping.db import database3
 from armi.reactor import grids
 from armi.reactor.tests import test_reactors
-
 from armi.tests import TEST_ROOT
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestDatabase3(unittest.TestCase):
+    r""" Tests for the Database3 class """
+
     def setUp(self):
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
         self.o, self.r = test_reactors.loadTestReactor(TEST_ROOT)
         cs = self.o.cs
 
@@ -41,6 +48,7 @@ class TestDatabase3(unittest.TestCase):
     def tearDown(self):
         self.db.close()
         self.stateRetainer.__exit__()
+        self.td.__exit__(None, None, None)
 
     def makeHistory(self):
         """
@@ -251,6 +259,7 @@ class TestDatabase3(unittest.TestCase):
         self._compareRoundTrip(dataDict)
 
     def test_mergeHistory(self):
+        # pylint: disable=protected-access
         self.makeHistory()
 
         # put some big data in an HDF5 attribute. This will exercise the code that pulls
@@ -267,7 +276,8 @@ class TestDatabase3(unittest.TestCase):
             },
         )
 
-        db2 = database3.Database3("restartDB.h5", "w")
+        db_path = "restartDB.h5"
+        db2 = database3.Database3(db_path, "w")
         with db2:
             db2.mergeHistory(self.db, 2, 2)
             self.r.p.cycle = 1
@@ -300,8 +310,33 @@ class TestDatabase3(unittest.TestCase):
             self.assertTrue("c02n00" not in newDb)
             self.assertTrue(newDb.attrs["databaseVersion"] == database3.DB_VERSION)
 
+            # validate that the min set of meta data keys exists
+            meta_data_keys = [
+                "appName",
+                "armiLocation",
+                "databaseVersion",
+                "hostname",
+                "localCommitHash",
+                "machines",
+                "platform",
+                "platformArch",
+                "platformRelease",
+                "platformVersion",
+                "pluginPaths",
+                "python",
+                "startTime",
+                "successfulCompletion",
+                "user",
+                "version",
+            ]
+            for meta_key in meta_data_keys:
+                self.assertIn(meta_key, newDb.attrs)
+                self.assertTrue(newDb.attrs[meta_key] is not None)
+
 
 class Test_LocationPacking(unittest.TestCase):
+    r"""Tests for database location"""
+
     def test_locationPacking(self):
         # pylint: disable=protected-access
         loc1 = grids.IndexLocation(1, 2, 3, None)
@@ -325,7 +360,5 @@ class Test_LocationPacking(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-
-    # sys.argv = ["", "TestDatabase3.test_splitDatabase"]
+    # import sys;sys.argv = ["", "TestDatabase3.test_splitDatabase"]
     unittest.main()

--- a/armi/nuclearDataIO/tests/.gitignore
+++ b/armi/nuclearDataIO/tests/.gitignore
@@ -6,3 +6,4 @@
 *.sum
 *.flux_ufg
 *.flux_bg
+*.nucdata

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -24,9 +24,17 @@ from armi.reactor.flags import Flags
 from armi.reactor.tests.test_blocks import loadTestBlock
 from armi.reactor.tests.test_reactors import loadTestReactor, TEST_ROOT
 from armi.utils import hexagon
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestBlockConverter(unittest.TestCase):
+    def setUp(self):
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
+
+    def tearDown(self):
+        self.td.__exit__(None, None, None)
+
     def test_dissolveWireIntoCoolant(self):
         self._test_dissolve(loadTestBlock(), "wire", "coolant")
         hotBlock = loadTestBlock(cold=False)
@@ -149,8 +157,9 @@ class TestBlockConverter(unittest.TestCase):
             convertedBlock = converter.convert()
             self.assertAlmostEqual(area * numBlocks, convertedBlock.getArea())
             self._checkCiclesAreInContact(convertedBlock)
-            converter.plotConvertedBlock(fName="convertedBlock.svg")
-            os.remove("convertedBlock.svg")
+            plotFile = "convertedBlock_{0}.svg".format(externalRings)
+            converter.plotConvertedBlock(fName=plotFile)
+            os.remove(plotFile)
 
             for c in list(reversed(convertedBlock))[:externalRings]:
                 self.assertTrue(c.isFuel(), "c was {}".format(c.name))


### PR DESCRIPTION
This PR is in reference to issue #191.

**Changes:**

1. The important changes are in database3.py.  I added three new blocks of metadata: platform info, plugin info, and Git commit.
2. Unit tests. Also, while running the `Database3` tests I noticed H5 files were being created in the top directory, but not cleaned.
3. `.gitignore`. While running the project unit tests I found many `*.nucdata` files were being created in tests folders.

**Discussion:**

In the #191 PR page we discussed several possibilities. The one I did not implement here was changing the version string to include the commit hash as @drewejohnson suggested (to something like `0.1.6-41-g3e7ac5a`). That is a nice idea, but I felt it would be over-stepping for me to change how the entire project is versioned.