### PR TITLE
Fixups to operator.py and geometryConverters.py

### DIFF
--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -262,6 +262,7 @@ class Operator:  # pylint: disable=too-many-public-methods
             startingNode = self.r.p.timeNode
         else:
             startingNode = 0
+            self.r.p.timeNode = startingNode
         halt = self.interactAllBOC(self.r.p.cycle)
         if halt:
             return False

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -1035,10 +1035,9 @@ class HexToRZThetaConverter(GeometryConverter):
                     return assignedMixtureBlockType
 
         assignedMixtureBlockType = "mixture structure"
-        runLog.extra(
-            "The mixture type for this homogenized block was not determined and is defaulting to {}".format(
-                assignedMixtureBlockType
-            )
+        runLog.debug(
+            f"The mixture type for this homogenized block {mostCommonHexBlockType} "
+            f"was not determined and is defaulting to {assignedMixtureBlockType}"
         )
 
         return assignedMixtureBlockType


### PR DESCRIPTION
* Reseting the reactor's time node to the startingNode at the beginning of the next cycle loop.

* Changing the geometry converter extra to a debug statement for classifying a specific homogenized region as `STRUCTURE`.