### PR TITLE
Allow for loading from databases with extra parameters

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1263,12 +1263,14 @@ class Database3(database.Database):
             try:
                 pDef = pDefs[paramName]
             except KeyError:
-                if re.match(r"^n[A-Z][a-z]?\d*", paramName):
-                    # This is a temporary viz param made by _addHomogenizedNumberDensities
-                    # ignore it safely
-                    continue
-                else:
-                    raise
+                # If a parameter exists in the database but not in the application
+                # reading it, we can technically keep going. Since this may lead to
+                # potential correctness issues, raise a warning
+                runLog.warning(
+                    "Found `{}` parameter `{}` in the database, which is not defined. "
+                    "Ignoring it.".format(compTypeName, paramName)
+                )
+                continue
 
             data = dataSet[:]
             attrs = _resolveAttrs(dataSet.attrs, h5group)

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1263,14 +1263,19 @@ class Database3(database.Database):
             try:
                 pDef = pDefs[paramName]
             except KeyError:
-                # If a parameter exists in the database but not in the application
-                # reading it, we can technically keep going. Since this may lead to
-                # potential correctness issues, raise a warning
-                runLog.warning(
-                    "Found `{}` parameter `{}` in the database, which is not defined. "
-                    "Ignoring it.".format(compTypeName, paramName)
-                )
-                continue
+                if re.match(r"^n[A-Z][a-z]?\d*", paramName):
+                    # This is a temporary viz param (number density) made by
+                    # _addHomogenizedNumberDensities ignore it safely
+                    continue
+                else:
+                    # If a parameter exists in the database but not in the application
+                    # reading it, we can technically keep going. Since this may lead to
+                    # potential correctness issues, raise a warning
+                    runLog.warning(
+                        "Found `{}` parameter `{}` in the database, which is not defined. "
+                        "Ignoring it.".format(compTypeName, paramName)
+                    )
+                    continue
 
             data = dataSet[:]
             attrs = _resolveAttrs(dataSet.attrs, h5group)

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1273,7 +1273,7 @@ class Database3(database.Database):
             except KeyError:
                 if re.match(r"^n[A-Z][a-z]?\d*", paramName):
                     # This is a temporary viz param (number density) made by
-                    # _addHomogenizedNumberDensities ignore it safely
+                    # _addHomogenizedNumberDensityParams ignore it safely
                     continue
                 else:
                     # If a parameter exists in the database but not in the application

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -101,6 +101,9 @@ class TestDatabase3(unittest.TestCase):
         self.r.p.cycleLength = cycle
         self.r.core[0].p.chargeTime = 3
 
+        # add some fake missing parameter data to test allowMissing
+        self.db.h5db["c00n00/Reactor/missingParam"] = "i don't exist"
+
     def _compareArrays(self, ref, src):
         """
         Compare two numpy arrays.
@@ -193,6 +196,14 @@ class TestDatabase3(unittest.TestCase):
         self.assertEqual(
             database3.Layout.computeAncestors(serialNums, numChildren, 3), expected_3
         )
+
+    def test_load(self) -> None:
+        self.makeShuffleHistory()
+        with self.assertRaises(KeyError):
+            r = self.db.load(0, 0)
+
+        del self.db.h5db["c00n00/Reactor/missingParam"]
+        r = self.db.load(0, 0)
 
     def test_history(self) -> None:
         self.makeShuffleHistory()

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -200,10 +200,12 @@ class TestDatabase3(unittest.TestCase):
     def test_load(self) -> None:
         self.makeShuffleHistory()
         with self.assertRaises(KeyError):
-            r = self.db.load(0, 0)
+            _r = self.db.load(0, 0)
+
+        _r = self.db.load(0, 0, allowMissing=True)
 
         del self.db.h5db["c00n00/Reactor/missingParam"]
-        r = self.db.load(0, 0)
+        _r = self.db.load(0, 0, allowMissing=False)
 
     def test_history(self) -> None:
         self.makeShuffleHistory()


### PR DESCRIPTION
This allows loading from old databases when parameters have since been
removed from the application. In such cases, a warning will be issued.