### PR TITLE
Deploying Docs to GitHub Pages using GitHub Actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,35 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Update package index
+        run: sudo apt-get update
+      - name: Install mpi libs
+        run: sudo apt-get -y install libopenmpi-dev
+      - name: Install Pandoc
+        run: sudo apt-get -y install pandoc
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Make HTML Docs
+        run: tox -e doc
+        continue-on-error: true
+      - name: Deploy Docs
+        uses: uibcdf/action-sphinx-docs-to-gh-pages@v1.0-beta.2
+        with:
+          branch: master
+          dir_docs: doc
+          sphinxopts: ''

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 dist-*/
 doc/*.png
 doc/_build
+doc/user/tutorials
 doc/tutorials/anl-afci-177*
 doc/tutorials/case-suite
 armi/tests/tutorials/case-suite

--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -1,0 +1,10 @@
+# these are most specified that usual, because Sphinx docs seem to be quite fragile
+Sphinx==2.2.0
+nbsphinx==0.8.7
+nbsphinx-link==1.3.0
+sphinx-gallery==0.9.0
+sphinx-rtd-theme==0.5.2
+sphinxcontrib-apidoc==0.3.0
+sphinxext-opengraph==0.4.2
+pandoc==1.1.0
+ipykernel==6.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist = py37,lint,cov
 # need pip at least with --prefer-binary
-requires = 
+requires =
 	pip >= 20.2
-	
+
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}
 deps=
@@ -14,6 +14,14 @@ setenv =
     USERNAME = armi
 commands =
     pytest --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
+
+[testenv:doc]
+whitelist_externals = /usr/bin/make
+deps=
+    -r{toxinidir}/doc/requirements-docs.txt
+changedir = doc
+commands =
+    make html
 
 [testenv:cov]
 deps=


### PR DESCRIPTION
Adding a GitHub Actions YAML file to start a Workflow that builds the ARMI docs and deploys them to the `gh-pages` branch in the repo. That branch will be used to auto-deploy the latest docs to GitHub Pages, every time a change is made the `master` branch.

To aid in this goal, there is also a new `tox` command to build the ARMI docs:

    tox -e doc

In order, the process to get these docs auto-deploying is:

1. Remove the `/armi/` folder from `terrrapower.github.io`
2. Get the `gh-pages` branch auto build happening in the ARMI repo (this PR)
3. In the `terrapower/armi` repo, go into **Settings** >> **Pages** >> **Source** and set branch to "gh-pages" and folder as "/root".