### PR TITLE
Improving Type Hinting

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -334,7 +334,7 @@ def configure(app: Optional[apps.App] = None, permissive=False):
     flags.registerPluginFlags(pm)
 
 
-def applyAsyncioWindowsWorkaround():
+def applyAsyncioWindowsWorkaround() -> None:
     """
     Apply Asyncio workaround for Windows and Python 3.8.
 

--- a/armi/context.py
+++ b/armi/context.py
@@ -159,7 +159,7 @@ _FAST_PATH_IS_TEMPORARY = False
 """Flag indicating whether or not the FAST_PATH should be cleaned up on exit."""
 
 
-def activateLocalFastPath():
+def activateLocalFastPath() -> None:
     """
     Specify a local temp directory to be the fast path.
 
@@ -187,7 +187,7 @@ def activateLocalFastPath():
     _FAST_PATH_IS_TEMPORARY = True
 
 
-def getFastPath():
+def getFastPath() -> str:
     """
     Callable to get the current FAST_PATH.
 
@@ -245,7 +245,7 @@ def cleanTempDirs(olderThanDays=None):
         cleanAllArmiTempDirs(olderThanDays)
 
 
-def cleanAllArmiTempDirs(olderThanDays: int):
+def cleanAllArmiTempDirs(olderThanDays: int) -> None:
     """
     Delete all ARMI-related files from other unrelated runs after `olderThanDays` days (in
     case this failed on earlier runs).
@@ -277,7 +277,7 @@ def cleanAllArmiTempDirs(olderThanDays: int):
             pass
 
 
-def disconnectAllHdfDBs():
+def disconnectAllHdfDBs() -> None:
     """
     Forcibly disconnect all instances of HdfDB objects
 
@@ -305,7 +305,7 @@ def disconnectAllHdfDBs():
 OS_SECONDS_TIMEOUT = 5 * 60
 
 
-def createLogDir(mpiRank=1, logDir=None):
+def createLogDir(mpiRank: int = 1, logDir: str = None) -> None:
     """A helper method to create the log directory"""
     # the usual case is the user does not pass in a log dir path, so we use the global one
     if logDir is None:

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -49,7 +49,7 @@ class B4C(material.Material):
         if TD_frac is not None:
             self.updateTD(TD_frac)
 
-    def updateTD(self, TD):
+    def updateTD(self, TD: float) -> None:
         self.p.theoreticalDensityFrac = TD
         self.clearCache()
 
@@ -112,7 +112,7 @@ class B4C(material.Material):
 
         return boron10MassGrams, boron11MassGrams, carbonMassGrams
 
-    def setDefaultMassFracs(self):
+    def setDefaultMassFracs(self) -> None:
         r"""B4C mass fractions. Using Natural B4C. 19.9% B-10/ 80.1% B-11
         Boron: 10.811 g/mol
         Carbon:  12.0107 g/mol
@@ -143,7 +143,7 @@ class B4C(material.Material):
         )
 
     @staticmethod
-    def getMassEnrichmentFromNumEnrich(naturalB10NumberFraction):
+    def getMassEnrichmentFromNumEnrich(naturalB10NumberFraction: float) -> float:
         b10AtomicMass = nuclideBases.byName["B10"].weight
         b11AtomicMass = nuclideBases.byName["B11"].weight
         return (
@@ -155,7 +155,7 @@ class B4C(material.Material):
             )
         )
 
-    def density(self, Tk=None, Tc=None):
+    def density(self, Tk: float = None, Tc: float = None) -> float:
         """
         mass density
         """
@@ -170,7 +170,7 @@ class B4C(material.Material):
             )
         return density * theoreticalDensityFrac  # g/cc
 
-    def linearExpansionPercent(self, Tk=None, Tc=None):
+    def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
         """Boron carbide expansion. Very preliminary"""
         Tc = getTc(Tc, Tk)
         self.checkTempRange(25, 500, Tc, "linear expansion percent")

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -66,7 +66,7 @@ class Material(composites.Leaf):
     """A tuple of :py:class:`~armi.nucDirectory.thermalScattering.ThermalScattering` instances 
     with information about thermal scattering."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         composites.Leaf.__init__(self, self.__class__.name)
         self.p.massFrac = {}
 
@@ -82,7 +82,7 @@ class Material(composites.Leaf):
         self.setDefaultMassFracs()
         self.propertyRangeUpdated = False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Material: {0}>".format(self.getName())
 
     def duplicate(self):
@@ -97,7 +97,7 @@ class Material(composites.Leaf):
 
         return m
 
-    def linearExpansion(self, Tk=None, Tc=None):
+    def linearExpansion(self, Tk: float = None, Tc: float = None) -> float:
         r"""
         the instantaneous linear expansion coefficient (dL/L)/dT
 
@@ -112,7 +112,7 @@ class Material(composites.Leaf):
             f"{self} does not have a linear expansion property defined"
         )
 
-    def linearExpansionPercent(self, Tk=None, Tc=None):
+    def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
         """
         Average thermal expansion dL/L. Used for computing hot dimensions and density.
 
@@ -136,7 +136,7 @@ class Material(composites.Leaf):
         """
         return 0.0
 
-    def linearExpansionFactor(self, Tc, T0):
+    def linearExpansionFactor(self, Tc: float, T0: float) -> float:
         """
         Return a dL/L factor relative to T0 instead of to the material-dependent reference
         temperature. This factor dL/Lc is a ratio and will be used in dimensions through the
@@ -174,7 +174,9 @@ class Material(composites.Leaf):
 
         return (dLLhot - dLLcold) / (100.0 + dLLcold)
 
-    def getThermalExpansionDensityReduction(self, prevTempInC, newTempInC):
+    def getThermalExpansionDensityReduction(
+        self, prevTempInC: float, newTempInC: float
+    ) -> float:
         """
         Return the factor required to update thermal expansion going from temperatureInC to temperatureInCNew.
         """
@@ -185,14 +187,14 @@ class Material(composites.Leaf):
         r"""mass fractions"""
         pass
 
-    def setMassFrac(self, nucName, massFrac):
+    def setMassFrac(self, nucName: str, massFrac: float) -> None:
         self.p.massFrac[nucName] = massFrac
 
     def applyInputParams(self):
         """Apply material-specific material input parameters."""
         pass
 
-    def adjustMassEnrichment(self, massEnrichment):
+    def adjustMassEnrichment(self, massEnrichment: float) -> None:
         """
         Adjust the enrichment of the material.
 
@@ -202,7 +204,7 @@ class Material(composites.Leaf):
         """
         self.adjustMassFrac(self.enrichedNuclide, massEnrichment)
 
-    def adjustMassFrac(self, nuclideName, massFraction):
+    def adjustMassFrac(self, nuclideName: str, massFraction: float) -> None:
         """
         Change the mass fraction of the specified nuclide.
 
@@ -312,7 +314,9 @@ class Material(composites.Leaf):
     def volumetricExpansion(self, Tk=None, Tc=None):
         pass
 
-    def getTemperatureAtDensity(self, targetDensity, temperatureGuessInC):
+    def getTemperatureAtDensity(
+        self, targetDensity: float, temperatureGuessInC: float
+    ) -> float:
         """Get the temperature at which the perturbed density occurs."""
         densFunc = (
             lambda temp: self.density(Tc=temp) - targetDensity
@@ -323,14 +327,14 @@ class Material(composites.Leaf):
         return tAtTargetDensity
 
     @property
-    def liquidPorosity(self):
+    def liquidPorosity(self) -> float:
         return 0.0 if self.parent is None else self.parent.liquidPorosity
 
     @property
-    def gasPorosity(self):
+    def gasPorosity(self) -> float:
         return 0.0 if self.parent is None else self.parent.gasPorosity
 
-    def density(self, Tk=None, Tc=None):
+    def density(self, Tk: float = None, Tc: float = None) -> float:
         """
         Return density that preserves mass when thermally expanded in 2D.
 
@@ -365,7 +369,7 @@ class Material(composites.Leaf):
         # rho = rho + dRho = (1 + dRho/rho) * rho
         return self.p.refDens / f  # g/cm^3
 
-    def densityKgM3(self, Tk=None, Tc=None):
+    def densityKgM3(self, Tk: float = None, Tc: float = None) -> float:
         """
         Return density that preserves mass when thermally expanded in 2D in units of kg/m^3
 
@@ -376,7 +380,7 @@ class Material(composites.Leaf):
         """
         return self.density(Tk, Tc) * 1000.0
 
-    def density3(self, Tk=None, Tc=None):
+    def density3(self, Tk: float = None, Tc: float = None) -> float:
         """
         Return density that preserves mass when thermally expanded in 3D.
 
@@ -402,7 +406,7 @@ class Material(composites.Leaf):
         dRhoOverRho = (1.0 - f) / f
         return refD * (dRhoOverRho + 1)
 
-    def density3KgM3(self, Tk=None, Tc=None):
+    def density3KgM3(self, Tk: float = None, Tc: float = None) -> float:
         """Return density that preserves mass when thermally expanded in 3D in units of kg/m^3.
 
         See Also
@@ -412,45 +416,49 @@ class Material(composites.Leaf):
         """
         return self.density3(Tk, Tc) * 1000.0
 
-    def getCorrosionRate(self, Tk=None, Tc=None):
+    def getCorrosionRate(self, Tk: float = None, Tc: float = None) -> float:
         r"""
         given a temperature, get the corrosion rate of the material
         """
         return 0.0
 
-    def getLifeMetalCorrelation(self, days, Tk):
+    def getLifeMetalCorrelation(self, days: float, Tk: float) -> float:
         r"""
         life-metal correlation calculates the wastage of the material due to fission products.
         """
         return 0.0
 
-    def getReverseLifeMetalCorrelation(self, thicknessFCCIWastageMicrons, Tk):
+    def getReverseLifeMetalCorrelation(
+        self, thicknessFCCIWastageMicrons: float, Tk: float
+    ) -> float:
         r"""
         Life metal correlation reverse lookup.  Knowing wastage and Temperature
         determine the effective time at that temperature.
         """
         return 0.0
 
-    def getLifeMetalConservativeFcciCoeff(self, Tk):
+    def getLifeMetalConservativeFcciCoeff(self, Tk: float) -> float:
         """
         Return the coefficient to be used in the LIFE-METAL correlation
         """
 
         return 0.0
 
-    def yieldStrength(self, Tk=None, Tc=None):
+    def yieldStrength(self, Tk: float = None, Tc: float = None) -> float:
         r"""
         returns yield strength at given T in MPa
         """
         return self.p.yieldStrength
 
-    def thermalConductivity(self, Tk=None, Tc=None):
+    def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
         r"""
         thermal conductivity in given T in K
         """
         return self.p.thermalConductivity
 
-    def getProperty(self, propName, Tk=None, Tc=None, **kwargs):
+    def getProperty(
+        self, propName: str, Tk: float = None, Tc: float = None, **kwargs
+    ) -> float:
         r"""gets properties in a way that caches them."""
         Tk = getTk(Tc, Tk)
 
@@ -511,12 +519,12 @@ class Material(composites.Leaf):
         """
         return self.p.massFrac.get(nucName, 0.0)
 
-    def clearMassFrac(self):
+    def clearMassFrac(self) -> None:
         r"""zero out all nuclide mass fractions."""
         self.p.massFrac.clear()
         self.p.massFracNorm = 0.0
 
-    def removeNucMassFrac(self, nuc):
+    def removeNucMassFrac(self, nuc: str) -> None:
         self.setMassFrac(nuc, 0)
         try:
             del self.p.massFrac[nuc]
@@ -524,7 +532,7 @@ class Material(composites.Leaf):
             # the nuc isn't in the mass Frac vector
             pass
 
-    def removeLumpedFissionProducts(self):
+    def removeLumpedFissionProducts(self) -> None:
         for nuc in self.getNuclides():
             if "LF" in nuc:
                 # this component has a lumped fission product to remove
@@ -565,7 +573,7 @@ class Material(composites.Leaf):
                     label="T out of bounds for {} {}".format(self.name, label),
                 )
 
-    def densityTimesHeatCapacity(self, Tk=None, Tc=None):
+    def densityTimesHeatCapacity(self, Tk: float = None, Tc: float = None) -> float:
         r"""
         Return heat capacity * density at a temperature
         Parameters
@@ -592,7 +600,9 @@ class Material(composites.Leaf):
         warnings.warn("Material.getNuclides is being deprecated.", DeprecationWarning)
         return self.parent.getNuclides()
 
-    def getTempChangeForDensityChange(self, Tc, densityFrac, quiet=True):
+    def getTempChangeForDensityChange(
+        self, Tc: float, densityFrac: float, quiet: bool = True
+    ) -> float:
         """Return a temperature difference for a given density perturbation."""
         linearExpansion = self.linearExpansion(Tc=Tc)
         linearChange = densityFrac ** (-1.0 / 3.0) - 1.0
@@ -637,7 +647,9 @@ class Fluid(Material):
         since it is a liquid it will fill its space."""
         return 0.0
 
-    def getTempChangeForDensityChange(self, Tc, densityFrac, quiet=True):
+    def getTempChangeForDensityChange(
+        self, Tc: float, densityFrac: float, quiet: bool = True
+    ) -> float:
         """Return a temperature difference for a given density perturbation."""
         currentDensity = self.density(Tc=Tc)
         perturbedDensity = currentDensity * densityFrac

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -66,7 +66,7 @@ class Material(composites.Leaf):
     """A tuple of :py:class:`~armi.nucDirectory.thermalScattering.ThermalScattering` instances 
     with information about thermal scattering."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         composites.Leaf.__init__(self, self.__class__.name)
         self.p.massFrac = {}
 
@@ -82,7 +82,7 @@ class Material(composites.Leaf):
         self.setDefaultMassFracs()
         self.propertyRangeUpdated = False
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return "<Material: {0}>".format(self.getName())
 
     def duplicate(self):

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -45,7 +45,7 @@ class Uranium(Material):
 
     propertyValidTemperature = {"thermal conductivity": ((255.4, 1173.2), "K")}
 
-    def thermalConductivity(self, Tk=None, Tc=None):
+    def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
         """The thermal conductivity of pure U in W-m/K."""
         Tk = getTk(Tc, Tk)
         (TLowerLimit, TUpperLimit) = self.propertyValidTemperature[

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -88,13 +88,15 @@ class UraniumOxide(material.FuelMaterial):
 
     enrichedNuclide = "U235"
 
-    def adjustTD(self, val):
+    def adjustTD(self, val: float) -> None:
         self.theoreticalDensityFrac = val
 
-    def getTD(self):
+    def getTD(self) -> float:
         return self.theoreticalDensityFrac
 
-    def applyInputParams(self, U235_wt_frac=None, TD_frac=None, *args, **kwargs):
+    def applyInputParams(
+        self, U235_wt_frac: float = None, TD_frac: float = None, *args, **kwargs
+    ) -> None:
         if U235_wt_frac is not None:
             self.adjustMassEnrichment(U235_wt_frac)
 
@@ -118,7 +120,7 @@ class UraniumOxide(material.FuelMaterial):
             self.adjustTD(1.00)  # default to fully dense.
         material.FuelMaterial.applyInputParams(self, *args, **kwargs)
 
-    def setDefaultMassFracs(self):
+    def setDefaultMassFracs(self) -> None:
         r"""
         UO2 mass fractions. Using Natural Uranium without U234
         """
@@ -147,7 +149,7 @@ class UraniumOxide(material.FuelMaterial):
         """
         return 3123.0
 
-    def density(self, Tk=None, Tc=None):
+    def density(self, Tk: float = None, Tc: float = None) -> float:
         """
         Density in (g/cc)
 
@@ -157,7 +159,7 @@ class UraniumOxide(material.FuelMaterial):
         self.checkTempRange(300, 3100, Tk, "thermal conductivity")
         return (-1.01147e-7 * Tk ** 2 - 1.29933e-4 * Tk + 1.09805e1) * self.getTD()
 
-    def thermalConductivity(self, Tk=None, Tc=None):
+    def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
         """
         Thermal conductivity
 
@@ -168,7 +170,7 @@ class UraniumOxide(material.FuelMaterial):
         self.checkTempRange(300, 3000, Tk, "density")
         return interp(Tk, self.thermalConductivityTableK, self.thermalConductivityTable)
 
-    def linearExpansion(self, Tk=None, Tc=None):
+    def linearExpansion(self, Tk: float = None, Tc: float = None) -> float:
         """
         Linear expansion coefficient.
 
@@ -177,7 +179,7 @@ class UraniumOxide(material.FuelMaterial):
         self.checkTempRange(273, 3120, Tk, "linear expansion")
         return 1.06817e-12 * Tk ** 2 - 1.37322e-9 * Tk + 1.02863e-5
 
-    def linearExpansionPercent(self, Tk=None, Tc=None):
+    def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
         """
         Return dL/L
 
@@ -194,7 +196,7 @@ class UraniumOxide(material.FuelMaterial):
                 -3.28e-03 + 1.179e-05 * Tk - 2.429e-09 * Tk ** 2 + 1.219e-12 * Tk ** 3
             ) * 100.0
 
-    def heatCapacity(self, Tk=None, Tc=None):
+    def heatCapacity(self, Tk: float = None, Tc: float = None) -> float:
         """
         Heat capacity in J/kg-K.
 

--- a/armi/materials/water.py
+++ b/armi/materials/water.py
@@ -75,7 +75,7 @@ class Water(Fluid):
     d[4] = -135.003439
     d[5] = 0.981825814
 
-    def setDefaultMassFracs(self):
+    def setDefaultMassFracs(self) -> None:
         massHydrogen = elements.bySymbol["H"].standardWeight
         massOxygen = elements.bySymbol["O"].standardWeight
         totalMass = 2 * massHydrogen + massOxygen
@@ -83,13 +83,13 @@ class Water(Fluid):
         for nucName, mfrac in massFrac.items():
             self.setMassFrac(nucName, mfrac)
 
-    def theta(self, Tk=None, Tc=None):
+    def theta(self, Tk: float = None, Tc: float = None) -> float:
         """
         returns temperature normalized to the critical temperature
         """
         return getTk(Tc=Tc, Tk=Tk) / self.TEMPERATURE_CRITICAL_K
 
-    def tau(self, Tc=None, Tk=None):
+    def tau(self, Tc: float = None, Tk: float = None) -> float:
         """
         returns 1 - temperature normalized to the critical temperature
 
@@ -99,7 +99,7 @@ class Water(Fluid):
         """
         return 1.0 - self.theta(Tc=Tc, Tk=Tk)
 
-    def vaporPressure(self, Tk=None, Tc=None):
+    def vaporPressure(self, Tk: float = None, Tc: float = None) -> float:
         """
         Returns vapor pressure in (Pa)
 
@@ -148,7 +148,9 @@ class Water(Fluid):
         # past the supercritical point tau's raised to .5 cause complex #'s
         return vapor_pressure.real
 
-    def vaporPressurePrime(self, Tk=None, Tc=None, dT=1e-6):
+    def vaporPressurePrime(
+        self, Tk: float = None, Tc: float = None, dT: float = 1e-6
+    ) -> float:
         """
         approximation of derivative of vapor pressure wrt temperature
 
@@ -169,7 +171,9 @@ class Water(Fluid):
         dp = self.vaporPressure(Tk=Thot) - self.vaporPressure(Tk=Tcold)
         return dp / dT
 
-    def auxiliaryQuantitySpecificEnthalpy(self, Tk=None, Tc=None):
+    def auxiliaryQuantitySpecificEnthalpy(
+        self, Tk: float = None, Tc: float = None
+    ) -> float:
         """
         Returns the auxiliary quantity for specific enthalpy
 
@@ -209,7 +213,9 @@ class Water(Fluid):
         # past the supercritical point tau's raised to .5 cause complex #'s
         return normalized_alpha.real * self.ALPHA_0
 
-    def auxiliaryQuantitySpecificEntropy(self, Tk=None, Tc=None):
+    def auxiliaryQuantitySpecificEntropy(
+        self, Tk: float = None, Tc: float = None
+    ) -> float:
         """
         Returns the auxiliary quantity for specific entropy
 
@@ -249,7 +255,7 @@ class Water(Fluid):
         # past the supercritical point tau's raised to .5 cause complex #'s
         return normalized_phi.real * self.PHI_0
 
-    def enthalpy(self, Tk=None, Tc=None):
+    def enthalpy(self, Tk: float = None, Tc: float = None) -> float:
         """
         Returns enthalpy of saturated water
 
@@ -279,7 +285,7 @@ class Water(Fluid):
 
         return alpha + T / rho * dp_dT
 
-    def entropy(self, Tk=None, Tc=None):
+    def entropy(self, Tk: float = None, Tc: float = None) -> float:
         """
         Returns entropy of saturated water
 
@@ -329,7 +335,7 @@ class SaturatedWater(Water):
 
     name = "SaturatedWater"
 
-    def density(self, Tk=None, Tc=None):
+    def density(self, Tk: float = None, Tc: float = None) -> float:
         """
         returns density in g/cc
 
@@ -388,7 +394,7 @@ class SaturatedSteam(Water):
 
     name = "SaturatedSteam"
 
-    def density(self, Tk=None, Tc=None):
+    def density(self, Tk: float = None, Tc: float = None) -> float:
         """
         returns density in g/cc
 

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -71,7 +71,7 @@ class ExecutionOptions:
         self.applyResultsToReactor = True
         self.paramsToScaleSubset = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self.label}>"
 
     def fromUserSettings(self, cs):
@@ -85,7 +85,7 @@ class ExecutionOptions:
     def resolveDerivedOptions(self):
         """Called by executers right before executing."""
 
-    def setRunDirFromCaseTitle(self, caseTitle):
+    def setRunDirFromCaseTitle(self, caseTitle: str) -> None:
         """
         Set run directory derived from case title and label.
 
@@ -100,7 +100,7 @@ class ExecutionOptions:
         caseTitleHash = str(hashlib.sha1(caseString).hexdigest())[:8]
         self.runDir = os.path.join(getFastPath(), f"{caseTitleHash}-{MPI_RANK}")
 
-    def describe(self):
+    def describe(self) -> str:
         """Make a string summary of all options."""
         lines = ["Options summary:", "----------------"]
         for key, val in sorted(self.__dict__.items()):
@@ -200,7 +200,7 @@ class DefaultExecuter(Executer):
         outputs.extend(self.options.extraOutputFiles)
         return inputs, outputs
 
-    def _execute(self):
+    def _execute(self) -> bool:
         runLog.extra(
             f"Executing {self.options.executablePath}\n"
             f"\tInput: {self.options.inputFile}\n"

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -71,7 +71,7 @@ class ExecutionOptions:
         self.applyResultsToReactor = True
         self.paramsToScaleSubset = None
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return f"<{self.__class__.__name__}: {self.label}>"
 
     def fromUserSettings(self, cs):

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -134,7 +134,7 @@ class BlockCollection(list):
             for t in validBlockTypes:
                 self._validRepresentativeBlockTypes.append(Flags.fromString(t))
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return "<{} with {} blocks>".format(self.__class__.__name__, len(self))
 
     def _getNewBlock(self):

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -84,7 +84,7 @@ def describeInterfaces(cs):
 _ALLOWABLE_XS_TYPE_LIST = list(string.ascii_uppercase)
 
 
-def getXSTypeNumberFromLabel(xsTypeLabel):
+def getXSTypeNumberFromLabel(xsTypeLabel: str) -> int:
     """
     Convert a XSID label (e.g. 'AA') to an integer.
 
@@ -95,7 +95,7 @@ def getXSTypeNumberFromLabel(xsTypeLabel):
     return int("".join(["{:02d}".format(ord(si)) for si in xsTypeLabel]))
 
 
-def getXSTypeLabelFromNumber(xsTypeNumber):
+def getXSTypeLabelFromNumber(xsTypeNumber: int) -> int:
     """
     Convert a XSID label (e.g. 65) to an XS label (e.g. 'A').
 
@@ -134,7 +134,7 @@ class BlockCollection(list):
             for t in validBlockTypes:
                 self._validRepresentativeBlockTypes.append(Flags.fromString(t))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{} with {} blocks>".format(self.__class__.__name__, len(self))
 
     def _getNewBlock(self):

--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -145,12 +145,12 @@ class XSSettings(dict):
     section settings are dependent on user settings.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         dict.__init__(self, *args, **kwargs)
         self._blockRepresentation = None
         self._validBlockTypes = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} with XS IDs {self.keys()}>"
 
     def __getitem__(self, xsID):

--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -145,12 +145,12 @@ class XSSettings(dict):
     section settings are dependent on user settings.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
         self._blockRepresentation = None
         self._validBlockTypes = None
 
-    def __repr__(self) -> str:
+    def __repr__(self):
         return f"<{self.__class__.__name__} with XS IDs {self.keys()}>"
 
     def __getitem__(self, xsID):

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -114,7 +114,7 @@ def getFileSHA1Hash(filePath, digits=40):
     return sha1.hexdigest()[:digits]
 
 
-def efmt(a):
+def efmt(a: str) -> str:
     r"""Converts string exponential number to another string with just 2 digits in the exponent."""
     # this assumes that none of our numbers will be more than 1e100 or less than 1e-100...
     if len(a.split("E")) != 2:
@@ -130,7 +130,7 @@ def efmt(a):
     return two[0] + "E" + exp
 
 
-def fixThreeDigitExp(strToFloat):
+def fixThreeDigitExp(strToFloat: str) -> float:
     """
     Convert FORTRAN numbers that cannot be converted into floats.
 
@@ -347,7 +347,7 @@ def getFloat(val):
         return None
 
 
-def relErr(v1, v2):
+def relErr(v1: float, v2: float) -> float:
     if v1:
         return (v2 - v1) / v1
     else:
@@ -759,7 +759,7 @@ def prependToList(originalList, listToPrepend):
     return originalList
 
 
-def capStrLen(string, length):
+def capStrLen(s: str, length: int) -> str:
     """
     Truncates a string to a certain length.
 
@@ -767,7 +767,7 @@ def capStrLen(string, length):
 
     Parameters
     ----------
-    string : str
+    s : str
         The string to cap at length l.
     length : int
         The maximum length of the string s.
@@ -775,10 +775,10 @@ def capStrLen(string, length):
     if length <= 2:
         raise Exception("l must be at least 3 in utils.capStrLen")
 
-    if len(string) <= length:
-        return string
+    if len(s) <= length:
+        return s
 
-    return string[0 : length - 3] + "..."
+    return s[0 : length - 3] + "..."
 
 
 def list2str(strings, width=None, preStrings=None, fmt=None):
@@ -1063,7 +1063,7 @@ def plotMatrix(
     plt.close()
 
 
-def userName():
+def userName() -> str:
     """
     Return a database-friendly username.
 
@@ -1171,7 +1171,7 @@ class MergeableDict(dict):
     Allows multiple dictionaries to be combined in a single line
     """
 
-    def merge(self, *otherDictionaries):
+    def merge(self, *otherDictionaries) -> None:
         for dictionary in otherDictionaries:
             self.update(dictionary)
 
@@ -1179,7 +1179,7 @@ class MergeableDict(dict):
 shutil_copy = shutil.copy
 
 
-def safeCopy(src, dst):
+def safeCopy(src: str, dst: str) -> None:
     """This copy overwrites ``shutil.copy`` and checks that copy operation is truly completed before continuing."""
     waitTime = 0.01  # 10 ms
     if os.path.isdir(dst):

--- a/armi/utils/triangle.py
+++ b/armi/utils/triangle.py
@@ -19,7 +19,9 @@ Generic triangle math.
 import math
 
 
-def getTriangleArea(x1, y1, x2, y2, x3, y3):
+def getTriangleArea(
+    x1: float, y1: float, x2: float, y2: float, x3: float, y3: float
+) -> float:
     """
     Get the area of a triangle given the verticies of a triangle using Heron's formula.
 
@@ -90,7 +92,9 @@ def getTriangleCentroid(x1, y1, x2, y2, x3, y3):
     return x, y
 
 
-def checkIfPointIsInTriangle(x1, y1, x2, y2, x3, y3, x, y):
+def checkIfPointIsInTriangle(
+    x1: float, y1: float, x2: float, y2: float, x3: float, y3: float, x: float, y: float
+) -> bool:
     """
     Test if a point defined by x,y coordinates is within a triangle defined by verticies with x,y coordinates.
 


### PR DESCRIPTION
## Description

This PR adds type hinting to an arbitrary subset of our code base; basically low-hanging fruit.  This action was undertaken as part of this discussion: https://github.com/terrapower/armi/discussions/493

The process taken to generate these type hints was relatively easy.

1. Install `monkeytype`.
2. Execute `monkeytype run armi/path/to/test_whatever.py` to determine type hints for functions.
   * This can be done on multiple test files, and all the type hints will be collated.
3. Execute `monkeytype stub armi.path.to.whatever` to print-to-screen type hints.

This process is easy to do. However, it is not perfect:

* Most of our unit test files cannot be run as-is using `monkeytype`, because they do no explicitly declare an `App()`, so without `pytest` they just fail.
* Many of the type hints `monkeytype` output that are our custom classes are only pseudo-correct. For instance, in many places in our codebase a method might return any subclass of one of our custom classes, and `monkeytype` doesn't handle OOP that well. (Conversely, it might be that Python's type hinting is not well designed to handle this very common use case).
* Some of the unit tests we run don't fully flex a given function, so `'monkeytype` just doesn't have the info necessary to get the type hinting 100% right. I have found many partial errors.

It seems to me that `monkeytype` is a useful tool. So I am opening this PR just as an example of the benefits it can generate. But due to the issues I listed above, it was not an automatic enough process for me to just sweep the whole code base and commit everything.