### PR TITLE
Adding MPI tests to code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,11 @@ omit =
     armi/cli/gridGui.py
     armi/utils/gridEditor.py
     armi/utils/tests/test_gridGui.py
+    venv/
+source = armi
+
+[coverage:run]
+parallel = true
 
 [report]
 omit =

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,10 +22,10 @@ jobs:
         run: sudo apt-get -y install libopenmpi-dev
       - name: Install Tox and any other packages
         run: pip install tox
-      - name: Run Tox 1
+      - name: Run Coverage Part 1
         if: always()
         run: tox -e cov1 || true
-      - name: Run Tox 2
+      - name: Run Coverage Part 2
         if: always()
         run: tox -e cov2,report
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -23,5 +23,6 @@ jobs:
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox
+        if: always()
         run: tox -e cov,report
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,5 +27,5 @@ jobs:
         run: tox -e cov1 || true
       - name: Run Tox 2
         if: always()
-        name: tox -e cov2,report
+        run: tox -e cov2,report
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -24,5 +24,5 @@ jobs:
         run: pip install tox
       - name: Run Tox
         if: always()
-        run: tox -e cov,report
+        run: tox -e cov,report || true
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,7 +22,10 @@ jobs:
         run: sudo apt-get -y install libopenmpi-dev
       - name: Install Tox and any other packages
         run: pip install tox
-      - name: Run Tox
+      - name: Run Tox 1
         if: always()
-        run: tox -e cov,report || true
+        run: tox -e cov1 || true
+      - name: Run Tox 2
+        if: always()
+        name: tox -e cov2,report
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands =
     git submodule update
     make html
 
+# First, run code coverage over the unit tests that run MPI library code.
 [testenv:cov1]
 deps=
     pip>=20.2
@@ -39,6 +40,7 @@ whitelist_externals =
 commands =
     mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
 
+# Second, run code coverage over the rest of the unit tests, and combine the coverage results together
 [testenv:cov2]
 deps=
     pip>=20.2

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ whitelist_externals =
     /usr/bin/rm
 commands =
     rm -f .coverage .coverage.*
-    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
+    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py || true
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ whitelist_externals =
     /usr/bin/mpiexec
 commands =
     mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py armi/tests/test_mpiFeatures.py
-    rm .coverage.*
+    rm -f .coverage.*
     pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-append --cov-fail-under=80 armi
 
 # NOTE: This only runs the MPI unit tests.

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps=
 whitelist_externals =
     /usr/bin/mpiexec
 commands =
-    mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py armi/tests/test_mpiFeatures.py || true
+    mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py armi/tests/test_mpiFeatures.py
     rm .coverage.*
     pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-append --cov-fail-under=80 armi
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,22 +28,6 @@ commands =
     git submodule update
     make html
 
-[testenv:cov]
-deps=
-    pip>=20.2
-    mpi4py
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/requirements-testing.txt
-whitelist_externals =
-    /usr/bin/find
-    /usr/bin/mpiexec
-    /usr/bin/rm
-commands =
-    rm -f .coverage .coverage.*
-    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
-    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
-    coverage combine --rcfile=.coveragerc --keep -a
-
 [testenv:cov1]
 deps=
     pip>=20.2
@@ -51,11 +35,8 @@ deps=
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-testing.txt
 whitelist_externals =
-    /usr/bin/find
     /usr/bin/mpiexec
-    /usr/bin/rm
 commands =
-    rm -f .coverage .coverage.*
     mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
 
 [testenv:cov2]
@@ -65,9 +46,7 @@ deps=
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-testing.txt
 whitelist_externals =
-    /usr/bin/find
     /usr/bin/mpiexec
-    /usr/bin/rm
 commands =
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ whitelist_externals =
     /usr/bin/mpiexec
 commands =
     mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py armi/tests/test_mpiFeatures.py
-    rm -f .coverage.*
     pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-append --cov-fail-under=80 armi
 
 # NOTE: This only runs the MPI unit tests.

--- a/tox.ini
+++ b/tox.ini
@@ -37,9 +37,9 @@ deps=
 whitelist_externals =
     /usr/bin/mpiexec
 commands =
-    mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-append armi/tests/test_mpiFeatures.py
+    mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py armi/tests/test_mpiFeatures.py
     rm .coverage.*
-    pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-fail-under=80 armi
+    pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-append --cov-fail-under=80 armi
 
 # NOTE: This only runs the MPI unit tests.
 # NOTE: This will only work in POSIX/BASH Linux.

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ whitelist_externals =
     /usr/bin/rm
 commands =
     rm -f .coverage .coverage.*
-    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py > /dev/null
+    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py | /dev/null
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,10 +35,16 @@ deps=
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-testing.txt
 whitelist_externals =
+    /usr/bin/find
     /usr/bin/mpiexec
+    /usr/bin/rm
 commands =
-    mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py armi/tests/test_mpiFeatures.py
-    pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-append --cov-fail-under=80 armi
+    rm -f .coverage .coverage.*
+    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
+    find .coverage.* -size 0 -type f -exec rm {} +
+    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
+    find .coverage.* -size 0 -type f -exec rm {} +
+    coverage combine --rcfile=.coveragerc --keep -a
 
 # NOTE: This only runs the MPI unit tests.
 # NOTE: This will only work in POSIX/BASH Linux.

--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,9 @@ whitelist_externals =
 commands =
     rm -f .coverage .coverage.*
     mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
-    find .coverage.* -size 0 -type f -exec rm {} +
+#    find .coverage.* -size 0 -type f -exec rm {} +
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
-    find .coverage.* -size 0 -type f -exec rm {} +
+#    find .coverage.* -size 0 -type f -exec rm {} +
     coverage combine --rcfile=.coveragerc --keep -a
 
 # NOTE: This only runs the MPI unit tests.

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,35 @@ whitelist_externals =
     /usr/bin/rm
 commands =
     rm -f .coverage .coverage.*
-    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py | /dev/null
+    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
+    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
+    coverage combine --rcfile=.coveragerc --keep -a
+
+[testenv:cov1]
+deps=
+    pip>=20.2
+    mpi4py
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-testing.txt
+whitelist_externals =
+    /usr/bin/find
+    /usr/bin/mpiexec
+    /usr/bin/rm
+commands =
+    rm -f .coverage .coverage.*
+    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
+
+[testenv:cov2]
+deps=
+    pip>=20.2
+    mpi4py
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-testing.txt
+whitelist_externals =
+    /usr/bin/find
+    /usr/bin/mpiexec
+    /usr/bin/rm
+commands =
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps=
 whitelist_externals =
     /usr/bin/mpiexec
 commands =
-    mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py armi/tests/test_mpiFeatures.py
+    mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py armi/tests/test_mpiFeatures.py || true
     rm .coverage.*
     pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-append --cov-fail-under=80 armi
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
     PYTHONPATH = {toxinidir}
     USERNAME = armi
 commands =
-    pytest --ignore=armi/utils/tests/test_gridGui.py {posargs} armi
+    pytest --ignore=armi/utils/tests/test_gridGui.py armi
 
 [testenv:doc]
 whitelist_externals =
@@ -31,10 +31,15 @@ commands =
 [testenv:cov]
 deps=
     pip>=20.2
+    mpi4py
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-testing.txt
+whitelist_externals =
+    /usr/bin/mpiexec
 commands =
-    pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-fail-under=80 {posargs} armi
+    mpiexec -n 2 --use-hwthread-cpus pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-append armi/tests/test_mpiFeatures.py
+    rm .coverage.*
+    pytest --cov-config=.coveragerc --cov=armi --ignore=armi/utils/tests/test_gridGui.py --cov-fail-under=80 armi
 
 # NOTE: This only runs the MPI unit tests.
 # NOTE: This will only work in POSIX/BASH Linux.

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ whitelist_externals =
     /usr/bin/rm
 commands =
     rm -f .coverage .coverage.*
-    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py || true
+    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py > /dev/null
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,7 @@ whitelist_externals =
 commands =
     rm -f .coverage .coverage.*
     mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
-#    find .coverage.* -size 0 -type f -exec rm {} +
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
-#    find .coverage.* -size 0 -type f -exec rm {} +
     coverage combine --rcfile=.coveragerc --keep -a
 
 # NOTE: This only runs the MPI unit tests.


### PR DESCRIPTION
## Description

This PR adds the MPI tests into the code coverage.  I'll be honest, I thought this would net us like 5% code coverage, but it was more like 0.5%.  BUT it's done now, so fine.

This is only a change to the build system, not to the code.