### PR TITLE
Using GitHub Actions to Auto-Deploy Docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,37 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Update package index
+        run: sudo apt-get update
+      - name: Install mpi libs
+        run: sudo apt-get -y install libopenmpi-dev
+      - name: Install Pandoc
+        run: sudo apt-get -y install pandoc
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Make HTML Docs
+        run: tox -e doc
+        continue-on-error: true
+      - name: deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          repository-name: ${{ github.actor }}/terrapower.github.io
+          branch: master
+          folder: doc/_build/html
+          target-folder: armi

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
-          repository-name: ${{ github.actor }}/terrapower.github.io
+          repository-name: ${{ github.repository_owner }}/terrapower.github.io
           branch: master
           folder: doc/_build/html
           target-folder: armi

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 dist-*/
 doc/*.png
 doc/_build
+doc/user/tutorials
 doc/tutorials/anl-afci-177*
 doc/tutorials/case-suite
 armi/tests/tutorials/case-suite

--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -1,0 +1,10 @@
+# these are most specified that usual, because Sphinx docs seem to be quite fragile
+Sphinx==2.2.0
+nbsphinx==0.8.7
+nbsphinx-link==1.3.0
+sphinx-gallery==0.9.0
+sphinx-rtd-theme==0.5.2
+sphinxcontrib-apidoc==0.3.0
+sphinxext-opengraph==0.4.2
+pandoc==1.1.0
+ipykernel==6.0.1

--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -6,10 +6,10 @@ This section will guide you through installing the ARMI Framework on your machin
 Prerequisites
 -------------
 These instructions target users with some software development knowledge. In
-particular, we assume familiarity with `Python <https://www.python.org/>`_, 
-`virtual environments <https://docs.python.org/3/tutorial/venv.html>`_, and `Git <https://git-scm.com/>`_. 
+particular, we assume familiarity with `Python <https://www.python.org/>`_,
+`virtual environments <https://docs.python.org/3/tutorial/venv.html>`_, and `Git <https://git-scm.com/>`_.
 
-You must have the following before proceeding:
+You must have the following installed before proceeding:
 
 * `Python <https://www.python.org/downloads/>`_ version 3.6 or later (preferably 64-bit)
 
@@ -36,8 +36,8 @@ This prevents dependencies from various tools conflicting with one another. ARMI
 of requirements and may conflict with other libraries on your system unless you do this
 step.
 
-Start a terminal and navigate to the directory you'd like to install ARMI into. 
-To create a new virtual environment, use a command like:: 
+Start a terminal and navigate to the directory you'd like to install ARMI into.
+To create a new virtual environment, use a command like::
 
     $ python -m venv armi-venv
 
@@ -50,12 +50,12 @@ To activate the environment, invoke the appropriate script. On Windows::
 Or on Linux::
 
     $ source armi-venv/bin/activate
-    
-.. note:: You'll have to activate the venv every time you open a new command line. 
+
+.. note:: You'll have to activate the venv every time you open a new command line.
 	Many people set up scripts to activate this automatically.
-	
+
 If you will be running ARMI in parallel over MPI, you must also install the ``mpi4py`` Python
-library. On Linux, doing so will require some MPI development libraries 
+library. On Linux, doing so will require some MPI development libraries
 (e.g. ``sudo apt install libopenmpi-dev``).
 
 Getting the code
@@ -91,11 +91,11 @@ Then, install ARMI into your venv with::
 
 	(armi-venv) $ pip install -e .
 
-.. tip:: If you don't want to install ARMI into your venv, you will need to add the ARMI source 
+.. tip:: If you don't want to install ARMI into your venv, you will need to add the ARMI source
 	location to your system's ``PYTHONPATH`` environment variable so that
 	Python will be able to find the code when you import it from other directories.
-	
-	In Windows, click *Start* and type ``Edit Environmental Variable`` to adjust ``PYTHONPATH``. 
+
+	In Windows, click *Start* and type ``Edit Environmental Variable`` to adjust ``PYTHONPATH``.
 	In Linux, add ``export PYTHONPATH=/path/to/armi/source`` in a  user profile script (like ``.bashrc``).
 
 
@@ -105,8 +105,8 @@ Check the installation status by running::
 
     (armi-venv) $ armi
 
-or, equivalently:: 
-    
+or, equivalently::
+
     (armi-venv) $ python -m armi
 
 If it worked, you should see the ARMI splash screen and no errors::
@@ -137,13 +137,13 @@ In many cases, a ``pip install`` should suffice::
 
     (armi-venv) $ pip install wxpython
 
-.. warning:: On some platforms, ``pip`` may try to compile wxpython from 
+.. warning:: On some platforms, ``pip`` may try to compile wxpython from
     source which can take a long time and require additional dependencies.
 
 GUI output
 ^^^^^^^^^^
 ARMI can write VTK and XDMF output files which can be viewed in tools such as
-`ParaView <https://www.paraview.org/>`_ and 
+`ParaView <https://www.paraview.org/>`_ and
 `VisIT <https://wci.llnl.gov/simulation/computer-codes/visit>`_. Download and install those
 tools from their websites.
 
@@ -151,12 +151,12 @@ RIPL-3 Nuclide Decay Database
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The RIPL-3 decay files (``levels.zip``) can be downloaded from `<https://www-nds.iaea.org/RIPL-3/levels/>`_.
 
-By default, nuclides within :py:mod:`armi.nucDirectory.nuclideBases` are initialized from 
-a subset of the RIPL-3 database, which ships with ARMI. The base data set contains 2339 
-nuclides and RIPL-3 decay data set increases this to 4379 nuclides. The RIPL-3 decay data 
-files mainly add metastable nuclides and other exotic nuclides that could be important for 
+By default, nuclides within :py:mod:`armi.nucDirectory.nuclideBases` are initialized from
+a subset of the RIPL-3 database, which ships with ARMI. The base data set contains 2339
+nuclides and RIPL-3 decay data set increases this to 4379 nuclides. The RIPL-3 decay data
+files mainly add metastable nuclides and other exotic nuclides that could be important for
 detailed depletion/decay models or activation analyses.
 
-Once the ``levels.zip`` file is downloaded and unzipped, an environment variable :envvar:`ARMI_RIPL_PATH` 
+Once the ``levels.zip`` file is downloaded and unzipped, an environment variable :envvar:`ARMI_RIPL_PATH`
 should be created and set to the directory containing the ``z*.dat`` files.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist = py37,lint,cov
 # need pip at least with --prefer-binary
-requires = 
+requires =
 	pip >= 20.2
-	
+
 [testenv]
 basepython = {env:PYTHON3_PATH:python3}
 deps=
@@ -14,6 +14,14 @@ setenv =
     USERNAME = armi
 commands =
     pytest --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
+
+[testenv:doc]
+whitelist_externals = /usr/bin/make
+deps=
+    -r{toxinidir}/doc/requirements-docs.txt
+changedir = doc
+commands =
+    make html
 
 [testenv:cov]
 deps=


### PR DESCRIPTION
The point of this PR is to ensure that we are always auto-deploying the latest docs to our public website.  And GitHub Pages makes this doable. Please see the new `docs.yaml` to see how I did this.

I also added a new `tox -e docs` that people can use to build the docs, and ensure that they have the right version of Sphinx and everything else to make that happen.  (Because Sphinx has some versioning issues.)

The bottom line is the docs now _build_ and _work_. Though they still throw a bunch of warnings and even a couple errors, but I figure we make it work first, then clean it up.

Please note that I tested if this auto-deploy works a bunch of times, and it seems to. In particular, I added the word "installed" and "TESTING" to `doc/user/user_install.rst`, and it auto-deployed a bunch of times correctly for my repos. See the example [here](https://antineutrino.net/terrapower.github.io/armi/installation.html).


