### PR TITLE
Fix centering of full-symmetry cartesian latticeMaps

### DIFF
--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -283,6 +283,8 @@ class TestGridBlueprintsSection(unittest.TestCase):
         self.assertEqual(gridDesign4.gridContents[-1, -1], "2")
         self.assertEqual(gridDesign4.gridContents[2, 2], "2")
         self.assertEqual(gridDesign4.gridContents[-3, -3], "1")
+        with self.assertRaises(KeyError):
+            self.assertEqual(gridDesign4.gridContents[-4, -3], "1")
 
 
 class TestRZTGridBlueprint(unittest.TestCase):

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -57,6 +57,27 @@ sfp:
         2 1 3 1 2
         2 3 1 1 2
         2 2 2 2 2
+
+sfp quarter:
+    geom: cartesian
+    symmetry: quarter through center assembly
+    lattice map: |
+        2 2 2 2 2
+        2 1 1 1 2
+        2 1 3 1 2
+        2 3 1 1 2
+        2 2 2 2 2
+
+sfp even:
+    geom: cartesian
+    symmetry: full
+    lattice map: |
+        1 2 2 2 2 2
+        1 2 1 1 1 2
+        1 2 1 4 1 2
+        1 2 2 1 1 2
+        1 2 2 2 2 2
+        1 1 1 1 1 1
 """
 
 RZT_BLUEPRINT = """
@@ -240,11 +261,28 @@ class TestGridBlueprintsSection(unittest.TestCase):
         _grid = gridDesign.construct()
         self.assertEqual(gridDesign.gridContents[0, -8], "6")
 
+        # Cartesian full, odd
         gridDesign2 = self.grids["sfp"]
         _grid = gridDesign2.construct()
         self.assertEqual(gridDesign2.gridContents[1, 1], "1")
         self.assertEqual(gridDesign2.gridContents[0, 0], "3")
         self.assertEqual(gridDesign2.gridContents[-1, -1], "3")
+
+        # Cartesian quarter, odd
+        gridDesign3 = self.grids["sfp quarter"]
+        _grid = gridDesign3.construct()
+        self.assertEqual(gridDesign3.gridContents[0, 0], "2")
+        self.assertEqual(gridDesign3.gridContents[1, 1], "3")
+        self.assertEqual(gridDesign3.gridContents[2, 2], "3")
+        self.assertEqual(gridDesign3.gridContents[3, 3], "1")
+
+        # Cartesian full, even/odd hybrid
+        gridDesign4 = self.grids["sfp even"]
+        _grid = gridDesign4.construct()
+        self.assertEqual(gridDesign4.gridContents[0, 0], "4")
+        self.assertEqual(gridDesign4.gridContents[-1, -1], "2")
+        self.assertEqual(gridDesign4.gridContents[2, 2], "2")
+        self.assertEqual(gridDesign4.gridContents[-3, -3], "1")
 
 
 class TestRZTGridBlueprint(unittest.TestCase):

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -242,7 +242,9 @@ class TestGridBlueprintsSection(unittest.TestCase):
 
         gridDesign2 = self.grids["sfp"]
         _grid = gridDesign2.construct()
-        self.assertEqual(gridDesign2.gridContents[1, 1], "3")
+        self.assertEqual(gridDesign2.gridContents[1, 1], "1")
+        self.assertEqual(gridDesign2.gridContents[0, 0], "3")
+        self.assertEqual(gridDesign2.gridContents[-1, -1], "3")
 
 
 class TestRZTGridBlueprint(unittest.TestCase):

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -379,7 +379,7 @@ class SymmetryType:
                 symmetryString, trimmedString
             )
             errorMsg += ", ".join(
-                [f"{sym}" for sym in self.createValidSymmetryStrings()]
+                [f"{sym}" for sym in cls.createValidSymmetryStrings()]
             )
             raise ValueError(errorMsg)
         return cls(domain, boundary, isThroughCenter)

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -154,6 +154,8 @@ class AsciiMap:
         _updateDimensionsFromAsciiLines : used when reading info from ascii lines
         """
         self._ijMax = max(sum(key) for key in self.asciiLabelByIndices)
+        self._asciiMaxCol = max(key[0] for key in self.asciiLabelByIndices) + 1
+        self._asciiMaxLine = max(key[1] for key in self.asciiLabelByIndices) + 1
 
     @staticmethod
     def fromReactor(reactor):
@@ -245,6 +247,9 @@ class AsciiMap:
     def items(self):
         return self.asciiLabelByIndices.items()
 
+    def keys(self):
+        return self.asciiLabelByIndices.keys()
+
 
 class AsciiMapCartesian(AsciiMap):
     """
@@ -262,6 +267,17 @@ class AsciiMapCartesian(AsciiMap):
             for ci, asciiLabel in enumerate(line):
                 ij = self._getIJFromColRow(ci, li)
                 self.asciiLabelByIndices[ij] = asciiLabel
+
+    def _updateDimensionsFromData(self):
+        AsciiMap._updateDimensionsFromData(self)
+        iMin = min(key[0] for key in self.asciiLabelByIndices)
+        jMin = min(key[1] for key in self.asciiLabelByIndices)
+
+        if iMin > 0 or jMin > 0:
+            raise ValueError(
+                "Asciimaps only supports sets of indices that "
+                "start at less than or equal to zero, got {}, {}".format(iMin, jMin)
+            )
 
     def _getIJFromColRow(self, columNum, lineNum):
         return columNum, lineNum

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -1709,7 +1709,9 @@ class NewGridBlueprintDialog(wx.Dialog):
         nameSizer.Add(self.gridName, 1, wx.EXPAND)
 
         self.geomType = wx.Choice(
-            self, id=wx.ID_ANY, choices=[gt.label for gt in self._geomFromIdx.values()],
+            self,
+            id=wx.ID_ANY,
+            choices=[gt.label for gt in self._geomFromIdx.values()],
         )
 
         self.Bind(wx.EVT_CHOICE, self.onSelectGeomType, self.geomType)

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -1487,11 +1487,22 @@ class GridBlueprintControl(wx.Panel):
                     aMap = asciimaps.asciiMapFromGeomAndSym(
                         self.grid.geomType, self.grid.symmetry
                     )()
-                    aMap.asciiLabelByIndices = gridDesign.gridContents
+                    # asciimaps can't handle negative indices, so we bump everything
+                    # forward if needed
+                    offset = (
+                        min(key[0] for key in gridDesign.gridContents.keys()),
+                        min(key[1] for key in gridDesign.gridContents.keys()),
+                    )
+                    aMap.asciiLabelByIndices = {
+                        (key[0] - offset[0], key[1] - offset[1]): val
+                        for key, val in gridDesign.gridContents.items()
+                    }
                     aMap.gridContentsToAscii()
-                except:
+                except Exception as e:
                     runLog.warning(
-                        "Cannot write geometry with asciimap. Defaulting to dict."
+                        "Cannot write geometry with asciimap. Defaulting to dict. Issue: {}".format(
+                            e
+                        )
                     )
                     aMap = None
 
@@ -1698,9 +1709,7 @@ class NewGridBlueprintDialog(wx.Dialog):
         nameSizer.Add(self.gridName, 1, wx.EXPAND)
 
         self.geomType = wx.Choice(
-            self,
-            id=wx.ID_ANY,
-            choices=[gt.label for gt in self._geomFromIdx.values()],
+            self, id=wx.ID_ANY, choices=[gt.label for gt in self._geomFromIdx.values()],
         )
 
         self.Bind(wx.EVT_CHOICE, self.onSelectGeomType, self.geomType)

--- a/armi/utils/tests/test_asciimaps.py
+++ b/armi/utils/tests/test_asciimaps.py
@@ -18,6 +18,7 @@ from armi.utils import asciimaps
 
 
 CARTESIAN_MAP = """2 2 2 2 2
+2 2 2 2 2
 2 1 1 1 2
 2 1 3 1 2
 2 3 1 1 2
@@ -178,18 +179,21 @@ class TestAsciiMaps(unittest.TestCase):
             stream.seek(0)
             asciimap.readAscii(stream.read())
 
-        with io.StringIO() as stream:
-            asciimap.writeAscii(stream)
-            stream.seek(0)
-            output = stream.read()
-            self.assertEqual(output, CARTESIAN_MAP)
-
         self.assertEqual(asciimap[0, 0], "2")
         self.assertEqual(asciimap[1, 1], "3")
         self.assertEqual(asciimap[2, 2], "3")
         self.assertEqual(asciimap[3, 3], "1")
         with self.assertRaises(KeyError):
             asciimap[5, 2]  # pylint: disable=pointless-statement
+
+        outMap = asciimaps.AsciiMapCartesian()
+        outMap.asciiLabelByIndices = asciimap.asciiLabelByIndices
+        outMap.gridContentsToAscii()
+        with io.StringIO() as stream:
+            outMap.writeAscii(stream)
+            stream.seek(0)
+            output = stream.read()
+            self.assertEqual(output, CARTESIAN_MAP)
 
     def test_hexThird(self):
         """Read 1/3 core flats-up maps."""


### PR DESCRIPTION
Asciimaps assume everything starts at (0,0), so grid blueprints need to
offset indices when reading in full geometry inputs. Also, when writing
asciimaps, gridContents need to be offset in the other direction for
things to work out correctly.

This also fixes a bug related to asciimaps writing cartesian maps at
all.