### PR TITLE
Python 2 to 3 Class Definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ doc/tutorials/case-suite
 armi/tests/tutorials/case-suite
 .apidocs/
 doc/gallery
+htmlcov/
 
 # No workspace crumbs.
 *~

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -658,7 +658,7 @@ class HistoryTrackerInterface(interfaces.Interface):
             return None
 
 
-class HistoryFile(object):
+class HistoryFile:
     r"""
     A general history file that contains the parameter history of an object.
 
@@ -777,7 +777,7 @@ class AssemblyHistory(HistoryFile):
         return mins, maxes
 
 
-class HistoryProcessor(object):
+class HistoryProcessor:
     r"""
     Processes stats on a bunch of assembly history files
 

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -345,7 +345,7 @@ class MemoryProfiler(interfaces.Interface):
         )
 
 
-class KlassCounter(object):
+class KlassCounter:
     def __init__(self, reportSize):
         self.counters = dict()
         self.reportSize = reportSize
@@ -387,7 +387,7 @@ class KlassCounter(object):
                     self.countObjects(v)
 
 
-class InstanceCounter(object):
+class InstanceCounter:
     def __init__(self, classType, reportSize):
         self.classType = classType
         self.count = 0
@@ -435,7 +435,7 @@ def _getModName(obj):
         return None
 
 
-class ObjectSizeBreakdown(object):
+class ObjectSizeBreakdown:
     def __init__(
         self,
         name,
@@ -511,7 +511,7 @@ class ProfileMemoryUsageAction(mpiActions.MpiAction):
         mem.displayMemoryUsage(self.timeDescription)
 
 
-class SystemAndProcessMemoryUsage(object):
+class SystemAndProcessMemoryUsage:
     def __init__(self):
         self.nodeName = armi.MPI_NODENAME
         # no psutil, no memory diagnostics. TODO: Ideally, we could just cut

--- a/armi/bookkeeping/report/data.py
+++ b/armi/bookkeeping/report/data.py
@@ -26,7 +26,7 @@ from armi.bookkeeping.report import html
 # --------------------------------------------
 #                REPORTS
 # --------------------------------------------
-class Report(object):
+class Report:
     """Storage for data separated out for a particular kind of user"""
 
     # stubs for "further stylization" in the report package init
@@ -148,7 +148,7 @@ class Report(object):
 # --------------------------------------------
 #                GROUPS
 # --------------------------------------------
-class Group(object):
+class Group:
     """Abstract class, when extended is used for storage for data within a report
 
     Only accepts things wrapped in the ReportDatum class

--- a/armi/bookkeeping/report/html.py
+++ b/armi/bookkeeping/report/html.py
@@ -24,7 +24,7 @@ import armi
 from armi import settings
 
 
-class HTMLFile(object):
+class HTMLFile:
     def __init__(self, *args, **kwds):
         self.args = args
         self.kwds = kwds
@@ -44,7 +44,7 @@ class HTMLFile(object):
         self._file.write(html.escape(str(value)))
 
 
-class Tag(object):
+class Tag:
     tag = NotImplementedError
 
     def __init__(self, f, attrs=None):

--- a/armi/cases/inputModifiers/inputModifiers.py
+++ b/armi/cases/inputModifiers/inputModifiers.py
@@ -1,7 +1,7 @@
 """Modifies inputs."""
 
 
-class InputModifier(object):
+class InputModifier:
     """
     Object that modifies input definitions in some well-defined way.
 

--- a/armi/cases/inputModifiers/tests/test_inputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_inputModifiers.py
@@ -17,7 +17,7 @@ from armi.cases.inputModifiers import (
 from armi.reactor.tests import test_reactors
 
 
-class MockGeom(object):
+class MockGeom:
     geomType = "hex"
 
 

--- a/armi/cases/inputModifiers/tests/test_pinTypeInputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_pinTypeInputModifiers.py
@@ -9,7 +9,7 @@ from armi import settings
 from armi.reactor import blueprints
 
 
-class MockGeom(object):
+class MockGeom:
     geomType = "hex"
 
 

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -40,7 +40,7 @@ def getInputModifiers(cls):
     ]
 
 
-class SuiteBuilder(object):
+class SuiteBuilder:
     """
     Class for constructing a CaseSuite from combinations of modifications on base inputs.
 

--- a/armi/config.py
+++ b/armi/config.py
@@ -23,7 +23,7 @@ from armi import runLog
 TEMPLATE_DATA = os.path.join(armi.RES, "config")
 
 
-class ConfigHandler(object):  # pylint: disable=missing-docstring
+class ConfigHandler:  # pylint: disable=missing-docstring
     def __init__(self):  # pass in RES to avoid circular import
         """
         Exposes the contents of the config files in the TEMPLATE_DATA location to pythonic access
@@ -180,7 +180,7 @@ class ConfigHandler(object):  # pylint: disable=missing-docstring
         setattr(self, cleaned_filename, _ExposedFile(filename, cleaned_filename, cfg))
 
 
-class _ExposedFile(object):  # pylint: disable=too-few-public-methods
+class _ExposedFile:  # pylint: disable=too-few-public-methods
     def __init__(self, fname, name, cfg):
         self.fname = fname
         self.name = name

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -39,7 +39,7 @@ from armi.utils import textProcessors
 from armi.reactor import parameters
 
 
-class STACK_ORDER(object):  # pylint: disable=invalid-name, too-few-public-methods
+class STACK_ORDER:  # pylint: disable=invalid-name, too-few-public-methods
     """
     Constants that help determine the order of modules in the interface stack.
 
@@ -81,7 +81,7 @@ class STACK_ORDER(object):  # pylint: disable=invalid-name, too-few-public-metho
     POSTPROCESSING = BOOKKEEPING + 1
 
 
-class Interface(object):
+class Interface:
     """
     The eponymous Interface between the ARMI Reactor model and modules that operate upon it.
 
@@ -119,7 +119,7 @@ class Interface(object):
     interfaces.
     """
 
-    class Distribute(object):  # pylint: disable=too-few-public-methods
+    class Distribute:  # pylint: disable=too-few-public-methods
         """Enum-like return flag for behavior on interface broadcasting with MPI."""
 
         DUPLICATE = 1
@@ -461,7 +461,7 @@ class Interface(object):
         pass
 
 
-class InputWriter(object):
+class InputWriter:
     """Use to write input files of external codes."""
 
     def __init__(self, r=None, externalCodeInterface=None, cs=None):
@@ -481,7 +481,7 @@ class InputWriter(object):
         raise NotImplementedError
 
 
-class OutputReader(object):
+class OutputReader:
     """
     A generic representation of a particular module's output.
 

--- a/armi/localization/tests/test_localization.py
+++ b/armi/localization/tests/test_localization.py
@@ -27,7 +27,7 @@ from armi.localization import info, info_once, important
 from armi.localization import warn, warn_once, warn_when_root, warn_once_when_root
 
 
-class DummyClass(object):
+class DummyClass:
     def __init__(self):
         if six.PY3:
             self.counts = [

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -24,7 +24,7 @@ from armi.utils import units
 from armi.nucDirectory import nuclideBases
 
 
-class _Material_Test(object):
+class _Material_Test:
     """Base for all specific material test cases."""
 
     MAT_CLASS = None

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -72,7 +72,7 @@ from armi import utils
 from armi.utils import iterables
 
 
-class MpiAction(object):
+class MpiAction:
     """Base of all MPI actions.
 
     MPI Actions are tasks that can be executed without needing lots of other

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -46,7 +46,7 @@ LANTHANIDE_ELEMENTS = [
 GASEOUS_ELEMENTS = ["XE", "KR"]
 
 
-class Element(object):
+class Element:
     r"""
     Represents an element, defined by its atomic number.
 

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -543,7 +543,7 @@ def _addNuclideToIndices(nuc):
             pass
 
 
-class IMcnpNuclide(object):
+class IMcnpNuclide:
     """Interface which defines the contract for getMcnpId."""
 
     def getMcnpId(self):
@@ -559,7 +559,7 @@ class IMcnpNuclide(object):
         raise NotImplementedError
 
 
-class NuclideInterface(object):
+class NuclideInterface:
     """An abstract nuclide implementation which defining various methods required for a nuclide object."""
 
     def getDatabaseName(self):

--- a/armi/nucDirectory/transmutations.py
+++ b/armi/nucDirectory/transmutations.py
@@ -94,7 +94,7 @@ DECAY_MODES = [
 PRODUCT_PARTICLES = {"nalph": "HE4", "np": "H1", "nd": "H2", "nt": "H3", "ad": "HE4"}
 
 
-class Transmutable(object):
+class Transmutable:
     """
     Transmutable base class.
 

--- a/armi/nuclearDataIO/__init__.py
+++ b/armi/nuclearDataIO/__init__.py
@@ -294,7 +294,7 @@ class VARSRC(NHFLUX):
         return pnOrder * (pnOrder + 1) / 2
 
 
-class MacroXS(object):
+class MacroXS:
     """
     Basic macroscopic XS library.
 

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -33,7 +33,7 @@ IMPLICIT_INT = "IJKLMN"
 """Letters that trigger implicit integer types in old FORTRAN 77 codes"""
 
 
-class IORecord(object):
+class IORecord:
     """
     A single CCCC record.
 
@@ -500,7 +500,7 @@ class DataContainer:
         self.metadata = nuclearFileMetadata._Metadata()
 
 
-class Stream(object):
+class Stream:
     """
     An abstract CCCC IO stream.
 

--- a/armi/nuclearDataIO/cccc/compxs.py
+++ b/armi/nuclearDataIO/cccc/compxs.py
@@ -321,7 +321,7 @@ writeBinary = _CompxsIO.writeBinary  # pylint: disable=invalid-name
 writeAscii = _CompxsIO.writeAscii  # pylint: disable=invalid-name
 
 
-class _CompxsRegionIO(object):
+class _CompxsRegionIO:
     """
     Specific object assigned a single region to read/write composition information.
 
@@ -441,7 +441,7 @@ class _CompxsRegionIO(object):
             sparseMat.addColumnData(dataj, indicesj)
 
 
-class _CompxsScatterMatrix(object):
+class _CompxsScatterMatrix:
     """When reading COMPXS scattering blocks, store the data here and then reconstruct after."""
 
     def __init__(self, shape):
@@ -462,7 +462,7 @@ class _CompxsScatterMatrix(object):
         return sparseFunc((self.data, self.indices, self.indptr), shape=self.shape)
 
 
-class CompxsRegion(object):
+class CompxsRegion:
     """
     Class for creating/tracking homogenized region information.
 

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -34,7 +34,7 @@ from armi.nuclearDataIO import nuclearFileMetadata
 ALLOWED_NUCLIDE_CONTRIBUTION_ERROR = 1e-5
 
 
-class DelayedNeutronData(object):
+class DelayedNeutronData:
     """
     Container of information about delayed neutron precursors.
 

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -336,7 +336,7 @@ writeBinary = _IsotxsIO.writeBinary  # pylint: disable=invalid-name
 writeAscii = _IsotxsIO.writeAscii  # pylint: disable=invalid-name
 
 
-class _IsotxsNuclideIO(object):
+class _IsotxsNuclideIO:
     """
     A reader/writer class for ISOTXS nuclides.
 

--- a/armi/nuclearDataIO/cccc/pmatrx.py
+++ b/armi/nuclearDataIO/cccc/pmatrx.py
@@ -278,7 +278,7 @@ class _PmatrxIO(cccc.Stream):
             raise NotImplementedError()
 
 
-class _PmatrxNuclideIO(object):
+class _PmatrxNuclideIO:
     def __init__(self, nuclide, pmatrixIO, numNeutronGroups, numGammaGroups):
         self._nuclide = nuclide
         self._metadata = nuclide.pmatrxMetadata

--- a/armi/nuclearDataIO/nuclearFileMetadata.py
+++ b/armi/nuclearDataIO/nuclearFileMetadata.py
@@ -37,7 +37,7 @@ REGIONXS_POWER_CONVERT_DIRECTIONAL_DIFF = [
 ]
 
 
-class _Metadata(object):
+class _Metadata:
     """Simple dictionary wrapper, that returns :code:`None` if the key does not exist.
 
     Notes

--- a/armi/nuclearDataIO/tests/.gitignore
+++ b/armi/nuclearDataIO/tests/.gitignore
@@ -6,3 +6,4 @@
 *.sum
 *.flux_ufg
 *.flux_bg
+*.nucdata

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -177,7 +177,7 @@ def createTestXSLibraryFiles(cachePath):
         shutil.move("ISOTXS.merged", GAMISO_LUMPED)
 
 
-class TempFileMixin(object):  # really a test case...
+class TempFileMixin:  # really a test case...
     @property
     def testFileName(self):
         return os.path.join(

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -94,7 +94,7 @@ E_CAPTURE = "ecapt"
 E_FISSION = "efiss"
 
 
-class XSCollection(object):
+class XSCollection:
     """A cross section collection."""
 
     _zeroes = {}
@@ -362,7 +362,7 @@ class XSCollection(object):
             )
 
 
-class MacroscopicCrossSectionCreator(object):
+class MacroscopicCrossSectionCreator:
     """
     Create macroscopic cross sections from micros and number density.
 

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -260,7 +260,7 @@ def mergeXSLibrariesInWorkingDirectory(lib, xsLibrarySuffix="", mergeGammaLibs=F
     return neutronVelocities
 
 
-class _XSLibrary(object):
+class _XSLibrary:
     """Parent class for Isotxs and Compxs library objects."""
 
     neutronEnergyUpperBounds = properties.createImmutableProperty(

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -33,7 +33,7 @@ from armi.nucDirectory.elements import LANTHANIDE_ELEMENTS, GASEOUS_ELEMENTS
 from .fissionProductModelSettings import CONF_LFP_COMPOSITION_FILE_PATH
 
 
-class LumpedFissionProduct(object):
+class LumpedFissionProduct:
     r"""
     Lumped fission product.
 
@@ -472,7 +472,7 @@ class SingleLumpedFissionProductCollection(LumpedFissionProductCollection):
         )
 
 
-class FissionProductDefinitionFile(object):
+class FissionProductDefinitionFile:
     """
     Reads a file that has definitions of one or more LFPs in it to produce LFPs
 

--- a/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
+++ b/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
@@ -192,7 +192,7 @@ class AbstractIsotopicDepletionReader(interfaces.OutputReader):
         raise NotImplementedError
 
 
-class Csrc(object):
+class Csrc:
     """
     Writes a continuous source term card in a depletion interface.
 

--- a/armi/physics/neutronics/tests/test_cross_section_manager.py
+++ b/armi/physics/neutronics/tests/test_cross_section_manager.py
@@ -355,13 +355,13 @@ class TestXSNumberConverters(unittest.TestCase):
         self.assertEqual(num, 9090)
 
 
-class MockReactor(object):
+class MockReactor:
     def __init__(self):
         self.blueprints = MockBlueprints()
         self.spatialGrid = None
 
 
-class MockBlueprints(object):
+class MockBlueprints:
     # this is only needed for allNuclidesInProblem and attributes were acting funky, so this was made.
     def __getattribute__(self, *args, **kwargs):
         return ["U235", "U235", "FE", "NA23"]

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -31,7 +31,7 @@ from armi import runLog
 SIN60 = math.sin(math.radians(60.0))
 
 
-class BlockConverter(object):
+class BlockConverter:
     """Converts a block."""
 
     def __init__(self, sourceBlock, quiet=False):

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -60,7 +60,7 @@ BLOCK_AXIAL_MESH_SPACING = (
 STR_SPACE = " "
 
 
-class GeometryChanger(object):
+class GeometryChanger:
     """Geometry changer class that updates the geometry (number of assems or blocks per assem) of a given reactor."""
 
     def __init__(self, cs=None, quiet=False):

--- a/armi/reactor/converters/meshConverters.py
+++ b/armi/reactor/converters/meshConverters.py
@@ -24,7 +24,7 @@ from armi.reactor import grids
 from armi.reactor.flags import Flags, TypeSpec
 
 
-class MeshConverter(object):
+class MeshConverter:
     """
     Base class for the reactor mesh conversions.
 

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -364,7 +364,7 @@ class Parameter:
         return self.location and self.location & loc
 
 
-class ParameterDefinitionCollection(object):
+class ParameterDefinitionCollection:
     r"""
     A very specialized container for managing parameter definitions.
 
@@ -555,7 +555,7 @@ class ParameterDefinitionCollection(object):
         return paramBuilder
 
 
-class ParameterBuilder(object):
+class ParameterBuilder:
     r"""Factory for creating Parameter and parameter properties"""
 
     def __init__(

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -135,7 +135,7 @@ class TestGeneralComponents(unittest.TestCase):
     componentDims = {"Tinput": 25.0, "Thot": 25.0}
 
     def setUp(self):
-        class _Parent(object):
+        class _Parent:
             def getSymmetryFactor(self):
                 return 1.0
 
@@ -939,7 +939,7 @@ class TestMaterialAdjustments(unittest.TestCase):
         dims = {"Tinput": 25.0, "Thot": 600.0, "od": 10.0, "id": 5.0, "mult": 1.0}
         self.fuel = Circle("fuel", "UZr", **dims)
 
-        class fakeBlock(object):
+        class fakeBlock:
             def getHeight(self):  # unit height
                 return 1.0
 

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -23,7 +23,7 @@ from armi.localization import exceptions
 from armi.reactor import composites
 
 
-class MockComposite(object):
+class MockComposite:
     def __init__(self, name):
         self.name = name
         self.p = {}
@@ -382,7 +382,7 @@ def makeComp(name):
     return c
 
 
-class SynchronizationTests(object):
+class SynchronizationTests:
     """Some unit tests that must be run with mpirun instead of the standard unittest system."""
 
     def setUp(self):
@@ -424,7 +424,7 @@ class SynchronizationTests(object):
         self.l.flush()
 
     def assertRaises(self, exceptionType):
-        class ExceptionCatcher(object):
+        class ExceptionCatcher:
             def __enter__(self):
                 pass
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -569,7 +569,7 @@ class HexReactorTests(ReactorTests):
 
     def test_saveAllFlux(self):
         # need a lightweight library to indicate number of groups.
-        class MockLib(object):
+        class MockLib:
             numGroups = 5
 
         self.r.core.lib = MockLib()
@@ -580,7 +580,7 @@ class HexReactorTests(ReactorTests):
         os.remove("allFlux.txt")
 
     def test_getFluxVector(self):
-        class MockLib(object):
+        class MockLib:
             numGroups = 5
 
         self.r.core.lib = MockLib()

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -29,7 +29,7 @@ from armi.utils import hexagon
 from armi.settings.fwSettings import globalSettings
 
 
-class Zone(object):
+class Zone:
     """
     A group of locations labels useful for choosing where to shuffle from or where to compute
     reactivity coefficients.
@@ -125,7 +125,7 @@ class Zone(object):
                 self.append(newLoc)
 
 
-class Zones(object):
+class Zones:
     """Collection of Zone objects."""
 
     def __init__(self, core, cs):

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -59,7 +59,7 @@ from armi.reactor import geometry
 PLACEHOLDER = "-"
 
 
-class AsciiMap(object):
+class AsciiMap:
     """
     Base class for maps.
 

--- a/armi/utils/codeTiming.py
+++ b/armi/utils/codeTiming.py
@@ -77,7 +77,7 @@ def getMasterTimer():
     return MasterTimer.getMasterTimer()
 
 
-class MasterTimer(object):
+class MasterTimer:
 
     _instance = None
 
@@ -313,7 +313,7 @@ class MasterTimer(object):
         return os.path.join(os.getcwd(), filename)
 
 
-class _Timer(object):
+class _Timer:
     r"""Code timer to call at various points to measure performance
 
     see MasterTimer.getTimer() for construction

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -135,7 +135,7 @@ def packHexStrings(valueDict):
 # -------------------------------
 
 
-class Overlap(object):
+class Overlap:
     """common list overlap comparison"""
 
     def __init__(self, src, ref):
@@ -156,7 +156,7 @@ class Overlap(object):
         )
 
 
-class Sequence(object):
+class Sequence:
     """
     The Sequence class partially implements a list-like interface,
     supporting methods like append and extend and also operations like + and +=.

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -457,7 +457,7 @@ def _setPlotValText(ax, texts, core, data, labels, labelFmt, fontSize):
 def _createFaceMapLegend(legendMap, cmap, norm):
     """Make special assembly-legend for the assembly face map plot with assembly counts."""
 
-    class AssemblyLegend(object):
+    class AssemblyLegend:
         """
         Custom Legend artist handler.
 
@@ -860,7 +860,7 @@ def plotBlockFlux(core, fName=None, bList=None, peak=False, adjoint=False, bList
     This is not a great method. It should be cleand up and migrated into ``utils.plotting``.
     """
 
-    class BlockListFlux(object):
+    class BlockListFlux:
         def __init__(
             self, nGroup, blockList=[], adjoint=False, peak=False, primary=False
         ):

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -67,7 +67,7 @@ def createImmutableProperty(name, dependencyAction, doc):
     --------
     The following example is esentially exactly how this should be used.
 
-    >>> class SomeClass(object):
+    >>> class SomeClass:
     ...     myNum = createImmutableProperty('myNum', 'You must invoke the initialize() method', 'My random number')
     ...     def initialize(self, val):
     ...         unlockImmutableProperties(self)

--- a/armi/utils/tests/test_properties.py
+++ b/armi/utils/tests/test_properties.py
@@ -18,7 +18,7 @@ import unittest
 from armi.utils import properties
 
 
-class ImmutableClass(object):
+class ImmutableClass:
     myNum = properties.createImmutableProperty(
         "myNum", "You must invoke the initialize() method", "My random number"
     )


### PR DESCRIPTION
In later versions of Python 2, it became popular to use the "new" class type, which meant switching from this class definition:

    class Thing:

to this:

    class Thing(object):

According to the `setup.py` file in this repo, this project is purely Python3.  In which case, the "new" class type is default, and this `(object)` is unnecessary.