### PR TITLE
Adding Instructions on How To Release ARMI

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -112,14 +112,12 @@ extensions = [
     "sphinx_gallery.gen_gallery",
 ]
 
-# private-member docs are generally not great to link to in high-level implementation
-# documentation because the implementation may change rapidly. Prefer putting info in
-# public entities. We  render docs with private-members shown, however, because there
-# are important implementation details in them in many cases.
+# Our API should make sense without documenting private/special members.
 autodoc_default_options = {
     "members": True,
     "undoc-members": True,
-    "private-members": True,
+    "private-members": False,
+    "special-members": False,
 }
 autodoc_member_order = "bysource"
 autoclass_content = "both"
@@ -135,7 +133,7 @@ napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
 napoleon_include_private_with_doc = False
-napoleon_include_special_with_doc = True
+napoleon_include_special_with_doc = False
 napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = True
 napoleon_use_admonition_for_references = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,7 +137,7 @@ napoleon_include_special_with_doc = False
 napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = True
 napoleon_use_admonition_for_references = False
-napoleon_use_ivar = False
+napoleon_use_ivar = True
 napoleon_use_param = True
 napoleon_use_rtype = True
 

--- a/doc/developer/making_armi_based_apps.rst
+++ b/doc/developer/making_armi_based_apps.rst
@@ -43,20 +43,6 @@ system! The :py:mod:`armi.plugins` module contains all of the plugin "hook" defi
 and their associated documentation. It is recommended to peruse those docs before
 getting started to get an idea of what is available.
 
-.. admonition:: Setting expectations
-
-   The Plugin API is relatively new, and is expected to change and evolve. We hope at
-   some point to mark parts of the API as stable, but we simply are not there yet. A
-   stable Plugin API is a major goal for a v1.0 release.
-
-   It is important to mention that the original Plugin API was designed to enable the
-   separation of the Framework from TerraPower's internal code suite. Effort has been made
-   to design the Plugin API to be general, and to anticipate future needs.  However, we
-   expect that the API has plenty of room for improvement and extension. If you find
-   yourself needing additional means of customization, or if any of the semantics of the
-   Plugin API are causing you problems, please open an issue and we would be happy to work
-   with you to improve it.
-
 Some implementation details
 ---------------------------
 One can just monkey-see-monkey-do their own plugins without fully understanding the

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -28,7 +28,29 @@ testing.
 
 Releasing a New Version of ARMI
 -------------------------------
-TBD
+In ARMI, we use the common ``major.minor.bump`` version scheme. Where a version string
+might look like ``0.1.7``, ``1.0.0``, or ``1.2.123``, and each number has a meaning:
+
+* ``major`` - Revved for NRC-sanctioned release or at the end of a long design cycle.
+* ``minor`` - Revved when we decide the code or our API has reached a stable point,
+  this might happen once a year.
+* ``bump`` - To be revved every time we modify the API, or at will, any time we want.
+
+**Any change to a major or minor version is considered a release.**
+
+Only a core member of the ARMI team may release a new version, or add a tag of any kind to
+the repo. The rule is *the only tags in the ARMI repo are for official versions*. If you
+want to release a version of ARMI, you will need admin privileges to multiple TerraPower
+repos on GitHub. Every release should follow this process:
+
+1. Ensure all unit tests pass and the documentation is building correctly.
+2. Add release notes to the documentation:
+   `here <https://github.com/terrapower/armi/tree/master/doc/release>`_.
+3. Tag the commit after it goes into the repo: ``git tag -a 1.0.0 -m "Release v1.0.0"``
+4. Also add the release notes on `the GitHub UI <https://github.com/terrapower/armi/releases>`_.
+5. Follow the instructions `here <https://github.com/terrapower/terrapower.github.io>`_ to
+   archive the new documentation.
+6. Tell everyone!
 
 Module-Level Logging
 --------------------

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -2,39 +2,36 @@ Tooling and infrastructure
 ==========================
 
 Packaging and dependency management
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The process of packaging and Python projects and managing their dependencies is
-somewhat challenging, nuanced, and in the opinion of the author, poorly-documented.
-We attempt to follow existing conventions, where they exist, and the contents of our
-``setup.py`` follow existing conventions as possible. Of particular note is the way that
-we express our dependencies. In this, we take inspiration from `this fantastic article
-<https://caremad.io/posts/2013/07/setup-vs-requirement/>`_
-about dependecy management in Python projects.
+-----------------------------------
+The process of packaging Python projects and managing their dependencies is somewhat
+challenging and nuanced. The contents of our ``setup.py`` follow existing conventions as
+much as possible. In particular, we follow `this fantastic article
+<https://caremad.io/posts/2013/07/setup-vs-requirement/>`_ about dependecy management in
+Python projects.
 
-The main points here are that the packages listed in the ``install_requires`` argument to
-``setup()`` are meant to express, as abstractly as possible, the packages that need to
-be installed **somehow** for the package to work. In addition, ``extras_require`` can be
-used to specify other packages that are not strictly required, but if installed enable
-extra functionality. On the other hand, ``requirements.txt`` exists to describe a
-complete environment more specifically, potentially including extra arguments to ``pip``
-to control its behavior. Dependencies specified in ``setup.py`` should include version
-bounds sparingly, only when needed to ensure compatibility, whereas ``requirements.txt``
-may sometimes point to an alternative package index, and include strict version bounds
-for all dependencies.
+setup.py
+^^^^^^^^
+The packages listed in the ``install_requires`` argument to ``setup()`` are meant to
+express, as abstractly as possible, the packages that need to be installed **somehow**
+for the package to work. In addition, ``extras_require`` are used to specify other
+packages that are not strictly required, but if installed enable extra functionality,
+like unit testing or building documentation.
 
-A common source of concern is that the list of dependencies would be duplicated between
-``setup.py`` and ``requirements.txt``. In our particular case, ARMI does not benefit
-from pointing to special package indices, and most version bounds are semantic. We
-therefore follow the recommendation in the above article of including in
-``requirements.txt`` a simple ``-e .``. This tells pip to install ``armi`` itself,
-deferring to ``setup.py`` for a list of requiremed dependencies. Non-semantic version
-bounds, such as those used to avoid bugs in the dependency, should be specified in
-``requirements.txt``, rather than ``setup.py``. ARMI itself has several requirements
-files, located at the root of the project, which can be used as jumping-off points for
-more complex scenarios.
+requirements.txt
+^^^^^^^^^^^^^^^^
+The ``requirements***.txt`` files exist to describe a complete environment more
+specifically. If specific versions of packages are required, they should be defined here.
+Any extra arguments to ``pip`` will also be placed here. For instance, there is a ``-e``
+that tells ``pip`` to install ARMI itself and defer to ``setup.py`` for a version-agnostic
+list of dependencies. We also have multiple requirements files for different needs, like
+testing.
+
+Releasing a New Version of ARMI
+-------------------------------
+TBD
 
 Module-Level Logging
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 In most of the modules in ``armi``, you will see logging using the ``runLog`` module.
 This is a custom, global logging object provided by the import:
 

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -47,9 +47,9 @@ Every release should follow this process:
 
 1. Ensure all unit tests pass and the documentation is building correctly.
 2. Add release notes to the documentation:
-   `here <https://github.com/terrapower/armi/tree/master/doc/release>`_.
+   `here <https://github.com/terrapower/armi/tree/master/doc/release>`__.
 3. Tag the commit after it goes into the repo: ``git tag -a 1.0.0 -m "Release v1.0.0"``
-4. Also add the release notes on `the GitHub UI <https://github.com/terrapower/armi/releases>`_.
+4. Also add the release notes on `the GitHub UI <https://github.com/terrapower/armi/releases>`__.
 5. Follow the instructions `here <https://github.com/terrapower/terrapower.github.io>`_ to
    archive the new documentation.
 6. Tell everyone!

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -28,20 +28,22 @@ testing.
 
 Releasing a New Version of ARMI
 -------------------------------
-In ARMI, we use the common ``major.minor.bump`` version scheme. Where a version string
-might look like ``0.1.7``, ``1.0.0``, or ``1.2.123``, and each number has a meaning:
+In ARMI, we use the common ``major.minor.bump`` version scheme where a version string
+might look like ``0.1.7``, ``1.0.0``, or ``1.2.123``. Each number has a specific meaning:
 
-* ``major`` - Revved for NRC-sanctioned release or at the end of a long design cycle.
-* ``minor`` - Revved when we decide the code or our API has reached a stable point,
+* ``major`` - Revved for NRC-sanctioned release or at the end of a long development cycle.
+* ``minor`` - Revved when we decide the code or our API has reached a stable point;
   this might happen once a year.
-* ``bump`` - To be revved every time we modify the API, or at will, any time we want.
+* ``bump`` - Revved every time we modify the API, or at will; any time we want.
 
 **Any change to a major or minor version is considered a release.**
 
 Only a core member of the ARMI team may release a new version, or add a tag of any kind to
-the repo. The rule is *the only tags in the ARMI repo are for official versions*. If you
-want to release a version of ARMI, you will need admin privileges to multiple TerraPower
-repos on GitHub. Every release should follow this process:
+the repository. The rule is *the only tags in the ARMI repo are for official versions*. If
+you want to release a version of ARMI, you will need admin privileges to multiple TerraPower
+repos on GitHub.
+
+Every release should follow this process:
 
 1. Ensure all unit tests pass and the documentation is building correctly.
 2. Add release notes to the documentation:


### PR DESCRIPTION
1. The primary goal of this PR _was_ to add instructions to our docs that give a clear, concise procedure to release a new version of ARMI. While I was at it, I added some some information about what our version numbers mean, and when to rev them.

2. This PR will also close #479.

3. Also, in `conf.py` I turned off documenting all `_private` and `__special__` code in the repo.  This *greatly* reduces the number of warnings and errors we get building the docs, but that's not why I did it. Our "API" is defined as the public methods and attributes in our code. And if those, with their docstrings, are not enough for users, that is a problem we need to fix in our code (by making a method public) or in our documentation (by adding more information). Adding thousands of private methods and attributes to our docs "just to make sure we cover everything" is bad. We should design our API better, and improve our docs, not just throw thousands of lines of _stuff_ into docs and tell people to figure it out. `#endrant`