### PR TITLE
Protecting against calls to wiping entire directories

### DIFF
--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -184,16 +184,16 @@ class MainInterface(interfaces.Interface):
             cycle = int(snapText[0:3])
             node = int(snapText[3:])
             newFolder = "snapShot{0}_{1}".format(cycle, node)
-            utils.cleanPath(newFolder)
+            utils.pathTools.cleanPath(newFolder)
 
         # delete database if it's SQLlite
         # no need to delete because the database won't have copied it back if using fastpath.
 
         # clean temp directories.
         if os.path.exists("shuffleBranches"):
-            utils.cleanPath("shuffleBranches")
+            utils.pathTools.cleanPath("shuffleBranches")
         if os.path.exists("failedRuns"):
-            utils.cleanPath("failedRuns")
+            utils.pathTools.cleanPath("failedRuns")
 
     # pylint: disable=no-self-use
     def cleanLastCycleFiles(self):

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -16,7 +16,7 @@ r"""
 The ``CaseSuite`` object is responsible for running, and executing a set of user inputs.  Many
 entry points redirect into ``CaseSuite`` methods, such as ``clone``, ``compare``, and ``submit``
 
-Used in conjunction with the :py:class:`~armi.cases.case.Case` object, ``CaseSuite`` can 
+Used in conjunction with the :py:class:`~armi.cases.case.Case` object, ``CaseSuite`` can
 be used to collect a series of cases
 and submit them to a cluster for execution. Furthermore, a ``CaseSuite`` can be used to gather
 executed cases for post-analysis.
@@ -183,7 +183,7 @@ class CaseSuite:
             else:
                 newDir = case.title
             with directoryChangers.ForcedCreationDirectoryChanger(
-                newDir, clean=True, dumpOnException=False
+                newDir, dumpOnException=False
             ):
                 clone.add(case.clone(modifiedSettings=modifiedSettings))
         return clone

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -167,11 +167,11 @@ class SuiteBuilder:
                     )
 
                 previousMods.append(type(mod))
-                mod(case.cs, case.bp, case.geom)
+                with case.cs._unlock():
+                    mod(case.cs, case.bp, case.geom)
                 case.independentVariables.update(mod.independentVariable)
 
             case.cs.path = namingFunc(index, case, modList)
-
             caseSuite.add(case)
 
         return caseSuite

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -129,6 +129,11 @@ class TestCaseSuiteDependencies(unittest.TestCase):
         self.c2.cs.path = "c2.yaml"
         self.suite.add(self.c2)
 
+    def test_clone(self):
+        # if you pass an invalid path, the clone can't happen, but it won't do any damage either
+        with self.assertRaises(RuntimeError):
+            clone = self.suite.clone("test_clone")
+
     def test_dependenciesWithObscurePaths(self):
         """
         Test directory dependence.

--- a/armi/context.py
+++ b/armi/context.py
@@ -218,9 +218,9 @@ def cleanTempDirs(olderThanDays=None):
         If provided, deletes other ARMI directories if they are older than the requested
         time.
     """
-    from armi import (
-        runLog,
-    )  # pylint: disable=import-outside-toplevel # avoid cyclic import
+    # pylint: disable=import-outside-toplevel # avoid cyclic import
+    from armi import runLog
+    from armi.utils.pathTools import cleanPath
 
     disconnectAllHdfDBs()
     printMsg = runLog.getVerbosity() <= DEBUG
@@ -231,7 +231,7 @@ def cleanTempDirs(olderThanDays=None):
                 file=sys.stdout,
             )
         try:
-            shutil.rmtree(_FAST_PATH)
+            cleanPath(_FAST_PATH)
         except Exception as error:  # pylint: disable=broad-except
             for outputStream in (sys.stderr, sys.stdout):
                 if printMsg:
@@ -254,6 +254,9 @@ def cleanAllArmiTempDirs(olderThanDays: int):
 
     This is a useful utility in HPC environments when some runs crash sometimes.
     """
+    # pylint: disable=import-outside-toplevel # avoid cyclic import
+    from armi.utils.pathTools import cleanPath
+
     gracePeriod = datetime.timedelta(days=olderThanDays)
     now = datetime.datetime.now()
     thisRunFolder = os.path.basename(_FAST_PATH)
@@ -269,7 +272,7 @@ def cleanAllArmiTempDirs(olderThanDays: int):
             runIsOldAndLikleyComplete = (now - dateOfFolder) > gracePeriod
             if runIsOldAndLikleyComplete or fromThisRun:
                 # Delete old files
-                shutil.rmtree(dirPath)
+                cleanPath(dirPath)
         except:  # pylint: disable=bare-except
             pass
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -918,7 +918,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         newFolder = "snapShot{0}_{1}".format(cycle, node)
         if os.path.exists(newFolder):
             runLog.important("Deleting existing snapshot data in {0}".format(newFolder))
-            utils.cleanPath(newFolder)  # careful with cleanPath!
+            utils.pathTools.cleanPath(newFolder)  # careful with cleanPath!
             # give it a minute.
             time.sleep(1)
 

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -188,76 +188,6 @@ def findClosest(listToSearch, val, indx=False):
         return minVal
 
 
-# TODO: move into pathTools
-def cleanPath(path):
-    r"""
-    Recursively delete a path.
-
-    !!! careful with this !!! It can delete the entire cluster.
-
-    We add copious os.path.exists checks in case an MPI set of things is trying to delete everything at the same time.
-    Always check filenames for some special flag when calling this, especially
-    with full permissions on the cluster. You could accidentally delete everyone's work
-    with one misplaced line! This doesn't ask questions.
-
-    Safety nets include a whitelist of paths.
-
-    This makes use of shutil.rmtree and os.remove
-
-    Returns
-    -------
-    success : bool
-        True if file was deleted. False if it was not.
-
-    """
-    valid = False
-    if os.path.exists(path):
-        runLog.extra("Clearing all files in {}".format(path))
-    else:
-        runLog.extra("Nothing to clean in {}. Doing nothing. ".format(path))
-        return True
-    for validPath in [
-        "users",
-        "shufflebranches",
-        "snapshot",
-        "failedruns",
-        "armiruns",
-        "mc2run",
-        "tests",
-        "mongoose",
-    ]:
-        if validPath in path.lower():
-            valid = True
-
-    if not valid:
-        raise Exception(
-            "Thou shalt not try to delete folders other than things in Users. Thou tried to delete {0}"
-            "".format(path)
-        )
-
-    for i in range(3):
-        try:
-            if os.path.exists(path) and os.path.isdir(path):
-                shutil.rmtree(path)
-            elif not os.path.isdir(path):
-                # it's just a file. Delete it.
-                os.remove(path)
-        except:
-            if i == 2:
-                pass
-            # in case the OS is behind or something
-            time.sleep(0.1)
-        time.sleep(0.3)
-        if not os.path.exists(path):
-            break
-        time.sleep(0.3)
-
-    if os.path.exists(path):
-        return False
-    else:
-        return True
-
-
 def copyWithoutBlocking(src, dest):
     """
     Copy a file in a separate thread to avoid blocking while IO completes.
@@ -792,7 +722,8 @@ def mkdir(dirname):
         try:
             os.mkdir(dirname)
             break
-
+        except FileExistsError:
+            break
         except Exception as err:
             numTimesTried += 1
             # Only ouput err every 10 times.

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -193,9 +193,22 @@ class TemporaryDirectoryChanger(DirectoryChanger):
         DirectoryChanger.__init__(
             self, root, filesToMove, filesToRetrieve, dumpOnException
         )
-        root = root or armi.context.getFastPath()
+
+        # if no root dir is given, enforce that this tmp dir is in /.armi/
+        if not root:
+            root = armi.context.getFastPath()
+            if ".armi" not in os.path.normpath(root).split(os.path.sep):
+                raise ValueError("Temporary directory not found.")
+
+        # make the tmp dir, if necessary
         if not os.path.exists(root):
-            os.makedirs(root)
+            try:
+                os.makedirs(root)
+            except FileExistsError:
+                # ignore the obvious race condition
+                pass
+
+        # init the important path attributes
         self.initial = os.path.abspath(os.getcwd())
         self.destination = TemporaryDirectoryChanger.GetRandomDirectory(root)
         while os.path.exists(self.destination):
@@ -217,17 +230,12 @@ class TemporaryDirectoryChanger(DirectoryChanger):
 
     def __exit__(self, exc_type, exc_value, traceback):
         DirectoryChanger.__exit__(self, exc_type, exc_value, traceback)
-        shutil.rmtree(self.destination)
+        pathTools.cleanPath(self.destination)
 
 
 class ForcedCreationDirectoryChanger(DirectoryChanger):
     """
     Creates the directory tree necessary to reach your desired destination
-
-    Attributes
-    ----------
-    clean : bool
-        if True and the directory exists, clear all contents on entry.
     """
 
     def __init__(
@@ -236,14 +244,12 @@ class ForcedCreationDirectoryChanger(DirectoryChanger):
         filesToMove=None,
         filesToRetrieve=None,
         dumpOnException=True,
-        clean=False,
     ):
         if not destination:
             raise ValueError("A destination directory must be provided.")
         DirectoryChanger.__init__(
             self, destination, filesToMove, filesToRetrieve, dumpOnException
         )
-        self.clean = clean
 
     def __enter__(self):
         if not os.path.exists(self.destination):
@@ -261,8 +267,7 @@ class ForcedCreationDirectoryChanger(DirectoryChanger):
         else:
             runLog.extra(f"Destination folder already exists: {self.destination}")
         DirectoryChanger.__enter__(self)
-        if self.clean:
-            shutil.rmtree(".", ignore_errors=True)
+
         return self
 
 

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -194,9 +194,12 @@ class TemporaryDirectoryChanger(DirectoryChanger):
             self, root, filesToMove, filesToRetrieve, dumpOnException
         )
 
-        # if no root dir is given, enforce that this tmp dir is in /.armi/
+        # If no root dir is given, the default path to grab in context is cwd(), which
+        # can lead to deleting any directory on the hard drive. So this check is here
+        # to ensure that if we grab a path from context, it is a proper temp dir.
         if not root:
             root = armi.context.getFastPath()
+            # ARMIs temp dirs are in an /.armi/ directory: validate this is a temp dir.
             if ".armi" not in os.path.normpath(root).split(os.path.sep):
                 raise ValueError("Temporary directory not found.")
 

--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -47,6 +47,7 @@ import json
 import subprocess
 
 from armi import runLog
+from armi.utils.pathTools import cleanPath
 
 MANIFEST_NAME = "CRC-manifest.json"
 
@@ -165,7 +166,7 @@ def deleteCache(cachedFolder):
     """
     if "Output_Cache" not in cachedFolder:
         raise RuntimeError("Cache location must contain safeword: `Output_Cache`.")
-    shutil.rmtree(cachedFolder)
+    cleanPath(cachedFolder)
 
 
 def cacheCall(


### PR DESCRIPTION
First, the `clean=True` is removed from the `ForcedDirectoryChanger`. That is really what causes the issue, while this may break some people's workflows, having code around that recursively deletes directories is pretty scary, and those workflows should change.

Second, the pre-existing `cleanPath` method was moved to a better location and is now used in place of all bare calls to `shutil.rmtree`. It is scary that a bare 'shutil.rmtree` was called in 8 different places in the repo, with no safety checks.

Lastly, there is a whitelisted set of directories in `cleanPath` that can be wiped. In an ideal world, the codebase and our workflows would change to allow for only one: `/.armi/`.

NOTE: this PR relates to bug described in issue https://github.com/terrapower/armi/issues/403