### PR TITLE
Converting snake_case to camelCase

### DIFF
--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -522,7 +522,7 @@ def _filterOutsideDomain(gridBp):
         del gridBp.gridContents[idx]
 
 
-def save_to_stream(stream, bluep, grid, full=False):
+def saveToStream(stream, bluep, grid, full=False):
     """Save the blueprints to the passed stream.
 
     This can save either the entire blueprints, or just the `grids:` section of the

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -23,7 +23,7 @@ if not isConfigured():
     configure()
 from armi.reactor import systemLayoutInput
 from armi.reactor.blueprints import Blueprints
-from armi.reactor.blueprints.gridBlueprint import Grids, save_to_stream
+from armi.reactor.blueprints.gridBlueprint import Grids, saveToStream
 from armi.reactor.blueprints.tests.test_blockBlueprints import FULL_BP, FULL_BP_GRID
 
 
@@ -313,7 +313,7 @@ class TestGridBlueprintsSection(unittest.TestCase):
         bp = Blueprints.load(FULL_BP)
         filePath = "TestGridBlueprintsSection__test_simpleReadLatticeMap.log"
         with open(filePath, "w") as stream:
-            save_to_stream(stream, bp, grid, True)
+            saveToStream(stream, bp, grid, True)
 
         # test that the output looks valid, and includes a lattice map
         with open(filePath, "r") as f:
@@ -348,7 +348,7 @@ class TestGridBlueprintsSection(unittest.TestCase):
         bp = Blueprints.load(FULL_BP_GRID)
         filePath = "TestGridBlueprintsSection__test_simpleReadNoLatticeMap.log"
         with open(filePath, "w") as stream:
-            save_to_stream(stream, bp, grid, True)
+            saveToStream(stream, bp, grid, True)
 
         # test that the output looks valid, and includes a lattice map
         with open(filePath, "r") as f:

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -62,7 +62,7 @@ from armi.reactor import blueprints
 from armi.reactor.flags import Flags
 import armi.reactor.blueprints
 from armi.reactor.blueprints import Blueprints, gridBlueprint, migrate
-from armi.reactor.blueprints.gridBlueprint import GridBlueprint, save_to_stream
+from armi.reactor.blueprints.gridBlueprint import GridBlueprint, saveToStream
 from armi.reactor.blueprints.assemblyBlueprint import AssemblyBlueprint
 from armi.settings.fwSettings import globalSettings
 
@@ -1360,11 +1360,11 @@ class GridBlueprintControl(wx.Panel):
         blueprints can be useful when cobbling blueprints together with !include flags.
         """
         if stream is None:
-            self._save_no_stream(full)
+            self._saveNoStream(full)
         else:
-            save_to_stream(stream, self.bp, self.grid, full)
+            saveToStream(stream, self.bp, self.grid, full)
 
-    def _save_no_stream(self, full=False):
+    def _saveNoStream(self, full=False):
         """Prompt for a file to save to.
 
         This can save either the entire blueprints, or just the `grids:` section of the
@@ -1428,7 +1428,7 @@ class GridBlueprintControl(wx.Panel):
         # way to don't destroy anything unless we know we have something with which
         # to replace it.
         bpStream = io.StringIO()
-        save_to_stream(bpStream, self.bp, self.grid, full)
+        saveToStream(bpStream, self.bp, self.grid, full)
         with open(path, "w") as stream:
             stream.write(bpStream.getvalue())
 


### PR DESCRIPTION
This PR changes the names of two functions:

* `save_to_stream` becomes `saveToStream`
* `_save_no_stream` becomes `_saveNoStream`

I ran all unit tests and they pass.