### PR TITLE
Adding the 1D/2D mesh reading/writing capabilities to the GEODST interface file.

### DIFF
--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -555,7 +555,7 @@ class Stream(object):
         return "<{} {}>".format(self.__class__.__name__, self._fileName)
 
     def __enter__(self):
-        """At the inception of a with command, navigate to a new directory if one is supplied"""
+        """At the inception of a with command, open up the file for a read/write."""
         try:
             self._stream = open(self._fileName, self._fileMode)
         except IOError:
@@ -564,7 +564,7 @@ class Stream(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        """At the termination of a with command, navigate back to the original directory"""
+        """At the termination of a with command, close the file."""
         self._stream.close()
 
     def readWrite(self):

--- a/armi/nuclearDataIO/cccc/geodst.py
+++ b/armi/nuclearDataIO/cccc/geodst.py
@@ -164,16 +164,32 @@ class GeodstStream(cccc.StreamWithDataContainer):
                 self._metadata[key] = record.rwInt(self._metadata[key])
 
     def _rw2DRecord(self):
-        """Read/write info for 1-D meshes."""
-        raise NotImplementedError(
-            "1-D geometry not yet implemented in GEODST reader/writer"
-        )
+        """Read/write 1-D coarse mesh boundaries and fine mesh intervals."""
+        with self.createRecord() as record:
+
+            self._data.xmesh = record.rwList(
+                self._data.xmesh, "double", self._metadata["NCINTI"] + 1
+            )
+            self._data.iintervals = record.rwList(
+                self._data.iintervals, "int", self._metadata["NCINTI"]
+            )
 
     def _rw3DRecord(self):
-        """Read/write info for 2-D meshes."""
-        raise NotImplementedError(
-            "2-D geometry not yet implemented in GEODST reader/writer"
-        )
+        """Read/write 2-D coarse mesh boundaries and fine mesh intervals."""
+        with self.createRecord() as record:
+
+            self._data.xmesh = record.rwList(
+                self._data.xmesh, "double", self._metadata["NCINTI"] + 1
+            )
+            self._data.ymesh = record.rwList(
+                self._data.ymesh, "double", self._metadata["NCINTJ"] + 1
+            )
+            self._data.iintervals = record.rwList(
+                self._data.iintervals, "int", self._metadata["NCINTI"]
+            )
+            self._data.jintervals = record.rwList(
+                self._data.jintervals, "int", self._metadata["NCINTJ"]
+            )
 
     def _rw4DRecord(self):
         """Read/write 3-D coarse mesh boundaries and fine mesh intervals."""


### PR DESCRIPTION
This adds the 1D and 2D reading capabilities to the existing `GEODST` interface file. This is useful for obtaining the coarse and mesh points in simple slab, sphere, and cylindrical (rz) geometries .