### PR TITLE
Add ability to plot Block Diagrams

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2004,8 +2004,7 @@ class HexBlock(Block):
                 if c.getDimension("mult") > 1:
                     c.spatialLocator = spatialLocators
                 elif c.getDimension("mult") == 1:
-
-                    c.spatialLocator = grids.IndexLocation(0, 0, 0, self.spatialGrid)
+                    c.spatialLocator = grid[0, 0, 0]
 
     def getPinCenterFlatToFlat(self, cold=False):
         """Return the flat-to-flat distance between the centers of opposing pins in the outermost ring."""

--- a/armi/tests/tutorials/c5g7-blueprints.yaml
+++ b/armi/tests/tutorials/c5g7-blueprints.yaml
@@ -177,6 +177,7 @@ blocks:
             widthInner: 21.42
             widthOuter: 21.42
             mult: 1.0
+            latticeIDs: [FC]
 # end-block-uo2
     mox: &block_mox
         grid name: MOX grid

--- a/armi/tests/tutorials/c5g7-blueprints.yaml
+++ b/armi/tests/tutorials/c5g7-blueprints.yaml
@@ -177,7 +177,10 @@ blocks:
             widthInner: 21.42
             widthOuter: 21.42
             mult: 1.0
-            latticeIDs: [FC]
+            latticeIDs: [FC] 
+            # latticeIDs is needed to ensure that the center of the bounding 
+            # Component shares the same center/origin as the rest of the 
+            # components in the block. See #332."
 # end-block-uo2
     mox: &block_mox
         grid name: MOX grid

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -1168,14 +1168,6 @@ def _makeComponentPatch(component, position, cold):
         cold: boolean
             True if looking for dimension at cold temps
 
-        nSides: int
-            Either 4 or 6, for Thermal vs. Fast Reactors.
-
-        smallestInnerForDerived: int
-                                The DerivedShape is the backdrop of everything else,
-                                so to draw it currently, it uses the smallest innerPitch(for HexBlocks)
-                                or smallest widthInner for Cartesian.
-
     Return
     ------
         blockPatch: List

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -1217,12 +1217,15 @@ def plotBlockDiagram(block, cmapName, num, temp):
     """Given a Block with a spatial Grid, plot the diagram of
     it with all of its components. (wire, duct, coolant, etc...)
 
-    Parameters:
-
-    block - block object
-    cmapName - name of a colorMap to use for block colors
-    num - for making the file name (What number block are we plotting)
-
+    Parameters
+    ----------
+    block : block object
+    cmapName : String
+        name of a colorMap to use for block colors
+    num : int
+        for making the file name (What number block are we plotting)
+    temp : boolean
+        cold is true, hot is false.
     """
     from collections import defaultdict
     import copy

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -1121,13 +1121,19 @@ def _makeBlockPinPatches(block, cold):
         sortedComps.remove(derivedComponent)
         cName = derivedComponent.name
         material = derivedComponent.material.name
+        location = comp.spatialLocator
+        if isinstance(location, grids.MultiIndexLocation):
+            location = location[0]
+        x, y, _ = location.getLocalCoordinates()
         if isinstance(comp, Hexagon):
             derivedPatch = matplotlib.patches.RegularPolygon(
-                (0, 0), 6, largestPitch / math.sqrt(3)
+                (x, y), 6, largestPitch / math.sqrt(3)
             )
         elif isinstance(comp, Square):
             derivedPatch = matplotlib.patches.Rectangle(
-                (0, 0), largestPitch[0], largestPitch[0]
+                (x - largestPitch[0] / 2, y - largestPitch[0] / 2),
+                largestPitch[0],
+                largestPitch[0],
             )
         else:
             raise TypeError(

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -1186,32 +1186,38 @@ def _makeComponentPatch(component, position, cold):
     if isinstance(component, Helix):
         blockPatch = matplotlib.patches.Wedge(
             (
-                x + component.getDimension("helixDiameter") / 2 * math.cos(math.pi / 6),
-                y + component.getDimension("helixDiameter") / 2 * math.sin(math.pi / 6),
+                x
+                + component.getDimension("helixDiameter", cold=cold)
+                / 2
+                * math.cos(math.pi / 6),
+                y
+                + component.getDimension("helixDiameter", cold=cold)
+                / 2
+                * math.sin(math.pi / 6),
             ),
-            component.getDimension("od", cold) / 2,
+            component.getDimension("od", cold=cold) / 2,
             0,
             360,
-            width=(component.getDimension("od", cold) / 2)
-            - (component.getDimension("id", cold) / 2),
+            width=(component.getDimension("od", cold=cold) / 2)
+            - (component.getDimension("id", cold=cold) / 2),
         )
     elif isinstance(component, Circle):
 
         blockPatch = matplotlib.patches.Wedge(
             (x, y),
-            component.getDimension("od", cold) / 2,
+            component.getDimension("od", cold=cold) / 2,
             0,
             360,
-            width=(component.getDimension("od", cold) / 2)
-            - (component.getDimension("id", cold) / 2),
+            width=(component.getDimension("od", cold=cold) / 2)
+            - (component.getDimension("id", cold=cold) / 2),
         )
     elif isinstance(component, Hexagon):
-        if component.getDimension("ip", cold) != 0:
+        if component.getDimension("ip", cold=cold) != 0:
             innerPoints = numpy.array(
-                hexagon.corners(30) * component.getDimension("ip", cold)
+                hexagon.corners(30) * component.getDimension("ip", cold=cold)
             )
             outerPoints = numpy.array(
-                hexagon.corners(30) * component.getDimension("op", cold)
+                hexagon.corners(30) * component.getDimension("op", cold=cold)
             )
             blockPatch = []
             for n in range(6):
@@ -1226,28 +1232,28 @@ def _makeComponentPatch(component, position, cold):
         else:
             # Just make it a hexagon...
             blockPatch = matplotlib.patches.RegularPolygon(
-                (x, y), 6, component.getDimension("op") / math.sqrt(3)
+                (x, y), 6, component.getDimension("op", cold=cold) / math.sqrt(3)
             )
 
     elif isinstance(component, Rectangle):
-        if component.getDimension("widthInner") != 0:
+        if component.getDimension("widthInner", cold=cold) != 0:
             innerPoints = numpy.array(
                 [
                     [
-                        x + component.getDimension("widthInner") / 2,
-                        y + component.getDimension("lengthInner") / 2,
+                        x + component.getDimension("widthInner", cold=cold) / 2,
+                        y + component.getDimension("lengthInner", cold=cold) / 2,
                     ],
                     [
-                        x + component.getDimension("widthInner") / 2,
-                        y - component.getDimension("lengthInner") / 2,
+                        x + component.getDimension("widthInner", cold=cold) / 2,
+                        y - component.getDimension("lengthInner", cold=cold) / 2,
                     ],
                     [
-                        x - component.getDimension("widthInner") / 2,
-                        y - component.getDimension("lengthInner") / 2,
+                        x - component.getDimension("widthInner", cold=cold) / 2,
+                        y - component.getDimension("lengthInner", cold=cold) / 2,
                     ],
                     [
-                        x - component.getDimension("widthInner") / 2,
-                        y + component.getDimension("lengthInner") / 2,
+                        x - component.getDimension("widthInner", cold=cold) / 2,
+                        y + component.getDimension("lengthInner", cold=cold) / 2,
                     ],
                 ]
             )
@@ -1255,20 +1261,20 @@ def _makeComponentPatch(component, position, cold):
             outerPoints = numpy.array(
                 [
                     [
-                        x + component.getDimension("widthOuter") / 2,
-                        y + component.getDimension("lengthOuter") / 2,
+                        x + component.getDimension("widthOuter", cold=cold) / 2,
+                        y + component.getDimension("lengthOuter", cold=cold) / 2,
                     ],
                     [
-                        x + component.getDimension("widthOuter") / 2,
-                        y - component.getDimension("lengthOuter") / 2,
+                        x + component.getDimension("widthOuter", cold=cold) / 2,
+                        y - component.getDimension("lengthOuter", cold=cold) / 2,
                     ],
                     [
-                        x - component.getDimension("widthOuter") / 2,
-                        y - component.getDimension("lengthOuter") / 2,
+                        x - component.getDimension("widthOuter", cold=cold) / 2,
+                        y - component.getDimension("lengthOuter", cold=cold) / 2,
                     ],
                     [
-                        x - component.getDimension("widthOuter") / 2,
-                        y + component.getDimension("lengthOuter") / 2,
+                        x - component.getDimension("widthOuter", cold=cold) / 2,
+                        y + component.getDimension("lengthOuter", cold=cold) / 2,
                     ],
                 ]
             )
@@ -1286,11 +1292,11 @@ def _makeComponentPatch(component, position, cold):
             # Just make it a rectangle...
             blockPatch = matplotlib.patches.Rectangle(
                 (
-                    x - component.getDimension("widthOuter", cold) / 2,
-                    y - component.getDimension("lengthOuter", cold) / 2,
+                    x - component.getDimension("widthOuter", cold=cold) / 2,
+                    y - component.getDimension("lengthOuter", cold=cold) / 2,
                 ),
-                component.getDimension("widthOuter", cold),
-                component.getDimension("lengthOuter", cold),
+                component.getDimension("widthOuter", cold=cold),
+                component.getDimension("lengthOuter", cold=cold),
             )
     if isinstance(blockPatch, list):
         return blockPatch

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -100,7 +100,9 @@ class TestPlotting(unittest.TestCase):
         from armi import settings
         from armi.reactor import blueprints, reactors
 
-        cs = settings.Settings(os.path.join(TEST_ROOT, "tutorials\\c5g7-settings.yaml"))
+        cs = settings.Settings(
+            os.path.join(TEST_ROOT, "tutorials", "c5g7-settings.yaml")
+        )
         blueprint = blueprints.loadFromCs(cs)
         r = reactors.factory(cs, blueprint)
 

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -90,8 +90,7 @@ class TestPlotting(unittest.TestCase):
             os.remove("bList2.png")  # created during the call.
 
     def test_plotHexBlock(self):
-        o, r = test_reactors.loadTestReactor()
-        first_fuel_block = r.core.getFirstBlock(Flags.FUEL)
+        first_fuel_block = self.r.core.getFirstBlock(Flags.FUEL)
         first_fuel_block.autoCreateSpatialGrids()
         plotting.plotBlockDiagram(first_fuel_block, "blockDiagram23.svg", True)
         self._checkExists("blockDiagram23.svg")
@@ -103,11 +102,13 @@ class TestPlotting(unittest.TestCase):
         cs = settings.Settings(
             os.path.join(TEST_ROOT, "tutorials", "c5g7-settings.yaml")
         )
+
         blueprint = blueprints.loadFromCs(cs)
         r = reactors.factory(cs, blueprint)
-        for b in r.core.getBlocks():
-            plotting.plotBlockDiagram(b, "blockDiagram25.svg", True)
-        self._checkExists("blockDiagram25.svg")
+        for name, bDesign in blueprint.blockDesigns.items():
+            b = bDesign.construct(cs, blueprint, 0, 1, 1, "AA", {})
+            plotting.plotBlockDiagram(b, "{}.svg".format(name), True)
+        self._checkExists("UO2.svg")
 
     def _checkExists(self, fName):
         self.assertTrue(os.path.exists(fName))

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -108,7 +108,7 @@ class TestPlotting(unittest.TestCase):
         for name, bDesign in blueprint.blockDesigns.items():
             b = bDesign.construct(cs, blueprint, 0, 1, 1, "AA", {})
             plotting.plotBlockDiagram(b, "{}.svg".format(name), True)
-        self._checkExists("UO2.svg")
+        self._checkExists("uo2.svg")
 
     def _checkExists(self, fName):
         self.assertTrue(os.path.exists(fName))

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -21,7 +21,8 @@ import unittest
 from armi.nuclearDataIO.cccc import isotxs
 from armi.utils import plotting
 from armi.reactor.tests import test_reactors
-from armi.tests import ISOAA_PATH
+from armi.tests import ISOAA_PATH, TEST_ROOT
+from armi.reactor.flags import Flags
 
 
 class TestPlotting(unittest.TestCase):
@@ -87,6 +88,26 @@ class TestPlotting(unittest.TestCase):
             os.remove("peak.png")  # created during the call.
             os.remove("bList2.txt")  # secondarily created during the call.
             os.remove("bList2.png")  # created during the call.
+
+    def test_plotHexBlock(self):
+        o, r = test_reactors.loadTestReactor()
+        first_fuel_block = r.core.getFirstBlock(Flags.FUEL)
+        first_fuel_block.autoCreateSpatialGrids()
+        plotting.plotBlockDiagram(first_fuel_block, "jet", 21, True)
+        self._checkExists("blockDiagram21.svg")
+
+    def test_plotCartesianBlock(self):
+        from armi import settings
+        from armi.reactor import blueprints, reactors
+
+        cs = settings.Settings(os.path.join(TEST_ROOT, "tutorials\\c5g7-settings.yaml"))
+        blueprint = blueprints.loadFromCs(cs)
+        r = reactors.factory(cs, blueprint)
+
+        for b in r.core.getBlocks():
+            plotting.plotBlockDiagram(b, "jet", 20, True)
+            break
+        self._checkExists("BlockDiagram20.svg")
 
     def _checkExists(self, fName):
         self.assertTrue(os.path.exists(fName))

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -93,8 +93,8 @@ class TestPlotting(unittest.TestCase):
         o, r = test_reactors.loadTestReactor()
         first_fuel_block = r.core.getFirstBlock(Flags.FUEL)
         first_fuel_block.autoCreateSpatialGrids()
-        plotting.plotBlockDiagram(first_fuel_block, "jet", 21, True)
-        self._checkExists("blockDiagram21.svg")
+        plotting.plotBlockDiagram(first_fuel_block, "jet", 23, True)
+        self._checkExists("blockDiagram23.svg")
 
     def test_plotCartesianBlock(self):
         from armi import settings
@@ -107,9 +107,9 @@ class TestPlotting(unittest.TestCase):
         r = reactors.factory(cs, blueprint)
 
         for b in r.core.getBlocks():
-            plotting.plotBlockDiagram(b, "jet", 20, True)
+            plotting.plotBlockDiagram(b, "jet", 22, True)
             break
-        self._checkExists("BlockDiagram20.svg")
+        self._checkExists("blockDiagram22.svg")
 
     def _checkExists(self, fName):
         self.assertTrue(os.path.exists(fName))

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -93,7 +93,7 @@ class TestPlotting(unittest.TestCase):
         o, r = test_reactors.loadTestReactor()
         first_fuel_block = r.core.getFirstBlock(Flags.FUEL)
         first_fuel_block.autoCreateSpatialGrids()
-        plotting.plotBlockDiagram(first_fuel_block, "jet", 23, True)
+        plotting.plotBlockDiagram(first_fuel_block, "blockDiagram23.svg", True)
         self._checkExists("blockDiagram23.svg")
 
     def test_plotCartesianBlock(self):
@@ -105,11 +105,9 @@ class TestPlotting(unittest.TestCase):
         )
         blueprint = blueprints.loadFromCs(cs)
         r = reactors.factory(cs, blueprint)
-
         for b in r.core.getBlocks():
-            plotting.plotBlockDiagram(b, "jet", 22, True)
-            break
-        self._checkExists("blockDiagram22.svg")
+            plotting.plotBlockDiagram(b, "blockDiagram25.svg", True)
+        self._checkExists("blockDiagram25.svg")
 
     def _checkExists(self, fName):
         self.assertTrue(os.path.exists(fName))


### PR DESCRIPTION
Create a function plotBlockDiagram in plotting.py in order to plot block
diagrams when a spatial grid is on the block. In addition, the
_makeBlockPinPatches and _makeComponentPatch work to create component
patches as long as the block's grid type is supported.

For each components spatialLocator, it creates a patch for the
components shape and size at the location/locations described by the
locator and colors according to material name the component is made out
of. Also creates a legend saying what color is what material. At the
end, plotBlockDiagram saves the figure as an SVG.