### PR TITLE
Update `findAssembly`'s docstring

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -705,6 +705,8 @@ class FuelHandler:
         mandatoryLocations : list, optional
             a list of string-representations of locations in the core for limiting the search to
             several places
+            
+            Any locations also included in `excludedLocations` will be excluded.
 
         excludedLocations : list, optional
             a list of string-representations of locations in the core that will be excluded from

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -705,7 +705,7 @@ class FuelHandler:
         mandatoryLocations : list, optional
             a list of string-representations of locations in the core for limiting the search to
             several places
-            
+
             Any locations also included in `excludedLocations` will be excluded.
 
         excludedLocations : list, optional


### PR DESCRIPTION
The `mandatoryLocations` and `excludedLocations` options of the `findAssembly` method can conflict. The docstring has been updated to reflect that the method's logic gives preference to `excludedLocations`.