### PR TITLE
Update description of `burnSteps`

### DIFF
--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -264,9 +264,9 @@ def defineSettings() -> List[setting.Setting]:
             CONF_BURN_STEPS,
             default=4,
             label="Burnup Steps per Cycle",
-            description="Number of depletion substeps in one cycle, n. Note: There "
-            "will be n+1 time nodes so the burnup step time will be computed as cycle "
-            "length/n+1.",
+            description="Number of depletion substeps, n, in one cycle. Note: There "
+            "will be n+1 time nodes and the burnup step time will be computed as cycle "
+            "length/n.",
         ),
         setting.Setting(
             CONF_BETA,


### PR DESCRIPTION
The description of `burnSteps` was not clear in its definition of 'n'. It also mistakenly stated that the burnup step would be calculated as `cycle length / n+1`. This was (1) unclear because it was missing parentheses and (2) incorrect because it should be instead `cycle length / n`.