### PR TITLE
Add implementation of detachedCopy() to MultiIndexLocation

### DIFF
--- a/armi/bookkeeping/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/tests/test_databaseInterface.py
@@ -34,6 +34,7 @@ from armi.cases import case
 from armi.utils import directoryChangers
 from armi import runLog
 from armi.reactor.tests import test_reactors
+from armi.reactor import grids
 
 
 def getSimpleDBOperator(cs):
@@ -265,7 +266,14 @@ class TestDatabaseReading(unittest.TestCase):
 
                 for c1, c2 in zip(sorted(b1), sorted(b2)):
                     self.assertEqual(c1.name, c2.name)
-                    assert_equal(c1.spatialLocator.indices, c2.spatialLocator.indices)
+                    if isinstance(c1.spatialLocator, grids.MultiIndexLocation):
+                        assert_equal(
+                            c1.spatialLocator.allIndices, c2.spatialLocator.allIndices
+                        )
+                    else:
+                        assert_equal(
+                            c1.spatialLocator.indices, c2.spatialLocator.indices
+                        )
                     self.assertEqual(c1.p.serialNum, c2.p.serialNum)
 
                 # volume is pretty difficult to get right. it relies upon linked dimensions

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -436,6 +436,11 @@ class MultiIndexLocation(IndexLocation):
     def __len__(self):
         return len(self._locations)
 
+    def detachedCopy(self):
+        loc = MultiIndexLocation(None)
+        loc.extend(self._locations)
+        return loc
+
     def getCompleteIndices(self) -> Tuple[int, int, int]:
         raise NotImplementedError("Multi locations cannot do this yet.")
 

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -457,6 +457,17 @@ class MultiIndexLocation(IndexLocation):
     def indices(self):
         raise NotImplementedError
 
+    @property
+    def allIndices(self):
+        """
+        Return a list containing the indices of all contained locations.
+
+        This could be done in the indices property, but that would violate LSP and
+        probably lead to lots of bugs when callers are expecting a single set of
+        indices, rather than a 2-D array of them.
+        """
+        return numpy.array([loc.indices for loc in self._locations])
+
 
 class CoordinateLocation(IndexLocation):
     """


### PR DESCRIPTION
MIL has a different init signature than its base IndexLocation, so it
needed its own implementation of detachedCopy()