### PR TITLE
Make it possible to add interfaces with the same function

### DIFF
--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -548,7 +548,12 @@ class Operator:  # pylint: disable=too-many-public-methods
             self.addInterface(klass(self.r, self.cs), **kwargs)
 
     def addInterface(
-        self, interface, index=None, reverseAtEOL=False, enabled=True, bolForce=False
+        self,
+        interface,
+        index=None,
+        reverseAtEOL=False,
+        enabled=True,
+        bolForce=False,
     ):
         """
         Attach an interface to this operator.
@@ -590,21 +595,30 @@ class Operator:  # pylint: disable=too-many-public-methods
             )
 
         iFunc = self.getInterface(function=interface.function)
+
         if iFunc:
-            raise RuntimeError(
-                "Cannot add {0}; the {1} already is designated "
-                "as the {2} interface. Multiple interfaces of the same "
-                "function is not supported.".format(
-                    interface, iFunc, interface.function
+            if issubclass(type(iFunc), type(interface)):
+                runLog.info(
+                    "Ignoring Interface {newFunc} because existing interface {old} already "
+                    " more specific".format(newFunc=interface, old=iFunc)
                 )
-            )
+                return
+            elif issubclass(type(interface), type(iFunc)):
+                self.removeInterface(iFunc)
+            else:
+                raise RuntimeError(
+                    "Cannot add {0}; the {1} already is designated "
+                    "as the {2} interface. Multiple interfaces of the same "
+                    "function is not supported.".format(
+                        interface, iFunc, interface.function
+                    )
+                )
 
         runLog.debug("Adding {0}".format(interface))
         if index is None:
             self.interfaces.append(interface)
         else:
             self.interfaces.insert(index, interface)
-
         if reverseAtEOL:
             interface.reverseAtEOL = True
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -605,6 +605,10 @@ class Operator:  # pylint: disable=too-many-public-methods
                 return
             elif issubclass(type(interface), type(iFunc)):
                 self.removeInterface(iFunc)
+                runLog.info(
+                    "Will Insert Interface {newFunc} because it is a subclass of {old} interface and "
+                    " more derived".format(newFunc=interface, old=iFunc)
+                )
             else:
                 raise RuntimeError(
                     "Cannot add {0}; the {1} already is designated "

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -73,7 +73,7 @@ class InterfaceA(Interface):
 
 
 class InterfaceB(InterfaceA):
-    """ Dummy Interface that extends A"""
+    """Dummy Interface that extends A"""
 
     function = "A"
     name = "Second"

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -16,15 +16,19 @@
 Tests for operators
 """
 # pylint: disable=abstract-method,no-self-use,unused-argument
+
 import os
 import unittest
 import subprocess
+
+import pytest
 
 import armi
 from armi import settings
 from armi.operators import OperatorMPI
 from armi.tests import ARMI_RUN_PATH
 from armi.interfaces import Interface
+from armi.reactor.tests import test_reactors
 
 
 class FailingInterface1(Interface):
@@ -63,7 +67,62 @@ class FailingInterface3(Interface):
         return False
 
 
+class InterfaceA(Interface):
+    function = "A"
+    name = "First"
+
+
+class InterfaceB(InterfaceA):
+    """ Dummy Interface that extends A"""
+
+    function = "A"
+    name = "Second"
+
+
+class InterfaceC(Interface):
+    function = "A"
+    name = "Third"
+
+
 class OperatorTests(unittest.TestCase):
+    def test_addInterfaceSubclassCollision(self):
+
+        self.cs = settings.Settings()
+        o, r = test_reactors.loadTestReactor()
+
+        interfaceA = InterfaceA(r, self.cs)
+
+        interfaceB = InterfaceB(r, self.cs)
+        o.addInterface(interfaceA)
+
+        # 1) Adds B and gets rid of A
+        o.addInterface(interfaceB)
+        self.assertEqual(o.getInterface("Second"), interfaceB)
+        self.assertEqual(o.getInterface("First"), None)
+
+        # 2) Now we have B which is a subclass of A,
+        #    we want to not add A (but also not have an error)
+
+        o.addInterface(interfaceA)
+        self.assertEqual(o.getInterface("Second"), interfaceB)
+        self.assertEqual(o.getInterface("First"), None)
+
+        # 3) Also if another class not a subclass has the same function,
+        #    raise an error
+        interfaceC = InterfaceC(r, self.cs)
+
+        self.assertRaises(RuntimeError, o.addInterface, interfaceC)
+
+        # 4) Check adding a different function Interface
+
+        interfaceC.function = "C"
+
+        o.addInterface(interfaceC)
+        self.assertEqual(o.getInterface("Second"), interfaceB)
+        self.assertEqual(o.getInterface("Third"), interfaceC)
+
+
+class OperatorMPITests(unittest.TestCase):
     """Testing the MPI parallelization operation"""
 
     # @unittest.skipIf(distutils.spawn.find_executable('mpiexec.exe') is None, "mpiexec is not in path.")
@@ -122,7 +181,8 @@ if armi.MPI_SIZE > 1:
 
 
 if __name__ == "__main__":
-    args = ["mpiexec", "-n", "2", "python", "-m", "unittest"]
+    """args = ["mpiexec", "-n", "2", "python", "-m", "unittest"]
     args += ["armi.tests.test_operators.OperatorTests"]
-    subprocess.call(args)
-    # unittest.main()
+    subprocess.call(args)"""
+
+    pytest.main()

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -181,8 +181,7 @@ if armi.MPI_SIZE > 1:
 
 
 if __name__ == "__main__":
-    """args = ["mpiexec", "-n", "2", "python", "-m", "unittest"]
-    args += ["armi.tests.test_operators.OperatorTests"]
-    subprocess.call(args)"""
-
+    # args = ["mpiexec", "-n", "2", "python", "-m", "unittest"]
+    # args += ["armi.tests.test_operators.OperatorTests"]
+    # subprocess.call(args)
     pytest.main()


### PR DESCRIPTION
Originally addInterface would raise an exception when the Interface
stack already contained an Interface with the same function as the one
passed into it. This was limiting when you had different plug-ins but
wanted the right Interface to take precedence.
So, now it adds an Interface even if it has the same function as one
previously if the new Interface is a subclass of the current Interface
with that function. This keeps the Interface that is more derived and
removes the old Interface. This still throws an exception if the new
Interface has the same function but shares no inheritance with the old
Interface. If the old Interface is instead a subclass of the new
Interface, neither interface is removed or added.