### PR TITLE
Remove deprecated np.float and np.int

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -2383,9 +2383,7 @@ NONE_MAP.update(
         )
     }
 )
-NONE_MAP.update(
-    {floatType: floatType("nan") for floatType in (float, numpy.float64)}
-)
+NONE_MAP.update({floatType: floatType("nan") for floatType in (float, numpy.float64)})
 
 
 def packSpecialData(

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -2364,7 +2364,6 @@ NONE_MAP.update(
         intType: numpy.iinfo(intType).min + 2
         for intType in (
             int,
-            numpy.int,
             numpy.int8,
             numpy.int16,
             numpy.int32,
@@ -2385,7 +2384,7 @@ NONE_MAP.update(
     }
 )
 NONE_MAP.update(
-    {floatType: floatType("nan") for floatType in (numpy.float, numpy.float64)}
+    {floatType: floatType("nan") for floatType in (float, numpy.float64)}
 )
 
 


### PR DESCRIPTION
<!--  
    Thanks in advance for you contribution!
-->
## Description
<!--  
    Please include a summary of the change and/or which issue is fixed.
-->

During testing, numpy was complaining about `np.int` and `np.float`, both of which should be replaced with builtins, it said. This does that.

---

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] Tests have been added/updated to verify that the new or changed code works.
- [ ] Docstrings were included and updated as necessary
- [x] The code is understandable and maintainable to people beyond the author
- [ ] There is no commented out code in this PR.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.  
