### PR TITLE
Fixing bug in addDummyNuclidesToLibrary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -434,6 +434,6 @@ only use third-party Python libraries that have MIT or BSD licenses.
 .. |Build Status| image:: https://github.com/terrapower/armi/actions/workflows/unittests.yaml/badge.svg?branch=master
     :target: https://github.com/terrapower/armi/actions/workflows/unittests.yaml
 
-.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=master&kill_cache=3
+.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=master&kill_cache=0
     :target: https://coveralls.io/github/terrapower/armi?branch=master
 

--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -87,8 +87,9 @@ def addDummyNuclidesToLibrary(lib, dummyNuclides):
 
     dummyNuclideKeysAddedToLibrary = []
     for dummyNuclide in dummyNuclides:
-        # dummyKey = dummyNuclide.nucLabel + lib.xsIDs[0]
-        dummyKey = dummyNuclide.nucLabel  # + lib.xsIDs[0]
+        dummyKey = dummyNuclide.nucLabel
+        if len(lib.xsIDs):
+            dummyKey += xsIDs[0]
         if dummyKey in lib:
             continue
 

--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -77,27 +77,33 @@ def addDummyNuclidesToLibrary(lib, dummyNuclides):
     if not dummyNuclides:
         runLog.important("No dummy nuclide data provided to be added to {}".format(lib))
         return False
-    if len(lib.xsIDs) > 1:
+    elif len(lib.xsIDs) > 1:
         runLog.warning(
             "Cannot add dummy nuclide data to GAMISO library {} containing data for more than 1 XS ID.".format(
                 lib
             )
         )
         return False
+
     dummyNuclideKeysAddedToLibrary = []
     for dummyNuclide in dummyNuclides:
-        dummyKey = dummyNuclide.nucLabel + lib.xsIDs[0]
+        # dummyKey = dummyNuclide.nucLabel + lib.xsIDs[0]
+        dummyKey = dummyNuclide.nucLabel  # + lib.xsIDs[0]
         if dummyKey in lib:
             continue
+
         runLog.debug("Adding {} nuclide data to {}".format(dummyKey, lib))
         newDummy = xsNuclides.XSNuclide(lib, dummyKey)
+
         # Copy gamiso metadata from the isotxs metadata of the given dummy nuclide
         for kk, vv in dummyNuclide.isotxsMetadata.items():
-            if vv in ["jj", "jband"]:
-                newDummy.gamisoMetadata[vv] = {}
-                for mm in dummyNuclide.isotxsMetadata[vv]:
-                    newDummy.gamisoMetadata[vv][mm] = 1
-            newDummy.gamisoMetadata[kk] = dummyNuclide.isotxsMetadata[kk]
+            if kk in ["jj", "jband"]:
+                newDummy.gamisoMetadata[kk] = {}
+                for mm in vv:
+                    newDummy.gamisoMetadata[kk][mm] = 1
+            else:
+                newDummy.gamisoMetadata[kk] = vv
+
         lib[dummyKey] = newDummy
         dummyNuclideKeysAddedToLibrary.append(dummyKey)
 

--- a/armi/nuclearDataIO/cccc/tests/test_gamiso.py
+++ b/armi/nuclearDataIO/cccc/tests/test_gamiso.py
@@ -1,0 +1,49 @@
+# Copyright 2022 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test GAMISO reading and writing"""
+
+from copy import deepcopy
+import os
+import unittest
+
+from armi.nuclearDataIO import xsLibraries
+from armi.nuclearDataIO.cccc import gamiso
+from armi.nuclearDataIO.xsNuclides import XSNuclide
+
+THIS_DIR = os.path.dirname(__file__)
+FIXTURE_DIR = os.path.join(THIS_DIR, "..", "..", "tests", "fixtures")
+GAMISO_AA = os.path.join(FIXTURE_DIR, "mc2v3-AA.gamiso")
+
+
+class TestGamiso(unittest.TestCase):
+    def setUp(self):
+        self.xsLib = xsLibraries.IsotxsLibrary()
+
+    def test_compare(self):
+        gamisoAA = gamiso.readBinary(GAMISO_AA)
+        self.xsLib.merge(deepcopy(gamisoAA))
+        self.assertTrue(gamiso.compare(self.xsLib, gamisoAA))
+
+    def test_addDummyNuclidesToLibrary(self):
+        dummyNuclides = [XSNuclide(None, "U238AA")]
+        before = self.xsLib.getNuclides("")
+        self.assertTrue(gamiso.addDummyNuclidesToLibrary(self.xsLib, dummyNuclides))
+
+        after = self.xsLib.getNuclides("")
+        self.assertGreater(len(after), len(before))
+
+        diff = set(after).difference(set(before))
+        self.assertEqual(len(diff), 1)
+        self.assertEqual(list(diff)[0].xsId, "38")

--- a/armi/nuclearDataIO/xsNuclides.py
+++ b/armi/nuclearDataIO/xsNuclides.py
@@ -247,7 +247,7 @@ def plotScatterMatrix(scatterMatrix, scatterTypeLabel="", fName=None):
         pyplot.show()
 
 
-def compareScatterMatrix(scatterMatrix1, scatterMatrix2, fName=None):
+def plotCompareScatterMatrix(scatterMatrix1, scatterMatrix2, fName=None):
     """Compares scatter matrices graphically between libraries."""
     from matplotlib import pyplot
 

--- a/armi/utils/codeTiming.py
+++ b/armi/utils/codeTiming.py
@@ -290,7 +290,7 @@ class MasterTimer:
         _loc, labels = plt.yticks()
         for tick in labels:
             tick.set_fontsize(40)
-        # plt.grid(True, axis='x')
+
         plt.tight_layout()
 
         # plot content draw

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -233,7 +233,6 @@ class Sequence:
 
                 newseq = seq.select(...).drop(...).transform(...)
         """
-        # self._iter = (i for i in self if pred(i))
         self._iter = filter(pred, self._iter)
         return self
 
@@ -244,7 +243,6 @@ class Sequence:
 
                 newseq = seq.select(...).drop(...).transform(...)
         """
-        # self._iter = (i for i in self if not pred(i))
         self._iter = filterfalse(pred, self._iter)
         return self
 


### PR DESCRIPTION
## Description

Fixing the long-standing bug recently reported by @Nebbychadnezzar in #630 

The method `addDummyNuclidesToLibrary()` certainly had a bug or two in it. Which this PR fixes. This PR also includes the first unit test for this method.

Moreover, I would like to note that this method does _not_ work with `DummyNuclide` objects as inputs, I played around and found that `XSNuclide` objects worked. Does that make sense to anyone else?

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
