### PR TITLE
Add settings table generator in dochelpers.

### DIFF
--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -262,7 +262,9 @@ def getAssemblyParameterDefinitions():
             units="cm",
             description="The initial starting position of the bottom of the control "
             "material when starting control operations as measured from the 0 point in the "
-            "reactor model",
+            "reactor model. Note that the starting height is taken to be a maximum withdrawn "
+            "location for the control rod for determining the position when the control rod "
+            "is fully withdrawn.",
         )
 
     with pDefs.createBuilder() as pb:

--- a/armi/tests/refSmallReactorBase.yaml
+++ b/armi/tests/refSmallReactorBase.yaml
@@ -73,7 +73,7 @@ blocks:
             ip: duct.op
             mult: 1.0
             op: 16.75
-    control: &block_control
+    moveable control: &block_control
         control:
             shape: Circle
             material: B4C
@@ -197,7 +197,7 @@ blocks:
             id: 0.0
             mult: shield.mult
             od: 0.10056
-    plenum: &block_plenum
+    moveable plenum: &block_plenum
         clad:
             shape: Circle
             material: HT9

--- a/armi/utils/dochelpers.py
+++ b/armi/utils/dochelpers.py
@@ -268,3 +268,40 @@ def generateParamTable(klass, fwParams, app=None):
         content.append(pluginContent + "\n")
 
     return "\n".join(content)
+
+
+def generatePluginSettingsTable(settings, pluginName):
+    """
+    Return a string containing one or more restructured text list tables containing
+    settings descriptions for a plugin.
+
+    Parameters
+    ----------
+    settings : list of Settings
+        This is a list of settings definitions, typically returned by a
+        ``defineSettings`` plugin hook.
+    """
+    headerContent = """
+    .. list-table:: Settings defined in the {}
+       :header-rows: 1
+       :widths: 20 10 50 20
+
+       * - Name
+         - Label
+         - Description
+         - Default Value
+    """.format(
+        pluginName
+    )
+
+    content = [f".. _{pluginName}-settings-table:"]
+    pluginContent = headerContent
+    for setting in settings:
+        default = None if setting.default == "" else setting.default
+        pluginContent += f"""   * - ``{setting.name}``
+         - {setting.label}
+         - {setting.description}
+         - {default}
+    """
+    content.append(pluginContent + "\n")
+    return "\n".join(content)

--- a/armi/utils/tests/test_dochelpers.py
+++ b/armi/utils/tests/test_dochelpers.py
@@ -17,11 +17,16 @@ import unittest
 
 from armi.reactor import reactors
 from armi.reactor import reactorParameters
-from armi.utils.dochelpers import create_figure, create_table, generateParamTable
+from armi.utils.dochelpers import (
+    create_figure,
+    create_table,
+    generateParamTable,
+    generatePluginSettingsTable,
+)
 
 
-class TestFlag(unittest.TestCase):
-    """Tests for the utility Flag class and cohorts."""
+class TestDocHelpers(unittest.TestCase):
+    """Tests for the utility dochelpers functionns."""
 
     def test_paramTable(self):
 
@@ -30,6 +35,17 @@ class TestFlag(unittest.TestCase):
             reactorParameters.defineCoreParameters(),
         )
         self.assertIn("keff", table)
+        self.assertNotIn("notAParameter", table)
+
+    def test_settingsTable(self):
+        from armi.settings.fwSettings import globalSettings
+
+        table = generatePluginSettingsTable(
+            globalSettings.defineSettings(),
+            "Framework",
+        )
+        self.assertIn("numProcessors", table)
+        self.assertNotIn("notASetting", table)
 
     def test_createFigure(self):
         rst = create_figure(


### PR DESCRIPTION
## Description

 - Add a documentation helper to auto-generate a settings table for software documentation.

- Add the MOVEABLE flag to the control and plenum blocks in the `refSmallReactorBase`.

- Update the description of the crStartingHeight assembly parameter.

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.
- [x] New or updated dependencies have been added to `setup.py`.
