### PR TITLE
Add coveralls reporting to workflows

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,5 +22,5 @@ jobs:
         run: pip install tox
       - name: Run Tox
         # Run tox using the version of Python in `PATH`
-        run: tox -e py,cov,report
+        run: tox -e cov,report
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,4 +1,4 @@
-name: ARMI unit tests
+name: Coverage
 
 on: [push, pull_request]
 
@@ -6,20 +6,21 @@ jobs:
   build:
 
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python: [3.7, 3.8, 3.9]
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.9
       - name: Install mpi libs
         run: sudo apt-get -y install libopenmpi-dev
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox
         # Run tox using the version of Python in `PATH`
-        run: tox -e py
+        run: tox -e py,cov,report
+

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -22,4 +22,4 @@ jobs:
         run: pip install tox
       - name: Run Tox
         # Run tox using the version of Python in `PATH`
-        run: tox -e py,cov
+        run: tox -e py,cov,report

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -22,4 +22,4 @@ jobs:
         run: pip install tox
       - name: Run Tox
         # Run tox using the version of Python in `PATH`
-        run: tox -e py
+        run: tox -e py,cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,lint,cov
+envlist = py37,lint,cov
 # need pip at least with --prefer-binary
 requires = 
 	pip >= 20.2
@@ -11,6 +11,7 @@ deps=
     -r{toxinidir}/requirements-testing.txt
 setenv =
     PYTHONPATH = {toxinidir}
+    USERNAME = armi
 commands =
     pytest --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps=
 commands =
     coverage report
     coverage html
-    coveralls
+    coveralls --service=github
 depends =
     cov
 passenv = TOXENV CI GITHUB_*


### PR DESCRIPTION
This adds a new GH workflow for running tests with code coverage and reporting
the results to coveralls.io