### PR TITLE
Clarify assembly parameter definitions

### DIFF
--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -72,25 +72,33 @@ def getAssemblyParameterDefinitions():
         pb.defParam(
             "chargeBu",
             units="%FIMA",
-            description="Max block-average burnup in this assembly when it entered the core.",
+            description="Max block-average burnup in this assembly when it most recently"
+            " entered the core. If the assembly was discharged and then re-charged,"
+            " this value will only reflect the most recent charge.",
         )
 
         pb.defParam(
             "chargeCycle",
             units="",
-            description="Cycle number that this assembly entered the core.",
+            description="Cycle number that this assembly most recently entered the core."
+            " If the assembly was discharged and then re-charged, this value will only"
+            " reflect the most recent charge.",
         )
 
         pb.defParam(
             "chargeFis",
             units="kg",
-            description="Fissile mass in assembly when it entered the core.",
+            description="Fissile mass in assembly when it most recently entered the core."
+            " If the assembly was discharged and then re-charged, this value will only"
+            " reflect the most recent charge.",
         )
 
         pb.defParam(
             "chargeTime",
             units="years",
-            description="Time at which this assembly entered the core.",
+            description="Time at which this assembly most recently entered the core."
+            " If the assembly was discharged and then re-charged, this value will only"
+            " reflect the most recent charge.",
             default=parameters.NoDefault,
         )
 


### PR DESCRIPTION
## Description
The assembly parameters that relate to conditions at charge time have been clarified to indicate that they are conditions at the most recent charge, not necessarily when the assemblies first entered the core.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [ ] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
