### PR TITLE
Remove unused SINCE_LAST_DB_TRANSMISSION on the parameter definitions 

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1145,7 +1145,7 @@ class Database3(database.Database):
             g = h5group[groupName]
 
         for paramDef in c.p.paramDefs.toWriteToDB(
-            parameters.SINCE_LAST_DB_TRANSMISSION
+            parameters.SINCE_ANYTHING | parameters.NEVER
         ):
             attrs = {}
 

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1144,9 +1144,7 @@ class Database3(database.Database):
         else:
             g = h5group[groupName]
 
-        for paramDef in c.p.paramDefs.toWriteToDB(
-            parameters.SINCE_ANYTHING | parameters.NEVER
-        ):
+        for paramDef in c.p.paramDefs.toWriteToDB():
             attrs = {}
 
             if hasattr(c, "DIMENSION_NAMES") and paramDef.name in c.DIMENSION_NAMES:

--- a/armi/reactor/parameters/__init__.py
+++ b/armi/reactor/parameters/__init__.py
@@ -200,7 +200,6 @@ from armi.reactor.parameters.parameterDefinitions import (
 
 from armi.reactor.parameters.parameterDefinitions import (
     SINCE_INITIALIZATION,
-    SINCE_LAST_DB_TRANSMISSION,
     SINCE_LAST_DISTRIBUTE_STATE,
     SINCE_LAST_GEOMETRY_TRANSFORMATION,
     SINCE_BACKUP,

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -45,13 +45,11 @@ from .exceptions import ParameterError, ParameterDefinitionError
 # In order for that to happen, the flags need to be cleared when the <time-description>
 # begins.
 SINCE_INITIALIZATION = 1
-SINCE_LAST_DB_TRANSMISSION = 2
 SINCE_LAST_DISTRIBUTE_STATE = 4
 SINCE_LAST_GEOMETRY_TRANSFORMATION = 8
 SINCE_BACKUP = 16
 SINCE_ANYTHING = (
     SINCE_LAST_DISTRIBUTE_STATE
-    | SINCE_LAST_DB_TRANSMISSION
     | SINCE_INITIALIZATION
     | SINCE_LAST_GEOMETRY_TRANSFORMATION
     | SINCE_BACKUP
@@ -531,7 +529,7 @@ class ParameterDefinitionCollection:
     def locked(self):
         return self._locked
 
-    def toWriteToDB(self, assignedMask):
+    def toWriteToDB(self, assignedMask: Optional[int] = None):
         """
         Get a list of acceptable parameters to store to the database for a level of the data model.
 
@@ -540,7 +538,8 @@ class ParameterDefinitionCollection:
         assignedMask : int
             a bitmask to down-filter which params to use based on how "stale" they are.
         """
-        return [p for p in self if p.saveToDB and p.assigned & assignedMask]
+        mask = assignMask or SINCE_ANYTHING
+        return [p for p in self if p.saveToDB and p.assigned & mask]
 
     def createBuilder(self, *args, **kwargs):
         """

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -538,7 +538,7 @@ class ParameterDefinitionCollection:
         assignedMask : int
             a bitmask to down-filter which params to use based on how "stale" they are.
         """
-        mask = assignMask or SINCE_ANYTHING
+        mask = assignedMask or SINCE_ANYTHING
         return [p for p in self if p.saveToDB and p.assigned & mask]
 
     def createBuilder(self, *args, **kwargs):


### PR DESCRIPTION
* Remove the SINCE_LAST_DB_TRANSMISSION since it was never unset when writing to the database.

* Update `toWriteToDB` to allow an implicit `None` to include writing all parameters that have been set `SINCE_ANYTHING`.