### PR TITLE
Fix encoding of images in HTML reports

### DIFF
--- a/armi/bookkeeping/report/html.py
+++ b/armi/bookkeeping/report/html.py
@@ -191,7 +191,9 @@ def encode64(file_path):
             file_path
         )
     with open(file_path, "rb") as img_src:
-        return r"data:image/{};base64,{}".format(xtn, base64.b64encode(img_src.read()))
+        return r"data:image/{};base64,{}".format(
+            xtn, base64.b64encode(img_src.read()).decode()
+        )
 
 
 # ---------------------------


### PR DESCRIPTION
After an ARMI run, none of the images in the `reports/*html` are
valid. Looking at the leading string in some of the reports, I see
`data:image/jpg;base64,b'/9j/4...`. When I pipe the output of the
image through `base64` and paste that into a browser after
`data:image/jpg;base64`, I see `data:image/jpg;base64,/9j/4A...` and
the image is displayed.

This decodes the binary string after `base64` encoding to remove the
leading `b'` in the string representation.