### PR TITLE
Change how assembly pitch is found

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1518,38 +1518,17 @@ class Core(composites.Composite):
 
     def getAssemblyPitch(self):
         """
-        Find the representative assembly pitch for the whole core.
+        Find the assembly pitch for the whole core.
 
-        This loops over all fuel blocks to find the best pitch.
+        This returns the pitch according to the spatialGrid.
 
         Returns
         -------
-        avgPitch : float
-            The average pitch of fuel assems in cm.
+        pitch : float
+            The assembly pitch.
 
         """
-        pitches = numpy.array([b.getPitch() for b in self.getBlocks(Flags.FUEL)])
-
-        # keepdims assures we get array of length one for when there is only one pitch
-        # value (such as in the hex case), so the same code can be used.
-        keepDims = False if pitches.ndim > 1 else True
-
-        # axis=0 will return average of the horizontal and vertical pitch independently
-        # in the case of rectangular lattice.
-        avgPitch = pitches.mean(axis=0, keepdims=keepDims)
-
-        # Check that pitches are consistent
-        minPitch = pitches.min(axis=0, keepdims=keepDims)
-        maxPitch = pitches.max(axis=0, keepdims=keepDims)
-        minDeviatesTooMuch = any(diff > 1e-10 for diff in avgPitch - minPitch)
-        maxDeviatesTooMuch = any(diff > 1e-10 for diff in maxPitch - avgPitch)
-        if minDeviatesTooMuch or maxDeviatesTooMuch:
-            raise RuntimeError(
-                "Not all fuel blocks have the same pitch (in cm). "
-                "Min: {}, Mean: {}, Max: {}".format(minPitch, avgPitch, maxPitch)
-            )
-        # not keepdims this time so non-tuples are unpacked
-        return pitches.mean(axis=0)
+        return self.spatialGrid.pitch
 
     def findNeighbors(
         self, a, showBlanks=True, duplicateAssembliesOnReflectiveBoundary=False

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1521,6 +1521,9 @@ class Core(composites.Composite):
         Find the assembly pitch for the whole core.
 
         This returns the pitch according to the spatialGrid.
+        To capture any thermal/hydraulic feedback of the core pitch,
+        T/H modules will need to modify the grid pitch directly based
+        on the relevant mechanical assumptions.
 
         Returns
         -------

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -54,14 +54,14 @@ def getEmptyHexReactor():
     return reactor
 
 
-def getEmptyCartesianReactor():
+def getEmptyCartesianReactor(pitch=(10.0, 16.0)):
     """Return an empty Cartesian reactor used in some tests."""
     from armi.reactor import blueprints
 
     bp = blueprints.Blueprints()
     reactor = reactors.Reactor("Reactor", bp)
     reactor.add(reactors.Core("Core"))
-    reactor.core.spatialGrid = grids.CartesianGrid.fromRectangle(1.0, 1.0)
+    reactor.core.spatialGrid = grids.CartesianGrid.fromRectangle(*pitch)
     reactor.core.spatialGrid.symmetry = geometry.SymmetryType(
         geometry.DomainType.QUARTER_CORE,
         geometry.BoundaryType.REFLECTIVE,


### PR DESCRIPTION
Originally, would take the average of assembly pitches and return that
as the assembly pitch. Ran into a problem when using blueprints from a
Thermal Reactor and it did not like how originally it called 
"pitches = numpy.array([b.getPitch() for b in self.getBlocks(Flags.FUEL)])" 
but in that specific case, no flags were fuel so pitches would be empty. 
But now, since we have spatialGrids, just calling self.spatialGrid.pitch may do 
what we want as well and get over this no
blocks with a certain flag issue.