### PR TITLE
Fixed bug where SettingsModifier was using old settings API

### DIFF
--- a/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
+++ b/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
@@ -40,7 +40,7 @@ class SettingsModifier(ParameterSweepConverter):
 
     def convert(self, r=None):
         ParameterSweepConverter.convert(self, r)
-        sType = self._cs.get(self.modifier).underlyingType
+        sType = self._cs.getSetting(self.modifier).underlyingType
         if sType is not type(None):
             # NOTE: this won't work with "new-style" settings related to the plugin system.
             # Using the type of the setting._default may be more appropriate if there are issues.

--- a/armi/reactor/converters/parameterSweeps/tests/test_paramSweepConverters.py
+++ b/armi/reactor/converters/parameterSweeps/tests/test_paramSweepConverters.py
@@ -25,8 +25,10 @@ from armi.reactor import geometry
 from armi.reactor import grids
 from armi.tests import TEST_ROOT
 from armi.reactor.converters.parameterSweeps.generalParameterSweepConverters import (
+    CustomModifier,
     NeutronicConvergenceModifier,
     ParameterSweepConverter,
+    SettingsModifier,
 )
 from armi.reactor.tests.test_reactors import loadTestReactor
 from armi.reactor.flags import Flags
@@ -55,3 +57,28 @@ class TestParamSweepConverters(unittest.TestCase):
 
         custom.convert(self.r)
         self.assertAlmostEqual(custom._cs["epsFSPoint"], 1, delta=1e-3)
+
+    def test_settingsModifier(self):
+        """Super basic test of the Settings Modifier"""
+        con = SettingsModifier(self.cs, "comment", "FakeParam")
+        self.assertEqual(con._parameter, "FakeParam")
+        val = self.cs["comment"]
+
+        con.convert(self.r)
+        self.assertEqual(con._sourceReactor, self.r)
+
+        # NOTE: Settings objects are not modified, but we point to new objects
+        self.assertIn("Simple test input", self.cs["comment"])
+        self.assertEqual(con._cs["comment"], "FakeParam")
+
+    def test_customModifier(self):
+        """Super basic test of the Custom Modifier"""
+        con = CustomModifier(self.cs, "FakeParam")
+        self.assertEqual(con._parameter, "FakeParam")
+
+        # For testing purposes, we need to add a dummy perturbation
+        fh = self.r.o.getInterface("fuelHandler")
+        fh.applyCustomPerturbation = lambda val: val
+
+        con.convert(self.r)
+        self.assertEqual(con._sourceReactor, self.r)


### PR DESCRIPTION
The `Settings` class no longer has a `.get()` method, we use `cs['thing']` or `cs.getSetting('thing')` now. This class was not tested, so it passed the recent settings changes without being modified.