### PR TITLE
Adding a DeprecationWarning that settings will be immutable soon.

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -727,7 +727,9 @@ class Database3(database.Database):
         from armi import settings
 
         cs = settings.Settings()
-        cs.caseTitle = os.path.splitext(os.path.basename(self.fileName))[0]
+        cs.caseTitle = os.path.splitext(os.path.basename(self.fileName))[
+            0
+        ]  # TODO: DeprecationWarning
         try:
             cs.loadFromString(self.h5db["inputs/settings"].asstr()[()])
         except KeyError:

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -307,6 +307,10 @@ class TestDatabase3(unittest.TestCase):
             attrs = database3._resolveAttrs(tnGroup["layout/serialNum"].attrs, tnGroup)
             self.assertTrue(numpy.array_equal(attrs["fakeBigData"], numpy.eye(6400)))
 
+            keys = sorted(db2.keys())
+            self.assertEqual(len(keys), 8)
+            self.assertEqual(keys[:3], ["/c00n00", "/c00n01", "/c00n02"])
+
     def test_splitDatabase(self):
         self.makeHistory()
 

--- a/armi/bookkeeping/snapshotInterface.py
+++ b/armi/bookkeeping/snapshotInterface.py
@@ -69,7 +69,9 @@ class SnapshotInterface(interfaces.Interface):
                 runLog.info(
                     "Adding default snapshot {0} to snapshot queue.".format(snapT)
                 )
+                self.cs.lock = False
                 self.cs["dumpSnapshot"] = self.cs["dumpSnapshot"] + [snapT]
+                self.cs.lock = True
 
     def _getSnapTimesEquilibrium(self):
         """Set BOEC, MOEC, EOEC snapshots."""

--- a/armi/bookkeeping/snapshotInterface.py
+++ b/armi/bookkeeping/snapshotInterface.py
@@ -69,9 +69,8 @@ class SnapshotInterface(interfaces.Interface):
                 runLog.info(
                     "Adding default snapshot {0} to snapshot queue.".format(snapT)
                 )
-                self.cs.lock = False
-                self.cs["dumpSnapshot"] = self.cs["dumpSnapshot"] + [snapT]
-                self.cs.lock = True
+                with self.cs.unlock():
+                    self.cs["dumpSnapshot"] = self.cs["dumpSnapshot"] + [snapT]
 
     def _getSnapTimesEquilibrium(self):
         """Set BOEC, MOEC, EOEC snapshots."""

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -72,14 +72,13 @@ class TestHistoryTracker(ArmiTestHelper):
         runTutorialNotebook()
 
         reloadCs = settings.Settings(f"{CASE_TITLE}.yaml")
-        reloadCs.lock = False
-        reloadCs.caseTitle = "armiRun"
-        reloadCs["db"] = True
-        reloadCs["reloadDBName"] = pathlib.Path(f"{CASE_TITLE}.h5").absolute()
-        reloadCs["runType"] = "Snapshots"
-        reloadCs["loadStyle"] = "fromDB"
-        reloadCs["detailAssemLocationsBOL"] = ["001-001"]
-        reloadCs.lock = True
+        with reloadCs.unlock():
+            reloadCs.caseTitle = "armiRun"
+            reloadCs["db"] = True
+            reloadCs["reloadDBName"] = pathlib.Path(f"{CASE_TITLE}.h5").absolute()
+            reloadCs["runType"] = "Snapshots"
+            reloadCs["loadStyle"] = "fromDB"
+            reloadCs["detailAssemLocationsBOL"] = ["001-001"]
         o = armi_init(cs=reloadCs)
         cls.o = o
 
@@ -89,13 +88,12 @@ class TestHistoryTracker(ArmiTestHelper):
 
     def setUp(self):
         cs = settings.Settings(f"{CASE_TITLE}.yaml")
-        cs.lock = False
-        cs["db"] = True
-        cs["reloadDBName"] = pathlib.Path(f"{CASE_TITLE}.h5").absolute()
-        cs["loadStyle"] = "fromDB"
-        cs["detailAssemLocationsBOL"] = ["001-001"]
-        cs["startNode"] = 1
-        cs.lock = True
+        with cs.unlock():
+            cs["db"] = True
+            cs["reloadDBName"] = pathlib.Path(f"{CASE_TITLE}.h5").absolute()
+            cs["loadStyle"] = "fromDB"
+            cs["detailAssemLocationsBOL"] = ["001-001"]
+            cs["startNode"] = 1
 
         self.td = directoryChangers.TemporaryDirectoryChanger()
         self.td.__enter__()
@@ -201,9 +199,8 @@ class TestHistoryTrackerNoModel(unittest.TestCase):
 
     def test_timestepFiltering(self):
         times = range(30)
-        self.history.cs.lock = False
-        self.history.cs["burnSteps"] = 2
-        self.history.cs.lock = True
+        with self.history.cs.unlock():
+            self.history.cs["burnSteps"] = 2
         inputs = [
             {"boc": True},
             {"moc": True},
@@ -222,9 +219,8 @@ class TestHistoryTrackerNoModel(unittest.TestCase):
 
     def test_timestepFilteringWithGap(self):
         times = list(range(10)) + list(range(15, 20))
-        self.history.cs.lock = False
-        self.history.cs["burnSteps"] = 2
-        self.history.cs.lock = True
+        with self.history.cs.unlock():
+            self.history.cs["burnSteps"] = 2
         runResults = self.history.filterTimeIndices(times, boc=True)
         self.assertEqual(runResults, [0, 3, 6, 9, 15, 18])
 

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -72,12 +72,14 @@ class TestHistoryTracker(ArmiTestHelper):
         runTutorialNotebook()
 
         reloadCs = settings.Settings(f"{CASE_TITLE}.yaml")
+        reloadCs.lock = False
         reloadCs.caseTitle = "armiRun"
         reloadCs["db"] = True
         reloadCs["reloadDBName"] = pathlib.Path(f"{CASE_TITLE}.h5").absolute()
         reloadCs["runType"] = "Snapshots"
         reloadCs["loadStyle"] = "fromDB"
         reloadCs["detailAssemLocationsBOL"] = ["001-001"]
+        reloadCs.lock = True
         o = armi_init(cs=reloadCs)
         cls.o = o
 
@@ -87,11 +89,13 @@ class TestHistoryTracker(ArmiTestHelper):
 
     def setUp(self):
         cs = settings.Settings(f"{CASE_TITLE}.yaml")
+        cs.lock = False
         cs["db"] = True
         cs["reloadDBName"] = pathlib.Path(f"{CASE_TITLE}.h5").absolute()
         cs["loadStyle"] = "fromDB"
         cs["detailAssemLocationsBOL"] = ["001-001"]
         cs["startNode"] = 1
+        cs.lock = True
 
         self.td = directoryChangers.TemporaryDirectoryChanger()
         self.td.__enter__()
@@ -197,7 +201,9 @@ class TestHistoryTrackerNoModel(unittest.TestCase):
 
     def test_timestepFiltering(self):
         times = range(30)
+        self.history.cs.lock = False
         self.history.cs["burnSteps"] = 2
+        self.history.cs.lock = True
         inputs = [
             {"boc": True},
             {"moc": True},
@@ -216,7 +222,9 @@ class TestHistoryTrackerNoModel(unittest.TestCase):
 
     def test_timestepFilteringWithGap(self):
         times = list(range(10)) + list(range(15, 20))
+        self.history.cs.lock = False
         self.history.cs["burnSteps"] = 2
+        self.history.cs.lock = True
         runResults = self.history.filterTimeIndices(times, boc=True)
         self.assertEqual(runResults, [0, 3, 6, 9, 15, 18])
 

--- a/armi/bookkeeping/tests/test_snapshot.py
+++ b/armi/bookkeeping/tests/test_snapshot.py
@@ -29,15 +29,19 @@ class TestSnapshotInterface(unittest.TestCase):
 
     def test_activeateDefaultSnapshots_30cycles2BurnSteps(self):
         self.assertEqual([], self.cs["dumpSnapshot"])
+        self.cs.lock = False
         self.cs["nCycles"] = 30
         self.cs["burnSteps"] = 2
+        self.cs.lock = True
         self.si.activateDefaultSnapshots()
         self.assertEqual(["000000", "014000", "029002"], self.cs["dumpSnapshot"])
 
     def test_activeateDefaultSnapshots_17cycles5BurnSteps(self):
         self.assertEqual([], self.cs["dumpSnapshot"])
+        self.cs.lock = False
         self.cs["nCycles"] = 17
         self.cs["burnSteps"] = 5
+        self.cs.lock = True
         self.si.activateDefaultSnapshots()
         self.assertEqual(["000000", "008000", "016005"], self.cs["dumpSnapshot"])
 

--- a/armi/bookkeeping/tests/test_snapshot.py
+++ b/armi/bookkeeping/tests/test_snapshot.py
@@ -29,19 +29,17 @@ class TestSnapshotInterface(unittest.TestCase):
 
     def test_activeateDefaultSnapshots_30cycles2BurnSteps(self):
         self.assertEqual([], self.cs["dumpSnapshot"])
-        self.cs.lock = False
-        self.cs["nCycles"] = 30
-        self.cs["burnSteps"] = 2
-        self.cs.lock = True
+        with self.cs.unlock():
+            self.cs["nCycles"] = 30
+            self.cs["burnSteps"] = 2
         self.si.activateDefaultSnapshots()
         self.assertEqual(["000000", "014000", "029002"], self.cs["dumpSnapshot"])
 
     def test_activeateDefaultSnapshots_17cycles5BurnSteps(self):
         self.assertEqual([], self.cs["dumpSnapshot"])
-        self.cs.lock = False
-        self.cs["nCycles"] = 17
-        self.cs["burnSteps"] = 5
-        self.cs.lock = True
+        with self.cs.unlock():
+            self.cs["nCycles"] = 17
+            self.cs["burnSteps"] = 5
         self.si.activateDefaultSnapshots()
         self.assertEqual(["000000", "008000", "016005"], self.cs["dumpSnapshot"])
 

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -675,26 +675,25 @@ class Case:
             # they are not yet initialized.
             self.bp  # pylint: disable=pointless-statement
             self.geom  # pylint: disable=pointless-statement
-            self.cs.lock = False
-            self.cs["loadingFile"] = self.title + "-blueprints.yaml"
-            if self.geom:
-                self.cs["geomFile"] = self.title + "-geom.yaml"
-                self.geom.writeGeom(self.cs["geomFile"])
-            if self.independentVariables:
-                self.cs["independentVariables"] = [
-                    "({}, {})".format(repr(varName), repr(val))
-                    for varName, val in self.independentVariables.items()
-                ]
+            with self.cs.unlock():
+                self.cs["loadingFile"] = self.title + "-blueprints.yaml"
+                if self.geom:
+                    self.cs["geomFile"] = self.title + "-geom.yaml"
+                    self.geom.writeGeom(self.cs["geomFile"])
+                if self.independentVariables:
+                    self.cs["independentVariables"] = [
+                        "({}, {})".format(repr(varName), repr(val))
+                        for varName, val in self.independentVariables.items()
+                    ]
 
-            with open(self.cs["loadingFile"], "w") as loadingFile:
-                blueprints.Blueprints.dump(self.bp, loadingFile)
+                with open(self.cs["loadingFile"], "w") as loadingFile:
+                    blueprints.Blueprints.dump(self.bp, loadingFile)
 
-            # copy input files from other modules/plugins
-            newSettings = copyInterfaceInputs(self.cs, ".", sourceDir)
+                # copy input files from other modules/plugins
+                newSettings = copyInterfaceInputs(self.cs, ".", sourceDir)
 
-            for settingName, value in newSettings.items():
-                self.cs[settingName] = value
-            self.cs.lock = True
+                for settingName, value in newSettings.items():
+                    self.cs[settingName] = value
 
             self.cs.writeToYamlFile(self.title + ".yaml")
 

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -675,6 +675,7 @@ class Case:
             # they are not yet initialized.
             self.bp  # pylint: disable=pointless-statement
             self.geom  # pylint: disable=pointless-statement
+            self.cs.lock = False
             self.cs["loadingFile"] = self.title + "-blueprints.yaml"
             if self.geom:
                 self.cs["geomFile"] = self.title + "-geom.yaml"
@@ -693,6 +694,7 @@ class Case:
 
             for settingName, value in newSettings.items():
                 self.cs[settingName] = value
+            self.cs.lock = True
 
             self.cs.writeToYamlFile(self.title + ".yaml")
 

--- a/armi/cases/inputModifiers/neutronicsModifiers.py
+++ b/armi/cases/inputModifiers/neutronicsModifiers.py
@@ -29,11 +29,10 @@ class NeutronicConvergenceModifier(inputModifiers.InputModifier):
             )
 
     def __call__(self, cs, blueprints, geom):
-        cs.lock = False
-        cs["epsFSAvg"] = self.value * 100
-        cs["epsFSPoint"] = self.value * 100
-        cs["epsEig"] = self.value
-        cs.lock = True
+        with cs.unlock():
+            cs["epsFSAvg"] = self.value * 100
+            cs["epsFSPoint"] = self.value * 100
+            cs["epsEig"] = self.value
 
 
 class NeutronicMeshsSizeModifier(inputModifiers.InputModifier):

--- a/armi/cases/inputModifiers/neutronicsModifiers.py
+++ b/armi/cases/inputModifiers/neutronicsModifiers.py
@@ -29,9 +29,11 @@ class NeutronicConvergenceModifier(inputModifiers.InputModifier):
             )
 
     def __call__(self, cs, blueprints, geom):
+        cs.lock = False
         cs["epsFSAvg"] = self.value * 100
         cs["epsFSPoint"] = self.value * 100
         cs["epsEig"] = self.value
+        cs.lock = True
 
 
 class NeutronicMeshsSizeModifier(inputModifiers.InputModifier):

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -84,7 +84,9 @@ class TestArmiCase(unittest.TestCase):
         """
         with directoryChangers.TemporaryDirectoryChanger():  # ensure we are not in IN_USE_TEST_ROOT
             cs = settings.Settings(ARMI_RUN_PATH)
+            cs.lock = False
             cs["verbosity"] = "important"
+            cs.lock = True
             case = cases.Case(cs)
             c2 = case.clone()
             c2.summarizeDesign(True, True)
@@ -96,7 +98,9 @@ class TestArmiCase(unittest.TestCase):
         geom.readGeomFromStream(io.StringIO(GEOM_INPUT))
         bp = blueprints.Blueprints.load(BLUEPRINT_INPUT)
         cs = settings.Settings(ARMI_RUN_PATH)
+        cs.lock = False
         cs["verbosity"] = "important"
+        cs.lock = True
         baseCase = cases.Case(cs, bp=bp, geom=geom)
         with directoryChangers.TemporaryDirectoryChanger():  # ensure we are not in IN_USE_TEST_ROOT
             vals = {"cladThickness": 1, "control strat": "good", "enrich": 0.9}
@@ -200,8 +204,10 @@ class TestCaseSuiteDependencies(unittest.TestCase):
         for p1, p2, dbPath, isIn in checks:
             self.c1.cs.path = p1
             self.c2.cs.path = p2
+            self.c2.cs.lock = False
             self.c2.cs["loadStyle"] = "fromDB"
             self.c2.cs["reloadDBName"] = dbPath
+            self.c2.cs.lock = True
             # note that case.dependencies is a property and
             # will actually reflect these changes
             self.assertEqual(
@@ -211,6 +217,7 @@ class TestCaseSuiteDependencies(unittest.TestCase):
             )
 
     def test_dependencyFromDBName(self):
+        self.c2.cs.lock = False
         self.c2.cs[
             "reloadDBName"
         ] = "c1.h5"  # no effect -> need to specify loadStyle, 'fromDB'
@@ -220,11 +227,14 @@ class TestCaseSuiteDependencies(unittest.TestCase):
 
         # the .h5 extension is optional
         self.c2.cs["reloadDBName"] = "c1"
+        self.c2.cs.lock = True
         self.assertIn(self.c1, self.c2.dependencies)
 
     def test_dependencyFromExplictRepeatShuffles(self):
         self.assertEqual(0, len(self.c2.dependencies))
+        self.c2.cs.lock = False
         self.c2.cs["explicitRepeatShuffles"] = "c1-SHUFFLES.txt"
+        self.c2.cs.lock = True
         self.assertIn(self.c1, self.c2.dependencies)
 
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -973,9 +973,8 @@ class Operator:  # pylint: disable=too-many-public-methods
     @staticmethod
     def setStateToDefault(cs):
         """Update the state of ARMI to fit the kind of run this operator manages"""
-        cs.lock = False
-        cs["runType"] = runTypes.RunTypes.STANDARD
-        cs.lock = True
+        with cs.unlock():
+            cs["runType"] = runTypes.RunTypes.STANDARD
 
     def couplingIsActive(self):
         """True if any kind of physics coupling is active."""

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -973,8 +973,9 @@ class Operator:  # pylint: disable=too-many-public-methods
     @staticmethod
     def setStateToDefault(cs):
         """Update the state of ARMI to fit the kind of run this operator manages"""
-
+        cs.lock = False
         cs["runType"] = runTypes.RunTypes.STANDARD
+        cs.lock = True
 
     def couplingIsActive(self):
         """True if any kind of physics coupling is active."""

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -497,8 +497,10 @@ class Inspector:
         )
 
         def _correctCycles():
+            self.cs.lock = False
             self.cs["nCycles"] = 1
             self.cs["burnSteps"] = 0
+            self.cs.lock = True
 
         self.addQuery(
             lambda: not self.cs["cycleLengths"] and self.cs["nCycles"] == 0,

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -497,10 +497,9 @@ class Inspector:
         )
 
         def _correctCycles():
-            self.cs.lock = False
-            self.cs["nCycles"] = 1
-            self.cs["burnSteps"] = 0
-            self.cs.lock = True
+            with self.cs.unlock():
+                self.cs["nCycles"] = 1
+                self.cs["burnSteps"] = 0
 
         self.addQuery(
             lambda: not self.cs["cycleLengths"] and self.cs["nCycles"] == 0,

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -89,4 +89,6 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
         """Update the state of ARMI to fit the kind of run this operator manages"""
         from armi import operators
 
+        cs.lock = False
         cs["runType"] = operators.RunTypes.SNAPSHOTS
+        cs.lock = True

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -89,6 +89,5 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
         """Update the state of ARMI to fit the kind of run this operator manages"""
         from armi import operators
 
-        cs.lock = False
-        cs["runType"] = operators.RunTypes.SNAPSHOTS
-        cs.lock = True
+        with cs.unlock():
+            cs["runType"] = operators.RunTypes.SNAPSHOTS

--- a/armi/operators/tests/test_inspectors.py
+++ b/armi/operators/tests/test_inspectors.py
@@ -63,10 +63,9 @@ class Test(unittest.TestCase):
         self.assertFalse(query)
 
         newCS = settings.getMasterCs().duplicate()
-        newCS.lock = False
-        newCS["runType"] = "banane"
-        newCS.lock = True
-        newCS["runType"] = "banane"
+        with newCS.unlock():
+            newCS["runType"] = "banane"
+
         self.inspector.cs = newCS
         self.assertTrue(query)
 

--- a/armi/operators/tests/test_inspectors.py
+++ b/armi/operators/tests/test_inspectors.py
@@ -63,6 +63,9 @@ class Test(unittest.TestCase):
         self.assertFalse(query)
 
         newCS = settings.getMasterCs().duplicate()
+        newCS.lock = False
+        newCS["runType"] = "banane"
+        newCS.lock = True
         newCS["runType"] = "banane"
         self.inspector.cs = newCS
         self.assertTrue(query)

--- a/armi/physics/fuelCycle/settings.py
+++ b/armi/physics/fuelCycle/settings.py
@@ -184,7 +184,9 @@ def getFuelCycleSettingValidators(inspector):
             if regexContent != srcContent:
                 dest.write("from armi import runLog\n")
             dest.write(regexContent)
+        inspector.cs.lock = False
         inspector.cs["shuffleLogic"] = destFile
+        inspector.cs.lock = True
 
     queries.append(
         settingsValidation.Query(

--- a/armi/physics/fuelCycle/settings.py
+++ b/armi/physics/fuelCycle/settings.py
@@ -184,9 +184,9 @@ def getFuelCycleSettingValidators(inspector):
             if regexContent != srcContent:
                 dest.write("from armi import runLog\n")
             dest.write(regexContent)
-        inspector.cs.lock = False
-        inspector.cs["shuffleLogic"] = destFile
-        inspector.cs.lock = True
+
+        with inspector.cs.unlock():
+            inspector.cs["shuffleLogic"] = destFile
 
     queries.append(
         settingsValidation.Query(

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -80,10 +80,10 @@ class NeutronicsReactorTests(unittest.TestCase):
 
         def _getModifiedSettings(customSettings):
             cs = settings.Settings()
-            cs.lock = False
-            for key, val in customSettings.items():
-                cs[key] = val
-            cs.lock = True
+            with cs.unlock():
+                for key, val in customSettings.items():
+                    cs[key] = val
+
             return cs
 
         r = tests.getEmptyHexReactor()

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -80,8 +80,10 @@ class NeutronicsReactorTests(unittest.TestCase):
 
         def _getModifiedSettings(customSettings):
             cs = settings.Settings()
+            cs.lock = False
             for key, val in customSettings.items():
                 cs[key] = val
+            cs.lock = True
             return cs
 
         r = tests.getEmptyHexReactor()

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -165,9 +165,9 @@ grids:
     def test_nuclidesMc2v2(self):
         """Tests that ZR is not expanded to its isotopics for this setting.."""
         cs = settings.Settings()
-        cs.lock = False
-        cs["xsKernel"] = "MC2v2"
-        cs.lock = True
+        with cs.unlock():
+            cs["xsKernel"] = "MC2v2"
+
         design = blueprints.Blueprints.load(self.yamlString)
         design._prepConstruction(cs)
         self.assertTrue(
@@ -182,9 +182,9 @@ grids:
     def test_nuclidesMc2v3(self):
         """Tests that ZR is expanded to its isotopics for MC2v3."""
         cs = settings.Settings()
-        cs.lock = False
-        cs["xsKernel"] = "MC2v3"
-        cs.lock = True
+        with cs.unlock():
+            cs["xsKernel"] = "MC2v3"
+
         design = blueprints.Blueprints.load(self.yamlString)
         design._prepConstruction(cs)
 

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -165,7 +165,9 @@ grids:
     def test_nuclidesMc2v2(self):
         """Tests that ZR is not expanded to its isotopics for this setting.."""
         cs = settings.Settings()
+        cs.lock = False
         cs["xsKernel"] = "MC2v2"
+        cs.lock = True
         design = blueprints.Blueprints.load(self.yamlString)
         design._prepConstruction(cs)
         self.assertTrue(
@@ -180,7 +182,9 @@ grids:
     def test_nuclidesMc2v3(self):
         """Tests that ZR is expanded to its isotopics for MC2v3."""
         cs = settings.Settings()
+        cs.lock = False
         cs["xsKernel"] = "MC2v3"
+        cs.lock = True
         design = blueprints.Blueprints.load(self.yamlString)
         design._prepConstruction(cs)
 

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -188,7 +188,9 @@ assemblies:
     @classmethod
     def setUpClass(cls):
         cs = settings.Settings()
+        cs.lock = False
         cs["xsKernel"] = "MC2v2"
+        cs.lock = True
         cls.bp = blueprints.Blueprints.load(cls.yamlString)
         cls.a = cls.bp.constructAssem(cs, name="fuel a")
         cls.numUZrNuclides = 29  # Number of nuclides defined `nuclide flags`
@@ -254,7 +256,9 @@ assemblies:
 
     def test_expandedNatural(self):
         cs = settings.Settings()
+        cs.lock = False
         cs["xsKernel"] = "MC2v3"
+        cs.lock = True
         bp = blueprints.Blueprints.load(self.yamlString)
         a = bp.constructAssem(cs, name="fuel a")
         b = a[-1]
@@ -349,7 +353,9 @@ assemblies:
 
     def test_expandedNatural(self):
         cs = settings.Settings()
+        cs.lock = False
         cs["xsKernel"] = "MC2v3"
+        cs.lock = True
         bp = blueprints.Blueprints.load(self.yamlString)
         a = bp.constructAssem(cs, name="fuel a")
         b = a[-1]

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -188,9 +188,9 @@ assemblies:
     @classmethod
     def setUpClass(cls):
         cs = settings.Settings()
-        cs.lock = False
-        cs["xsKernel"] = "MC2v2"
-        cs.lock = True
+        with cs.unlock():
+            cs["xsKernel"] = "MC2v2"
+
         cls.bp = blueprints.Blueprints.load(cls.yamlString)
         cls.a = cls.bp.constructAssem(cs, name="fuel a")
         cls.numUZrNuclides = 29  # Number of nuclides defined `nuclide flags`
@@ -256,9 +256,9 @@ assemblies:
 
     def test_expandedNatural(self):
         cs = settings.Settings()
-        cs.lock = False
-        cs["xsKernel"] = "MC2v3"
-        cs.lock = True
+        with cs.unlock():
+            cs["xsKernel"] = "MC2v3"
+
         bp = blueprints.Blueprints.load(self.yamlString)
         a = bp.constructAssem(cs, name="fuel a")
         b = a[-1]
@@ -353,9 +353,9 @@ assemblies:
 
     def test_expandedNatural(self):
         cs = settings.Settings()
-        cs.lock = False
-        cs["xsKernel"] = "MC2v3"
-        cs.lock = True
+        with cs.unlock():
+            cs["xsKernel"] = "MC2v3"
+
         bp = blueprints.Blueprints.load(self.yamlString)
         a = bp.constructAssem(cs, name="fuel a")
         b = a[-1]

--- a/armi/reactor/blueprints/tests/test_reactorBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_reactorBlueprints.py
@@ -81,6 +81,7 @@ class TestReactorBlueprints(unittest.TestCase):
             with open(fn, "w") as f:
                 f.write(GEOM)
         cs = settings.Settings()
+        cs.lock = False
         # test migration from geometry xml files
         cs["geomFile"] = self._testMethodName + "geometry.xml"
         bp = blueprints.Blueprints.load(
@@ -93,6 +94,7 @@ class TestReactorBlueprints(unittest.TestCase):
         sfp = bp.systemDesigns["sfp"].construct(cs, bp, reactor)
         for fn in fnames:
             os.remove(fn)
+        cs.lock = True
         return core, sfp
 
     def test_construct(self):

--- a/armi/reactor/blueprints/tests/test_reactorBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_reactorBlueprints.py
@@ -81,20 +81,20 @@ class TestReactorBlueprints(unittest.TestCase):
             with open(fn, "w") as f:
                 f.write(GEOM)
         cs = settings.Settings()
-        cs.lock = False
-        # test migration from geometry xml files
-        cs["geomFile"] = self._testMethodName + "geometry.xml"
-        bp = blueprints.Blueprints.load(
-            test_customIsotopics.TestCustomIsotopics.yamlString
-        )
-        bp.systemDesigns = self.systemDesigns
-        bp.gridDesigns = self.gridDesigns
-        reactor = reactors.Reactor(cs.caseTitle, bp)
-        core = bp.systemDesigns["core"].construct(cs, bp, reactor)
-        sfp = bp.systemDesigns["sfp"].construct(cs, bp, reactor)
-        for fn in fnames:
-            os.remove(fn)
-        cs.lock = True
+        with cs.unlock():
+            # test migration from geometry xml files
+            cs["geomFile"] = self._testMethodName + "geometry.xml"
+            bp = blueprints.Blueprints.load(
+                test_customIsotopics.TestCustomIsotopics.yamlString
+            )
+            bp.systemDesigns = self.systemDesigns
+            bp.gridDesigns = self.gridDesigns
+            reactor = reactors.Reactor(cs.caseTitle, bp)
+            core = bp.systemDesigns["core"].construct(cs, bp, reactor)
+            sfp = bp.systemDesigns["sfp"].construct(cs, bp, reactor)
+            for fn in fnames:
+                os.remove(fn)
+
         return core, sfp
 
     def test_construct(self):

--- a/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
+++ b/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
@@ -62,8 +62,7 @@ class NeutronicConvergenceModifier(ParameterSweepConverter):
     def convert(self, r=None):
         ParameterSweepConverter.convert(self, r)
         fs = 1.0e-12 + self._parameter * 1.0e-3
-        self._cs.lock = False
-        self._cs["epsFSAvg"] = fs
-        self._cs["epsFSPoint"] = fs
-        self._cs["epsEig"] = 1.0e-14 + self._parameter * 1.0e-4
-        self._cs.lock = True
+        with self._cs.unlock():
+            self._cs["epsFSAvg"] = fs
+            self._cs["epsFSPoint"] = fs
+            self._cs["epsEig"] = 1.0e-14 + self._parameter * 1.0e-4

--- a/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
+++ b/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
@@ -62,6 +62,8 @@ class NeutronicConvergenceModifier(ParameterSweepConverter):
     def convert(self, r=None):
         ParameterSweepConverter.convert(self, r)
         fs = 1.0e-12 + self._parameter * 1.0e-3
+        self._cs.lock = False
         self._cs["epsFSAvg"] = fs
         self._cs["epsFSPoint"] = fs
         self._cs["epsEig"] = 1.0e-14 + self._parameter * 1.0e-4
+        self._cs.lock = True

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2277,7 +2277,9 @@ class Core(composites.Composite):
                     "Detected a grid plate {}.  Adding to stationary blocks".format(b)
                 )  # TODO: remove hard-coded assumption of grid plates (T3019)
 
-        cs["stationaryBlocks"] = stationaryBlocks
+        cs[
+            "stationaryBlocks"
+        ] = stationaryBlocks  # TODO: DeprecationWarning - changing settings
 
         # Perform initial zoning task
         self.buildZones(cs)

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -567,7 +567,9 @@ class Assembly_TestCase(unittest.TestCase):
     def _setup_blueprints(self, filename="refSmallReactor.yaml"):
         # need this for the getAllNuclides call
         with directoryChangers.DirectoryChanger(TEST_ROOT):
+            self.cs.lock = False
             self.cs["loadingFile"] = filename
+            self.cs.lock = True
             with open(self.cs["loadingFile"], "r") as y:
                 y = textProcessors.resolveMarkupInclusions(
                     y, pathlib.Path(self.cs.inputDirectory)
@@ -1384,7 +1386,9 @@ class AnnularFuelTestCase(unittest.TestCase):
     # pylint: disable=locally-disabled,protected-access
     def setUp(self):
         self.cs = settings.Settings()
+        self.cs.lock = False
         self.cs["xsKernel"] = "MC2v2"  # don't try to expand elementals
+        self.cs.lock = True
         settings.setMasterCs(self.cs)
         bp = blueprints.Blueprints()
         self.r = reactors.Reactor("test", bp)

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -567,9 +567,9 @@ class Assembly_TestCase(unittest.TestCase):
     def _setup_blueprints(self, filename="refSmallReactor.yaml"):
         # need this for the getAllNuclides call
         with directoryChangers.DirectoryChanger(TEST_ROOT):
-            self.cs.lock = False
-            self.cs["loadingFile"] = filename
-            self.cs.lock = True
+            with self.cs.unlock():
+                self.cs["loadingFile"] = filename
+
             with open(self.cs["loadingFile"], "r") as y:
                 y = textProcessors.resolveMarkupInclusions(
                     y, pathlib.Path(self.cs.inputDirectory)
@@ -1386,9 +1386,9 @@ class AnnularFuelTestCase(unittest.TestCase):
     # pylint: disable=locally-disabled,protected-access
     def setUp(self):
         self.cs = settings.Settings()
-        self.cs.lock = False
-        self.cs["xsKernel"] = "MC2v2"  # don't try to expand elementals
-        self.cs.lock = True
+        with self.cs.unlock():
+            self.cs["xsKernel"] = "MC2v2"  # don't try to expand elementals
+
         settings.setMasterCs(self.cs)
         bp = blueprints.Blueprints()
         self.r = reactors.Reactor("test", bp)

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -452,9 +452,10 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(ref, cur, places=places)
 
     def test_getXsType(self):
-
         self.cs = settings.getMasterCs()
+        self.cs.lock = False
         self.cs["loadingFile"] = os.path.join(TEST_ROOT, "refSmallReactor.yaml")
+        self.cs.lock = True
 
         self.Block.p.xsType = "B"
         cur = self.Block.p.xsType
@@ -462,12 +463,16 @@ class Block_TestCase(unittest.TestCase):
         self.assertEqual(cur, ref)
 
         oldBuGroups = self.cs["buGroups"]
+        self.cs.lock = False
         self.cs["buGroups"] = [100]
+        self.cs.lock = True
         self.Block.p.xsType = "BB"
         cur = self.Block.p.xsType
         ref = "BB"
         self.assertEqual(cur, ref)
+        self.cs.lock = False
         self.cs["buGroups"] = oldBuGroups
+        self.cs.lock = True
 
     def test27b_setBuGroup(self):
         type_ = "A"

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -453,9 +453,8 @@ class Block_TestCase(unittest.TestCase):
 
     def test_getXsType(self):
         self.cs = settings.getMasterCs()
-        self.cs.lock = False
-        self.cs["loadingFile"] = os.path.join(TEST_ROOT, "refSmallReactor.yaml")
-        self.cs.lock = True
+        with self.cs.unlock():
+            self.cs["loadingFile"] = os.path.join(TEST_ROOT, "refSmallReactor.yaml")
 
         self.Block.p.xsType = "B"
         cur = self.Block.p.xsType
@@ -463,16 +462,15 @@ class Block_TestCase(unittest.TestCase):
         self.assertEqual(cur, ref)
 
         oldBuGroups = self.cs["buGroups"]
-        self.cs.lock = False
-        self.cs["buGroups"] = [100]
-        self.cs.lock = True
+        with self.cs.unlock():
+            self.cs["buGroups"] = [100]
+
         self.Block.p.xsType = "BB"
         cur = self.Block.p.xsType
         ref = "BB"
         self.assertEqual(cur, ref)
-        self.cs.lock = False
-        self.cs["buGroups"] = oldBuGroups
-        self.cs.lock = True
+        with self.cs.unlock():
+            self.cs["buGroups"] = oldBuGroups
 
     def test27b_setBuGroup(self):
         type_ = "A"

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -54,7 +54,9 @@ def buildOperatorOfEmptyHexBlocks(customSettings=None):
     """
     settings.setMasterCs(None)  # clear
     cs = settings.getMasterCs()  # fetch new
+    cs.lock = False
     cs["db"] = False  # stop use of database
+    cs.lock = True
     if customSettings is not None:
         cs.update(customSettings)
     r = tests.getEmptyHexReactor()
@@ -88,7 +90,9 @@ def buildOperatorOfEmptyCartesianBlocks(customSettings=None):
     """
     settings.setMasterCs(None)  # clear
     cs = settings.getMasterCs()  # fetch new
+    cs.lock = False
     cs["db"] = False  # stop use of database
+    cs.lock = True
     if customSettings is not None:
         cs.update(customSettings)
     r = tests.getEmptyCartesianReactor()
@@ -155,17 +159,22 @@ def loadTestReactor(
         return o, r
 
     cs = settings.Settings(fName=fName)
+    cs.lock = False
 
     # Overwrite settings if desired
     if customSettings:
+        cs.lock = False
         for settingKey, settingVal in customSettings.items():
             cs[settingKey] = settingVal
+        cs.lock = True
 
     if "verbosity" not in customSettings:
         runLog.setVerbosity("error")
     settings.setMasterCs(cs)
+    cs.lock = False
     cs["stationaryBlocks"] = []
     cs["nCycles"] = 3
+    cs.lock = True
 
     o = operators.factory(cs)
     r = reactors.loadFromCs(cs)
@@ -182,6 +191,7 @@ def loadTestReactor(
         # cache it for fast load for other future tests
         # protocol=2 allows for classes with __slots__ but not __getstate__ to be pickled
         TEST_REACTOR = cPickle.dumps((o, o.r, assemblies.getAssemNum()), protocol=2)
+    cs.lock = True
     return o, o.r
 
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -54,9 +54,9 @@ def buildOperatorOfEmptyHexBlocks(customSettings=None):
     """
     settings.setMasterCs(None)  # clear
     cs = settings.getMasterCs()  # fetch new
-    cs.lock = False
-    cs["db"] = False  # stop use of database
-    cs.lock = True
+    with cs.unlock():
+        cs["db"] = False  # stop use of database
+
     if customSettings is not None:
         cs.update(customSettings)
     r = tests.getEmptyHexReactor()
@@ -90,9 +90,9 @@ def buildOperatorOfEmptyCartesianBlocks(customSettings=None):
     """
     settings.setMasterCs(None)  # clear
     cs = settings.getMasterCs()  # fetch new
-    cs.lock = False
-    cs["db"] = False  # stop use of database
-    cs.lock = True
+    with cs.unlock():
+        cs["db"] = False  # stop use of database
+
     if customSettings is not None:
         cs.update(customSettings)
     r = tests.getEmptyCartesianReactor()
@@ -159,22 +159,19 @@ def loadTestReactor(
         return o, r
 
     cs = settings.Settings(fName=fName)
-    cs.lock = False
 
     # Overwrite settings if desired
     if customSettings:
-        cs.lock = False
-        for settingKey, settingVal in customSettings.items():
-            cs[settingKey] = settingVal
-        cs.lock = True
+        with cs.unlock():
+            for settingKey, settingVal in customSettings.items():
+                cs[settingKey] = settingVal
 
     if "verbosity" not in customSettings:
         runLog.setVerbosity("error")
     settings.setMasterCs(cs)
-    cs.lock = False
-    cs["stationaryBlocks"] = []
-    cs["nCycles"] = 3
-    cs.lock = True
+    with cs.unlock():
+        cs["stationaryBlocks"] = []
+        cs["nCycles"] = 3
 
     o = operators.factory(cs)
     r = reactors.loadFromCs(cs)
@@ -191,7 +188,7 @@ def loadTestReactor(
         # cache it for fast load for other future tests
         # protocol=2 allows for classes with __slots__ but not __getstate__ to be pickled
         TEST_REACTOR = cPickle.dumps((o, o.r, assemblies.getAssemNum()), protocol=2)
-    cs.lock = True
+
     return o, o.r
 
 

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -110,6 +110,7 @@ class Zones_InReactor(unittest.TestCase):
     def test_buildRingZones(self):
         o, r = self.o, self.r
         cs = o.cs
+        cs.lock = False
         cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
         cs["ringZones"] = []
         zonez = zones.buildZones(r.core, cs)
@@ -133,10 +134,12 @@ class Zones_InReactor(unittest.TestCase):
         self.assertEqual(len(list(zonez)), 3)
         zone = zonez["ring-3"]
         self.assertEqual(len(zone), 30)  # rings 8 and 9. See above comment
+        cs.lock = True
 
     def test_buildManualZones(self):
         o, r = self.o, self.r
         cs = o.cs
+        cs.lock = False
         cs[globalSettings.CONF_ZONING_STRATEGY] = "manual"
         cs["zoneDefinitions"] = [
             "ring-1: 001-001",
@@ -144,12 +147,14 @@ class Zones_InReactor(unittest.TestCase):
             "ring-3: 003-001, 003-002, 003-003",
         ]
         zonez = zones.buildZones(r.core, cs)
+        cs.lock = True
         self.assertEqual(len(list(zonez)), 3)
         self.assertIn("003-002", zonez["ring-3"])
 
     def test_buildAssemTypeZones(self):
         o, r = self.o, self.r
         cs = o.cs
+        cs.lock = False
         cs[globalSettings.CONF_ZONING_STRATEGY] = "byFuelType"
         zonez = zones.buildZones(r.core, cs)
         self.assertEqual(len(list(zonez)), 4)
@@ -157,12 +162,15 @@ class Zones_InReactor(unittest.TestCase):
         self.assertIn("005-023", zonez["igniter fuel"])
         self.assertIn("003-002", zonez["lta fuel"])
         self.assertIn("004-003", zonez["lta fuel b"])
+        cs.lock = True
 
     def test_buildZonesForEachFA(self):
         o, r = self.o, self.r
         cs = o.cs
+        cs.lock = False
         cs[globalSettings.CONF_ZONING_STRATEGY] = "everyFA"
         zonez = zones.buildZones(r.core, cs)
+        cs.lock = True
         self.assertEqual(len(list(zonez)), 53)
         self.assertIn("008-040", zonez["channel 1"])
         self.assertIn("005-023", zonez["channel 2"])
@@ -171,8 +179,10 @@ class Zones_InReactor(unittest.TestCase):
     def test_buildZonesByOrifice(self):
         o, r = self.o, self.r
         cs = o.cs
+        cs.lock = False
         cs[globalSettings.CONF_ZONING_STRATEGY] = "byOrifice"
         zonez = zones.buildZones(r.core, cs)
+        cs.lock = True
         self.assertEqual(len(list(zonez)), 2)
         self.assertIn("008-040", zonez["zone0"])
         self.assertIn("005-023", zonez["zone0"])
@@ -181,11 +191,13 @@ class Zones_InReactor(unittest.TestCase):
     def test_removeZone(self):
         o, r = self.o, self.r
         cs = o.cs
+        cs.lock = False
         cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
         cs["ringZones"] = [5, 8]
         # produce 2 zones, with the names ringzone0 and ringzone1
         daZones = zones.buildZones(r.core, cs)
         daZones.removeZone("ring-1")
+        cs.lock = True
         # The names list should only house the only other remaining zone now
         self.assertEqual(["ring-2"], daZones.names)
 
@@ -199,6 +211,7 @@ class Zones_InReactor(unittest.TestCase):
 
     def test_findZoneAssemblyIsIn(self):
         cs = self.o.cs
+        cs.lock = False
         cs["ringZones"] = [5, 7, 8]
         daZones = zones.buildZones(self.r.core, cs)
         for zone in daZones:
@@ -212,6 +225,7 @@ class Zones_InReactor(unittest.TestCase):
         daZones.removeZone(
             daZones.names[0]
         )  # remove a zone to ensure that our assem does not have a zone anymore
+        cs.lock = True
         self.assertEqual(daZones.findZoneAssemblyIsIn(a), None)
 
 
@@ -222,6 +236,7 @@ class Zones_InRZReactor(unittest.TestCase):
 
         o, r = test_reactors.loadTestReactor()
         cs = o.cs
+        cs.lock = False
         cs["splitZones"] = False
         cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
         cs["ringZones"] = [1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -246,6 +261,7 @@ class Zones_InRZReactor(unittest.TestCase):
         # this should split diverseZone into multiple zones by nodalization type.
         cs["splitZones"] = True
         zones.splitZones(r.core, cs, daZones)
+        cs.lock = True
         # test to make sure that we split the ring zone correctly
         self.assertEqual(len(daZones["ring-4-igniter-fuel-5"]), 4)
         self.assertEqual(len(daZones["ring-4-igniter-fuel-6"]), 1)
@@ -258,6 +274,7 @@ class Zones_InRZReactor(unittest.TestCase):
         # Test that if a hot zone can not be created from a single assembly zone.
         o, r = test_reactors.loadTestReactor()
         cs = o.cs
+        cs.lock = False
         cs["splitZones"] = False
         cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
         cs["ringZones"] = [9]  # build one giant zone
@@ -337,6 +354,7 @@ class Zones_InRZReactor(unittest.TestCase):
                 normalCount += 1
         self.assertEqual(hotCount, 1)
         self.assertEqual(normalCount, 2)
+        cs.lock = True
 
 
 if __name__ == "__main__":

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -110,67 +110,65 @@ class Zones_InReactor(unittest.TestCase):
     def test_buildRingZones(self):
         o, r = self.o, self.r
         cs = o.cs
-        cs.lock = False
-        cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
-        cs["ringZones"] = []
-        zonez = zones.buildZones(r.core, cs)
-        self.assertEqual(len(list(zonez)), 1)
-        self.assertEqual(9, r.core.numRings)
+        with cs.unlock():
+            cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
+            cs["ringZones"] = []
+            zonez = zones.buildZones(r.core, cs)
+            self.assertEqual(len(list(zonez)), 1)
+            self.assertEqual(9, r.core.numRings)
 
-        cs["ringZones"] = [5, 8]
-        zonez = zones.buildZones(r.core, cs)
-        self.assertEqual(len(list(zonez)), 2)
-        zone = zonez["ring-1"]
-        self.assertEqual(len(zone), (5 * (5 - 1) + 1))
-        zone = zonez["ring-2"]
-        # Note that the actual number of rings in the reactor model is 9. Even though we
-        # asked for the last zone to to to 8, the zone engine should bump it out. Not
-        # sure if this is behavior that we want to preserve, but at least it's being
-        # tested properly now.
-        self.assertEqual(len(zone), (9 * (9 - 1) + 1) - (5 * (5 - 1) + 1))
+            cs["ringZones"] = [5, 8]
+            zonez = zones.buildZones(r.core, cs)
+            self.assertEqual(len(list(zonez)), 2)
+            zone = zonez["ring-1"]
+            self.assertEqual(len(zone), (5 * (5 - 1) + 1))
+            zone = zonez["ring-2"]
+            # Note that the actual number of rings in the reactor model is 9. Even though we
+            # asked for the last zone to to to 8, the zone engine should bump it out. Not
+            # sure if this is behavior that we want to preserve, but at least it's being
+            # tested properly now.
+            self.assertEqual(len(zone), (9 * (9 - 1) + 1) - (5 * (5 - 1) + 1))
 
-        cs["ringZones"] = [5, 7, 8]
-        zonez = zones.buildZones(r.core, cs)
-        self.assertEqual(len(list(zonez)), 3)
-        zone = zonez["ring-3"]
-        self.assertEqual(len(zone), 30)  # rings 8 and 9. See above comment
-        cs.lock = True
+            cs["ringZones"] = [5, 7, 8]
+            zonez = zones.buildZones(r.core, cs)
+            self.assertEqual(len(list(zonez)), 3)
+            zone = zonez["ring-3"]
+            self.assertEqual(len(zone), 30)  # rings 8 and 9. See above comment
 
     def test_buildManualZones(self):
         o, r = self.o, self.r
         cs = o.cs
-        cs.lock = False
-        cs[globalSettings.CONF_ZONING_STRATEGY] = "manual"
-        cs["zoneDefinitions"] = [
-            "ring-1: 001-001",
-            "ring-2: 002-001, 002-002",
-            "ring-3: 003-001, 003-002, 003-003",
-        ]
-        zonez = zones.buildZones(r.core, cs)
-        cs.lock = True
+        with cs.unlock():
+            cs[globalSettings.CONF_ZONING_STRATEGY] = "manual"
+            cs["zoneDefinitions"] = [
+                "ring-1: 001-001",
+                "ring-2: 002-001, 002-002",
+                "ring-3: 003-001, 003-002, 003-003",
+            ]
+            zonez = zones.buildZones(r.core, cs)
+
         self.assertEqual(len(list(zonez)), 3)
         self.assertIn("003-002", zonez["ring-3"])
 
     def test_buildAssemTypeZones(self):
         o, r = self.o, self.r
         cs = o.cs
-        cs.lock = False
-        cs[globalSettings.CONF_ZONING_STRATEGY] = "byFuelType"
-        zonez = zones.buildZones(r.core, cs)
-        self.assertEqual(len(list(zonez)), 4)
-        self.assertIn("008-040", zonez["feed fuel"])
-        self.assertIn("005-023", zonez["igniter fuel"])
-        self.assertIn("003-002", zonez["lta fuel"])
-        self.assertIn("004-003", zonez["lta fuel b"])
-        cs.lock = True
+        with cs.unlock():
+            cs[globalSettings.CONF_ZONING_STRATEGY] = "byFuelType"
+            zonez = zones.buildZones(r.core, cs)
+            self.assertEqual(len(list(zonez)), 4)
+            self.assertIn("008-040", zonez["feed fuel"])
+            self.assertIn("005-023", zonez["igniter fuel"])
+            self.assertIn("003-002", zonez["lta fuel"])
+            self.assertIn("004-003", zonez["lta fuel b"])
 
     def test_buildZonesForEachFA(self):
         o, r = self.o, self.r
         cs = o.cs
-        cs.lock = False
-        cs[globalSettings.CONF_ZONING_STRATEGY] = "everyFA"
-        zonez = zones.buildZones(r.core, cs)
-        cs.lock = True
+        with cs.unlock():
+            cs[globalSettings.CONF_ZONING_STRATEGY] = "everyFA"
+            zonez = zones.buildZones(r.core, cs)
+
         self.assertEqual(len(list(zonez)), 53)
         self.assertIn("008-040", zonez["channel 1"])
         self.assertIn("005-023", zonez["channel 2"])
@@ -179,10 +177,10 @@ class Zones_InReactor(unittest.TestCase):
     def test_buildZonesByOrifice(self):
         o, r = self.o, self.r
         cs = o.cs
-        cs.lock = False
-        cs[globalSettings.CONF_ZONING_STRATEGY] = "byOrifice"
-        zonez = zones.buildZones(r.core, cs)
-        cs.lock = True
+        with cs.unlock():
+            cs[globalSettings.CONF_ZONING_STRATEGY] = "byOrifice"
+            zonez = zones.buildZones(r.core, cs)
+
         self.assertEqual(len(list(zonez)), 2)
         self.assertIn("008-040", zonez["zone0"])
         self.assertIn("005-023", zonez["zone0"])
@@ -191,13 +189,13 @@ class Zones_InReactor(unittest.TestCase):
     def test_removeZone(self):
         o, r = self.o, self.r
         cs = o.cs
-        cs.lock = False
-        cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
-        cs["ringZones"] = [5, 8]
-        # produce 2 zones, with the names ringzone0 and ringzone1
-        daZones = zones.buildZones(r.core, cs)
-        daZones.removeZone("ring-1")
-        cs.lock = True
+        with cs.unlock():
+            cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
+            cs["ringZones"] = [5, 8]
+            # produce 2 zones, with the names ringzone0 and ringzone1
+            daZones = zones.buildZones(r.core, cs)
+            daZones.removeZone("ring-1")
+
         # The names list should only house the only other remaining zone now
         self.assertEqual(["ring-2"], daZones.names)
 
@@ -211,21 +209,21 @@ class Zones_InReactor(unittest.TestCase):
 
     def test_findZoneAssemblyIsIn(self):
         cs = self.o.cs
-        cs.lock = False
-        cs["ringZones"] = [5, 7, 8]
-        daZones = zones.buildZones(self.r.core, cs)
-        for zone in daZones:
-            a = self.r.core.getAssemblyWithStringLocation(zone.locList[0])
-            aZone = daZones.findZoneAssemblyIsIn(a)
-            self.assertEqual(aZone, zone)
-        # lets test if we get a none and a warning if the assembly does not exist in a zone
-        a = self.r.core.getAssemblyWithStringLocation(
-            daZones[daZones.names[0]].locList[0]
-        )  # get assem from first zone
-        daZones.removeZone(
-            daZones.names[0]
-        )  # remove a zone to ensure that our assem does not have a zone anymore
-        cs.lock = True
+        with cs.unlock():
+            cs["ringZones"] = [5, 7, 8]
+            daZones = zones.buildZones(self.r.core, cs)
+            for zone in daZones:
+                a = self.r.core.getAssemblyWithStringLocation(zone.locList[0])
+                aZone = daZones.findZoneAssemblyIsIn(a)
+                self.assertEqual(aZone, zone)
+            # lets test if we get a none and a warning if the assembly does not exist in a zone
+            a = self.r.core.getAssemblyWithStringLocation(
+                daZones[daZones.names[0]].locList[0]
+            )  # get assem from first zone
+            daZones.removeZone(
+                daZones.names[0]
+            )  # remove a zone to ensure that our assem does not have a zone anymore
+
         self.assertEqual(daZones.findZoneAssemblyIsIn(a), None)
 
 
@@ -236,32 +234,32 @@ class Zones_InRZReactor(unittest.TestCase):
 
         o, r = test_reactors.loadTestReactor()
         cs = o.cs
-        cs.lock = False
-        cs["splitZones"] = False
-        cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
-        cs["ringZones"] = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        diverseZone = "ring-4"
-        r.core.buildZones(cs)
-        daZones = r.core.zones
-        # lets make one of the assemblies have an extra block
-        zoneLocations = daZones.getZoneLocations(diverseZone)
-        originalAssemblies = r.core.getLocationContents(
-            zoneLocations, assemblyLevel=True
-        )
-        fuel = [a for a in originalAssemblies if a.hasFlags(Flags.FUEL)][0]
-        newBlock = copy.deepcopy(fuel[-1])
-        fuel.add(newBlock)
+        with cs.unlock():
+            cs["splitZones"] = False
+            cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
+            cs["ringZones"] = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            diverseZone = "ring-4"
+            r.core.buildZones(cs)
+            daZones = r.core.zones
+            # lets make one of the assemblies have an extra block
+            zoneLocations = daZones.getZoneLocations(diverseZone)
+            originalAssemblies = r.core.getLocationContents(
+                zoneLocations, assemblyLevel=True
+            )
+            fuel = [a for a in originalAssemblies if a.hasFlags(Flags.FUEL)][0]
+            newBlock = copy.deepcopy(fuel[-1])
+            fuel.add(newBlock)
 
-        # should contain a zone for every ring zone
-        # we only want one ring zone for this test, containing assemblies of different types.
-        zoneTup = tuple(daZones.names)
-        for zoneName in zoneTup:
-            if zoneName != diverseZone:
-                daZones.removeZone(zoneName)
-        # this should split diverseZone into multiple zones by nodalization type.
-        cs["splitZones"] = True
-        zones.splitZones(r.core, cs, daZones)
-        cs.lock = True
+            # should contain a zone for every ring zone
+            # we only want one ring zone for this test, containing assemblies of different types.
+            zoneTup = tuple(daZones.names)
+            for zoneName in zoneTup:
+                if zoneName != diverseZone:
+                    daZones.removeZone(zoneName)
+            # this should split diverseZone into multiple zones by nodalization type.
+            cs["splitZones"] = True
+            zones.splitZones(r.core, cs, daZones)
+
         # test to make sure that we split the ring zone correctly
         self.assertEqual(len(daZones["ring-4-igniter-fuel-5"]), 4)
         self.assertEqual(len(daZones["ring-4-igniter-fuel-6"]), 1)
@@ -274,87 +272,87 @@ class Zones_InRZReactor(unittest.TestCase):
         # Test that if a hot zone can not be created from a single assembly zone.
         o, r = test_reactors.loadTestReactor()
         cs = o.cs
-        cs.lock = False
-        cs["splitZones"] = False
-        cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
-        cs["ringZones"] = [9]  # build one giant zone
-        r.core.buildZones(cs)
-        daZones = r.core.zones
+        with cs.unlock():
+            cs["splitZones"] = False
+            cs[globalSettings.CONF_ZONING_STRATEGY] = "byRingZone"
+            cs["ringZones"] = [9]  # build one giant zone
+            r.core.buildZones(cs)
+            daZones = r.core.zones
 
-        originalassemblies = []
-        originalPower = 0.0
-        peakZonePFRatios = []
+            originalassemblies = []
+            originalPower = 0.0
+            peakZonePFRatios = []
 
-        # Create a single assembly zone to verify that it will not create a hot zone
-        single = zones.Zone("single")
-        daZones.add(single)
-        aLoc = next(
-            a
-            for a in r.core.getAssemblies(Flags.FUEL)
-            if a.spatialLocator.getRingPos() == (1, 1)
-        ).getLocation()
-        single.append(aLoc)
+            # Create a single assembly zone to verify that it will not create a hot zone
+            single = zones.Zone("single")
+            daZones.add(single)
+            aLoc = next(
+                a
+                for a in r.core.getAssemblies(Flags.FUEL)
+                if a.spatialLocator.getRingPos() == (1, 1)
+            ).getLocation()
+            single.append(aLoc)
 
-        # Set power and flow.
-        # Also gather channel peak P/F ratios, assemblies and power.
-        for zone in daZones:
-            powerToFlow = []
-            zoneLocations = daZones.getZoneLocations(zone.name)
-            assems = r.core.getLocationContents(zoneLocations, assemblyLevel=True)
-            power = 300.0
-            flow = 300.0
-            for a in assems:
-                a.getFirstBlock().p.power = power
-                assemblyPower = a.calcTotalParam("power")
-                a[-1].p.THmassFlowRate = flow
-                powerToFlow.append(assemblyPower / a[-1].p.THmassFlowRate)
-                originalPower += assemblyPower
-                originalassemblies.append(a)
-                power += 1
-                flow -= 1
-            peakZonePFRatios.append(max(powerToFlow))
+            # Set power and flow.
+            # Also gather channel peak P/F ratios, assemblies and power.
+            for zone in daZones:
+                powerToFlow = []
+                zoneLocations = daZones.getZoneLocations(zone.name)
+                assems = r.core.getLocationContents(zoneLocations, assemblyLevel=True)
+                power = 300.0
+                flow = 300.0
+                for a in assems:
+                    a.getFirstBlock().p.power = power
+                    assemblyPower = a.calcTotalParam("power")
+                    a[-1].p.THmassFlowRate = flow
+                    powerToFlow.append(assemblyPower / a[-1].p.THmassFlowRate)
+                    originalPower += assemblyPower
+                    originalassemblies.append(a)
+                    power += 1
+                    flow -= 1
+                peakZonePFRatios.append(max(powerToFlow))
 
-        daZones = zones.createHotZones(r.core, daZones)
-        # Test that the hot zones have the peak P/F from the host channels
-        i = 0
-        for zone in daZones:
-            if zone.hotZone:
-                hotAssemLocation = daZones.getZoneLocations(zone.name)
-                hotAssem = r.core.getLocationContents(
-                    hotAssemLocation, assemblyLevel=True
-                )[0]
-                self.assertEqual(
-                    peakZonePFRatios[i],
-                    hotAssem.calcTotalParam("power") / hotAssem[-1].p.THmassFlowRate,
-                )
-                i += 1
+            daZones = zones.createHotZones(r.core, daZones)
+            # Test that the hot zones have the peak P/F from the host channels
+            i = 0
+            for zone in daZones:
+                if zone.hotZone:
+                    hotAssemLocation = daZones.getZoneLocations(zone.name)
+                    hotAssem = r.core.getLocationContents(
+                        hotAssemLocation, assemblyLevel=True
+                    )[0]
+                    self.assertEqual(
+                        peakZonePFRatios[i],
+                        hotAssem.calcTotalParam("power")
+                        / hotAssem[-1].p.THmassFlowRate,
+                    )
+                    i += 1
 
-        powerAfterHotZoning = 0.0
-        assembliesAfterHotZoning = []
+            powerAfterHotZoning = 0.0
+            assembliesAfterHotZoning = []
 
-        # Check that power is conserved and that we did not lose any assemblies
-        for zone in daZones:
-            locs = daZones.getZoneLocations(zone.name)
-            assems = r.core.getLocationContents(locs, assemblyLevel=True)
-            for a in assems:
-                assembliesAfterHotZoning.append(a)
-                powerAfterHotZoning += a.calcTotalParam("power")
-        self.assertEqual(powerAfterHotZoning, originalPower)
-        self.assertEqual(len(assembliesAfterHotZoning), len(originalassemblies))
+            # Check that power is conserved and that we did not lose any assemblies
+            for zone in daZones:
+                locs = daZones.getZoneLocations(zone.name)
+                assems = r.core.getLocationContents(locs, assemblyLevel=True)
+                for a in assems:
+                    assembliesAfterHotZoning.append(a)
+                    powerAfterHotZoning += a.calcTotalParam("power")
+            self.assertEqual(powerAfterHotZoning, originalPower)
+            self.assertEqual(len(assembliesAfterHotZoning), len(originalassemblies))
 
-        # check that the original zone with 1 channel has False for hotzone
-        self.assertEqual(single.hotZone, False)
-        # check that we have the correct number of hot and normal zones.
-        hotCount = 0
-        normalCount = 0
-        for zone in daZones:
-            if zone.hotZone:
-                hotCount += 1
-            else:
-                normalCount += 1
-        self.assertEqual(hotCount, 1)
-        self.assertEqual(normalCount, 2)
-        cs.lock = True
+            # check that the original zone with 1 channel has False for hotzone
+            self.assertEqual(single.hotZone, False)
+            # check that we have the correct number of hot and normal zones.
+            hotCount = 0
+            normalCount = 0
+            for zone in daZones:
+                if zone.hotZone:
+                    hotCount += 1
+                else:
+                    normalCount += 1
+            self.assertEqual(hotCount, 1)
+            self.assertEqual(normalCount, 2)
 
 
 if __name__ == "__main__":

--- a/armi/scripts/migration/m0_1_0_settings.py
+++ b/armi/scripts/migration/m0_1_0_settings.py
@@ -58,4 +58,6 @@ def _modify_settings(cs):
             "Converting deprecated Rx. Coeffs ``runType` setting to Snapshots. "
             "You may need to manually disable modules you don't want to run"
         )
+        cs.lock = False
         cs["runType"] = "Snapshots"
+        cs.lock = True

--- a/armi/scripts/migration/m0_1_0_settings.py
+++ b/armi/scripts/migration/m0_1_0_settings.py
@@ -58,6 +58,5 @@ def _modify_settings(cs):
             "Converting deprecated Rx. Coeffs ``runType` setting to Snapshots. "
             "You may need to manually disable modules you don't want to run"
         )
-        cs.lock = False
-        cs["runType"] = "Snapshots"
-        cs.lock = True
+        with cs.unlock():
+            cs["runType"] = "Snapshots"

--- a/armi/scripts/migration/m0_1_6_locationLabels.py
+++ b/armi/scripts/migration/m0_1_6_locationLabels.py
@@ -71,7 +71,9 @@ def _modify_settings(cs):
                 loc = newLoc
             newLocs.append(loc)
 
+        cs.lock = False
         cs["detailAssemLocationsBOL"] = newLocs
+        cs.lock = True
 
 
 def getIndicesFromDIF3DStyleLocatorLabel(label):

--- a/armi/scripts/migration/m0_1_6_locationLabels.py
+++ b/armi/scripts/migration/m0_1_6_locationLabels.py
@@ -71,9 +71,8 @@ def _modify_settings(cs):
                 loc = newLoc
             newLocs.append(loc)
 
-        cs.lock = False
-        cs["detailAssemLocationsBOL"] = newLocs
-        cs.lock = True
+        with cs.unlock():
+            cs["detailAssemLocationsBOL"] = newLocs
 
 
 def getIndicesFromDIF3DStyleLocatorLabel(label):

--- a/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
+++ b/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
@@ -13,7 +13,9 @@ class TestMigration(unittest.TestCase):
     def testLocationLabelMigration(self):
         """Make a setting with an old value and make sure it migrates to expected new value."""
         cs = caseSettings.Settings()
+        cs.lock = False
         cs["detailAssemLocationsBOL"] = ["B1012"]
+        cs.lock = True
         writer = SettingsWriter(cs)
         stream = io.StringIO()
         writer.writeYaml(stream)

--- a/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
+++ b/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
@@ -13,9 +13,9 @@ class TestMigration(unittest.TestCase):
     def testLocationLabelMigration(self):
         """Make a setting with an old value and make sure it migrates to expected new value."""
         cs = caseSettings.Settings()
-        cs.lock = False
-        cs["detailAssemLocationsBOL"] = ["B1012"]
-        cs.lock = True
+        with cs.unlock():
+            cs["detailAssemLocationsBOL"] = ["B1012"]
+
         writer = SettingsWriter(cs)
         stream = io.StringIO()
         writer.writeYaml(stream)

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -182,10 +182,16 @@ class Settings:
         return self.settings.keys()
 
     def update(self, values):
+        if self._lock:
+            runLog.warning(DEP_WARNING.format(sorted(values.keys())), single=True)
+
         for key, val in values.items():
             self[key] = val
 
     def clear(self):
+        if self._lock:
+            runLog.warning(DEP_WARNING.format("ALL"), single=True)
+
         self.settings.clear()
 
     def duplicate(self):

--- a/armi/settings/settingsRules.py
+++ b/armi/settings/settingsRules.py
@@ -193,7 +193,7 @@ def addToDumpSnapshots(cs, _name, _value):
     if not cs["dumpSnapshot"]:
         # Nothing was specified in standard cycle/node or dumpSnapshots.
         # Give old default of 0, 0.
-        cs.lock = False
-        cs["dumpSnapshot"] = ["000000"]
-        cs.lock = True
+        with cs.unlock():
+            cs["dumpSnapshot"] = ["000000"]
+
     return {}

--- a/armi/settings/settingsRules.py
+++ b/armi/settings/settingsRules.py
@@ -193,5 +193,7 @@ def addToDumpSnapshots(cs, _name, _value):
     if not cs["dumpSnapshot"]:
         # Nothing was specified in standard cycle/node or dumpSnapshots.
         # Give old default of 0, 0.
+        cs.lock = False
         cs["dumpSnapshot"] = ["000000"]
+        cs.lock = True
     return {}

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -164,7 +164,9 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
 
     def test_pluginValidatorsAreDiscovered(self):
         cs = caseSettings.Settings()
+        cs.lock = False
         cs["shuffleLogic"] = "nothere"
+        cs.lock = True
         inspector = settingsValidation.Inspector(cs)
         self.assertTrue(
             any(
@@ -180,6 +182,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         pm.register(DummyPlugin1)
         # We have a setting; this should be fine
         cs = caseSettings.Settings()
+        cs.lock = False
         self.assertEqual(cs["extendableOption"], "DEFAULT")
         # We shouldn't have any settings from the other plugin, so this should be an
         # error.
@@ -202,6 +205,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         cs = caseSettings.Settings()
         self.assertEqual(cs["extendableOption"], "PLUGIN")
         cs["extendableOption"] = "PLUGIN"
+        cs.lock = True
 
     def test_default(self):
         """Make sure default updating mechanism works."""
@@ -221,7 +225,9 @@ class TestSettingsConversion(unittest.TestCase):
 
     def test_empty(self):
         cs = caseSettings.Settings()
+        cs.lock = False
         cs["buGroups"] = []
+        cs.lock = True
         self.assertEqual(cs["buGroups"], [])
 
 

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -164,9 +164,9 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
 
     def test_pluginValidatorsAreDiscovered(self):
         cs = caseSettings.Settings()
-        cs.lock = False
-        cs["shuffleLogic"] = "nothere"
-        cs.lock = True
+        with cs.unlock():
+            cs["shuffleLogic"] = "nothere"
+
         inspector = settingsValidation.Inspector(cs)
         self.assertTrue(
             any(
@@ -182,30 +182,29 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         pm.register(DummyPlugin1)
         # We have a setting; this should be fine
         cs = caseSettings.Settings()
-        cs.lock = False
-        self.assertEqual(cs["extendableOption"], "DEFAULT")
-        # We shouldn't have any settings from the other plugin, so this should be an
-        # error.
-        with self.assertRaises(vol.error.MultipleInvalid):
+        with cs.unlock():
+            self.assertEqual(cs["extendableOption"], "DEFAULT")
+            # We shouldn't have any settings from the other plugin, so this should be an
+            # error.
+            with self.assertRaises(vol.error.MultipleInvalid):
+                cs["extendableOption"] = "PLUGIN"
+
+            pm.register(DummyPlugin2)
+            cs = caseSettings.Settings()
+            self.assertEqual(cs["extendableOption"], "PLUGIN")
+            # Now we should have the option from plugin 2; make sure that works
             cs["extendableOption"] = "PLUGIN"
+            self.assertIn("extendableOption", cs.keys())
+            pm.unregister(DummyPlugin2)
+            pm.unregister(DummyPlugin1)
 
-        pm.register(DummyPlugin2)
-        cs = caseSettings.Settings()
-        self.assertEqual(cs["extendableOption"], "PLUGIN")
-        # Now we should have the option from plugin 2; make sure that works
-        cs["extendableOption"] = "PLUGIN"
-        self.assertIn("extendableOption", cs.keys())
-        pm.unregister(DummyPlugin2)
-        pm.unregister(DummyPlugin1)
-
-        # Now try the same, but adding the plugins in a different order. This is to make
-        # sure that it doesnt matter if the Setting or its Options come first
-        pm.register(DummyPlugin2)
-        pm.register(DummyPlugin1)
-        cs = caseSettings.Settings()
-        self.assertEqual(cs["extendableOption"], "PLUGIN")
-        cs["extendableOption"] = "PLUGIN"
-        cs.lock = True
+            # Now try the same, but adding the plugins in a different order. This is to make
+            # sure that it doesnt matter if the Setting or its Options come first
+            pm.register(DummyPlugin2)
+            pm.register(DummyPlugin1)
+            cs = caseSettings.Settings()
+            self.assertEqual(cs["extendableOption"], "PLUGIN")
+            cs["extendableOption"] = "PLUGIN"
 
     def test_default(self):
         """Make sure default updating mechanism works."""
@@ -225,9 +224,9 @@ class TestSettingsConversion(unittest.TestCase):
 
     def test_empty(self):
         cs = caseSettings.Settings()
-        cs.lock = False
-        cs["buGroups"] = []
-        cs.lock = True
+        with cs.unlock():
+            cs["buGroups"] = []
+
         self.assertEqual(cs["buGroups"], [])
 
 

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -110,9 +110,8 @@ class SettingsWriterTests(unittest.TestCase):
             os.getcwd(), self._testMethodName + "test_setting_io.yaml"
         )
         self.cs = settings.Settings()
-        self.cs.lock = False
-        self.cs["nCycles"] = 55
-        self.cs.lock = True
+        with self.cs.unlock():
+            self.cs["nCycles"] = 55
 
     def tearDown(self):
         armi.Mode.setMode(self.init_mode)

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -110,7 +110,9 @@ class SettingsWriterTests(unittest.TestCase):
             os.getcwd(), self._testMethodName + "test_setting_io.yaml"
         )
         self.cs = settings.Settings()
+        self.cs.lock = False
         self.cs["nCycles"] = 55
+        self.cs.lock = True
 
     def tearDown(self):
         armi.Mode.setMode(self.init_mode)

--- a/armi/tests/test_fuelHandlers.py
+++ b/armi/tests/test_fuelHandlers.py
@@ -393,11 +393,10 @@ class TestFuelHandler(ArmiTestHelper):
         # reset core to BOL state
         # reset assembly counter to get the same assem nums.
         self.setUp()
-        self.o.cs.lock = False
-        self.o.cs["plotShuffleArrows"] = True
-        # now repeat shuffles
-        self.o.cs["explicitRepeatShuffles"] = "armiRun-SHUFFLES.txt"
-        self.o.cs.lock = True
+        with self.o.cs.unlock():
+            self.o.cs["plotShuffleArrows"] = True
+            # now repeat shuffles
+            self.o.cs["explicitRepeatShuffles"] = "armiRun-SHUFFLES.txt"
 
         fh = self.r.o.getInterface("fuelHandler")
 
@@ -470,9 +469,8 @@ class TestFuelHandler(ArmiTestHelper):
 
     def test_simpleAssemblyRotation(self):
         fh = fuelHandlers.FuelHandler(self.o)
-        self.o.cs.lock = False
-        self.o.cs["assemblyRotationStationary"] = True
-        self.o.cs.lock = True
+        with self.o.cs.unlock():
+            self.o.cs["assemblyRotationStationary"] = True
         hist = self.o.getInterface("history")
         assems = hist.o.r.core.getAssemblies(Flags.FUEL)[:5]
         addSomeDetailAssemblies(hist, assems)
@@ -485,9 +483,8 @@ class TestFuelHandler(ArmiTestHelper):
     def test_buReducingAssemblyRotation(self):
         fh = fuelHandlers.FuelHandler(self.o)
         hist = self.o.getInterface("history")
-        self.o.cs.lock = False
-        self.o.cs["assemblyRotationStationary"] = True
-        self.o.cs.lock = True
+        with self.o.cs.unlock():
+            self.o.cs["assemblyRotationStationary"] = True
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
         # apply dummy pin-level data to allow intelligent rotation
         for b in assem.getBlocks(Flags.FUEL):

--- a/armi/tests/test_fuelHandlers.py
+++ b/armi/tests/test_fuelHandlers.py
@@ -393,9 +393,11 @@ class TestFuelHandler(ArmiTestHelper):
         # reset core to BOL state
         # reset assembly counter to get the same assem nums.
         self.setUp()
+        self.o.cs.lock = False
         self.o.cs["plotShuffleArrows"] = True
         # now repeat shuffles
         self.o.cs["explicitRepeatShuffles"] = "armiRun-SHUFFLES.txt"
+        self.o.cs.lock = True
 
         fh = self.r.o.getInterface("fuelHandler")
 
@@ -468,7 +470,9 @@ class TestFuelHandler(ArmiTestHelper):
 
     def test_simpleAssemblyRotation(self):
         fh = fuelHandlers.FuelHandler(self.o)
+        self.o.cs.lock = False
         self.o.cs["assemblyRotationStationary"] = True
+        self.o.cs.lock = True
         hist = self.o.getInterface("history")
         assems = hist.o.r.core.getAssemblies(Flags.FUEL)[:5]
         addSomeDetailAssemblies(hist, assems)
@@ -481,7 +485,9 @@ class TestFuelHandler(ArmiTestHelper):
     def test_buReducingAssemblyRotation(self):
         fh = fuelHandlers.FuelHandler(self.o)
         hist = self.o.getInterface("history")
+        self.o.cs.lock = False
         self.o.cs["assemblyRotationStationary"] = True
+        self.o.cs.lock = True
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
         # apply dummy pin-level data to allow intelligent rotation
         for b in assem.getBlocks(Flags.FUEL):

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -35,9 +35,8 @@ class TestCodeInterface(unittest.TestCase):
         Tests notification of detail points.
         """
         cs = settings.Settings()
-        cs.lock = False
-        cs["dumpSnapshot"] = ["000001", "995190"]
-        cs.lock = True
+        with cs.unlock():
+            cs["dumpSnapshot"] = ["000001", "995190"]
         i = DummyInterface(None, cs)
 
         self.assertEqual(i.isRequestedDetailPoint(0, 1), True)

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -35,7 +35,9 @@ class TestCodeInterface(unittest.TestCase):
         Tests notification of detail points.
         """
         cs = settings.Settings()
+        cs.lock = False
         cs["dumpSnapshot"] = ["000001", "995190"]
+        cs.lock = True
         i = DummyInterface(None, cs)
 
         self.assertEqual(i.isRequestedDetailPoint(0, 1), True)


### PR DESCRIPTION
Here is my little experiment in response to terrapower#371.

There are a lot of decisions that went into this experiment that people might have a different opinion on. For instance, I fixed a TON of unit tests so they wouldn't throw the deprecation warning. Also, the `lock` I put in the `Settings` class is very simple. I can change these if people like, but I was focused on the experiment.

This experiment also shows us that `reactors.py` and `database3.py` will need to be slightly re-designed if we want settings to be immutable during a run.

This PR would serve as a good warning to people working on plugins that a big change is on it's way.