### PR TITLE
Fixing issue with multiple startLog calls.

### DIFF
--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -247,8 +247,7 @@ class _RunLog:
 
     def startLog(self, name):
         """Initialize the streams when parallel processing"""
-        # close the old logger and open a new one
-        self.logger.close()
+        # open the main logger
         self.logger = logging.getLogger(STDOUT_LOGGER_NAME + SEP + str(self._mpiRank))
 
         # if there was a pre-existing _verbosity, use it now
@@ -256,9 +255,6 @@ class _RunLog:
             self.setVerbosity(self._verbosity)
 
         if self._mpiRank != 0:
-            # grab any old error logging lying aroudn and close it
-            self.stderrLogger.close()
-
             # init stderr intercepting logging
             filePath = os.path.join(
                 context.LOG_DIR, _RunLog.STDERR_NAME.format(name, self._mpiRank)

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -242,6 +242,16 @@ class TestRunLog(unittest.TestCase):
             self.assertIn("hi3", mock._outputStream)
             mock._outputStream = ""
 
+            # call startLog() again, with a duplicate logger name
+            runLog.LOG.startLog("test_callingStartLogMultipleTimes3")
+            runLog.LOG.setVerbosity(logging.INFO)
+
+            # we should start at info level, and that should be working correctly
+            self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
+            runLog.info("hi333")
+            self.assertIn("hi333", mock._outputStream)
+            mock._outputStream = ""
+
     def test_concatenateLogs(self):
         """simple test of the concat logs function"""
         # create the log dir


### PR DESCRIPTION
The issue here is that calling startLog() multiple times interacts with the logging module in several fun ways. Our solution is to
revert the earlier attempt to simplify the process and just let the logging module handle it.