### PR TITLE
Making logging directory global

### DIFF
--- a/armi/context.py
+++ b/armi/context.py
@@ -53,7 +53,7 @@ import h5py
 
 BLUEPRINTS_IMPORTED = False
 BLUEPRINTS_IMPORT_CONTEXT = ""
-
+LOG_DIR = os.path.join(os.getcwd(), "logs")
 
 # App name is used when spawning new tasks that should invoke a specific ARMI
 # application. For instance, the framework provides some features to help with
@@ -302,8 +302,12 @@ def disconnectAllHdfDBs():
 OS_SECONDS_TIMEOUT = 5 * 60
 
 
-def createLogDir(mpiRank=1, logDir="logs"):
+def createLogDir(mpiRank=1, logDir=None):
     """A helper method to create the log directory"""
+    # the usual case is the user does not pass in a log dir path, so we use the global one
+    if logDir is None:
+        logDir = LOG_DIR
+
     # let only do this from one thread
     if mpiRank == 0:
         if not os.path.exists(logDir):

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -239,7 +239,7 @@ class _RunLog:
         if self._mpiRank != 0:
             # init stderr intercepting logging
             filePath = os.path.join(
-                "logs", _RunLog.STDERR_NAME.format(name, self._mpiRank)
+                context.LOG_DIR, _RunLog.STDERR_NAME.format(name, self._mpiRank)
             )
             self.stderrLogger = logging.getLogger(STDERR_LOGGER_NAME)
             h = logging.FileHandler(filePath)
@@ -444,7 +444,7 @@ class RunLogger(logging.Logger):
             self.setLevel(logging.INFO)
         else:
             filePath = os.path.join(
-                "logs", _RunLog.STDOUT_NAME.format(args[0], mpiRank)
+                context.LOG_DIR, _RunLog.STDOUT_NAME.format(args[0], mpiRank)
             )
             handler = logging.FileHandler(filePath)
             handler.setLevel(logging.WARNING)


### PR DESCRIPTION
Here we move the log directory to a place inside context.

This allows us to access an absolute path to the log dir anywhere in the code.
In particular, this is used to help third-party libraries use our logging tools.