### PR TITLE
Reducing the instances of bare "import armi".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,11 @@ tags
 .cache/
 .pytest_cache/
 .vim-bookmarks
-.venv*/
+venv*/
 .mypy_cache/
 **/__pycache__
 **/.coverage*
+**/logs/*
 
 # Misc. exclusions
 *.html

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -28,18 +28,15 @@ import os
 
 import matplotlib
 
-import armi
-from armi.tests import TEST_ROOT
-from armi import apps
-from armi import settings
+from armi import apps, configure, context, settings
 from armi.settings import caseSettings
-from armi import context
+from armi.tests import TEST_ROOT
 
 
 def pytest_sessionstart(session):
 
     print("Initializing generic ARMI Framework application")
-    armi.configure(apps.App())
+    configure(apps.App())
     bootstrapArmiTestEnv()
 
 

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -32,9 +32,7 @@ from typing import List
 from typing import Dict
 from abc import ABCMeta, abstractmethod
 
-import armi
-from armi import settings
-from armi import utils
+from armi import getPluginManagerOrFail, settings, utils
 from armi.utils import textProcessors
 from armi.reactor import parameters
 
@@ -550,7 +548,7 @@ def getActiveInterfaceInfo(cs):
     """
     interfaceInfo = []
     # pylint: disable = no-member
-    for info in armi.getPluginManagerOrFail().hook.exposeInterfaces(cs=cs):
+    for info in getPluginManagerOrFail().hook.exposeInterfaces(cs=cs):
         interfaceInfo += info
 
     interfaceInfo = [

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -19,15 +19,13 @@ import os
 from ruamel.yaml import YAML
 import voluptuous as vol
 
-from armi.tests.test_plugins import TestPlugin
 from armi.physics import neutronics
-from armi.settings import caseSettings
 from armi.physics.neutronics.const import CONF_CROSS_SECTION
-from armi.utils import directoryChangers
-from armi import tests
+from armi.settings import caseSettings
 from armi.tests import TEST_ROOT
-from armi import settings
-import armi
+from armi.tests.test_plugins import TestPlugin
+from armi.utils import directoryChangers
+from armi import getPluginManagerOrFail, settings, tests
 
 XS_EXAMPLE = """AA:
     geometry: 0D
@@ -100,7 +98,7 @@ class NeutronicsReactorTests(unittest.TestCase):
                 "decayConstants": [0.0] * 6,
             }
         )
-        armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
         r.core.setOptionsFromCs(cs)
         self.assertEqual(r.core.p.beta, sum(cs["beta"]))
         self.assertListEqual(list(r.core.p.betaComponents), cs["beta"])
@@ -111,7 +109,7 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"beta": 0.00670},
         )
-        armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
         self.assertEqual(r.core.p.beta, cs["beta"])
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -124,7 +122,7 @@ class NeutronicsReactorTests(unittest.TestCase):
                 "beta": [0.0] * 6,
             },
         )
-        armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
         self.assertIsNone(r.core.p.beta)
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -136,7 +134,7 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"beta": [0.0], "decayConstants": [0.0]},
         )
-        armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
         self.assertEqual(r.core.p.beta, sum(cs["beta"]))
         self.assertListEqual(list(r.core.p.betaComponents), cs["beta"])
         self.assertListEqual(list(r.core.p.betaDecayConstants), cs["decayConstants"])
@@ -147,7 +145,7 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"decayConstants": [0.0] * 6},
         )
-        armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
         self.assertIsNone(r.core.p.beta)
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -159,7 +157,7 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"decayConstants": [0.0] * 6, "beta": 0.0},
         )
-        armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
         self.assertEqual(r.core.p.beta, cs["beta"])
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -170,7 +168,7 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"decayConstants": None, "beta": None},
         )
-        armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
         self.assertEqual(r.core.p.beta, cs["beta"])
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -182,7 +180,7 @@ class NeutronicsReactorTests(unittest.TestCase):
             cs = _getModifiedSettings(
                 customSettings={"decayConstants": [0.0] * 6, "beta": [0.0]},
             )
-            armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+            getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
 
         # Test that an error is raised if the decay constants
         # and group-wise beta are inconsistent sizes
@@ -191,7 +189,7 @@ class NeutronicsReactorTests(unittest.TestCase):
             cs = _getModifiedSettings(
                 customSettings={"decayConstants": [0.0] * 6, "beta": [0.0] * 5},
             )
-            armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+            getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
 
         # The following tests check the voluptuous schema definition. This
         # ensures that anything except NoneType, [float], float are not valid
@@ -201,28 +199,28 @@ class NeutronicsReactorTests(unittest.TestCase):
             cs = _getModifiedSettings(
                 customSettings={"decayConstants": [1]},
             )
-            armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+            getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
 
         with self.assertRaises(vol.AnyInvalid):
             r = tests.getEmptyHexReactor()
             cs = _getModifiedSettings(
                 customSettings={"beta": [1]},
             )
-            armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+            getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
 
         with self.assertRaises(vol.AnyInvalid):
             r = tests.getEmptyHexReactor()
             cs = _getModifiedSettings(
                 customSettings={"beta": 1},
             )
-            armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+            getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
 
         with self.assertRaises(vol.AnyInvalid):
             r = tests.getEmptyHexReactor()
             cs = _getModifiedSettings(
                 customSettings={"beta": (1, 2, 3)},
             )
-            armi.getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+            getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
 
 
 if __name__ == "__main__":

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -81,19 +81,19 @@ import yamlize
 import yamlize.objects
 import ordered_set
 
-import armi
 from armi import context
+from armi import getPluginManager, getPluginManagerOrFail
+from armi import plugins
 from armi import runLog
 from armi import settings
-from armi import plugins
 from armi.localization.exceptions import InputError
 from armi.nucDirectory import nuclideBases
 from armi.nucDirectory import elements
 from armi.scripts import migration
 from armi.utils import textProcessors
+from armi.reactor import assemblies
 from armi.reactor import geometry
 from armi.reactor import systemLayoutInput
-from armi.reactor import assemblies
 
 # NOTE: using non-ARMI-standard imports because these are all a part of this package,
 # and using the module imports would make the attribute definitions extremely long
@@ -144,7 +144,7 @@ class _BlueprintsPluginCollector(yamlize.objects.ObjectType):
 
     def __new__(mcs, name, bases, attrs):
         # pylint: disable=no-member
-        pm = armi.getPluginManager()
+        pm = getPluginManager()
         if pm is None:
             runLog.warning(
                 "Blueprints were instantiated before the framework was "
@@ -304,7 +304,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             runLog.header("=========== Verifying Assembly Configurations ===========")
 
             # pylint: disable=no-member
-            armi.getPluginManagerOrFail().hook.afterConstructionOfAssemblies(
+            getPluginManagerOrFail().hook.afterConstructionOfAssemblies(
                 assemblies=self.assemblies.values(), cs=cs
             )
 

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -24,7 +24,7 @@ geometry type as a surrogate).
 """
 import yamlize
 
-import armi
+from armi import getPluginManagerOrFail
 from armi import runLog
 from armi.reactor import assemblies
 from armi.reactor.flags import Flags
@@ -35,7 +35,7 @@ from armi.reactor import grids
 
 def _configureAssemblyTypes():
     assemTypes = dict()
-    pm = armi.getPluginManagerOrFail()
+    pm = getPluginManagerOrFail()
     for pluginAssemTypes in pm.hook.defineAssemblyTypes():
         for blockType, assemType in pluginAssemTypes:
             assemTypes[blockType] = assemType

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -16,10 +16,10 @@
 import io
 import unittest
 
-import armi
+from armi import configure, isConfigured
 
-if not armi.isConfigured():
-    armi.configure()
+if not isConfigured():
+    configure()
 from armi.reactor.blueprints import gridBlueprint
 from armi.reactor import systemLayoutInput
 

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -29,8 +29,8 @@ import xml.etree.ElementTree as ET
 from ruamel.yaml import YAML
 import ruamel.yaml.comments
 
-import armi
 from armi import runLog
+from armi.meta import __version__ as version
 from armi.localization import exceptions
 from armi.settings.setting import Setting
 from armi.settings import settingsRules
@@ -159,8 +159,8 @@ class SettingsReader:
 
         self.invalidSettings = set()
         self.settingsAlreadyRead = set()
-        self.liveVersion = armi.__version__
-        self.inputVersion = armi.__version__
+        self.liveVersion = version
+        self.inputVersion = version
 
         self._renamer = SettingRenamer(self.cs.settings)
 
@@ -406,7 +406,7 @@ class SettingsWriter:
 
     @staticmethod
     def _getVersion():
-        tag, attrib = Roots.CUSTOM, {Roots.VERSION: armi.__version__}
+        tag, attrib = Roots.CUSTOM, {Roots.VERSION: version}
         return tag, attrib
 
     def writeXml(self, stream):

--- a/armi/utils/tests/test_gridGui.py
+++ b/armi/utils/tests/test_gridGui.py
@@ -54,10 +54,10 @@ import test.support
 # rest of the module. Neat!
 wx = test.support.import_module("wx")
 
-import armi
+from armi import configure, getApp
 
-if armi._app is None:
-    armi.configure()
+if getApp() is None:
+    configure()
 from armi.utils import gridEditor
 
 _SECONDS_PER_TICK = 0.05

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -169,8 +169,6 @@ copyright = "2009-{}, TerraPower, LLC".format(datetime.datetime.now().year)
 # built documents.
 #
 # The short X.Y version.
-import armi
-
 version = armi.__version__  #'.'.join(armi.__version__.split('.')[:2])
 # The full version, including alpha/beta/rc tags.
 release = armi.__version__


### PR DESCRIPTION
There are several places in the code where a bare `import armi` is done from within the armi module. Python is really good about lazily importing large swaths of code to prevent circular imports. But this sort of thing can still cause opaque runtime errors.

There are more places in the code where `import armi` is used, but those will all require some code refactoring to provide different pathways for the desired usage. This PR only covers the simplest cases where we can just remove the bare import and replace it without a more specific one.