### PR TITLE
Various updates to runLog outputs to the standard output

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -317,6 +317,15 @@ class Case:
         Room for improvement: The coverage, profiling, etc. stuff can probably be moved
         out of here to a more elegant place (like a context manager?).
         """
+        # Start the log here so that the verbosities for the head and workers
+        # can be configured based on the user settings for the rest of the
+        # run.
+        runLog.LOG.startLog(self.cs.caseTitle)
+        if armi.MPI_RANK == 0:
+            runLog.setVerbosity(self.cs["verbosity"])
+        else:
+            runLog.setVerbosity(self.cs["branchVerbosity"])
+
         cov = None
         if self.cs["coverage"]:
             cov = coverage.Coverage(
@@ -449,7 +458,7 @@ class Case:
                         )
                     )
 
-                if queryData:
+                if queryData and armi.MPI_RANK == 0:
                     runLog.header("=========== Settings Input Queries ===========")
                     runLog.info(
                         tabulate.tabulate(

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -96,6 +96,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         """
         self.r = None
         self.cs = cs
+        runLog.LOG.startLog(self.cs.caseTitle)
         self.timer = codeTiming.getMasterTimer()
         self.interfaces = []
         self.restartData = []

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -51,7 +51,6 @@ class OperatorMPI(Operator):
     """MPI-aware Operator."""
 
     def __init__(self, cs):
-        runLog.LOG.startLog(cs.caseTitle)
         try:
             Operator.__init__(self, cs)
         except:

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -67,11 +67,11 @@ class FuelHandlerInterface(interfaces.Interface):
     @staticmethod
     def specifyInputs(cs):
         files = {
-            cs.settings[label]: [
-                cs[label],
+            cs.settings[setting].label: [
+                cs[setting],
             ]
-            for label in ["shuffleLogic", "explicitRepeatShuffles"]
-            if cs[label]
+            for setting in ["shuffleLogic", "explicitRepeatShuffles"]
+            if cs[setting]
         }
         return files
 

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -67,11 +67,11 @@ class FuelHandlerInterface(interfaces.Interface):
     @staticmethod
     def specifyInputs(cs):
         files = {
-            cs.settings[setting].label: [
-                cs[setting],
+            cs.settings[settingName].label: [
+                cs[settingName],
             ]
-            for setting in ["shuffleLogic", "explicitRepeatShuffles"]
-            if cs[setting]
+            for settingName in ["shuffleLogic", "explicitRepeatShuffles"]
+            if cs[settingName]
         }
         return files
 

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -377,21 +377,38 @@ class LatticePhysicsInterface(interfaces.Interface):
             # changes that occurred during fuel management?
             missing = set(xsIDs) - set(self.r.core.lib.xsIDs)
             if missing and not executeXSGen:
-                runLog.warning(
-                    "Even though XS generation is not activated, new XS {0} are needed. "
-                    "Perhaps a booster came in.".format(missing)
+                runLog.info(
+                    f"Although a XS library {self.r.core._lib} exists on {self.r.core}, "
+                    f"there are missing XS IDs {missing} required. The XS generation on cycle {cycle} "
+                    f"is not enabled, but will be run to generate these missing cross sections."
                 )
+                executeXSGen = True
             elif missing:
-                runLog.important(
-                    "New XS sets {0} will be generated for this cycle".format(missing)
+                runLog.info(
+                    f"Although a XS library {self.r.core._lib} exists on {self.r.core}, "
+                    f"there are missing XS IDs {missing} required. These will be generated "
+                    f"on cycle {cycle}."
                 )
+                executeXSGen = True
             else:
-                runLog.important(
-                    "No new XS needed for this cycle. {0} exist. Skipping".format(
-                        self.r.core.lib.xsIDs
-                    )
+                runLog.info(
+                    f"A XS library {self.r.core._lib} exists on {self.r.core} and contains "
+                    f"the required XS data for XS IDs {self.r.core.lib.xsIDs}. The generation "
+                    "of XS will be skipped."
                 )
-                executeXSGen = False  # no newXs
+                executeXSGen = False
+
+        if executeXSGen:
+            runLog.info(
+                f"Cross sections will be generated on cycle {cycle} for the "
+                f"following XS IDs: {xsIDs}"
+            )
+        else:
+            runLog.info(
+                f"Cross sections will not be generated on cycle {cycle}. The "
+                f"setting `genXS` is {self.cs['genXS']} and `skipCycles` "
+                f"is {self.cs['skipCycles']}"
+            )
 
         return executeXSGen
 

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -555,7 +555,7 @@ def defineSettings() -> List[setting.Setting]:
         setting.Setting(
             CONF_EXPLICIT_REPEAT_SHUFFLES,
             default="",
-            label="Browse for shuffle history to repeat",
+            label="Explicit Shuffles File",
             description="Path to file that contains a detailed shuffling history that "
             "is to be repeated exactly.",
             oldNames=[("movesFile", None), ("shuffleFileName", None)],

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -62,6 +62,8 @@ def copyOrWarn(fileDescription, sourcePath, destinationPath):
         runLog.debug(
             "Copied {}: {} -> {}".format(fileDescription, sourcePath, destinationPath)
         )
+    except shutil.SameFileError:
+        pass
     except Exception as e:
         runLog.warning(
             "Could not copy {} from {} to {}\nError was: {}".format(


### PR DESCRIPTION
* Add start of runLog to the case.py so that the verbosity can be set when a run begins versus waiting until an operator is created.

* Update to the `specifyInputs` labels in fuel handlers so that the stdout has the correct labels for shuffle logic and explicit shuffles files.

* Add more runLog messages around checking if the lattice physics interface will create XS for the current cycle. This helps a user to debug what is going on.

* Add check for `SameFileError` exception during the `copyOrWarn` path tools function. This skips providing a user warning if a file is being copied to the same path and just lets it happen silently.