### PR TITLE
Relaxing XS settings validation failure when assigning file location and geometry inputs.

### DIFF
--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -423,7 +423,8 @@ class XSModelingOptions:
         if self.fileLocation is not None and self.geometry is not None:
             runLog.warning(
                 f"Either file location or geometry inputs in {self} should be given, but not both. "
-                "Remove one or the other in the `crossSectionSettings` input to fix this."
+                "The file location setting will take precedence over the geometry inputs. "
+                "Remove one or the other in the `crossSectionSettings` input to fix this warning."
             )
 
         invalids = []

--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -421,9 +421,9 @@ class XSModelingOptions:
             raise ValueError(f"{self} is missing a geometry input or a file location.")
 
         if self.fileLocation is not None and self.geometry is not None:
-            raise ValueError(
-                f"Either file location or geometry inputs in {self} must be given, but not both. "
-                "Remove one or the other."
+            runLog.warning(
+                f"Either file location or geometry inputs in {self} should be given, but not both. "
+                "Remove one or the other in the `crossSectionSettings` input to fix this."
             )
 
         invalids = []


### PR DESCRIPTION
Relaxing cross section settings restrictions so that the case does not fail if the XS are overspecified with setting the file location
and the geometry information.