### PR TITLE
Fix issues with Grids and  multi-index locations

### DIFF
--- a/armi/bookkeeping/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/tests/test_databaseInterface.py
@@ -268,7 +268,8 @@ class TestDatabaseReading(unittest.TestCase):
                     self.assertEqual(c1.name, c2.name)
                     if isinstance(c1.spatialLocator, grids.MultiIndexLocation):
                         assert_equal(
-                            c1.spatialLocator.allIndices, c2.spatialLocator.allIndices
+                            numpy.array(c1.spatialLocator.indices),
+                            numpy.array(c2.spatialLocator.indices),
                         )
                     else:
                         assert_equal(

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -414,6 +414,10 @@ class ArmiObject(metaclass=CompositeModelType):
 
         if self.spatialGrid is not None:
             self.spatialGrid.armiObject = self
+            # Spatial locators also get disassociated with their grids when detached;
+            # make sure they get hooked back up
+            for c in self:
+                c.spatialLocator.associate(self.spatialGrid)
 
         # now "reattach" children
         for c in self:

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -813,7 +813,9 @@ class Grid:
             locators = [self[idx] for idx in ijk]
             val.extend(locators)
         else:
-            raise TypeError("Unsupported index type `{}` for `{}`".format(type(ijk), ijk))
+            raise TypeError(
+                "Unsupported index type `{}` for `{}`".format(type(ijk), ijk)
+            )
         return val
 
     def __len__(self):

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -475,21 +475,17 @@ class MultiIndexLocation(IndexLocation):
     @property
     def indices(self):
         """
-        This should be at least symmetric with the way indices passed to __getitem__ on
-        Grid behaves.
-        """
-        return list(self.allIndices)
+        Return indices for all locations.
 
-    @property
-    def allIndices(self):
+        Notes
+        -----
+        Notice that this returns a list of all of the indices, unlike the ``indices()``
+        implementation for :py:class:`IndexLocation`. This is intended to make the
+        behavior of getting the indices from the Locator symmetric with passing a list
+        of indices to the Grid's ``__getitem__()`` function, which constructs and
+        returns a ``MultiIndexLocation`` containing those indices.
         """
-        Return a list containing the indices of all contained locations.
-
-        This could be done in the indices property, but that would violate LSP and
-        probably lead to lots of bugs when callers are expecting a single set of
-        indices, rather than a 2-D array of them.
-        """
-        return numpy.array([loc.indices for loc in self._locations])
+        return [loc.indices for loc in self._locations]
 
 
 class CoordinateLocation(IndexLocation):


### PR DESCRIPTION
 - Add an `associate()` method to LocationBase, allowing to bind a
   location to a new grid. MultiIndexLocation implements this
   appropriately
 - Remove `__hash__()` from MIL, since it can't support it. There are
   still some substitutability issues in Locations, which we should
   address at some point to cut down on how special a case MIL is.
 - Add code to Composite `__setstate__()` to ensure that spatialLocators
   of children are properly associated with their new parent grid
 - Teach the GridBlueprint to infer "through center" based on the number
   of things in the lattice being even or odd.