### PR TITLE
Addressing PyLint Concerns

### DIFF
--- a/armi/_bootstrap.py
+++ b/armi/_bootstrap.py
@@ -17,9 +17,7 @@ Collection of code that needs to be executed before most ARMI components are saf
 import.
 """
 
-import os
 import sys
-
 import tabulate
 
 # This needs to happen pretty darn early, as one of it's purposes is to provide a better

--- a/armi/bookkeeping/db/factory.py
+++ b/armi/bookkeeping/db/factory.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import pathlib
 from typing import Optional
 

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -325,7 +325,5 @@ class Test_LocationPacking(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-
-    # sys.argv = ["", "TestDatabase3.test_splitDatabase"]
+    # import sys;sys.argv = ["", "TestDatabase3.test_splitDatabase"]
     unittest.main()

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -784,7 +784,8 @@ class HistoryProcessor(object):
     Original use: computing ranges of operation for testing program
     """
 
-    def findHistoryFiles(self, path=None, title=None):
+    @staticmethod
+    def findHistoryFiles(path=None, title=None):
         r"""
         Finds a list of all history files in a directory
 
@@ -980,7 +981,8 @@ class HistoryProcessor(object):
 
         return validHistories, dataSets
 
-    def plotBounds(self, filteredSets, filteredBounds, assemTypes):
+    @staticmethod
+    def plotBounds(filteredSets, filteredBounds, assemTypes):
         """
         Plots an incredibly useful figure showing which assemblies have which PICT through the lifetime
 
@@ -1100,7 +1102,8 @@ class HistoryProcessor(object):
             print(aType)
             self.printBoundingHistories(aType, params, minMax)
 
-    def printBoundingHistories(self, aType, params, minMax):
+    @staticmethod
+    def printBoundingHistories(aType, params, minMax):
         r"""
         Prints a summary of bounding parameter values for all detail assemblies.
 
@@ -1109,7 +1112,6 @@ class HistoryProcessor(object):
         minMax : dict
             Keys are tracked keys, vals are (value, assembly, timestep) tuples for min and max.
         """
-
         print("Detail History Statistical Summary")
         print(
             "{key:40s} {minV:11s} {maxV:11s}"

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -267,7 +267,8 @@ class MemoryProfiler(interfaces.Interface):
         if reportSize:
             operator.reattach(reactor, cs)
 
-    def _getSpecificReferrers(self, klass, ancestorKlass):
+    @staticmethod
+    def _getSpecificReferrers(klass, ancestorKlass):
         """Try to determine some useful information about the structure of ArmiObjects and potential
         orphans.
 
@@ -328,7 +329,8 @@ class MemoryProfiler(interfaces.Interface):
         for item in info:
             runLog.important("{}".format(item))
 
-    def _getReferrers(self, obj):
+    @staticmethod
+    def _getReferrers(obj):
         """
         Print referrers in a useful way (as opposed to gigabytes of text
         """
@@ -336,7 +338,8 @@ class MemoryProfiler(interfaces.Interface):
         for ref in gc.get_referrers(obj)[:100]:
             print("ref for {}: {}".format(obj, repr(ref)[:100]))
 
-    def _discussSkipped(self, skipped, errors):
+    @staticmethod
+    def _discussSkipped(skipped, errors):
         runLog.warning("Skipped {} objects".format(skipped))
         runLog.warning(
             "errored out on {0} objects:\n {1}".format(

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -18,7 +18,6 @@ to show in PDF form to others this is the place to do it.
 """
 import re
 
-import armi
 from armi import runLog
 from armi import interfaces
 from armi.utils import directoryChangers

--- a/armi/bookkeeping/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/tests/test_databaseInterface.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+r""" Tests of the Database Interface 
+"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import os
 import unittest

--- a/armi/bookkeeping/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/tests/test_databaseInterface.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import os
 import unittest
 import types
@@ -394,7 +393,5 @@ class TestStandardFollowOn(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-
-    # sys.argv = ["", "TestStandardFollowOn.test_standardRestart"]
+    # import sys;sys.argv = ["", "TestStandardFollowOn.test_standardRestart"]
     unittest.main()

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -231,7 +231,5 @@ class TestHistoryTrackerNoModel(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-
-    # sys.argv = ["", "TestHistoryTracker.testHistoryReport"]
+    # import sys;sys.argv = ["", "TestHistoryTracker.testHistoryReport"]
     unittest.main()

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -16,7 +16,6 @@
 Tests for memoryProfiler
 """
 import unittest
-import math
 
 from armi.bookkeeping import memoryProfiler
 from armi.reactor.tests import test_reactors

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -15,6 +15,7 @@
 """
 Tests for memoryProfiler
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import unittest
 
 from armi.bookkeeping import memoryProfiler

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -34,8 +34,6 @@ import time
 import textwrap
 import ast
 from typing import Dict, Optional, Sequence
-import glob
-
 import tabulate
 import six
 import coverage

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -282,7 +282,8 @@ class CaseSuite:
         for case in self:
             case.writeInputs(sourceDir=self.cs.inputDirectory)
 
-    def writeTable(self, tableResults):
+    @staticmethod
+    def writeTable(tableResults):
         """Write a table summarizing the test differences."""
         fmt = "psql"
         print(

--- a/armi/cli/checkInputs.py
+++ b/armi/cli/checkInputs.py
@@ -19,7 +19,6 @@ Entry point into ARMI to check inputs of a case or a whole folder of cases.
 import sys
 import traceback
 
-import armi
 from armi import runLog
 from armi.cli.entryPoint import EntryPoint
 

--- a/armi/cli/clone.py
+++ b/armi/cli/clone.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import os
-import glob
 
-import armi
 from armi.cli.entryPoint import EntryPoint
 
 

--- a/armi/cli/compareCases.py
+++ b/armi/cli/compareCases.py
@@ -15,7 +15,6 @@
 import os
 import sys
 
-import armi
 from armi import runLog
 from armi.cli.entryPoint import EntryPoint
 

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -18,7 +18,6 @@ See :doc:`/developer/entrypoints`.
 # limitations under the License.
 
 import argparse
-import textwrap
 from typing import Optional, Union
 
 import six

--- a/armi/cli/migrateInputs.py
+++ b/armi/cli/migrateInputs.py
@@ -53,7 +53,8 @@ class MigrateInputs(EntryPoint):
         else:
             self._migrate(self.args.settings_path, self.args.database_path)
 
-    def _migrate(self, settingsPath, dbPath):
+    @staticmethod
+    def _migrate(settingsPath, dbPath):
         """
         Run all migrations.
 

--- a/armi/cli/modify.py
+++ b/armi/cli/modify.py
@@ -17,7 +17,6 @@ Search through a directory tree and modify ARMI settings in existing input
 file(s). All valid settings may be used as keyword arguments.
 """
 
-import armi
 from armi import operators
 from armi import runLog
 from armi import settings

--- a/armi/cli/run.py
+++ b/armi/cli/run.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Run an ARMI case."""
-import armi
 from armi.cli.entryPoint import EntryPoint
 
 

--- a/armi/cli/runSuite.py
+++ b/armi/cli/runSuite.py
@@ -15,8 +15,6 @@
 """Run multiple ARMI cases one after the other on the local machine."""
 import os
 
-import tabulate
-
 from armi.cli.run import RunEntryPoint
 from armi import cases
 from armi.utils import directoryChangers

--- a/armi/localization/tests/test_localization.py
+++ b/armi/localization/tests/test_localization.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
-
-
+r"""Basic tests of the localization functionality
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import unittest
 
 import six

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -126,7 +126,8 @@ class B4C(material.Material):
             DEFAULT_THEORETICAL_DENSITY_FRAC  # normally is around 0.88-93.
         )
 
-    def getMassEnrichmentFromNumEnrich(self, naturalB10NumberFraction):
+    @staticmethod
+    def getMassEnrichmentFromNumEnrich(naturalB10NumberFraction):
         b10AtomicMass = nuclideBases.byName["B10"].weight
         b11AtomicMass = nuclideBases.byName["B11"].weight
         return (

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 r"""Tests materials.py"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import unittest
 import pickle

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -230,7 +230,8 @@ class MpiAction(object):
         self.cs = cs
         return self.invokeHook()
 
-    def mpiFlatten(self, allCPUResults):
+    @staticmethod
+    def mpiFlatten(allCPUResults):
         """
         Flatten results to the same order they were in before making a list of mpiIter results.
 
@@ -240,7 +241,8 @@ class MpiAction(object):
         """
         return iterables.flatten(allCPUResults)
 
-    def mpiIter(self, objectsForAllCoresToIter):
+    @staticmethod
+    def mpiIter(objectsForAllCoresToIter):
         """
         Generate the subset of objects one node is responsible for in MPI.
 

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -97,7 +97,6 @@ U235_7
 
 import os
 import pathlib
-import zlib
 
 import yaml
 

--- a/armi/nuclearDataIO/__init__.py
+++ b/armi/nuclearDataIO/__init__.py
@@ -290,7 +290,8 @@ class VARSRC(NHFLUX):
     def _getNumberOfOddParityTerms(self, pnOrder):
         return self._getNumberOfEvenParityTerms(pnOrder) + pnOrder + 1
 
-    def _getNumberOfEvenParityTerms(self, pnOrder):
+    @staticmethod
+    def _getNumberOfEvenParityTerms(pnOrder):
         return pnOrder * (pnOrder + 1) / 2
 
 

--- a/armi/nuclearDataIO/tests/.gitignore
+++ b/armi/nuclearDataIO/tests/.gitignore
@@ -6,3 +6,4 @@
 *.sum
 *.flux_ufg
 *.flux_bg
+*.nucdata

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 r"""
-
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import unittest
 
 from armi.nuclearDataIO import xsNuclides

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -16,7 +16,6 @@ r"""
 
 """
 import unittest
-import types
 
 from armi.nuclearDataIO import xsNuclides
 from armi.nucDirectory import nuclideBases

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -110,7 +110,8 @@ class Operator:  # pylint: disable=too-many-public-methods
 
         self._initFastPath()
 
-    def _initFastPath(self):
+    @staticmethod
+    def _initFastPath():
         """
         Create the FAST_PATH directory for fast local operations
 

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -26,7 +26,9 @@ from armi.operators import OperatorMPI
 from armi.tests import ARMI_RUN_PATH
 
 
-class FailingInterface1(armi.interfaces.Interface):
+class FailingInterface1(
+    armi.interfaces.Interface
+):  # pylint: disable=abstract-method,no-self-use,unused-argument
     """utility classes to make sure the logging system fails properly"""
 
     name = "failer"
@@ -35,14 +37,20 @@ class FailingInterface1(armi.interfaces.Interface):
         raise RuntimeError("Failing interface failure")
 
 
-class FailingInterface2(armi.interfaces.Interface):
+class FailingInterface2(
+    armi.interfaces.Interface
+):  # pylint: disable=abstract-method,no-self-use,unused-argument
+    """utility class to make sure the logging system fails properly"""
+
     name = "failer"
 
     def interactEveryNode(self, cycle, node):
         raise RuntimeError("Failing interface critical failure")
 
 
-class FailingInterface3(armi.interfaces.Interface):
+class FailingInterface3(
+    armi.interfaces.Interface
+):  # pylint: disable=abstract-method,no-self-use,unused-argument
     """fails on worker operate"""
 
     name = "failer"
@@ -50,7 +58,7 @@ class FailingInterface3(armi.interfaces.Interface):
     def fail(self):
         raise RuntimeError("Failing interface critical worker failure")
 
-    def interactEveryNode(self, c, n):
+    def interactEveryNode(self, c, n):  # pylint:disable=unused-argument
         armi.MPI_COMM.bcast("fail", root=0)
 
     def workerOperate(self, cmd):
@@ -60,27 +68,33 @@ class FailingInterface3(armi.interfaces.Interface):
         return False
 
 
-class OperatorTests(unittest.TestCase):
+class OperatorTests(
+    unittest.TestCase
+):  # pylint: disable=abstract-method,no-self-use,unused-argument
+    """Testing the MPI parallelization operation"""
+
     # @unittest.skipIf(distutils.spawn.find_executable('mpiexec.exe') is None, "mpiexec is not in path.")
     @unittest.skip("MPI tests are not working")
-    def testMpiOperator(self):
+    def testMpiOperator(self):  # pylint: disable=abstract-method,no-self-use
         """
         Calls a subprocess to spawn new tests.
 
         The subprocess is redirected to dev/null (windows <any-dir>\\NUL), to prevent excessive
         output. In order to debug, this test you will likely need to modify this code.
         """
-        args = ["mpiexec", "-n", "2", "python", "-m", "unittest"]
-        args += ["armi.tests.test_operators.MpiOperatorTests"]
+        cmds = ["mpiexec", "-n", "2", "python", "-m", "unittest"]
+        cmds += ["armi.tests.test_operators.MpiOperatorTests"]
         with open(os.devnull, "w") as null:
             # check_call needed because call will just keep going in the event
             # of failures.
-            subprocess.check_call(args, stdout=null, stderr=subprocess.STDOUT)
+            subprocess.check_call(cmds, stdout=null, stderr=subprocess.STDOUT)
 
 
 if armi.MPI_SIZE > 1:
 
     class MpiOperatorTests(unittest.TestCase):
+        """Testing the MPI parallelization operation"""
+
         def setUp(self):
             self.cs = settings.Settings(fName=ARMI_RUN_PATH)
             settings.setMasterCs(self.cs)

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -498,7 +498,8 @@ class FuelHandler:
 
         runLog.info("Rotated {0} assemblies".format(numRotated))
 
-    def getOptimalAssemblyOrientation(self, a, aPrev):
+    @staticmethod
+    def getOptimalAssemblyOrientation(a, aPrev):
         """
         Get optimal assembly orientation/rotation to minimize peak burnup.
 
@@ -1545,7 +1546,8 @@ class FuelHandler:
 
         return moved
 
-    def readMoves(self, fname):
+    @staticmethod
+    def readMoves(fname):
         r"""
         reads a shuffle output file and sets up the moves dictionary
 

--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -16,7 +16,7 @@
 The data structures and schema of the cross section modeling options.
 
 These are advanced/compound settings that are carried along in the normal cs
-object but aren't simple key/value pairs. 
+object but aren't simple key/value pairs.
 
 The cs object could either hold the base data (dicts) and create instances
 of these data structure objects as needed, or the settings system could actually

--- a/armi/physics/neutronics/diffIsotxs.py
+++ b/armi/physics/neutronics/diffIsotxs.py
@@ -15,7 +15,6 @@
 """
 This script is used to compare ISOTXS files.
 """
-import armi
 from armi import runLog
 from armi.cli.entryPoint import EntryPoint
 

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -16,13 +16,11 @@
 The Global flux interface provide a base class for all neutronics tools that compute the neutron and/or photon flux.
 """
 import math
-import os
 from typing import Dict, Optional
 
 import numpy
 import scipy.integrate
 
-import armi
 from armi import runLog
 from armi import interfaces
 from armi.utils import units

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -19,7 +19,6 @@ import math
 import os
 from typing import Dict, Optional
 
-
 import numpy
 import scipy.integrate
 
@@ -225,7 +224,8 @@ class GlobalFluxInterfaceUsingExecuters(GlobalFluxInterface):
 
         GlobalFluxInterface.interactCoupled(self, iteration)
 
-    def getOptionsCls(self):
+    @staticmethod
+    def getOptionsCls():
         """
         Get a blank options object.
 
@@ -233,7 +233,8 @@ class GlobalFluxInterfaceUsingExecuters(GlobalFluxInterface):
         """
         return GlobalFluxOptions
 
-    def getExecuterCls(self):
+    @staticmethod
+    def getExecuterCls():
         return GlobalFluxExecuter
 
     def getExecuterOptions(self, label=None):

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -152,7 +152,8 @@ class LatticePhysicsInterface(interfaces.Interface):
     def makeCycleXSFilesAsBaseFiles(self, cycle):
         raise NotImplementedError
 
-    def _copyLibraryFilesForCycle(self, cycle, libFiles):
+    @staticmethod
+    def _copyLibraryFilesForCycle(cycle, libFiles):
         runLog.extra("Current library files: {}".format(libFiles))
         for baseName, cycleName in libFiles.items():
             if not os.path.exists(cycleName):

--- a/armi/physics/neutronics/tests/test_cross_section_manager.py
+++ b/armi/physics/neutronics/tests/test_cross_section_manager.py
@@ -17,6 +17,7 @@ Test the cross section manager
 
 :py:mod:`armi.physics.neutronics.crossSectionGroupManager`
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import unittest
 import copy

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -161,7 +161,8 @@ class Assembly(composites.Composite):
             b.makeUnique()
             b.setName(b.makeName(self.p.assemNum, bi))
 
-    def makeNameFromAssemNum(self, assemNum):
+    @staticmethod
+    def makeNameFromAssemNum(assemNum):
         """
         Set the name of this assembly (and the containing blocks) based on an assemNum.
 
@@ -1331,7 +1332,8 @@ class HexAssembly(Assembly):
                 b.printContents()
         return numpy.average(pList)
 
-    def convert2DPinValsTo1D(self, vals, imax, jmax):
+    @staticmethod
+    def convert2DPinValsTo1D(vals, imax, jmax):
         """
         This converts a 2-D list of vals as a function of (i,j) = (ring-1,pos-1)
         to a 1-D list of the same vals indexed by n = sum(jmax[0:i]) + j

--- a/armi/reactor/assemblyLists.py
+++ b/armi/reactor/assemblyLists.py
@@ -27,8 +27,6 @@ as instance attributes of the ``Core``, and moving them into sibling systems on 
 import abc
 import itertools
 
-import numpy
-
 from armi import runLog
 from armi.utils import units
 from armi.reactor import grids

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -23,7 +23,6 @@ Blocks are made of components.
 import math
 import copy
 import collections
-import os
 from typing import Optional, Type, Tuple, ClassVar
 
 import matplotlib.pyplot as plt

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -182,7 +182,8 @@ class BlockBlueprint(yamlize.KeyedList):
             return blueprint.gridDesigns[self.gridName]
         return None
 
-    def _mergeComponents(self, b):
+    @staticmethod
+    def _mergeComponents(b):
         solventNamesToMergeInto = set(c.p.mergeWith for c in b if c.p.mergeWith)
 
         if solventNamesToMergeInto:

--- a/armi/reactor/blueprints/tests/test_materialModifications.py
+++ b/armi/reactor/blueprints/tests/test_materialModifications.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import unittest
 

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -611,7 +611,8 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             self.convertedBlock.add(circularHexagon)
             innerDiameter = outerDiam
 
-    def _addSolidMaterialRing(self, baseComponent, innerDiameter, outDiameter, name):
+    @staticmethod
+    def _addSolidMaterialRing(baseComponent, innerDiameter, outDiameter, name):
         circle = components.Circle(
             name,
             baseComponent.material,

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -1249,7 +1249,8 @@ class HexToRZThetaConverter(GeometryConverter):
             )
         )
 
-    def _getBlockColor(self, colConverter, colGenerator, blockColors, blockType):
+    @staticmethod
+    def _getBlockColor(colConverter, colGenerator, blockColors, blockType):
         nextColor = None
         if blockType not in blockColors:
             if "fuel" in blockType:
@@ -1490,7 +1491,8 @@ class EdgeAssemblyChanger(GeometryChanger):
         else:
             runLog.extra("No edge assemblies to remove")
 
-    def scaleParamsRelatedToSymmetry(self, reactor, paramsToScaleSubset=None):
+    @staticmethod
+    def scaleParamsRelatedToSymmetry(reactor, paramsToScaleSubset=None):
         """
         Scale volume-dependent params like power to account for cut-off edges
 

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Module to test geometry converters."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import math
 import os
 import unittest

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -330,9 +330,8 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-    import armi
-
-    armi.configure()
+    # import sys
+    # import armi
+    # armi.configure()
     # sys.argv = ["", "TestEdgeAssemblyChanger"]
     unittest.main()

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -62,7 +62,6 @@ current grid.
 """
 import itertools
 import math
-import re
 from typing import Tuple, List, Optional, Sequence, Union
 import collections
 

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -868,18 +868,21 @@ class Grid:
             self._centroidBySteps(indices - 1) + self._centroidBySteps(indices)
         ) / 2.0
 
-    def _centroidByBounds(self, index, bounds):
+    @staticmethod
+    def _centroidByBounds(index, bounds):
         if index < 0:
             # avoid wrap-around
             raise IndexError("Bounds-defined indices may not be negative.")
         return (bounds[index + 1] + bounds[index]) / 2.0
 
-    def _meshBaseByBounds(self, index, bounds):
+    @staticmethod
+    def _meshBaseByBounds(index, bounds):
         if index < 0:
             raise IndexError("Bounds-defined indices may not be negative.")
         return bounds[index]
 
-    def getNeighboringCellIndices(self, i, j=0, k=0):
+    @staticmethod
+    def getNeighboringCellIndices(i, j=0, k=0):
         """Return the indices of the immediate neighbors of a mesh point in the plane."""
         return ((i + 1, j, k), (1, j + 1, k), (i - 1, j, k), (i, j - 1, k))
 
@@ -895,7 +898,8 @@ class Grid:
         """
         raise NotImplementedError
 
-    def getAboveAndBelowCellIndices(self, indices):
+    @staticmethod
+    def getAboveAndBelowCellIndices(indices):
         i, j, k = indices
         return ((i, j, k + 1), (i, j, k - 1))
 
@@ -1402,7 +1406,8 @@ class HexGrid(Grid):
         """
         return hexagon.numRingsToHoldNumCells(n)
 
-    def getNeighboringCellIndices(self, i, j=0, k=0):
+    @staticmethod
+    def getNeighboringCellIndices(i, j=0, k=0):
         """
         Return the indices of the immediate neighbors of a mesh point in the plane.
 

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -584,7 +584,8 @@ class ParameterBuilder(object):
             return
         self._entered = False
 
-    def _assertDefaultIsProperType(self, default):
+    @staticmethod
+    def _assertDefaultIsProperType(default):
         if default in (NoDefault, None) or isinstance(
             default, (int, str, float, bool, Flags)
         ):

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests assemblies.py"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import pathlib
 import random
 import unittest

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -27,7 +27,17 @@ from armi.reactor import components
 from armi.reactor import geometry
 from armi.reactor import parameters
 from armi.reactor import reactors
-from armi.reactor.assemblies import *
+from armi.reactor.assemblies import (
+    blocks,
+    CartesianAssembly,
+    copy,
+    Flags,
+    grids,
+    HexAssembly,
+    math,
+    numpy,
+    runLog,
+)
 from armi.tests import TEST_ROOT
 from armi.utils import directoryChangers
 from armi.utils import textProcessors

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 r"""Tests blocks.py"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
 import math
 import os

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -15,6 +15,7 @@
 """
 Tests functionalities of components within ARMI
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
 import math
 import unittest

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for the composite pattern."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 from copy import deepcopy
 import unittest
 

--- a/armi/reactor/tests/test_geometry.py
+++ b/armi/reactor/tests/test_geometry.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests the geometry (loading input) file"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import os
 import unittest
 import io

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for grids."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import unittest
 import math
 from io import BytesIO

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -591,7 +591,5 @@ class TestCartesianGrid(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-
-    # sys.argv = ["", "TestHexGrid.testPositions"]
+    # import sys;sys.argv = ["", "TestHexGrid.testPositions"]
     unittest.main()

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 from __future__ import print_function
 import unittest

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -20,14 +20,12 @@ import unittest
 
 from six.moves import cPickle
 from numpy.testing import assert_allclose, assert_equal
-import armi
-
-from armi.materials import uZr
 
 from armi import operators
 from armi import runLog
 from armi import settings
 from armi import tests
+from armi.materials import uZr
 from armi.reactor.flags import Flags
 from armi.reactor import assemblies
 from armi.reactor import blocks
@@ -745,7 +743,5 @@ class CartesianReactorTests(ReactorTests):
 
 
 if __name__ == "__main__":
-    import sys
-
-    # sys.argv = ["", "ReactorTests.test_genAssembliesAddedThisCycle"]
+    # import sys;sys.argv = ["", "ReactorTests.test_genAssembliesAddedThisCycle"]
     unittest.main()

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -14,6 +14,7 @@
 r"""
 testing for reactors.py
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
 import os
 import unittest

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -17,7 +17,6 @@ import copy
 import unittest
 import os
 
-import armi
 from armi.reactor import assemblies
 from armi.reactor import blueprints
 from armi.reactor import geometry

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Test for Zones"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
 import unittest
 import os

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -15,9 +15,6 @@
 """
 Zones are collections of locations.
 """
-
-import math
-
 import tabulate
 
 from armi import runLog

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -27,9 +27,7 @@ A master case settings is created as ``masterCs``
 """
 import io
 import os
-import sys
 import copy
-import collections
 
 import armi
 from armi import runLog

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -222,18 +222,15 @@ class Setting:
 
     def addOption(self, option: Option):
         """Extend this Setting's options with an extra option."""
-        self.addOptions(
-            [
-                option,
-            ]
-        )
+        self.addOptions([option])
 
     def changeDefault(self, newDefault: Default):
         """Change the default of a setting, and also the current value."""
         self._default = newDefault.value
         self.value = newDefault.value
 
-    def _load(self, inputVal):
+    @staticmethod
+    def _load(inputVal):
         """
         Create setting value from input value.
 

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -404,7 +404,8 @@ class SettingsWriter:
         if style not in {self.Styles.short, self.Styles.full}:
             raise ValueError("Invalid supplied setting writing style {}".format(style))
 
-    def _getVersion(self):
+    @staticmethod
+    def _getVersion():
         tag, attrib = Roots.CUSTOM, {Roots.VERSION: armi.__version__}
         return tag, attrib
 

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for new settings system with plugin import"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import unittest
 import io
 import copy

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import datetime
 import io

--- a/armi/tests/test_docs.py
+++ b/armi/tests/test_docs.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import os
 import unittest

--- a/armi/tests/test_fuelHandlers.py
+++ b/armi/tests/test_fuelHandlers.py
@@ -18,6 +18,7 @@ Tests some capabilities of the fuel handling machine.
 This test is high enough level that it requires input files to be present. The ones to use
 are called armiRun.yaml which is located in armi.tests
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import collections
 import copy
 import os

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import distutils.spawn
 import os

--- a/armi/tests/test_notebooks.py
+++ b/armi/tests/test_notebooks.py
@@ -13,7 +13,6 @@ import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
 
 from armi.tests import TEST_ROOT
-import armi
 
 TUTORIALS = os.path.join(TEST_ROOT, "tutorials")
 

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -211,7 +211,8 @@ class AsciiMap(object):
         self._updateSlotSizeFromData()
         self._makeOffsets()
 
-    def _removeTrailingPlaceholders(self, line):
+    @staticmethod
+    def _removeTrailingPlaceholders(line):
         newLine = []
         noDataYet = True
         for col in reversed(line):
@@ -489,8 +490,7 @@ class AsciiMapHexFullTipsUp(AsciiMap):
 
 
 def asciiMapFromGeomAndSym(
-    geomType: Union[str, geometry.GeomType],
-    symmetry: Union[str, geometry.SymmetryType],
+    geomType: Union[str, geometry.GeomType], symmetry: Union[str, geometry.SymmetryType]
 ) -> "AsciiMap":
     """Get a ascii map class from a geometry and symmetry type."""
     from armi.reactor import geometry

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -23,7 +23,6 @@ Hexagons are fundamental to advanced reactors.
 """
 
 import math
-import itertools
 
 import numpy
 

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -18,7 +18,6 @@ Module of utilities to help dealing with iterable objects in python
 
 from __future__ import print_function
 import struct
-import collections
 from itertools import tee, chain
 
 from builtins import object  # pylint: disable=redefined-builtin

--- a/armi/utils/tests/test_flags.py
+++ b/armi/utils/tests/test_flags.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+r""" Testing flags.py
+"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import unittest
 

--- a/armi/utils/tests/test_gridGui.py
+++ b/armi/utils/tests/test_gridGui.py
@@ -41,6 +41,7 @@ loginctl list-sessions --no-legend | \
 ```
 If it outputs "x11", it should work (and if it outputs "wayland", it probably won't, for now).
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import asyncio
 import os
 import pytest

--- a/armi/utils/tests/test_triangle.py
+++ b/armi/utils/tests/test_triangle.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+r""" Test the basic triangle math
+"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import unittest
 from armi.utils import triangle
 
@@ -19,7 +21,6 @@ from armi.utils import triangle
 class triangleTests(unittest.TestCase):
     def test_getTriangleArea(self):
         """Test that getTriangleArea correctly calculates the area of a right triangle."""
-
         x1 = 0.0
         y1 = 0.0
         x2 = 1.0
@@ -32,7 +33,6 @@ class triangleTests(unittest.TestCase):
 
     def test_checkIfPointIsInTriangle(self):
         """Test that checkIfPointIsInTrinagle can correctly identify if a point is inside or outside of a triangle."""
-
         # First check the right triangle case
         xT1 = 0.0
         yT1 = 0.0

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
-
+r""" Testing some utility functions
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import unittest
 import math
 
@@ -26,12 +26,6 @@ import armi.utils as utils
 
 
 class Utils_TestCase(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_parabola(self):
         # test the parabola function
         a, b, c = utils.parabolaFromPoints((0, 1), (1, 2), (-1, 2))


### PR DESCRIPTION
This is a low-priority, low-risk PR addressing purely PyLint concerns. It specifically addresses two PyLint warnings:

* **R0201** - method could be function
* **W0614** - unused imports

Also, there were a great many warnings in the unit test files that just don't matter, so I suppressed them.  For instance, do you really need a docstring on a unit test class?

NOTE: Viewing the changes in this PR might be easier if you look at the commits individually.