### PR TITLE
Hex to RZ mesh converter assemblies in ring fix

### DIFF
--- a/armi/reactor/converters/meshConverters.py
+++ b/armi/reactor/converters/meshConverters.py
@@ -273,7 +273,9 @@ class _RZThetaReactorMeshConverterByRingComposition(RZThetaReactorMeshConverter)
         ringCompositions = []
         numRings = [r for r in range(1, self._numRingsInCore + 1)]
         for _i, ring in enumerate(numRings):
-            assemsInRing = core.getAssembliesInRing(ring)
+            # Note that this needs to be in a HEX ring - Circular ring mode
+            # is not supported.
+            assemsInRing = core.getAssembliesInSquareOrHexRing(ring)
             compsInRing = []
             for a in assemsInRing:
                 assemType = a.getType().lower()


### PR DESCRIPTION
The `_RZThetaReactorMeshConverterByRingComposition` class was
incorrectly using the `core.getAssembliesInRing` method to obtain
the assemblies within a given ring. This class is intended
to be used for non-circular geometries, like HEX or Cartesian,
so the method call is now set to `core.getAssembliesInSquareOrHexRing`.

This change is made to decouple the behavior of this class
with the `circularRingMode` setting. Otherwise, the behavior
of the `HexToRZThetaConverter` class changes depending on whether
or not the user sets `circularRingMode` to True or False. The
`circularRingMode` is intended for use in fuel management and
not in this conversion process.