### PR TITLE
Axial expansion update

### DIFF
--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -33,17 +33,16 @@ class AxialExpansionChanger:
         establishes object to store and access relevant expansion data
     """
 
-    def __init__(self, converterSettings: dict):
+    def __init__(self, detailedAxialExpansion: bool = False):
         """
         Build an axial expansion converter.
 
         Parameters
         ----------
-        converterSettings : dict
-            A set of str, value settings used in mesh conversion. Required
-            settings are implementation specific.
+        detailedAxialExpansion : bool, optional
+            A boolean to indicate whether or not detailedAxialExpansion is to be utilized.
         """
-        self._converterSettings = converterSettings
+        self._detailedAxialExpansion = detailedAxialExpansion
         self.linked = None
         self.expansionData = None
 
@@ -129,13 +128,10 @@ class AxialExpansionChanger:
                 "Top most block will be artificially chopped "
                 "to preserve assembly height".format(self.linked.a)
             )
-            if "detailedAxialExpansion" in self._converterSettings:  # avoid KeyError
-                if self._converterSettings["detailedAxialExpansion"]:
-                    runLog.error(
-                        "Cannot run detailedAxialExpansion without a dummy block"
-                        "at the top of the assembly!"
-                    )
-                    raise RuntimeError
+            if self._detailedAxialExpansion:
+                msg = "Cannot run detailedAxialExpansion without a dummy block at the top of the assembly!"
+                runLog.error(msg)
+                raise RuntimeError(msg)
 
     def axiallyExpandAssembly(self, thermal: bool = False):
         """Utilizes assembly linkage to do axial expansion
@@ -263,7 +259,7 @@ class AxialExpansionChanger:
         - if no detailedAxialExpansion, then do "cheap" approach to uniformMesh converter.
         - update average core mesh values with call to r.core.updateAxialMesh()
         """
-        if not self._converterSettings["detailedAxialExpansion"]:
+        if not self._detailedAxialExpansion:
             # loop through again now that the reference is adjusted and adjust the non-fuel assemblies.
             refAssem = r.core.refAssem
             axMesh = refAssem.getAxialMesh()

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -47,16 +47,48 @@ class AxialExpansionChanger:
         self.linked = None
         self.expansionData = None
 
-    def prescribedAxialExpansion(
+    def performPrescribedAxialExpansion(
         self, a, componentLst: list, percents: list, setFuel=True
     ):
-        """do prescribed axial expansion of an assembly"""
+        """Perform axial expansion of an assembly given prescribed expansion percentages
+
+        Parameters
+        ----------
+        a : :py:class:`Assembly <armi.reactor.assemblies.Assembly>` object.
+            ARMI assembly to be changed
+        componentList : :py:class:`Component <armi.reactor.components.component.Component>`, list
+            list of :py:class:`Component <armi.reactor.components.component.Component>` objects to be expanded
+        percents : float, list
+            list of expansion percentages for each component listed in componentList
+        setFuel : boolean, optional
+            Boolean to determine whether or not fuel blocks should have their target components set
+            This is useful when target components within a fuel block need to be determined on-the-fly.
+
+        Notes
+        -----
+        - percents may be positive (expansion) or negative (contraction)
+        """
         self.setAssembly(a, setFuel)
         self.expansionData.setExpansionFactors(componentLst, percents)
         self.axiallyExpandAssembly(thermal=False)
 
-    def thermalAxialExpansion(self, a, tempGrid: list, tempField: list, setFuel=True):
-        """do thermal expansion for an assembly given an axial temperature grid and field"""
+    def performThermalAxialExpansion(
+        self, a, tempGrid: list, tempField: list, setFuel=True
+    ):
+        """Perform thermal expansion for an assembly given an axial temperature grid and field
+
+        Parameters
+        ----------
+        a : :py:class:`Assembly <armi.reactor.assemblies.Assembly>` object.
+            ARMI assembly to be changed
+        tempGrid : float, list
+            Axial temperature grid (in cm) (i.e., physical locations where temp is stored)
+        tempField : float, list
+            Temperature values (in C) along grid
+        setFuel : boolean, optional
+            Boolean to determine whether or not fuel blocks should have their target components set
+            This is useful when target components within a fuel block need to be determined on-the-fly.
+        """
         self.setAssembly(a, setFuel)
         self.expansionData.mapHotTempToComponents(tempGrid, tempField)
         self.expansionData.computeThermalExpansionFactors()
@@ -73,6 +105,9 @@ class AxialExpansionChanger:
         ----------
          a : :py:class:`Assembly <armi.reactor.assemblies.Assembly>` object.
             ARMI assembly to be changed
+        setFuel : boolean, optional
+            Boolean to determine whether or not fuel blocks should have their target components set
+            This is useful when target components within a fuel block need to be determined on-the-fly.
         """
         self.linked = AssemblyAxialLinkage(a)
         self.expansionData = ExpansionData(a, setFuel)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -747,8 +747,8 @@ class HexReactorTests(ReactorTests):
         # creation with modified enrichment on an expanded BOL assem.
         fuelComp = fuelBlock.getComponent(Flags.FUEL)
         bol = self.r.blueprints.assemblies[aOld.getType()]
-        changer = AxialExpansionChanger(converterSettings={})
-        changer.prescribedAxialExpansion(bol, [fuelComp], [0.05])
+        changer = AxialExpansionChanger()
+        changer.performPrescribedAxialExpansion(bol, [fuelComp], [0.05])
         aNew3 = self.r.core.createAssemblyOfType(aOld.getType(), 0.195)
         self.assertAlmostEqual(
             aNew3.getFirstBlock(Flags.FUEL).getUraniumMassEnrich(), 0.195


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description
A few commits based on updated feedback from @jakehader . Thanks, Jake! 

The only non-docstring related change is in regard to the constructor of the expansion changer object. Instead of passing in a dictionary with relevant settings (which only looked for "detailedAxialExpansion"), they are now just read from the core ARMI settings. This simplifies the use of the changer and expects "detailedAxialExpansion" to be set in the settings input. By default it's set to False. 
 
<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
