### PR TITLE
Update to running directory in the generic ExecutionOptions class.

### DIFF
--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -6,6 +6,7 @@ data pathways.
 """
 
 import os
+import hashlib
 
 from armi.utils import directoryChangers
 from armi import runLog
@@ -82,7 +83,8 @@ class ExecutionOptions:
         # This creates a hash of the case title plus the label
         # to shorten the running directory and to avoid path length
         # limitations on the OS.
-        caseTitleHash = str(hash(f"{caseTitle}-{self.label}"))[:8]
+        caseString = f"{caseTitle}-{str(self.label)}".encode("utf-8")
+        caseTitleHash = str(hashlib.sha1(caseString).hexdigest())[:8]
         self.runDir = os.path.join(getFastPath(), f"{caseTitleHash}-{MPI_RANK}")
 
     def describe(self):

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -79,9 +79,11 @@ class ExecutionOptions:
         use this, you will get a relatively consistent naming convention
         for your fast-past folders.
         """
-        self.runDir = os.path.join(
-            getFastPath(), f"{caseTitle}-{self.label}-{MPI_RANK}"
-        )
+        # This creates a hash of the case title plus the label
+        # to shorten the running directory and to avoid path length
+        # limitations on the OS.
+        caseTitleHash = str(hash(f"{caseTitle}-{self.label}"))[:8]
+        self.runDir = os.path.join(getFastPath(), f"{caseTitleHash}-{MPI_RANK}")
 
     def describe(self):
         """Make a string summary of all options."""

--- a/armi/physics/tests/test_executers.py
+++ b/armi/physics/tests/test_executers.py
@@ -1,0 +1,30 @@
+"""This module provides tests for the generic Executers."""
+
+import os
+import unittest
+
+from armi.physics import executers
+
+
+class TestExecutionOptions(unittest.TestCase):
+    def test_runningDirectoryPath(self):
+        """
+        Test that the running directory path is set up correctly
+        based on the case title and label provided.
+        """
+        e = executers.ExecutionOptions(label=None)
+        e.setRunDirFromCaseTitle(caseTitle="test")
+        self.assertEqual(os.path.basename(e.runDir), "508bc04f-0")
+
+        e = executers.ExecutionOptions(label="label")
+        e.setRunDirFromCaseTitle(caseTitle="test")
+        self.assertEqual(os.path.basename(e.runDir), "b07da087-0")
+
+        e = executers.ExecutionOptions(label="label2")
+        e.setRunDirFromCaseTitle(caseTitle="test")
+        self.assertEqual(os.path.basename(e.runDir), "9c1c83cb-0")
+
+
+if __name__ == "__main__":
+    # import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -247,16 +247,19 @@ class ForcedCreationDirectoryChanger(DirectoryChanger):
 
     def __enter__(self):
         if not os.path.exists(self.destination):
-            runLog.debug(f"Creating destination folder {self.destination}")
+            runLog.extra(f"Creating destination folder: {self.destination}")
             try:
                 os.makedirs(self.destination)
-            except OSError:
+            except OSError as ee:
                 # even though we checked exists, this still fails
                 # sometimes when multiple MPI nodes try
                 # to make the dirs due to I/O delays
-                runLog.debug(f"Failed to make destination folder")
+                runLog.error(
+                    f"Failed to make destination folder: {self.destination}. "
+                    f"Exception: {ee}"
+                )
         else:
-            runLog.debug(f"Destination folder already exists: {self.destination}")
+            runLog.extra(f"Destination folder already exists: {self.destination}")
         DirectoryChanger.__enter__(self)
         if self.clean:
             shutil.rmtree(".", ignore_errors=True)


### PR DESCRIPTION
Updating the default run directory within the generic ExecutionOptions to be based on the first eight chateracters of the hash of combining the case title and the label. This helps to create a unique directory name for running the case but also helps to avoid OS related file path length issues (particularly in Windows).