### PR TITLE
Fix building of MacroXS tables when MPI import fails #357

### DIFF
--- a/armi/physics/neutronics/macroXSGenerationInterface.py
+++ b/armi/physics/neutronics/macroXSGenerationInterface.py
@@ -84,8 +84,8 @@ class MacroXSGenerator(mpiActions.MpiAction):
             allMacros = [mc.createMacrosFromMicros(lib, b, libType=self.libType) for b in allBlocks]
 
         if armi.MPI_RANK == 0:
-                for b, macro in zip(allBlocks, allMacros):
-                    b.macros = macro
+            for b, macro in zip(allBlocks, allMacros):
+                b.macros = macro
 
 
 class MacroXSGenerationInterface(interfaces.Interface):

--- a/armi/physics/neutronics/macroXSGenerationInterface.py
+++ b/armi/physics/neutronics/macroXSGenerationInterface.py
@@ -75,13 +75,17 @@ class MacroXSGenerator(mpiActions.MpiAction):
             lib = armi.MPI_COMM.bcast(lib, root=0)
 
             myMacros = [
-                mc.createMacrosFromMicros(lib, b, libType=self.libType) for b in myBlocks
+                mc.createMacrosFromMicros(lib, b, libType=self.libType)
+                for b in myBlocks
             ]
 
             allMacros = _gatherList(myMacros)
 
         else:
-            allMacros = [mc.createMacrosFromMicros(lib, b, libType=self.libType) for b in allBlocks]
+            allMacros = [
+                mc.createMacrosFromMicros(lib, b, libType=self.libType)
+                for b in allBlocks
+            ]
 
         if armi.MPI_RANK == 0:
             for b, macro in zip(allBlocks, allMacros):


### PR DESCRIPTION
When mpi4py import fails, `MPI_SIZE` defaults to 1. Use this to disable the
execution of MPI commands. See #357 