### PR TITLE
Fixing issue where UML diagrams weren't in docs

### DIFF
--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -13,7 +13,7 @@ What's new in ARMI v0.2.3
 
 Bug fixes
 ---------
-#. TBD
+#. Fixed issue where UML diagrams weren't being generated in docs (`#550 <https://github.com/terrapower/armi/issues/550>`_)
 
 
 ARMI v0.2.2

--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -28,3 +28,6 @@ ipykernel==6.7.0
 
 # helps us use RST files
 docutils<0.18
+
+# used to generate UML diagrams
+pylint==2.7.4


### PR DESCRIPTION
## Description

Due to a missed dependency, the UML diagrams in our docs weren't being generated the past ~several months.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
