### PR TITLE
Application permissive configure fix 

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -306,7 +306,7 @@ def configure(app: Optional[apps.App] = None, permissive=False):
     app = app or apps.App()
 
     if _app is not None:
-        if permissive and type(_app) is type(app):
+        if permissive and isinstance(app, apps.App):
             return
         else:
             raise RuntimeError(


### PR DESCRIPTION
## Description

Fix to a bug where an ARMI application could not call `armi.configure(app, permissive=True)`. This error is due to fact that the type check for the application that is passed in would never be equal to the type of the base ARMI app class. This now checks if the application passed in is instead an instance of the ARMI app.
