### PR TITLE
Clean up grid blueprint serialization

### DIFF
--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -115,6 +115,7 @@ from ruamel.yaml import scalarstring
 from armi.utils.customExceptions import InputError
 from armi.utils import asciimaps
 from armi.reactor import geometry, grids
+from armi.reactor import blueprints
 from armi import runLog
 
 
@@ -180,8 +181,9 @@ class GridBlueprint(yamlize.Object):
         ),
     )
     # gridContents is the final form of grid contents information;
-    # it is set regardless of how the input is read. This is how all
-    # grid contents information is written out.
+    # it is set regardless of how the input is read. When writing, we attempt to
+    # preserve the input mode and write ascii map if that was what was originally
+    # provided.
     gridContents = yamlize.Attribute(key="grid contents", type=dict, default=None)
 
     @gridContents.validator
@@ -222,10 +224,22 @@ class GridBlueprint(yamlize.Object):
         self.name = name
         self.geom = str(geom)
         self.latticeMap = latticeMap
-        self.readFromLatticeMap = False
+        self._readFromLatticeMap = False
         self.symmetry = str(symmetry)
         self.gridContents = gridContents
         self.gridBounds = gridBounds
+
+    @property
+    def readFromLatticeMap(self):
+        """
+        This is implemented as a property, since as a Yamlize object, __init__ is not
+        always called and we have to lazily evaluate its default value.
+        """
+        return getattr(self, "_readFromLatticeMap", False)
+
+    @readFromLatticeMap.setter
+    def readFromLatticeMap(self, value):
+        self._readFromLatticeMap = value
 
     def construct(self):
         """Build a Grid from a grid definition."""
@@ -389,7 +403,7 @@ class GridBlueprint(yamlize.Object):
         self.readFromLatticeMap = True
         symmetry = geometry.SymmetryType.fromStr(self.symmetry)
         geom = geometry.GeomType.fromStr(self.geom)
-        latticeCls = asciimaps.asciiMapFromGeomAndSym(self.geom, self.symmetry)
+        latticeCls = asciimaps.asciiMapFromGeomAndDomain(self.geom, symmetry.domain)
         asciimap = latticeCls()
         asciimap.readAscii(self.latticeMap)
         self.gridContents = dict()
@@ -522,7 +536,7 @@ def _filterOutsideDomain(gridBp):
         del gridBp.gridContents[idx]
 
 
-def saveToStream(stream, bluep, grid, full=False):
+def saveToStream(stream, bluep, full=False, tryMap=False):
     """Save the blueprints to the passed stream.
 
     This can save either the entire blueprints, or just the `grids:` section of the
@@ -530,9 +544,10 @@ def saveToStream(stream, bluep, grid, full=False):
     blueprints can be useful when cobbling blueprints together with !include flags.
 
     stream: file output stream of some kind
-    bluep: armi.reactor.blueprints.Blueprints
-    grid: armi.reactor.grids.Grid
+    bluep: armi.reactor.blueprints.Blueprints, or Grids
     full: bool ~ Is this a full output file, or just a partial/grids?
+    tryMap: regardless of input form, attempt to output as a lattice map. let's face it;
+    they're prettier.
     """
     # To save, we want to try our best to output our grid blueprints in the lattice
     # map style. However, we do not want to wreck the state that the current
@@ -540,7 +555,14 @@ def saveToStream(stream, bluep, grid, full=False):
     # canonicalize it and save that, leaving the original blueprints unmolested.
     bp = copy.deepcopy(bluep)
 
-    for gridDesignType, gridDesign in bp.gridDesigns.items():
+    if isinstance(bp, blueprints.Blueprints):
+        gridDesigns = bp.gridDesigns
+    elif isinstance(bp, blueprints.Grids):
+        gridDesigns = bp
+    else:
+        raise TypeError("Expected Blueprints or Grids, got {}".format(type(bp)))
+
+    for gridDesignType, gridDesign in gridDesigns.items():
         # The core equilibrium path should be put into the
         # grid contents rather than a lattice map until we write
         # a string-> tuple parser for reading it back in. Skip
@@ -553,42 +575,50 @@ def saveToStream(stream, bluep, grid, full=False):
             # there is no grid, so there must be lattice, and that goes to output
             continue
 
-        readFromLatticeMap = getattr(gridDesign, "readFromLatticeMap", False)
-        if not readFromLatticeMap:
-            # there is a grid, but we didn't read from latttice, so we block lattic output
-            gridDesign.latticeMap = None
-            continue
-
-        try:
-            aMap = asciimaps.asciiMapFromGeomAndSym(grid.geomType, grid.symmetry)()
-            # asciimaps can't handle negative indices, so we bump everything
-            # forward if needed
-            offset = (
-                min(key[0] for key in gridDesign.gridContents.keys()),
-                min(key[1] for key in gridDesign.gridContents.keys()),
-            )
-            aMap.asciiLabelByIndices = {
-                (key[0] - offset[0], key[1] - offset[1]): val
-                for key, val in gridDesign.gridContents.items()
-            }
-            aMap.gridContentsToAscii()
-        except Exception as e:
-            runLog.warning(
-                "Cannot write geometry with asciimap. Defaulting to dict. Issue: {}".format(
-                    e
+        if gridDesign.readFromLatticeMap or tryMap:
+            geomType = geometry.GeomType.fromStr(gridDesign.geom)
+            symmetry = geometry.SymmetryType.fromStr(gridDesign.symmetry)
+            try:
+                aMap = asciimaps.asciiMapFromGeomAndDomain(
+                    gridDesign.geom, symmetry.domain
+                )()
+                aMap.asciiLabelByIndices = {
+                    (key[0], key[1]): val
+                    for key, val in gridDesign.gridContents.items()
+                }
+                aMap.gridContentsToAscii()
+            except Exception as e:
+                runLog.warning(
+                    "Cannot write geometry with asciimap. Defaulting to dict. Issue: {}".format(
+                        e
+                    )
                 )
-            )
-            aMap = None
+                aMap = None
 
-        gridDesign.gridContents = None
-        if aMap is not None:
-            mapString = StringIO()
-            aMap.writeAscii(mapString)
-            # deep ruamel.yaml magic
-            fmtStr = scalarstring.LiteralScalarString(mapString.getvalue())
-            gridDesign.latticeMap = fmtStr
+            if aMap is not None:
+                gridDesign.gridContents = None
+                if not isinstance(aMap, asciimaps.AsciiMapHexFullTipsUp):
+                    # this specific implementation of asciimap is broken, so we only
+                    # attempt to use the other implementations. If hex, full, tips-up is
+                    # being used we just preserve whatever was in the blueprints
+                    # already. this is bad, but we can do away with it when #437 is
+                    # fixed.
+                    mapString = StringIO()
+                    aMap.writeAscii(mapString)
+                    gridDesign.latticeMap = mapString.getvalue()
+                gridDesign.latticeMap = scalarstring.LiteralScalarString(
+                    gridDesign.latticeMap
+                )
+            else:
+                gridDesign.latticeMap = None
 
-    toSave = bp if full else bp.gridDesigns
+        else:
+            # grid contents were supplied as a dictionary, so we shouldnt even have a
+            # latticeMap, unless it was set explicitly in code somewhere. Discard if
+            # there is one.
+            gridDesign.latticeMap = None
+
+    toSave = bp if full else gridDesigns
 
     # NOTE: type(bp) here used because importing Blueprints causes a circular import
     type(toSave).dump(toSave, stream)

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -262,6 +262,54 @@ RTH_GEOM = """
 """
 
 
+SMALL_HEX = """core:
+  geom: hex
+  symmetry: third periodic
+  lattice map: |
+    F
+     F
+    F F
+     F
+    F F
+pins:
+  geom: hex
+  symmetry: full
+  lattice map: |
+    -   -   FP
+      -   FP  FP
+    -   CL  CL  CL
+      FP  FP  FP  FP
+    FP  FP  FP  FP  FP
+      CL  CL  CL  CL
+    FP  FP  FP  FP  FP
+      FP  FP  FP  FP
+    CL  CL  CL  CL  CL
+      FP  FP  FP  FP
+    FP  FP  FP  FP  FP
+      CL  CL  CL  CL
+    FP  FP  FP  FP  FP
+      FP  FP  FP  FP
+        CL  CL  CL
+          FP  FP
+            FP
+"""
+
+
+class TestRoundTrip(unittest.TestCase):
+    def setUp(self):
+        self.grids = Grids.load(SMALL_HEX)
+
+    def test_contents(self):
+        self.assertIn("core", self.grids)
+
+    def test_roundTrip(self):
+        stream = io.StringIO()
+        saveToStream(stream, self.grids, False, True)
+        stream.seek(0)
+        gridBp = Grids.load(stream)
+        self.assertIn("third", gridBp["core"].symmetry)
+
+
 class TestGridBlueprintsSection(unittest.TestCase):
     """Tests for lattice blueprint section."""
 
@@ -313,7 +361,7 @@ class TestGridBlueprintsSection(unittest.TestCase):
         bp = Blueprints.load(FULL_BP)
         filePath = "TestGridBlueprintsSection__test_simpleReadLatticeMap.log"
         with open(filePath, "w") as stream:
-            saveToStream(stream, bp, grid, True)
+            saveToStream(stream, bp, True)
 
         # test that the output looks valid, and includes a lattice map
         with open(filePath, "r") as f:
@@ -348,7 +396,7 @@ class TestGridBlueprintsSection(unittest.TestCase):
         bp = Blueprints.load(FULL_BP_GRID)
         filePath = "TestGridBlueprintsSection__test_simpleReadNoLatticeMap.log"
         with open(filePath, "w") as stream:
-            saveToStream(stream, bp, grid, True)
+            saveToStream(stream, bp, True)
 
         # test that the output looks valid, and includes a lattice map
         with open(filePath, "r") as f:

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -114,6 +114,7 @@ class AsciiMap:
 
         Update placeholder size according to largest thing read."""
         text = text.strip().splitlines()
+
         self.asciiLines = []
         self._asciiMaxCol = 0
         for li, line in enumerate(text):
@@ -240,6 +241,9 @@ class AsciiMap:
     def __getitem__(self, ijKey):
         """Get ascii item by grid i,j index."""
         return self.asciiLabelByIndices[ijKey]
+
+    def __setitem__(self, ijKey, item):
+        self.asciiLabelByIndices[ijKey] = item
 
     def _makeOffsets(self):
         """Build offsets"""
@@ -505,13 +509,16 @@ class AsciiMapHexFullTipsUp(AsciiMap):
         self._ijMax = (self._asciiMaxCol - 1) // 2
 
 
-def asciiMapFromGeomAndSym(
-    geomType: Union[str, geometry.GeomType], symmetry: Union[str, geometry.SymmetryType]
+def asciiMapFromGeomAndDomain(
+    geomType: Union[str, geometry.GeomType], domain: Union[str, geometry.DomainType]
 ) -> "AsciiMap":
-    """Get a ascii map class from a geometry and symmetry type."""
+    """Get a ascii map class from a geometry and domain type."""
     from armi.reactor import geometry
 
-    if str(geomType) == geometry.HEX_CORNERS_UP and geometry.FULL_CORE in str(symmetry):
+    if (
+        str(geomType) == geometry.HEX_CORNERS_UP
+        and geometry.DomainType.fromAny(domain) == geometry.DomainType.FULL_CORE
+    ):
         return AsciiMapHexFullTipsUp
 
     MAP_FROM_GEOM = {
@@ -531,6 +538,6 @@ def asciiMapFromGeomAndSym(
     return MAP_FROM_GEOM[
         (
             geometry.GeomType.fromAny(geomType),
-            geometry.SymmetryType.fromAny(symmetry).domain,
+            geometry.DomainType.fromAny(domain),
         )
     ]

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -1362,7 +1362,7 @@ class GridBlueprintControl(wx.Panel):
         if stream is None:
             self._saveNoStream(full)
         else:
-            saveToStream(stream, self.bp, self.grid, full)
+            saveToStream(stream, self.bp, full, tryMap=True)
 
     def _saveNoStream(self, full=False):
         """Prompt for a file to save to.
@@ -1428,7 +1428,7 @@ class GridBlueprintControl(wx.Panel):
         # way to don't destroy anything unless we know we have something with which
         # to replace it.
         bpStream = io.StringIO()
-        saveToStream(bpStream, self.bp, self.grid, full)
+        saveToStream(bpStream, self.bp, full, tryMap=True)
         with open(path, "w") as stream:
             stream.write(bpStream.getvalue())
 

--- a/armi/utils/tests/test_asciimaps.py
+++ b/armi/utils/tests/test_asciimaps.py
@@ -167,6 +167,13 @@ ORS     IRS     RR7     OC      OC      IC      OC      OC      RR7     IRS     
                                 ORS     ORS     ORS 
 """
 
+HEX_FULL_MAP_SMALL = """F
+ F F
+F
+F F
+ F
+"""
+
 
 class TestAsciiMaps(unittest.TestCase):
     """Test ascii maps."""
@@ -331,6 +338,19 @@ class TestAsciiMaps(unittest.TestCase):
             stream.seek(0)
             output = stream.read()
             self.assertEqual(output, HEX_FULL_MAP_FLAT)
+
+    def test_hexSmallFlat(self):
+        asciimap = asciimaps.AsciiMapHexFullFlatsUp()
+        with io.StringIO() as stream:
+            stream.write(HEX_FULL_MAP_SMALL)
+            stream.seek(0)
+            asciimap.readAscii(stream.read())
+
+        with io.StringIO() as stream:
+            asciimap.writeAscii(stream)
+            stream.seek(0)
+            output = stream.read()
+            self.assertEqual(output, HEX_FULL_MAP_SMALL)
 
     def test_flatHexBases(self):
         """For the full core with 2 lines chopped, get the first 3 bases"""


### PR DESCRIPTION
 - fix logic in which form to output
 - remove grid argument to saveToStream; it was causing all output grid
   blueprints to use the same geom settings, and wasnt really needed in
   the first place
 - add tryMap optional arg to attempt lattice map output regardless of
   how grid layout was read in.
 - add some more testing
 - change behavior of grid editor to prefer lattice map