### PR TITLE
Implement various improvements related to GridBlueprints

### DIFF
--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -292,7 +292,7 @@ class GridBlueprint(yamlize.Object):
             # available, we can also infer "through center" based on the contents.
             # Note that the "through center" symmetry check cannot be performed when
             # the grid contents has not been provided (i.e., None or empty).
-            if self.gridContents:
+            if self.gridContents and symmetry.domain == geometry.DomainType.FULL_CORE:
                 nx, ny = _getGridSize(self.gridContents.keys())
                 if nx == ny and nx % 2 == 1:
                     symmetry.isThroughCenterAssembly = True

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -68,6 +68,16 @@ sfp quarter:
         2 3 1 1 2
         2 2 2 2 2
 
+sfp quarter even:
+    geom: cartesian
+    symmetry: quarter core
+    lattice map: |
+        2 2 2 2 2
+        2 1 1 1 2
+        2 1 3 1 2
+        2 3 1 1 2
+        2 2 2 2 2
+
 sfp even:
     geom: cartesian
     symmetry: full
@@ -275,6 +285,12 @@ class TestGridBlueprintsSection(unittest.TestCase):
         self.assertEqual(gridDesign3.gridContents[1, 1], "3")
         self.assertEqual(gridDesign3.gridContents[2, 2], "3")
         self.assertEqual(gridDesign3.gridContents[3, 3], "1")
+        self.assertTrue(_grid.symmetry.isThroughCenterAssembly)
+
+        # cartesian quarter, even not through center
+        gridDesign3 = self.grids["sfp quarter even"]
+        _grid = gridDesign3.construct()
+        self.assertFalse(_grid.symmetry.isThroughCenterAssembly)
 
         # Cartesian full, even/odd hybrid
         gridDesign4 = self.grids["sfp even"]

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -266,8 +266,10 @@ class BoundaryType(enum.Enum):
         elif canonical == REFLECTIVE:
             return cls.REFLECTIVE
 
-        errorMsg = "{} is not a valid boundary option. Valid boundary options are:".format(
-            str(canonical)
+        errorMsg = (
+            "{} is not a valid boundary option. Valid boundary options are:".format(
+                str(canonical)
+            )
         )
         errorMsg += ", ".join([f"{sym}" for sym in boundaryTypes])
         raise ValueError(errorMsg)
@@ -449,7 +451,8 @@ class SymmetryType:
 
 
 def checkValidGeomSymmetryCombo(
-    geomType: Union[str, "GeomType"], symmetryInput: Union[str, "SymmetryType"],
+    geomType: Union[str, "GeomType"],
+    symmetryInput: Union[str, "SymmetryType"],
 ) -> bool:
     """
     Check if the given combination of GeomType and SymmetryType is valid.

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -266,10 +266,8 @@ class BoundaryType(enum.Enum):
         elif canonical == REFLECTIVE:
             return cls.REFLECTIVE
 
-        errorMsg = (
-            "{} is not a valid boundary option. Valid boundary options are:".format(
-                str(canonical)
-            )
+        errorMsg = "{} is not a valid boundary option. Valid boundary options are:".format(
+            str(canonical)
         )
         errorMsg += ", ".join([f"{sym}" for sym in boundaryTypes])
         raise ValueError(errorMsg)
@@ -359,8 +357,10 @@ class SymmetryType:
     def fromStr(cls, symmetryString: str) -> "SymmetryType":
         """Construct a SymmetryType object from a valid string"""
         canonical = symmetryString.lower().strip()
+        # ignore "assembly" since it is unnecessary and overly-verbose and too specific
+        noAssembly = canonical.replace("assembly", "").strip()
         isThroughCenter = cls._checkIfThroughCenter(canonical)
-        coreString = canonical.replace(THROUGH_CENTER_ASSEMBLY, "").strip()
+        coreString = noAssembly.replace(THROUGH_CENTER_ASSEMBLY, "").strip()
         trimmedString = coreString.replace("core", "").strip()
         pieces = trimmedString.split()
         domain = DomainType.fromStr(pieces[0])
@@ -449,8 +449,7 @@ class SymmetryType:
 
 
 def checkValidGeomSymmetryCombo(
-    geomType: Union[str, "GeomType"],
-    symmetryInput: Union[str, "SymmetryType"],
+    geomType: Union[str, "GeomType"], symmetryInput: Union[str, "SymmetryType"],
 ) -> bool:
     """
     Check if the given combination of GeomType and SymmetryType is valid.
@@ -519,9 +518,8 @@ SIXTEENTH_CORE = "sixteenth"
 REFLECTIVE = "reflective"
 PERIODIC = "periodic"
 NO_SYMMETRY = "no symmetry"
-THROUGH_CENTER_ASSEMBLY = (
-    "through center assembly"  # through center assembly applies only to cartesian
-)
+# through center assembly applies only to cartesian
+THROUGH_CENTER_ASSEMBLY = "through center"
 
 geomTypes = {HEX, CARTESIAN, RZT, RZ}
 domainTypes = {FULL_CORE, THIRD_CORE, QUARTER_CORE, EIGHTH_CORE, SIXTEENTH_CORE}

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -732,6 +732,14 @@ class Grid:
     def symmetry(self, symmetry: Union[str, geometry.SymmetryType]):
         self._symmetry = str(geometry.SymmetryType.fromAny(symmetry))
 
+    @property
+    def offset(self):
+        return self._offset
+
+    @offset.setter
+    def offset(self, offset):
+        self._offset = offset
+
     def __repr__(self):
         msg = (
             ["<{} -- {}\nBounds:\n".format(self.__class__.__name__, id(self))]


### PR DESCRIPTION
This:
 - Restricts the through-center-assembly inferrence to full-symmetry
   cases. Fractional cases nx-ny do not carry enough information on
   their own.
 - Makes "assembly" option to activate "through center" for Symmetry;
   assembly is overly specific and weird, since many lattices are for
   laying out pins.
 - Adds adds a public getter/setter to Grid._offset. This allows client
   code to reach in and change the offset if necessary.