### PR TITLE
Fix links to parameter definition tables in user docs

### DIFF
--- a/doc/user/inputs/blueprints.rst
+++ b/doc/user/inputs/blueprints.rst
@@ -156,6 +156,7 @@ id
 od
     Outer diameter (in cm).
 
+.. _componentTypes:
 
 Component Types
 ---------------

--- a/doc/user/manual_data_access.rst
+++ b/doc/user/manual_data_access.rst
@@ -13,10 +13,11 @@ The following links contain large tables describing the various global settings
 and state parameters in use across ARMI.
 
 * :doc:`Table of all global settings </user/inputs/settings_report>`
-* :py:mod:`Reactor Parameters <armi.reactor.reactorParameters>`
-* :py:mod:`Assembly Parameters <armi.reactor.assemblyParameters>`
-* :py:mod:`Block Parameters <armi.reactor.blockParameters>`
-* :py:mod:`Component Parameters <armi.reactor.components.componentParameters>`
+* :doc:`Reactor Parameters </user/reactor_parameters_report>`
+* :doc:`Core Parameters </user/core_parameters_report>`
+* :doc:`Assembly Parameters </user/assembly_parameters_report>`
+* :doc:`Block Parameters </user/block_parameters_report>`
+* :ref:`Component Parameters <componentTypes>`
 
 
 Accessing Some Interesting Info


### PR DESCRIPTION
Current links to the pages containing the parameter definitions in the user docs
are not consistent. Some of them go to the tabular listings, while others link
to the API documentation. These links are updated so that all of them go to the
tabular listings.

In addition, a link was missing for the Core Parameters table. This link has
been added.

One exception to the consistency among links is that no page currently exists
with a comprehensive tabulation of the Component Parameters. It will take a good
amount of work to generate such a page, so for now this link points to a partial
tabulation elsewhere in the existing docs. This should be changed in the future,
and this need has been documented in an issue on GitHub.