### PR TITLE
Add expand-bp entry point

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -316,8 +316,6 @@ def configure(app: Optional[apps.App] = None, permissive=False):
     parameters.collectPluginParameters(pm)
     parameters.applyAllParameters()
     flags.registerPluginFlags(pm)
-    if MPI_RANK == 0:
-        runLog.raw(app.splashText)
 
 
 def applyAsyncioWindowsWorkaround():

--- a/armi/cli/checkInputs.py
+++ b/armi/cli/checkInputs.py
@@ -41,6 +41,8 @@ def _runInspectorOnSettings(cs):
 class ExpandBlueprints(EntryPoint):
     """
     Perform expansion of !include directives in a blueprint file.
+
+    This is useful for testing inputs that make heavy use of !include directives.
     """
 
     name = "expand-bp"

--- a/armi/cli/checkInputs.py
+++ b/armi/cli/checkInputs.py
@@ -16,11 +16,13 @@
 Entry point into ARMI to check inputs of a case or a whole folder of cases.
 """
 
+import pathlib
 import sys
 import traceback
 
 from armi import runLog
 from armi.cli.entryPoint import EntryPoint
+from armi.utils.textProcessors import resolveMarkupInclusions
 
 
 def _runInspectorOnSettings(cs):
@@ -34,6 +36,31 @@ def _runInspectorOnSettings(cs):
         if query and query.correction is not None and query._passed != True
     ]  # pylint: disable=protected-access
     return issues
+
+
+class ExpandBlueprints(EntryPoint):
+    """
+    Perform expansion of !include directives in a blueprint file.
+    """
+
+    name = "expand-bp"
+
+    splash = False
+
+    def addOptions(self):
+        self.parser.add_argument(
+            "blueprints", type=str, help="Path to root blueprints file"
+        )
+
+    def invoke(self):
+        p = pathlib.Path(self.args.blueprints)
+        if not p.exists():
+            runLog.error("Blueprints file `{}` does not exist".format(str(p)))
+            return 1
+        stream = resolveMarkupInclusions(p)
+        sys.stdout.write(stream.read())
+
+        return None
 
 
 class CheckInputEntryPoint(EntryPoint):

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -75,6 +75,14 @@ class EntryPoint:
     then it is an optional positional argument. Finally, if settingsArgument is
     None, then no settings file argument is added."""
 
+    splash = True
+    """
+    Whether running the entry point should produce a splash text upon executing.
+
+    Setting this to ``False`` is useful for utility commands that produce standard
+    output that would be needlessly cluttered by the splash text.
+    """
+
     #: One of {armi.Mode.BATCH, armi.Mode.INTERACTIVE, armi.Mode.GUI}, optional.
     #: Specifies the ARMI mode in which the command is run. Default is armi.Mode.BATCH.
     mode: Optional[int] = None

--- a/doc/user/inputs/blueprints.rst
+++ b/doc/user/inputs/blueprints.rst
@@ -24,7 +24,10 @@ For example::
        core: !include path/to/core_grid.yaml
 
 would have the effect of copy-pasting the contents of ``path/to/core_grid.yaml`` into
-the main blueprints file.
+the main blueprints file. The rules that ARMI uses to handle things like indentation of
+the included text are usually rather intuitive, but sometimes it can be useful to
+witness the behavior first-hand. The ``expand-bp`` command can be used to do a dry run
+for testing inputs with !includes.
 
 ARMI models are built hierarchically, first by defining components, and then by larger and larger
 collections of the levels of the reactor.


### PR DESCRIPTION
This entry point will process the !include directives in an ARMI YAML
file, emitting the results to standard output. This also adds a class
attribute the the EntryPoint class to control whether a splash text
should be writen to stdout, allowing the output to be safely captured in
a new YAML file.