### PR TITLE
Using git submodule to display tutorial examples in docs

### DIFF
--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -8,7 +8,8 @@ Making your first ARMI-based App
 
 In this tutorial we will build a nuclear analysis application that runs (dummy) neutron
 flux and thermal/hydraulics calculations. Applications that do real analysis can be
-modeled after this starting point.
+modeled after this starting point. A complete, working version of this application can
+be found `here <https://github.com/terrapower/armi-example-app>`_.
 
 We'll assume you have the :doc:`ARMI Framework installed </user/user_install>` already.
 You can make sure it is ready by running the following command in a shell prompt::
@@ -47,6 +48,7 @@ files for us to fill in, like this::
             app.py
             plugin.py
             fluxSolver.py
+            materials.py
             thermalSolver.py
         doc/
         setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -17,11 +17,15 @@ commands =
     pytest --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
 
 [testenv:doc]
-whitelist_externals = /usr/bin/make
+whitelist_externals =
+    /usr/bin/git
+    /usr/bin/make
 deps=
     -r{toxinidir}/doc/requirements-docs.txt
 changedir = doc
 commands =
+    git submodule init
+    git submodule update
     make html
 
 [testenv:cov]


### PR DESCRIPTION
## Description

As it happens, the tutorials in our docs were supposed to be showing code snippets from the [example-armi-app](https://github.com/terrapower/armi-example-app), but the `git submodule` was not being called on GitHub when we were building and deploying our docs.

This PR remedies that, so people will see the easy example of how to add custom materials to their runs via plugins.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.