### PR TITLE
Fixing the Setting copy to also copy non-default values.

### DIFF
--- a/armi/meta.py
+++ b/armi/meta.py
@@ -16,4 +16,4 @@
 Metadata describing an ARMI distribution.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -326,6 +326,7 @@ class Setting:
             isEnvironment=bool(self.isEnvironment),
             oldNames=None if self.oldNames is None else list(self.oldNames),
         )
+        setting.value = copy.deepcopy(self._value)
         return setting
 
 

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -303,6 +303,25 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         self.assertTrue(hasattr(s2, "schema"))
         self.assertTrue(hasattr(s2, "_customSchema"))
 
+    def test_copySettingNotDefault(self):
+        """Ensure that when we copy a Setting() object, the result is sound
+        when the Setting value is set to a non-default value.
+        """
+        # get a baseline: show how the Setting object looks to start
+        s1 = setting.Setting("testCopy", 765)
+        s1.value = 999
+        self.assertEquals(s1.name, "testCopy")
+        self.assertEquals(s1._value, 999)
+        self.assertTrue(hasattr(s1, "schema"))
+        self.assertTrue(hasattr(s1, "_customSchema"))
+
+        # show that copy(Setting) is working correctly
+        s2 = copy.copy(s1)
+        self.assertEquals(s2._value, 999)
+        self.assertEquals(s2.name, "testCopy")
+        self.assertTrue(hasattr(s2, "schema"))
+        self.assertTrue(hasattr(s2, "_customSchema"))
+
 
 class TestSettingsConversion(unittest.TestCase):
     """Make sure we can convert from old XML type settings to new Yaml settings."""

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -3,9 +3,22 @@ ARMI v0.2 Release Notes
 =======================
 
 
-ARMI v0.2.1
+ARMI v0.2.2
 ===========
 Release Date: TBD
+
+What's new in ARMI v0.2.2
+-------------------------
+#. TBD
+
+Bug fixes
+---------
+#. TBD
+
+
+ARMI v0.2.1
+===========
+Release Date: 2022-01-13
 
 What's new in ARMI v0.2.1
 -------------------------
@@ -15,6 +28,7 @@ Bug fixes
 ---------
 #. Fixed issue where grid GUI was not saving lattice maps (`#490 <https://github.com/terrapower/armi/issues/490>`_)
 #. Fixed issue where SettingsModifier was using old Settings API (`#500 <https://github.com/terrapower/armi/issues/500>`_)
+#. Fixed issue where copying a Setting only copied the default value (`PR#534 <https://github.com/terrapower/armi/pull/534>`_)
 
 
 ARMI v0.2.0


### PR DESCRIPTION
## Description

It appears that a past PR removed a single line of code from `setting.py`, this has lead to a invisibly broken system that works for nearly all unit tests.

I have added a unit test to explicitly check for this important feature in the future.

---

## Checklist

- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] Docstrings were included and updated as necessary
- [X] The code is understandable and maintainable to people beyond the author
- [X] There is no commented out code in this PR.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
- [X] New or updated dependencies have been added to `setup.py`.  

---

## Questions

I am trying to decide if this bug fix should come with a minor version bump (to `0.2.1`). 