### PR TITLE
Fixing missing docstring in the auto docs

### DIFF
--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -44,8 +44,8 @@ class ThoriumOxide(Material):
         self.setMassFrac("O16", 0.1212)
 
     def density(self, Tk=None, Tc=None):
-        Tk = getTk(Tc, Tk)
         """g/cc from IAEA TE 1450"""
+        Tk = getTk(Tc, Tk)
         return 10.00
 
     def linearExpansion(self, Tk=None, Tc=None):


### PR DESCRIPTION
As @keckler points out, the documentation for the thorium oxide density method is wrong:

https://terrapower.github.io/armi/.apidocs/armi.materials.thoriumOxide.html#armi.materials.thoriumOxide.ThoriumOxide.density

Essentially, the docstring for that method is shifted by one line, so Sphinx thinks it is missing. As such, the docstring shown is from the parent class.

Happily, this is an easy fix.