### PR TITLE
We were reporting test coverage of the test files themselves

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,4 +9,7 @@ omit =
 omit =
     armi/cli/gridGui.py
     armi/utils/gridEditor.py
-    armi/utils/tests/test_gridGui.py
+    */tests/*
+
+exclude_lines =
+    raise NotImplementedError


### PR DESCRIPTION
> **NOTE**: This PR will reduce test coverage from 80% to 76%. Travis will hate it.

This is a common issue. Because of the way PyTest calculates code coverage, it is really easy to accidentally report the code coverage of the unit tests (.py files) themselves. Of course, the code coverage of unit tests files is ~100%, so the coverage is over-reported.

(In the other direction, I have excluded `raise NotImplementedError` from the code coverage because we don't expect to be calling those lines anyway.)