### PR TITLE
Cross section settings warning to debug message

### DIFF
--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -456,7 +456,7 @@ class XSModelingOptions:
                 f"The following inputs in {self} are not valid when `{self.geometry}` geometry type is set:"
             )
             for var, val in invalids:
-                runLog.warning(f"\tAttribute: {var}, Value: {val}")
+                runLog.debug(f"\tAttribute: {var}, Value: {val}")
             runLog.debug(
                 f"The valid options for the `{self.geometry}` geometry are: {validOptions}"
             )


### PR DESCRIPTION
Missed a warning message that should have been changed to debug in #298. 