### PR TITLE
Add debug messages to uniform mesh converter

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -952,6 +952,19 @@ class Assembly(composites.Composite):
                 if heightHere / b.getHeight() > EPS:
                     blocksHere.append((b, heightHere))
 
+        totalHeight = 0.0
+        expectedHeight = zUpper - zLower
+        for _b, height in blocksHere.items():
+            totalHeight += height
+
+        # Verify that the heights of all the blocks are equal to the expected
+        # height for the given zUpper and zLower.
+        msg = (
+            f"The cumulative height of {blocksHere} is {totalHeight} cm "
+            f"and does not equal the expected height of {expectedHeight} cm"
+        )
+        assert abs(totalHeight - expectedHeight) < EPS, msg
+
         return blocksHere
 
     def getBlockLengthAboveAndBelowHeight(self, height):

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -941,8 +941,11 @@ class Assembly(composites.Composite):
         """
         EPS = 1e-10
         blocksHere = []
+        allMeshPoints = set()
         for b in self:
             if b.p.ztop >= zLower and b.p.zbottom <= zUpper:
+                allMeshPoints.add(b.p.zbottom)
+                allMeshPoints.add(b.p.ztop)
                 # at least some of this block overlaps the window of interest
                 top = min(b.p.ztop, zUpper)
                 bottom = max(b.p.zbottom, zLower)
@@ -953,7 +956,10 @@ class Assembly(composites.Composite):
                     blocksHere.append((b, heightHere))
 
         totalHeight = 0.0
-        expectedHeight = zUpper - zLower
+        # The expected height snaps to the minimum height that is requested
+        expectedHeight = min(
+            sorted(allMeshPoints)[-1] - sorted(allMeshPoints)[0], zUpper - zLower
+        )
         for _b, height in blocksHere:
             totalHeight += height
 

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -954,7 +954,7 @@ class Assembly(composites.Composite):
 
         totalHeight = 0.0
         expectedHeight = zUpper - zLower
-        for _b, height in blocksHere.items():
+        for _b, height in blocksHere:
             totalHeight += height
 
         # Verify that the heights of all the blocks are equal to the expected

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -959,7 +959,7 @@ class Assembly(composites.Composite):
 
         # Verify that the heights of all the blocks are equal to the expected
         # height for the given zUpper and zLower.
-        if abs(totalHeight - expectedHeight) > EPS:
+        if abs(totalHeight - expectedHeight) > 1e-5:
             raise ValueError(
                 f"The cumulative height of {blocksHere} is {totalHeight} cm "
                 f"and does not equal the expected height of {expectedHeight} cm"

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -959,11 +959,11 @@ class Assembly(composites.Composite):
 
         # Verify that the heights of all the blocks are equal to the expected
         # height for the given zUpper and zLower.
-        msg = (
-            f"The cumulative height of {blocksHere} is {totalHeight} cm "
-            f"and does not equal the expected height of {expectedHeight} cm"
-        )
-        assert abs(totalHeight - expectedHeight) < EPS, msg
+        if abs(totalHeight - expectedHeight) > EPS:
+            raise ValueError(
+                f"The cumulative height of {blocksHere} is {totalHeight} cm "
+                f"and does not equal the expected height of {expectedHeight} cm"
+            )
 
         return blocksHere
 


### PR DESCRIPTION
* Replace the existing messages with more information for a user to verify that the
axial homogenization of blocks within the `UniformMeshGeometryConverter` is
being performed correctly. 

* Add verification check that the block heights calculated in `getBlocksBetweenElevations` have a cumulative height equal to the height from the user-supplied `zUpper` and `zLower` values.