### PR TITLE
 Cleanup empty logs from third party libraries

### DIFF
--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -58,6 +58,9 @@ class TestRunLog(unittest.TestCase):
         with self.assertRaises(KeyError):
             runLog.setVerbosity("taco")
 
+        with self.assertRaises(TypeError):
+            runLog.setVerbosity(["debug"])
+
     def test_parentRunLogging(self):
         """A basic test of the logging of the parent runLog"""
         # init the _RunLog object
@@ -75,6 +78,8 @@ class TestRunLog(unittest.TestCase):
         log.log("debug", "You shouldn't see this.", single=False, label=None)
         log.log("warning", "Hello, ", single=False, label=None)
         log.log("error", "world!", single=False, label=None)
+        log.logger.flush()
+        log.logger.close()
         runLog.close(99)
 
         # test what was logged


### PR DESCRIPTION
This is in response to: #373

I decided to fix the problem (of lots of empty third-party logs) in two directions:

    Added the delay=True to all of our custom logging.FileHandlers, to make our log file creation more lazy.
    Removed all the empty log files that still exist at the end of a run.

Doing (1) meant doing some re-org of our concatLogs() function, but that's fine.