### PR TITLE
Add allowMissing kwarg to loadOperator

### DIFF
--- a/armi/bookkeeping/db/__init__.py
+++ b/armi/bookkeeping/db/__init__.py
@@ -75,7 +75,7 @@ __all__ = [
 ]
 
 
-def loadOperator(pathToDb, loadCycle, loadNode):
+def loadOperator(pathToDb, loadCycle, loadNode, allowMissing=False):
     """
     Return an operator given the path to a database.
 
@@ -87,6 +87,9 @@ def loadOperator(pathToDb, loadCycle, loadNode):
         The cycle to load the reactor state from.
     loadNode : int
         The time node to load the reactor from.
+    allowMissing : bool
+        Whether to emit a warning, rather than crash if reading a database
+        with undefined parameters. Default False.
 
     See Also
     --------
@@ -132,7 +135,7 @@ def loadOperator(pathToDb, loadCycle, loadNode):
         cs = db.loadCS()
         thisCase = cases.Case(cs)
 
-        r = db.load(loadCycle, loadNode)
+        r = db.load(loadCycle, loadNode, allowMissing=allowMissing)
     settings.setMasterCs(cs)
 
     # Update the global assembly number because, if the user is loading a reactor from


### PR DESCRIPTION
## Description

Adds `kwarg` to `loadOperator` to support more easily loading databases that have parameters not defined within the current ARMI version.  This is helpful for backward compatibility when post-processing a database that had a param that was removed from ARMI .

---

## Checklist

- [ ] Tests have been added/updated to verify that the new or changed code works.
- [x] Docstrings were included and updated as necessary
- [x] The code is understandable and maintainable to people beyond the author
- [x] There is no commented out code in this PR.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.  
