### PR TITLE
Fix broken rendering of badges on GH.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,7 @@
 
-.. The LaTeX builder doesn't support SVGs, and these badges are SVGs
 
-.. only:: html
 
-  |Build Status| |Code Coverage|
+|Build Status| |Code Coverage|
 
 The Advanced Reactor Modeling Interface (ARMI\ :sup:`®`) is an open-source tool that
 streamlines your nuclear reactor design/analysis needs by providing a

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -122,6 +122,7 @@ extensions = [
     "nbsphinx_link",
     "sphinxext.opengraph",
     "sphinx_gallery.gen_gallery",
+    "sphinx.ext.imgconverter",  # to convert GH Actions badge SVGs to PNG for LaTeX
 ]
 
 # Our API should make sense without documenting private/special members.
@@ -420,3 +421,10 @@ warnings.filterwarnings(
 )
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+
+# these are defaults in Windows in more recent versions of the imgconverter plugin and
+# can be removed if/when we upgrade Sphinx beyond 2.2.
+# Otherwise, 'convert' from system32 folder is used.
+if "win32" in sys.platform:
+    image_converter = "magick"
+    image_converter_args = ["convert"]

--- a/doc/developer/documenting.rst
+++ b/doc/developer/documenting.rst
@@ -23,8 +23,16 @@ your ARMI virtual environment with::
 
     pip3 install -r requirements-testing.txt
 
-You also need to have `Graphviz <https://graphviz.org/>`_ and `Pandoc
-<https://pandoc.org/>`_ installed.
+You also need to have the following utilities available in your PATH:
+
+* `Graphviz <https://graphviz.org/>`_
+* `Pandoc <https://pandoc.org/>`_
+
+If you want to build the documentation into a PDF using the Sphinx LaTeX
+builder, you also need:
+
+* LaTeX (`MikTeX <https://miktex.org/>`_ on Windows)
+* `ImageMagick <https://imagemagick.org/>`_
 
 The documentation depends on at least one submodule as well, so you must be sure
 it is available in your source tree with::
@@ -32,7 +40,7 @@ it is available in your source tree with::
     git submodule update --init
 
 
-To build the ARMI documentation, go to the ``doc`` folder and run::
+To build the ARMI documentation as html, go to the ``doc`` folder and run::
 
     make html
 


### PR DESCRIPTION
In #539 we made some fixes to try to get LaTeX and HTML documentation
builds to both work. In doing so, the fix we made broke the badge
rendering on the main landing page of the repo on Github. Thus, this is
a different fix for that issue.

This uses a sphinx plugin to automatically convert the SVGs to pngs
before rendering and removes the .. only:: directive from the README.

<!--  
    Thanks in advance for you contribution!
-->
## Description
<!--  
    Please include a summary of the change and/or which issue is fixed.
-->


---

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] Tests have been added/updated to verify that the new or changed code works.
- [ ] Docstrings were included and updated as necessary
- [x] The code is understandable and maintainable to people beyond the author
- [x] There is no commented out code in this PR.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.  
