### PR TITLE
Uniform mesh deepcopy fix

### DIFF
--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -96,7 +96,7 @@ class SystemBlueprint(yamlize.Object):
 
     def construct(self, cs, bp, reactor, geom=None, loadAssems=True):
         """Build a core/IVS/EVST/whatever and fill it with children.
-        
+
         Parameters
         ----------
         cs : :py:class:`Settings <armi.settings.Settings>` object.
@@ -107,7 +107,7 @@ class SystemBlueprint(yamlize.Object):
             reactor to fill
         geom : optional
         loadAssems : bool, optional
-            whether to fill reactor with assemblies, as defined in blueprints, or not. Is False in 
+            whether to fill reactor with assemblies, as defined in blueprints, or not. Is False in
             :py:class:`UniformMeshGeometryConverter <armi.reactor.converters.uniformMesh.UniformMeshGeometryConverter>`
             within the initNewReactor() class method.
 

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -94,8 +94,30 @@ class SystemBlueprint(yamlize.Object):
 
         return cls
 
-    def construct(self, cs, bp, reactor, geom=None):
-        """Build a core/IVS/EVST/whatever and fill it with children."""
+    def construct(self, cs, bp, reactor, geom=None, loadAssems=True):
+        """Build a core/IVS/EVST/whatever and fill it with children.
+        
+        Parameters
+        ----------
+        cs : :py:class:`Settings <armi.settings.Settings>` object.
+            armi settings to apply
+        bp : :py:class:`Reactor <armi.reactor.blueprints.Blueprints>` object.
+            armi blueprints to apply
+        reactor : :py:class:`Reactor <armi.reactor.reactors.Reactor>` object.
+            reactor to fill
+        geom : optional
+        loadAssems : bool, optional
+            whether to fill reactor with assemblies, as defined in blueprints, or not. Is False in 
+            :py:class:`UniformMeshGeometryConverter <armi.reactor.converters.uniformMesh.UniformMeshGeometryConverter>`
+            within the initNewReactor() class method.
+
+        Raises
+        ------
+        ValueError
+            input error, no grid design provided
+        ValueError
+            for 1/3 core maps, assemblies are defined outside the expected 1/3 core region
+        """
         from armi.reactor import reactors  # avoid circular import
 
         runLog.info("Constructing the `{}`".format(self.name))
@@ -139,20 +161,21 @@ class SystemBlueprint(yamlize.Object):
         # TODO: This is also pretty specific to Core-like things. We envision systems
         # with non-Core-like structure. Again, probably only doable with subclassing of
         # Blueprints
-        self._loadAssemblies(cs, system, gridDesign, gridDesign.gridContents, bp)
+        if loadAssems:
+            self._loadAssemblies(cs, system, gridDesign, gridDesign.gridContents, bp)
 
-        # TODO: This post-construction work is specific to Cores for now. We need to
-        # generalize this. Things to consider:
-        # - Should the Core be able to do geom modifications itself, since it already
-        # has the grid constructed from the grid design?
-        # - Should the summary be so specifically Material data? Should this be done for
-        # non-Cores? Like geom modifications, could this just be done in processLoading?
-        # Should it be invoked higher up, by whatever code is requesting the Reactor be
-        # built from Blueprints?
-        if isinstance(system, reactors.Core):
-            summarizeMaterialData(system)
-            self._modifyGeometry(system, gridDesign)
-            system.processLoading(cs)
+            # TODO: This post-construction work is specific to Cores for now. We need to
+            # generalize this. Things to consider:
+            # - Should the Core be able to do geom modifications itself, since it already
+            # has the grid constructed from the grid design?
+            # - Should the summary be so specifically Material data? Should this be done for
+            # non-Cores? Like geom modifications, could this just be done in processLoading?
+            # Should it be invoked higher up, by whatever code is requesting the Reactor be
+            # built from Blueprints?
+            if isinstance(system, reactors.Core):
+                summarizeMaterialData(system)
+                self._modifyGeometry(system, gridDesign)
+                system.processLoading(cs)
         return system
 
     # pylint: disable=no-self-use

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -63,10 +63,7 @@ class TestUniformMeshComponents(unittest.TestCase):
         self.assertNotEqual(refMesh[4], avgMesh[4], "Not equal above the fuel.")
 
     def test_blueprintCopy(self):
-        """ensure that necessary blueprint attributes are set
-
-        see https://github.com/terrapower/armi/pull/645#discussion_r861210649
-        """
+        """Ensure that necessary blueprint attributes are set"""
         convReactor = self.converter.initNewReactor(self.converter._sourceReactor)
         converted = convReactor.blueprints
         original = self.converter._sourceReactor.blueprints
@@ -79,6 +76,8 @@ class TestUniformMeshComponents(unittest.TestCase):
         for attr in toCompare:
             for c, o in zip(getattr(converted, attr), getattr(original, attr)):
                 self.assertEqual(c, o)
+        # ensure that the assemblies were copied over
+        self.assertTrue(converted.assemblies, msg="Assembly objects not copied!")
 
 
 def applyNonUniformHeightDistribution(reactor):

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -62,6 +62,24 @@ class TestUniformMeshComponents(unittest.TestCase):
         self.assertEqual(refMesh[0], avgMesh[0])
         self.assertNotEqual(refMesh[4], avgMesh[4], "Not equal above the fuel.")
 
+    def test_blueprintCopy(self):
+        """ensure that necessary blueprint attributes are set
+
+        see https://github.com/terrapower/armi/pull/645#discussion_r861210649
+        """
+        convReactor = self.converter.initNewReactor(self.converter._sourceReactor)
+        converted = convReactor.blueprints
+        original = self.converter._sourceReactor.blueprints
+        toCompare = [
+            "activeNuclides",
+            "allNuclidesInProblem",
+            "elementsToExpand",
+            "inertNuclides",
+        ]  # note, items within toCompare must be list or "list-like", like an ordered set
+        for attr in toCompare:
+            for c, o in zip(getattr(converted, attr), getattr(original, attr)):
+                self.assertEqual(c, o)
+
 
 def applyNonUniformHeightDistribution(reactor):
     """Modifies some assemblies to have non-uniform axial meshes"""

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -114,13 +114,11 @@ class UniformMeshGeometryConverter(GeometryConverter):
         # attributes are set when assemblies are added in coreDesign.construct(), however
         # since we skip that here, they never get set; therefore the need for the deepcopy.
         bp = copy.deepcopy(sourceReactor.blueprints)
-        # create new reactor from blueprints used to create sourceReactor
         newReactor = Reactor(sourceReactor.o.cs.caseTitle, bp)
-        # create core based on loaded blueprints and do not load the assemblies
         coreDesign = bp.systemDesigns["core"]
         coreDesign.construct(sourceReactor.o.cs, bp, newReactor, loadAssems=False)
-        # initialize the interfaces and set some values
         newReactor.core.lib = sourceReactor.core.lib
+        newReactor.core.setPitchUniform(sourceReactor.core.getAssemblyPitch())
         return newReactor
 
     def _computeAverageAxialMesh(self):

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -254,10 +254,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
         )
         for sourceAssem in self._sourceReactor.core:
             newAssem = self.makeAssemWithUniformMesh(sourceAssem, self._uniformMesh)
-            newAssem.r = self.convReactor
-            # would be nicer if this happened in add but there's  complication between
-            # moveTo and add precedence and location-already-filled-issues.
-            newAssem.parent = self.convReactor.core
             src = sourceAssem.spatialLocator
             newLoc = self.convReactor.core.spatialGrid[src.i, src.j, 0]
             self.convReactor.core.add(newAssem, newLoc)


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description
- Addressing "deepcopy is extremely wasteful" statement in uniformMesh.py:::UniformMeshGeometryConverter::initNewReactor
- Now creates a new, empty, reactor with same settings as sourceReactor.
- A timing test (via timeit with 10 executions) shows that this new approach is about 10x faster than the deepcopy approach.
- also updating docstrings for methods changed to be more verbose.

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
