### PR TITLE
Switching form a Setting deepcopy to a copy

### DIFF
--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -64,9 +64,7 @@ class TestDatabase3(unittest.TestCase):
             self.db.writeToDB(self.r)
 
     def makeShuffleHistory(self):
-        """
-        Walk the reactor through a few time steps with some shuffling.
-        """
+        """Walk the reactor through a few time steps with some shuffling."""
         # Serial numbers *are not stable* (i.e., they can be different between test runs
         # due to parallelism and test run order). However, they are the simplest way to
         # check correctness of location-based history tracking. So we stash the serial
@@ -76,7 +74,8 @@ class TestDatabase3(unittest.TestCase):
         self.centralTopBlockSerialNums = []
 
         grid = self.r.core.spatialGrid
-        for cycle in range(3):
+
+        for cycle in range(2):
             a1 = self.r.core.childrenByLocator[grid[cycle, 0, 0]]
             a2 = self.r.core.childrenByLocator[grid[0, 0, 0]]
             olda1Loc = a1.spatialLocator
@@ -86,7 +85,7 @@ class TestDatabase3(unittest.TestCase):
             self.centralAssemSerialNums.append(c.p.serialNum)
             self.centralTopBlockSerialNums.append(c[-1].p.serialNum)
 
-            for node in range(3):
+            for node in range(2):
                 self.r.p.cycle = cycle
                 self.r.p.timeNode = node
                 # something that splitDatabase won't change, so that we can make sure
@@ -94,12 +93,13 @@ class TestDatabase3(unittest.TestCase):
                 self.r.p.cycleLength = cycle
 
                 self.db.writeToDB(self.r)
+
         # add some more data that isnt written to the database to test the
         # DatabaseInterface API
-        self.r.p.cycle = 3
+        self.r.p.cycle = 2
         self.r.p.timeNode = 0
         self.r.p.cycleLength = cycle
-        self.r.core[0].p.chargeTime = 3
+        self.r.core[0].p.chargeTime = 2
 
         # add some fake missing parameter data to test allowMissing
         self.db.h5db["c00n00/Reactor/missingParam"] = "i don't exist"
@@ -207,7 +207,7 @@ class TestDatabase3(unittest.TestCase):
         del self.db.h5db["c00n00/Reactor/missingParam"]
         _r = self.db.load(0, 0, allowMissing=False)
 
-    def test_history(self) -> None:
+    def test_history(self):
         self.makeShuffleHistory()
 
         grid = self.r.core.spatialGrid
@@ -219,15 +219,15 @@ class TestDatabase3(unittest.TestCase):
             testAssem, params=["chargeTime", "serialNum"]
         )
         expectedSn = {
-            (c, n): self.centralAssemSerialNums[c] for c in range(3) for n in range(3)
+            (c, n): self.centralAssemSerialNums[c] for c in range(2) for n in range(2)
         }
         self.assertEqual(expectedSn, hist["serialNum"])
 
         # test block
         hists = self.db.getHistoriesByLocation(
-            [testBlock], params=["serialNum"], timeSteps=[(0, 0), (1, 0), (2, 0)]
+            [testBlock], params=["serialNum"], timeSteps=[(0, 0), (1, 0)]
         )
-        expectedSn = {(c, 0): self.centralTopBlockSerialNums[c] for c in range(3)}
+        expectedSn = {(c, 0): self.centralTopBlockSerialNums[c] for c in range(2)}
         self.assertEqual(expectedSn, hists[testBlock]["serialNum"])
 
         # cant mix blocks and assems, since they are different distance from core
@@ -238,8 +238,8 @@ class TestDatabase3(unittest.TestCase):
         hist = self.dbi.getHistory(
             self.r.core[0], params=["chargeTime", "serialNum"], byLocation=True
         )
-        self.assertIn((3, 0), hist["chargeTime"].keys())
-        self.assertEqual(hist["chargeTime"][(3, 0)], 3)
+        self.assertIn((2, 0), hist["chargeTime"].keys())
+        self.assertEqual(hist["chargeTime"][(2, 0)], 2)
 
     def test_replaceNones(self):
         """

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -146,7 +146,7 @@ class Settings:
         NOTE: This is used very rarely, try to organize your code to only need a Setting value.
         """
         if key in self.__settings:
-            return deepcopy(self.__settings[key])
+            return copy(self.__settings[key])
         elif default is not None:
             return default
         else:

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -328,21 +328,6 @@ class Setting:
         )
         return setting
 
-    def __deepcopy__(self, meta):
-        setting = Setting(
-            str(self.name),
-            copy.deepcopy(self._default),
-            description=None if self.description is None else str(self.description),
-            label=None if self.label is None else str(self.label),
-            options=copy.deepcopy(self.options),
-            schema=copy.deepcopy(self.schema) if hasattr(self, "schema") else None,
-            enforcedOptions=bool(self.enforcedOptions),
-            subLabels=copy.deepcopy(self.subLabels),
-            isEnvironment=bool(self.isEnvironment),
-            oldNames=None if self.oldNames is None else list(self.oldNames),
-        )
-        return setting
-
 
 class FlagListSetting(Setting):
     """Subclass of :py:class:`Setting <armi.settings.Setting>` convert settings between flags and strings."""

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -328,6 +328,21 @@ class Setting:
         )
         return setting
 
+    def __deepcopy__(self, meta):
+        setting = Setting(
+            str(self.name),
+            copy.deepcopy(self._default),
+            description=None if self.description is None else str(self.description),
+            label=None if self.label is None else str(self.label),
+            options=copy.deepcopy(self.options),
+            schema=copy.deepcopy(self.schema) if hasattr(self, "schema") else None,
+            enforcedOptions=bool(self.enforcedOptions),
+            subLabels=copy.deepcopy(self.subLabels),
+            isEnvironment=bool(self.isEnvironment),
+            oldNames=None if self.oldNames is None else list(self.oldNames),
+        )
+        return setting
+
 
 class FlagListSetting(Setting):
     """Subclass of :py:class:`Setting <armi.settings.Setting>` convert settings between flags and strings."""

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -291,6 +291,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         """
         # get a baseline: show how the Setting object looks to start
         s1 = setting.Setting("testCopy", 765)
+        self.assertEquals(s1.name, "testCopy")
         self.assertEquals(s1._value, 765)
         self.assertTrue(hasattr(s1, "schema"))
         self.assertTrue(hasattr(s1, "_customSchema"))
@@ -298,12 +299,14 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         # show that copy(Setting) is working correctly
         s2 = copy.copy(s1)
         self.assertEquals(s2._value, 765)
+        self.assertEquals(s2.name, "testCopy")
         self.assertTrue(hasattr(s2, "schema"))
         self.assertTrue(hasattr(s2, "_customSchema"))
 
         # show that deepcopy(Setting) is working correctly
         s3 = copy.deepcopy(s1)
         self.assertEquals(s3._value, 765)
+        self.assertEquals(s3.name, "testCopy")
         self.assertTrue(hasattr(s3, "schema"))
         self.assertTrue(hasattr(s3, "_customSchema"))
 

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -284,8 +284,8 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         cs3 = cs2.modified(newSettings={"numberofGenericParams": 7})
         cs4 = cs3.modified(newSettings={"somethingElse": 123})
 
-    def test_copyDeepcopySetting(self):
-        """Ensure that when we copy/deepcopy a Setting() object, the result is sound.
+    def test_copySetting(self):
+        """Ensure that when we copy a Setting() object, the result is sound.
         NOTE: In particuar, self.schema and self._customSchema on a Setting object are
               removed by Setting.__getstate__, and that has been a problem in the past.
         """
@@ -302,13 +302,6 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         self.assertEquals(s2.name, "testCopy")
         self.assertTrue(hasattr(s2, "schema"))
         self.assertTrue(hasattr(s2, "_customSchema"))
-
-        # show that deepcopy(Setting) is working correctly
-        s3 = copy.deepcopy(s1)
-        self.assertEquals(s3._value, 765)
-        self.assertEquals(s3.name, "testCopy")
-        self.assertTrue(hasattr(s3, "schema"))
-        self.assertTrue(hasattr(s3, "_customSchema"))
 
 
 class TestSettingsConversion(unittest.TestCase):

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -284,6 +284,29 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         cs3 = cs2.modified(newSettings={"numberofGenericParams": 7})
         cs4 = cs3.modified(newSettings={"somethingElse": 123})
 
+    def test_copyDeepcopySetting(self):
+        """Ensure that when we copy/deepcopy a Setting() object, the result is sound.
+        NOTE: In particuar, self.schema and self._customSchema on a Setting object are
+              removed by Setting.__getstate__, and that has been a problem in the past.
+        """
+        # get a baseline: show how the Setting object looks to start
+        s1 = setting.Setting("testCopy", 765)
+        self.assertEquals(s1._value, 765)
+        self.assertTrue(hasattr(s1, "schema"))
+        self.assertTrue(hasattr(s1, "_customSchema"))
+
+        # show that copy(Setting) is working correctly
+        s2 = copy.copy(s1)
+        self.assertEquals(s2._value, 765)
+        self.assertTrue(hasattr(s2, "schema"))
+        self.assertTrue(hasattr(s2, "_customSchema"))
+
+        # show that deepcopy(Setting) is working correctly
+        s3 = copy.deepcopy(s1)
+        self.assertEquals(s3._value, 765)
+        self.assertTrue(hasattr(s3, "schema"))
+        self.assertTrue(hasattr(s3, "_customSchema"))
+
 
 class TestSettingsConversion(unittest.TestCase):
     """Make sure we can convert from old XML type settings to new Yaml settings."""


### PR DESCRIPTION
Essentially, this is designed to fix a bug where we were doing a `deepcopy` of a `Setting` object in `Settings.getSetting()`, but the `Setting` object was over-riding `__getstate__`, which is used inside the standard library implementation of `__deepcopy__`.  The short version was, this was causing us to lose `self.schema` and `self.customSchema` from each `Setting` during the `deepcopy()`.

My solution was originally to add a `__deepcopy__` method to the `Setting` class, but it turns out this breaks our pickling of `Settings` in several places. So I decided to just `copy(Setting)` in the `Settings.getSetting()` method. This is fine, since we control what's inside `Setting.__copy__()` anyway.

This PR will close #475 