### PR TITLE
Fixing infinite loop in interpreter

### DIFF
--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -23,6 +23,7 @@ import enum
 import os
 import re
 from typing import Dict, Tuple, Set
+import sys
 import warnings
 import xml.etree.ElementTree as ET
 
@@ -625,6 +626,7 @@ def prompt(statement, question, *options):
         while response not in responses:
             runLog.LOG.log("prompt", statement)
             runLog.LOG.log("prompt", "{} ({}): ".format(question, ", ".join(responses)))
+            response = sys.stdin.readline().strip().upper()
 
         if response == "CANCEL":
             raise RunLogPromptCancel("Manual cancellation of interactive prompt")


### PR DESCRIPTION
This PR is in response to [this bug ticket](https://github.com/terrapower/armi/issues/381).

The explanation for the bug is simple: I somehow dropped a line while copy/pasting the `prompt()` function from one file to another.

What is less obvious is how we could build a unit test to catch this type of bug in the future.  We would either have to do some namespace hackery to override the `sys.stdin`, or pass an optional parameter to `prompt()` and the like that provides a different stream for unit-test-faked-user-input.

I want to get this bug fixed now-ish, so I am creating the PR without it. Still, it might be a good idea to build a ticket for expanding CLI unit testing power in the future.