### PR TITLE
Create Grid and Locators for a Block

### DIFF
--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -162,6 +162,12 @@ class BlockBlueprint(yamlize.KeyedList):
         b.verifyBlockDims()
         b.spatialGrid = spatialGrid
 
+        if b.spatialGrid is None:
+            try:
+                b.autoCreateSpatialGrids()
+            except (ValueError, NotImplementedError) as e:
+                runLog.warning(str(e), single=True)
+                b.spatialGrid = None
         return b
 
     def _getGridDesign(self, blueprint):

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -167,7 +167,6 @@ class BlockBlueprint(yamlize.KeyedList):
                 b.autoCreateSpatialGrids()
             except (ValueError, NotImplementedError) as e:
                 runLog.warning(str(e), single=True)
-                b.spatialGrid = None
         return b
 
     def _getGridDesign(self, blueprint):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1704,6 +1704,39 @@ class HexBlock_TestCase(unittest.TestCase):
         f2f = self.HexBlock.getPinCenterFlatToFlat()
         self.assertAlmostEqual(pinCenterFlatToFlat, f2f)
 
+    def test_gridCreation(self):
+        b = self.HexBlock
+        # The block should have a spatial grid at construction,
+        # since it has mults = 1 or 169 from setup
+        b.autoCreateSpatialGrid()
+        self.assertTrue(b.spatialGrid is not None)
+        for c in b:
+            if c.getDimension("mult", cold=True) == 169:
+                # Then it's spatialLocator must be of size 217
+                locations = c.spatialLocator
+                self.assertEqual(type(locations), grids.MultiIndexLocation)
+                mult = 0
+                for loc in locations:
+                    mult = mult + 1
+                self.assertEqual(mult, 169)
+
+    def test_gridNotCreatedMultipleMultiplicities(self):
+        wireDims = {
+            "Tinput": 200,
+            "Thot": 200,
+            "od": 0.1,
+            "id": 0.0,
+            "axialPitch": 30.0,
+            "helixDiameter": 1.1,
+            "mult": 21.0,
+        }
+        # add a wire only some places in the block, so grid should not be created.
+        wire = components.Helix("wire", "HT9", **wireDims)
+        self.HexBlock.add(wire)
+        with self.assertRaises(ValueError):
+            self.HexBlock.autoCreateSpatialGrid()
+
+        self.assertTrue(self.HexBlock.spatialGrid is None)
 
 class ThRZBlock_TestCase(unittest.TestCase):
     def setUp(self):
@@ -1812,6 +1845,12 @@ class ThRZBlock_TestCase(unittest.TestCase):
         """
         self.ThRZBlock.verifyBlockDims()
 
+    def test_getThetaRZGrid(self):
+        b = self.ThRZBlock
+        with self.assertRaises(NotImplementedError):
+            b.autoCreateSpatialGrid()
+        # Since not applicable to Cartesian Grids.
+
 
 class CartesianBlock_TestCase(unittest.TestCase):
     """Tests for blocks with rectangular/square outer shape."""
@@ -1904,6 +1943,12 @@ class CartesianBlock_TestCase(unittest.TestCase):
         self.assertEqual(desiredPitch, cartBlock.getPitch())
         self.assertAlmostEqual(rectTotalArea, cartBlock.getMaxArea())
         self.assertAlmostEqual(sum(c.getArea() for c in cartBlock), rectTotalArea)
+
+    def test_getCartesianGrid(self):
+        b = self.cartesianBlock
+        with self.assertRaises(NotImplementedError):
+            b.autoCreateSpatialGrid()
+        # Since not applicable to Cartesian Grids.
 
 
 class PointTests(unittest.TestCase):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1738,6 +1738,7 @@ class HexBlock_TestCase(unittest.TestCase):
 
         self.assertTrue(self.HexBlock.spatialGrid is None)
 
+
 class ThRZBlock_TestCase(unittest.TestCase):
     def setUp(self):
         _ = settings.Settings()

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1708,17 +1708,44 @@ class HexBlock_TestCase(unittest.TestCase):
         b = self.HexBlock
         # The block should have a spatial grid at construction,
         # since it has mults = 1 or 169 from setup
-        b.autoCreateSpatialGrid()
+        b.autoCreateSpatialGrids()
         self.assertTrue(b.spatialGrid is not None)
         for c in b:
             if c.getDimension("mult", cold=True) == 169:
-                # Then it's spatialLocator must be of size 217
+                # Then it's spatialLocator must be of size 169
                 locations = c.spatialLocator
                 self.assertEqual(type(locations), grids.MultiIndexLocation)
                 mult = 0
                 for loc in locations:
                     mult = mult + 1
                 self.assertEqual(mult, 169)
+
+    def test_gridNumPinsAndLocations(self):
+        b = blocks.HexBlock("fuel", height=10.0)
+
+        fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 168.0}
+        cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.77, "mult": 168.0}
+        ductDims = {"Tinput": 25.0, "Thot": 400, "op": 16, "ip": 15.3, "mult": 1.0}
+        wireDims = {
+            "Tinput": 25.0,
+            "Thot": 600,
+            "od": 0.1,
+            "id": 0.0,
+            "axialPitch": 30.0,
+            "helixDiameter": 0.9,
+            "mult": 168.0,
+        }
+        wire = components.Helix("wire", "HT9", **wireDims)
+        fuel = components.Circle("fuel", "UZr", **fuelDims)
+        clad = components.Circle("clad", "HT9", **cladDims)
+        duct = components.Hexagon("duct", "HT9", **ductDims)
+        b.add(fuel)
+        b.add(clad)
+        b.add(duct)
+        b.add(wire)
+        with self.assertRaises(ValueError):
+            b.autoCreateSpatialGrids()
+        self.assertTrue(b.spatialGrid is None)
 
     def test_gridNotCreatedMultipleMultiplicities(self):
         wireDims = {
@@ -1734,7 +1761,7 @@ class HexBlock_TestCase(unittest.TestCase):
         wire = components.Helix("wire", "HT9", **wireDims)
         self.HexBlock.add(wire)
         with self.assertRaises(ValueError):
-            self.HexBlock.autoCreateSpatialGrid()
+            self.HexBlock.autoCreateSpatialGrids()
 
         self.assertTrue(self.HexBlock.spatialGrid is None)
 
@@ -1849,7 +1876,7 @@ class ThRZBlock_TestCase(unittest.TestCase):
     def test_getThetaRZGrid(self):
         b = self.ThRZBlock
         with self.assertRaises(NotImplementedError):
-            b.autoCreateSpatialGrid()
+            b.autoCreateSpatialGrids()
         # Since not applicable to Cartesian Grids.
 
 
@@ -1948,7 +1975,7 @@ class CartesianBlock_TestCase(unittest.TestCase):
     def test_getCartesianGrid(self):
         b = self.cartesianBlock
         with self.assertRaises(NotImplementedError):
-            b.autoCreateSpatialGrid()
+            b.autoCreateSpatialGrids()
         # Since not applicable to Cartesian Grids.
 
 


### PR DESCRIPTION
In blocks, creates autoCreateSpatialGrids() that when called upon for
a block with no spatialGrid currently, will create one for it if it
meets certain conditions. These conditions are that among the blocks
components, the multiplicities are either equal to 1 or N. (So there can
be no greater than two multiplicities among the components and one of
the multiplicities must be 1). Things with mult equal to 1 will have a
spatialLocation located at the center of the grid. Those with
multiplicity N will have a MultIndexLocation and appear at every pin
position location in the grid (they will appear N times). The
functionality of this is for the added feature of Block Diagrams.

In blockBlueprints, makes it so that at construction, a block is given a
spatialGrid and its components spatialLocators if certain conditions are
met. These conditions are that it is a HexBlock (meaning the function
autoCreateSpatialGrids within blocks.py is not implemented for non-Hex
Blocks, and an exception is caught and the grid remains none) and it has
basic multiplicities as defined within autoCreateSpatialGrids (mult = 1
or N, only two possible multiplicities). This sets up blocks so that
they may later be used to create basic block diagrams in cases where the spatialGrid was
not originally provided but the component placement could be inferred.