### PR TITLE
Warning user when a Material Modification is unused.

### DIFF
--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -29,10 +29,13 @@ class B4C(material.Material):
     def applyInputParams(
         self, B10_wt_frac=None, theoretical_density=None, TD_frac=None, *args, **kwargs
     ):
+        self._warnIfUnusedModifications(kwargs)
+
         if B10_wt_frac is not None:
             # we can't just use the generic enrichment adjustment here because the
             # carbon has to change with enrich.
             self.adjustMassEnrichment(B10_wt_frac)
+
         if theoretical_density is not None:
             runLog.warning(
                 "The 'threoretical_density' material modification for B4C will be "
@@ -46,6 +49,7 @@ class B4C(material.Material):
                 )
             else:
                 self.updateTD(theoretical_density)
+
         if TD_frac is not None:
             self.updateTD(TD_frac)
 

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Boron carbide; a very typical reactor control material."""
-from armi.materials import material
+from armi.materials.material import Material
 from armi.nucDirectory import nuclideBases
 from armi import runLog
 from armi.utils.units import getTc
@@ -22,7 +22,7 @@ DEFAULT_THEORETICAL_DENSITY_FRAC = 0.90
 DEFAULT_MASS_DENSITY = 2.52
 
 
-class B4C(material.Material):
+class B4C(Material):
     name = "B4C"
     enrichedNuclide = "B10"
 
@@ -163,7 +163,7 @@ class B4C(material.Material):
         """
         mass density
         """
-        density = material.Material.density(self, Tk, Tc)
+        density = Material.density(self, Tk, Tc)
         theoreticalDensityFrac = self.p.theoreticalDensityFrac
         if theoreticalDensityFrac is None:
             theoreticalDensityFrac = 1.0

--- a/armi/materials/lithium.py
+++ b/armi/materials/lithium.py
@@ -29,6 +29,7 @@ class Lithium(material.Fluid):
     enrichedNuclide = "LI6"
 
     def applyInputParams(self, LI_wt_frac=None, *args, **kwargs):
+        self._warnIfUnusedModifications(kwargs)
         enrich = utils.getFloat(LI_wt_frac)
         # allow 0.0 to pass in!
         if enrich is not None:

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -616,6 +616,15 @@ class Material(composites.Leaf):
             f"Material {type(self).__name__} does not implement heatCapacity"
         )
 
+    def _warnIfUnusedModifications(self, unused):
+        """Users will want to be warned if some of their material modifications are not used."""
+        if len(unused):
+            runLog.warning(
+                "{0} has unused material modifications: {1}".format(
+                    self.__class__.__name__, unused
+                )
+            )
+
 
 class Fluid(Material):
     """A material that fills its container. Could also be a gas."""
@@ -694,8 +703,7 @@ class FuelMaterial(Material):
         not parameterized with any kind of enrichment.
         """
         # Users will want to be warned if some of their material modifications are not used.
-        if len(kwargs):
-            runLog.warning("Unusable material modifications: {0}".format(kwargs))
+        self._warnIfUnusedModifications(kwargs)
 
         # Save class data for future reconstructions (e.g. in closed cycles)
         self.p.class1_wt_frac = class1_wt_frac

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -63,7 +63,7 @@ class Material(composites.Leaf):
     """Constants that may be used in intepolation functions for property lookups"""
 
     thermalScatteringLaws = ()
-    """A tuple of :py:class:`~armi.nucDirectory.thermalScattering.ThermalScattering` instances 
+    """A tuple of :py:class:`~armi.nucDirectory.thermalScattering.ThermalScattering` instances
     with information about thermal scattering."""
 
     def __init__(self):
@@ -679,6 +679,7 @@ class FuelMaterial(Material):
         class2_custom_isotopics=None,
         class1_wt_frac=None,
         customIsotopics=None,
+        **kwargs,
     ):
         """Apply optional class 1/class 2 custom enrichment input.
 
@@ -692,6 +693,10 @@ class FuelMaterial(Material):
         kinds of parameters to coolants and structural material, which are often
         not parameterized with any kind of enrichment.
         """
+        # Users will want to be warned if some of their material modifications are not used.
+        if len(kwargs):
+            runLog.warning("Unusable material modifications: {0}".format(kwargs))
+
         # Save class data for future reconstructions (e.g. in closed cycles)
         self.p.class1_wt_frac = class1_wt_frac
         self.p.class1_custom_isotopics = class1_custom_isotopics

--- a/armi/materials/thU.py
+++ b/armi/materials/thU.py
@@ -22,11 +22,11 @@ Data is from [#IAEA-TECDOCT-1450]_.
 """
 
 from armi.utils.units import getTk
-from armi.materials import material
+from armi.materials.material import FuelMaterial, Material
 from armi import runLog
 
 
-class ThU(material.Material):
+class ThU(Material):
     name = "ThU"
     enrichedNuclide = "U233"
 
@@ -40,7 +40,7 @@ class ThU(material.Material):
 
         if U233_wt_frac is not None:
             self.adjustMassEnrichment(U233_wt_frac)
-        material.FuelMaterial.applyInputParams(self, *args, **kwargs)
+        FuelMaterial.applyInputParams(self, *args, **kwargs)
 
     def setDefaultMassFracs(self):
         self.setMassFrac("TH232", 1.0)

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -21,7 +21,6 @@ from armi.materials.material import Material
 from armi import runLog
 
 
-# TODO: Why isn't this subclassing FuelMaterial?
 class UThZr(Material):
     """
     U-235 enriched uranium with Thorium 232 - Zirc fuel.

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -21,6 +21,7 @@ from armi.materials.material import Material
 from armi import runLog
 
 
+# TODO: Why isn't this subclassing FuelMaterial?
 class UThZr(Material):
     """
     U-235 enriched uranium with Thorium 232 - Zirc fuel.

--- a/armi/reactor/blueprints/tests/test_materialModifications.py
+++ b/armi/reactor/blueprints/tests/test_materialModifications.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
+from io import StringIO
+import logging
 import unittest
 
 from numpy.testing import assert_allclose
 
+from armi import context
 from armi import materials
+from armi import runLog
 from armi import settings
 from armi.reactor import blueprints
 
@@ -89,6 +93,18 @@ assemblies:
         assert_allclose(0.077, zr / totalMass)
 
     def test_both_u235_zr_wt_frac_modification(self):
+        # init the _RunLog object
+        log = runLog.LOG = runLog._RunLog(0)
+        log.startLog("test_both_u235_zr_wt_frac_modification")
+        context.createLogDir(0)
+        log.setVerbosity(logging.INFO)
+
+        # divert the logging to a stream, to make testing easier
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        log.logger.handlers = [handler]
+
+        # load an assembly, with only valid mat mods
         a = self.loadUZrAssembly(
             """
         material modifications:
@@ -107,6 +123,41 @@ assemblies:
         totalMass = fuelComponent.getMass()
         zr = fuelComponent.getMass("ZR")
         assert_allclose(0.077, zr / totalMass)
+
+        # test that we don't get the "invalid material mod" warnings
+        streamVal = stream.getvalue()
+        self.assertNotIn("material modifications", streamVal, msg=streamVal)
+        self.assertNotIn("ZR_wt_frac", streamVal, msg=streamVal)
+        self.assertNotIn("U235_wt_frac", streamVal, msg=streamVal)
+
+    def test_unusedMaterialModifications(self):
+        """
+        Users will want to be warned if the explictly put material modifications in a YAML file, but they aren't
+        used. If it is a spelling error or invalid string, errors should not pass silently.
+        """
+        # init the _RunLog object
+        log = runLog.LOG = runLog._RunLog(0)
+        log.startLog("test_unusedMaterialModifications")
+        context.createLogDir(0)
+        log.setVerbosity(logging.INFO)
+
+        # divert the logging to a stream, to make testing easier
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        log.logger.handlers = [handler]
+
+        # load an assembly, with a wonky mat mod
+        a = self.loadUZrAssembly(
+            """
+        material modifications:
+            this_is_a_fake_setting: [0.5]
+        """
+        )
+
+        # test that the invalid mat mod was logged
+        streamVal = stream.getvalue()
+        self.assertIn("material modifications", streamVal, msg=streamVal)
+        self.assertIn("this_is_a_fake_setting", streamVal, msg=streamVal)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When the user puts a material modification in a YAML file (or in code), they expect the mods to be used. In the past, a fictitious (or unused) mat mod would be passed silently. It seems greatly preferable that users be informed that their run probably wasn't what they expected.

This PR will close #402 