### PR TITLE
Remove Charge Fuel Pool (CFP) from core object

### DIFF
--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -160,7 +160,6 @@ class MemoryProfiler(interfaces.Interface):
                     "Dict {:30s} has {:4d} assemblies".format(attrName, len(attrObj))
                 )
         runLog.important("SFP has {:4d} assemblies".format(len(self.r.core.sfp)))
-        runLog.important("CFP has {:4d} assemblies".format(len(self.r.core.cfp)))
 
     def _checkForDuplicateObjectsOnArmiModel(self, attrName, refObject):
         """

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -182,4 +182,3 @@ class ReportInterface(interfaces.Interface):
 
         self.r.core.sfp.report()  # spent fuel pool report
         self.r.core.sfp.count()
-        self.r.core.cfp.report()  # charged fuel pool report

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -94,10 +94,6 @@ class FuelHandlerInterface(interfaces.Interface):
         if self.enabled():
             self.manageFuel(cycle)
 
-        self.r.core.p.numAssembliesInSFP = self.r.core.powerMultiplier * len(
-            self.r.core.sfp
-        )
-
     def interactEOC(self, cycle=None):
         timeYears = self.r.p.time
         # keep track of the EOC time in years.
@@ -105,11 +101,6 @@ class FuelHandlerInterface(interfaces.Interface):
         runLog.extra(
             "There are {} assemblies in the Spent Fuel Pool".format(
                 len(self.r.core.sfp)
-            )
-        )
-        runLog.extra(
-            "There are {} assemblies in the Fresh Fuel Pool".format(
-                len(self.r.core.cfp)
             )
         )
 

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -78,13 +78,12 @@ class Assembly(composites.Composite):
 
     LOAD_QUEUE = "LoadQueue"
     SPENT_FUEL_POOL = "SFP"
-    CHARGED_FUEL_POOL = "CFP"
     # For assemblies coming in from the database, waiting to be loaded to their old
     # position. This is a necessary distinction, since we need to make sure that a bunch
     # of fuel management stuff doesn't treat its re-placement into the core as a new
     # move
     DATABASE = "database"
-    NOT_IN_CORE = [LOAD_QUEUE, SPENT_FUEL_POOL, CHARGED_FUEL_POOL]
+    NOT_IN_CORE = [LOAD_QUEUE, SPENT_FUEL_POOL]
 
     def __init__(self, typ, assemNum=None):
         """
@@ -123,12 +122,11 @@ class Assembly(composites.Composite):
         As with other ArmiObjects, Assemblies are sorted based on location. Assemblies
         are more permissive in the grid consistency checks to accomodate situations
         where assemblies might be children of the same Core, but not in the same grid as
-        each other (as can be the case in the spent fuel or charge fuel pools). In these
-        situations, the operator returns ``False``.  This behavior may lead to some
-        strange sorting behavior when two or more Assemblies are being compared that do
-        not live in the same grid. It may be beneficial in the future to maintain the
-        more strict behavior of ArmiObject's ``__lt__`` implementation once the SFP/CFP
-        situation is cleared up.
+        each other (as can be the case in the spent fuel pool). In these situations,
+        the operator returns ``False``.  This behavior may lead to some strange sorting
+        behavior when two or more Assemblies are being compared that do not live in the
+        same grid. It may be beneficial in the future to maintain the more strict behavior
+        of ArmiObject's ``__lt__`` implementation once the SFP situation is cleared up.
 
         See also
         --------
@@ -218,8 +216,6 @@ class Assembly(composites.Composite):
             return self.LOAD_QUEUE
         elif isinstance(self.parent, assemblyLists.SpentFuelPool):
             return self.SPENT_FUEL_POOL
-        elif isinstance(self.parent, assemblyLists.ChargedFuelPool):
-            return self.CHARGED_FUEL_POOL
         return self.parent.spatialGrid.getLabel(
             self.spatialLocator.getCompleteIndices()[:2]
         )

--- a/armi/reactor/assemblyLists.py
+++ b/armi/reactor/assemblyLists.py
@@ -19,10 +19,9 @@ Assembly Lists are core-like objects that store collections of Assemblies. They 
 originally developed to serve as things like spent-fuel pools and the like, where
 spatial location of Assemblies need not be quite as precise.
 
-Presently, the :py:class:`armi.reactor.reactors.Core` constructs a pair of these as
-`self.sfp` and `self.cfp` (charged-fuel pool). We are in the process of removing these
-as instance attributes of the ``Core``, and moving them into sibling systems on the root
-:py:class:`armi.reactor.reactors.Reactor` object.
+Presently, the :py:class:`armi.reactor.reactors.Core` constructs a spent fuel pool
+`self.sfp`. We are in the process of removing these as instance attributes of the 
+``Core``, and moving them into sibling systems on the root :py:class:`armi.reactor.reactors.Reactor` object.
 """
 import abc
 import itertools
@@ -220,43 +219,5 @@ class SpentFuelPool(AssemblyList):
         runLog.important(
             "Total full-core fissile inventory of {0} is {1:.4E} MT".format(
                 self, totFis / 1000.0
-            )
-        )
-
-
-class ChargedFuelPool(AssemblyList):
-    """A place to put boosters so you can see how much you added. Can tell you inventory stats, etc."""
-
-    def report(self):
-        title = "{0} Report".format(self.name)
-        runLog.important("-" * len(title))
-        runLog.important(title)
-        runLog.important("-" * len(title))
-        totFis = 0.0
-        runLog.important(
-            "{assembly:15s} {dTime:10s} {cycle:3s} {bu:5s} {fiss:13s} {cum:13s}".format(
-                assembly="Assem. Name",
-                dTime="Charge Time",
-                cycle="Charge cyc",
-                bu="BU",
-                fiss="kg fis (full core)",
-                cum="Cumulative fis (full, MT)",
-            )
-        )
-        for a in self.getChildren():
-            totFis += a.p.chargeFis * a.p.multiplicity / 1000.0
-            runLog.important(
-                "{assembly:15s} {dTime:10f} {cycle:3f} {bu:5.2f} {fiss:13.4f} {cum:13.4f}".format(
-                    assembly=a,
-                    dTime=a.p.chargeTime,
-                    cycle=a.p.chargeCycle,
-                    fiss=a.p.chargeFis,
-                    bu=a.p.chargeBu,
-                    cum=totFis,
-                )
-            )
-        runLog.important(
-            "Total full core fissile inventory of {0} is {1:.4E} MT".format(
-                self, totFis
             )
         )

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -166,28 +166,7 @@ def defineCoreParameters():
             "maxAssemNum", units=None, description="maximum assembly number", default=0
         )
 
-        pb.defParam(
-            "numAssembliesFabricated",
-            units="",
-            description="numAssembliesFabricated",
-            default=0,
-        )
-
-        pb.defParam(
-            "numAssembliesInSFP", units="", description="numAssembliesInSFP", default=0
-        )
-
         pb.defParam("numMoves", units="", description="numMoves", default=0)
-
-        pb.defParam("timingDepletion", units="", description="timingDepletion")
-
-        pb.defParam("timingDif3d", units="", description="timingDif3d")
-
-        pb.defParam("timingDistribute", units="", description="timingDistribute")
-
-        pb.defParam("timingMc2", units="", description="timingMc2")
-
-        pb.defParam("timingSubchan", units="", description="timingSubchan")
 
     with pDefs.createBuilder(default=0.0, location="N/A") as pb:
 


### PR DESCRIPTION
* Removing the ChargeFuelPool from the core since it was essentially unused and lead to duplication of assembly objects between the core's children and the CFP children. This resulted in erroneous sorting of assemblies within the `__lt__` implementation on the reactor. 

* Removing unused reactor/core timing parameters that are specific to plugins/third party codes like `DIF3D`, `MC2`, `Subchan`, etc.

* Removing the `numAssembliesFabricated` parameter as it was implied incorrectly within the fuel handler and unused throughout the code base.

* Removing the `numAssembliesInSFP` parameter since this is not being stored in the database and can be calculated directly by calling `len(core.sfp)`.