### PR TITLE
Enabling save to database for the crRodLength assembly parameter.

### DIFF
--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -247,7 +247,6 @@ def getAssemblyParameterDefinitions():
             "crRodLength",
             units="cm",
             description="length of the control material within the control rod",
-            saveToDB=False,
         )
 
         pb.defParam(


### PR DESCRIPTION
The `crRodLength` parameter should be saved to the database so that the length of the control rod region can be
recovered when loading from an existing database (in Standard or Snapshot runs). Currently the other control rod
assembly parameters are saved, but this was overlooked.