### PR TITLE
Validate YAML Files

### DIFF
--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -275,6 +275,9 @@ class SettingsReader:
         for settingName, settingVal in caseSettings.items():
             self._applySettings(settingName, settingVal)
 
+        if handleInvalids:
+            self._checkInvalidSettings()
+
     def _checkInvalidSettings(self):
         if not self.invalidSettings:
             return

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -205,7 +205,7 @@ class SettingsReader:
         self.format = fmt
         if self.format == self.SettingsInputFormat.YAML:
             try:
-                self._readYaml(stream, handleInvalids=handleInvalids)
+                self._readYaml(stream)
             except ruamel.yaml.scanner.ScannerError:
                 # mediocre way to detect xml vs. yaml at the stream level
                 runLog.info(
@@ -213,10 +213,14 @@ class SettingsReader:
                 )
                 self.format = self.SettingsInputFormat.XML
                 stream.seek(0)
-        if self.format == self.SettingsInputFormat.XML:
-            self._readXml(stream, handleInvalids=handleInvalids)
 
-    def _readXml(self, stream, handleInvalids=True):
+        if self.format == self.SettingsInputFormat.XML:
+            self._readXml(stream)
+
+        if handleInvalids:
+            self._checkInvalidSettings()
+
+    def _readXml(self, stream):
         """
         Read user settings from XML stream.
         """
@@ -246,10 +250,7 @@ class SettingsReader:
         for settingElement in list(settingRoot):
             self._interpretXmlSetting(settingElement)
 
-        if handleInvalids:
-            self._checkInvalidSettings()
-
-    def _readYaml(self, stream, handleInvalids=True):
+    def _readYaml(self, stream):
         """
         Read settings from a YAML stream.
 
@@ -274,9 +275,6 @@ class SettingsReader:
         self.inputVersion = tree["metadata"][Roots.VERSION]
         for settingName, settingVal in caseSettings.items():
             self._applySettings(settingName, settingVal)
-
-        if handleInvalids:
-            self._checkInvalidSettings()
 
     def _checkInvalidSettings(self):
         if not self.invalidSettings:

--- a/armi/tests/test_fuelHandlers.py
+++ b/armi/tests/test_fuelHandlers.py
@@ -506,9 +506,9 @@ class TestFuelHandler(ArmiTestHelper):
         self.assertEqual(widths, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
         # test 2
-        schedule, widths = fh.buildRingSchedule(1, 17, jumpRingFrom=0)
+        schedule, widths = fh.buildRingSchedule(1, 17, jumpRingFrom=5)
         self.assertEqual(
-            schedule, [17, 16, 15, 14, 13, 12, 11, 10, 2, 3, 4, 5, 6, 7, 8, 9, 1]
+            schedule, [17, 16, 15, 14, 13, 12, 11, 10, 6, 7, 8, 9, 5, 4, 3, 2, 1]
         )
         self.assertEqual(widths, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 

--- a/armi/tests/test_fuelHandlers.py
+++ b/armi/tests/test_fuelHandlers.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Tests some capabilities of the fuel handling machine.
 
@@ -499,8 +498,17 @@ class TestFuelHandler(ArmiTestHelper):
     def test_buildRingSchedule(self):
         fh = fuelHandlers.FuelHandler(self.o)
         schedule, widths = fh.buildRingSchedule(17, 1, jumpRingFrom=14)
+
+        # test 1
         self.assertEqual(
             schedule, [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 14, 15, 16, 17]
+        )
+        self.assertEqual(widths, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+        # test 2
+        schedule, widths = fh.buildRingSchedule(1, 17, jumpRingFrom=0)
+        self.assertEqual(
+            schedule, [17, 16, 15, 14, 13, 12, 11, 10, 2, 3, 4, 5, 6, 7, 8, 9, 1]
         )
         self.assertEqual(widths, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -66,8 +66,7 @@ class C5G7ReactorTests(unittest.TestCase):
             self.assertGreater(streamVal.count("custom isotopics"), 32, msg=streamVal)
             self.assertIn("Uranium Oxide", streamVal, msg=streamVal)
             self.assertIn("SaturatedWater", streamVal, msg=streamVal)
-            self.assertIn("fakeBad", streamVal, msg=streamVal)
-            self.assertIn("invalid setting", streamVal, msg=streamVal)
+            self.assertIn("invalid settings: fakeBad", streamVal, msg=streamVal)
 
             # test that there are 100 of each high, medium, and low MOX pins
             fuelPinsHigh = b.getComponent(Flags.HIGH | Flags.MOX)

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for C5G7 input files."""
-import unittest
+from logging import WARNING
 import os
+import unittest
 
 import numpy
 
-from armi.utils import directoryChangers
-from armi.tests import TEST_ROOT
-from armi.reactor.flags import Flags
+from armi import runLog
 from armi import init as armi_init
 from armi.bookkeeping import db
+from armi.reactor.flags import Flags
+from armi.tests import mockRunLogs
+from armi.tests import TEST_ROOT
+from armi.utils import directoryChangers
 
 TEST_INPUT_TITLE = "c5g7-settings"
 
@@ -42,15 +45,33 @@ class C5G7ReactorTests(unittest.TestCase):
     def test_loadC5G7(self):
         """
         Load the C5G7 case from input and check basic counts.
+        (Also, check that we are getting material warnings.)
         """
-        o = armi_init(fName=TEST_INPUT_TITLE + ".yaml")
-        b = o.r.core.getFirstBlock(Flags.MOX)
-        # there are 100 of each high, medium, and low MOX pins
-        fuelPinsHigh = b.getComponent(Flags.HIGH | Flags.MOX)
-        self.assertEqual(fuelPinsHigh.getDimension("mult"), 100)
+        with mockRunLogs.BufferLog() as mock:
+            # we should start with a clean slate
+            self.assertEqual("", mock._outputStream)
+            runLog.LOG.startLog("test_loadC5G7")
+            runLog.LOG.setVerbosity(WARNING)
 
-        gt = b.getComponent(Flags.GUIDE_TUBE)
-        self.assertEqual(gt.getDimension("mult"), 24)
+            # ingest the settings file
+            o = armi_init(fName=TEST_INPUT_TITLE + ".yaml")
+            b = o.r.core.getFirstBlock(Flags.MOX)
+
+            # test warnings are being logged for malformed isotopics info in the settings file
+            # streamVal = stream.getvalue()
+            streamVal = mock._outputStream
+            self.assertGreater(streamVal.count("[warn]"), 32, msg=streamVal)
+            self.assertGreater(streamVal.count("custom isotopics"), 32, msg=streamVal)
+            self.assertIn("Uranium Oxide", streamVal, msg=streamVal)
+            self.assertIn("SaturatedWater", streamVal, msg=streamVal)
+
+            # test that there are 100 of each high, medium, and low MOX pins
+            fuelPinsHigh = b.getComponent(Flags.HIGH | Flags.MOX)
+            self.assertEqual(fuelPinsHigh.getDimension("mult"), 100)
+
+            # test the Guide Tube dimensions
+            gt = b.getComponent(Flags.GUIDE_TUBE)
+            self.assertEqual(gt.getDimension("mult"), 24)
 
     def test_runAndLoadC5G7(self):
         """
@@ -59,17 +80,17 @@ class C5G7ReactorTests(unittest.TestCase):
         This ensures that these kinds of cases can be read from DB.
         """
 
-        def _loadLocs(o, locs):
+        def loadLocs(o, locs):
             for b in o.r.core.getBlocks():
                 indices = b.spatialLocator.getCompleteIndices()
                 locs[indices] = b.spatialLocator.getGlobalCoordinates()
 
         o = armi_init(fName=TEST_INPUT_TITLE + ".yaml")
         locsInput, locsDB = {}, {}
-        _loadLocs(o, locsInput)
+        loadLocs(o, locsInput)
         o.operate()
         o2 = db.loadOperator(TEST_INPUT_TITLE + ".h5", 0, 0)
-        _loadLocs(o2, locsDB)
+        loadLocs(o2, locsDB)
 
         for indices, coordsInput in sorted(locsInput.items()):
             coordsDB = locsDB[indices]

--- a/armi/tests/tutorials/c5g7-settings.yaml
+++ b/armi/tests/tutorials/c5g7-settings.yaml
@@ -2,6 +2,7 @@ metadata:
   version: uncontrolled
 settings:
   availabilityFactor: 0.9
+  fakeBad: 123456
   power: 1000000000.0
   cycleLength: 411.11
   loadingFile: c5g7-blueprints.yaml


### PR DESCRIPTION
At some point, I believe we turned off validation of YAML files, but kept the validation on XML files. I'm not sure when, how, or why. But this PR applies the XML validation we have been doing the past ~two years to the YAML files.

This will probably raise some warnings for people that they don't expect. It might make people take a closer look at their materials, for instance. But it will also straight up throw warnings, and prompt users to acknowledge if there are bogus settings going into a file (see my unit test for an example).

This PR closes this ticket: https://github.com/terrapower/armi/issues/461