### PR TITLE
Update DoseResultsMapper.apply() to accept blockList

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -632,7 +632,17 @@ class DoseResultsMapper(GlobalFluxResultMapper):
     """
     Updates fluence and dpa when time shifts.
 
-    Often called after a depletion step.
+    Often called after a depletion step. It is invoked using :py:meth:`apply() <.DoseResultsMapper.apply>`.
+
+    Parameters
+    ----------
+    depletionSeconds: float, required
+        Length of depletion step in units of seconds
+
+    options: GlobalFluxOptions, required
+        Object describing options used by the global flux solver. A few attributes from
+        this object are used to run the methods in DoseResultsMapper. An example
+        attribute is aclpDoseLimit.
 
     Notes
     -----
@@ -647,14 +657,31 @@ class DoseResultsMapper(GlobalFluxResultMapper):
         self.r = None
         self.depletionSeconds = depletionSeconds
 
-    def apply(self, reactor):
+    def apply(self, reactor, blockList=None):
+        """
+        Invokes :py:meth:`updateFluenceAndDpa() <.DoseResultsMapper.updateFluenceAndDpa>`
+        for a provided Reactor object.
+
+        Parameters
+        ----------
+        reactor: Reactor, required
+            ARMI Reactor object
+
+        blockList: list, optional
+            List of ARMI blocks to be processed by the class. If no blocks are provided, then
+            blocks returned by :py:meth:`getBlocks() <.reactors.Core.getBlocks>` are used.
+
+        Returns
+        -------
+        None
+        """
         runLog.extra("Updating fluence and dpa on reactor based on depletion step.")
         self.r = reactor
-        self.updateFluenceAndDpa(self.depletionSeconds)
+        self.updateFluenceAndDpa(self.depletionSeconds, blockList=blockList)
 
     def updateFluenceAndDpa(self, stepTimeInSeconds, blockList=None):
         r"""
-        updates the fast fluence and the DPA of the blocklist
+        Updates the fast fluence and the DPA of the blocklist
 
         The dpa rate from the previous timestep is used to compute the dpa here.
 
@@ -663,7 +690,8 @@ class DoseResultsMapper(GlobalFluxResultMapper):
             * detailedDpaPeak: The peak dpa of a block, considering axial and radial peaking
                 The peaking is based either on a user-provided peaking factor (computed in a
                 pin reconstructed rotation study) or the nodal flux peaking factors
-            * dpaPeakFromFluence: fast fluence * fluence conversion factor (old and inaccurate). Used to be dpaPeak
+            * dpaPeakFromFluence: fast fluence * fluence conversion factor (old and inaccurate).
+                Used to be dpaPeak
 
         Parameters
         ----------

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -172,11 +172,14 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         mapper.updateDpaRate()
         block = r.core.getFirstBlock()
         self.assertGreater(block.p.detailedDpaRate, 0)
-
         self.assertEqual(block.p.detailedDpa, 0)
+
+        # Test DoseResultsMapper. Pass in full list of blocks to apply() in order
+        # to exercise blockList option (does not change behavior, since this is what
+        # apply() does anyway)
         opts = globalFluxInterface.GlobalFluxOptions("test")
         dosemapper = globalFluxInterface.DoseResultsMapper(1000, opts)
-        dosemapper.apply(r)
+        dosemapper.apply(r, blockList=r.core.getBlocks())
         self.assertGreater(block.p.detailedDpa, 0)
 
         mapper.clearFlux()


### PR DESCRIPTION
`apply()` is a convenience method that makes a call to `updateFluenceAndDpa()` in the class `DoseResultsMapper`.
However, it does not allow for passing in a `blockList` parameter, which is a parameter that `updateFluenceAndDpa()` accepts. This PR updates `apply()` to accept a `blockList` parameter that is then passed to `updateFluenceAndDpa()`.

This is a trivial change, but it's my first pull request ever, so I am partly doing this to get some exercise on the process. The motivation for the PR is for the use of this method in the flux reconstruction plugin. The only other plugin that makes use of `apply()` is depletion, and I have confirmed that this change does not alter the behavior of that plugin.

Please be gentle.