### PR TITLE
Fix to saving lattice map using the Grids GUI

### DIFF
--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -265,7 +265,7 @@ class GridBlueprint(yamlize.Object):
         runLog.extra("Creating the spatial grid")
         if geom in (geometry.RZT, geometry.RZ):
             if self.gridBounds is None:
-                # This check is regrattably late. It would be nice if we could validate
+                # This check is regrettably late. It would be nice if we could validate
                 # that bounds are provided if R-Theta mesh is being used.
                 raise InputError(
                     "Grid bounds must be provided for `{}` to specify a grid with "

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -305,6 +305,7 @@ TINY_GRID = """core:
        : IF
 """
 
+
 class TestRoundTrip(unittest.TestCase):
     def setUp(self):
         self.grids = Grids.load(SMALL_HEX)
@@ -322,7 +323,7 @@ class TestRoundTrip(unittest.TestCase):
     def test_tiny_map(self):
         grid = Grids.load(TINY_GRID)
         stream = io.StringIO()
-        #import pdb; pdb.set_trace()
+        # import pdb; pdb.set_trace()
         saveToStream(stream, grid, full=True, tryMap=True)
         stream.seek(0)
         text = stream.read()
@@ -331,7 +332,6 @@ class TestRoundTrip(unittest.TestCase):
         gridBp = Grids.load(stream)
         self.assertIn("full", gridBp["core"].symmetry)
         self.assertIn("IF", gridBp["core"].latticeMap)
-
 
 
 class TestGridBlueprintsSection(unittest.TestCase):

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -294,6 +294,16 @@ pins:
             FP
 """
 
+TINY_GRID = """core:
+    geom: hex
+    lattice map:
+    grid bounds:
+    symmetry: full
+    grid contents:
+       ? - 0
+         - 0
+       : IF
+"""
 
 class TestRoundTrip(unittest.TestCase):
     def setUp(self):
@@ -308,6 +318,20 @@ class TestRoundTrip(unittest.TestCase):
         stream.seek(0)
         gridBp = Grids.load(stream)
         self.assertIn("third", gridBp["core"].symmetry)
+
+    def test_tiny_map(self):
+        grid = Grids.load(TINY_GRID)
+        stream = io.StringIO()
+        #import pdb; pdb.set_trace()
+        saveToStream(stream, grid, full=True, tryMap=True)
+        stream.seek(0)
+        text = stream.read()
+        self.assertIn("IF", text)
+        stream.seek(0)
+        gridBp = Grids.load(stream)
+        self.assertIn("full", gridBp["core"].symmetry)
+        self.assertIn("IF", gridBp["core"].latticeMap)
+
 
 
 class TestGridBlueprintsSection(unittest.TestCase):

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -323,7 +323,6 @@ class TestRoundTrip(unittest.TestCase):
     def test_tiny_map(self):
         grid = Grids.load(TINY_GRID)
         stream = io.StringIO()
-        # import pdb; pdb.set_trace()
         saveToStream(stream, grid, full=True, tryMap=True)
         stream.seek(0)
         text = stream.read()

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -215,7 +215,7 @@ class AsciiMap:
                 # doing pure rows from data is made programmatically.
                 # newLines.append(line)
                 raise ValueError(
-                    "Cannot write asciimaps with blank rows from pure data yet."
+                    f"Cannot write asciimaps with blank rows from pure data yet."
                 )
         if not newLines:
             raise ValueError("No data found")
@@ -434,12 +434,14 @@ class AsciiMapHexThirdFlatsUp(AsciiMap):
         # Check the j=0 ray to see how many peripheral locations are blank.
         # assume symmetry with the other corner.
         # The cap is basically the distance from the (I, 0) or (0, J) loc to self._ijMax
-        maxIWithData = max(i for i, j in self.asciiLabelByIndices if j == 0)
+        iWithData = [i for i, j in self.asciiLabelByIndices if j == 0]
+        maxIWithData = max(iWithData) if len(iWithData) else -1
         self._asciiLinesOffCorner = (self._ijMax - maxIWithData) * 2 - 1
 
         # in jagged systems we have to also check the neighbor.
         # TODO: maybe even more corner positions could be left out in very large maps.
-        nextMaxIWithData = max(i for i, j in self.asciiLabelByIndices if j == 1)
+        nextIWithData = [i for i, j in self.asciiLabelByIndices if j == 1]
+        nextMaxIWithData = max( nextIWithData ) if len(nextIWithData) else -1
         if nextMaxIWithData == maxIWithData - 1:
             # the jagged edge is lopped off too.
             self._asciiLinesOffCorner += 1

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -435,13 +435,13 @@ class AsciiMapHexThirdFlatsUp(AsciiMap):
         # assume symmetry with the other corner.
         # The cap is basically the distance from the (I, 0) or (0, J) loc to self._ijMax
         iWithData = [i for i, j in self.asciiLabelByIndices if j == 0]
-        maxIWithData = max(iWithData) if len(iWithData) else -1
+        maxIWithData = max(iWithData) if iWithData else -1
         self._asciiLinesOffCorner = (self._ijMax - maxIWithData) * 2 - 1
 
         # in jagged systems we have to also check the neighbor.
         # TODO: maybe even more corner positions could be left out in very large maps.
         nextIWithData = [i for i, j in self.asciiLabelByIndices if j == 1]
-        nextMaxIWithData = max( nextIWithData ) if len(nextIWithData) else -1
+        nextMaxIWithData = max(nextIWithData) if nextIWithData else -1
         if nextMaxIWithData == maxIWithData - 1:
             # the jagged edge is lopped off too.
             self._asciiLinesOffCorner += 1

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -3,6 +3,15 @@ ARMI v0.2 Release Notes
 =======================
 
 
+ARMI v0.2.1
+===========
+Release Date: TBD
+
+
+Bug fixes
+---------
+* Fixed issue where grid GUI was not saving lattice maps (`#490 <https://github.com/terrapower/armi/issues/490>`_)
+
 
 ARMI v0.2.0
 ===========


### PR DESCRIPTION
Fix to writing the lattice map as a string when saving the core map from the Grids GUI. This fixes a bug introduced in #440.