### PR TITLE
Draft: Particle fuel modeling

### DIFF
--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -56,6 +56,7 @@ class ReportInterface(interfaces.Interface):
         runLog.important("Beginning of BOL Reports")
         reportingUtils.makeCoreAndAssemblyMaps(self.r, self.cs)
         reportingUtils.writeAssemblyMassSummary(self.r)
+        reportingUtils.makeParticleFuelDesignReport(self.r)
 
         if self.cs["summarizeAssemDesign"]:
             reportingUtils.summarizePinDesign(self.r.core)
@@ -114,6 +115,8 @@ class ReportInterface(interfaces.Interface):
             self.r, self.cs, generateFullCoreMap, showBlockAxMesh
         )
         reportingUtils.makeBlockDesignReport(self.r)
+
+        reportingUtils.makeParticleFuelDesignReport(self.r)
 
     def interactEOL(self):
         """Adds the data to the report, and generates it"""

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -104,6 +104,7 @@ from armi.reactor.blueprints.assemblyBlueprint import AssemblyKeyedList
 from armi.reactor.blueprints.blockBlueprint import BlockKeyedList
 from armi.reactor.blueprints import isotopicOptions
 from armi.reactor.blueprints.gridBlueprint import Grids, Triplet
+from armi.reactor.blueprints.componentBlueprint import ParticleFuelKeyedList
 
 context.BLUEPRINTS_IMPORTED = True
 context.BLUEPRINTS_IMPORT_CONTEXT = "".join(traceback.format_stack())
@@ -185,6 +186,9 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
     )
     systemDesigns = yamlize.Attribute(key="systems", type=Systems, default=None)
     gridDesigns = yamlize.Attribute(key="grids", type=Grids, default=None)
+    particleFuelDesigns = yamlize.Attribute(
+        key="particle fuel", type=ParticleFuelKeyedList, default=None
+    )
 
     # These are used to set up new attributes that come from plugins. Defining its
     # initial state here to make pylint happy

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -168,6 +168,14 @@ class BlockBlueprint(yamlize.KeyedList):
                 b.autoCreateSpatialGrids()
             except (ValueError, NotImplementedError) as e:
                 runLog.warning(str(e), single=True)
+        # check if particle fuel exists and set particle mult
+        # Note: these changes occur here during block construction instead of during
+        # component contruction because component parent parameters (i.e., height)
+        # are needed for volume calculations
+        for component in b.getChildren():
+            if component.particleFuel:
+                component.setParticleMultiplicity()
+
         return b
 
     def _getGridDesign(self, blueprint):

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -17,6 +17,8 @@ This module defines the ARMI input for a component definition, and code for cons
 
 Special logic is required for handling component links.
 """
+from math import isclose, inf
+
 import six
 import yamlize
 
@@ -24,8 +26,22 @@ from armi import runLog
 from armi import materials
 from armi.reactor import components
 from armi.reactor.flags import Flags
+from armi.reactor.particleFuel import ParticleFuel
 from armi.utils import densityTools
-from armi.nucDirectory import nuclideBases
+from armi.nucDirectory import nuclideBases, nucDir
+
+
+class ComponentParticleFuel(yamlize.Object):
+    specifier = yamlize.Attribute(type=str)
+    packingFraction = yamlize.Attribute(type=float)
+
+    @packingFraction.validator
+    def packingFraction(self, packingFraction):
+        if not 0 < packingFraction < 1:
+            raise ValueError(
+                "Packing fraction must be between 0 and 1, exclusive. Got "
+                "{}".format(packingFraction)
+            )
 
 
 class ComponentDimension(yamlize.Object):
@@ -144,6 +160,8 @@ class ComponentBlueprint(yamlize.Object):
     orientation = yamlize.Attribute(type=str, default=None)
     mergeWith = yamlize.Attribute(type=str, default=None)
     area = yamlize.Attribute(type=float, default=None)
+    particleFuelSpec = yamlize.Attribute(type=str, default=None)
+    particleFuelPackingFraction = yamlize.Attribute(type=float, default=None)
 
     def construct(self, blueprint, matMods):
         """Construct a component"""
@@ -167,6 +185,7 @@ class ComponentBlueprint(yamlize.Object):
         if component.hasFlags(Flags.DEPLETABLE):
             # depletable components, whether auto-derived or explicitly flagged need expanded nucs
             _insertDepletableNuclideKeys(component, blueprint)
+
         return component
 
     def _conformKwargs(self, blueprint, matMods):
@@ -189,6 +208,16 @@ class ComponentBlueprint(yamlize.Object):
                 # Don't pass these to the component constructor. These are used to
                 # override the flags derived from the type, if present.
                 continue
+            elif attr.name == "particleFuelSpec":
+                design = blueprint.particleFuelDesigns[val]
+                value = design.construct(blueprint, matMods)
+            elif attr.name == "particleFuelPackingFraction":
+                value = attr.get_value(self)
+                if value <= 0 or value >= 1:
+                    raise ValueError(
+                        f"Packing fraction {value} not allowed: must be between "
+                        "0 and 1 exclusive",
+                    )
             else:
                 value = attr.get_value(self)
 
@@ -202,48 +231,77 @@ class ComponentBlueprint(yamlize.Object):
         return kwargs
 
     def _constructMaterial(self, blueprint, matMods):
-        nucsInProblem = blueprint.allNuclidesInProblem
-        # make material with defaults
-        mat = materials.resolveMaterialClassByName(self.material)()
+        return constructMaterial(self.material, blueprint, matMods, self.isotopics)
 
-        if self.isotopics is not None:
-            # Apply custom isotopics before processing input mods so
-            # the input mods have the final word
-            blueprint.customIsotopics.apply(mat, self.isotopics)
 
-        # add mass fraction custom isotopics info, since some material modifications need to see them
-        # e.g. in the base Material.applyInputParams
-        matMods.update(
-            {
-                "customIsotopics": {
-                    k: v.massFracs for k, v in blueprint.customIsotopics.items()
-                }
+def constructMaterial(name, blueprint, matMods, isotopics):
+    """Create a material from blueprint, applying material modifications as necessary
+
+    Parameters
+    ----------
+    name : str
+        Name of this material. ARMI must know how to resolve the material
+        class given the string name
+    blueprint : Blueprints
+        Various detailed information, such as nuclides to model
+    matMods : dict
+        Material modifications to be applied to this material
+    isotopics : dict or none
+        Isotopics to apply to this material, if given. Must conform to
+        ``custom isotopics`` blueprints specification.
+
+    Returns
+    -------
+    armi.materials.Material
+
+    Raises
+    ------
+    ValueError
+        Nuclides found in the material aren't modelled in the ``nuclide flags``
+        section of the blueprints problem
+
+    """
+    # make material with defaults
+    mat = materials.resolveMaterialClassByName(name)()
+
+    if isotopics is not None:
+        # Apply custom isotopics before processing input mods so
+        # the input mods have the final word
+        blueprint.customIsotopics.apply(mat, isotopics)
+
+    # add mass fraction custom isotopics info, since some material modifications need to see them
+    # e.g. in the base Material.applyInputParams
+    matMods.update(
+        {
+            "customIsotopics": {
+                k: v.massFracs for k, v in blueprint.customIsotopics.items()
             }
-        )
-        if len(matMods) > 1:
-            # don't apply if only customIsotopics is in there
-            try:
-                # update material with updated input params from blueprints file.
-                mat.applyInputParams(**matMods)
-            except TypeError:
-                # This component does not accept material modification inputs of the names passed in
-                # Keep going since the modification could work for another component
-                pass
+        }
+    )
+    if len(matMods) > 1:
+        # don't apply if only customIsotopics is in there
+        try:
+            # update material with updated input params from blueprints file.
+            mat.applyInputParams(**matMods)
+        except TypeError:
+            # This component does not accept material modification inputs of the names passed in
+            # Keep going since the modification could work for another component
+            pass
 
-        expandElementals(mat, blueprint)
+    expandElementals(mat, blueprint)
 
-        missing = set(mat.p.massFrac.keys()).difference(nucsInProblem)
+    missing = set(mat.p.massFrac.keys()).difference(blueprint.allNuclidesInProblem)
 
-        if missing:
-            raise ValueError(
-                "The nuclides {} are present in material {} by compositions, but are not "
-                "specified in the `nuclide flags` section of the input file. "
-                "They need to be added, or custom isotopics need to be applied.".format(
-                    missing, mat
-                )
+    if missing:
+        raise ValueError(
+            "The nuclides {} are present in material {} by compositions, but are not "
+            "specified in the `nuclide flags` section of the input file. "
+            "They need to be added, or custom isotopics need to be applied.".format(
+                missing, mat
             )
+        )
 
-        return mat
+    return mat
 
 
 def expandElementals(mat, blueprint):
@@ -310,3 +368,179 @@ for dimName in set(
         dimName,
         yamlize.Attribute(name=dimName, type=ComponentDimension, default=None),
     )
+
+
+class _ParticleFuelLayer(yamlize.Object):
+    """Component-like specification for a single layer in particle fuel"""
+
+    name = yamlize.Attribute(key="name", type=str)
+    material = yamlize.Attribute(type=str)
+    innerDiam = yamlize.Attribute(key="id", type=float, default=0)
+    od = yamlize.Attribute(key="od", type=float)
+    Tinput = yamlize.Attribute(type=float)
+    Thot = yamlize.Attribute(type=float)
+    # Need this to pick up flags like depletable
+    flags = yamlize.Attribute(type=str, default=None)
+
+    def construct(self, blueprint, matMods):
+        """Construct a sphere and assign to a parent"""
+        # Very similar to ComponentBlueprint.construct, maybe share?
+        runLog.debug(f"Constructing particle fuel layer {self.name}")
+        kwargs = self._conformKwargs(blueprint, matMods)
+        component = components.factory("sphere", [], kwargs)
+
+        # the component __init__ calls setType(), which gives us our initial guess at
+        # what the flags should be.
+        if self.flags is not None:
+            # override the flags from __init__ with the ones from the blueprint
+            component.p.flags = Flags.fromString(self.flags)
+        else:
+            # potentially add the DEPLETABLE flag. Don't do this if we set flags
+            # explicitly. WARNING: If you add flags explicitly, it will
+            # turn off depletion so be sure to add depletable to your list of flags
+            # if you expect depletion
+            if any(nuc in blueprint.activeNuclides for nuc in component.getNuclides()):
+                component.p.flags |= Flags.DEPLETABLE
+
+        if component.hasFlags(Flags.DEPLETABLE):
+            # depletable components, whether auto-derived or explicitly flagged
+            # need expanded nucs
+            _insertDepletableNuclideKeys(component, blueprint)
+
+        if any(nucDir.isHeavyMetal(nucName) for nucName in component.getNuclides()):
+            component.p.flags |= Flags.FUEL
+
+        return component
+
+    def _conformKwargs(self, blueprint, matMods) -> dict:
+        """Return dictionary of arguments to help with component construction"""
+        kwargs = {}
+        for attr in self.attributes:
+            key = attr.name
+            if key == "innerDiam":
+                key = "id"
+            elif key == "flags":
+                continue
+            val = attr.get_value(self)
+            if key == "material":
+                value = constructMaterial(val, blueprint, matMods, None)
+            else:
+                value = attr.get_value(self)
+            kwargs[key] = value
+        return kwargs
+
+
+class ParticleFuelSpec(yamlize.KeyedList):
+    """Specification for a single particle fuel type"""
+
+    item_type = _ParticleFuelLayer
+    key_attr = _ParticleFuelLayer.name
+    name = yamlize.Attribute(type=str)
+
+    def construct(self, blueprint, matMods):
+        """Produce a particle fuel instance that can be attached to a component"""
+        bounds = set()
+
+        layers = sorted(self.values(), key=lambda spec: spec.od)
+        spec = ParticleFuel(self.name)
+
+        prevInner = -inf
+        for layer in layers:
+            comp = layer.construct(blueprint, matMods)
+            innerDim = comp.getDimension("id")
+            if innerDim < 0:
+                raise ValueError(
+                    f"{layer.name} inner diameter must be non-negative, got "
+                    f"{innerDim}"
+                )
+            if innerDim <= prevInner:
+                inners = [ring.innerDiam for ring in layers]
+                raise ValueError(
+                    f"{self.name} has inconsistent inner diameters: not "
+                    f"increasing {inners}"
+                )
+            od = comp.getDimension("od")
+            if innerDim >= od:
+                raise ValueError(
+                    f"{layer.name} outer diameter must be greater than inner diameter. "
+                    f"Got {od} {innerDim}"
+                )
+
+            bounds.update((innerDim, od))
+            spec.add(comp)
+            prevInner = innerDim
+
+        nLayers = len(self)
+        if len(bounds) != nLayers + 1:
+            names = [m.name for m in spec]
+            raise ValueError(
+                f"{self.name} does not have consistent boundaries. Bounds: "
+                f"{sorted(bounds)}, compositions: {names}"
+            )
+
+        if not isclose(min(bounds), 0):
+            raise ValueError(
+                f"Particle fuel {self.name} does not start at radius of zero"
+            )
+
+        return spec
+
+
+class ParticleFuelKeyedList(yamlize.KeyedList):
+    """Keyed list to enable the ``particleFuel`` section
+
+    Structure
+    ---------
+
+    ..code:: yaml
+
+        particle fuel:
+            <specifier>:
+                <layer>:  # not strictly in increasing order
+                    material: <string>
+                    id: <float>
+                    od: <float>
+                    Tinput: <float>
+                    Thot: <float>
+                    flags: <optional list of strings>
+
+    Example
+    -------
+
+    ..code:: yaml
+
+        particle fuel:
+            TRISO:
+                kernel:
+                    material: UO2
+                    id: 0.6
+                    od: 0.61
+                    Tinput: 900
+                    Thot: 900
+                    flags: DEPLETABLE
+                buffer:
+                    material: SiC
+                    id: 0.6
+                    od: 0.62
+                    Tinput: 900
+                    Thot: 900
+                ...
+
+    This enables components to have a ``particle fuel`` section in the
+    blueprints file, indicating a material like a matrix is filled with particle
+    fuel
+
+    ..code:: yaml
+
+        <block>:
+            <component>:
+                name:  matrix
+                material: Graphite
+                # more options
+                particleFuelSpec: TRISO
+                particleFuelPackingFraction: 0.4  # 40% packing
+
+    """
+
+    item_type = ParticleFuelSpec
+    key_attr = ParticleFuelSpec.name

--- a/armi/reactor/components/basicShapes.py
+++ b/armi/reactor/components/basicShapes.py
@@ -47,6 +47,8 @@ class Circle(ShapedComponent):
         isotopics=None,
         mergeWith=None,
         components=None,
+        particleFuelSpec=None,
+        particleFuelPackingFraction: float = 0,
     ):
         ShapedComponent.__init__(
             self,
@@ -57,6 +59,8 @@ class Circle(ShapedComponent):
             isotopics=isotopics,
             mergeWith=mergeWith,
             components=components,
+            particleFuelSpec=particleFuelSpec,
+            particleFuelPackingFraction=particleFuelPackingFraction,
         )
         self._linkAndStoreDimensions(
             components, od=od, id=id, mult=mult, modArea=modArea

--- a/armi/reactor/components/componentParameters.py
+++ b/armi/reactor/components/componentParameters.py
@@ -121,6 +121,17 @@ def getComponentParameterDefinitions():
             description="Pin number of this component in some mesh. Starts at 1.",
             default=None,
         )
+
+        pb.defParam(
+            "packingFractionBOL",
+            default=0.0,
+            units=None,
+            description=(
+                "Packing fraction between zero and one for particle fuel on "
+                "this component. A value of zero indicates no packed particles"
+            ),
+        )
+
     return pDefs
 
 

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -67,8 +67,25 @@ class Sphere(ShapedComponent):
         od = self.getDimension("od")
         iD = self.getDimension("id")
         mult = self.getDimension("mult")
+        mult = mult if mult is not None else 1
         vol = mult * 4.0 / 3.0 * math.pi * ((od / 2.0) ** 3 - (iD / 2.0) ** 3)
         return vol
+
+    def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
+        """Return outer diameter of the sphere given thermal conditions
+
+        Parameters
+        ----------
+        Tc : float, optional
+            Temperature in C
+        cold : bool, optional
+
+        Returns
+        -------
+        float
+            Outer diameter
+        """
+        return self.getDimension("od", Tc=Tc, cold=cold)
 
 
 class Cube(ShapedComponent):

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -276,6 +276,7 @@ class Flags(Flag):
 
     STRUCTURE = auto()
     DEPLETABLE = auto()
+    MATRIX = auto()
 
     @classmethod
     def fromStringIgnoreErrors(cls, typeSpec):

--- a/armi/reactor/particleFuel.py
+++ b/armi/reactor/particleFuel.py
@@ -1,0 +1,90 @@
+from typing import Tuple, Any, Union
+
+from armi.reactor.composites import Composite
+from armi.reactor.components.volumetricShapes import Sphere
+
+
+class ParticleFuel(Composite):
+    """Composite structure representing concentric spheres of particle fuel
+
+    Each layer of the particle fuel is expected to be added via :meth:`add`
+    rather than ``__init__`` because we need this to be constructable via
+    blueprint file and the heirarchy written to / read from the database file.
+
+    Parameters
+    ----------
+    name : str
+        Name of this specification, typically something that is easily
+        recognizable by an engineering team, e.g., ``"AGR TRISO"``
+
+    Attributes
+    ----------
+    layers : tuple of :class:`~armi.reactor.components.Sphere`
+        Each layer of the specification in order of increasing outer
+        diameter
+
+    """
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._layers = None
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__qualname__}({self.name}, {self.layers}>"
+
+    def _checkChildAndClearCacheBeforeAdding(self, obj: Union[Any, Sphere]):
+        if isinstance(obj, Sphere):
+            self._layers = None
+            return
+        raise TypeError(f"Cannot add non-spherical layer {obj} to {self}")
+
+    def add(self, obj: Union[Any, Sphere]):
+        """Add a component layer to this spec"""
+        self._checkChildAndClearCacheBeforeAdding(obj)
+        return super().add(obj)
+
+    def remove(self, obj: Union[Any, Sphere]):
+        """Remove a layer from this spec"""
+        self._checkChildAndClearCacheBeforeAdding(obj)
+        return super().remove(obj)
+
+    def insert(self, index: int, obj: Union[Any, Sphere]):
+        """Insert a layer in this spec
+
+        .. note::
+
+            Ordering of layers is not based on ordering
+            of the children as ARMI defines them, but the
+            outer diameter of each individual layer
+
+        """
+        self._checkChildAndClearCacheBeforeAdding(obj)
+        return super().insert(index, obj)
+
+    def append(self, obj: Union[Any, Sphere]):
+        """Append a layer to the children of this spec
+
+        .. note::
+
+            Ordering of layers is not based on ordering
+            of the children as ARMI defines them, but the
+            outer diameter of each individual layer
+
+        """
+        self._checkChildAndClearCacheBeforeAdding(obj)
+        return super().append(obj)
+
+    @property
+    def layers(self) -> Tuple[Sphere]:
+        if self._layers is None:
+            self._layers = tuple(sorted(self))
+        return self._layers
+
+    def __lt__(self, other: Union["ParticleFuel", Any]) -> bool:
+        """Is the outer diameter of the this spec less than that of another spec"""
+        if isinstance(other, type(self)):
+            mine = self.layers
+            theirs = other.layers
+            if mine is not None and theirs is not None:
+                return mine[-1].getDimension("od") < theirs[-1].getDimension("od")
+        return super().__lt__(other)

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -103,6 +103,8 @@ class TestComponentFactory(unittest.TestCase):
             thisAttrs["name"] = "banana{}".format(i)
             if "modArea" in thisAttrs:
                 thisAttrs["modArea"] = None
+            if "particleFuelSpec" in thisAttrs:
+                thisAttrs["particleFuelSpec"] = None
             component = components.factory(name, [], thisAttrs)
             duped = copy.deepcopy(component)
             for key, val in component.p.items():
@@ -840,6 +842,11 @@ class TestSphere(TestShapedComponent):
 
     def test_thermallyExpands(self):
         self.assertFalse(self.component.THERMAL_EXPANSION_DIMS)
+
+    def test_getBoundingCircleOuterDiameter(self):
+        od = self.component.getDimension("od")
+        actual = self.component.getBoundingCircleOuterDiameter()
+        self.assertEqual(actual, od)
 
 
 class TestTorus(TestShapedComponent):


### PR DESCRIPTION
Provides a yaml-interface for
- modeling particle fuel with arbitrary layers
- multiple particle fuel types in the reactor
- assigning particle fuel as children to some parent component

We have been decently successful with these changes internally in that
downstream plugins can see `Component.particleFuel` and perform actions
based on their content. What follows is an overview of the interface,
implementation, and a discussion of where to go next.

Related to https://github.com/terrapower/armi/issues/228 and
would support modeling the MHTGR-350 benchmark
https://github.com/terrapower/armi/issues/224

This patch is submitted to kick-start a discussion on better ways to add
this feature into ARMI, leveraging the domain knowledge of the ARMI
developers and the "particle fuel aware" plugins internally developed at
USNC Tech.

Input interface
---------------

```yaml
particle fuel:
    demo:
        kernel:
            material: UO2
            id: 0
            od: 0.6
            Tinput: 900
            Thot: 900
            flags: DEPLETABLE
        buffer:
            material: SiC
            id: 0.6
            od: 0.61
            Tinput: 900
            Thot: 900
```

```yaml
matrix:
    shape: Circle
    material: Graphite
    Tinput: 1200
    Thot: 1200
    id: 0.0
    od: 2.2
    latticeIDs: [F]
    flags: DEPLETABLE
    particleFuelSpec: demo
    particleFuelPackingFraction: 0.4

```

With this interface it's possible to define several specifications
in the model and assign them to different cylindrical components.

Implementation
--------------

The particle fuel is stored as a child of the parent component, such
that `<Circle: Matrix>.children` is used to dynamically find the particle
fuel spec. We can't store the specification as an attribute because we
have to support potentially dynamic addition and removal of children to this
component. Something like `self.particleFuel = spec` that makes spec a
child would also have to understand what happens if we remove the spec
from the parent, e.g., `self.remove(self.particleFuel)`. What is then the
outcome of `self.particleFuel` unless we always check the children of the
matrix?

By making the particle fuel spec a `Composite` and placing it in the
`.children` of the parent, the spec is able to be written to and read
from the database.

Adds `Component.setParticleMultiplicity`. The method is called during
block construction when the block's height is available to the matrix
component (particle's parent). The multiplicity is determined from the
matrix volume and target packing fraction.

Note: the particle mult is, by design, for a single component.

Unresolved issues
-----------------

- Volume of the parent matrix is not reduced by the volume occupied
by the particles.
- No support for homogenizing regions that contain particle fuel
- Various homogenization properties don't account for particle fuel
  (e.g., `Core.getHM*`)
- Particle fuel is not included in some text-reporting, leading to
statements like

```
[info] Nuclide categorization for cross section temperature assignments:
       ------------------  ------------------------------------------------------
       Nuclide Category    Nuclides
       ------------------  ------------------------------------------------------
       Fuel
```
and
```
[warn] The system has no heavy metal and therefore is not a nuclear reactor. Please make sure that this is intended and not a input error.
```

- No provided routines for packing the particles into their parent. This
  could be facilitated with a dedicated packing plugin and an unstructured
  3-D `SpatialGrid` class. It's burdensome to expect the user to define
  the exact location of _every_ particle every time. But, if some `Plugin`
  performs the packing and creates this spatial grid, the multiplicity is
  tackled, and you potentially avoid adding or removing particles as their
  parent expands or contracts.
- Unsure if material modifications make their way down to the materials
  in the particle fuel spec. The implementation suggests it as the `matMods`
  argument is passed into the particle fuel YAML object constructor. But
  we have yet to stress test that

Next steps
----------

This patch is submitted because we continue to find places where this
approach does not play well with the rest of the ARMI stack. While Blocks
that contain particle fuel are correctly able to compute their heavy
metal mass by iterating over their children, which in turn finds the
particle fuel. However, higher-level actions like `Core.getHM*` do not
go down to the sub-block level, instead asking to homogenize Blocks.
The homogenization methods are not yet aware of the particle fuel because
they rely on `Component.getNuclides` which reports the nuclides for it's
`Material`, and does not include the children.

This approach is sensible because if I'm writing a neutronic input file
and I can exactly model the matrix and it's particle fuel, I would expect
`matrix.getNuclides` to return the nuclides for _just the matrix_. Then,
being informed of the particle fuel, I can write those materials and geometry
uniquely. However, codes that cannot handle particle fuel and/or work
with homogenized regions (e.g., nodal diffusion) would need this
homogenized data. Allowing `Component.getNuclides` to return the nuclides
on the child particle fuel would support this case, but not the previous case.

My speculation is that the optimal strategy lies somewhere in making the
matrix object not a `Component` but a `Block` and having the ARMI Composite
tree accept blocks that potentially contain blocks. I think this is valid
using the API but the user interface would need some work. Having the matrix
be a block would provide a better interface for homogenization and exact
representation of the particle fuel. I think...

Other related changes
---------------------

Added `Sphere.getBoundingCircleOuterDiameter` so that the particle fuel
composites can be properly added to the database. They need to be
"sortable" other wise `Database3._createLayout` breaks trying to sort
components. This enables the particle fuel spec to be added to and read
from the HDF data file

The material constructor is a more public function as it is needed both
in creating `Components` but also in creating the particle fuel spec.

Added `MATRIX` flag

Signed-off-by: Andrew Johnson <a.johnson@usnc-tech.com>