### PR TITLE
Added MOVABLE flag to allow for lower plenum to move with control rod…

### DIFF
--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -216,7 +216,7 @@ class Flags(Flag):
     FUEL = auto()
     TEST = auto()
     CONTROL = auto()
-    MOVABLE = auto() # Allows movement of lower plenum with control rod
+    MOVABLE = auto()  # Allows movement of lower plenum with control rod
     ULTIMATE = auto()
     SHUTDOWN = auto()
     SHIELD = auto()

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -278,7 +278,7 @@ class Flags(Flag):
     DEPLETABLE = auto()
 
     # Allows movement of lower plenum with control rod
-    MOVABLE = auto()
+    MOVEABLE = auto()
 
     @classmethod
     def fromStringIgnoreErrors(cls, typeSpec):

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -216,6 +216,7 @@ class Flags(Flag):
     FUEL = auto()
     TEST = auto()
     CONTROL = auto()
+    MOVABLE = auto() # Allows movement of lower plenum with control rod
     ULTIMATE = auto()
     SHUTDOWN = auto()
     SHIELD = auto()

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -216,7 +216,6 @@ class Flags(Flag):
     FUEL = auto()
     TEST = auto()
     CONTROL = auto()
-    MOVABLE = auto()  # Allows movement of lower plenum with control rod
     ULTIMATE = auto()
     SHUTDOWN = auto()
     SHIELD = auto()
@@ -277,6 +276,9 @@ class Flags(Flag):
 
     STRUCTURE = auto()
     DEPLETABLE = auto()
+
+    # Allows movement of lower plenum with control rod
+    MOVABLE = auto()
 
     @classmethod
     def fromStringIgnoreErrors(cls, typeSpec):


### PR DESCRIPTION
## Description

Added MOVABLE flag to allow for a lower plenum on a control rod to move along with control material defined. This is in conjunction with changes being made to the control rod handler.

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.