### PR TITLE
Provide ArmiPlugin.defineSystemGrid builders

### DIFF
--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -120,12 +120,15 @@ the Plugin-based architecture, and as the need arise may be migrated to here.
    user settings. This also predated the plugin infrastructure, and may one day be
    replaced with plugin-based fuel handler logic.
 """
-from typing import Dict, Union
+from typing import Dict, Union, Callable, Optional, TYPE_CHECKING
 
 import pluggy
 
 from armi import pluginManager
 from armi.utils import flags
+
+if TYPE_CHECKING:
+    from armi.reactor.composites import Composite
 
 
 HOOKSPEC = pluggy.HookspecMarker("armi")
@@ -560,6 +563,37 @@ class ArmiPlugin:
 
         blueprint : Blueprint, optional
             for a reactor (if None, only partial contents created)
+        """
+
+    @staticmethod
+    @HOOKSPEC
+    def defineSystemGridBuilders() -> Dict[str, Callable[[str], "Composite"]]:
+        """
+        Convert a user-string from the systems section into a valid composite builder
+
+        Parameters
+        ----------
+        name : str
+            Name of the system type defined by the user, e.g., ``"core"``
+
+        Returns
+        -------
+        dict
+            Dictionary that maps a grid type from the input file (e.g., ``"core"``)
+            to a function responsible for building a grid of that type, e.g.,
+
+            .. code::
+
+                {
+                    "core": armi.reactor.reactors.Core,
+                    "sfp": armi.reactor.assemblyLists.SpentFuelPool,
+                }
+
+        Notes
+        -----
+        The default :class:`~armi.reactor.ReactorPlugin` defines a ``"core"`` lookup
+        and a ``"sfp"`` lookup, triggered to run after all other hooks have been run.
+
         """
 
 

--- a/armi/reactor/__init__.py
+++ b/armi/reactor/__init__.py
@@ -30,7 +30,14 @@ The key classes of the reactor package are shown below:
 See :doc:`/developer/index`.
 """
 
+from typing import Dict, Callable, Union, TYPE_CHECKING
+
 from armi import plugins
+
+# Provide type checking but avoid circular imports
+if TYPE_CHECKING:
+    from armi.reactor.reactors import Core
+    from armi.reactor.assemblyLists import SpentFuelPool
 
 
 class ReactorPlugin(plugins.ArmiPlugin):
@@ -66,3 +73,16 @@ class ReactorPlugin(plugins.ArmiPlugin):
             (CartesianBlock, CartesianAssembly),
             (ThRZBlock, ThRZAssembly),
         ]
+
+    @staticmethod
+    @plugins.HOOKIMPL(trylast=True)
+    def defineSystemGridBuilders() -> Dict[
+        str, Callable[[str], Union["Core", "SpentFuelPool"]]
+    ]:
+        from armi.reactor.reactors import Core
+        from armi.reactor.assemblyLists import SpentFuelPool
+
+        return {
+            "core": Core,
+            "sfp": SpentFuelPool,
+        }

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -188,7 +188,7 @@ class Block(composites.Composite):
 
         core = self.core
         if core is None:
-            return None
+            return self.getAncestor(lambda o: isinstance(o, Reactor))
 
         if not isinstance(core.parent, Reactor):
             raise TypeError(


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---
Provide ArmiPlugin.defineSystemGrid builders

Goal is to let a plugin define additional sections that
can reside in the ``systems`` section, e.g.,
```yaml
systems:
    core:
        grid name: core
        origin:
            x: 0
            y: 0
            z: 0
    sfp:
        grid name: spent fuel pool
        type: sfp
        ...
```

The end goal is to have a new system for control drums, pointing to a designated
grid, and allowing assemblies to be added to that grid rather than the core grid.

The plugins basically define a map from the system grid type (defaults to "core"
in the blueprint) and the builder function. The builder function will most likely
be the class of the thing to be built (e.g., ``"core"`` returns a ``Core`` **type**
and the blueprint construct method creates the instance given the name of the grid.
In the core example it's not super helpful. But for the spent fuel pool, the
``type`` is ``sfp`` but the name is defined by the key one level up and does not
have to match any specific criteria.

The `ReactorPlugin` defines the existing ``"core"`` and ``"sfp"`` builders, but is
tagged to go last (or near last) in the YAML construction sequence. This allows other
plugins to define their own core builders and let those have preference over the
default.

Signed-off-by: Andrew Johnson <a.johnson@usnc-tech.com>

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] The code is understandable and maintainable to people beyond the author.
- [ ] Tests have been added/updated to verify that the new or changed code works.
- [ ] There is no commented out code in this PR.
- [ ] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [ ] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
