### PR TITLE
Adding options to Settings Report

### DIFF
--- a/doc/user/inputs/settings_report.rst
+++ b/doc/user/inputs/settings_report.rst
@@ -15,13 +15,15 @@ through the :py:class:`armi.settings.caseSettings.Settings` object, which is typ
     cs = settings.Settings()
     # User textwrap to split up long words that mess up the table.
     wrapper = textwrap.TextWrapper(width=25, subsequent_indent='')
-    content = '\n.. list-table:: ARMI Settings\n   :header-rows: 1\n   :widths: 30 40 30\n    \n'
-    content += '   * - Name\n     - Description\n     - Default\n'
+    wrapper2 = textwrap.TextWrapper(width=10, subsequent_indent='')
+    content = '\n.. list-table:: ARMI Settings\n   :header-rows: 1\n   :widths: 30 30 10 10\n    \n'
+    content += '   * - Name\n     - Description\n     - Default\n     - Options\n'
 
     for setting in sorted(cs.values(), key=lambda s: s.name):
         content += '   * - {}\n'.format(' '.join(wrapper.wrap(setting.name)))
         content += '     - {}\n'.format(' '.join(wrapper.wrap(setting.description or '')))
-        content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper.wrap(str(getattr(setting,'default','') or ''))]))
+        content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper2.wrap(str(getattr(setting,'default','') or '').split("/")[-1])]))
+        content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper.wrap(str(getattr(setting,'options','') or ''))]))
 
     content += '\n'
 


### PR DESCRIPTION
## Description

To make the Settings Report in the documentation a little more useful, we add a column for the Settings Options (if any exist).

This is in response to this Issue: https://github.com/terrapower/armi/issues/596