### PR TITLE
Document new logging features

### DIFF
--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -371,6 +371,29 @@ class Test_LocationPacking(unittest.TestCase):
         self.assertEqual(unpackedData[1], (4.0, 5.0, 6.0))
         self.assertEqual(unpackedData[2], [(7, 8, 9), (10, 11, 12)])
 
+    def test_locationPackingOlderVerions(self):
+        # pylint: disable=protected-access
+        for version in [1, 2]:
+            loc1 = grids.IndexLocation(1, 2, 3, None)
+            loc2 = grids.CoordinateLocation(4.0, 5.0, 6.0, None)
+            loc3 = grids.MultiIndexLocation(None)
+            loc3.append(grids.IndexLocation(7, 8, 9, None))
+            loc3.append(grids.IndexLocation(10, 11, 12, None))
+
+            locs = [loc1, loc2, loc3]
+            tp, data = database3._packLocations(locs, minorVersion=version)
+
+            self.assertEqual(tp[0], "IndexLocation")
+            self.assertEqual(tp[1], "CoordinateLocation")
+            self.assertEqual(tp[2], "MultiIndexLocation")
+
+            unpackedData = database3._unpackLocations(tp, data, minorVersion=version)
+
+            self.assertEqual(unpackedData[0], (1, 2, 3))
+            self.assertEqual(unpackedData[1], (4.0, 5.0, 6.0))
+            self.assertEqual(unpackedData[2][0].tolist(), [7, 8, 9])
+            self.assertEqual(unpackedData[2][1].tolist(), [10, 11, 12])
+
 
 if __name__ == "__main__":
     # import sys;sys.argv = ["", "TestDatabase3.test_splitDatabase"]

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -16,22 +16,34 @@ r"""
 This module handles logging of console output (e.g. warnings, information, errors)
 during an armi run.
 
-The default way of using the ARMI runLog is:
+The default way of calling and the global armi logger is to just import it:
 
 .. code::
 
-    import armi.runLog as runLog
-    runLog.setVerbosity('debug')
-    runLog.info('information here')
-    runLog.error('extra error info here')
-    raise SomeException  # runLog.error() implies that the code will crash!
+    from armi import runLog
 
-You can interact with the logger in much the same way now by doing:
+You may want a logger specific to a single module, say to provide debug logging
+for only one module. That functionality is provided by a global override of
+logging imports:
 
 .. code::
 
     import logging
-    runLog = logging.getLogger('whatever')
+    runLog = logging.getLogger(__name__)
+
+In either case, you can then log things the same way:
+
+.. code::
+
+    runLog.info('information here')
+    runLog.error('extra error info here')
+    raise SomeException  # runLog.error() implies that the code will crash!
+
+Or change the log level the same way:
+
+.. code::
+
+    runLog.setVerbosity('debug')
 
 """
 from __future__ import print_function
@@ -87,10 +99,10 @@ class _RunLog:
         self.logger = None
         self.stderrLogger = None
 
-        self._setNullLoggers()
+        self.setNullLoggers()
         self._setLogLevels()
 
-    def _setNullLoggers(self):
+    def setNullLoggers(self):
         """Helper method to set both of our loggers to Null handlers"""
         self.logger = NullLogger("NULL")
         self.stderrLogger = NullLogger("NULL2", isStderr=True)
@@ -227,7 +239,7 @@ class _RunLog:
         """Return the global runLog verbosity."""
         return self._verbosity
 
-    def _restoreStandardStreams(self):
+    def restoreStandardStreams(self):
         """Set the system stderr back to its default (as it was when the run started)."""
         if self.initialErr is not None and self._mpiRank > 0:
             sys.stderr = self.initialErr
@@ -271,8 +283,8 @@ def close(mpiRank=None):
         if LOG.logger:
             _ = [h.close() for h in LOG.logger.handlers]
 
-    LOG._setNullLoggers()
-    LOG._restoreStandardStreams()
+    LOG.setNullLoggers()
+    LOG.restoreStandardStreams()
 
 
 def concatenateLogs(logDir=None):
@@ -548,6 +560,11 @@ class RunLogger(logging.Logger):
 
 
 class NullLogger(RunLogger):
+    """This is really just a placeholder for logging before or after the span of a normal armi run.
+    It will forward all logging to stdout/stderr, as you'd normally expect.
+    But it will preserve the formatting and duplication tools of the armi library.
+    """
+
     def __init__(self, name, isStderr=False):
         RunLogger.__init__(self, name)
         if isStderr:

--- a/armi/utils/tests/test_iterables.py
+++ b/armi/utils/tests/test_iterables.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 """
-
-
 unittests for iterables.py
 """
 import time
@@ -22,8 +20,13 @@ import unittest
 
 from armi.utils import iterables
 
+# CONSTANTS
+_TEST_DATA = {"turtle": [float(vv) for vv in range(-2000, 2000)]}
+
 
 class TestIterables(unittest.TestCase):
+    """Testing our custom Iterables"""
+
     def test_flatten(self):
         self.assertEqual(
             iterables.flatten([[1, 2, 3], [4, 5, 6], [7, 8], [9, 10]]),
@@ -65,23 +68,51 @@ class TestIterables(unittest.TestCase):
         unchu = iterables.flatten(chu)
         self.assertEqual(unchu, data)
 
-    testData = {"turtle": [float(vv) for vv in range(-2000, 2000)]}
-
     def test_packingAndUnpackingBinaryStrings(self):
         start = time.perf_counter()
-        packed = iterables.packBinaryStrings(self.testData)
+        packed = iterables.packBinaryStrings(_TEST_DATA)
         unpacked = iterables.unpackBinaryStrings(packed["turtle"][0])
         timeDelta = time.perf_counter() - start
-        self.assertEqual(self.testData["turtle"], unpacked)
+        self.assertEqual(_TEST_DATA["turtle"], unpacked)
         return timeDelta
 
     def test_packingAndUnpackingHexStrings(self):
         start = time.perf_counter()
-        packed = iterables.packHexStrings(self.testData)
+        packed = iterables.packHexStrings(_TEST_DATA)
         unpacked = iterables.unpackHexStrings(packed["turtle"][0])
         timeDelta = time.perf_counter() - start
-        self.assertEqual(self.testData["turtle"], unpacked)
+        self.assertEqual(_TEST_DATA["turtle"], unpacked)
         return timeDelta
+
+    def test_sequence(self):
+        # sequentially using methods in the usual way
+        s = iterables.Sequence(range(1000000))
+        s.drop(lambda i: i % 2 == 0)
+        s.select(lambda i: i < 20)
+        s.transform(lambda i: i * 10)
+        result = tuple(s)
+        self.assertEqual(result, (10, 30, 50, 70, 90, 110, 130, 150, 170, 190))
+
+        # stringing together the methods in a more modern Python way
+        s = iterables.Sequence(range(1000000))
+        result = tuple(
+            s.drop(lambda i: i % 2 == 0)
+            .select(lambda i: i < 20)
+            .transform(lambda i: i * 10)
+        )
+        self.assertEqual(result, (10, 30, 50, 70, 90, 110, 130, 150, 170, 190))
+
+        # call tuple() after a couple methods
+        s = iterables.Sequence(range(1000000))
+        s.drop(lambda i: i % 2 == 0)
+        s.select(lambda i: i < 20)
+        result = tuple(s)
+        self.assertEqual(result, (1, 3, 5, 7, 9, 11, 13, 15, 17, 19))
+
+        # you can't just call tuple() a second time, there is no data left
+        s.transform(lambda i: i * 10)
+        result = tuple(s)
+        self.assertEqual(result, ())
 
 
 if __name__ == "__main__":

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -32,3 +32,28 @@ bounds, such as those used to avoid bugs in the dependency, should be specified 
 ``requirements.txt``, rather than ``setup.py``. ARMI itself has several requirements
 files, located at the root of the project, which can be used as jumping-off points for
 more complex scenarios.
+
+Module-Level Logging
+^^^^^^^^^^^^^^^^^^^^
+In most of the modules in ``armi``, you will see logging using the ``runLog`` module.
+This is a custom, global logging object provided by the import:
+
+    from armi import runLog
+
+If you want a logger specific to a single module, say to provide debug logging for only
+one module, that functionality is provided by what might look like a bare Python logging
+import, but is actually calling the same underlying ``armi`` logging tooling:
+
+    import logging
+    runLog = logging.getLogger(__name__)
+
+In either case, you can then log using the same, easy interface:
+
+    runLog.info('information here')
+    runLog.error('extra error info here')
+
+Finally, you can change the logging level in either above scenario by doing:
+
+    runLog.setVerbosity(logging.DEBUG)
+    # or
+    runLog.setVerbosity('debug')


### PR DESCRIPTION
We have some new logging features that were already "documented" in the docstring of `runLog.py`, but that's not very visible. So this change also documents our logging abilities in the `/docs/` area as well.

(Also, I had a couple of extra unit tests lying around that I've been meaning to add, purely for coverage reasons. These aren't important or relevant, but every little bit helps.)