### PR TITLE
Refactoring runLog to use logging standard library

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -169,7 +169,7 @@ def init(choice=None, fName=None, cs=None):
         return armiCase.initializeOperator()
     except:  # Catch any and all errors. Naked exception on purpose.
         # Concatenate errors to the master log file.
-        runLog.LOG.close()
+        runLog.close()
         raise
 
 

--- a/armi/context.py
+++ b/armi/context.py
@@ -20,14 +20,15 @@ running. Things like the MPI environment, executing user, etc. live here. These 
 re-exported by the `armi` package, but live here so that import loops won't lead to
 as many issues.
 """
+from logging import DEBUG
 import datetime
+import enum
+import gc
 import getpass
 import os
-import time
-import sys
-import enum
 import shutil
-import gc
+import sys
+import time
 
 # h5py needs to be imported here, so that the disconnectAllHdfDBs() call that gets bound
 # to atexit below doesn't lead to a segfault on python exit. The Database3 module is
@@ -149,7 +150,7 @@ MPI_DISTRIBUTABLE = MPI_RANK == 0 and MPI_SIZE > 1
 
 _FAST_PATH = os.path.join(os.getcwd())
 """
-A directory available for high-performance I/O  
+A directory available for high-performance I/O
 
 .. warning:: This is not a constant and can change at runtime.
 """
@@ -222,7 +223,7 @@ def cleanTempDirs(olderThanDays=None):
     )  # pylint: disable=import-outside-toplevel # avoid cyclic import
 
     disconnectAllHdfDBs()
-    printMsg = runLog.getVerbosity() <= runLog.getLogVerbosityRank("debug")
+    printMsg = runLog.getVerbosity() <= DEBUG
     if _FAST_PATH_IS_TEMPORARY and os.path.exists(_FAST_PATH):
         if printMsg:
             print(

--- a/armi/localization/tests/test_localization.py
+++ b/armi/localization/tests/test_localization.py
@@ -82,12 +82,10 @@ class LocalizationTests(unittest.TestCase):
 
     def test_info_decorator(self):
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream.getvalue())
+            self.assertEqual("", mock._outputStream)
             for ii in range(1, 3):
                 self.exampleInfoMessage()
-                self.assertEqual(
-                    "[info] output message\n" * ii, mock._outputStream.getvalue()
-                )
+                self.assertEqual("[info] output message\n" * ii, mock._outputStream)
 
     @info_once
     def exampleInfoOnceMessage(self):
@@ -95,12 +93,10 @@ class LocalizationTests(unittest.TestCase):
 
     def test_single_message_only_prints_once(self):
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream.getvalue())
+            self.assertEqual("", mock._outputStream)
             for _ in range(1, 3):
                 self.exampleInfoOnceMessage()
-                self.assertEqual(
-                    "[info] example single message\n", mock._outputStream.getvalue()
-                )
+                self.assertEqual("[info] example single message\n", mock._outputStream)
 
     @info_once
     def exampleOutputOnceMessageWithExtraArgs(self, hi, my, name=None, isJerry=False):
@@ -108,12 +104,10 @@ class LocalizationTests(unittest.TestCase):
 
     def test_single_message_with_args_prints_correctly(self):
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream.getvalue())
+            self.assertEqual("", mock._outputStream)
             for _ in range(1, 3):
                 self.exampleOutputOnceMessageWithExtraArgs("yo", "dawg")
-                self.assertEqual(
-                    "[info] yo dawg None False\n", mock._outputStream.getvalue()
-                )
+                self.assertEqual("[info] yo dawg None False\n", mock._outputStream)
 
     @important
     def exampleImportantMessage(self):
@@ -121,12 +115,10 @@ class LocalizationTests(unittest.TestCase):
 
     def test_important_decorator(self):
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream.getvalue())
+            self.assertEqual("", mock._outputStream)
             for ii in range(1, 3):
                 self.exampleImportantMessage()
-                self.assertEqual(
-                    "[impt] important message?\n" * ii, mock._outputStream.getvalue()
-                )
+                self.assertEqual("[impt] important message?\n" * ii, mock._outputStream)
 
     @count_calls
     def exampleCountedMessage(self):
@@ -171,7 +163,7 @@ class LocalizationTests(unittest.TestCase):
                 self.exampleWarnMessage()
                 self.assertEqual(
                     "[warn] you're not tall enough to ride this elephant\n" * ii,
-                    mock._outputStream.getvalue(),
+                    mock._outputStream,
                 )
 
     @warn_once
@@ -182,9 +174,7 @@ class LocalizationTests(unittest.TestCase):
         with mockRunLogs.BufferLog() as mock:
             for _ in range(1, 4):
                 self.exampleWarnOnceMessage()
-                self.assertEqual(
-                    "[warn] single warning\n", mock._outputStream.getvalue()
-                )
+                self.assertEqual("[warn] single warning\n", mock._outputStream)
 
     def test_warn_once_decorator_with_multiple_instances(self):
         with mockRunLogs.BufferLog() as mock:
@@ -194,7 +184,7 @@ class LocalizationTests(unittest.TestCase):
                     mt.exampleWarnOnceMessageForInstances()
                     self.assertEqual(
                         "[warn] exampleWarnOnceMessageForInstances\n",
-                        mock._outputStream.getvalue(),
+                        mock._outputStream,
                     )
 
     @warn_when_root
@@ -206,10 +196,10 @@ class LocalizationTests(unittest.TestCase):
             for ii in range(1, 4):
                 self.exampleWarnWhenRootMessage()
                 msg = "[warn] warning from root\n" * ii
-                self.assertEqual(msg, mock._outputStream.getvalue())
+                self.assertEqual(msg, mock._outputStream)
                 armi.MPI_RANK = 1
                 self.exampleWarnWhenRootMessage()
-                self.assertEqual(msg, mock._outputStream.getvalue())
+                self.assertEqual(msg, mock._outputStream)
                 armi.MPI_RANK = 0
 
     @warn_once_when_root
@@ -221,10 +211,10 @@ class LocalizationTests(unittest.TestCase):
         with mockRunLogs.BufferLog() as mock:
             for _ in range(1, 4):
                 self.exampleWarnOnceWhenRootMessage()
-                self.assertEqual(msg, mock._outputStream.getvalue())
+                self.assertEqual(msg, mock._outputStream)
                 armi.MPI_RANK = 1
                 self.exampleWarnOnceWhenRootMessage()
-                self.assertEqual(msg, mock._outputStream.getvalue())
+                self.assertEqual(msg, mock._outputStream)
                 armi.MPI_RANK = 0
 
     def test_warn_once_when_root_decorator_with_multiple_instances(self):
@@ -234,10 +224,10 @@ class LocalizationTests(unittest.TestCase):
                 mt = DummyClass()
                 for _ in range(1, 4):
                     mt.exampleWarnOnceWhenRootMessageForInstances()
-                    self.assertEqual(msg, mock._outputStream.getvalue())
+                    self.assertEqual(msg, mock._outputStream)
                     armi.MPI_RANK = 1
                     self.exampleWarnOnceWhenRootMessage()
-                    self.assertEqual(msg, mock._outputStream.getvalue())
+                    self.assertEqual(msg, mock._outputStream)
                     armi.MPI_RANK = 0
 
 

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 """Tests for xsLibraries.IsotxsLibrary"""
+import copy
 import filecmp
 import os
-import unittest
 import shutil
-import copy
 import subprocess
 import traceback
+import unittest
 
 from six.moves import cPickle
 
@@ -236,6 +236,7 @@ class TestXSLibrary(unittest.TestCase, TempFileMixin):
         dummyFileName = "ISOSOMEFILE"
         with open(dummyFileName, "w") as someFile:
             someFile.write("hi")
+
         try:
             with mockRunLogs.BufferLog() as log:
                 lib = xsLibraries.IsotxsLibrary()

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -64,30 +64,30 @@ class NuclideTests(unittest.TestCase):
 
     def test_nuclide_newLabelsDontCauseWarnings(self):
         with mockRunLogs.BufferLog() as logCapture:
-            self.assertEqual("", logCapture._outputStream.getvalue())
+            self.assertEqual("", logCapture._outputStream)
             fe = nuclideBases.byName["FE"]
             feNuc = xsNuclides.XSNuclide(None, "FEAA")
             feNuc.isotxsMetadata["nuclideId"] = fe.getMcc3Id()
             feNuc.updateBaseNuclide()
             self.assertEqual(fe, feNuc._base)
-            self.assertEqual("", logCapture._outputStream.getvalue())
+            self.assertEqual("", logCapture._outputStream)
 
     def test_nuclide_oldLabelsCauseWarnings(self):
         with mockRunLogs.BufferLog() as logCapture:
-            self.assertEqual("", logCapture._outputStream.getvalue())
+            self.assertEqual("", logCapture._outputStream)
             pu = nuclideBases.byName["PU239"]
             puNuc = xsNuclides.XSNuclide(None, "PLUTAA")
             puNuc.isotxsMetadata["nuclideId"] = pu.mc2id
             puNuc.updateBaseNuclide()
             self.assertEqual(pu, puNuc._base)
-            length = len(logCapture._outputStream.getvalue())
+            length = len(logCapture._outputStream)
             self.assertGreater(length, 15)
             # now get it with a legitmate same label, length shouldn't change
             puNuc = xsNuclides.XSNuclide(None, "PLUTAB")
             puNuc.isotxsMetadata["nuclideId"] = pu.mc2id
             puNuc.updateBaseNuclide()
             self.assertEqual(pu, puNuc._base)
-            self.assertEqual(length, len(logCapture._outputStream.getvalue()))
+            self.assertEqual(length, len(logCapture._outputStream))
 
     def test_nuclide_nuclideBaseMethodsShouldNotFail(self):
         for nuc in self.lib.nuclides:

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -97,7 +97,7 @@ class OperatorMPI(Operator):
                     1
                 )  # even though we waited, still need more time to close stdout.
                 runLog.debug("Main operate finished")
-                runLog.LOG.close()  # concatenate all logs.
+                runLog.close()  # concatenate all logs.
         else:
             try:
                 self.workerOperate()
@@ -110,7 +110,7 @@ class OperatorMPI(Operator):
                 # different bcast or gather.
                 traceback.print_exc()
                 runLog.debug("Worker failed")
-                runLog.LOG.close()
+                runLog.close()
                 raise
 
     def workerOperate(self):
@@ -227,7 +227,7 @@ class OperatorMPI(Operator):
     @staticmethod
     def workerQuit():
         runLog.debug("Worker ending")
-        runLog.LOG.close()  # no more messages.
+        runLog.close()  # no more messages.
         # wait until all workers are closed so we can delete them.
         armi.MPI_COMM.bcast("finished", root=0)
 

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -22,19 +22,19 @@ is impossible. Would you like to switch to ___?"
 
 """
 import os
+import sys
 from typing import Union
 
 import armi
-from armi import runLog
+from armi import runLog, settings, utils
 from armi.localization import exceptions
-from armi import utils
 from armi.utils import pathTools
 from armi.reactor import geometry
 from armi.reactor import systemLayoutInput
 from armi.physics import neutronics
-from armi import settings
 from armi.utils import directoryChangers
 from armi.settings.fwSettings import globalSettings
+from armi.settings.settingsIO import prompt
 
 
 class Query:
@@ -95,7 +95,7 @@ class Query:
             try:
                 if self.isCorrective():
                     try:
-                        make_correction = runLog.prompt(
+                        make_correction = prompt(
                             "INSPECTOR: " + self.statement,
                             self.question,
                             "YES_NO",
@@ -111,7 +111,7 @@ class Query:
                         raise exceptions.InputInspectionDiscontinued()
                 else:
                     try:
-                        continue_submission = runLog.prompt(
+                        continue_submission = prompt(
                             "INSPECTOR: " + self.statement,
                             "Continue?",
                             "YES_NO",

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -24,6 +24,7 @@ plant-wide state variables such as keff, cycle, and node.
 import collections
 import copy
 import itertools
+import logging
 from typing import Optional
 import tabulate
 import time
@@ -31,7 +32,7 @@ import os
 
 import numpy
 
-from armi import getPluginManagerOrFail, runLog, nuclearDataIO, settings
+from armi import getPluginManagerOrFail, materials, nuclearDataIO, settings, utils
 from armi.localization import exceptions
 from armi.reactor import assemblies
 from armi.reactor import assemblyLists
@@ -42,14 +43,15 @@ from armi.reactor import grids
 from armi.reactor import parameters
 from armi.reactor import zones
 from armi.reactor import reactorParameters
-from armi import materials
-from armi import utils
 from armi.utils import units
 from armi.utils.iterables import Sequence
 from armi.utils import directoryChangers
 from armi.reactor.flags import Flags
 from armi.settings.fwSettings.globalSettings import CONF_MATERIAL_NAMESPACE_ORDER
 from armi.nuclearDataIO import xsLibraries
+
+# init logger
+runLog = logging.getLogger(__name__)
 
 
 class Reactor(composites.Composite):

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -26,168 +26,117 @@ The default way of using the ARMI runLog is:
     runLog.error('extra error info here')
     raise SomeException  # runLog.error() implies that the code will crash!
 
-.. note::
-    We plan to reimplement this with the standard Python logging module. It was customized
-    to add a few features in a HPC/MPI environment but we now think we can use the standard
-    system.
-
 """
 from __future__ import print_function
-import sys
-import os
+from glob import glob
 import collections
+import logging
 import operator
+import os
+import sys
 import time
 
-from six import StringIO
-
 from armi import context
-from armi.context import Mode
-from armi import meta
 
 
-# use ordereddict so we can get right order of options in GUI.
-_logLevels = collections.OrderedDict(
-    [
-        ("debug", (0, "dbug")),
-        ("extra", (10, "xtra")),
-        ("info", (20, "info")),
-        ("important", (25, "impt")),
-        ("prompt", (27, "prmt")),
-        ("warning", (30, "warn")),
-        ("error", (50, "err ")),
-        ("header", (100, "")),
-    ]
-)
-
-_stderrName = "{0}.{1:04d}.stderr"
-_stdoutName = "{0}.{1:04d}.stdout"
-
-
-def getLogVerbosityLevels():
-    """Return a list of the available log levels (e.g., debug, extra, etc.)."""
-    return list(_logLevels.keys())
-
-
-def getLogVerbosityRank(level):
-    """Return integer verbosity rank given the string verbosity name."""
-    if level not in getLogVerbosityLevels():
-        raise KeyError(
-            "{} is not a valid verbosity level. Choose from {}".format(
-                level, getLogVerbosityLevels()
-            )
-        )
-    return _logLevels[level][0]
-
-
-def _checkLogVerbsityRank(rank):
-    """Check that the verbosity rank is defined within the _logLevels and return it if it is."""
-    validRanks = []
-    for level in getLogVerbosityLevels():
-        expectedRank = getLogVerbosityRank(level)
-        validRanks.append(rank)
-        if rank == expectedRank:
-            return rank
-    raise KeyError(
-        "Invalid verbosity rank {}. Valid options are: {}".format(rank, validRanks)
-    )
-
-
-class Log:
+class RunLog:
     """
-    Abstract class that ARMI code calls to be rendered to some kind of log.
+    Handles all the logging
+    For the parent process, things are allowed to print to stdout and stderr,
+    but the stdout prints are formatted like log statements.
+    For the child processes, everything is piped to log files.
     """
 
-    def __init__(self, verbosity=50):  # pylint: disable=unused-argument
+    STDERR_NAME = "{0}.{1:04d}.stderr"
+    STDOUT_NAME = "{0}.{1:04d}.stdout"
+
+    def __init__(self, mpiRank=0):
         """
         Build a log object
 
         Parameters
         ----------
-        verbosity : int
-            if a msg verbosity is > this, it will be  emitted.
-            The default of 50 means only error messages will be emitted.
-            This usually gets adjusted by user settings quickly after instantiation.
+        mpiRank : int
+            If this is zero, we are in the parent process, otherwise child process.
+            The default of 0 means we assume the parent process.
+            This should not be adjusted after instantiation.
 
         """
-        self._verbosity = verbosity
+        self._mpiRank = mpiRank
+        self._verbosity = logging.INFO
         self._singleMessageCounts = collections.defaultdict(lambda: 0)
         self._singleWarningMessageCounts = collections.defaultdict(lambda: 0)
-        self._outputStream = None
-        self._errStream = None
-        # https://docs.python.org/2/library/sys.html says
-        # to explicitly save these instead of relying upon __stdout__, etc.
-        if context.MPI_RANK == 0:
-            self.initialOut = sys.stdout
-            self.initialErr = sys.stderr
-        else:
-            # Attach output streams to a null device until we open log files. We don't know what to
-            # call them until we have processed some of the settings, and any errors encountered in
-            # that should be encountered on the master process anyway.
-            self.initialOut = open(os.devnull, "w")
-            self.initialErr = open(os.devnull, "w")
-        self.setStreams(self.initialOut, self.initialErr)
-        self.name = "log"
+        self.initialErr = None
+        self.logger = None
+        self.stderrLogger = None
+        self._logLevels = None
+        self._whitespace = " " * 6
 
-    def _emit(self, msg):
-        """
-        send the raw message to the stream that you want it to go to.
-        """
-        raise NotImplementedError
+        self._setLogLevels()
+        self._createLogDir()
 
-    def flush(self):
-        self._errStream.flush()
-        self._outputStream.flush()
+    def _setLogLevels(self):
+        """Here we fill the logLevels dict with custom strings that depend on the MPI rank"""
+        # NOTE: use ordereddict so we can get right order of options in GUI
+        _rank = "" if self._mpiRank == 0 else "-{:>03d}".format(self._mpiRank)
+        self._logLevels = collections.OrderedDict(
+            [
+                ("debug", (logging.DEBUG, "[dbug{}] ".format(_rank))),
+                ("extra", (15, "[xtra{}] ".format(_rank))),
+                ("info", (logging.DEBUG, "[info{}] ".format(_rank))),
+                ("important", (25, "[impt{}] ".format(_rank))),
+                ("prompt", (27, "[prmt{}] ".format(_rank))),
+                ("warning", (logging.WARNING, "[warn{}] ".format(_rank))),
+                ("error", (logging.ERROR, "[err {}] ".format(_rank))),
+                ("header", (100, "".format(_rank))),
+            ]
+        )
+        self._whitespace = " " * len(max([l[1] for l in self._logLevels.values()]))
 
-    def standardLogMsg(self, msgType, msg, single=False, label=None):
+        # modify the logging module strings for printing
+        for logValue, shortLogString in self._logLevels.values():
+            logging.addLevelName(logValue, shortLogString)
+
+    def log(self, msgType, msg, single=False, label=None):
         """
         Add formatting to a message and handle its singleness, if applicable.
 
-        This is a wrapper around _emit that does most of the work and is
+        This is a wrapper around logger.log() that does most of the work and is
         used by all message passers (e.g. info, warning, etc.).
-
-        The MPI_RANK printout was removed because it's obvious in the stdout now.
         """
-        if label is None:
-            label = msg
-
-        msgVerbosity, msgLabel = _logLevels[msgType]
         # Skip writing the message if it is below the set verbosity
+        msgVerbosity = self._logLevels[msgType][0]
         if msgVerbosity < self._verbosity:
             return
 
-        if single:
-            if self._msgHasAlreadyBeenEmitted(label, msgType):
-                return
+        # the message label is only used to determine unique for single-print warnings
+        if label is None:
+            label = msg
 
-        # Set up the prefix for the line (e.g. [info], [info-001])
-        if context.MPI_RANK == 0:
-            prefixAdder = ""
+        # Skip writing the message if it is single-print warning
+        if single and self._msgHasAlreadyBeenEmitted(label, msgType):
+            return
+
+        # Do the actual logging, but add that custom indenting first
+        msg = self._cleanMsg(msg)
+        if self._mpiRank == 0:
+            print(self._logLevels[msgType][1] + msg)
         else:
-            prefixAdder = "-{:>03d}".format(context.MPI_RANK)
+            self.logger.write(msgVerbosity, msg)
 
-        linePrefix = "[" + msgLabel + prefixAdder + "] " if msgLabel else msgLabel
-        linePrefixSpacing = len(linePrefix) * " "
-
-        # Write lines to the stream
-        lines = str(msg).split("\n")
-        for i, line in enumerate(lines):
-            prefix = linePrefix if i == 0 else linePrefixSpacing
-            self._emit("{}{}".format(prefix, line))
+    def _cleanMsg(self, msg):
+        """Messages need to be strings, and tabbed if multi-line"""
+        return str(msg).rstrip().replace("\n", "\n" + self._whitespace)
 
     def _msgHasAlreadyBeenEmitted(self, label, msgType=""):
         """Return True if the count of the label is greater than 1."""
-        if msgType == "warning" or msgType == "critical":
+        if msgType in ("warning", "critical"):
             self._singleWarningMessageCounts[label] += 1
-            if (
-                self._singleWarningMessageCounts[label] > 1
-            ):  # short circuit because error has changed
+            if self._singleWarningMessageCounts[label] > 1:
                 return True
         else:
             self._singleMessageCounts[label] += 1
-            if (
-                self._singleMessageCounts[label] > 1
-            ):  # short circuit because error has changed
+            if self._singleMessageCounts[label] > 1:
                 return True
         return False
 
@@ -204,10 +153,22 @@ class Log:
         for label, count in sorted(
             self._singleWarningMessageCounts.items(), key=operator.itemgetter(1)
         ):
-            info("  {0:10d}   {1:<25s}".format(count, str(label)))
+            info("  {0:^10s}   {1:^25s}".format(str(count), str(label)))
         info("------------------------------------")
 
-    def setVerbosity(self, levelInput):
+    def _getLogVerbosityRank(self, lvl):
+        """Return integer verbosity rank given the string verbosity name."""
+        level = lvl.strip().lower()
+        if level not in self._logLevels:
+            log_strs = list(self._logLevels.keys())
+            raise KeyError(
+                "{} is not a valid verbosity level. Choose from {}".format(
+                    level, log_strs
+                )
+            )
+        return self._logLevels[level][0]
+
+    def setVerbosity(self, level):
         """
         Sets the minimum output verbosity for the logger.
 
@@ -216,7 +177,7 @@ class Log:
 
         Parameters
         ----------
-        levelInput : int or str
+        level : int or str
             The level to set the log output verbosity to.
             Valid numbers are 0-50 and valid strings are keys of _logLevels
 
@@ -226,226 +187,175 @@ class Log:
         >>> setVerbosity(0) -> sets to 0
 
         """
-        self._verbosity = (
-            getLogVerbosityRank(levelInput)
-            if isinstance(levelInput, str)
-            else _checkLogVerbsityRank(levelInput)
-        )
+        if isinstance(level, str):
+            self._verbosity = self._getLogVerbosityRank(level)
+        elif isinstance(level, int):
+            if level < 0 or level > 100:
+                raise KeyError(
+                    "Invalid verbosity rank {}. ".format(level)
+                    + "It needs to be in the range [0, 100]."
+                )
+            self._verbosity = level
+        else:
+            raise TypeError("Invalid verbosity rank {}.".format(level))
+
+        if self.logger is not None:
+            self.logger.setLevel(self._verbosity)
 
     def getVerbosity(self):
         """Return the global runLog verbosity."""
         return self._verbosity
 
-    def setStreams(self, stdout, stderr):
-        """Set the stdout and stderr streams to any stream object."""
-        sys.stdout = self._outputStream = stdout
-        sys.stderr = self._errStream = stderr
-
-    def _getStreams(self):
-        return self._outputStream, self._errStream
-
-    def _restoreStandardStreams(self):
-        """Set the system stdout/stderr to their defaults (as they were when the run started)."""
-        if sys.stdout == self._outputStream:
-            sys.stdout = self.initialOut  # sys.__stdout__
-            sys.stderr = self.initialErr  # sys.__stderr__
-
-
-class PrintLog(Log):
-    """Log that emits to stdout/stderr or file-based streams (for MPI workers) with print."""
+    def _restoreErrStream(self):
+        """Set the system stderr back to its default (as it was when the run started)."""
+        if self.initialErr is not None and self._mpiRank > 0:
+            sys.stderr = self.initialErr
 
     def startLog(self, name):
         """Initialize the streams when parallel processing"""
-        if context.MPI_SIZE == 1:
-            return
-        if context.MPI_RANK == 0:
-            self.name = name
-            if not os.path.exists("logs"):
+        # set up the child loggers
+        if self._mpiRank > 0:
+            # init stdout handler
+            filePath = os.path.join(
+                "logs", RunLog.STDOUT_NAME.format(name, self._mpiRank)
+            )
+            fmt = "%(levelname)s%(message)s"
+            self.logger = StreamToLogger("ARMI", filePath, self._verbosity, fmt)
+
+            # init stderr handler
+            filePath = os.path.join(
+                "logs", RunLog.STDERR_NAME.format(name, self._mpiRank)
+            )
+            fmt = "%(message)s"
+            self.stderrLogger = StreamToLogger(
+                "ARMI_ERROR", filePath, logging.WARNING, fmt
+            )
+
+            # force the error logger onto stderr
+            self.initialErr = sys.stderr
+            sys.stderr = self.stderrLogger
+
+    def _createLogDir(self):
+        """A helper method to create the log directory"""
+        # make the directory
+        if not os.path.exists("logs"):
+            try:
                 os.makedirs("logs")
-            # stall until it shows up in file system (SMB caching issue?)
-            while not os.path.exists("logs"):
-                time.sleep(0.5)
+            except FileExistsError:
+                pass
 
-        context.MPI_COMM.barrier()
-
-        if context.MPI_RANK > 0:
-            self.name = os.path.join("logs", name)
-            outputStream = open(_stdoutName.format(self.name, context.MPI_RANK), "w")
-            errStream = open(_stderrName.format(self.name, context.MPI_RANK), "w")
-            self.setStreams(outputStream, errStream)
+        # stall until it shows up in file system (SMB caching issue?)
+        while not os.path.exists("logs"):
+            time.sleep(0.1)
 
     def close(self):
         """End use of the log. Concatenate if needed and restore defaults"""
-        if context.MPI_RANK == 0 and context.MPI_SIZE > 1:
+        if self._mpiRank == 0:
             try:
                 self.concatenateLogs()
             except IOError as ee:
                 warning("Failed to concatenate logs due to IOError.")
                 error(ee)
-        elif context.MPI_RANK > 0 and context.MPI_SIZE > 1:
-            for fileObj in [self._outputStream, self._errStream]:
-                fileObj.flush()
-                fileObj.close()
-        self._restoreStandardStreams()
+        else:
+            if self.stderrLogger:
+                _ = [h.close() for h in self.stderrLogger.logger.handlers]
+                self.stderrLogger = None
+            if self.logger:
+                _ = [h.close() for h in self.logger.logger.handlers]
+                self.logger = None
 
-    def _emit(self, msg):
-        print(msg)
+        self._restoreErrStream()
 
-    def concatenateLogs(self):
+    @staticmethod
+    def concatenateLogs():
         """
         Concatenate the armi run logs and delete them.
 
-        Should only ever be called by master.
+        Should only ever be called by parent.
         """
-        info("Concatenating {0} standard streams".format(context.MPI_SIZE))
-        for rank in range(context.MPI_SIZE):
-            if not rank:
-                # skip log 0
-                continue
-            stdoutName = os.path.join("logs", _stdoutName.format(self.name, rank))
-            stderrName = os.path.join("logs", _stderrName.format(self.name, rank))
+        # find all the logging-module-based log files
+        stdoutFiles = sorted(glob(os.path.join("logs", "*.stdout")))
+        if not len(stdoutFiles):
+            return
 
-            for streamName, stream, logName in zip(
-                ["STDOUT", "STDERR"],
-                [self._outputStream, self._errStream],
-                [stdoutName, stderrName],
-            ):
-                with open(logName) as logFile:
-                    data = logFile.read()
+        info(
+            "Concatenating {0} log files and standard error streams".format(
+                len(stdoutFiles) + 1
+            )
+        )
+
+        for stdoutName in stdoutFiles:
+            # NOTE: If the log file name format changes, this will need to change.
+            rank = filePath.split(".")[-2]
+
+            # first, print the log messages for a child process
+            with open(stdoutName, "r") as logFile:
+                data = logFile.read()
                 if data:
-                    # only write if there's something to write.
-                    rankId = "\n{0} RANK {1:03d} {2} {3}\n".format(
-                        "-" * 10, rank, streamName, "-" * 60
+                    # only write if there's something to write
+                    rankId = "\n{0} RANK {1:03d} STDOUT {2}\n".format(
+                        "-" * 10, rank, "-" * 60
                     )
-                    stream.write(rankId)
-                    stream.write(data)
+                    print(rankId)
+                    print(data)
+            try:
+                os.remove(stdoutName)
+            except OSError:
+                warning("Could not delete {0}".format(stdoutName))
+
+            # then print the stderr messages for that child process
+            stderrName = stdouitName[:-3] + "err"
+            if os.path.exists(stderrName):
+                with open(stderrName) as logFile:
+                    data = logFile.read()
+                    if data:
+                        # only write if there's something to write.
+                        rankId = "\n{0} RANK {1:03d} STDERR {2}\n".format(
+                            "-" * 10, rank, "-" * 60
+                        )
+                        print(rankId, file=sys.stderr)
+                        print(data, file=sys.stderr)
                 try:
-                    os.remove(logName)
+                    os.remove(stderrName)
                 except OSError:
-                    warning("Could not delete {0}".format(logName))
-
-
-class PrintLogCombined(PrintLog):
-    """
-    Print log that doesn't break up into files
-    """
-
-    def startLog(self, name):
-        pass
-
-    def close(self):
-        pass
-
-    def concatenateLogs(self):
-        pass
+                    warning("Could not delete {0}".format(stderrName))
 
 
 # Here are all the module-level functions that should be used for most outputs.
-# They use the PrintLog object behind the scenes.
+# They use the Log object behind the scenes.
 def raw(msg):
     """
     Print raw text without any special functionality.
     """
-    LOG._emit(msg)  #  pylint: disable=protected-access
+    LOG.log("header", msg, single=False, label=msg)
 
 
 def extra(msg, single=False, label=None):
-    LOG.standardLogMsg("extra", msg, single=single, label=label)
+    LOG.log("extra", msg, single=single, label=label)
 
 
 def debug(msg, single=False, label=None):
-    LOG.standardLogMsg("debug", msg, single=single, label=label)
+    LOG.log("debug", msg, single=single, label=label)
 
 
 def info(msg, single=False, label=None):
-    LOG.standardLogMsg("info", msg, single=single, label=label)
+    LOG.log("info", msg, single=single, label=label)
 
 
 def important(msg, single=False, label=None):
-    LOG.standardLogMsg("important", msg, single=single, label=label)
+    LOG.log("important", msg, single=single, label=label)
 
 
 def warning(msg, single=False, label=None):
-    LOG.standardLogMsg("warning", msg, single=single, label=label)
+    LOG.log("warning", msg, single=single, label=label)
 
 
 def error(msg, single=False, label=None):
-    LOG.standardLogMsg("error", msg, single=single, label=label)
+    LOG.log("error", msg, single=single, label=label)
 
 
 def header(msg, single=False, label=None):
-    LOG.standardLogMsg("header", msg, single=single, label=label)
-
-
-def flush():
-    """Flush LOG's output in the err and output streams"""
-    LOG.flush()
-
-
-def prompt(statement, question, *options):
-    """ "Prompt the user for some information."""
-    from armi.localization import exceptions
-
-    if context.CURRENT_MODE == Mode.GUI:
-        # avoid hard dependency on wx
-        import wx  # pylint: disable=import-error
-
-        msg = statement + "\n\n\n" + question
-        if len(msg) < 300:
-            style = wx.CENTER
-            for opt in options:
-                style |= getattr(wx, opt)
-            dlg = wx.MessageDialog(None, msg, style=style)
-        else:
-            # for shame. Might make sense to move the styles stuff back into the
-            # Framework
-            from tparmi.gui.styles import dialogues
-
-            dlg = dialogues.ScrolledMessageDialog(None, msg, "Prompt")
-        response = dlg.ShowModal()
-        dlg.Destroy()
-        if response == wx.ID_CANCEL:
-            raise exceptions.RunLogPromptCancel("Manual cancellation of GUI prompt")
-        return response in [wx.ID_OK, wx.ID_YES]
-
-    elif context.CURRENT_MODE == Mode.INTERACTIVE:
-        response = ""
-        responses = [
-            opt for opt in options if opt in ["YES_NO", "YES", "NO", "CANCEL", "OK"]
-        ]
-
-        if "YES_NO" in responses:
-            index = responses.index("YES_NO")
-            responses[index] = "NO"
-            responses.insert(index, "YES")
-
-        if not any(responses):
-            raise RuntimeError("No suitable responses in {}".format(responses))
-
-        # highly requested shorthand responses
-        if "YES" in responses:
-            responses.append("Y")
-        if "NO" in responses:
-            responses.append("N")
-
-        while response not in responses:
-            LOG.standardLogMsg("prompt", statement)
-            LOG.standardLogMsg(
-                "prompt", "{} ({}): ".format(question, ", ".join(responses))
-            )
-            response = sys.stdin.readline().strip().upper()
-
-        if response == "CANCEL":
-            raise exceptions.RunLogPromptCancel(
-                "Manual cancellation of interactive prompt"
-            )
-
-        return response in ["YES", "Y", "OK"]
-
-    else:
-        raise exceptions.RunLogPromptUnresolvable(
-            "Incorrect CURRENT_MODE for prompting user: {}".format(context.CURRENT_MODE)
-        )
+    LOG.log("header", msg, single=single, label=label)
 
 
 def warningReport():
@@ -453,7 +363,6 @@ def warningReport():
 
 
 def setVerbosity(level):
-    # convenience function
     LOG.setVerbosity(level)
 
 
@@ -464,27 +373,45 @@ def getVerbosity():
 # ---------------------------------------
 
 
+class StreamToLogger:
+    """
+    File-like stream object that redirects writes to a logger instance.
+    """
+
+    def __init__(self, name, filePath, level, fmt):
+        self.name = name
+        self.filePath = filePath
+        self.level = level
+        self.fmt = fmt
+
+        # configure the logger
+        self.logger = logging.getLogger(self.name)
+        form = logging.Formatter(self.fmt)
+
+        if self.filePath:
+            h = logging.FileHandler(self.filePath)
+        else:
+            h = logging.StreamHandler()
+
+        h.setFormatter(form)
+        self.logger.addHandler(h)
+        self.logger.setLevel(level)
+
+    def write(self, level, message):
+        """generic write method, as required by the standard streams"""
+        self.logger.log(level, message)
+
+    def flush(self):
+        """generic flush method, as required by the standard streams"""
+        pass
+
+
+# ---------------------------------------
+
+
 def logFactory():
     """Create the default logging object."""
-    if context.MPI_RANK == 0:
-        verbosity = _logLevels["info"][0]
-    else:
-        verbosity = _logLevels["warning"][0]
-    return PrintLog(verbosity)
+    return RunLog(int(context.MPI_RANK))
 
 
 LOG = logFactory()
-
-# Copyright 2009-2019 TerraPower, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -31,6 +31,7 @@ import ruamel.yaml.comments
 
 from armi import runLog
 from armi.meta import __version__ as version
+from armi import context
 from armi.localization import exceptions
 from armi.settings.setting import Setting
 from armi.settings import settingsRules
@@ -278,7 +279,7 @@ class SettingsReader:
             return
         try:
             invalidNames = "\n\t".join(self.invalidSettings)
-            proceed = runLog.prompt(
+            proceed = prompt(
                 "Found {} invalid settings in {}.\n\n {} \n\t".format(
                     len(self.invalidSettings), self.inputPath, invalidNames
                 ),
@@ -574,3 +575,66 @@ class SettingsWriter:
             "&(?!quot;|lt;|gt;|amp;|apos;)", "&amp;", s
         )  # protects against chaining &amp
         return s
+
+
+def prompt(statement, question, *options):
+    """Prompt the user for some information."""
+    from armi.localization import exceptions
+
+    if context.CURRENT_MODE == context.Mode.GUI:
+        # avoid hard dependency on wx
+        import wx  # pylint: disable=import-error
+
+        msg = statement + "\n\n\n" + question
+        if len(msg) < 300:
+            style = wx.CENTER
+            for opt in options:
+                style |= getattr(wx, opt)
+            dlg = wx.MessageDialog(None, msg, style=style)
+        else:
+            # for shame. Might make sense to move the styles stuff back into the
+            # Framework
+            from tparmi.gui.styles import dialogues
+
+            dlg = dialogues.ScrolledMessageDialog(None, msg, "Prompt")
+        response = dlg.ShowModal()
+        dlg.Destroy()
+        if response == wx.ID_CANCEL:
+            raise exceptions.RunLogPromptCancel("Manual cancellation of GUI prompt")
+        return response in [wx.ID_OK, wx.ID_YES]
+
+    elif context.CURRENT_MODE == context.Mode.INTERACTIVE:
+        response = ""
+        responses = [
+            opt for opt in options if opt in ["YES_NO", "YES", "NO", "CANCEL", "OK"]
+        ]
+
+        if "YES_NO" in responses:
+            index = responses.index("YES_NO")
+            responses[index] = "NO"
+            responses.insert(index, "YES")
+
+        if not any(responses):
+            raise RuntimeError("No suitable responses in {}".format(responses))
+
+        # highly requested shorthand responses
+        if "YES" in responses:
+            responses.append("Y")
+        if "NO" in responses:
+            responses.append("N")
+
+        while response not in responses:
+            runLog.LOG.log("prompt", statement)
+            runLog.LOG.log("prompt", "{} ({}): ".format(question, ", ".join(responses)))
+
+        if response == "CANCEL":
+            raise exceptions.RunLogPromptCancel(
+                "Manual cancellation of interactive prompt"
+            )
+
+        return response in ["YES", "Y", "OK"]
+
+    else:
+        raise exceptions.RunLogPromptUnresolvable(
+            "Incorrect CURRENT_MODE for prompting user: {}".format(context.CURRENT_MODE)
+        )

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -623,6 +623,7 @@ def prompt(statement, question, *options):
         if "NO" in responses:
             responses.append("N")
 
+        # TODO: Using the logger is strange. Perhaps this is a rare use-case for bare print? Or something bespoke.
         while response not in responses:
             runLog.LOG.log("prompt", statement)
             runLog.LOG.log("prompt", "{} ({}): ".format(question, ", ".join(responses)))

--- a/armi/tests/mockRunLogs.py
+++ b/armi/tests/mockRunLogs.py
@@ -13,16 +13,17 @@
 # limitations under the License.
 
 """
-This module contains subclasses of the armi.runLog.Log class that can be used to determine whether or not
+This module contains subclasses of the armi.runLog.RunLog class that can be used to determine whether or not
 one of the specific methods were called. These should only be used in testing.
 """
 
 import six
+import sys
 
 from armi import runLog
 
 
-class BufferLog(runLog.PrintLog):
+class BufferLog(runLog.RunLog):
     r"""Log which captures the output in attributes instead of emitting them
 
     Used mostly in testing to ensure certain things get output, or to prevent any output
@@ -30,11 +31,11 @@ class BufferLog(runLog.PrintLog):
     """
 
     def __init__(self, *args, **kwargs):
-        runLog.PrintLog.__init__(self, *args, **kwargs)
+        runLog.RunLog.__init__(self, *args, **kwargs)
         self.originalLog = None
-        outputStream = six.StringIO()
-        errStream = six.StringIO()
-        self.setStreams(outputStream, errStream)
+        self._outputStream = ""
+        self._errStream = six.StringIO()
+        sys.stderr = self._errStream
         self.setVerbosity(0)
 
     def __enter__(self):
@@ -44,10 +45,35 @@ class BufferLog(runLog.PrintLog):
 
     def __exit__(self, exception_type, exception_value, traceback):
         runLog.LOG = self.originalLog
-        runLog.LOG.setStreams(runLog.LOG._outputStream, runLog.LOG._errStream)
+
+    def log(self, msgType, msg, single=False, label=None):
+        """
+        Add formatting to a message and handle its singleness, if applicable.
+
+        This is a wrapper around logger.log() that does most of the work and is
+        used by all message passers (e.g. info, warning, etc.).
+        """
+        # the message label is only used to determine unique for single-print warnings
+        if label is None:
+            label = msg
+
+        # Skip writing the message if it is below the set verbosity
+        msgVerbosity = self._logLevels[msgType][0]  # pylint: disable=protected-access
+        if msgVerbosity < self._verbosity:
+            return
+
+        # Skip writing the message if it is single-print warning
+        if single and self._msgHasAlreadyBeenEmitted(label, msgType):
+            return
+
+        # Do the actual logging, but add that custom indenting first
+        msg = (
+            self._logLevels[msgType][1] + self._cleanMsg(msg) + "\n"
+        )  # pylint: disable=protected-access
+        self._outputStream += msg
 
     def getStdoutValue(self):
-        return self._outputStream.getvalue()
+        return self._outputStream
 
     def getStderrValue(self):
         return self._errStream.getvalue()
@@ -61,7 +87,7 @@ class LogCounter(BufferLog):
 
     def __init__(self, *args, **kwargs):
         BufferLog.__init__(self)
-        self.messageCounts = {msgType: 0 for msgType in runLog.getLogVerbosityLevels()}
+        self.messageCounts = {msgType: 0 for msgType in self._logLevels().keys()}
 
-    def standardLogMsg(self, msgType, *args, **kwargs):
+    def log(self, msgType, *args, **kwargs):
         self.messageCounts[msgType] += 1

--- a/armi/tests/test_context.py
+++ b/armi/tests/test_context.py
@@ -1,0 +1,44 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pytest
+import shutil
+import unittest
+
+from armi import context
+
+# CONSTANTS FOR TESTING
+TEST_DIR1 = "test_createLogDir"
+
+
+class TestContext(unittest.TestCase):
+    def tearDown(self):
+        # clean up any existing test directories
+        testDirs = [TEST_DIR1]
+        for testDir in testDirs:
+            if os.path.exists(testDir):
+                shutil.rmtree(testDir, ignore_errors=True)
+
+    def test_createLogDir(self):
+        """Test the createLogDir() method"""
+        logDir = TEST_DIR1
+        self.assertFalse(os.path.exists(logDir))
+        context.createLogDir(0, logDir)
+        self.assertTrue(os.path.exists(logDir))
+
+
+if __name__ == "__main__":
+    # import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -12,26 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import logging
+import os
+import pytest
+import sys
 import unittest
 
-from armi import runLog
+from armi import context, runLog
 
 
 class TestRunLog(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        """This pytest fixture allows us to caption logging messages that pytest interupts"""
+        self._caplog = caplog
+
     def test_setVerbosityFromInteger(self):
         """Test that the log verbosity can be set with an integer."""
-        expectedStrVerbosity = runLog.getLogVerbosityLevels()[0]
-        verbosityRank = runLog.getLogVerbosityRank(expectedStrVerbosity)
+        log = runLog.RunLog(1)
+        expectedStrVerbosity = "debug"
+        verbosityRank = log._getLogVerbosityRank(expectedStrVerbosity)
         runLog.setVerbosity(verbosityRank)
         self.assertEqual(verbosityRank, runLog.getVerbosity())
+        self.assertEqual(verbosityRank, logging.DEBUG)
 
     def test_setVerbosityFromString(self):
         """Test that the log verbosity can be set with a string."""
-        expectedStrVerbosity = runLog.getLogVerbosityLevels()[0]
-        verbosityRank = runLog.getLogVerbosityRank(expectedStrVerbosity)
+        log = runLog.RunLog(1)
+        expectedStrVerbosity = "error"
+        verbosityRank = log._getLogVerbosityRank(expectedStrVerbosity)
         runLog.setVerbosity(expectedStrVerbosity)
         self.assertEqual(verbosityRank, runLog.getVerbosity())
+        self.assertEqual(verbosityRank, logging.ERROR)
 
     def test_invalidSetVerbosityByRank(self):
         """Test that the log verbosity setting fails if the integer is invalid."""
@@ -42,6 +54,51 @@ class TestRunLog(unittest.TestCase):
         """Test that the log verbosity setting fails if the integer is invalid."""
         with self.assertRaises(KeyError):
             runLog.setVerbosity("taco")
+
+    def test_createLogDir(self):
+        """Test the createLogDir() method"""
+        log = runLog.RunLog(1)
+        log._createLogDir()
+        self.assertTrue(os.path.exists("logs"))
+
+    @unittest.skipIf(context.MPI_COMM is None, "MPI libraries are not installed.")
+    def test_caplogBasicRunLogging(self):
+        """A basic test of the logging of the child runLog"""
+        with self._caplog.at_level(logging.WARNING):
+            runLog.setVerbosity("info")
+            log = runLog.RunLog(1)
+            log._createLogDir()
+            log.startLog("test_caplogBasicChildRunLog")
+            log.log("debug", "You shouldn't see this.", single=False, label=None)
+            log.log("warning", "Hello, ", single=False, label=None)
+            log.log("error", "world!", single=False, label=None)
+            log.close()
+
+        messages = [r.message for r in self._caplog.records]
+        self.assertGreater(len(messages), 0)
+        self.assertIn("Hello", messages[0])
+        self.assertIn("world", messages[1])
+
+    @unittest.skipIf(context.MPI_COMM is None, "MPI libraries are not installed.")
+    def test_warningReport(self):
+        """A simple test of the warning tracking and reporting logic"""
+        with self._caplog.at_level(logging.INFO):
+            runLog.setVerbosity("info")
+            log = runLog.RunLog(1)
+            log.startLog("test_warningReport")
+            log.log("warning", "hello", single=True, label=None)
+            log.log("debug", "invisible due to log level", single=False, label=None)
+            log.log("warning", "hello", single=True, label=None)
+            log.log("error", "invisible due to log level", single=False, label=None)
+            self.assertEqual(
+                len(log._singleWarningMessageCounts), 1
+            )  # pylint: disable=protected-access
+            log.warningReport()
+            log.close()
+
+        messages = [r.message for r in self._caplog.records]
+        self.assertEqual(len(messages), 2)
+        self.assertIn("hello", messages[0])
 
 
 if __name__ == "__main__":

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 python_files=test_*.py
 python_functions=nothing matches this pattern
-addopts = --durations=30 --tb=native
+addopts = --durations=30 --tb=native -n 1 --dist=loadfile
 filterwarnings =
     ignore:\s*the matrix subclass is not the recommended way:PendingDeprecationWarning
     ignore:\s*Loading from XML-format settings:DeprecationWarning


### PR DESCRIPTION
This PR is broken up into two commits:

1. Refactor `runLog.py` to use the Python standard library `logging`.
2. Allow module-specific logging (see `reactors.py` for an example).

I tried to keep this PR as minimal as possible, but touching anything in our logging has long fingers. So even without moving code to `context.py` this ended up being a 16-file PR. Changing `runLog.py` meant making significant changes to `mockRunLog.py`, which lead to all kinds of unit testing changes. 

I also found that testing logging changes in Python is exceptionally tedious, as PyTest intercepts *all* logging, for the purposes of display. So you can't use PyTest to test your logging functionality without changing the outputs: see Heisenberg.

I also moved the `prompt()` stuff out of `runLog.py` and into `settingsIO.py`.