### PR TITLE
Cleaning up Settings issues

### DIFF
--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -137,7 +137,7 @@ class Settings:
         else:
             raise NonexistentSetting(key)
 
-    def getSetting(self, key):
+    def getSetting(self, key, default=None):
         """
         Return a copy of an actual Setting object, instead of just its value.
 
@@ -145,6 +145,8 @@ class Settings:
         """
         if key in self.__settings:
             return deepcopy(self.__settings[key])
+        elif default is not None:
+            return default
         else:
             raise NonexistentSetting(key)
 
@@ -176,7 +178,12 @@ class Settings:
         # with schema restored, restore all setting values
         for name, settingState in state["_Settings__settings"].items():
             # pylint: disable=protected-access
-            self.__settings[name]._value = settingState.value
+            if name in self.__settings:
+                self.__settings[name]._value = settingState.value
+            elif isinstance(settingState, Setting):
+                self.__settings[name] = settingState
+            else:
+                raise NonexistentSetting(name)
 
     def keys(self):
         return self.__settings.keys()

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -28,7 +28,7 @@ A master case settings is created as ``masterCs``
 import io
 import logging
 import os
-from copy import deepcopy
+from copy import copy, deepcopy
 
 import armi
 from armi import runLog
@@ -181,7 +181,7 @@ class Settings:
             if name in self.__settings:
                 self.__settings[name]._value = settingState.value
             elif isinstance(settingState, Setting):
-                self.__settings[name] = settingState
+                self.__settings[name] = copy(settingState)
             else:
                 raise NonexistentSetting(name)
 
@@ -358,7 +358,7 @@ class Settings:
         if newSettings:
             for key, val in newSettings.items():
                 if isinstance(val, Setting):
-                    settings.__settings[key] = val
+                    settings.__settings[key] = copy(val)
                 elif key in settings.__settings:
                     settings.__settings[key].setValue(val)
                 else:

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -313,6 +313,21 @@ class Setting:
             "default": self.default,
         }
 
+    def __copy__(self):
+        setting = Setting(
+            str(self.name),
+            copy.copy(self._default),
+            description=None if self.description is None else str(self.description),
+            label=None if self.label is None else str(self.label),
+            options=copy.copy(self.options),
+            schema=copy.copy(self.schema) if hasattr(self, "schema") else None,
+            enforcedOptions=bool(self.enforcedOptions),
+            subLabels=copy.copy(self.subLabels),
+            isEnvironment=bool(self.isEnvironment),
+            oldNames=None if self.oldNames is None else list(self.oldNames),
+        )
+        return setting
+
 
 class FlagListSetting(Setting):
     """Subclass of :py:class:`Setting <armi.settings.Setting>` convert settings between flags and strings."""

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -264,6 +264,10 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         with self.assertRaises(NonexistentSetting):
             cs.getSetting("extendableOption")
 
+        # ensure that defaults in getSetting works
+        val = cs.getSetting("extendableOption", 789)
+        self.assertEqual(val, 789)
+
         # prove the new settings object has the new setting
         cs2 = cs.modified(newSettings={"extendableOption": "PLUGIN"})
         self.assertEqual(cs2["extendableOption"], "PLUGIN")
@@ -271,6 +275,10 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         # prove modified() didn't alter the original object
         with self.assertRaises(NonexistentSetting):
             cs.getSetting("extendableOption")
+
+        # prove that successive applications of "modified" don't fail
+        cs3 = cs2.modified(newSettings={"numberofGenericParams": 7})
+        cs4 = cs3.modified(newSettings={"somethingElse": 123})
 
 
 class TestSettingsConversion(unittest.TestCase):
@@ -356,5 +364,4 @@ class TestFlagListSetting(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/doc/release/0.1.rst
+++ b/doc/release/0.1.rst
@@ -219,3 +219,18 @@ Bug fixes
 ---------
 
  * Fix bug in loading from databases when multi-index locations are used.
+
+
+ARMI v0.1.8
+===========
+Release Date: TBD
+
+API changes
+-----------
+
+* ``Settings`` are now immutable (or nearly so).
+
+Bug fixes
+---------
+
+ * TBD


### PR DESCRIPTION
1. While working on updating various plugins to meet the new Immutable Settings feature, I found we want to improve `__setstate__` to support repeated applications of the new `modified()` method.
2. I also added a default value to `getSetting()` method, as that will get a _lot_ of use.
3. Upon thinking about it more, when we `duplicate()` a `Settings` object, we should be copying each `Setting` object inside it to, because we are currently just referencing the same object.