### PR TITLE
Bug Fixes - logging inconsistency

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -322,6 +322,7 @@ def configure(app: Optional[apps.App] = None, permissive=False):
     _app = app
 
     if _liveInterpreter():
+        runLog.LOG.startLog(name=f"interactive-{app.name}")
         cli.splash()
 
     pm = app.pluginManager

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -16,7 +16,6 @@ testing for reactors.py
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
-import logging
 import os
 import unittest
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -18,13 +18,11 @@ testing for reactors.py
 import copy
 import logging
 import os
-import pytest
 import unittest
 
 from six.moves import cPickle
 from numpy.testing import assert_allclose, assert_equal
 
-from armi import context
 from armi import operators
 from armi import runLog
 from armi import settings
@@ -38,7 +36,7 @@ from armi.reactor import geometry
 from armi.reactor import reactors
 from armi.reactor.components import Hexagon, Rectangle
 from armi.reactor.converters import geometryConverters
-from armi.tests import TEST_ROOT, ARMI_RUN_PATH
+from armi.tests import ARMI_RUN_PATH, mockRunLogs, TEST_ROOT
 from armi.utils import directoryChangers
 
 TEST_REACTOR = None  # pickled string of test reactor (for fast caching)
@@ -731,11 +729,6 @@ class CartesianReactorTests(ReactorTests):
         self.o = buildOperatorOfEmptyCartesianBlocks()
         self.r = self.o.r
 
-    @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog):
-        """This pytest fixture allows us to caption logging messages that pytest interupts"""
-        self._caplog = caplog
-
     def test_getAssemblyPitch(self):
         # Cartesian pitch should have 2 dims since it could be a rectangle that is not square.
         assert_equal(self.r.core.getAssemblyPitch(), [10.0, 16.0])
@@ -749,17 +742,22 @@ class CartesianReactorTests(ReactorTests):
             )
         self.assertSequenceEqual(actualAssemsInRing, expectedAssemsInRing)
 
-    @unittest.skipIf(context.MPI_COMM is None, "MPI libraries are not installed.")
-    def test_caplogGetNuclideCategoriesLogging(self):
+    def test_getNuclideCategoriesLogging(self):
         """Simplest possible test of the getNuclideCategories method and its logging"""
-        with self._caplog.at_level(logging.INFO):
-            self.r.core.getNuclideCategories()
+        log = mockRunLogs.BufferLog()
 
-        messages = [r.message for r in self._caplog.records]
-        catMessages = "\n".join(messages)
-        self.assertGreaterEqual(len(messages), 14, msg=catMessages)
-        self.assertIn("Case Information", catMessages)
-        self.assertIn("Completed Init Event", catMessages)
+        # this strange namespace-stomping is used to the test to set the logger in reactors.Core
+        from armi.reactor import reactors  # pylint: disable=import-outside-toplevel
+
+        reactors.runLog = runLog
+        runLog.LOG = log
+
+        # run the actual method in question
+        self.r.core.getNuclideCategories()
+        messages = log.getStdoutValue()
+
+        self.assertIn("Nuclide categorization", messages)
+        self.assertIn("Structure", messages)
 
 
 if __name__ == "__main__":

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -41,7 +41,6 @@ import logging
 import operator
 import os
 import sys
-import time
 
 from armi import context
 
@@ -171,7 +170,7 @@ class _RunLog:
         """Summarize all warnings for the run."""
         self.logger.warningReport()
 
-    def _getLogVerbosityRank(self, level):
+    def getLogVerbosityRank(self, level):
         """Return integer verbosity rank given the string verbosity name."""
         try:
             return self._logLevels[level][0]
@@ -202,7 +201,7 @@ class _RunLog:
 
         """
         if isinstance(level, str):
-            self._verbosity = self._getLogVerbosityRank(level)
+            self._verbosity = self.getLogVerbosityRank(level)
         elif isinstance(level, int):
             # The logging module does strange things if you set the log level to something other than DEBUG, INFO, etc
             # So, if someone tries, we HAVE to set the log level at a canonical value.

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -47,11 +47,14 @@ from armi import context
 
 
 # global constants
-_WHITE_SPACE = " " * 6
 _ADD_LOG_METHOD_STR = """def {0}(self, message, *args, **kws):
     if self.isEnabledFor({1}):
         self._log({1}, message, args, **kws)
 logging.Logger.{0} = {0}"""
+_WHITE_SPACE = " " * 6
+SEP = "|"
+STDERR_LOGGER_NAME = "ARMI_ERROR"
+STDOUT_LOGGER_NAME = "ARMI"
 
 
 class _RunLog:
@@ -81,12 +84,17 @@ class _RunLog:
         self._verbosity = logging.INFO
         self.initialErr = None
         self._logLevels = None
-        self.logger = logging.getLogger("NULL")
-        self.logger.addHandler(logging.NullHandler())
-        self.stderrLogger = logging.getLogger("NULL2")
-        self.stderrLogger.addHandler(logging.NullHandler())
+        self._logLevelNumbers = []
+        self.logger = None
+        self.stderrLogger = None
 
+        self._setNullLoggers()
         self._setLogLevels()
+
+    def _setNullLoggers(self):
+        """Helper method to set both of our loggers to Null handlers"""
+        self.logger = NullLogger("NULL")
+        self.stderrLogger = NullLogger("NULL2", isStderr=True)
 
     def _setLogLevels(self):
         """Here we fill the logLevels dict with custom strings that depend on the MPI rank"""
@@ -104,6 +112,7 @@ class _RunLog:
                 ("header", (100, "".format(_rank))),
             ]
         )
+        self._logLevelNumbers = sorted([l[0] for l in self._logLevels.values()])
         global _WHITE_SPACE
         _WHITE_SPACE = " " * len(max([l[1] for l in self._logLevels.values()]))
 
@@ -195,18 +204,24 @@ class _RunLog:
         if isinstance(level, str):
             self._verbosity = self._getLogVerbosityRank(level)
         elif isinstance(level, int):
-            if level < 0 or level > 100:
-                raise KeyError(
-                    "Invalid verbosity rank {}. ".format(level)
-                    + "It needs to be in the range [0, 100]."
-                )
-            self._verbosity = level
+            # The logging module does strange things if you set the log level to something other than DEBUG, INFO, etc
+            # So, if someone tries, we HAVE to set the log level at a canonical value.
+            # Otherwise, nearly all log statements will be silently dropped.
+            if level in self._logLevelNumbers:
+                self._verbosity = level
+            elif level < self._logLevelNumbers[0]:
+                self._verbosity = self._logLevelNumbers[0]
+            else:
+                for i in range(len(self._logLevelNumbers) - 1, -1, -1):
+                    if level >= self._logLevelNumbers[i]:
+                        self._verbosity = self._logLevelNumbers[i]
+                        break
         else:
             raise TypeError("Invalid verbosity rank {}.".format(level))
 
         if self.logger is not None:
-            for h in self.logger.handlers:
-                h.setLevel(self._verbosity)
+            for handler in self.logger.handlers:
+                handler.setLevel(self._verbosity)
             self.logger.setLevel(self._verbosity)
 
     def getVerbosity(self):
@@ -220,14 +235,14 @@ class _RunLog:
 
     def startLog(self, name):
         """Initialize the streams when parallel processing"""
-        self.logger = RunLogger("ARMI", mpiRank=self._mpiRank)
+        self.logger = logging.getLogger(STDOUT_LOGGER_NAME + SEP + str(self._mpiRank))
 
         if self._mpiRank != 0:
             # init stderr intercepting logging
             filePath = os.path.join(
                 "logs", _RunLog.STDERR_NAME.format(name, self._mpiRank)
             )
-            self.stderrLogger = logging.Logger("ARMI_ERROR")
+            self.stderrLogger = logging.getLogger(STDERR_LOGGER_NAME)
             h = logging.FileHandler(filePath)
             fmt = "%(message)s"
             form = logging.Formatter(fmt)
@@ -241,9 +256,11 @@ class _RunLog:
             sys.stderr = self.stderrLogger
 
 
-def close():
+def close(mpiRank=None):
     """End use of the log. Concatenate if needed and restore defaults"""
-    if context.MPI_RANK == 0:
+    mpiRank = context.MPI_RANK if mpiRank is None else mpiRank
+
+    if mpiRank == 0:
         try:
             concatenateLogs()
         except IOError as ee:
@@ -251,12 +268,11 @@ def close():
             error(ee)
     else:
         if LOG.stderrLogger:
-            _ = [h.close() for h in LOG.stderrLogger.logger.handlers]
-            LOG.stderrLogger = None
+            _ = [h.close() for h in LOG.stderrLogger.handlers]
         if LOG.logger:
-            _ = [h.close() for h in LOG.logger.logger.handlers]
-            LOG.logger = None
+            _ = [h.close() for h in LOG.logger.handlers]
 
+    LOG._setNullLoggers()
     LOG._restoreStandardStreams()
 
 
@@ -269,13 +285,10 @@ def concatenateLogs():
     # find all the logging-module-based log files
     stdoutFiles = sorted(glob(os.path.join("logs", "*.stdout")))
     if not len(stdoutFiles):
+        info("No log files found to concatenate.")
         return
 
-    info(
-        "Concatenating {0} log files and standard error streams".format(
-            len(stdoutFiles) + 1
-        )
-    )
+    info("Concatenating {0} log files".format(len(stdoutFiles)))
 
     for stdoutName in stdoutFiles:
         # NOTE: If the log file name format changes, this will need to change.
@@ -289,8 +302,8 @@ def concatenateLogs():
                 rankId = "\n{0} RANK {1:03d} STDOUT {2}\n".format(
                     "-" * 10, rank, "-" * 60
                 )
-                print(rankId)
-                print(data)
+                print(rankId, file=sys.stdout)
+                print(data, file=sys.stdout)
         try:
             os.remove(stdoutName)
         except OSError:
@@ -375,7 +388,7 @@ class DeduplicationFilter(logging.Filter):
     """
 
     def __init__(self, *args, **kwargs):
-        super(DeduplicationFilter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.singleMessageCounts = {}
         self.singleWarningMessageCounts = {}
 
@@ -416,27 +429,31 @@ class RunLogger(logging.Logger):
     FMT = "%(levelname)s%(message)s"
 
     def __init__(self, *args, **kwargs):
-        # optionally, the user can pass in the MPI_RANK
-        mpiRank = int(kwargs.pop("mpiRank", context.MPI_RANK))
+        # optionally, the user can pass in the MPI_RANK by putting it in the logger name after a separator string
+        if SEP in args[0]:
+            mpiRank = int(args[0].split(SEP)[-1].strip())
+            args = (args[0].split(SEP)[0],)
+        else:
+            mpiRank = context.MPI_RANK
 
-        super(RunLogger, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.allowStopDuplicates()
 
         if mpiRank == 0:
-            h = logging.StreamHandler()
-            h.setLevel(logging.INFO)
+            handler = logging.StreamHandler(sys.stdout)
+            handler.setLevel(logging.INFO)
             self.setLevel(logging.INFO)
         else:
             filePath = os.path.join(
                 "logs", _RunLog.STDOUT_NAME.format(args[0], mpiRank)
             )
-            h = logging.FileHandler(filePath)
-            h.setLevel(logging.WARNING)
+            handler = logging.FileHandler(filePath)
+            handler.setLevel(logging.WARNING)
             self.setLevel(logging.WARNING)
 
         form = logging.Formatter(RunLogger.FMT)
-        h.setFormatter(form)
-        self.addHandler(h)
+        handler.setFormatter(form)
+        self.addHandler(handler)
 
     def log(self, msgType, msg, single=False, label=None):
         """
@@ -450,9 +467,7 @@ class RunLogger(logging.Logger):
         msgLevel = msgType if isinstance(msgType, int) else LOG._logLevels[msgType][0]
 
         # Do the actual logging
-        super(RunLogger, self).log(
-            msgLevel, str(msg), extra={"single": single, "label": label}
-        )
+        super().log(msgLevel, str(msg), extra={"single": single, "label": label})
 
     def _log(self, *args, **kwargs):
         """wrapper around the standard library Logger._log() method
@@ -474,7 +489,7 @@ class RunLogger(logging.Logger):
             kwargs["extra"]["single"] = single
             kwargs["extra"]["label"] = label
 
-        super(RunLogger, self)._log(*args, **kwargs)
+        super()._log(*args, **kwargs)
 
     def allowStopDuplicates(self):
         """helper method to allow us to safely add the deduplication filter at any time"""
@@ -526,6 +541,19 @@ class RunLogger(logging.Logger):
     def setVerbosity(self, intLevel):
         """A helper method to try to partially support the local, historical method of the same name"""
         self.setLevel(intLevel)
+
+
+class NullLogger(RunLogger):
+    def __init__(self, name, isStderr=False):
+        super().__init__(name)
+        if isStderr:
+            self.handlers = [logging.StreamHandler(sys.stderr)]
+        else:
+            self.handlers = [logging.StreamHandler(sys.stdout)]
+
+    def addHandler(self, *args, **kwargs):
+        """ensure this STAYS a null logger"""
+        pass
 
 
 # Setting the default logging class to be ours

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -388,7 +388,7 @@ class DeduplicationFilter(logging.Filter):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        logging.Filter.__init__(self, *args, **kwargs)
         self.singleMessageCounts = {}
         self.singleWarningMessageCounts = {}
 
@@ -436,7 +436,7 @@ class RunLogger(logging.Logger):
         else:
             mpiRank = context.MPI_RANK
 
-        super().__init__(*args, **kwargs)
+        logging.Logger.__init__(self, *args, **kwargs)
         self.allowStopDuplicates()
 
         if mpiRank == 0:
@@ -467,7 +467,9 @@ class RunLogger(logging.Logger):
         msgLevel = msgType if isinstance(msgType, int) else LOG._logLevels[msgType][0]
 
         # Do the actual logging
-        super().log(msgLevel, str(msg), extra={"single": single, "label": label})
+        logging.Logger.log(
+            self, msgLevel, str(msg), extra={"single": single, "label": label}
+        )
 
     def _log(self, *args, **kwargs):
         """wrapper around the standard library Logger._log() method
@@ -489,7 +491,7 @@ class RunLogger(logging.Logger):
             kwargs["extra"]["single"] = single
             kwargs["extra"]["label"] = label
 
-        super()._log(*args, **kwargs)
+        logging.Logger._log(self, *args, **kwargs)
 
     def allowStopDuplicates(self):
         """helper method to allow us to safely add the deduplication filter at any time"""
@@ -545,7 +547,7 @@ class RunLogger(logging.Logger):
 
 class NullLogger(RunLogger):
     def __init__(self, name, isStderr=False):
-        super().__init__(name)
+        RunLogger.__init__(self, name)
         if isStderr:
             self.handlers = [logging.StreamHandler(sys.stderr)]
         else:

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -14,20 +14,13 @@
 
 from io import StringIO
 import logging
-import os
-import pytest
-import shutil
 import unittest
 
 from armi import context, runLog
+from armi.tests import mockRunLogs
 
 
 class TestRunLog(unittest.TestCase):
-    @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog):
-        """This pytest fixture allows us to caption logging messages that pytest interupts"""
-        self._caplog = caplog
-
     def test_setVerbosityFromInteger(self):
         """Test that the log verbosity can be set with an integer."""
         log = runLog._RunLog(1)  # pylint: disable=bare-except
@@ -48,8 +41,10 @@ class TestRunLog(unittest.TestCase):
 
     def test_invalidSetVerbosityByRank(self):
         """Test that the log verbosity setting fails if the integer is invalid."""
-        with self.assertRaises(KeyError):
-            runLog.setVerbosity(5000)
+        runLog.setVerbosity(5000)
+        self.assertEqual(
+            runLog.LOG.logger.level, max([v[0] for v in runLog.LOG._logLevels.values()])
+        )
 
     def test_invalidSetVerbosityByString(self):
         """Test that the log verbosity setting fails if the integer is invalid."""
@@ -59,9 +54,10 @@ class TestRunLog(unittest.TestCase):
     def test_parentRunLogging(self):
         """A basic test of the logging of the parent runLog"""
         # init the _RunLog object
-        log = runLog.LOG = runLog._RunLog(0)  # pylint: disable=bare-except
+        log = runLog.LOG = runLog._RunLog(0)  # pylint: disable=protected-access
         log.startLog("test_parentRunLogging")
         context.createLogDir(0)
+        log.setVerbosity(logging.INFO)
 
         # divert the logging to a stream, to make testing easier
         stream = StringIO()
@@ -72,7 +68,7 @@ class TestRunLog(unittest.TestCase):
         log.log("debug", "You shouldn't see this.", single=False, label=None)
         log.log("warning", "Hello, ", single=False, label=None)
         log.log("error", "world!", single=False, label=None)
-        runLog.close()
+        runLog.close(99)
 
         # test what was logged
         streamVal = stream.getvalue()
@@ -82,7 +78,7 @@ class TestRunLog(unittest.TestCase):
     def test_warningReport(self):
         """A simple test of the warning tracking and reporting logic"""
         # create the logger and do some logging
-        log = runLog.LOG = runLog._RunLog(321)  # pylint: disable=bare-except
+        log = runLog.LOG = runLog._RunLog(321)  # pylint: disable=protected-access
         log.startLog("test_warningReport")
         context.createLogDir(0)
 
@@ -106,12 +102,72 @@ class TestRunLog(unittest.TestCase):
 
         # run the warning report
         log.warningReport()
+        runLog.close(1)
+        runLog.close(0)
 
         # test what was logged
         streamVal = stream.getvalue()
         self.assertIn("test_warningReport", streamVal, msg=streamVal)
         self.assertIn("Final Warning Count", streamVal, msg=streamVal)
         self.assertEqual(streamVal.count("test_warningReport"), 2, msg=streamVal)
+
+    def test_closeLogging(self):
+        """A basic test of the close() functionality"""
+
+        def validate_loggers(log):
+            """little test helper, to make sure our loggers still look right"""
+            handlers = [str(h) for h in log.logger.handlers]
+            self.assertEqual(len(handlers), 1, msg=",".join(handlers))
+
+            stderrHandlers = [str(h) for h in log.stderrLogger.handlers]
+            self.assertEqual(len(stderrHandlers), 1, msg=",".join(stderrHandlers))
+
+        # init logger
+        log = runLog.LOG = runLog._RunLog(777)  # pylint: disable=protected-access
+        validate_loggers(log)
+
+        # start the logging for real
+        log.startLog("test_closeLogging")
+        context.createLogDir(0)
+        validate_loggers(log)
+
+        # close() and test that we have correctly nullified our loggers
+        runLog.close(1)
+        validate_loggers(log)
+
+        # in a real run, the parent process would close() after all the children
+        runLog.close(0)
+
+    def test_setVerbosity(self):
+        """Let's test the setVerbosity() method carefully"""
+        with mockRunLogs.BufferLog() as mock:
+            # we should start with a clean slate
+            self.assertEqual("", mock._outputStream)  # pylint: disable=protected-access
+            runLog.LOG.startLog("test_setVerbosity")
+            runLog.LOG.setVerbosity(logging.INFO)
+
+            # we should start at info level, and that should be working correctly
+            self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
+            runLog.info("hi")
+            self.assertIn("hi", mock._outputStream)
+            mock._outputStream = ""
+
+            runLog.debug("invisible")
+            self.assertEqual("", mock._outputStream)
+
+            # if we use setVerbosity() to change the log level, it should work
+            runLog.LOG.setVerbosity(logging.WARNING)
+
+            runLog.info("still invisible")
+            self.assertEqual("", mock._outputStream)
+
+            runLog.warning("visible")
+            self.assertIn("visible", mock._outputStream)
+
+            # we shouldn't be able to setVerbosity() to a non-canonical value (logging module defense)
+            self.assertEqual(runLog.LOG.getVerbosity(), logging.WARNING)
+            runLog.LOG.setVerbosity(logging.WARNING + 1)
+            self.assertEqual(runLog.LOG.getVerbosity(), logging.WARNING)
 
 
 if __name__ == "__main__":

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -23,18 +23,18 @@ from armi.tests import mockRunLogs
 class TestRunLog(unittest.TestCase):
     def test_setVerbosityFromInteger(self):
         """Test that the log verbosity can be set with an integer."""
-        log = runLog._RunLog(1)  # pylint: disable=bare-except
+        log = runLog._RunLog(1)  # pylint: disable=protected-access
         expectedStrVerbosity = "debug"
-        verbosityRank = log._getLogVerbosityRank(expectedStrVerbosity)
+        verbosityRank = log.getLogVerbosityRank(expectedStrVerbosity)
         runLog.setVerbosity(verbosityRank)
         self.assertEqual(verbosityRank, runLog.getVerbosity())
         self.assertEqual(verbosityRank, logging.DEBUG)
 
     def test_setVerbosityFromString(self):
         """Test that the log verbosity can be set with a string."""
-        log = runLog._RunLog(1)  # pylint: disable=bare-except
+        log = runLog._RunLog(1)  # pylint: disable=protected-access
         expectedStrVerbosity = "error"
-        verbosityRank = log._getLogVerbosityRank(expectedStrVerbosity)
+        verbosityRank = log.getLogVerbosityRank(expectedStrVerbosity)
         runLog.setVerbosity(expectedStrVerbosity)
         self.assertEqual(verbosityRank, runLog.getVerbosity())
         self.assertEqual(verbosityRank, logging.ERROR)
@@ -154,32 +154,38 @@ class TestRunLog(unittest.TestCase):
             # we should start at info level, and that should be working correctly
             self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
             runLog.info("hi")
-            self.assertIn("hi", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("hi", mock._outputStream)  # pylint: disable=protected-access
+            mock._outputStream = ""  # pylint: disable=protected-access
 
             runLog.debug("invisible")
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock._outputStream)  # pylint: disable=protected-access
 
             # setVerbosity() to WARNING, and verify it is working
             runLog.LOG.setVerbosity(logging.WARNING)
             runLog.info("still invisible")
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock._outputStream)  # pylint: disable=protected-access
             runLog.warning("visible")
-            self.assertIn("visible", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn(
+                "visible", mock._outputStream
+            )  # pylint: disable=protected-access
+            mock._outputStream = ""  # pylint: disable=protected-access
 
             # setVerbosity() to DEBUG, and verify it is working
             runLog.LOG.setVerbosity(logging.DEBUG)
             runLog.debug("Visible")
-            self.assertIn("Visible", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn(
+                "Visible", mock._outputStream
+            )  # pylint: disable=protected-access
+            mock._outputStream = ""  # pylint: disable=protected-access
 
             # setVerbosity() to ERROR, and verify it is working
             runLog.LOG.setVerbosity(logging.ERROR)
             runLog.warning("Still Invisible")
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock._outputStream)  # pylint: disable=protected-access
             runLog.error("Visible!")
-            self.assertIn("Visible!", mock._outputStream)
+            self.assertIn(
+                "Visible!", mock._outputStream
+            )  # pylint: disable=protected-access
 
             # we shouldn't be able to setVerbosity() to a non-canonical value (logging module defense)
             self.assertEqual(runLog.LOG.getVerbosity(), logging.ERROR)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 python_files=test_*.py
 python_functions=nothing matches this pattern
-addopts = --durations=30 --tb=native -n 1 --dist=loadfile
+addopts = --durations=30 --tb=native
 filterwarnings =
     ignore:\s*the matrix subclass is not the recommended way:PendingDeprecationWarning
     ignore:\s*Loading from XML-format settings:DeprecationWarning


### PR DESCRIPTION
This PR fixes the issues @jakehader brought up in this ticket:  https://github.com/terrapower/armi/issues/366

Essentially, it fixes two separate problems:

1. An issue in `_RunLog.close()` where the stderr logger was being called incorrectly in some circumstances.
2. An issue where (I believe) everything was being written purely to stderr, not stdout, in the parent process.

Bonus Features:

1. While I was at it, I removed the PyTest "caplog" dependency. I added it in the original logging PR, and I didn't like it. 
2. Also, there was an issue with logging being called during testing before the `runLog.py` was fully called and instantiated. So I added a new `NullLogger` class to fix that.