### PR TITLE
Removing duplicate versioning strings

### DIFF
--- a/armi/meta.py
+++ b/armi/meta.py
@@ -16,7 +16,4 @@
 Metadata describing an ARMI distribution.
 """
 
-# duplicating with setup.py for now. This is because in order to import meta.py, we
-# need to run armi.__init__, which does a whole heck of a lot of stuff that setup.py
-# shouldn't need. We should clean this up in the future.
 __version__ = "0.2.0"

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -57,13 +57,14 @@ repos on GitHub.
 Every release should follow this process:
 
 1. Ensure all unit tests pass and the documentation is building correctly.
-2. Add release notes to the documentation:
+2. Bump the ``__version__`` string in ``armi/meta.py``.
+3. Add release notes to the documentation:
    `here <https://github.com/terrapower/armi/tree/master/doc/release>`__.
-3. Tag the commit after it goes into the repo: ``git tag -a 1.0.0 -m "Release v1.0.0"``
-4. Also add the release notes on `the GitHub UI <https://github.com/terrapower/armi/releases>`__.
-5. Follow the instructions `here <https://github.com/terrapower/terrapower.github.io>`_ to
+4. Tag the commit after it goes into the repo: ``git tag -a 1.0.0 -m "Release v1.0.0"``
+5. Also add the release notes on `the GitHub UI <https://github.com/terrapower/armi/releases>`__.
+6. Follow the instructions `here <https://github.com/terrapower/terrapower.github.io>`_ to
    archive the new documentation.
-6. Tell everyone!
+7. Tell everyone!
 
 Module-Level Logging
 --------------------

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,14 @@
 # limitations under the License.
 
 """Setup.py script for the Advanced Reactor Modeling Interface (ARMI)"""
-import re
 from setuptools import setup, find_packages
+import os
+import pathlib
+import re
 
+# grab __version__ from meta.py, without calling __init__.py
+this_file = pathlib.Path(__file__).parent.absolute()
+exec(open(os.path.join(this_file, "armi", "meta.py"), "r").read())
 
 with open("README.rst") as f:
     README = f.read()
@@ -38,8 +43,7 @@ EXTRA_FILES = collectExtraFiles()
 
 setup(
     name="armi",
-    # duplicating with meta.py for now. See comments there for rationale.
-    version="0.2.0",
+    version=__version__,
     description="The Advanced Reactor Modeling Interface",
     author="TerraPower, LLC",
     author_email="armi-devs@terrapower.com",
@@ -50,7 +54,6 @@ setup(
     packages=find_packages(),
     package_data={"armi": ["resources/*", "resources/**/*"] + EXTRA_FILES},
     entry_points={"console_scripts": ["armi = armi.__main__:main"]},
-    # note that these are duplicated in requirements.txt
     install_requires=[
         "configparser",
         "coverage",


### PR DESCRIPTION
## Description

In the past, every time I have wanted to bump our `armi.__version__`, I've had to do it in two places. This has always made me sad.

We have been duplicating our version string between `setup.py` and `meta.py`. Essentially, we had a lot of comments and documents explaining that putting the `__version__` string in `armi/__init__.py` file meant calling a bunch of code in `setup.py`, and that was deemed inefficient.

While this solution includes one kind of fugly line of Python code, it means we get to remove a lot of confusing comments, and streamline our release process.

---

## Checklist

- [X] Docstrings were included and updated as necessary
- [X] The code is understandable and maintainable to people beyond the author
- [X] There is no commented out code in this PR.
- [X] Documentation added/updated in the `doc` folder.
