### PR TITLE
Fixing the example gallery in our docs.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,6 @@ jobs:
         run: pip install tox
       - name: Make HTML Docs
         run: tox -e doc
-        continue-on-error: true
       - name: deploy
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ doc/tutorials/case-suite
 armi/tests/tutorials/case-suite
 .apidocs/
 doc/gallery
+doc/gallery-src/framework/*.yaml
 htmlcov/
 
 # No workspace crumbs.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -399,6 +399,8 @@ sphinx_gallery_conf = {
     "default_thumb_file": os.path.join(RES, "images", "TerraPowerLogo.png"),
 }
 
+suppress_warnings: ["autoapi.python_import_resolution"]
+
 # filter out this warning which shows up in sphinx-gallery builds.
 # this is suggested in the sphinx-gallery example but doesn't actually work?
 warnings.filterwarnings(

--- a/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
+++ b/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
@@ -9,6 +9,7 @@ Normally, code-specific utility code would belong in a code-specific ARMI
 plugin. But in this case, the need for MCNP materials cards is so pervasive
 that it made it into the framework.
 """
+# sphinx_gallery_thumbnail_path = '.static/armi-logo.png'
 import logging
 
 from armi.reactor.tests import test_reactors

--- a/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
+++ b/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
@@ -9,13 +9,18 @@ Normally, code-specific utility code would belong in a code-specific ARMI
 plugin. But in this case, the need for MCNP materials cards is so pervasive
 that it made it into the framework.
 """
+import logging
 
 from armi.reactor.tests import test_reactors
 from armi.reactor.flags import Flags
 from armi.utils.densityTools import formatMaterialCard
 from armi.nucDirectory import nuclideBases as nb
-from armi import configure
+from armi import configure, runLog
 
+# init ARMI logging tools
+logging.setLoggerClass(runLog.RunLogger)
+
+# configure ARMI
 configure(permissive=True)
 
 _o, r = test_reactors.loadTestReactor()

--- a/doc/gallery-src/analysis/run_hexReactorToRZ.py
+++ b/doc/gallery-src/analysis/run_hexReactorToRZ.py
@@ -4,14 +4,14 @@ Hex reactor to RZ geometry conversion
 This shows how an entire reactor specified in full hex detail can be
 automatically converted to a 2-D or 3-D RZ case with conserved mass.
 
-.. warning:: 
+.. warning::
     This uses :py:mod:`armi.reactor.converters.geometryConverters`, which
     will only work on a constrained set of hex-based geometries. For your systems,
     consider these an example and starting point and build your own converters as
     appropriate.
-
-
 """
+import logging
+
 # sphinx_gallery_thumbnail_number=2
 import math
 
@@ -21,8 +21,12 @@ from armi.reactor.tests import test_reactors
 from armi.reactor.flags import Flags
 from armi.reactor.converters import geometryConverters
 from armi.utils import plotting
-from armi import configure
+from armi import configure, runLog
 
+# init ARMI logging tools
+logging.setLoggerClass(runLog.RunLogger)
+
+# configure ARMI
 configure(permissive=True)
 
 o, r = test_reactors.loadTestReactor()

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -15,6 +15,8 @@ ARMI to do fuel management. Thus, this example applies a dummy burnup distributi
 demonstration purposes.
 
 """
+import logging
+
 # Tell the gallery to feature the 2nd image
 # sphinx_gallery_thumbnail_number = 2
 import math
@@ -24,8 +26,12 @@ from armi.reactor.tests import test_reactors
 from armi.physics.fuelCycle import fuelHandlers
 from armi.utils import plotting
 
-from armi import configure
+from armi import configure, runLog
 
+# init ARMI logging tools
+logging.setLoggerClass(runLog.RunLogger)
+
+# configure ARMI
 configure(permissive=True)
 
 o, reactor = test_reactors.loadTestReactor(inputFileName="refTestCartesian.yaml")

--- a/doc/gallery-src/framework/run_programmaticReactorDefinition.py
+++ b/doc/gallery-src/framework/run_programmaticReactorDefinition.py
@@ -15,10 +15,17 @@ This example shows how to make Blueprints objects programmatically completely
 from scratch.
 
 """
-import matplotlib.pyplot as plt
-from armi import configure
+import logging
 
+import matplotlib.pyplot as plt
+from armi import configure, runLog
+
+# init ARMI logging tools
+logging.setLoggerClass(runLog.RunLogger)
+
+# configure ARMI
 configure(permissive=True)
+
 # pylint: disable=wrong-import-position
 from armi.reactor import blueprints
 from armi import settings

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -5,10 +5,16 @@ Plot a reactor facemap
 Load a test reactor from the test suite and plot a dummy
 power distribution from it. You can plot any block parameter.
 """
+import logging
+
 from armi.reactor.tests import test_reactors
 from armi.utils import plotting
-from armi import configure
+from armi import configure, runLog
 
+# init ARMI logging tools
+logging.setLoggerClass(runLog.RunLogger)
+
+# configure ARMI
 configure(permissive=True)
 
 operator, reactor = test_reactors.loadTestReactor()


### PR DESCRIPTION
This is in response to: https://github.com/terrapower/armi/issues/417

It was actually a combination of a few things:

1. Our docs had gotten a bit out of date and had some issues, that we started addressing recently
2. The logging change broke a few of the API examples run by ARMI, but that didn't break the build
3. One of the examples wasn't actually broken, but it didn't generate an image, so a thumbnail popped up that said "BROKEN".