### PR TITLE
Adding Graphviz to docs build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,6 +24,8 @@ jobs:
         run: sudo apt-get -y install pandoc
       - name: Install Tox and any other packages
         run: pip install tox
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v1
       - name: Make HTML Docs
         run: tox -e doc
       - name: deploy


### PR DESCRIPTION
## Description

It turns out we need Graphviz to build our docs. So I am adding it to the GitHub Actions as a dependency.