### PR TITLE
Removing unused ThermalHydraulics parameters

### DIFF
--- a/armi/physics/thermalHydraulics/parameters.py
+++ b/armi/physics/thermalHydraulics/parameters.py
@@ -77,13 +77,6 @@ def _getBlockParams():
         )
 
         pb.defParam(
-            "THdeltaPFric",
-            units="Pa",
-            saveToDB=False,
-            description="Friction component to the pressure drop.",
-        )
-
-        pb.defParam(
             "THdeltaPInlet",
             units="Pa",
             saveToDB=False,
@@ -312,13 +305,6 @@ def _getBlockParams():
         )
 
         pb.defParam(
-            "THassemPressDrop",
-            units="Pa",
-            description="The pressure drop across this block",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "THaveCoolantVel",
             units="m/s",
             description="Average of the inlet and outlet coolant velocities",
@@ -372,13 +358,6 @@ def _getBlockParams():
             "THcoolantStaticT",
             units=units.DEGC,
             description="Volume-based average coolant temperature, recommended for neutronics",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "THdPfrict",
-            units="Pa",
-            description="Frictional pressure drop",
             location=ParamLocation.AVERAGE,
         )
 

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -317,7 +317,7 @@ def defineSettings() -> List[setting.Setting]:
             default=[10, 20, 30, 100],
             label="Burnup Groups",
             description="The range of burnups where cross-sections will be the same "
-            "for a given assembly type",
+            "for a given assembly type (units of %FIMA).",
             schema=vol.Schema([vol.Any(int, float)]),
         ),
         setting.Setting(


### PR DESCRIPTION
## Description

This PR removes some Thermal Hydraulics parameters that appear to be entirely unused, and redundant besides.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.