### PR TITLE
Add component group capabilities

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1149,7 +1149,7 @@ class Database3(database.Database):
 
         # Need to keep a collection of Component instances for linked dimension
         # resolution, before they can be add()ed to their parents. Not just filtering
-        # out of `children`, since _resolveLinkedDims() needs a dict
+        # out of `children`, since resolveLinkedDims() needs a dict
         childComponents = collections.OrderedDict()
         children = []
 
@@ -1160,7 +1160,7 @@ class Database3(database.Database):
                 childComponents[child.name] = child
 
         for _childName, child in childComponents.items():
-            child._resolveLinkedDims(childComponents)
+            child.resolveLinkedDims(childComponents)
 
         for child in children:
             comp.add(child)

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -834,7 +834,7 @@ class Block(composites.Composite):
         self.p.enrichmentBOL = self.getFissileMassEnrich()
         massHmBOL = 0.0
         sf = self.getSymmetryFactor()
-        for child in self:
+        for child in self.iterComponents():
             child.p.massHmBOL = child.getHMMass() * sf  # scale to full block
             massHmBOL += child.p.massHmBOL
         self.p.massHmBOL = massHmBOL
@@ -910,10 +910,14 @@ class Block(composites.Composite):
 
         self.derivedMustUpdate = True
         self.clearCache()
-        mult = int(c.getDimension("mult"))
-        if self.p.percentBuByPin is None or len(self.p.percentBuByPin) < mult:
-            # this may be a little wasteful, but we can fix it later...
-            self.p.percentBuByPin = [0.0] * mult
+        try:
+            mult = int(c.getDimension("mult"))
+            if self.p.percentBuByPin is None or len(self.p.percentBuByPin) < mult:
+                # this may be a little wasteful, but we can fix it later...
+                self.p.percentBuByPin = [0.0] * mult
+        except AttributeError:
+            # maybe adding a Composite of components rather than a single
+            pass
         self._updatePitchComponent(c)
 
     def removeAll(self, recomputeAreaFractions=True):
@@ -1972,7 +1976,7 @@ class HexBlock(Block):
         """
 
         # Check multiplicities...
-        mults = {c.getDimension("mult") for c in self}
+        mults = {c.getDimension("mult") for c in self.iterComponents()}
 
         if len(mults) != 2 or 1 not in mults:
             raise ValueError(

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -103,6 +103,7 @@ from armi.reactor.blueprints.reactorBlueprint import Systems, SystemBlueprint
 from armi.reactor.blueprints.assemblyBlueprint import AssemblyKeyedList
 from armi.reactor.blueprints.blockBlueprint import BlockKeyedList
 from armi.reactor.blueprints.componentBlueprint import ComponentKeyedList
+from armi.reactor.blueprints.componentBlueprint import ComponentGroups
 from armi.reactor.blueprints import isotopicOptions
 from armi.reactor.blueprints.gridBlueprint import Grids, Triplet
 
@@ -188,6 +189,9 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
     gridDesigns = yamlize.Attribute(key="grids", type=Grids, default=None)
     componentDesigns = yamlize.Attribute(
         key="components", type=ComponentKeyedList, default=None
+    )
+    componentGroups = yamlize.Attribute(
+        key="component groups", type=ComponentGroups, default=None
     )
 
     # These are used to set up new attributes that come from plugins. Defining its

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -139,8 +139,9 @@ class BlockBlueprint(yamlize.KeyedList):
                         # learn mult from grid definition
                         c.setDimension("mult", len(c.spatialLocator))
 
+        # Resolve linked dims after all components in the block are created
         for c in components.values():
-            c._resolveLinkedDims(components)
+            c.resolveLinkedDims(components)
 
         boundingComp = sorted(components.values())[-1]
         # give a temporary name (will be updated by b.makeName as real blocks populate systems)
@@ -237,7 +238,9 @@ class BlockBlueprint(yamlize.KeyedList):
 
     @staticmethod
     def _mergeComponents(b):
-        solventNamesToMergeInto = set(c.p.mergeWith for c in b if c.p.mergeWith)
+        solventNamesToMergeInto = set(
+            c.p.mergeWith for c in b.iterComponents() if c.p.mergeWith
+        )
 
         if solventNamesToMergeInto:
             runLog.warning(

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -329,6 +329,13 @@ class DerivedShape(UnshapedComponent):
         both the volume and area based on its context within the scope
         of the parent object by considering the volumes and areas of
         the surrounding components.
+
+        Since some components are volumetric shapes, this must consider the volume
+        so that it wraps around in all three dimensions.
+
+        But there are also situations where we need to handle zero-height blocks
+        with purely 2D components. Thus we track area and volume fractions here
+        when possible.
         """
 
         if self.parent is None:
@@ -338,8 +345,8 @@ class DerivedShape(UnshapedComponent):
 
         # Determine the volume/areas of the non-derived shape components
         # within the parent.
-        siblingArea = 0.0
         siblingVolume = 0.0
+        siblingArea = 0.0
         for sibling in self.parent.getChildren():
             if sibling is self:
                 continue
@@ -348,20 +355,25 @@ class DerivedShape(UnshapedComponent):
                     f"More than one ``DerivedShape`` component in {self.parent} is not allowed."
                 )
 
-            siblingArea += sibling.getArea()
             siblingVolume += sibling.getVolume()
+            try:
+                if siblingArea is not None:
+                    siblingArea += sibling.getArea()
+            except:
+                siblingArea = None
 
-        remainingArea = self.parent.getMaxArea() - siblingArea
         remainingVolume = self.parent.getMaxVolume() - siblingVolume
+        if siblingArea:
+            remainingArea = self.parent.getMaxArea() - siblingArea
 
-        # Check for negative area
-        if remainingArea < 0:
+        # Check for negative
+        if remainingVolume < 0:
             msg = (
                 f"The component areas in {self.parent} exceed the maximum "
-                f"allowable area based on the geometry. Check that the "
+                f"allowable volume based on the geometry. Check that the "
                 f"geometry is defined correctly.\n"
-                f"Maximum allowable area: {self.parent.getMaxArea()} cm^2\n"
-                f"Area of all non-derived shape components: {siblingArea} cm^2\n"
+                f"Maximum allowable volume: {self.parent.getMaxVolume()} cm^3\n"
+                f"Volume of all non-derived shape components: {siblingVolume} cm^3\n"
             )
             runLog.error(msg)
             raise ValueError(
@@ -369,7 +381,14 @@ class DerivedShape(UnshapedComponent):
                 "Check log for errors."
             )
 
-        self.p.area = remainingArea
+        height = self.parent.getHeight()
+        if not height:
+            # special handling for 0-height blocks
+            if not remainingArea:
+                raise ValueError(f"Cannot derive area in 0-height block {self.parent}")
+            self.p.area = remainingArea
+        else:
+            self.p.area = remainingVolume / height
         return remainingVolume
 
     def getVolume(self):

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -21,7 +21,6 @@ import re
 import copy
 
 import numpy
-import six
 
 from armi.materials import material
 from armi.materials import custom
@@ -277,12 +276,13 @@ class Component(composites.Composite, metaclass=ComponentType):
             self.setDimension(key, val)
 
         if components:
-            self._resolveLinkedDims(components)
+            self.resolveLinkedDims(components)
 
-    def _resolveLinkedDims(self, components):
+    def resolveLinkedDims(self, components):
+        """Convert dimension link strings to actual links."""
         for dimName in self.DIMENSION_NAMES:
             value = self.p[dimName]
-            if not isinstance(value, six.string_types):
+            if not isinstance(value, str):
                 continue
 
             match = COMPONENT_LINK_REGEX.search(value)

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -59,13 +59,22 @@ class Sphere(ShapedComponent):
             components, od=od, id=id, mult=mult, modArea=modArea
         )
 
-    def getComponentArea(self, cold=False):
-        raise NotImplementedError("Cannot compute area of a sphere component.")
+    def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
+        """Abstract bounding circle method that should be overwritten by each shape subclass."""
+        return self.getDimension("od")
 
-    def getComponentVolume(self):
+    def getComponentArea(self, cold=False):
+        """Compute an average area over the height"""
+        from armi.reactor.blocks import Block  # avoid circular import
+
+        block = self.getAncestor(lambda c: isinstance(c, Block))
+        return self.getComponentVolume(cold) / block.getHeight()
+        # raise NotImplementedError("Cannot compute area of a sphere component.")
+
+    def getComponentVolume(self, cold=False):
         """Computes the volume of the sphere in cm^3."""
-        od = self.getDimension("od")
-        iD = self.getDimension("id")
+        od = self.getDimension("od", cold=cold)
+        iD = self.getDimension("id", cold=cold)
         mult = self.getDimension("mult")
         vol = mult * 4.0 / 3.0 * math.pi * ((od / 2.0) ** 3 - (iD / 2.0) ** 3)
         return vol

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -29,6 +29,7 @@ analogy of the model to the physical nature of nuclear reactors.
 
 See Also: :doc:`/developer/index`.
 """
+import math
 import collections
 import itertools
 import timeit
@@ -786,6 +787,9 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def getVolume(self):
         return sum(child.getVolume() for child in self)
+
+    def getArea(self, cold=False):
+        return sum(child.getArea(cold) for child in self)
 
     def _updateVolume(self):
         """Recompute and store volume."""
@@ -2571,6 +2575,11 @@ class ArmiObject(metaclass=CompositeModelType):
 
         return tempNumerator / totalVol
 
+    def resolveLinkedDims(self, components):
+        """Resolve link strings to links on all child components."""
+        for component in self.iterComponents():
+            component.resolveLinkedDims(components)
+
     def getDominantMaterial(self, typeSpec: TypeSpec = None, exact=False):
         """
         Return the first sample of the most dominant material (by volume) in this object.
@@ -3141,6 +3150,19 @@ class Composite(ArmiObject):
         self.childrenByLocator = {}
         for child in self:
             self.childrenByLocator[child.spatialLocator] = child
+
+    def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
+        """
+        Get sum circle bound.
+
+        Used to roughly approximate relative size vs. other objects
+        """
+        return sum(
+            [
+                comp.getBoundingCircleOuterDiameter(Tc, cold)
+                for comp in self.iterComponents()
+            ]
+        )
 
 
 class Leaf(Composite):

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -92,7 +92,9 @@ class BlockConverter:
         # merged component due to void gaps between components
         oldArea = solvent.getArea()
         runLog.debug("removing {}".format(solute))
-        newBlock.remove(solute)
+        # skip recomputation of area fractions because the blocks still have 0 height at this stage and derived
+        # shape volume computations will fail
+        newBlock.remove(solute, recomputeAreaFractions=False)
         self._sourceBlock = newBlock
 
         # adjust new shape area.

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1519,6 +1519,43 @@ class Block_TestCase(unittest.TestCase):
         self.assertIn(self.Block.getComponent(Flags.FUEL).p.od, dims)
 
 
+class Test_NegativeVolume(unittest.TestCase):
+    def test_negativeVolume(self):
+        """Build a block with WAY too many fuel pins and show that the derived volume is negative"""
+        block = blocks.HexBlock("TestHexBlock")
+
+        coldTemp = 20
+        hotTemp = 200
+
+        fuelDims = {
+            "Tinput": coldTemp,
+            "Thot": hotTemp,
+            "od": 0.84,
+            "id": 0.6,
+            "mult": 1000.0,  # pack in too many fuels
+        }
+        fuel = components.Circle("fuel", "UZr", **fuelDims)
+
+        coolantDims = {"Tinput": hotTemp, "Thot": hotTemp}
+        coolant = components.DerivedShape("coolant", "Sodium", **coolantDims)
+
+        interDims = {
+            "Tinput": hotTemp,
+            "Thot": hotTemp,
+            "op": 17.8,
+            "ip": 17.3,
+            "mult": 1.0,
+        }
+        interSodium = components.Hexagon("interCoolant", "Sodium", **interDims)
+
+        block.add(fuel)
+        block.add(coolant)
+        block.add(interSodium)
+        block.setHeight(16.0)
+        with self.assertRaises(ValueError):
+            block.getVolumeFractions()
+
+
 class HexBlock_TestCase(unittest.TestCase):
     def setUp(self):
         _ = settings.Settings()

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -204,10 +204,6 @@ class TestUnshapedComponent(TestGeneralComponents):
 class TestShapedComponent(TestGeneralComponents):
     """Abstract class for all shaped components"""
 
-    def test_getBoundingCircleOuterDiameter(self):
-        with self.assertRaises(NotImplementedError):
-            self.component.getBoundingCircleOuterDiameter(cold=True)
-
     def test_preserveMassDuringThermalExpansion(self):
         if not self.component.THERMAL_EXPANSION_DIMS:
             return

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -65,6 +65,13 @@ class DummyLeaf(composites.Leaf):
         composites.Leaf.__init__(self, name)
         self.p.type = name
 
+    def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
+        return 1.0
+
+    def iterComponents(self, typeSpec=None, exact=False):
+        if self.hasFlags(typeSpec, exact):
+            yield self
+
 
 class TestCompositePattern(unittest.TestCase):
     def setUp(self):
@@ -93,6 +100,9 @@ class TestCompositePattern(unittest.TestCase):
 
         allChildren = container.getChildren(deep=True)
         self.assertEqual(len(allChildren), 8)
+
+    def testIterComponents(self):
+        self.assertIn(self.thirdGen, list(self.container.iterComponents()))
 
     def testGetChildren(self):
         # There are 5 leaves and 1 composite in container. The composite has one leaf.
@@ -185,6 +195,10 @@ class TestCompositePattern(unittest.TestCase):
         for t in types:
             self.assertTrue(self.container.hasFlags(t))
             self.assertFalse(self.container.hasFlags(t, exact=True))
+
+    def test_getBoundingCirlceOuterDiameter(self):
+        od = self.container.getBoundingCircleOuterDiameter()
+        self.assertAlmostEqual(od, len(list(self.container.iterComponents())))
 
 
 class TestCompositeTree(unittest.TestCase):

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -11,12 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+General framework-wide testing functions and files.
 
+This package contains some input files that can be used across
+a wide variety of unit tests in other lower-level subpackages.
+"""
 import os
 import datetime
-import inspect
 import itertools
-import timeit
 import unittest
 import re
 import shutil
@@ -24,9 +27,6 @@ from typing import Optional
 
 import armi
 from armi import runLog
-from armi import settings
-from armi.utils import directoryChangers
-from armi.reactor import assemblies
 from armi.reactor import geometry
 from armi.reactor import reactors
 from armi.reactor import grids
@@ -73,7 +73,8 @@ def getEmptyCartesianReactor(pitch=(10.0, 16.0)):
 
 
 class Fixture:
-    r"""Fixture for presenting a consistent data source for testing.
+    """
+    Fixture for presenting a consistent data source for testing.
 
     A Fixture is a class that wraps a function which generates resources needed by one
     or more tests that doesn't need to be updated every time tests are run.

--- a/doc/user/inputs/blueprints.rst
+++ b/doc/user/inputs/blueprints.rst
@@ -101,6 +101,10 @@ input. The structure will be something like::
     the reactor model must currently be done programatically. We are currently
     developing additional input capabilities to use these more flexibly.
 
+    Associated with this is a ``component groups:`` section which can collect
+    different free components with different volume fractions. This also
+    is not fully implemented yet.
+
 Defining a Component
 --------------------
 The **Components** section defines the pin (if modeling a pin-type reactor) and assembly in-plane


### PR DESCRIPTION

<!--  
    Thanks in advance for you contribution!
-->
## Description
<!--  
    Please include a summary of the change and/or which issue is fixed.
-->
This just allows the user input of component groups intended to mix
different free components in different fractions. As is, this only
allows the input but does not implement any actual construction of
objects. It is a follow-up to #505 as part of the larger #504 task
related to improving input flexibility.

This needs to have a test that shows it reading/writing to/from
the database.

---

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] Docstrings were included and updated as necessary
- [x] The code is understandable and maintainable to people beyond the author
- [x] There is no commented out code in this PR.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.  
