### PR TITLE
Add support for explicit Case dependencies

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -213,7 +213,7 @@ class Case:
         with the other, implicitly discovered, dependencies.
         """
         if case in self._dependencies:
-            runLog.warn(
+            runLog.warning(
                 "The case {} is already explicity specified as a dependency of "
                 "{}".format(case, self)
             )

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -33,7 +33,7 @@ import trace
 import time
 import textwrap
 import ast
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence, Set
 import glob
 import tabulate
 import six
@@ -98,6 +98,7 @@ class Case:
         self._startTime = time.time()
         self._caseSuite = caseSuite
         self._tasks = []
+        self._dependencies: Set[Case] = set()
         self.enabled = True
 
         # NOTE: in order to prevent slow submission times for loading massively large
@@ -196,9 +197,27 @@ class Case:
                 )
             )
         # ensure that a case doesn't appear to be its own dependency
+        dependencies.update(self._dependencies)
         dependencies.discard(self)
 
         return dependencies
+
+    def addExplicitDependency(self, case):
+        """
+        Register an explicit dependency
+
+        When evaluating the ``dependency`` property, dynamic dependencies are probed
+        using the current case settings and plugin hooks. Sometimes, it is necessary to
+        impose dependencies that are not expressed through settings and hooks. This
+        method stores another case as an explicit dependency, which will be included
+        with the other, implicitly discovered, dependencies.
+        """
+        if case in self._dependencies:
+            runLog.warn(
+                "The case {} is already explicity specified as a dependency of "
+                "{}".format(case, self)
+            )
+        self._dependencies.add(case)
 
     def getPotentialParentFromSettingValue(self, settingValue, filePattern):
         """

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -238,6 +238,11 @@ class TestCaseSuiteDependencies(unittest.TestCase):
             self.c2.cs["explicitRepeatShuffles"] = "c1-SHUFFLES.txt"
         self.assertIn(self.c1, self.c2.dependencies)
 
+    def test_explicitDependency(self):
+        self.c1.addExplicitDependency(self.c2)
+
+        self.assertIn(self.c2, self.c1.dependencies)
+
 
 class TestExtraInputWriting(unittest.TestCase):
     """Make sure extra inputs from interfaces are written."""


### PR DESCRIPTION
This is in response to #400. We probably want to ultimately get to a place where Case dependencies are managed from the Suite side, but this should compose well with that (case.addDependency() could still function by interacting under the hood with it's parent Suite), and solves the immediate issue of supporting simple, explicit Case dependencies.

@jakehader, could you shake this down, see if it fits your needs?