### PR TITLE
Doc errors

### DIFF
--- a/armi/tests/tutorials/anl-afci-177.yaml
+++ b/armi/tests/tutorials/anl-afci-177.yaml
@@ -2,6 +2,7 @@
 # uses .. literalinclude to bring in sections of this file. Thus, 
 # the comments and order are important. These will get wiped out
 # if you load and re-write a settings file via the ARMI gui, unfortunately.
+# begin-metadata
 metadata:
   version: uncontrolled
 # begin-settings

--- a/armi/tests/tutorials/data_model.ipynb
+++ b/armi/tests/tutorials/data_model.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "    Reactor, assembly, blocks, etc. objects act like lists as well, so you can get the fifth\n",
     "    assembly out of a reactor just like you'd get the fifth item out of any other list\n",
-    "    (don't forget that Python uses `zero-based numbering <http://en.wikipedia.org/wiki/Zero-based_numbering>`_).::\n",
+    "    (don't forget that Python uses `zero-based numbering <http://en.wikipedia.org/wiki/Zero-based_numbering>`_)::\n",
     "\n",
     "        >>> fifthAssem = core[4]"
    ]

--- a/armi/tests/tutorials/data_model.ipynb
+++ b/armi/tests/tutorials/data_model.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "    Reactor, assembly, blocks, etc. objects act like lists as well, so you can get the fifth\n",
     "    assembly out of a reactor just like you'd get the fifth item out of any other list\n",
-    "    (don't forget that python uses `zero-based numbering <http://en.wikipedia.org/wiki/Zero-based_numbering>`_).::\n",
+    "    (don't forget that Python uses `zero-based numbering <http://en.wikipedia.org/wiki/Zero-based_numbering>`_).::\n",
     "\n",
     "        >>> fifthAssem = core[4]"
    ]
@@ -257,7 +257,7 @@
    "metadata": {},
    "source": [
     "## Modifying the state of the reactor\n",
-    "Each object in the Reactor model has a bunch of *state parameters* contained in it's special `.p` attribute, called it's *Parameter Collection*). The state parameters are defined both by the ARMI framework and the collection of plugins. For instance, you can look at the core's keff parameters or each individual block's power and multi-group flux parameters like this:"
+    "Each object in the Reactor model has a bunch of *state parameters* contained in its special `.p` attribute, called its *Parameter Collection*. The state parameters are defined both by the ARMI framework and the collection of plugins. For instance, you can look at the core's keff parameters or each individual block's power and multi-group flux parameters like this:"
    ]
   },
   {

--- a/armi/tests/tutorials/param_sweep.ipynb
+++ b/armi/tests/tutorials/param_sweep.ipynb
@@ -279,9 +279,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "At this point, you have two options based on your needs:\n",
-    "* Read the ARMI HDF5 output databases directly (useful if you just need to pull certain scalar parameters directly out of the database)\n",
-    "* Have ARMI load HDF5 output databases into full ARMI reactor objects and use the ARMI API to extract data (useful if you want to loop over certain parts of the plant to sum things up)\n",
+    "At this point, you have two options based on your needs:\n\n",
+    "- Read the ARMI HDF5 output databases directly (useful if you just need to pull certain scalar parameters directly out of the database)\n",
+    "- Have ARMI load HDF5 output databases into full ARMI reactor objects and use the ARMI API to extract data (useful if you want to loop over certain parts of the plant to sum things up)\n",
     "\n",
     "Directly reading the database will be inherently less stable (e.g. in case the underlying DB format changes), but can be very fast. Loading ARMI reactors for each case is slower, but should also be more powerful and more stable.\n",
     "\n",

--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -148,7 +148,7 @@ Plugin code can exist in any directory structure in an app. In this app we
 put it in the :file:`myapp/plugin.py` file.
 
 .. note:: For "serious" plugins, we recommend mirroring the ``armi/physics/[subphysics]``
-    structure of the ARMI framework :py:mod:`physics plugin subpackage <armi.physics>`.
+    structure of the ARMI Framework :py:mod:`physics plugin subpackage <armi.physics>`.
 
 We will start the plugin by pointing to the two physics kernels we wish to register. We
 hook them in and tell ARMI the ``ORDER`` they should be run in based on the built-in
@@ -262,7 +262,7 @@ the directory that contains our app. For testing, an example value for this migh
 
 Make a run directory with some input files in it. You can use the same SFR input files
 we've used in previous tutorials for starters (but quickly transition to your own inputs
-for your own interests!)
+for your own interests!).
 
 Here are the files you can download into the run directory.
 

--- a/doc/tutorials/walkthrough_inputs.rst
+++ b/doc/tutorials/walkthrough_inputs.rst
@@ -353,6 +353,13 @@ Now we need to specify some **settings** that define fundamental reactor
 parameters, as well as modeling approximation options. For this, we make a
 **settings file**, called ``anl-afci-177.yaml``.
 
+First we need to supply some metadata.
+
+.. literalinclude:: ../../armi/tests/tutorials/anl-afci-177.yaml
+    :language: yaml
+    :start-after: begin-metadata
+    :end-before: begin-settings-1
+
 The thermal power in this reference is 1000 MWt. The thermal efficiency isn't
 specified, so let's assume 0.38. From Table 4.8, the cycle length is 370 EFPD.
 Let's also assume a 0.90 capacity factor which will gives full cycles of 411.1

--- a/doc/tutorials/walkthrough_inputs.rst
+++ b/doc/tutorials/walkthrough_inputs.rst
@@ -358,7 +358,7 @@ First we need to supply some metadata.
 .. literalinclude:: ../../armi/tests/tutorials/anl-afci-177.yaml
     :language: yaml
     :start-after: begin-metadata
-    :end-before: begin-settings-1
+    :end-before: begin-settings
 
 The thermal power in this reference is 1000 MWt. The thermal efficiency isn't
 specified, so let's assume 0.38. From Table 4.8, the cycle length is 370 EFPD.

--- a/doc/user/assorted_guide.rst
+++ b/doc/user/assorted_guide.rst
@@ -1,6 +1,6 @@
 Branch Searching
 ----------------
-An powerful ARMI feature that exists in the Operator is the branch search.
+A powerful ARMI feature that exists in the Operator is the branch search.
 This runs multiple possible fuel management options in parallel and then
 selects the one that is preferred by the user before going on to the
 next time step. A branch search involves several methods.


### PR DESCRIPTION
Fixed various grammatical and typographical errors that I found while going through the tutorial docs. 

The only change more complicated than simple typos is the addition of the metadata setting to the SFR tutorial. Without this addition, the input that a user builds by following the tutorial will not run. I added a step in the tutorial to put the needed metadata entry into their settings file and added a yaml anchor to the stored input file so that the code renders in the docs.