### PR TITLE
Fix copying interface input files with wildcard

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -760,10 +760,16 @@ def copyInterfaceInputs(
                     # looks like an extant, absolute path; no need to do anything
                     pass
                 else:
-                    if not (path.exists() and path.is_file()):
-                        runLog.extra(
-                            f"Input file `{f}` not found. Checking for file at path `{sourceDirPath}`"
-                        )
+                    # An OSError can occur if a wildcard is included in the file name so
+                    # this is wrapped in a try/except to circumvent instances where an
+                    # interface requests to copy multiple files based on some prefix/suffix.
+                    try:
+                        if not (path.exists() and path.is_file()):
+                            runLog.extra(
+                                f"Input file `{f}` not found. Checking for file at path `{sourceDirPath}`"
+                            )
+                    except OSError:
+                        pass
 
                     # relative path/glob. Should be safe to just use glob resolution.
                     # Note that `glob.glob` is being used here rather than `pathlib.glob` because


### PR DESCRIPTION
An error occured within the `copyInterfaceInputs` function when a file path was provided with a wildcard.

In this case, any file checks using pathlib.Path would crash with an OSError. To circumvent this issue, the path checks are wrapped
in a try/except so that glob function may still be used to copy all files that end up meeting the wildcard criteria.