### PR TITLE
Realistically, we have not been supporting Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     url="https://github.com/terrapower/armi/",
     license="Apache 2.0",
     long_description=README,
-    python_requres=">=3.7",
+    python_requires=">=3.7",
     packages=find_packages(),
     package_data={"armi": ["resources/*", "resources/**/*"] + EXTRA_FILES},
     entry_points={"console_scripts": ["armi = armi.__main__:main"]},

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     url="https://github.com/terrapower/armi/",
     license="Apache 2.0",
     long_description=README,
-    python_requres=">=3.6",
+    python_requres=">=3.7",
     packages=find_packages(),
     package_data={"armi": ["resources/*", "resources/**/*"] + EXTRA_FILES},
     entry_points={"console_scripts": ["armi = armi.__main__:main"]},


### PR DESCRIPTION
To the best of my knowledge, everyone who uses ARMI only uses Python 3.7 or 3.9.

I am not sure we really support 3.6, and we certainly don't test for it.