### PR TITLE
Fix tutorial documentation associated with fluxSolver and thermalSolver

### DIFF
--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -209,7 +209,7 @@ block-level temperature (and flow velocity) distribution as we go.
 
 .. math::
 
-    q''' = \dot{m} C_p \Delta T
+    \dot{Q} = \dot{m} C_p \Delta T
 
 .. literalinclude:: armi-example-app/myapp/thermalSolver.py
     :caption: ``myapp/thermalSolver.py``


### PR DESCRIPTION
This commit specifically fixes the heat balance equation represented as part of
the `thermalSolver` script in the 'making your own app' tutorial. This is done
in tandem with another fix in the [armi-example-app repo](https://github.com/terrapower/armi-example-app/pull/1)
which updates the psuedocode in the comments of `thermalSolver` to be consistent
with the changes of this commit.