### PR TITLE
Update `loadTestReactor` docstring

### DIFF
--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -144,7 +144,7 @@ def loadTestReactor(
         for that key.
 
     inputFileName : str, default="armiRun.yaml"
-        Name of the input file to run.        
+        Name of the input file to run.
 
     Returns
     -------

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -136,12 +136,15 @@ def loadTestReactor(
     Parameters
     ----------
     inputFilePath : str
-        Path to the directory of the armiRun.yaml input file.
+        Path to the directory of the input file.
 
     customSettings : dict with str keys and values of any type
         For each key in customSettings, the cs which is loaded from the
         armiRun.yaml will be overwritten to the value given in customSettings
         for that key.
+
+    inputFileName : str, default="armiRun.yaml"
+        Name of the input file to run.        
 
     Returns
     -------


### PR DESCRIPTION
## Description

One of the parameters was missing and the description of the `inputFilePath` parameter was a little confusing since it assumed a file name.

---

## Checklist

- [X] All docstrings are still up-to-date with these changes.
