### PR TITLE
Add code to distribute parameter assigned state

### DIFF
--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -560,6 +560,7 @@ class DistributeStateAction(MpiAction):
         self.o.reattach(self.r, cs)  # sets r and cs
 
     def _distributeParamAssignments(self):
+        data = dict()
         if armi.MPI_RANK == 0:
             data = {
                 (pName, pdType.__name__): pDef.assigned

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -563,13 +563,16 @@ class DistributeStateAction(MpiAction):
         if armi.MPI_RANK == 0:
             data = {
                 (pName, pdType.__name__): pDef.assigned
-                for (pName, pdType), pDef in parameterDefinitions.ALL_DEFINITIONS.items()
+                for (
+                    pName,
+                    pdType,
+                ), pDef in parameterDefinitions.ALL_DEFINITIONS.items()
             }
 
         data = armi.MPI_COMM.bcast(data, root=0)
 
         if armi.MPI_RANK != 0:
-            for (pName, pdType), pDef  in parameterDefinitions.ALL_DEFINITIONS.items():
+            for (pName, pdType), pDef in parameterDefinitions.ALL_DEFINITIONS.items():
                 pDef.assigned = data[pName, pdType.__name__]
 
     def _distributeInterfaces(self):

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -483,7 +483,7 @@ class DistributeStateAction(MpiAction):
             # same.
             # XXX: this is an indication we need to revamp either how the operator attachment works
             # or how the interfaces are distributed.
-            self.r.core._markSynchronized()  # pylint: disable=protected-access
+            self.r._markSynchronized()  # pylint: disable=protected-access
 
         except (cPickle.PicklingError, TypeError) as error:
             runLog.error("Failed to transmit on distribute state root MPI bcast")

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2854,7 +2854,7 @@ class Composite(ArmiObject):
             number of parameters synchronized over all components
         """
         if armi.MPI_SIZE == 1:
-            return
+            return 0
 
         startTime = timeit.default_timer()
         # sync parameters...

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -429,6 +429,9 @@ class ParameterDefinitionCollection:
         pdc.extend(filter(filterFunc, self._paramDefs))
         return pdc
 
+    def items(self):
+        return self._paramDefDict.items()
+
     def extend(self, other):
         """
         Grow a parameter definition collection by another parameter definition collection

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -151,16 +151,12 @@ if armi.MPI_SIZE > 1:
                 self.assertEqual(self.cs, self.o.cs)
                 self.assertEqual(original_reactor, self.o.r)
                 self.assertEqual(original_interfaces, self.o.interfaces)
-                self.assertDictEqual(
-                    original_bolassems, self.o.r.blueprints.assemblies
-                )
+                self.assertDictEqual(original_bolassems, self.o.r.blueprints.assemblies)
                 self.assertEqual(original_lib, self.o.r.core.lib)
             else:
                 self.assertNotEqual(self.cs, self.o.cs)
                 self.assertNotEqual(original_reactor, self.o.r)
-                self.assertNotEqual(
-                    original_bolassems, self.o.r.blueprints.assemblies
-                )
+                self.assertNotEqual(original_bolassems, self.o.r.blueprints.assemblies)
                 self.assertEqual(original_interfaces, self.o.interfaces)
                 self.assertEqual(original_lib, self.o.r.core.lib)
 

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -114,7 +114,6 @@ if armi.MPI_SIZE > 1:
                         del original[key]
                     if key in current:
                         del current[key]
-                            type(current)))
                 for key, val in original.items():
                     self.assertEqual(original[key], current[key])
 


### PR DESCRIPTION
We were not explicitly communicating the state of parameter definitions' `.assigned` state, making behavior dependent on when parameters are set function strangely on higher-rank MPI nodes. This adds code to the DistributeStateAction that explicitly broadcasts this state to workers, so they have a consistent view of when parameters were set.

Specifically, this adds support for allowing worker nodes to create database files without skipping parameters because they think they have never been set.