### PR TITLE
Another Pylint PR

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -102,7 +102,7 @@ _ignoreConfigures = False
 def isStableReleaseVersion(version=None):
     """Determine if the version should be considered a stable release"""
     version = version or __version__
-    return not "-" in version
+    return "-" not in version
 
 
 def _registerUserPlugin(plugManager, userPluginName):

--- a/armi/__main__.py
+++ b/armi/__main__.py
@@ -18,7 +18,6 @@ Primary entry point into ARMI.
 There are a variety of entry points in the ``cli`` package that define the various run options.
 This invokes them according to command-line user input.
 """
-from __future__ import print_function
 import sys
 
 import armi

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -31,11 +31,7 @@ customizing much of the Framework's behavior.
 from typing import Dict, Optional, Tuple, List
 import collections
 
-import armi
-from armi import plugins
-from armi import pluginManager
-from armi import meta
-
+from armi import plugins, pluginManager, meta, settings
 from armi.settings import Setting
 from armi.settings import fwSettings
 from armi.reactor import parameters
@@ -121,14 +117,12 @@ class App:
         # setting.  If all plugins' settings have been processed and the cache is not
         # empty, that's an error, because a plugin must have provided options to a
         # setting that doesn't exist.
-        optionsCache: Dict[str, List[armi.settings.Option]] = collections.defaultdict(
-            list
-        )
-        defaultsCache: Dict[str, armi.settings.Default] = {}
+        optionsCache: Dict[str, List[settings.Option]] = collections.defaultdict(list)
+        defaultsCache: Dict[str, settings.Default] = {}
 
         for pluginSettings in self._pm.hook.defineSettings():
             for pluginSetting in pluginSettings:
-                if isinstance(pluginSetting, armi.settings.Setting):
+                if isinstance(pluginSetting, settings.Setting):
                     name = pluginSetting.name
                     if name in settingDefs:
                         raise ValueError(
@@ -141,14 +135,14 @@ class App:
                         settingDefs[name].addOptions(optionsCache.pop(name))
                     if name in defaultsCache:
                         settingDefs[name].changeDefault(defaultsCache.pop(name))
-                elif isinstance(pluginSetting, armi.settings.Option):
+                elif isinstance(pluginSetting, settings.Option):
                     if pluginSetting.settingName in settingDefs:
                         # modifier loaded after setting, so just apply it (no cache needed)
                         settingDefs[pluginSetting.settingName].addOption(pluginSetting)
                     else:
                         # no setting yet, cache it and apply when it arrives
                         optionsCache[pluginSetting.settingName].append(pluginSetting)
-                elif isinstance(pluginSetting, armi.settings.Default):
+                elif isinstance(pluginSetting, settings.Default):
                     if pluginSetting.settingName in settingDefs:
                         # modifier loaded after setting, so just apply it (no cache needed)
                         settingDefs[pluginSetting.settingName].changeDefault(

--- a/armi/bookkeeping/db/__init__.py
+++ b/armi/bookkeeping/db/__init__.py
@@ -55,7 +55,6 @@ minor revision.
 import os
 from typing import Optional, List, Tuple
 
-import armi
 from armi import settings
 from armi.utils import pathTools
 from armi import runLog

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -690,7 +690,7 @@ class Database3(database.Database):
 
             # Copy everything except time node data
             timeSteps = set()
-            for groupName, group in dbIn.items():
+            for groupName, _ in dbIn.items():
                 m = self.timeNodeGroupPattern.match(groupName)
                 if m:
                     timeSteps.add((int(m.group(1)), int(m.group(2))))
@@ -1069,8 +1069,7 @@ class Database3(database.Database):
         Given a flat collection of all of the ArmiObjects in the model, reconstitute the
         hierarchy.
         """
-
-        comp, serialNum, numChildren, location = next(comps)
+        comp, _, numChildren, location = next(comps)
 
         # attach the parent early, if provided; some cases need the parent attached for
         # the rest of _compose to work properly.
@@ -1146,7 +1145,7 @@ class Database3(database.Database):
                 linkedDims = []
                 data = []
 
-                for i, c in enumerate(comps):
+                for _, c in enumerate(comps):
                     val = c.p[paramDef.name]
                     if isinstance(val, tuple):
                         linkedDims.append("{}.{}".format(val[0].name, val[1]))
@@ -1223,7 +1222,7 @@ class Database3(database.Database):
                 dataset = g.create_dataset(paramDef.name, data=data, compression="gzip")
                 if any(attrs):
                     _writeAttrs(dataset, h5group, attrs)
-            except Exception as e:
+            except Exception:
                 runLog.error(
                     "Failed to write {} to database. Data: "
                     "{}".format(paramDef.name, data)
@@ -2078,7 +2077,7 @@ class Layout:
             compType,
             name,
             serialNum,
-            indexInData,
+            _,
             numChildren,
             location,
             material,
@@ -2261,7 +2260,7 @@ class Layout:
             # original ancestor array
             indexMap = {sn: i for i, sn in enumerate(serialNum)}
             origAncestors = ancestors
-            for generation in range(depth - 1):
+            for _ in range(depth - 1):
                 ancestors = [
                     origAncestors[indexMap[ia]] if ia is not None else None
                     for ia in ancestors

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -567,7 +567,6 @@ class HistoryTrackerInterface(interfaces.Interface):
             val = self._preloadedBlockHistory[block][paramName][ts]
         # not in preloaded or preloaded failed
         except (TypeError, ValueError, KeyError, IndexError):
-            index = 0
             dbi = self.getInterface("database")
             try:
                 data = dbi.database.getHistory(block, [paramName], [ts])

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -187,7 +187,7 @@ class MemoryProfiler(interfaces.Interface):
         for i in self.o.getInterfaces():
             checkAttr(i)
             if i.name == "xsGroups":
-                for xsid, block in i.representativeBlocks.items():
+                for _, block in i.representativeBlocks.items():
                     checkAttr(block)
 
         if len(uniqueIds) == 0:
@@ -653,7 +653,7 @@ def _walkReferrers(o, maxLevel=0, level=0, memo=None, whitelist=None):
         if referrer.__class__.__name__ != "frame" and id(referrer) in whitelist
     ]
     memo.update({oid for (_obj, oid, _seen) in referrers})
-    for (obj, oid, seen) in referrers:
+    for (obj, _, seen) in referrers:
         runLog.important(
             "{}{}    {} at {:x} seen: {}".format(
                 "-" * level, type(obj), "{}".format(obj)[:100], id(obj), seen

--- a/armi/bookkeeping/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/tests/test_databaseInterface.py
@@ -190,7 +190,7 @@ class TestDatabaseWriter(unittest.TestCase):
 
             # we are now in cycle 2, node 3 ... AFTER setFluxAwesome
             # lets get the 3rd block ... whatever that is
-            _ = db.getHistory(b, params=["flux"])
+            _fluxes = db.getHistory(b, params=["flux"])
 
         self.o.interfaces.append(MockInterface(self.o.r, self.o.cs, setFluxAwesome))
         self.o.interfaces.append(MockInterface(self.o.r, self.o.cs, getFluxAwesome))

--- a/armi/bookkeeping/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/tests/test_databaseInterface.py
@@ -190,7 +190,7 @@ class TestDatabaseWriter(unittest.TestCase):
 
             # we are now in cycle 2, node 3 ... AFTER setFluxAwesome
             # lets get the 3rd block ... whatever that is
-            fluxes = db.getHistory(b, params=["flux"])
+            _ = db.getHistory(b, params=["flux"])
 
         self.o.interfaces.append(MockInterface(self.o.r, self.o.cs, setFluxAwesome))
         self.o.interfaces.append(MockInterface(self.o.r, self.o.cs, getFluxAwesome))

--- a/armi/bookkeeping/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/tests/test_databaseInterface.py
@@ -23,13 +23,13 @@ import h5py
 import numpy
 from numpy.testing import assert_allclose, assert_equal
 
-import armi
 from armi.reactor.flags import Flags
 from armi import interfaces
 from armi.bookkeeping.db.database3 import DatabaseInterface, Database3
 from armi.bookkeeping.db import convertDatabase
 from armi import settings
 from armi.tests import TEST_ROOT
+from armi import __version__ as version
 from armi.cases import case
 from armi.utils import directoryChangers
 from armi import runLog
@@ -100,7 +100,7 @@ class TestDatabaseWriter(unittest.TestCase):
 
         with h5py.File(self.o.cs.caseTitle + ".h5", "r") as h5:
             self.assertTrue(h5.attrs["successfulCompletion"])
-            self.assertEqual(h5.attrs["version"], armi.__version__)
+            self.assertEqual(h5.attrs["version"], version)
             self.assertIn("user", h5.attrs)
             self.assertIn("python", h5.attrs)
             self.assertIn("armiLocation", h5.attrs)
@@ -128,7 +128,7 @@ class TestDatabaseWriter(unittest.TestCase):
 
         with h5py.File(self.o.cs.caseTitle + ".h5", "r") as h5:
             self.assertFalse(h5.attrs["successfulCompletion"])
-            self.assertEqual(h5.attrs["version"], armi.__version__)
+            self.assertEqual(h5.attrs["version"], version)
             self.assertIn("caseTitle", h5.attrs)
 
     @unittest.skip(
@@ -200,7 +200,7 @@ class TestDatabaseWriter(unittest.TestCase):
 
         with h5py.File(self.o.cs.caseTitle + ".h5", "r") as h5:
             self.assertFalse(h5.attrs["successfulCompletion"])
-            self.assertEqual(h5.attrs["version"], armi.__version__)
+            self.assertEqual(h5.attrs["version"], version)
 
 
 class TestDatabaseReading(unittest.TestCase):

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -24,7 +24,8 @@ import os
 import pathlib
 import shutil
 
-import armi
+from armi.context import ROOT
+from armi import init as armi_init
 from armi import utils
 from armi.bookkeeping import historyTracker
 from armi.reactor import blocks
@@ -37,7 +38,7 @@ from armi.tests import ArmiTestHelper
 from armi.bookkeeping.tests._constants import TUTORIAL_FILES
 
 THIS_DIR = os.path.dirname(__file__)  # b/c tests don't run in this folder
-TUTORIAL_DIR = os.path.join(armi.context.ROOT, "tests", "tutorials")
+TUTORIAL_DIR = os.path.join(ROOT, "tests", "tutorials")
 CASE_TITLE = "anl-afci-177"
 
 
@@ -77,7 +78,7 @@ class TestHistoryTracker(ArmiTestHelper):
         reloadCs["runType"] = "Snapshots"
         reloadCs["loadStyle"] = "fromDB"
         reloadCs["detailAssemLocationsBOL"] = ["001-001"]
-        o = armi.init(cs=reloadCs)
+        o = armi_init(cs=reloadCs)
         cls.o = o
 
     @classmethod

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -40,7 +40,7 @@ class MemoryProfilerTests(unittest.TestCase):
         results = self.memPro._printFullMemoryBreakdown(
             startsWith="armi.physics", reportSize=False
         )
-        objects, count, size = results["Dif3dInterface"]
+        _, count, _ = results["Dif3dInterface"]
         self.assertGreater(count, 0)
 
 

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -40,7 +40,7 @@ class MemoryProfilerTests(unittest.TestCase):
         results = self.memPro._printFullMemoryBreakdown(
             startsWith="armi.physics", reportSize=False
         )
-        _, count, _ = results["Dif3dInterface"]
+        _objects, count, _size = results["Dif3dInterface"]
         self.assertGreater(count, 0)
 
 

--- a/armi/bookkeeping/visualization/xdmf.py
+++ b/armi/bookkeeping/visualization/xdmf.py
@@ -287,7 +287,6 @@ class XdmfDumper(dumper.VisFileDumper):
         node = r.p.timeNode
 
         timeGroupName = database3.getH5GroupName(cycle, node)
-        dbVersion = self._inputDb.version
 
         # careful here! we are trying to use the database datasets as the source of hard
         # data without copying, so the order that we make the mesh needs to be the same

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -741,7 +741,7 @@ def copyInterfaceInputs(
 
     assert destPath.is_dir()
 
-    for klass, kwargs in activeInterfaces:
+    for klass, _ in activeInterfaces:
         interfaceFileNames = klass.specifyInputs(cs)
         # returned files can be absolute paths, relative paths, or even glob patterns.
         # Since we don't have an explicit way to signal about these, we sort of have to

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -98,7 +98,7 @@ class TestArmiCase(unittest.TestCase):
         cs = settings.Settings(ARMI_RUN_PATH)
         cs["verbosity"] = "important"
         baseCase = cases.Case(cs, bp=bp, geom=geom)
-        with directoryChangers.TemporaryDirectoryChanger() as cwd:  # ensure we are not in IN_USE_TEST_ROOT
+        with directoryChangers.TemporaryDirectoryChanger():  # ensure we are not in IN_USE_TEST_ROOT
             vals = {"cladThickness": 1, "control strat": "good", "enrich": 0.9}
             case = baseCase.clone()
             case._independentVariables = vals  # pylint: disable=protected-access

--- a/armi/cli/checkInputs.py
+++ b/armi/cli/checkInputs.py
@@ -109,7 +109,7 @@ class CheckInputEntryPoint(EntryPoint):
                     canStart = "PASSED"
                 else:
                     canStart = "UNKNOWN"
-            except Exception as ee:
+            except Exception:
                 runLog.error("Failed to initialize/summarize {}".format(case))
                 runLog.error(traceback.format_exc())
                 canStart = "FAILED"

--- a/armi/cli/copyDB.py
+++ b/armi/cli/copyDB.py
@@ -14,7 +14,7 @@
 
 """Copy database entry point."""
 
-import armi
+from armi import init as armi_init
 from armi import settings
 from armi.bookkeeping import db
 from armi.utils import directoryChangers
@@ -52,5 +52,5 @@ class CopyDB(EntryPoint):
         cs = settings.Settings(fName=self.args.csPath)
 
         with directoryChangers.DirectoryChanger(cs.inputDirectory):
-            o = armi.init(cs=cs)
+            o = armi_init(cs=cs)
             db.copyDatabase(o.r, srcDB, tarDB)

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -22,9 +22,7 @@ from typing import Optional, Union
 
 import six
 
-import armi
-from armi import settings
-from armi import runLog
+from armi import context, runLog, settings
 
 
 class _EntryPointEnforcer(type):
@@ -88,7 +86,7 @@ class EntryPoint:
             )
 
         self.parser = argparse.ArgumentParser(
-            prog="{} {}".format(armi.context.APP_NAME, self.name),
+            prog="{} {}".format(context.APP_NAME, self.name),
             description=self.description or self.__doc__,
         )
 

--- a/armi/localization/tests/test_localization.py
+++ b/armi/localization/tests/test_localization.py
@@ -180,7 +180,7 @@ class LocalizationTests(unittest.TestCase):
 
     def test_warn_once_decorator(self):
         with mockRunLogs.BufferLog() as mock:
-            for ii in range(1, 4):
+            for _ in range(1, 4):
                 self.exampleWarnOnceMessage()
                 self.assertEqual(
                     "[warn] single warning\n", mock._outputStream.getvalue()

--- a/armi/materials/__init__.py
+++ b/armi/materials/__init__.py
@@ -39,7 +39,6 @@ import inspect
 
 from armi.materials.material import Material
 from armi.utils import dynamicImporter
-import armi
 
 # this will frequently be updated by the CONF_MATERIAL_NAMESPACE_ORDER setting
 # during reactor construction (see armi.reactor.reactors.factory)

--- a/armi/materials/tests/test_graphite.py
+++ b/armi/materials/tests/test_graphite.py
@@ -3,13 +3,30 @@ Tests for graphite material
 """
 import unittest
 
-
 from armi.materials.graphite import Graphite
 from armi.materials.tests import test_materials
 
 
-class Graphite_TestCase(test_materials._Material_Test, unittest.TestCase):
+class Graphite_TestCase(unittest.TestCase):
     MAT_CLASS = Graphite
+
+    def setUp(self):
+        self.mat = self.MAT_CLASS()
+
+    def test_linearExpansionPercent(self):
+        accuracy = 2
+
+        cur = self.mat.linearExpansionPercent(330)
+        ref = 0.013186
+        self.assertAlmostEqual(cur, ref, accuracy)
+
+        cur = self.mat.linearExpansionPercent(1500)
+        ref = 0.748161
+        self.assertAlmostEqual(cur, ref, accuracy)
+
+        cur = self.mat.linearExpansionPercent(3000)
+        ref = 2.149009
+        self.assertAlmostEqual(cur, ref, accuracy)
 
 
 if __name__ == "__main__":

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -98,6 +98,89 @@ class Magnesium_TestCase(_Material_Test, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
 
+class Molybdenum_TestCase(_Material_Test, unittest.TestCase):
+    MAT_CLASS = materials.Molybdenum
+
+    def test_density(self):
+        cur = self.mat.density(333)
+        ref = 10.28
+        delta = ref * 0.0001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.density(1390)
+        ref = 10.28
+        delta = ref * 0.0001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+
+class Potassium_TestCase(_Material_Test, unittest.TestCase):
+    MAT_CLASS = materials.Potassium
+
+    def test_density(self):
+        cur = self.mat.density(333)
+        ref = 0.828
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.density(500)
+        ref = 0.7909
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.density(750)
+        ref = 0.732
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+
+class Sodium_TestCase(_Material_Test, unittest.TestCase):
+    MAT_CLASS = materials.Sodium
+
+    def test_density(self):
+        cur = self.mat.density(300)
+        ref = 0.941
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.density(1700)
+        ref = 0.597
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+    def test_specificVolumeLiquid(self):
+        cur = self.mat.specificVolumeLiquid(300)
+        ref = 0.001062
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.specificVolumeLiquid(1700)
+        ref = 0.001674
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+    def test_enthalpy(self):
+        cur = self.mat.enthalpy(300)
+        ref = 107518.523
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.enthalpy(1700)
+        ref = 1959147.963
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+    def test_thermalConductivity(self):
+        cur = self.mat.thermalConductivity(300)
+        ref = 95.1776
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.thermalConductivity(1700)
+        ref = 32.616
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+
 class Uranium_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Uranium
 
@@ -1064,7 +1147,5 @@ class TZM_TestCase(_Material_Test, unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # import sys
-    # sys.argv = ["", "Sodium_TestCase"]
-
+    # import sys; sys.argv = ["", "Sodium_TestCase"]
     unittest.main()

--- a/armi/materials/tests/test_sic.py
+++ b/armi/materials/tests/test_sic.py
@@ -16,6 +16,23 @@ class Test_SiC(test_materials._Material_Test, unittest.TestCase):
         delta = ref * 0.001
         self.assertAlmostEqual(cur, ref, delta=delta)
 
+    def test_meltingPoint(self):
+        cur = self.mat.meltingPoint()
+        ref = 3003
+        delta = ref * 0.0001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+    def test_heatCapacity(self):
+        delta = 0.0001
+
+        cur = self.mat.heatCapacity(300)
+        ref = 982.20789
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.heatCapacity(1500)
+        ref = 1330.27867
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -234,7 +234,7 @@ def clearNuclideBases():
 
     Necessary when initializing nuclide base information multiple times (often in testing).
     """
-    for name, element in byName.items():
+    for _, element in byName.items():
         element.nuclideBases = []
 
 

--- a/armi/nuclearDataIO/__init__.py
+++ b/armi/nuclearDataIO/__init__.py
@@ -15,24 +15,7 @@
 """
 Read and/or write data files associated with nuclear data and reactor physics data.
 """
-import os
-import struct
-import math
-import re
-import traceback
 
-import glob
-import numpy
-import pylab
-import scipy.interpolate
-
-from armi.utils import properties
-from armi import runLog
-from armi import settings
-from armi.localization import exceptions
-from armi.utils import units
-from armi.nuclearDataIO import cccc
->>>>>>> 402d35f... py2to3 - removing future print import
 from armi.physics import neutronics
 
 # export the cccc modules here to keep external clients happy,

--- a/armi/nuclearDataIO/__init__.py
+++ b/armi/nuclearDataIO/__init__.py
@@ -15,7 +15,24 @@
 """
 Read and/or write data files associated with nuclear data and reactor physics data.
 """
+import os
+import struct
+import math
+import re
+import traceback
 
+import glob
+import numpy
+import pylab
+import scipy.interpolate
+
+from armi.utils import properties
+from armi import runLog
+from armi import settings
+from armi.localization import exceptions
+from armi.utils import units
+from armi.nuclearDataIO import cccc
+>>>>>>> 402d35f... py2to3 - removing future print import
 from armi.physics import neutronics
 
 # export the cccc modules here to keep external clients happy,

--- a/armi/nuclearDataIO/ripl.py
+++ b/armi/nuclearDataIO/ripl.py
@@ -55,7 +55,7 @@ def getNuclideDecayConstants(fileName):
     with readerClass(fileName) as reader:
         nuclideDecayConstants = {}
         while reader.searchForPattern(r"\d+[A-Z]{1,1}[a-z]{0,1}\s+\d+\s+\d+\s+\d+"):
-            symb, a, z, nol, _Nog, _Nmax, _Nc, _Sn, _Sp = reader.line.split()
+            _, a, z, nol, _Nog, _Nmax, _Nc, _Sn, _Sp = reader.line.split()
 
             level = 0
             numLevels = int(nol)

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Tests for xsLibraries.IsotxsLibrary"""
-from __future__ import print_function
 import filecmp
 import os
 import unittest

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -15,6 +15,7 @@
 """
 Tests for operators
 """
+# pylint: disable=abstract-method,no-self-use,unused-argument
 import os
 import unittest
 import subprocess
@@ -22,13 +23,11 @@ import subprocess
 import armi
 from armi import settings
 from armi.operators import OperatorMPI
-
 from armi.tests import ARMI_RUN_PATH
+from armi.interfaces import Interface
 
 
-class FailingInterface1(
-    armi.interfaces.Interface
-):  # pylint: disable=abstract-method,no-self-use,unused-argument
+class FailingInterface1(Interface):
     """utility classes to make sure the logging system fails properly"""
 
     name = "failer"
@@ -37,9 +36,7 @@ class FailingInterface1(
         raise RuntimeError("Failing interface failure")
 
 
-class FailingInterface2(
-    armi.interfaces.Interface
-):  # pylint: disable=abstract-method,no-self-use,unused-argument
+class FailingInterface2(Interface):
     """utility class to make sure the logging system fails properly"""
 
     name = "failer"
@@ -48,9 +45,7 @@ class FailingInterface2(
         raise RuntimeError("Failing interface critical failure")
 
 
-class FailingInterface3(
-    armi.interfaces.Interface
-):  # pylint: disable=abstract-method,no-self-use,unused-argument
+class FailingInterface3(Interface):
     """fails on worker operate"""
 
     name = "failer"
@@ -68,9 +63,7 @@ class FailingInterface3(
         return False
 
 
-class OperatorTests(
-    unittest.TestCase
-):  # pylint: disable=abstract-method,no-self-use,unused-argument
+class OperatorTests(unittest.TestCase):
     """Testing the MPI parallelization operation"""
 
     # @unittest.skipIf(distutils.spawn.find_executable('mpiexec.exe') is None, "mpiexec is not in path.")

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -125,8 +125,7 @@ class FuelHandlerInterface(interfaces.Interface):
         # take note of where each assembly is located before the outage
         # for mapping after the outage
         self.r.core.locateAllAssemblies()
-        cycleDuration = self.r.p.cycleLength
-        shuffleFactors, factorSearchFlags = fh.getFactorList(cycle)
+        shuffleFactors, _ = fh.getFactorList(cycle)
         fh.outage(shuffleFactors)  # move the assemblies around
         if self.cs["plotShuffleArrows"]:
             arrows = fh.makeShuffleArrows()

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -369,7 +369,7 @@ class LumpedFissionProductCollection(dict):
         lastVal = -1
         for lfp in self.values():
             myVal = lfp.getGasRemovedFrac()
-            if lastVal != -1 and myVal != lastVal:
+            if lastVal not in (-1, lastVal):
                 raise RuntimeError(
                     "Fission gas release fracs in {0} are decoupled" "".format(self)
                 )

--- a/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
@@ -102,7 +102,7 @@ class TestLumpedFissionProduct(unittest.TestCase):
         self.assertLess(frac, 1.0)
 
     def test_printDensities(self):
-        xe135 = nuclideBases.fromName("XE135")
+        _ = nuclideBases.fromName("XE135")
         lfp = self.fpd.createSingleLFPFromFile("LFP38")
         lfp.printDensities(10.0)
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1462,7 +1462,7 @@ class Block(composites.Composite):
 
         # update moles at BOL for each pin
         self.p.molesHmBOLByPin = []
-        for pinNum, pin in enumerate(self.iterComponents(Flags.FUEL)):
+        for pin in self.iterComponents(Flags.FUEL):
             # Update the fuel component flags to be the same as before the split (i.e., DEPLETABLE)
             pin.p.flags = fuelFlags
             self.p.molesHmBOLByPin.append(pin.getHMMoles())

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -357,8 +357,6 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             expansions,
         ) = isotopicOptions.autoSelectElementsToKeepFromSettings(cs)
 
-        _ = actives | inerts  # join
-
         # Flag all elementals for expansion unless they've been flagged otherwise by
         # user input or automatic lattice/datalib rules.
         for elemental in nuclideBases.instances:

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -357,7 +357,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             expansions,
         ) = isotopicOptions.autoSelectElementsToKeepFromSettings(cs)
 
-        nucsFromInput = actives | inerts  # join
+        _ = actives | inerts  # join
 
         # Flag all elementals for expansion unless they've been flagged otherwise by
         # user input or automatic lattice/datalib rules.

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -19,8 +19,7 @@ import collections
 
 import yamlize
 
-import armi
-from armi import runLog
+from armi import getPluginManagerOrFail, runLog
 from armi.reactor import blocks
 from armi.reactor import parameters
 from armi.reactor.flags import Flags
@@ -31,7 +30,7 @@ from armi.reactor import grids
 
 def _configureGeomOptions():
     blockTypes = dict()
-    pm = armi.getPluginManagerOrFail()
+    pm = getPluginManagerOrFail()
     for pluginBlockTypes in pm.hook.defineBlockTypes():
         for compType, blockType in pluginBlockTypes:
             blockTypes[compType] = blockType

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -97,7 +97,7 @@ assemblies:
             )
         )
         cs = settings.Settings()
-        a = bp.constructAssem(cs, "assembly")
+        _ = bp.constructAssem(cs, "assembly")
 
     def test_autoDepletable(self):
         nuclideFlags = (

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -272,7 +272,7 @@ assemblies:
 class TestCustomIsotopics_ErrorConditions(unittest.TestCase):
     def test_densityMustBePositive(self):
         with self.assertRaises(yamlize.YamlizingError):
-            ci = isotopicOptions.CustomIsotopic.load(
+            _ = isotopicOptions.CustomIsotopic.load(
                 r"""
             name: atom repellent
             input format: mass fractions
@@ -285,7 +285,7 @@ class TestCustomIsotopics_ErrorConditions(unittest.TestCase):
 
     def test_nonConformantElementName(self):
         with self.assertRaises(yamlize.YamlizingError):
-            ci = isotopicOptions.CustomIsotopic.load(
+            _ = isotopicOptions.CustomIsotopic.load(
                 r"""
             name: non-upper case
             input format: number densities
@@ -295,7 +295,7 @@ class TestCustomIsotopics_ErrorConditions(unittest.TestCase):
 
     def test_numberDensitiesCannotSpecifyDensity(self):
         with self.assertRaises(yamlize.YamlizingError):
-            ci = isotopicOptions.CustomIsotopic.load(
+            _ = isotopicOptions.CustomIsotopic.load(
                 r"""
             name: over-specified isotopics
             input format: number densities

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for grid blueprints."""
+# pylint: disable=wrong-import-position
 import io
 import unittest
 
@@ -266,7 +267,11 @@ class TestRZTGridBlueprint(unittest.TestCase):
     def test_geomFile(self):
         geom = systemLayoutInput.SystemLayoutInput()
         geom.readGeomFromStream(io.StringIO(RTH_GEOM))
-        _ = geom.toGridBlueprints("test_grid")[0]
+        gridDesign = geom.toGridBlueprints("test_grid")[0]
+        self.assertEqual(gridDesign.name, "test_grid")
+        self.assertEqual(gridDesign.geom, "thetarz")
+        self.assertEqual(gridDesign.symmetry, "eighth periodic")
+        self.assertEqual(gridDesign.geom, "thetarz")
 
 
 if __name__ == "__main__":

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -266,7 +266,7 @@ class TestRZTGridBlueprint(unittest.TestCase):
     def test_geomFile(self):
         geom = systemLayoutInput.SystemLayoutInput()
         geom.readGeomFromStream(io.StringIO(RTH_GEOM))
-        gridDesign = geom.toGridBlueprints("test_grid")[0]
+        _ = geom.toGridBlueprints("test_grid")[0]
 
 
 if __name__ == "__main__":

--- a/armi/reactor/blueprints/tests/test_materialModifications.py
+++ b/armi/reactor/blueprints/tests/test_materialModifications.py
@@ -72,7 +72,6 @@ assemblies:
         """
         )
         fuelComponent = a[0][0]
-        _ = fuelComponent.p.numberDensities
         u235 = fuelComponent.getMass("U235")
         u = fuelComponent.getMass("U")
         assert_allclose(0.20, u235 / u)

--- a/armi/reactor/blueprints/tests/test_materialModifications.py
+++ b/armi/reactor/blueprints/tests/test_materialModifications.py
@@ -72,7 +72,7 @@ assemblies:
         """
         )
         fuelComponent = a[0][0]
-        nd = fuelComponent.p.numberDensities
+        _ = fuelComponent.p.numberDensities
         u235 = fuelComponent.getMass("U235")
         u = fuelComponent.getMass("U")
         assert_allclose(0.20, u235 / u)

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -97,7 +97,7 @@ class TestGeometryConverters(unittest.TestCase):
         # checks that outer assemblies are removed
         locator = self.r.core.spatialGrid.getLocatorFromRingAndPos(9, 1)
         with self.assertRaises(KeyError):
-            loc = self.r.core.childrenByLocator[locator]
+            _ = self.r.core.childrenByLocator[locator]
 
         # tests ability to remove fuel assemblies
         converter.numFuelAssems = 20

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -295,7 +295,7 @@ class BoundaryType(enum.Enum):
             return REFLECTIVE
 
     def hasSymmetry(self):
-        return not self == self.NO_SYMMETRY
+        return self != self.NO_SYMMETRY
 
 
 class SymmetryType:

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -72,7 +72,7 @@ class GeomType(enum.Enum):
     def fromStr(cls, geomStr: str) -> "GeomType":
         # case-insensitive
         canonical = geomStr.lower().strip()
-        if canonical == HEX or canonical == HEX_CORNERS_UP:
+        if canonical in (HEX, HEX_CORNERS_UP):
             # corners-up is used to rotate grids, but shouldn't be needed after the grid
             # is appropriately oriented, so we collapse to HEX in the enumeration. If
             # there is a good reason to make corners-up HEX its own geom type, we will
@@ -207,7 +207,7 @@ class DomainType(enum.Enum):
             return ""
 
     def symmetryFactor(self) -> float:
-        if self == self.FULL_CORE or self == self.NULL:
+        if self in (self.FULL_CORE, self == self.NULL):
             return 1.0
         elif self == self.THIRD_CORE:
             return 3.0

--- a/armi/reactor/parameters/parameterCollections.py
+++ b/armi/reactor/parameters/parameterCollections.py
@@ -503,8 +503,6 @@ def collectPluginParameters(pm):
         for klass, pDefs in pluginParamDefnCollections.items():
             klass.pDefs.extend(pDefs)
 
-    return
-
 
 def applyAllParameters(klass=None):
     klass = klass or ParameterCollection

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -21,7 +21,6 @@ more refinement in representing the physical reactor. The reactor is the owner o
 plant-wide state variables such as keff, cycle, and node.
 
 """
-from __future__ import print_function
 import collections
 import copy
 import itertools

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -32,10 +32,7 @@ import os
 
 import numpy
 
-import armi
-from armi import runLog
-from armi import nuclearDataIO
-from armi import settings
+from armi import getPluginManagerOrFail, runLog, nuclearDataIO, settings
 from armi.localization import exceptions
 from armi.reactor import assemblies
 from armi.reactor import assemblyLists
@@ -2323,4 +2320,4 @@ class Core(composites.Composite):
 
         self.p.maxAssemNum = self.getMaxParam("assemNum")
 
-        armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=self, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(core=self, cs=cs)

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1974,7 +1974,7 @@ class Core(composites.Composite):
             generates submesh points to further discretize the theta reactor mesh
 
         """
-        i, j, k = self.findAllMeshPoints(extraAssems, applySubMesh)
+        i, _, _ = self.findAllMeshPoints(extraAssems, applySubMesh)
         return i
 
     def findAllRadMeshPoints(self, extraAssems=None, applySubMesh=True):
@@ -1994,7 +1994,7 @@ class Core(composites.Composite):
             (not implemented) generates submesh points to further discretize the radial reactor mesh
 
         """
-        i, j, k = self.findAllMeshPoints(extraAssems, applySubMesh)
+        _, j, _ = self.findAllMeshPoints(extraAssems, applySubMesh)
         return j
 
     def getMaxBlockParam(self, *args, **kwargs):

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -864,7 +864,7 @@ class Assembly_TestCase(unittest.TestCase):
                 "mult": 1.0,
             }
 
-            if i in (0, 4):
+            if (i == 0) or (i == 4):
                 b.setType("plenum")
                 h = components.Hexagon("intercoolant", "Sodium", **self.hexDims)
             else:
@@ -906,7 +906,7 @@ class Assembly_TestCase(unittest.TestCase):
 
             # Check densities
             for nuc, dens in b.getNumberDensities().items():
-                if i in (0, 4):
+                if (i == 0) or (i == 4):
                     ref = densities[i][nuc]
                 else:
                     ref = densities[i][nuc] / expandFrac
@@ -941,7 +941,7 @@ class Assembly_TestCase(unittest.TestCase):
                 "ip": 0.0,
                 "mult": 1.0,
             }
-            if blockI in (0, 4):
+            if (blockI == 0) or (blockI == 4):
                 b.setType("plenum")
                 h = components.Hexagon("intercoolant", "Sodium", **self.hexDims)
             else:
@@ -982,7 +982,7 @@ class Assembly_TestCase(unittest.TestCase):
 
             # Check densities
             for nuc, dens in b.getNumberDensities().items():
-                if i in (0, 4):
+                if (i == 0) or (i == 4):
                     # these blocks should be unchanged in mass/density.
                     ref = densities[i][nuc]
                 else:

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -864,7 +864,7 @@ class Assembly_TestCase(unittest.TestCase):
                 "mult": 1.0,
             }
 
-            if (i == 0) or (i == 4):
+            if i in (0, 4):
                 b.setType("plenum")
                 h = components.Hexagon("intercoolant", "Sodium", **self.hexDims)
             else:
@@ -906,7 +906,7 @@ class Assembly_TestCase(unittest.TestCase):
 
             # Check densities
             for nuc, dens in b.getNumberDensities().items():
-                if (i == 0) or (i == 4):
+                if i in (0, 4):
                     ref = densities[i][nuc]
                 else:
                     ref = densities[i][nuc] / expandFrac
@@ -941,7 +941,7 @@ class Assembly_TestCase(unittest.TestCase):
                 "ip": 0.0,
                 "mult": 1.0,
             }
-            if (blockI == 0) or (blockI == 4):
+            if blockI in (0, 4):
                 b.setType("plenum")
                 h = components.Hexagon("intercoolant", "Sodium", **self.hexDims)
             else:
@@ -982,7 +982,7 @@ class Assembly_TestCase(unittest.TestCase):
 
             # Check densities
             for nuc, dens in b.getNumberDensities().items():
-                if (i == 0) or (i == 4):
+                if i in (0, 4):
                     # these blocks should be unchanged in mass/density.
                     ref = densities[i][nuc]
                 else:

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1502,7 +1502,7 @@ class Block_TestCase(unittest.TestCase):
 
         comps.pop(0)
         with self.assertRaises(RuntimeError):
-            comps2 = self.Block.getComponentsInLinkedOrder(comps)
+            _ = self.Block.getComponentsInLinkedOrder(comps)
 
     def test_mergeWithBlock(self):
         fuel1 = self.Block.getComponent(Flags.FUEL)
@@ -1522,7 +1522,7 @@ class Block_TestCase(unittest.TestCase):
 
 class HexBlock_TestCase(unittest.TestCase):
     def setUp(self):
-        caseSetting = settings.Settings()
+        _ = settings.Settings()
         self.HexBlock = blocks.HexBlock("TestHexBlock")
         hexDims = {"Tinput": 273.0, "Thot": 273.0, "op": 70.6, "ip": 70.0, "mult": 1.0}
         self.hexComponent = components.Hexagon("duct", "UZr", **hexDims)
@@ -1707,7 +1707,7 @@ class HexBlock_TestCase(unittest.TestCase):
 
 class ThRZBlock_TestCase(unittest.TestCase):
     def setUp(self):
-        caseSetting = settings.Settings()
+        _ = settings.Settings()
         self.ThRZBlock = blocks.ThRZBlock("TestThRZBlock")
         self.ThRZBlock.add(
             components.DifferentialRadialSegment(

--- a/armi/reactor/tests/test_geometry.py
+++ b/armi/reactor/tests/test_geometry.py
@@ -212,7 +212,7 @@ class TestSymmetryType(unittest.TestCase):
         self.assertTrue(geometry.checkValidGeomSymmetryCombo(geomRZ, fullCore))
 
         with self.assertRaises(ValueError):
-            thirdReflective = geometry.SymmetryType(
+            _ = geometry.SymmetryType(
                 geometry.DomainType.THIRD_CORE,
                 geometry.BoundaryType.REFLECTIVE,
                 False,
@@ -270,7 +270,7 @@ class TestSystemLayoutInput(unittest.TestCase):
         self.assertEqual(geom2.assemTypeByIndices[2, 2], "A2")
         os.remove(fName)
 
-    def test_asciimap(self):
+    def test_asciimap(self):  # pylint: disable=no-self-use
         """Ensure this can write ascii maps"""
         geom = SystemLayoutInput()
         geom.readGeomFromStream(io.StringIO(GEOM_INPUT))

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -185,7 +185,7 @@ class TestGrid(unittest.TestCase):
         """
         grid = grids.HexGrid.fromPitch(1.0, numRings=0)
         self.assertNotIn((0, 0, 0), grid._locations)
-        loc = grid[0, 0, 0]
+        _ = grid[0, 0, 0]
         self.assertIn((0, 0, 0), grid._locations)
 
         multiLoc = grid[[(0, 0, 0), (1, 0, 0), (0, 1, 0)]]

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -194,7 +194,7 @@ class ParameterTests(unittest.TestCase):
                     pb.defParam("sameName", "units", "description 1", "location")
                     pb.defParam("sameName", "units", "description 2", "location")
 
-            p = MockParamCollection()
+            _ = MockParamCollection()
 
     def test_paramDefinitionsCompose(self):
         class MockBaseParamCollection(parameters.ParameterCollection):
@@ -243,7 +243,7 @@ class ParameterTests(unittest.TestCase):
                 with pDefs.createBuilder() as pb:
                     pb.defParam("sameName", "units", "description 4", "location")
 
-            p = MockPCChild()
+            _ = MockPCChild()
 
         # same name along a different branch from the base ParameterCollection should be fine
         class MockPCUncle(parameters.ParameterCollection):
@@ -261,11 +261,11 @@ class ParameterTests(unittest.TestCase):
 
     def test_cannotCreateInstanceOf_NoDefault(self):
         with self.assertRaises(NotImplementedError):
-            thing = parameters.NoDefault()
+            _ = parameters.NoDefault()
 
     def test_cannotCreateInstanceOf_Undefined(self):
         with self.assertRaises(NotImplementedError):
-            _thing = parameters.parameterDefinitions._Undefined()
+            _ = parameters.parameterDefinitions._Undefined()
 
     def test_defaultLocation(self):
         class MockPC(parameters.ParameterCollection):
@@ -409,7 +409,7 @@ class SynchronizationTests:
                     try:
                         self.setUp()
                         getattr(self, methodName)()
-                    except Exception as ex:
+                    except Exception:
                         self.write("failed, big time")
                         traceback.print_exc(file=self.l)
                         self.write("*** printed exception")
@@ -514,7 +514,7 @@ class SynchronizationTests:
 
     def mpitest_conflictsMaintainWithStateRetainer(self):
         with self.r.retainState(parameters.inCategory("cat2")):
-            for ci, comp in enumerate(self.comps):
+            for _, comp in enumerate(self.comps):
                 comp.p.param2 = 99 * armi.MPI_RANK
 
         with self.assertRaises(exceptions.SynchronizationError):

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+""" tests of the Parameters class """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
-
-from __future__ import print_function
 import unittest
 import traceback
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -37,7 +37,6 @@ from armi.reactor.components import Hexagon, Rectangle
 from armi.reactor.converters import geometryConverters
 from armi.tests import TEST_ROOT, ARMI_RUN_PATH
 from armi.utils import directoryChangers
-from armi.physics.neutronics import isotopicDepletion
 
 TEST_REACTOR = None  # pickled string of test reactor (for fast caching)
 
@@ -593,12 +592,13 @@ class HexReactorTests(ReactorTests):
         expFlux = [i for i in range(5) for b in self.r.core.getBlocks()]
         expAdjFlux = [i + 0.1 for b in self.r.core.getBlocks() for i in range(5)]
         expSrcVec = [i + 0.2 for b in self.r.core.getBlocks() for i in range(5)]
+        expFluxVol = list(range(5)) * len(self.r.core.getBlocks())
         assert_allclose(expFlux, mgFlux)
         assert_allclose(expAdjFlux, adjFlux)
         assert_allclose(expSrcVec, srcVec)
+        assert_allclose(expFluxVol, fluxVol)
 
     def test_getFuelBottomHeight(self):
-
         for a in self.r.core.getAssemblies(Flags.FUEL):
             if a[0].hasFlags(Flags.FUEL):
                 a[0].setType("mud")

--- a/armi/reactor/tests/test_rz_reactors.py
+++ b/armi/reactor/tests/test_rz_reactors.py
@@ -40,7 +40,7 @@ class Test_RZT_Reactor(unittest.TestCase):
         self.assertTrue(all(aziMesh == 8 for aziMesh in aziMeshes))
 
     def test_findAllMeshPoints(self):
-        i, j, k = self.r.core.findAllMeshPoints()
+        i, _, _ = self.r.core.findAllMeshPoints()
         self.assertLess(i[-1], 2 * math.pi)
 
 

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -191,11 +191,11 @@ class Zones_InReactor(unittest.TestCase):
 
         # if indexed like a dict, the zones object should give a key error from the removed zone
         with self.assertRaises(KeyError):
-            daZones["ring-1"]
+            daZones["ring-1"]  # pylint: disable=pointless-statement
 
         # Ensure we can still iterate through our zones object
         for name in daZones.names:
-            aZone = daZones[name]
+            _ = daZones[name]
 
     def test_findZoneAssemblyIsIn(self):
         cs = self.o.cs

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -32,6 +32,7 @@ The default way of using the ARMI runLog is:
     system.
 
 """
+from __future__ import print_function
 import sys
 import os
 import collections
@@ -176,7 +177,7 @@ class Log:
 
     def _msgHasAlreadyBeenEmitted(self, label, msgType=""):
         """Return True if the count of the label is greater than 1."""
-        if msgType in ("warning", "critical"):
+        if msgType == "warning" or msgType == "critical":
             self._singleWarningMessageCounts[label] += 1
             if (
                 self._singleWarningMessageCounts[label] > 1

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -32,7 +32,6 @@ The default way of using the ARMI runLog is:
     system.
 
 """
-from __future__ import print_function
 import sys
 import os
 import collections

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -177,7 +177,7 @@ class Log:
 
     def _msgHasAlreadyBeenEmitted(self, label, msgType=""):
         """Return True if the count of the label is greater than 1."""
-        if msgType == "warning" or msgType == "critical":
+        if msgType in ("warning", "critical"):
             self._singleWarningMessageCounts[label] += 1
             if (
                 self._singleWarningMessageCounts[label] > 1

--- a/armi/scripts/migration/m0_1_0_newDbFormat.py
+++ b/armi/scripts/migration/m0_1_0_newDbFormat.py
@@ -26,12 +26,10 @@ import io
 
 import h5py
 
-import armi
-from armi import runLog
-from armi import utils
+from armi import __version__ as version
+from armi import getApp, runLog, utils
 from armi.reactor import geometry
 from armi.reactor import systemLayoutInput
-
 from armi.scripts.migration.base import DatabaseMigration
 
 
@@ -96,7 +94,7 @@ def _migrateDatabase(databasePath, preCollector, visitor, postApplier):
         newDB.attrs["original-armi-version"] = oldDB.attrs["version"]
         newDB.attrs["original-db-hash"] = shaHash
         newDB.attrs["original-databaseVersion"] = oldDB.attrs["databaseVersion"]
-        newDB.attrs["version"] = armi.__version__
+        newDB.attrs["version"] = version
 
         postApplier(oldDB, newDB, preCollection)
 
@@ -169,7 +167,7 @@ def _updateParams(newDB, preCollection, name, dataset):
 
 
 def _collectParamRenames():
-    return {"paramRenames": armi.getApp().getParamRenames()}
+    return {"paramRenames": getApp().getParamRenames()}
 
 
 def _collectSymmetry(oldDB):

--- a/armi/settings/__init__.py
+++ b/armi/settings/__init__.py
@@ -28,7 +28,6 @@ from typing import List, Union
 
 from ruamel import yaml
 
-import armi
 from armi import runLog
 from armi.localization import exceptions
 from armi.settings.caseSettings import Settings

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -10,7 +10,8 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License0.
+""" Testing the settingsIO """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import datetime
@@ -90,7 +91,7 @@ class SettingsRenameTests(unittest.TestCase):
             ]
         }
         with self.assertRaises(exceptions.SettingException):
-            renamer = settingsIO.SettingRenamer(settings)
+            _ = settingsIO.SettingRenamer(settings)
 
 
 class SettingsWriterTests(unittest.TestCase):

--- a/armi/tests/test_docs.py
+++ b/armi/tests/test_docs.py
@@ -16,19 +16,13 @@
 import os
 import unittest
 import doctest
-import armi
+from armi import DOC
 
 
 class TestDocs(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     @unittest.skip("Doc code examples need some love before this is going to work.")
     def test_docsHaveWorkingCodeExamples(self):
-        for root, _dirs, files in os.walk(armi.DOC):
+        for root, _dirs, files in os.walk(DOC):
             for f in files:
                 fullpath = os.path.join(root, f)
 

--- a/armi/tests/test_docs.py
+++ b/armi/tests/test_docs.py
@@ -34,7 +34,7 @@ class TestDocs(unittest.TestCase):
 
                 try:
                     doctest.testfile(fullpath)
-                except Exception as ee:
+                except Exception:
                     pass
 
 

--- a/armi/tests/test_fuelHandlers.py
+++ b/armi/tests/test_fuelHandlers.py
@@ -450,10 +450,10 @@ class TestFuelHandler(ArmiTestHelper):
         (
             loadChains,
             loopChains,
-            enriches,
-            loadChargeTypes,
+            _,
+            _,
             loadNames,
-            alreadyDone,
+            _,
         ) = fh.processMoveList(moves[2])
         self.assertIn("A0085", loadNames)
         self.assertIn(None, loadNames)
@@ -463,7 +463,7 @@ class TestFuelHandler(ArmiTestHelper):
 
     def test_getFactorList(self):
         fh = fuelHandlers.FuelHandler(self.o)
-        factors, flags = fh.getFactorList(0)
+        factors, _ = fh.getFactorList(0)
         self.assertIn("eqShuffles", factors)
 
     def test_simpleAssemblyRotation(self):

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -20,7 +20,7 @@ import numpy
 from armi.utils import directoryChangers
 from armi.tests import TEST_ROOT
 from armi.reactor.flags import Flags
-import armi
+from armi import init as armi_init
 from armi.bookkeeping import db
 
 TEST_INPUT_TITLE = "c5g7-settings"
@@ -43,7 +43,7 @@ class C5G7ReactorTests(unittest.TestCase):
         """
         Load the C5G7 case from input and check basic counts.
         """
-        o = armi.init(fName=TEST_INPUT_TITLE + ".yaml")
+        o = armi_init(fName=TEST_INPUT_TITLE + ".yaml")
         b = o.r.core.getFirstBlock(Flags.MOX)
         # there are 100 of each high, medium, and low MOX pins
         fuelPinsHigh = b.getComponent(Flags.HIGH | Flags.MOX)
@@ -64,7 +64,7 @@ class C5G7ReactorTests(unittest.TestCase):
                 indices = b.spatialLocator.getCompleteIndices()
                 locs[indices] = b.spatialLocator.getGlobalCoordinates()
 
-        o = armi.init(fName=TEST_INPUT_TITLE + ".yaml")
+        o = armi_init(fName=TEST_INPUT_TITLE + ".yaml")
         locsInput, locsDB = {}, {}
         _loadLocs(o, locsInput)
         o.operate()

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 """Generic ARMI utilities"""
-from __future__ import print_function
-
 import os
 import sys
 import time

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -341,14 +341,14 @@ class AsciiMapHexThirdFlatsUp(AsciiMap):
         """
         self.asciiOffsets = []
         for li, _line in enumerate(self.asciiLines):
-            iBase, jBase = self._getIJBaseByAsciiLine(li)
+            iBase, _ = self._getIJBaseByAsciiLine(li)
             self.asciiOffsets.append(iBase - 1)
         self.asciiOffsets.reverse()  # since getIJ works from bottom to top
         newOffsets = []
 
         # renomalize the offsets to start at 0
         minOffset = min(self.asciiOffsets)
-        for li, (line, offset) in enumerate(zip(self.asciiLines, self.asciiOffsets)):
+        for li, (_, offset) in enumerate(zip(self.asciiLines, self.asciiOffsets)):
             newOffsets.append(offset - minOffset)
         self.asciiOffsets = newOffsets
 

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -304,7 +304,7 @@ class Flag(metaclass=_FlagMeta):
         sense to play with this more.
         """
         new = self._value
-        for name, val in self._nameToValue.items():
+        for _, val in self._nameToValue.items():
             if val & new:
                 new -= val
             else:
@@ -312,7 +312,7 @@ class Flag(metaclass=_FlagMeta):
         return type(self)(new)
 
     def __iter__(self):
-        for name, value in self._nameToValue.items():
+        for _, value in self._nameToValue.items():
             if value & self._value:
                 yield type(self)(value)
 

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -52,7 +52,6 @@ import numpy
 import numpy.linalg
 from ruamel.yaml import scalarstring
 
-import armi
 from armi import runLog
 from armi.utils import hexagon
 from armi.utils import textProcessors
@@ -63,8 +62,7 @@ from armi.reactor import grids
 from armi.reactor import blueprints
 from armi.reactor.flags import Flags
 import armi.reactor.blueprints
-from armi.reactor.blueprints import Blueprints
-from armi.reactor.blueprints import gridBlueprint
+from armi.reactor.blueprints import Blueprints, gridBlueprint, migrate
 from armi.reactor.blueprints.gridBlueprint import GridBlueprint
 from armi.reactor.blueprints.assemblyBlueprint import AssemblyBlueprint
 from armi.settings.fwSettings import globalSettings
@@ -1523,7 +1521,7 @@ class GridBlueprintControl(wx.Panel):
                     # blueprints. Give up.
                     return
 
-                armi.reactor.blueprints.migrate(bp, cs)
+                migrate(bp, cs)
 
         self.bp = bp
 

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -692,7 +692,7 @@ class GridGui(wx.ScrolledWindow):
 
         @property
         def isPosition(self):
-            return self == self.POSITION_IJ or self == self.POSITION_RINGPOS
+            return self in (self.POSITION_IJ, self.POSITION_RINGPOS)
 
     def __init__(self, parent, bp=None, defaultGeom=geometry.CARTESIAN):
         """

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -917,7 +917,7 @@ class GridGui(wx.ScrolledWindow):
         self.pdc.SetBrush(brush)
 
         for idx, loc in self.grid.items():
-            ring, pos = self.grid.getRingPos(idx)
+            ring, _ = self.grid.getRingPos(idx)
             if not self.grid.locatorInDomain(loc) or ring > self.numRings:
                 continue
 
@@ -1085,7 +1085,7 @@ class GridGui(wx.ScrolledWindow):
         region = self.GetUpdateRegion()
         region.Offset(dx * xv, dy * yv)
 
-        rect = region.GetBox()
+        _ = region.GetBox()
 
         self.pdc.DrawToDC(dc)
 
@@ -1095,8 +1095,8 @@ class GridGui(wx.ScrolledWindow):
             return
 
         if event.LeftDown():
-            x = event.GetX()
-            y = event.GetY()
+            _ = event.GetX()
+            _ = event.GetY()
 
             objId = self._getObjectFromEvent(event)
 
@@ -1225,7 +1225,7 @@ class GridGui(wx.ScrolledWindow):
             and self.grid.getRingPos(loc)[0] <= self.numRings
         }
 
-        coordScale = self._gridScale(self.grid)
+        _ = self._gridScale(self.grid)
 
         allCenters = numpy.array(
             [self.grid.getCoordinates(idx)[:2] for idx in inDomain]
@@ -1780,11 +1780,6 @@ class NewGridBlueprintDialog(wx.Dialog):
         else:
             bc = geometry.BoundaryType.NO_SYMMETRY
 
-        if self.throughCenter.GetValue():
-            through = geometry.THROUGH_CENTER_ASSEMBLY
-        else:
-            through = ""
-
         symmetry = geometry.SymmetryType(domain, bc, self.throughCenter.GetValue())
 
         assert symmetry.checkValidSymmetry()
@@ -1798,7 +1793,6 @@ if __name__ == "__main__":
     import sys
 
     app = wx.App()
-
     frame = wx.Frame(None, wx.ID_ANY, title="Grid Blueprints GUI", size=(1000, 1000))
 
     gui = GridBlueprintControl(frame)

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -15,8 +15,6 @@
 """
 Module of utilities to help dealing with iterable objects in python
 """
-
-from __future__ import print_function
 import struct
 from itertools import tee, chain
 

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -271,7 +271,7 @@ def plotFaceMap(
     """
     if referencesToKeep:
         patches, collection, texts = referencesToKeep
-        fig, ax = plt.gcf(), plt.gca()
+        _, ax = plt.gcf(), plt.gca()
     else:
         fig, ax = plt.subplots(figsize=(12, 12), dpi=100)
         # set patch (shapes such as hexagon) heat map values
@@ -433,7 +433,7 @@ def _makeAssemPatches(core):
 
 def _setPlotValText(ax, texts, core, data, labels, labelFmt, fontSize):
     """Write param values down, and return text so it can be edited later."""
-    pitch = core.getAssemblyPitch()
+    _ = core.getAssemblyPitch()
     for a, val, label in zip(core, data, labels):
         x, y, _ = a.spatialLocator.getLocalCoordinates()
 
@@ -944,7 +944,7 @@ def plotBlockFlux(core, fName=None, bList=None, peak=False, adjoint=False, bList
                     "Energy_Group", "Average_Flux", "Peak_Flux"
                 )
             )
-            for g, (eMax, avgFlux, peakFlux) in bf1.getTable():
+            for _, (eMax, avgFlux, peakFlux) in bf1.getTable():
                 f.write("{0:12E} {1:12E} {2:12E}\n".format(eMax, avgFlux, peakFlux))
 
     if max(bf1.avgFlux) <= 0.0:

--- a/armi/utils/tests/test_directoryChangers.py
+++ b/armi/utils/tests/test_directoryChangers.py
@@ -124,7 +124,7 @@ class TestDirectoryChangers(unittest.TestCase):
 
         with directoryChangers.TemporaryDirectoryChanger(
             filesToRetrieve=[(f("file1.txt"), f("newfile1.txt"))]
-        ) as dc:
+        ):
             Path(f("file1.txt")).touch()
             Path(f("file2.txt")).touch()
 

--- a/armi/utils/tests/test_flags.py
+++ b/armi/utils/tests/test_flags.py
@@ -80,7 +80,7 @@ class TestFlag(unittest.TestCase):
         """
         with self.assertRaises(AssertionError):
 
-            class F(Flag):
+            class F(Flag):  # pylint: disable=unused-variable
                 foo = 1
                 bar = 1
 

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -63,7 +63,7 @@ class TestPlotting(unittest.TestCase):
             self.r.core.lib = xslib
 
             blockList = self.r.core.getBlocks()
-            for i, b in enumerate(blockList):
+            for _, b in enumerate(blockList):
                 b.p.mgFlux = range(33)
 
             plotting.plotBlockFlux(self.r.core, fName="flux.png", bList=blockList)

--- a/armi/utils/tests/test_properties.py
+++ b/armi/utils/tests/test_properties.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
+""" tests of the propereties class """
 import unittest
 
 from armi.utils import properties

--- a/armi/utils/tests/test_triangle.py
+++ b/armi/utils/tests/test_triangle.py
@@ -88,11 +88,11 @@ class triangleTests(unittest.TestCase):
         y3 = 0.376
         xP = 0.0
         yP = 0.17
-        # generalTriangleInOrOut = triangle.checkIfPointIsInTriangle(xT1, yT1, xT2, yT2, xT3, yT3, xP, yP)
+        # FIXME: generalTriangleInOrOut = triangle.checkIfPointIsInTriangle(xT1, yT1, xT2, yT2, xT3, yT3, xP, yP)
         self.assertFalse(generalTriangleInOrOut)
 
     def test_checkIfPointIsInTriangle2(self):
-        """Test that barycentricCheckIfPointIsInTriangle can  identify if a point is inside or outside of a triangle."""
+        """Test that barycentricCheckIfPointIsInTriangle can identify if a point is inside or outside of a triangle."""
 
         # First check the right triangle case
         xT1 = 0.0
@@ -118,7 +118,7 @@ class triangleTests(unittest.TestCase):
         xP = 0.0
         yP = 0.17
         generalTriangleInOrOut = triangle.checkIfPointIsInTriangle(
-            xT1, yT1, xT2, yT2, xT3, yT3, xP, yP
+            x1, y1, x2, y2, x3, y3, xP, yP
         )
         self.assertTrue(generalTriangleInOrOut)
 

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -55,7 +55,7 @@ class Utils_TestCase(unittest.TestCase):
         self.assertEqual(x2, 50.0)
 
         with self.assertRaises(ZeroDivisionError):
-            error = utils.linearInterpolation(1.0, 1.0, 1.0, 2.0)
+            _ = utils.linearInterpolation(1.0, 1.0, 1.0, 2.0)
 
     def test_parabolicInterpolation(self):
         realRoots = utils.parabolicInterpolation(2.0e-6, -5.0e-4, 1.02, 1.0)
@@ -68,7 +68,7 @@ class Utils_TestCase(unittest.TestCase):
         self.assertAlmostEqual(noRoots[0][1], 0.0)
         # 3. run time error
         with self.assertRaises(RuntimeError):
-            error = utils.parabolicInterpolation(2.0e-6, 4.0e-4, 1.02, 1.0)
+            _ = utils.parabolicInterpolation(2.0e-6, 4.0e-4, 1.02, 1.0)
 
     def test_rotateXY(self):
         x = [1.0, -1.0]

--- a/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
+++ b/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
@@ -14,9 +14,9 @@ from armi.reactor.tests import test_reactors
 from armi.reactor.flags import Flags
 from armi.utils.densityTools import formatMaterialCard
 from armi.nucDirectory import nuclideBases as nb
-import armi
+from armi import configure
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 _o, r = test_reactors.loadTestReactor()
 

--- a/doc/gallery-src/analysis/run_hexBlockToRZConversion.py
+++ b/doc/gallery-src/analysis/run_hexBlockToRZConversion.py
@@ -32,9 +32,9 @@ efficient analysis.
 from armi.reactor.tests import test_reactors
 from armi.reactor.flags import Flags
 from armi.reactor.converters import blockConverters
-import armi
+from armi import configure
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 _o, r = test_reactors.loadTestReactor()
 

--- a/doc/gallery-src/analysis/run_hexReactorToRZ.py
+++ b/doc/gallery-src/analysis/run_hexReactorToRZ.py
@@ -21,9 +21,9 @@ from armi.reactor.tests import test_reactors
 from armi.reactor.flags import Flags
 from armi.reactor.converters import geometryConverters
 from armi.utils import plotting
-import armi
+from armi import configure
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 o, r = test_reactors.loadTestReactor()
 kgFis = [a.getHMMass() for a in r.core]

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -17,9 +17,9 @@ import collections
 import tabulate
 import matplotlib.pyplot as plt
 
-import armi
+from armi import configure
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_blocks import buildSimpleFuelBlock

--- a/doc/gallery-src/framework/run_chartOfNuclides.py
+++ b/doc/gallery-src/framework/run_chartOfNuclides.py
@@ -13,9 +13,9 @@ coloring the squares with the natural abundance.
 import matplotlib.pyplot as plt
 
 from armi.nucDirectory import nuclideBases
-import armi
+from armi import configure
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 xyc = []
 for name, base in nuclideBases.byName.items():

--- a/doc/gallery-src/framework/run_computeReactionRates.py
+++ b/doc/gallery-src/framework/run_computeReactionRates.py
@@ -13,8 +13,7 @@ rather than relying upon input files.
 import numpy as np
 import matplotlib.pyplot as plt
 
-from armi import settings
-from armi import nuclideBases
+from armi import configure, nuclideBases, settings
 
 from armi.reactor.flags import Flags
 from armi.reactor import grids
@@ -34,9 +33,8 @@ from armi.reactor.components import DerivedShape
 from armi.materials import uZr
 from armi.materials import ht9
 from armi.materials import sodium
-import armi
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 
 def _addFlux(b):

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -22,12 +22,11 @@ import math
 from armi.reactor.flags import Flags
 from armi.reactor.tests import test_reactors
 from armi.physics.fuelCycle import fuelHandlers
-
 from armi.utils import plotting
 
-import armi
+from armi import configure
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 o, reactor = test_reactors.loadTestReactor(inputFileName="refTestCartesian.yaml")
 

--- a/doc/gallery-src/framework/run_grids1_hex.py
+++ b/doc/gallery-src/framework/run_grids1_hex.py
@@ -14,10 +14,9 @@ import matplotlib.patches as mpatches
 from matplotlib.collections import PatchCollection
 
 from armi.reactor import grids
+from armi import configure
 
-import armi
-
-armi.configure(permissive=True)
+configure(permissive=True)
 
 hexes = grids.HexGrid.fromPitch(1.0)
 

--- a/doc/gallery-src/framework/run_grids2_cartesian.py
+++ b/doc/gallery-src/framework/run_grids2_cartesian.py
@@ -12,10 +12,9 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 
 from armi.reactor import grids
+from armi import configure
 
-import armi
-
-armi.configure(permissive=True)
+configure(permissive=True)
 
 fig = plt.figure()
 zCoords = [1, 4, 8]

--- a/doc/gallery-src/framework/run_grids3_rzt.py
+++ b/doc/gallery-src/framework/run_grids3_rzt.py
@@ -13,10 +13,9 @@ from mpl_toolkits.mplot3d import Axes3D
 import numpy as np
 
 from armi.reactor import grids
+from armi import configure
 
-import armi
-
-armi.configure(permissive=True)
+configure(permissive=True)
 
 fig = plt.figure()
 theta = np.linspace(0, 2 * np.pi, 10)

--- a/doc/gallery-src/framework/run_isotxs.py
+++ b/doc/gallery-src/framework/run_isotxs.py
@@ -3,7 +3,7 @@ Plotting Multi-group XS from ISOTXS
 ===================================
 
 In this example, several cross sections are plotted from
-an existing binary cross section library file in :py:mod:`ISOTXS <armi.nuclearDataIO.isotxs>` format. 
+an existing binary cross section library file in :py:mod:`ISOTXS <armi.nuclearDataIO.isotxs>` format.
 
 """
 
@@ -12,9 +12,9 @@ import matplotlib.pyplot as plt
 from armi.physics.neutronics import energyGroups
 from armi.tests import ISOAA_PATH
 from armi.nuclearDataIO.cccc import isotxs
-import armi
+from armi import configure
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 gs = energyGroups.getGroupStructure("ANL33")
 lib = isotxs.readBinary(ISOAA_PATH)

--- a/doc/gallery-src/framework/run_isotxs2_matrix.py
+++ b/doc/gallery-src/framework/run_isotxs2_matrix.py
@@ -16,10 +16,9 @@ from armi.utils import units
 from armi.tests import ISOAA_PATH
 from armi.nuclearDataIO.cccc import isotxs
 from armi.nuclearDataIO import xsNuclides
-import armi
+from armi import configure
 
-
-armi.configure(permissive=True)
+configure(permissive=True)
 
 lib = isotxs.readBinary(ISOAA_PATH)
 

--- a/doc/gallery-src/framework/run_materials.py
+++ b/doc/gallery-src/framework/run_materials.py
@@ -14,13 +14,12 @@ More info about the materials here: :py:mod:`armi.materials`.
 import numpy as np
 import matplotlib.pyplot as plt
 
-import armi
-from armi import materials
+from armi import configure, materials
 from armi.nucDirectory import nuclideBases
 
 MAX_Z = 96  # stop at Curium
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 materialNames = []
 mats = list(materials.iterAllMaterialClassesInNamespace(materials))

--- a/doc/gallery-src/framework/run_programmaticReactorDefinition.py
+++ b/doc/gallery-src/framework/run_programmaticReactorDefinition.py
@@ -3,22 +3,22 @@ Build Reactor Inputs Programmatically
 =====================================
 
 Sometimes it's desirable to build input definitions for ARMI using
-code rather than by writing the textual input files directly. 
+code rather than by writing the textual input files directly.
 In ARMI you can either make the ARMI reactor objects directly,
 or you can define Blueprints objects. The benefit of making Blueprints
 objects is that they can in turn be used to create both ARMI reactor
 objects as well as textual input itself. This is nice when you want to
 have traceable input files associated with a run that was developed
-programmatically (e.g. for parameter sweeps). 
+programmatically (e.g. for parameter sweeps).
 
 This example shows how to make Blueprints objects programmatically completely
 from scratch.
 
 """
 import matplotlib.pyplot as plt
-import armi
+from armi import configure
 
-armi.configure(permissive=True)
+configure(permissive=True)
 # pylint: disable=wrong-import-position
 from armi.reactor import blueprints
 from armi import settings

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -7,9 +7,9 @@ power distribution from it. You can plot any block parameter.
 """
 from armi.reactor.tests import test_reactors
 from armi.utils import plotting
-import armi
+from armi import configure
 
-armi.configure(permissive=True)
+configure(permissive=True)
 
 operator, reactor = test_reactors.loadTestReactor()
 reactor.core.growToFullCore(None)

--- a/pylintrc
+++ b/pylintrc
@@ -19,6 +19,7 @@
 #     popular idiom
 # useless-object-inheritance: New-style classes in python 2
 # no-else-return: multiple return statements are not considered bad practice
+# duplicate-code: The duplicate code pylint founds is just not interesting.
 disable =
     bad-whitespace,
     trailing-whitespace,
@@ -39,7 +40,8 @@ disable =
     missing-return-doc,
     too-few-public-methods,
     useless-object-inheritance,
-    no-else-return
+    no-else-return,
+    duplicate-code
 
 [BASIC]
 dummy-variables-rgx=_[a-zA-Z_]*


### PR DESCRIPTION
This is a low-priority, low-risk, Pylint PR.

I have no excuse for myself. I've just been trying to wrap my head around the code base and understand what's going on, and I tend to do cleanup as I read. I can quit any time I want, I swear.

This PR fixes these Pylint errors:

* **R1711** useless-return
* **W0612** unused-variable
* **R1714** consider-using-in
* **C0113** correct use of not in

Three other issues are also addressed:

* **py2to3** - removed 'from __future__ print import', as this is Python 3 code and these statements appear to do nothing
* Removing circular imports from several places, though some still remain
* Removing useless Pylint code duplication detection, this appeared to be 100% false positives to me.
