### PR TITLE
Fix add option

### DIFF
--- a/armi/meta.py
+++ b/armi/meta.py
@@ -16,4 +16,4 @@
 Metadata describing an ARMI distribution.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -319,17 +319,13 @@ class Setting:
             copy.copy(self._default),
             description=None if self.description is None else str(self.description),
             label=None if self.label is None else str(self.label),
-            # options=copy.copy(self.options),
-            options=[],
-            # schema=copy.copy(self.schema) if hasattr(self, "schema") else None,
-            schema=None,
+            options=copy.copy(self.options),
+            schema=copy.copy(self.schema) if hasattr(self, "schema") else None,
             enforcedOptions=bool(self.enforcedOptions),
             subLabels=copy.copy(self.subLabels),
             isEnvironment=bool(self.isEnvironment),
             oldNames=None if self.oldNames is None else list(self.oldNames),
         )
-        setting.schema = copy.copy(self.schema) if hasattr(self, "schema") else None
-        setting.options = copy.copy(self.options)
         setting._value = copy.copy(self._value)
         return setting
 

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -326,7 +326,7 @@ class Setting:
             isEnvironment=bool(self.isEnvironment),
             oldNames=None if self.oldNames is None else list(self.oldNames),
         )
-        setting._value = copy.copy(self._value)
+        setting._value = copy.deepcopy(self._value)
         return setting
 
 

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -319,14 +319,18 @@ class Setting:
             copy.copy(self._default),
             description=None if self.description is None else str(self.description),
             label=None if self.label is None else str(self.label),
-            options=copy.copy(self.options),
-            schema=copy.copy(self.schema) if hasattr(self, "schema") else None,
+            # options=copy.copy(self.options),
+            options=[],
+            # schema=copy.copy(self.schema) if hasattr(self, "schema") else None,
+            schema=None,
             enforcedOptions=bool(self.enforcedOptions),
             subLabels=copy.copy(self.subLabels),
             isEnvironment=bool(self.isEnvironment),
             oldNames=None if self.oldNames is None else list(self.oldNames),
         )
-        setting.value = copy.deepcopy(self._value)
+        setting.schema = copy.copy(self.schema) if hasattr(self, "schema") else None
+        setting.options = copy.copy(self.options)
+        setting._value = copy.copy(self._value)
         return setting
 
 

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -25,10 +25,12 @@ import voluptuous as vol
 
 import armi
 from armi.physics.fuelCycle import FuelHandlerPlugin
+from armi.physics.neutronics import settings as neutronicsSettings
 from armi import settings
 from armi.settings import caseSettings
 from armi.settings import setting
 from armi.operators import settingsValidation
+from armi.tests import TEST_ROOT
 from armi import plugins
 from armi.utils import directoryChangers
 from armi.reactor.flags import Flags
@@ -64,6 +66,16 @@ class DummyPlugin2(plugins.ArmiPlugin):
         ]
 
 
+class PluginAddsOptions(plugins.ArmiPlugin):
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineSettings():
+        return [
+            setting.Option("MCNP", "neutronicsKernel"),
+            setting.Option("MCNP_Slab", "neutronicsKernel"),
+        ]
+
+
 class TestCaseSettings(unittest.TestCase):
     def setUp(self):
         self.cs = caseSettings.Settings()
@@ -84,6 +96,32 @@ class TestCaseSettings(unittest.TestCase):
         newEnv["moduleVerbosity"] = {}
         self.cs.updateEnvironmentSettingsFrom(newEnv)
         self.assertEqual(self.cs["verbosity"], "9")
+
+
+class TestAddingOptions(unittest.TestCase):
+    def setUp(self):
+        self.dc = directoryChangers.TemporaryDirectoryChanger()
+        self.dc.__enter__()
+
+    def tearDown(self):
+        self.dc.__exit__(None, None, None)
+
+    def test_addingOptions(self):
+        # load in the plugin with extra, added options
+        pm = armi.getPluginManagerOrFail()
+        pm.register(PluginAddsOptions)
+
+        # modify the default/text settings YAML file to include neutronicsKernel
+        fin = os.path.join(TEST_ROOT, "armiRun.yaml")
+        txt = open(fin, "r").read()
+        txt = txt.replace("\n  nodeGroup:", "\n  neutronicsKernel: MCNP\n  nodeGroup:")
+        fout = "test_addingOptions.yaml"
+        open(fout, "w").write(txt)
+
+        # this settings file should load fine, and test some basics
+        cs = settings.Settings(fout)
+        self.assertEqual(cs["burnSteps"], 2)
+        self.assertEqual(cs["neutronicsKernel"], "MCNP")
 
 
 class TestSettings2(unittest.TestCase):

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -444,4 +444,5 @@ class TestFlagListSetting(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    #armi.configure()import sys;sys.argv = ["", "TestAddingOptions.test_addingOptions"]
     unittest.main()

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -444,5 +444,5 @@ class TestFlagListSetting(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    #armi.configure()import sys;sys.argv = ["", "TestAddingOptions.test_addingOptions"]
+    # armi.configure()import sys;sys.argv = ["", "TestAddingOptions.test_addingOptions"]
     unittest.main()

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -444,5 +444,4 @@ class TestFlagListSetting(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # armi.configure()import sys;sys.argv = ["", "TestAddingOptions.test_addingOptions"]
     unittest.main()

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -3,17 +3,26 @@ ARMI v0.2 Release Notes
 =======================
 
 
-ARMI v0.2.2
+ARMI v0.2.3
 ===========
 Release Date: TBD
 
-What's new in ARMI v0.2.2
+What's new in ARMI v0.2.3
 -------------------------
 #. TBD
 
 Bug fixes
 ---------
 #. TBD
+
+
+ARMI v0.2.2
+===========
+Release Date: 2022-01-19
+
+Bug fixes
+---------
+#. Fixed issue where copying a Setting with a defined list of options would throw an error (`PR#540 <https://github.com/terrapower/armi/pull/540>`_)
 
 
 ARMI v0.2.1

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -20,6 +20,13 @@ ARMI v0.2.2
 ===========
 Release Date: 2022-01-19
 
+What's new in ARMI v0.2.2
+-------------------------
+#. Improved type hinting
+#. Flushed out the ability to build the docs as PDF
+#. Material modifications can now be made per-component
+#. The ``loadOperator`` method now has the optional ``allowMissing`` argument
+
 Bug fixes
 ---------
 #. Fixed issue where copying a Setting with a defined list of options would throw an error (`PR#540 <https://github.com/terrapower/armi/pull/540>`_)


### PR DESCRIPTION
## Description

As it turns out, the last fix for copying the value of a setting was problematic for a subset of settings that had a list of custom (non-default) options.  This amounts to something that would only happening when reading certain kinds of YAML files. And the fix is only one character. Never-the-less, I added a unit test to cover this YAML-reading, custom-options issue in the future.

---

## Checklist

- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] Docstrings were included and updated as necessary
- [X] The code is understandable and maintainable to people beyond the author
- [X] There is no commented out code in this PR.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
