### PR TITLE
Fix to block diagram plotting in new reports with custom materials

### DIFF
--- a/armi/bookkeeping/newReportUtils.py
+++ b/armi/bookkeeping/newReportUtils.py
@@ -11,6 +11,7 @@ from armi.utils import plotting
 from armi.utils import units
 from armi.utils import iterables
 from armi.cli.reportsEntryPoint import ReportStage
+from armi.materials import custom
 
 
 def insertBlueprintContent(r, cs, report, blueprint):

--- a/armi/bookkeeping/newReportUtils.py
+++ b/armi/bookkeeping/newReportUtils.py
@@ -337,8 +337,12 @@ def insertBlockDiagrams(cs, blueprint, report, cold):
     for bDesign in blueprint.blockDesigns:
         block = bDesign.construct(cs, blueprint, 0, 1, 0, "A", dict())
         for component in block:
-            if component.material.name not in materialList:
-                materialList.append(component.material.name)
+            if isinstance(component.material, custom.Custom):
+                materialName = component.p.customIsotopicsName
+            else:
+                materialName = component.material.name
+            if materialName not in materialList:
+                materialList.append(materialName)
 
     report[DESIGN]["Block Diagrams"] = newReports.Section("Block Diagrams")
     for bDesign in blueprint.blockDesigns:


### PR DESCRIPTION
Update to handle custom material names in the block diagram creation and to fix the memory issue with creating a large subplot (i.e., 50 x 50).