### PR TITLE
Add a setting to control auto-creation of Block grids

### DIFF
--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -26,6 +26,7 @@ from armi.reactor.flags import Flags
 from armi.reactor.blueprints import componentBlueprint
 from armi.reactor.converters import blockConverters
 from armi.reactor import grids
+from armi.settings.fwSettings import globalSettings
 
 
 def _configureGeomOptions():
@@ -162,7 +163,7 @@ class BlockBlueprint(yamlize.KeyedList):
         b.verifyBlockDims()
         b.spatialGrid = spatialGrid
 
-        if b.spatialGrid is None:
+        if b.spatialGrid is None and cs[globalSettings.CONF_BLOCK_AUTO_GRID]:
             try:
                 b.autoCreateSpatialGrids()
             except (ValueError, NotImplementedError) as e:

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -186,7 +186,9 @@ def defineSettings() -> List[setting.Setting]:
             description="Turn on the profiler for the submitted case. The profiler "
             "results will not include all import times.",
             isEnvironment=True,
-            oldNames=[("turnOnProfiler", None),],
+            oldNames=[
+                ("turnOnProfiler", None),
+            ],
         ),
         setting.Setting(
             CONF_COVERAGE,
@@ -210,7 +212,9 @@ def defineSettings() -> List[setting.Setting]:
             description="Duration of one single cycle. If availability factor is below "
             "1, the reactor will be at power less than this. If variable, use "
             "cycleLengths setting.",
-            oldNames=[("burnTime", None),],
+            oldNames=[
+                ("burnTime", None),
+            ],
         ),
         setting.Setting(
             CONF_CYCLE_LENGTHS,
@@ -229,7 +233,9 @@ def defineSettings() -> List[setting.Setting]:
             description="Availability factor of the plant. This is the fraction of the "
             "time that the plant is operating. If variable, use availabilityFactors "
             "setting.",
-            oldNames=[("capacityFactor", None),],
+            oldNames=[
+                ("capacityFactor", None),
+            ],
         ),
         setting.Setting(
             CONF_AVAILABILITY_FACTORS,
@@ -268,7 +274,9 @@ def defineSettings() -> List[setting.Setting]:
             schema=vol.Any(
                 [float], None, float, msg="Expected NoneType, float, or list of floats."
             ),
-            oldNames=[("betaComponents", None),],
+            oldNames=[
+                ("betaComponents", None),
+            ],
         ),
         setting.Setting(
             CONF_DECAY_CONSTANTS,
@@ -436,7 +444,9 @@ def defineSettings() -> List[setting.Setting]:
             label="Start Cycle",
             description="Cycle number to continue calculation from. Database will "
             "load from the time step just before. For snapshots use `dumpSnapshot`",
-            oldNames=[("loadCycle", None),],
+            oldNames=[
+                ("loadCycle", None),
+            ],
         ),
         setting.Setting(
             CONF_LOADING_FILE,
@@ -451,7 +461,9 @@ def defineSettings() -> List[setting.Setting]:
             label="StartNode",
             description="Timenode number (0 for BOC, etc.) to continue calulation from. "
             "Database will load from the time step just before.",
-            oldNames=[("loadNode", None),],
+            oldNames=[
+                ("loadNode", None),
+            ],
         ),
         setting.Setting(
             CONF_LOAD_STYLE,

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -110,6 +110,7 @@ CONF_DEFERRED_INTERFACE_NAMES = "deferredInterfaceNames"
 CONF_OUTPUT_CACHE_LOCATION = "outputCacheLocation"
 CONF_MATERIAL_NAMESPACE_ORDER = "materialNamespaceOrder"
 CONF_DETAILED_AXIAL_EXPANSION = "detailedAxialExpansion"
+CONF_BLOCK_AUTO_GRID = "autoGenerateBlockGrids"
 
 
 def defineSettings() -> List[setting.Setting]:
@@ -185,9 +186,7 @@ def defineSettings() -> List[setting.Setting]:
             description="Turn on the profiler for the submitted case. The profiler "
             "results will not include all import times.",
             isEnvironment=True,
-            oldNames=[
-                ("turnOnProfiler", None),
-            ],
+            oldNames=[("turnOnProfiler", None),],
         ),
         setting.Setting(
             CONF_COVERAGE,
@@ -211,9 +210,7 @@ def defineSettings() -> List[setting.Setting]:
             description="Duration of one single cycle. If availability factor is below "
             "1, the reactor will be at power less than this. If variable, use "
             "cycleLengths setting.",
-            oldNames=[
-                ("burnTime", None),
-            ],
+            oldNames=[("burnTime", None),],
         ),
         setting.Setting(
             CONF_CYCLE_LENGTHS,
@@ -232,9 +229,7 @@ def defineSettings() -> List[setting.Setting]:
             description="Availability factor of the plant. This is the fraction of the "
             "time that the plant is operating. If variable, use availabilityFactors "
             "setting.",
-            oldNames=[
-                ("capacityFactor", None),
-            ],
+            oldNames=[("capacityFactor", None),],
         ),
         setting.Setting(
             CONF_AVAILABILITY_FACTORS,
@@ -273,9 +268,7 @@ def defineSettings() -> List[setting.Setting]:
             schema=vol.Any(
                 [float], None, float, msg="Expected NoneType, float, or list of floats."
             ),
-            oldNames=[
-                ("betaComponents", None),
-            ],
+            oldNames=[("betaComponents", None),],
         ),
         setting.Setting(
             CONF_DECAY_CONSTANTS,
@@ -443,9 +436,7 @@ def defineSettings() -> List[setting.Setting]:
             label="Start Cycle",
             description="Cycle number to continue calculation from. Database will "
             "load from the time step just before. For snapshots use `dumpSnapshot`",
-            oldNames=[
-                ("loadCycle", None),
-            ],
+            oldNames=[("loadCycle", None),],
         ),
         setting.Setting(
             CONF_LOADING_FILE,
@@ -460,9 +451,7 @@ def defineSettings() -> List[setting.Setting]:
             label="StartNode",
             description="Timenode number (0 for BOC, etc.) to continue calulation from. "
             "Database will load from the time step just before.",
-            oldNames=[
-                ("loadNode", None),
-            ],
+            oldNames=[("loadNode", None),],
         ),
         setting.Setting(
             CONF_LOAD_STYLE,
@@ -717,6 +706,15 @@ def defineSettings() -> List[setting.Setting]:
                 "This allows users to specify to get materials out of a plugin rather "
                 "than from the framework."
             ),
+        ),
+        # It may make sense to remove this setting when MILs become more stable.
+        setting.Setting(
+            CONF_BLOCK_AUTO_GRID,
+            default=True,
+            label="Auto-generate Block grids",
+            description="Should block blueprints attempt to auto-generate a spatial "
+            "grid upon construction? This feature makes heavy use of multi-index "
+            "locations, which are not yet universally supported.",
         ),
     ]
     return settings


### PR DESCRIPTION
These rely pretty heavily on MultiIndexLocation, which still isn't fully
supported across the code. Apps can override the default value of the
setting to opt out of the feature until it is more mature.