### PR TITLE
remove extraneous `mpicov` arg from tox.ini envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,lint,cov,mpicov
+envlist = py38,lint,cov
 # need pip at least with --prefer-binary
 requires =
 	pip >= 20.2


### PR DESCRIPTION
## Description

This PR addresses #603 by removing the extraneous `mpicov` argument from the `envlist` definition in `tox.ini`.

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.