### PR TITLE
Make description of `cycleLength` parameter consistent with `availabilityFactor`

### DIFF
--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -49,8 +49,8 @@ def defineReactorParameters():
 
         pb.defParam(
             "cycleLength",
-            units="EFP days",
-            description="The cycle length of the reactor while power is being produced",
+            units="days",
+            description="Length of the cycle, including outage time described by availabilityFactor",
         )
 
         pb.defParam(


### PR DESCRIPTION

## Description

The description provided for the `cycleLength` parameter indicates that it should include only effective full power days. This is incorrect. In order for `cycleLength` to be consistent with the `availabilityFactor` parameter, it also includes the outage days that are represented by the `availabilityFactor`.

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] The code is understandable and maintainable to people beyond the author.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
