### PR TITLE
Fix docstring for doxygen formatting

### DIFF
--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -37,6 +37,12 @@ class DirectoryChanger:
     """
     Utility to change directory.
 
+    Use with 'with' statements to execute code in a different dir, guaranteeing a clean
+    return to the original directory
+
+    >>> with DirectoryChanger('C:\\whatever')
+    ...     pass
+
     Parameters
     ----------
     destination : str
@@ -48,13 +54,6 @@ class DirectoryChanger:
     dumpOnException : bool, optional
         Flag to tell system to retrieve the entire directory if an exception
         is raised within a the context manager.
-
-    Use with 'with' statements to execute code in a different dir, guaranteeing a clean
-    return to the original directory
-
-    >>> with DirectoryChanger('C:\\whatever')
-    ...     pass
-
     """
 
     def __init__(


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

Another case where the ordering of comments in a docstring was leading to messed up formatting in the rendered docs:

![image](https://user-images.githubusercontent.com/21959600/165319328-ee2c9cae-2a4b-4d0e-ab04-9552ed8a566e.png)

---

## Checklist

- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.