### PR TITLE
Moving to faster YAML reads by default

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -142,7 +142,7 @@ class Case:
         This property allows lazy loading.
         """
         if self._bp is None:
-            self._bp = blueprints.loadFromCs(self.cs)
+            self._bp = blueprints.loadFromCs(self.cs, roundTrip=True)
         return self._bp
 
     @bp.setter

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -34,10 +34,10 @@ import time
 import textwrap
 import ast
 from typing import Dict, Optional, Sequence
+import glob
 import tabulate
 import six
 import coverage
-import glob
 
 import armi
 from armi import context
@@ -46,7 +46,6 @@ from armi import operators
 from armi import runLog
 from armi import interfaces
 from armi.reactor import blueprints
-from armi.reactor import geometry
 from armi.reactor import systemLayoutInput
 from armi.reactor import reactors
 from armi.bookkeeping import report
@@ -674,8 +673,8 @@ class Case:
         ):
             # trick: these seemingly no-ops load the bp and geom via properties if
             # they are not yet initialized.
-            self.bp
-            self.geom
+            self.bp  # pylint: disable=pointless-statement
+            self.geom  # pylint: disable=pointless-statement
             self.cs["loadingFile"] = self.title + "-blueprints.yaml"
             if self.geom:
                 self.cs["geomFile"] = self.title + "-geom.yaml"

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -511,6 +511,12 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
     @classmethod
     def load(cls, stream, roundTrip=False):
+        """This class method is a wrapper around the `yamlize.Object.load()` method.
+
+        The reason for the wrapper is to allow us to default to `Cloader`. Essentially,
+        the `CLoader` class is 10x faster, but doesn't allow for "round trip" (read-
+        write) access to YAMLs; for that we have the `RoundTripLoader`.
+        """
         loader = RoundTripLoader if roundTrip else CLoader
         return super().load(stream, Loader=loader)
 
@@ -533,7 +539,6 @@ def migrate(bp: Blueprints, cs):
     dedicated migration portion of the code, and not perform the migration so
     implicitly.
     """
-    from armi.reactor import blueprints
     from armi.reactor.blueprints import gridBlueprint
 
     if bp.systemDesigns is None:

--- a/armi/tests/tutorials/.gitignore
+++ b/armi/tests/tutorials/.gitignore
@@ -1,0 +1,1 @@
+dump-temp-*


### PR DESCRIPTION
The `yamlize` library defaults to using a read-and-write YAML library to read: `ruamel.yaml.RoundTripLoader`, but this is ~12x slower at reading large YAML files than `ruamel.yaml.CLoader`, which is best for read-only situations.

So, this PR updates our use of the `yamlize` API to default to non-round-trip scenarios. The change is in some ways a slam-dunk, straight-forward speed improvement. But I have two concerns:

1. I am new to the code base, and may have missed a YAML-writing function that needs to be updated for this change.
2. This change will affect plugins and such, so perhaps we need to inform people of this semi-opaque change.

**Speed Comparisons:**

For the first test, I read a very large, example YAML file using various `yamlize`/`ruamel` options:

| YAML Loader | Pure Python implementation? | cProfile time (seconds) |
| :-------- | :-------- | :-------- |
| `RoundTripLoader` | True | 33.040 |
| `RoundTripLoader` | False | 33.270 |
| `CLoader` | True | 26.231 |
| `CLoader` | False | 2.744 |

So, it appears that using `CLoader` is >10x speed improvement over our current pathway. But, of course, loading a YAML blueprint in ARMI involves more than just the YAML string parsing. So, I ran another test where I loaded the above, large blueprint file:

| ARMI command | cProfile time (seconds) |
| :-------- | :-------- |
| `Blueprints().load(file, Loader=RoundTripLoader)` | 38.007 |
| `Blueprints().load(file, Loader=CLoader)` | 7.450 |