### PR TITLE
Add new top-level components input for blueprints.

### DIFF
--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -102,6 +102,7 @@ from armi.utils import textProcessors
 from armi.reactor.blueprints.reactorBlueprint import Systems, SystemBlueprint
 from armi.reactor.blueprints.assemblyBlueprint import AssemblyKeyedList
 from armi.reactor.blueprints.blockBlueprint import BlockKeyedList
+from armi.reactor.blueprints.componentBlueprint import ComponentKeyedList
 from armi.reactor.blueprints import isotopicOptions
 from armi.reactor.blueprints.gridBlueprint import Grids, Triplet
 
@@ -185,6 +186,9 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
     )
     systemDesigns = yamlize.Attribute(key="systems", type=Systems, default=None)
     gridDesigns = yamlize.Attribute(key="grids", type=Grids, default=None)
+    componentDesigns = yamlize.Attribute(
+        key="components", type=ComponentKeyedList, default=None
+    )
 
     # These are used to set up new attributes that come from plugins. Defining its
     # initial state here to make pylint happy

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -295,7 +295,7 @@ def _insertDepletableNuclideKeys(c, blueprint):
 
 class ComponentKeyedList(yamlize.KeyedList):
     """
-    An OrderedDict of CompnentBlueprints keyed on the name.
+    An OrderedDict of ComponentBlueprints keyed on the name.
 
     This is used within the ``components:`` main entry of the blueprints.
 

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -211,8 +211,8 @@ class ComponentBlueprint(yamlize.Object):
             # the input mods have the final word
             blueprint.customIsotopics.apply(mat, self.isotopics)
 
-        # add mass fraction custom isotopics info, since some material modifications need to see them
-        # e.g. in the base Material.applyInputParams
+        # add mass fraction custom isotopics info, since some material modifications need
+        # to see them e.g. in the base Material.applyInputParams
         matMods.update(
             {
                 "customIsotopics": {
@@ -291,6 +291,20 @@ def _insertDepletableNuclideKeys(c, blueprint):
     nuclideBases.initReachableActiveNuclidesThroughBurnChain(
         c.p.numberDensities, blueprint.activeNuclides
     )
+
+
+class ComponentKeyedList(yamlize.KeyedList):
+    """
+    An OrderedDict of CompnentBlueprints keyed on the name.
+
+    This is used within the ``components:`` main entry of the blueprints.
+
+    This is *not* (yet) used when components are defined within a block blueprint.
+    That is handled in the blockBlueprint construct method.
+    """
+
+    item_type = ComponentBlueprint
+    key_attr = ComponentBlueprint.name
 
 
 # This import-time magic requires all possible components

--- a/doc/user/inputs/blueprints.rst
+++ b/doc/user/inputs/blueprints.rst
@@ -96,6 +96,11 @@ input. The structure will be something like::
             component name 2:
                 ...
 
+.. note:: You can also define components at the top level of the blueprints file under
+    the ``components:`` top level section, but bringing anything defined there into
+    the reactor model must currently be done programatically. We are currently
+    developing additional input capabilities to use these more flexibly.
+
 Defining a Component
 --------------------
 The **Components** section defines the pin (if modeling a pin-type reactor) and assembly in-plane


### PR DESCRIPTION

<!--  
    Thanks in advance for you contribution!
-->
## Description
<!--  
    Please include a summary of the change and/or which issue is fixed.
-->
This adds a new `components` section to the top-level
blueprints input file. Components defined there are loaded
into the new `blueprints.componentDesigns` data structure,
where they can be found and used to construct components.

This is a new and optional way to define components, separate
from the traditional way of defining them within parent blocks.

Note that with this commit, there is no way to automatically
load components into blocks, etc. That would have to be done
programmatically, for now.

This is related to a desire to have more flexible ways to define
models, including e.g. TRISO fuel, MSR models, etc.

This is part of #504, but doesn't fully complete it since we need to also
make ways to mix/match components and then load them into
systems. 

---

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] Docstrings were included and updated as necessary
- [x] The code is understandable and maintainable to people beyond the author
- [x] There is no commented out code in this PR.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.  
