### PR TITLE
Fixes to XS pre-generated file copying and ACLP dose evaluations for fixed source calculations

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -736,16 +736,12 @@ class CrossSectionGroupManager(interfaces.Interface):
 
         for xsFileLocation, xsFileName in self._getPregeneratedXsFileLocationData(xsID):
             dest = os.path.join(os.getcwd(), xsFileName)
-            # Optimization to reduce the number of times the files are copied over
-            if not os.path.exists(dest):
-                runLog.extra(
-                    "Copying pre-generated XS file {} from {} for XS ID {}".format(
-                        xsFileName, os.path.dirname(xsFileLocation), xsID
-                    )
+            runLog.extra(
+                "Copying pre-generated XS file {} from {} for XS ID {}".format(
+                    xsFileName, os.path.dirname(xsFileLocation), xsID
                 )
-                shutil.copy(xsFileLocation, dest)
-            else:
-                runLog.extra("Using existing pre-generated XS file: {}".format(dest))
+            )
+            shutil.copy(xsFileLocation, dest)
 
     def _getPregeneratedXsFileLocationData(self, xsID):
         """

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -744,6 +744,9 @@ class DoseResultsMapper(GlobalFluxResultMapper):
                     peakDoseAssem = a
             self.r.core.p.maxDetailedDpaThisCycle = maxDetailedDpaThisCycle
 
+            if peakDoseAssem is None:
+                return
+
             doseHalfMaxHeights = peakDoseAssem.getElevationsMatchingParamValue(
                 "detailedDpaThisCycle", maxDetailedDpaThisCycle / 2.0
             )


### PR DESCRIPTION
* Remove the file transfer optimization with the pre-generated cross section files. This could lead to a bug with cached/stale ISOTXS files in the working directory for a user.

* Skip calculation of the ACLP doses if the `detailedDpaThisCycle` block parameter was not calculated from the global flux analysis. This can be true for non-eigenvalue calculations.