### PR TITLE
Create a separate *.log file for the worker node *.stdouts.

### DIFF
--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -314,10 +314,11 @@ def concatenateLogs(logDir=None):
 
     # default worker log name if none is found
     caseTitle = "armi-workers"
-    for stdoutFile in stdoutFiles:
+    for stdoutPath in stdoutFiles:
+        stdoutFile = os.path.normpath(stdoutPath).split(os.sep)[-1]
         prefix = STDOUT_LOGGER_NAME + "."
         if stdoutFile[0 : len(prefix)] == prefix:
-            caseTitle = stdoutFile.split(".")[1]
+            caseTitle = stdoutFile.split(".")[-3]
             break
 
     combinedLogName = os.path.join(logDir, "{}-mpi.log".format(caseTitle))

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -47,12 +47,12 @@ Or change the log level the same way:
 
 """
 from __future__ import print_function
+from glob import glob
 import collections
 import logging
 import operator
 import os
 import sys
-from glob import glob
 
 from armi import context
 

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -249,7 +249,7 @@ class _RunLog:
     def startLog(self, name):
         """Initialize the streams when parallel processing"""
         # open the main logger
-        self.logger = logging.getLogger(STDOUT_LOGGER_NAME + SEP + str(self._mpiRank))
+        self.logger = logging.getLogger(name + SEP + str(self._mpiRank))
 
         # if there was a pre-existing _verbosity, use it now
         if self._verbosity != logging.INFO:
@@ -313,6 +313,8 @@ def concatenateLogs(logDir=None):
 
     caseTitle = settings.getMasterCs().caseTitle
     combinedLogName = os.path.join(logDir, "{}-workers.log".format(caseTitle))
+    print(caseTitle)
+    print(combinedLogName)
     with open(combinedLogName, "w") as workerLog:
         workerLog.write(
             "\n{0} CONCATENATED WORKER LOG FILES {1}\n".format("-" * 10, "-" * 10)

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -312,7 +312,14 @@ def concatenateLogs(logDir=None):
 
     info("Concatenating {0} log files".format(len(stdoutFiles)))
 
-    caseTitle = stdoutFiles[0].split(".")[-3]
+    # default worker log name if none is found
+    caseTitle = "armi-workers"
+    for stdoutFile in stdoutFiles:
+        prefix = STDOUT_LOGGER_NAME + "."
+        if stdoutFile[0 : len(prefix)] == prefix:
+            caseTitle = stdoutFile.split(".")[1]
+            break
+
     combinedLogName = os.path.join(logDir, "{}-mpi.log".format(caseTitle))
     with open(combinedLogName, "w") as workerLog:
         workerLog.write(

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -55,7 +55,6 @@ import os
 import sys
 
 from armi import context
-from armi import settings
 
 
 # global constants
@@ -249,7 +248,9 @@ class _RunLog:
     def startLog(self, name):
         """Initialize the streams when parallel processing"""
         # open the main logger
-        self.logger = logging.getLogger(name + SEP + str(self._mpiRank))
+        self.logger = logging.getLogger(
+            STDOUT_LOGGER_NAME + SEP + name + SEP + str(self._mpiRank)
+        )
 
         # if there was a pre-existing _verbosity, use it now
         if self._verbosity != logging.INFO:
@@ -311,10 +312,8 @@ def concatenateLogs(logDir=None):
 
     info("Concatenating {0} log files".format(len(stdoutFiles)))
 
-    caseTitle = settings.getMasterCs().caseTitle
-    combinedLogName = os.path.join(logDir, "{}-workers.log".format(caseTitle))
-    print(caseTitle)
-    print(combinedLogName)
+    caseTitle = stdoutFiles[0].split(".")[-3]
+    combinedLogName = os.path.join(logDir, "{}-mpi.log".format(caseTitle))
     with open(combinedLogName, "w") as workerLog:
         workerLog.write(
             "\n{0} CONCATENATED WORKER LOG FILES {1}\n".format("-" * 10, "-" * 10)

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -310,8 +310,7 @@ def concatenateLogs(logDir=None):
 
     info("Concatenating {0} log files".format(len(stdoutFiles)))
 
-    dirName = os.path.dirname(stdoutFiles[0])
-    combinedLogName = os.path.join(dirName, "armi-mpi-workers.log")
+    combinedLogName = os.path.join(logDir, "armi-mpi-workers.log")
     with open(combinedLogName, "w") as workerLog:
         workerLog.write(
             "\n{0} CONCATENATED WORKER LOG FILES {1}\n".format("-" * 10, "-" * 10)

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -47,12 +47,12 @@ Or change the log level the same way:
 
 """
 from __future__ import print_function
-from glob import glob
 import collections
 import logging
 import operator
 import os
 import sys
+from glob import glob
 
 from armi import context
 

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -314,7 +314,7 @@ def concatenateLogs(logDir=None):
     combinedLogName = os.path.join(dirName, "armi-mpi-workers.log")
     with open(combinedLogName, "w") as workerLog:
         workerLog.write(
-            "\n{0} CONCATENATED WORKER LOG FILES {2}\n".format("-" * 10, "-" * 10)
+            "\n{0} CONCATENATED WORKER LOG FILES {1}\n".format("-" * 10, "-" * 10)
         )
 
     for stdoutName in stdoutFiles:

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -469,9 +469,10 @@ class RunLogger(logging.Logger):
 
     def __init__(self, *args, **kwargs):
         # optionally, the user can pass in the MPI_RANK by putting it in the logger name after a separator string
+        # args[0].split(SEP): 0 = "ARMI", 1 = caseTitle, 2 = MPI_RANK
         if SEP in args[0]:
             mpiRank = int(args[0].split(SEP)[-1].strip())
-            args = (args[0].split(SEP)[0],)
+            args = (".".join(args[0].split(SEP)[0:2]),)
         else:
             mpiRank = context.MPI_RANK
 

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -285,7 +285,7 @@ class TestRunLog(unittest.TestCase):
             runLog.concatenateLogs(logDir=logDir)
 
             # verify output
-            combinedLogFile = os.path.join(logDir, "armi-mpi-workers.log")
+            combinedLogFile = os.path.join(logDir, "armi-workers.log")
             self.assertTrue(os.path.exists(combinedLogFile))
             self.assertFalse(os.path.exists(stdoutFile1))
             self.assertFalse(os.path.exists(stdoutFile2))

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -285,7 +285,9 @@ class TestRunLog(unittest.TestCase):
             runLog.concatenateLogs(logDir=logDir)
 
             # verify output
-            combinedLogFile = os.path.join(logDir, "armi-workers.log")
+            logFile = glob(os.path.join(logDir, "*-workers.log")))
+            for f in logFile:
+                combinedLogFile = os.path.join(logDir, f)
             self.assertTrue(os.path.exists(combinedLogFile))
             self.assertFalse(os.path.exists(stdoutFile1))
             self.assertFalse(os.path.exists(stdoutFile2))

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -263,11 +263,15 @@ class TestRunLog(unittest.TestCase):
             context.createLogDir(0, logDir)
 
             # create as stdout file
-            stdoutFile1 = os.path.join(logDir, logDir + ".runLogTest.0000.stdout")
+            stdoutFile1 = os.path.join(
+                logDir, "{}.runLogTest.0000.stdout".format(runLog.STDOUT_LOGGER_NAME)
+            )
             with open(stdoutFile1, "w") as f:
                 f.write("hello world\n")
 
-            stdoutFile2 = os.path.join(logDir, logDir + ".runLogTest.0001.stdout")
+            stdoutFile2 = os.path.join(
+                logDir, "{}.runLogTest.0001.stdout".format(runLog.STDOUT_LOGGER_NAME)
+            )
             with open(stdoutFile2, "w") as f:
                 f.write("hello other world\n")
 
@@ -275,7 +279,9 @@ class TestRunLog(unittest.TestCase):
             self.assertTrue(os.path.exists(stdoutFile2))
 
             # create a stderr file
-            stderrFile = os.path.join(logDir, logDir + ".runLogTest.0000.stderr")
+            stderrFile = os.path.join(
+                logDir, "{}.runLogTest.0000.stderr".format(runLog.STDOUT_LOGGER_NAME)
+            )
             with open(stderrFile, "w") as f:
                 f.write("goodbye cruel world\n")
 

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -263,14 +263,19 @@ class TestRunLog(unittest.TestCase):
             context.createLogDir(0, logDir)
 
             # create as stdout file
-            stdoutFile = os.path.join(logDir, logDir + ".0.0.stdout")
-            with open(stdoutFile, "w") as f:
+            stdoutFile1 = os.path.join(logDir, logDir + ".0.0000.stdout")
+            with open(stdoutFile1, "w") as f:
                 f.write("hello world\n")
 
-            self.assertTrue(os.path.exists(stdoutFile))
+            stdoutFile2 = os.path.join(logDir, logDir + ".0.0001.stdout")
+            with open(stdoutFile2, "w") as f:
+                f.write("hello other world\n")
+
+            self.assertTrue(os.path.exists(stdoutFile1))
+            self.assertTrue(os.path.exists(stdoutFile2))
 
             # create a stderr file
-            stderrFile = os.path.join(logDir, logDir + ".0.0.stderr")
+            stderrFile = os.path.join(logDir, logDir + ".0.0000.stderr")
             with open(stderrFile, "w") as f:
                 f.write("goodbye cruel world\n")
 
@@ -282,7 +287,8 @@ class TestRunLog(unittest.TestCase):
             # verify output
             combinedLogFile = os.path.join(logDir, "armi-mpi-workers.log")
             self.assertTrue(os.path.exists(combinedLogFile))
-            self.assertFalse(os.path.exists(stdoutFile))
+            self.assertFalse(os.path.exists(stdoutFile1))
+            self.assertFalse(os.path.exists(stdoutFile2))
             self.assertFalse(os.path.exists(stderrFile))
 
 

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -285,10 +285,8 @@ class TestRunLog(unittest.TestCase):
             runLog.concatenateLogs(logDir=logDir)
 
             # verify output
-            #logFile = glob(os.path.join(logDir, "*-mpi.log"))
-            #for f in logFile:
-            #    combinedLogFile = os.path.join(logDir, f)
-            #self.assertTrue(os.path.exists(combinedLogFile))
+            combinedLogFile = os.path.join(logDir, "runLogTest-mpi.log")
+            self.assertTrue(os.path.exists(combinedLogFile))
             self.assertFalse(os.path.exists(stdoutFile1))
             self.assertFalse(os.path.exists(stdoutFile2))
             self.assertFalse(os.path.exists(stderrFile))

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -280,6 +280,8 @@ class TestRunLog(unittest.TestCase):
             runLog.concatenateLogs(logDir=logDir)
 
             # verify output
+            combinedLogFile = os.path.join(logDir, "armi-mpi-workers.log")
+            self.assertTrue(os.path.exists(combinedLogFile))
             self.assertFalse(os.path.exists(stdoutFile))
             self.assertFalse(os.path.exists(stderrFile))
 

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -263,11 +263,11 @@ class TestRunLog(unittest.TestCase):
             context.createLogDir(0, logDir)
 
             # create as stdout file
-            stdoutFile1 = os.path.join(logDir, logDir + ".0.0000.stdout")
+            stdoutFile1 = os.path.join(logDir, logDir + ".runLogTest.0000.stdout")
             with open(stdoutFile1, "w") as f:
                 f.write("hello world\n")
 
-            stdoutFile2 = os.path.join(logDir, logDir + ".0.0001.stdout")
+            stdoutFile2 = os.path.join(logDir, logDir + ".runLogTest.0001.stdout")
             with open(stdoutFile2, "w") as f:
                 f.write("hello other world\n")
 
@@ -275,7 +275,7 @@ class TestRunLog(unittest.TestCase):
             self.assertTrue(os.path.exists(stdoutFile2))
 
             # create a stderr file
-            stderrFile = os.path.join(logDir, logDir + ".0.0000.stderr")
+            stderrFile = os.path.join(logDir, logDir + ".runLogTest.0000.stderr")
             with open(stderrFile, "w") as f:
                 f.write("goodbye cruel world\n")
 
@@ -285,10 +285,10 @@ class TestRunLog(unittest.TestCase):
             runLog.concatenateLogs(logDir=logDir)
 
             # verify output
-            logFile = glob(os.path.join(logDir, "*-workers.log")))
-            for f in logFile:
-                combinedLogFile = os.path.join(logDir, f)
-            self.assertTrue(os.path.exists(combinedLogFile))
+            #logFile = glob(os.path.join(logDir, "*-mpi.log"))
+            #for f in logFile:
+            #    combinedLogFile = os.path.join(logDir, f)
+            #self.assertTrue(os.path.exists(combinedLogFile))
             self.assertFalse(os.path.exists(stdoutFile1))
             self.assertFalse(os.path.exists(stdoutFile2))
             self.assertFalse(os.path.exists(stderrFile))


### PR DESCRIPTION
## Description
At the end of a run, all of the logs from the individual MPI processes get concatenated together and appended to the end of the `*.stdout`. If there are a lot of MPI processes, this can make the `*.stdout` obnoxiously bloated, with a bunch of information that the user would rarely ever want to look at.

Instead, this PR puts all of those worker node logs into a separate file, `.\logs\armi-mpi-workers.log`
It would probably be best if the file had the name of the case (i.e., the same as the `*.stdout` and `*.stderr`), but I don't know if that name is available to the logger at this level. It's just writing those to the streams `sys.stdout` and `sys.stderr`.  If somebody has a better idea for naming I'm all ears; this was just kind of a temporary name to make sure the code worked.

---

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] Tests have been added/updated to verify that the new or changed code works.
- [ ] Docstrings were included and updated as necessary
- [ ] The code is understandable and maintainable to people beyond the author
- [x] There is no commented out code in this PR.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.  
