### PR TITLE
Update docs to remove sphinx warnings

### DIFF
--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -31,6 +31,7 @@ means that one generally should not be worried about a converted database having
 parameters in it that the one produced directly may not, assuming that the extra
 converted parameters are the default. Also, especially at the Component level, some of
 the parameters are expected to be different. Specifically the following:
+
 * temperatures: The old database format simply did not store these on the component
   level, so when converting a database, the components in a block will uniformly get
   whatever the Block temperature was.
@@ -40,6 +41,7 @@ the parameters are expected to be different. Specifically the following:
   temperatures
 * memory usage: Relatively self-evident. Resource usage will vary from run to run,
   even if the code hasn't changed.
+
 """
 import collections
 import os

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -2407,6 +2407,7 @@ def packSpecialData(
     if each block has a parameter that is a dictionary, ``data`` would be a ndarray,
     where each element is a dictionary. This routine supports a number of different
     "strange" things:
+
     * Dict[str, float]: These are stored by finding the set of all keys for all
       instances, and storing those keys as a list in an attribute. The data themselves
       are stored as arrays indexed by object, then key index. Dictionaries lacking data

--- a/armi/bookkeeping/newReportUtils.py
+++ b/armi/bookkeeping/newReportUtils.py
@@ -296,11 +296,14 @@ def _setGeneralSimulationData(core, cs, coreDesignTable):
 
 
 def insertEndOfLifeContent(r, report):
-    """Generate End of Life Content for the report
+    """
+    Generate End of Life Content for the report
 
-    Parameters:
-    r: Reactor
-    report: ReportContent
+    Parameters
+    ----------
+    r : Reactor
+        the reactor
+    report : ReportContent
         The report to be added to.
 
     """
@@ -492,13 +495,18 @@ def getPinDesignTable(core):
 
 
 def insertAreaFractionsReport(block, report):
-    """Adds to an Assembly Area Fractions table subsection of the Comprehensive Section
+    """
+    Adds to an Assembly Area Fractions
+
+    Adds to the table subsection of the Comprehensive Section
     of the report.
 
-        Parameters
-        ----------
-        block: Block
-        report: ReportContent
+    Parameters
+    ----------
+    block : Block
+        The block
+    report : ReportContent
+        The report
 
     """
     for c, frac in block.getVolumeFractions():

--- a/armi/bookkeeping/plotting.py
+++ b/armi/bookkeeping/plotting.py
@@ -43,7 +43,7 @@ def plotReactorPerformance(reactor, dbi, buGroups, extension=None):
     reactor : armi.reactor.reactors.Reactor
         The reactor to plot
 
-    dbi : DatabaseInterface
+    dbi : armi.bookkeeping.db.DatabaseInterface
         The DatabaseInterface object from which to pull historical data
 
     buGroups : list of float

--- a/armi/bookkeeping/visualization/vtk.py
+++ b/armi/bookkeeping/visualization/vtk.py
@@ -18,14 +18,16 @@ Visualization implementation for VTK files.
 Limitations
 -----------
 This version of the VTK file writer comes with a number of limitations and/or aspects
-that can be improved upon. For instance
- - Only the Block and Assembly meshes and related parameters are exported to the VTK
-   file. Adding Core data is totally doable, and will be the product of future work.
-   With more considerable effort, arbitrary components may be visualizable!
- - No efforts are made to de-duplicate the vertices in the mesh, so there are more
-   vertices than needed. Some fancy canned algorithms probably exist to do this, and it
-   wouldn't be too difficult to do here either. Also future work, but probably not super
-   important unless dealing with really big meshes.
+that can be improved upon. For instance:
+
+* Only the Block and Assembly meshes and related parameters are exported to the VTK
+  file. Adding Core data is totally doable, and will be the product of future work.
+  With more considerable effort, arbitrary components may be visualizable!
+* No efforts are made to de-duplicate the vertices in the mesh, so there are more
+  vertices than needed. Some fancy canned algorithms probably exist to do this, and it
+  wouldn't be too difficult to do here either. Also future work, but probably not super
+  important unless dealing with really big meshes.
+
 """
 
 from typing import Dict, Any, List, Optional, Set, Tuple

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -67,7 +67,7 @@ class Case:
 
     A Case is capable of loading inputs, checking that they are valid, and
     initializing a reactor model. Cases can also compare against
-    other cases and be collected into :py:class:`~armi.cases.suite.CaseSuite`s.
+    other cases and be collected into :py:class:`armi.cases.suite.CaseSuite`\ s.
     """
 
     def __init__(self, cs, caseSuite=None, bp=None, geom=None):
@@ -86,7 +86,7 @@ class Case:
             snapshot testing or more complex analysis sequences).
 
         bp : Blueprints, optional
-            :py:class:`~armi.reactor.blueprints.Blueprints` object containing the assembly
+            :py:class:`armi.reactor.blueprints.Blueprints` object containing the assembly
             definitions and other information. If not supplied, it will be loaded from the
             ``cs`` as needed.
 

--- a/armi/cases/inputModifiers/inputModifiers.py
+++ b/armi/cases/inputModifiers/inputModifiers.py
@@ -147,9 +147,11 @@ class MultiSettingModifier(InputModifier):
 
     Examples
     --------
-    inputModifiers.MultiSettingModifier(
-        {CONF_NEUTRONICS_TYPE: "both", CONF_COARSE_MESH_REBALANCE: -1}
-    )
+
+    >>> inputModifiers.MultiSettingModifier(
+    ...    {CONF_NEUTRONICS_TYPE: "both", CONF_COARSE_MESH_REBALANCE: -1}
+    ... )
+
     """
 
     def __init__(self, settingVals: dict):

--- a/armi/cli/modify.py
+++ b/armi/cli/modify.py
@@ -28,9 +28,10 @@ class ModifyCaseSettingsCommand(EntryPoint):
     Search through a directory tree and modify ARMI settings in existing input file(s).
     All valid settings may be used as keyword arguments.
 
-    Example
-    -------
-    $ python -m armi modify --numProcessors=3 *.xml
+    Run the entry point like this::
+
+        $ python -m armi modify --numProcessors=3 *.xml
+
     """
 
     name = "modify"

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -214,7 +214,7 @@ class MpiAction:
 
         Parameters
         ----------
-        o : :py:class:`armi.operators.Operator`
+        o : :py:class:`armi.operators.operator.Operator`
             the operator for this process
         r : :py:class:`armi.reactor.reactors.Reactor`
             the reactor represented in this process

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -18,7 +18,7 @@ The nuclideBases module classes for providing *base* nuclide information, such a
 For details on how to setup the RIPL-3 data files to process extra nuclide data see:
 :doc:`/user/user_install`
 
-The nuclide class structure is outlined in :ref:`nuclide-bases-class-diagram`.
+The nuclide class structure is outlined in :ref:`the figure <nuclide-bases-class-diagram>`.
 
 .. _nuclide-bases-class-diagram:
 

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -528,9 +528,10 @@ def migrate(bp: Blueprints, cs):
     This is a good place to perform migrations that address changes to the system design
     description (settings, blueprints, geom file). We have access to all three here, so
     we can even move stuff between files. Namely, this:
-     - creates a grid blueprint to represent the core layout from the old ``geomFile``
+
+     * creates a grid blueprint to represent the core layout from the old ``geomFile``
        setting, and applies that grid to a ``core`` system.
-     - moves the radial and azimuthal submesh values from the ``geomFile`` to the
+     * moves the radial and azimuthal submesh values from the ``geomFile`` to the
        assembly designs, but only if they are uniform (this is limiting, but could be
        made more sophisticated in the future, if there is need)
 

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -36,6 +36,7 @@ armi.utils.asciimaps
 
 Examples
 --------
+
 ::
 
     grids:
@@ -101,6 +102,7 @@ Examples
                          IC   IC   MC   OC   RR   SH
                            IC   MC   MC   OC   RR
                          IC   IC   MC   PC   RR   SH
+
 
 """
 import copy
@@ -213,12 +215,12 @@ class GridBlueprint(yamlize.Object):
 
         Notes
         -----
-        yamlize does not call an __init__ method, instead it uses __new__ and setattr
-        this is only needed for when you want to make this object from a non-YAML
+        yamlize does not call an ``__init__`` method, instead it uses ``__new__`` and
+        setattr this is only needed for when you want to make this object from a non-YAML
         source.
 
         .. warning:: This is a Yamlize object, so ``__init__`` never really gets called.
-        Only ``__new__`` does.
+               Only ``__new__`` does.
 
         """
         self.name = name

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -296,10 +296,11 @@ class DerivedShape(UnshapedComponent):
         -----
         This is used to sort components relative to one another.
 
-        There can only be one derived component per block, this is generally the coolant inside a
-        duct. Under most circumstances, the volume (or area) of coolant will be greater than any
-        other (single) component (i.e. a single pin) within the assembly. So, sorting based on the
-        Dh of the DerivedShape will result in somewhat expected results.
+        There can only be one derived component per block, this is generally the coolant
+        inside a duct. Under most circumstances, the volume (or area) of coolant will be
+        greater than any other (single) component (i.e. a single pin) within the assembly.
+        So, sorting based on the Dh of the DerivedShape will result in somewhat expected
+        results.
         """
         if self.parent is None:
             # since this is only used for comparison, and it must be smaller than at
@@ -315,7 +316,7 @@ class DerivedShape(UnshapedComponent):
 
     def _deriveVolumeAndArea(self):
         """
-        Derive the volume and area of ``DerivedShape``s.
+        Derive the volume and area of ``DerivedShape``\ s.
 
         Notes
         -----
@@ -370,11 +371,12 @@ class DerivedShape(UnshapedComponent):
         """
         Get volume of derived shape.
 
-        The DerivedShape must pay attention to all of the companion objects, because if they change, this changes.
-        However it's inefficient to always recompute the derived volume, so we have to rely on the parent to know
-        if anything has changed.
+        The DerivedShape must pay attention to all of the companion objects, because if
+        they change, this changes.  However it's inefficient to always recompute the
+        derived volume, so we have to rely on the parent to know if anything has changed.
 
-        Since each parent is only allowed one DerivedShape, we can reset the update flag here.
+        Since each parent is only allowed one DerivedShape, we can reset the update flag
+        here.
 
         Returns
         -------

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -141,43 +141,50 @@ class Cube(ShapedComponent):
 
 
 class Torus(ShapedComponent):
-    r"""Theta defines the extent the radial segment is rotated around the Z-axis
+    r"""
+    A torus.
+
+    Theta defines the extent the radial segment is rotated around the Z-axis
     phi defines the extent around the major radius (i.e. a half torus is from 0 to pi)
 
     Notes
     -----
-    p0 - inner minor radius
-    p1 - outer minor radius
-    p2 - major radius
-    p3 - multiplier
-    p4 - inner theta (optional) 0 (default)
-    p5 - outer theta (optional) 2pi (default)
-    p6 - inner phi (optional) 0 (default)
-    p7 - outer phi (optional) 2pi (default)
-    p8 - height (optional) <set as outer minor radius > (default)
-    p9 - reference volume (optional)
+    The dimensions are:
 
-    Z
-    |
-    |
-    |
-    |            - ^ -
-    |          /   | minor radius
-    |-----------------------> major radius, R
-    |          \      /
-    |           - - -
-    |
+    * p0 - inner minor radius
+    * p1 - outer minor radius
+    * p2 - major radius
+    * p3 - multiplier
+    * p4 - inner theta (optional) 0 (default)
+    * p5 - outer theta (optional) 2pi (default)
+    * p6 - inner phi (optional) 0 (default)
+    * p7 - outer phi (optional) 2pi (default)
+    * p8 - height (optional) <set as outer minor radius > (default)
+    * p9 - reference volume (optional)
 
-    Y
-    ^                      -
-    |                 -
-    |            -    \
-    |       -  \       \
-    |  theta   |       |
-   ZX-----------------------> major radius, X
-    |
-    |
-    |
+    Image::
+
+        Z
+        |
+        |
+        |
+        |            - ^ -
+        |          /   | minor radius
+        |-----------------------> major radius, R
+        |          \      /
+        |           - - -
+        |
+
+        Y
+        ^                      -
+        |                 -
+        |            -    \
+        |       -  \       \
+        |  theta   |       |
+       ZX-----------------------> major radius, X
+        |
+        |
+        |
     """
 
     is3D = True

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -268,6 +268,7 @@ class ArmiObject(metaclass=CompositeModelType):
     The abstract base class for all composites and leaves.
 
     This:
+
     * declares the interface for objects in the composition
     * implements default behavior for the interface common to all
       classes
@@ -454,9 +455,10 @@ class ArmiObject(metaclass=CompositeModelType):
         Make a clean copy of this object.
 
         .. warning:: Be careful with inter-object dependencies. If one object contains a
-        reference to another object which contains links to the entire hierarchical
-        tree, memory can fill up rather rapidly. Weak references are designed to help
-        with this problem.
+            reference to another object which contains links to the entire hierarchical
+            tree, memory can fill up rather rapidly. Weak references are designed to help
+            with this problem.
+
         """
         raise NotImplementedError
 
@@ -1825,6 +1827,7 @@ class ArmiObject(metaclass=CompositeModelType):
         generationNum : int, optional
             Which generation to average over (1 for children, 2 for grandchildren)
 
+
         The weighted sum is:
 
         .. math::
@@ -1843,6 +1846,7 @@ class ArmiObject(metaclass=CompositeModelType):
         -------
         float
             The average parameter value.
+
         """
         total = 0.0
         weightSum = 0.0

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -680,21 +680,21 @@ class HexToRZThetaConverter(GeometryConverter):
         """
         Add a new stack of circles to the TRZ reactor by homogenizing assems
 
-        Inputs
-        ------
-        innerDiameter:
+        Parameters
+        ----------
+        innerDiameter : float
             The current innerDiameter of the radial-theta zone
 
-        thetaIndex:
+        thetaIndex : float
             The theta index of the radial-theta zone
 
-        radialIndex:
+        radialIndex : float
             The radial index of the radial-theta zone
 
-        lowerTheta:
+        lowerTheta : float
             The lower theta bound for the radial-theta zone
 
-        upperTheta:
+        upperTheta : float
             The upper theta bound for the radial-theta zone
 
         Returns

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -30,12 +30,13 @@ class GeomType(enum.Enum):
     and symmetry conditions. This makes interpretation of user input straightforward,
     but is less ergonomic, less efficient, and more error-prone within the code. For
     instance:
-     - is "quarter reflective" the same as "reflective quarter"? Should it be?
-     - code that needs to interpret these need to use string operations, which are
-       non-trivial compared to enum comparisons.
-     - rules about mutual exclusion (hex and Cartesian can't both be used in the same
-       context) and composability (geometry type + domain + symmetry type) are harder to
-       enforce.
+
+    * is "quarter reflective" the same as "reflective quarter"? Should it be?
+    * code that needs to interpret these need to use string operations, which are
+      non-trivial compared to enum comparisons.
+    * rules about mutual exclusion (hex and Cartesian can't both be used in the same
+      context) and composability (geometry type + domain + symmetry type) are harder to
+      enforce.
 
     Instead, we hope to parse user input into a collection of enumerations and use those
     internally throughout the code. Future work should expand this to satisfy all needs
@@ -56,10 +57,12 @@ class GeomType(enum.Enum):
         There will remain situations where a geomType may be provided in string or enum
         form, in which the consuming code would have to check the type before
         proceeding. This function serves two useful purposes:
-         - Relieve client code from having to if/elif/else on ``isinstance()`` checks
-         - Provide a location to instrument these conversions for when we actually try
-           to deprecate the strings. E.g., produce a warning when this is called, or
-           eventually forbidding the conversion entirely.
+
+        * Relieve client code from having to if/elif/else on ``isinstance()`` checks
+        * Provide a location to instrument these conversions for when we actually try
+          to deprecate the strings. E.g., produce a warning when this is called, or
+          eventually forbidding the conversion entirely.
+
         """
         if isinstance(source, GeomType):
             return source
@@ -133,18 +136,6 @@ class DomainType(enum.Enum):
 
     @classmethod
     def fromAny(cls, source: Union[str, "DomainType"]) -> "DomainType":
-        """
-        Safely convert from string representation, no-op if already an enum instance.
-
-        This is useful as we transition to using enumerations more throughout the code.
-        There will remain situations where a DomainType may be provided in string or enum
-        form, in which the consuming code would have to check the type before
-        proceeding. This function serves two useful purposes:
-         - Relieve client code from having to if/elif/else on ``isinstance()`` checks
-         - Provide a location to instrument these conversions for when we actually try
-           to deprecate the strings. E.g., produce a warning when this is called, or
-           eventually forbidding the conversion entirely.
-        """
         if isinstance(source, DomainType):
             return source
         elif isinstance(source, str):
@@ -236,18 +227,6 @@ class BoundaryType(enum.Enum):
 
     @classmethod
     def fromAny(cls, source: Union[str, "BoundaryType"]) -> "BoundaryType":
-        """
-        Safely convert from string representation, no-op if already an enum instance.
-
-        This is useful as we transition to using enumerations more throughout the code.
-        There will remain situations where a BoundaryType may be provided in string or enum
-        form, in which the consuming code would have to check the type before
-        proceeding. This function serves two useful purposes:
-         - Relieve client code from having to if/elif/else on ``isinstance()`` checks
-         - Provide a location to instrument these conversions for when we actually try
-           to deprecate the strings. E.g., produce a warning when this is called, or
-           eventually forbidding the conversion entirely.
-        """
         if isinstance(source, BoundaryType):
             return source
         elif isinstance(source, str):
@@ -388,18 +367,6 @@ class SymmetryType:
 
     @classmethod
     def fromAny(cls, source: Union[str, "SymmetryType"]) -> "SymmetryType":
-        """
-        Safely convert from string representation, no-op if already an enum instance.
-
-        This is useful as we transition to using enumerations more throughout the code.
-        There will remain situations where a SymmetryType may be provided in string or enum
-        form, in which the consuming code would have to check the type before
-        proceeding. This function serves two useful purposes:
-         - Relieve client code from having to if/elif/else on ``isinstance()`` checks
-         - Provide a location to instrument these conversions for when we actually try
-           to deprecate the strings. E.g., produce a warning when this is called, or
-           eventually forbidding the conversion entirely.
-        """
         if isinstance(source, SymmetryType):
             return source
         elif isinstance(source, str):

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -39,10 +39,10 @@ a grid or in arbitrary, continuous space (using a :py:class:`CoordinateLocation`
 
 Below is a basic example of how to use a 2-D grid::
 
->>> grid = CartesianGrid.fromRectangle(1.0, 1.0)  # 1 cm square-pitch Cartesian grid
->>> location = grid[1,2,0]
->>> location.getGlobalCoordinates()
-array([ 1.,  2.,  0.])
+    >>> grid = CartesianGrid.fromRectangle(1.0, 1.0)  # 1 cm square-pitch Cartesian grid
+    >>> location = grid[1,2,0]
+    >>> location.getGlobalCoordinates()
+    array([ 1.,  2.,  0.])
 
 Grids can be chained together in a parent-child relationship. This is often used in ARMI
 where a 1-D axial grid (e.g. in an assembly) is being positioned in a core or spent-fuel
@@ -296,9 +296,11 @@ class IndexLocation(LocationBase):
         equality (i.e. (0,0,0) in a storage rack is not equal to (0,0,0) in a core).
 
         It is a numpy array for two reasons:
+
         1. It can be added and subtracted for the recursive computations
            through different coordinate systems
         2. It can be written/read from the database.
+
         """
         return numpy.array(self[:3])
 
@@ -533,7 +535,8 @@ class Grid:
             (dxi, dxj, jxk), (dyi, dyj, dyk), (dzi, dzj, dzk)
 
         where ``dmn`` is the distance (in cm) that dimension ``m`` will change as a
-                function of index ``n``.
+        function of index ``n``.
+
         Unit steps are used as a generic method for defining repetitive grids in a
         variety of geometries, including hexagonal and Cartesian.  The tuples are not
         vectors in the direction of the translation, but rather grouped by direction. If

--- a/armi/reactor/parameters/exceptions.py
+++ b/armi/reactor/parameters/exceptions.py
@@ -20,7 +20,9 @@ class ParameterDefinitionError(Exception):
 
     * Attempting to create two parameters with the same name.
     * Attempting to create a parameter outside of a :py:class:`ParameterFactory`
-    ``with`` statement."""
+      ``with`` statement.
+
+    """
 
     def __init__(self, message):
         Exception.__init__(
@@ -36,9 +38,10 @@ class ParameterError(Exception):
     Usage errors include:
 
     * Attempting to get the value of a parameter that has not been defined a value, and
-    has no default.
+      has no default.
     * Attempting to set the value of a parameter that cannot be set through
-    ``setParam``.
+      ``setParam``.
+
     """
 
 
@@ -48,4 +51,5 @@ class UnknownParameterError(ParameterError):
     Usage errors include:
 
     * Attempting to set the value of a parameter that has no definition and no rename
+
     """

--- a/armi/reactor/parameters/resolveCollections.py
+++ b/armi/reactor/parameters/resolveCollections.py
@@ -44,23 +44,25 @@ to the related hierarchy of classes inheriting the root ``ArmiObject`` class. It
 be rare for an ARMI developer not engaged directly with Framework development to need to
 know exactly how this works, but a proficient ARMI developer must keep in mind the
 following rules about how this system behaves in practice:
-    - When defining subclasses of ``ArmiObject``, defining a class attribute called
-      ``pDefs`` of the ``ParameterDefinitionCollection`` type signals to the system that
-      this is a *Parameter Class*.
-    - When defining a *Parameter Class*, it will trigger the creation of a new
-      ``ParameterCollection`` class, which will be derived from the
-      ``ParameterCollection`` class of the most immediate *Parameter Class* ancestor
-      the new class's inheritance tree.
-    - All classes derived from ``ArmiObject`` will receive an associated subclass of
-      ``ParameterCollection``, which will ultimately include all of the relevant
-      Parameters for that class. The specific class is the ``ParameterCollection``
-      subclass defined for the most immediate *Parameter Class* in the classes
-      inheritance tree.
-    - Parameter definitions can be added to a *Parameter Class*'s ``pDefs`` until
-      Parameters have been "compiled" for it. After compiling parameters, the ``pDefs``
-      are locked, and any attempts at defining additional parameters will cause an
-      error.
-    - ``ArmiObject`` s cannot be instantiated until after parameters have been compiled.
+
+* When defining subclasses of ``ArmiObject``, defining a class attribute called
+  ``pDefs`` of the ``ParameterDefinitionCollection`` type signals to the system that
+  this is a *Parameter Class*.
+* When defining a *Parameter Class*, it will trigger the creation of a new
+  ``ParameterCollection`` class, which will be derived from the
+  ``ParameterCollection`` class of the most immediate *Parameter Class* ancestor
+  the new class's inheritance tree.
+* All classes derived from ``ArmiObject`` will receive an associated subclass of
+  ``ParameterCollection``, which will ultimately include all of the relevant
+  Parameters for that class. The specific class is the ``ParameterCollection``
+  subclass defined for the most immediate *Parameter Class* in the classes
+  inheritance tree.
+* Parameter definitions can be added to a *Parameter Class*'s ``pDefs`` until
+  Parameters have been "compiled" for it. After compiling parameters, the ``pDefs``
+  are locked, and any attempts at defining additional parameters will cause an
+  error.
+* ``ArmiObject`` s cannot be instantiated until after parameters have been compiled.
+
 """
 
 from armi.reactor.parameters.parameterCollections import ParameterCollection

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -395,14 +395,18 @@ class Core(composites.Composite):
         discharge : bool, optional
             Discharge the assembly, including adding it to the SFP. Default: True
 
-        Originally, this held onto all assemblies in the spend fuel pool. However, having this sitting in memory
-        becomes constraining for large problems. It is more memory-efficient to only save the assemblies
-        that are required for detailed history tracking. In fact, there's no need to save the assembly object at all,
-        just have the history interface save the relevant parameters. This is an important cleanup.
+
+        Originally, this held onto all assemblies in the spend fuel pool. However, having
+        this sitting in memory becomes constraining for large problems. It is more
+        memory-efficient to only save the assemblies that are required for detailed
+        history tracking. In fact, there's no need to save the assembly object at all,
+        just have the history interface save the relevant parameters. This is an important
+        cleanup.
 
         See Also
         --------
         add : adds an assembly
+
         """
         paramDefs = set(parameters.ALL_DEFINITIONS)
         paramDefs.difference_update(set(parameters.forType(Core)))
@@ -1243,12 +1247,13 @@ class Core(composites.Composite):
         This is used to categorize nuclides for Doppler broadening. Control nuclides are treated as structure.
 
         The categories are defined in the following way:
+
         1. Add nuclides from coolant components to coolantNuclides
-        2. Add nuclides from fuel components to fuelNuclides (this may be incomplete, e.g. at BOL there are no fission
-           products)
+        2. Add nuclides from fuel components to fuelNuclides (this may be incomplete, e.g.
+           at BOL there are no fission products)
         3. Add nuclides from all other components to structureNuclides
-        4. Since fuelNuclides may be incomplete, add anything else the user wants to model that isn't already listed
-           in coolantNuclides or structureNuclides.
+        4. Since fuelNuclides may be incomplete, add anything else the user wants to model
+           that isn't already listed in coolantNuclides or structureNuclides.
 
         Returns
         -------
@@ -1260,6 +1265,7 @@ class Core(composites.Composite):
 
         structureNuclides : set
             set of nuclide names
+
         """
         if not self._nuclideCategories:
             coolantNuclides = set()
@@ -1529,7 +1535,8 @@ class Core(composites.Composite):
         """
         Find assemblies that are next this assembly.
 
-        Return a list of neighboring assemblies from the 30 degree point (point 1) then counterclockwise around.
+        Return a list of neighboring assemblies from the 30 degree point (point 1) then
+        counterclockwise around.
 
         Parameters
         ----------
@@ -1537,49 +1544,63 @@ class Core(composites.Composite):
             The assembly to find neighbors of.
 
         showBlanks : Boolean, optional
-            If True, the returned array of 6 neighbors will return "None" for neighbors that do not explicitly
-                exist in the 1/3 core model (including many that WOULD exist in a full core model).
-            If False, the returned array will not include the "None" neighbors. If one or more neighbors does
-                not explicitly exist in the 1/3 core model, the returned array will have a length of less than 6.
+            If True, the returned array of 6 neighbors will return "None" for neighbors
+            that do not explicitly exist in the 1/3 core model (including many that WOULD
+            exist in a full core model).
+
+            If False, the returned array will not include the "None" neighbors. If one or
+            more neighbors does not explicitly exist in the 1/3 core model, the returned
+            array will have a length of less than 6.
 
         duplicateAssembliesOnReflectiveBoundary : Boolean, optional
-            If True, findNeighbors duplicates neighbor assemblies into their "symmetric identicals" so that
-                even assemblies that border symmetry lines will have 6 neighbors. The only assemblies that
-                will have fewer than 6 neighbors are those that border the outer core boundary (usually vacuum).
-            If False, findNeighbors returns None for assemblies that do not exist in a 1/3 core model
-                (but WOULD exist in a full core model).
-            For example, applying findNeighbors for the central assembly (ring, pos) = (1, 1) in 1/3 core symmetry
-                (with duplicateAssembliesOnReflectiveBoundary = True) would return a list of 6 assemblies, but
-                those 6 would really only be assemblies (2, 1) and (2, 2) repeated 3 times each.
-            Note that the value of duplicateAssembliesOnReflectiveBoundary only really if showBlanks = True.
-            This will have no effect if the model is full core since asymmetric models could find many
-            duplicates in the other thirds
+            If True, findNeighbors duplicates neighbor assemblies into their "symmetric
+            identicals" so that even assemblies that border symmetry lines will have 6
+            neighbors. The only assemblies that will have fewer than 6 neighbors are those
+            that border the outer core boundary (usually vacuum).
+
+            If False, findNeighbors returns None for assemblies that do not exist in a 1/3
+            core model (but WOULD exist in a full core model).
+
+            For example, applying findNeighbors for the central assembly (ring, pos) = (1,
+            1) in 1/3 core symmetry (with duplicateAssembliesOnReflectiveBoundary = True)
+            would return a list of 6 assemblies, but those 6 would really only be
+            assemblies (2, 1) and (2, 2) repeated 3 times each.
+
+            Note that the value of duplicateAssembliesOnReflectiveBoundary only really if
+            showBlanks = True.  This will have no effect if the model is full core since
+            asymmetric models could find many duplicates in the other thirds
 
 
         Notes
         -----
         This only works for 1/3 or full core symmetry.
 
-        This uses the 'mcnp' index map (MCNP GEODST hex coordinates)
-        instead of the standard (ring, pos) map. because neighbors have consistent indices this way.
-        We then convert over to (ring, pos) using the lookup table that a reactor has.
+        This uses the 'mcnp' index map (MCNP GEODST hex coordinates) instead of the
+        standard (ring, pos) map. because neighbors have consistent indices this way.  We
+        then convert over to (ring, pos) using the lookup table that a reactor has.
 
 
         Returns
         -------
         neighbors : list of assembly objects
             This is a list of "nearest neighbors" to assembly a.
-            If showBlanks = False, it will return fewer than 6 neighbors if not all 6 neighbors explicitly exist in the core model.
-            If showBlanks = True and duplicateAssembliesOnReflectiveBoundary = False, it will have a "None" for assemblies
-                that do not exist in the 1/3 model.
-            If showBlanks = True and duplicateAssembliesOnReflectiveBoundary = True, it will return the existing "symmetric identical"
-                assembly of a non-existing assembly. It will only return "None" for an assembly when that assembly is non-existing AND
-                has no existing "symmetric identical".
+
+            If showBlanks = False, it will return fewer than 6 neighbors if not all 6
+            neighbors explicitly exist in the core model.
+
+            If showBlanks = True and duplicateAssembliesOnReflectiveBoundary = False, it
+            will have a "None" for assemblies that do not exist in the 1/3 model.
+
+            If showBlanks = True and duplicateAssembliesOnReflectiveBoundary = True, it
+            will return the existing "symmetric identical" assembly of a non-existing
+            assembly. It will only return "None" for an assembly when that assembly is
+            non-existing AND has no existing "symmetric identical".
 
 
         See Also
         --------
         grids.Grid.getSymmetricEquivalents
+
         """
         neighborIndices = self.spatialGrid.getNeighboringCellIndices(
             *a.spatialLocator.getCompleteIndices()
@@ -1942,20 +1963,19 @@ class Core(composites.Composite):
         return i
 
     def findAllRadMeshPoints(self, extraAssems=None, applySubMesh=True):
-        r"""
-        returns a list of all radial-mesh positions in the core.
+        """
+        Return a list of all radial-mesh positions in the core.
 
-        Notes
-        -----
 
         Parameters
         ----------
         extraAssems : list
-            additional assemblies to consider when determining the mesh points.
-            They may be useful in the MCPNXT models to represent the fuel management dummies.
+            additional assemblies to consider when determining the mesh points.  They may
+            be useful in the MCPNXT models to represent the fuel management dummies.
 
         applySubMesh : bool
-            (not implemented) generates submesh points to further discretize the radial reactor mesh
+            (not implemented) generates submesh points to further discretize the radial
+            reactor mesh
 
         """
         _, j, _ = self.findAllMeshPoints(extraAssems, applySubMesh)

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -492,10 +492,15 @@ class RunLogger(logging.Logger):
         )
 
     def _log(self, *args, **kwargs):
-        """wrapper around the standard library Logger._log() method
+        """
+        Wrapper around the standard library Logger._log() method
+
         The primary goal here is to allow us to support the deduplication of warnings.
-        NOTE: All of the *args and **kwargs logic here are mandatory, as the standard library implementation of this
-        method has been changing the number of kwargs between Python v3.4 and v3.9.
+
+        .. note:: All of the ``*args`` and ``**kwargs`` logic here are mandatory, as the
+            standard library implementation of this method has been changing the number of
+            kwargs between Python v3.4 and v3.9.
+
         """
         # we need 'extra' as an output keyword, even if empty
         if "extra" not in kwargs:

--- a/armi/utils/codeTiming.py
+++ b/armi/utils/codeTiming.py
@@ -21,17 +21,20 @@ import os
 
 
 def timed(*args):
-    """Decorate functions to time how long they take.
+    """
+    Decorate functions to measure how long they take.
 
     Examples
     --------
-    @timed # your timer will be called the module+method name
-    def mymethod(stuff):
-        do stuff
+    ::
 
-    @timed('call my timer this instead')
-    def mymethod2(stuff)
-       do even more stuff
+        @timed # your timer will be called the module+method name
+        def mymethod(stuff):
+            do stuff
+
+        @timed('call my timer this instead')
+        def mymethod2(stuff)
+           do even more stuff
 
     """
 

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -17,34 +17,32 @@ GUI elements for manipulating grid layout and contents.
 This provides a handful of classes which provide wxPython Controls for manipulating
 grids and grid Blueprints.
 
-Use
-===
 The grid editor may be invoked with the :py:mod:`armi.cli.gridGui` entry point::
 
     $ python -m armi grids
 
 
-Known Issues
-============
+**Known Issues**
 
- * There is no action stack or undo functionality. Save frequently if you want to
- recover previous states
+* There is no action stack or undo functionality. Save frequently if you want to
+  recover previous states
 
- * Cartesian grids are supported, but not rendered as nicely as their Hex counterparts.
- The "through center assembly" case is not rendered properly with the half-assemblies
- that lie along the edges.
+* Cartesian grids are supported, but not rendered as nicely as their Hex counterparts.
+  The "through center assembly" case is not rendered properly with the half-assemblies
+  that lie along the edges.
 
- * The controls are optimized for manipulating a Core layout, displaying an "Assembly
- palette" that contains the Assembly designs found in the top-level blueprints. A little
- extra work and this could also be made to manipulate block grids or other things.
+* The controls are optimized for manipulating a Core layout, displaying an "Assembly
+  palette" that contains the Assembly designs found in the top-level blueprints. A little
+  extra work and this could also be made to manipulate block grids or other things.
 
- * Assembly colors are derived from the set of flags applied to them, but the mapping of
- colors to flags is not particularly rich, and there isn't anything to disambiguate
- between asemblies of different design, but the same flags.
+* Assembly colors are derived from the set of flags applied to them, but the mapping of
+  colors to flags is not particularly rich, and there isn't anything to disambiguate
+  between asemblies of different design, but the same flags.
 
- * No proper zoom support, and object sizes are fixed and don't accommodate long
- specifiers. Adding zoom would make for a fun first task to a new developer interested
- in computer graphics.
+* No proper zoom support, and object sizes are fixed and don't accommodate long
+  specifiers. Adding zoom would make for a fun first task to a new developer interested
+  in computer graphics.
+
 """
 
 import colorsys
@@ -630,9 +628,10 @@ class GridGui(wx.ScrolledWindow):
     This is the actual viewer that displays the grid and grid blueprints contents, and
     responds to mouse events. Under the hood, it uses a wx.PseudoDC to handle the
     drawing, which provides the following benefits over a regular DC:
-     - Drawn objects can be associated with an ID, allowing parts of the drawing to be
+
+     * Drawn objects can be associated with an ID, allowing parts of the drawing to be
        modified or cleared without having to re-draw everything.
-     - The IDs associated with the objects can be used to distinguish what was clicked
+     * The IDs associated with the objects can be used to distinguish what was clicked
        on in a mouse event (though the support for this isn't super great, so we do have
        to do some of our own object disambiguation).
 
@@ -679,7 +678,7 @@ class GridGui(wx.ScrolledWindow):
         parent : wx.Window
             The parent control
 
-        bp : Optional set of grid blueprints
+        bp : set of grid blueprints, optional
             This should be the ``gridDesigns`` section of a root Blueprints object. If
             not provided, a dictionary will be created with an empty "core" grid
             blueprint.

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -210,12 +210,13 @@ def plotFaceMap(
     param : str, optional
         The block-parameter to plot. Default: pdens
 
-    vals : ['peak', 'average', 'sum'], optional
-        the type of vals to produce. Will find peak, average, or sum of block values
-        in an assembly. Default: peak
+    vals : str, optional
+        Can be 'peak', 'average', or 'sum'. The type of vals to produce. Will find peak,
+        average, or sum of block values in an assembly. Default: peak
 
-    data : list(numeric)
-        rather than using param and vals, use the data supplied as is. It must be in the same order as iter(r).
+    data : list, optional
+        rather than using param and vals, use the data supplied as is. It must be in the
+        same order as iter(r).
 
     fName : str, optional
         File name to create. If none, will show on screen.
@@ -227,7 +228,7 @@ def plotFaceMap(
         The name of the matplotlib colormap to use. Default: jet
         Other possibilities: http://matplotlib.org/examples/pylab_examples/show_colormaps.html
 
-    labels : iterable(str), optional
+    labels : list of str, optional
         Data labels corresponding to data values.
 
     labelFmt : str, optional
@@ -247,11 +248,13 @@ def plotFaceMap(
 
     axisEqual : Boolean, optional
         If True, horizontal and vertical axes are scaled equally such that a circle
-            appears as a circle rather than an ellipse.
+        appears as a circle rather than an ellipse.
+
         If False, this scaling constraint is not imposed.
 
     makeColorBar : Boolean, optional
         If True, a vertical color bar is added on the right-hand side of the plot.
+
         If False, no color bar is added.
 
     cBarLabel : String, optional
@@ -272,8 +275,9 @@ def plotFaceMap(
 
     Examples
     --------
-    Plotting a BOL assembly type facemap with a legend:
-    >>> plotFaceMap(core, param='typeNumAssem', cmapName='RdYlBu')
+    Plotting a BOL assembly type facemap with a legend::
+
+        >>> plotFaceMap(core, param='typeNumAssem', cmapName='RdYlBu')
 
     """
     if referencesToKeep:

--- a/doc/developer/guide.rst
+++ b/doc/developer/guide.rst
@@ -50,30 +50,31 @@ Under most circumstances a :py:class:`armi.reactor.reactors.Reactor` instance wi
 ``.core`` attribute, which is an instance of :py:class:`armi.reactor.reactors.Core`. While the
 Composite pattern discussed above can be used very generally, the ``Core`` class
 enforces a couple of constrains that can be very useful:
-    * A ``Core`` is a 2-D arrangement of :py:class:`armi.reactor.assemblies.Assembly`
-      objects.
-    * Each ``Assembly`` is a 1-D arrangement of :py:class:`armi.reactor.blocks.Block`
-      objects.
-    * Blocks are :py:class:`armi.reactor.composites.Composite` objects with some extra
-      parameter bindings, utility functions, and other implementation details that let
-      them play nicely with their containing ``Assembly``.
+
+* A ``Core`` is a 2-D arrangement of :py:class:`armi.reactor.assemblies.Assembly`
+  objects.
+* Each ``Assembly`` is a 1-D arrangement of :py:class:`armi.reactor.blocks.Block`
+  objects.
+* Blocks are :py:class:`armi.reactor.composites.Composite` objects with some extra
+  parameter bindings, utility functions, and other implementation details that let
+  them play nicely with their containing ``Assembly``.
 
 In many scenarios, one wants to access specific assemblies or blocks from a core. There
-are a few ways to get the objects that you're interested in.
+are a few ways to get the objects that you're interested in:
 
-    * The `r.core.childrenByLocator` dictionary maps
-      :py:class:`armi.reactor.grids.IndexLocation` objects to whichever assembly is at
-      that location. For example ::
+* The `r.core.childrenByLocator` dictionary maps
+  :py:class:`armi.reactor.grids.IndexLocation` objects to whichever assembly is at
+  that location. For example ::
 
-          >>> loc = r.core.spatialGrid[i, j, 0]
-          >>> a = r.core.childrenByLocator[loc]
+      >>> loc = r.core.spatialGrid[i, j, 0]
+      >>> a = r.core.childrenByLocator[loc]
 
-      To access the ``k`` -th block in an assembly, try::
+  To access the ``k`` -th block in an assembly, try::
 
-          >>> b = a[k]
+      >>> b = a[k]
 
-    * `r.core.getAssemblies()` loops through all assemblies in the core for when you
-      need to do something to all assemblies.
+* `r.core.getAssemblies()` loops through all assemblies in the core for when you
+  need to do something to all assemblies.
 
 
 Parameters

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ ARMI
    developer/index
    blog/index
    release/index
+   glossary
    API Docs <.apidocs/modules>
 
 

--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -89,7 +89,7 @@ These files are:
   put it there.
 
 * :file:`doc/` is an optional folder where your application documentation source may go.
-  If you choose to use Sphinx you can run ``sphinx-quickstart` in that folder to begin
+  If you choose to use Sphinx you can run ``sphinx-quickstart`` in that folder to begin
   documentation.
 
 Registering the app with ARMI

--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -6,12 +6,12 @@ This section will guide you through installing the ARMI Framework on your machin
 Prerequisites
 -------------
 These instructions target users with some software development knowledge. In
-particular, we assume familiarity with `Python <https://www.python.org/>`_,
+particular, we assume familiarity with `Python <https://www.python.org/>`__,
 `virtual environments <https://docs.python.org/3/tutorial/venv.html>`_, and `Git <https://git-scm.com/>`_.
 
 You must have the following installed before proceeding:
 
-* `Python <https://www.python.org/downloads/>`_ version 3.6 or later (preferably 64-bit)
+* `Python <https://www.python.org/downloads/>`__ version 3.6 or later (preferably 64-bit)
 
   .. admonition:: The right Python command
 


### PR DESCRIPTION
These changes are based on the sphinx build warnings emitted
when running ``make html``. Most of the warnings have been removed,
excepting a few highly-repeated warnings that stem from some upstream
dependencies.