### PR TITLE
updating `class Block` constructor and docstring

### DIFF
--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -91,7 +91,7 @@ class TestFuelHandler(ArmiTestHelper):
         interSodium = components.Hexagon("interCoolant", "Sodium", **interDims)
 
         # generate a block
-        self.block = blocks.HexBlock("TestHexBlock", self.o.cs)
+        self.block = blocks.HexBlock("TestHexBlock")
         self.block.setType("fuel")
         self.block.setHeight(10.0)
         self.block.add(fuel)

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -78,14 +78,11 @@ class Block(composites.Composite):
 
     pDefs = blockParameters.getBlockParameterDefinitions()
 
-    def __init__(self, name, height=1.0, location=None):
+    def __init__(self, name: str, height: float = 1.0):
         """
         Builds a new ARMI block
 
-        caseSettings : Settings object, optional
-            The settings object to use to build the block
-
-        name : str, optional
+        name : str
             The name of this block
 
         height : float, optional
@@ -95,9 +92,6 @@ class Block(composites.Composite):
         composites.Composite.__init__(self, name)
         self.p.height = height
 
-        if location:
-            k = location.axial
-            self.spatialLocator = grids.IndexLocation(0, 0, k, None)
         self.p.orientation = numpy.array((0.0, 0.0, 0.0))
 
         self.points = []
@@ -1562,8 +1556,8 @@ class HexBlock(Block):
 
     PITCH_COMPONENT_TYPE: ClassVar[_PitchDefiningComponent] = (components.Hexagon,)
 
-    def __init__(self, name, height=1.0, location=None):
-        Block.__init__(self, name, height, location)
+    def __init__(self, name, height=1.0):
+        Block.__init__(self, name, height)
 
     def coords(self, rotationDegreesCCW=0.0):
         x, y, _z = self.spatialLocator.getGlobalCoordinates()

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -109,8 +109,8 @@ def buildTestAssemblies():
 
     interSodium = components.Hexagon("interCoolant", "Sodium", **interDims)
 
-    block = blocks.HexBlock("fuel", caseSetting)
-    block2 = blocks.HexBlock("fuel", caseSetting)
+    block = blocks.HexBlock("fuel")
+    block2 = blocks.HexBlock("fuel")
     block.setType("fuel")
     block.setHeight(10.0)
     block.add(fuelUZr)
@@ -256,7 +256,7 @@ class Assembly_TestCase(unittest.TestCase):
         # add some blocks with a component
         self.blockList = []
         for i in range(NUM_BLOCKS):
-            b = blocks.HexBlock("TestHexBlock", self.cs)
+            b = blocks.HexBlock("TestHexBlock")
             b.setHeight(self.height)
 
             self.hexDims = {
@@ -297,7 +297,7 @@ class Assembly_TestCase(unittest.TestCase):
         self.assertEqual(cur, ref)
 
     def test_append(self):
-        b = blocks.HexBlock("TestBlock", self.cs)
+        b = blocks.HexBlock("TestBlock")
         self.blockList.append(b)
         self.Assembly.append(b)
         cur = self.Assembly.getBlocks()
@@ -307,7 +307,7 @@ class Assembly_TestCase(unittest.TestCase):
     def test_extend(self):
         blockList = []
         for _ in range(2):
-            b = blocks.HexBlock("TestBlock", self.cs)
+            b = blocks.HexBlock("TestBlock")
             self.blockList.append(b)
             blockList.append(b)
 
@@ -381,7 +381,7 @@ class Assembly_TestCase(unittest.TestCase):
 
         # add some blocks with a component
         for _ in range(assemNum2):
-            b = blocks.HexBlock("TestBlock", self.cs)
+            b = blocks.HexBlock("TestBlock")
             b.setHeight(height2)
             assembly2.add(b)
 
@@ -513,7 +513,7 @@ class Assembly_TestCase(unittest.TestCase):
             }
 
             h = components.Hexagon("fuel", "UZr", **self.hexDims)
-            b = blocks.HexBlock("fuel", self.cs)
+            b = blocks.HexBlock("fuel")
             b.setType("igniter fuel")
             b.add(h)
             b.setHeight(height2)
@@ -739,7 +739,7 @@ class Assembly_TestCase(unittest.TestCase):
 
         # add some blocks with a component
         for i in range(self.assemNum):
-            b = blocks.HexBlock("TestBlock", self.cs)
+            b = blocks.HexBlock("TestBlock")
 
             # Set the 1st block to have higher params than the rest.
             self.blockParamsTemp = {}
@@ -789,7 +789,7 @@ class Assembly_TestCase(unittest.TestCase):
 
         # add some blocks with a component
         for i in range(self.assemNum):
-            b = blocks.HexBlock("TestBlock", self.cs)
+            b = blocks.HexBlock("TestBlock")
 
             # Set the 1st block to have higher params than the rest.
             self.blockParamsTemp = {}
@@ -846,7 +846,7 @@ class Assembly_TestCase(unittest.TestCase):
 
         # add some blocks with a component
         for i in range(self.assemNum):
-            b = blocks.HexBlock("TestBlock", self.cs)
+            b = blocks.HexBlock("TestBlock")
 
             # Set the 1st block to have higher params than the rest.
             self.blockParamsTemp = {}
@@ -926,7 +926,7 @@ class Assembly_TestCase(unittest.TestCase):
 
         # add some blocks with a component
         for blockI in range(self.assemNum):
-            b = blocks.HexBlock("TestBlock", self.cs)
+            b = blocks.HexBlock("TestBlock")
 
             # Set the 1st block to have higher params than the rest.
             self.blockParamsTemp = {}


### PR DESCRIPTION
Summary:
- several unit tests were passing parameters relevant to an old version of the `class Block` constructor. Namely, case settings were being passed as blocks heights which is not correct.
- this corrects those, updates the constructor, and docstring.
- the parameter `location` is also removed from the class constructor. Its use was unclear and was not used in any of the tests (assumed out of date/stale)

<!-- Thanks in advance for you contribution! -->

## Description

<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
