### PR TITLE
Move getWettedPerimeter to HexBlock

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -505,19 +505,7 @@ class Block(composites.Composite):
             self.parent.calculateZCoords()
 
     def getWettedPerimeter(self):
-        """Return wetted perimeter per pin with duct averaged in."""
-        duct = self.getComponent(Flags.DUCT)
-        clad = self.getComponent(Flags.CLAD)
-        wire = self.getComponent(Flags.WIRE)
-        if not (duct and clad):
-            raise ValueError(
-                "Wetted perimeter cannot be computed in {}. No duct and clad components exist.".format(
-                    self
-                )
-            )
-        return math.pi * (
-            clad.getDimension("od") + wire.getDimension("od")
-        ) + 6 * duct.getDimension("ip") / math.sqrt(3) / clad.getDimension("mult")
+        raise NotImplementedError
 
     def getFlowAreaPerPin(self):
         """
@@ -539,22 +527,7 @@ class Block(composites.Composite):
             )
 
     def getHydraulicDiameter(self):
-        """
-        Return the hydraulic diameter in this block in cm.
-
-        Hydraulic diameter is 4A/P where A is the flow area and P is the wetted perimeter.
-        In a hex assembly, the wetted perimeter includes the cladding, the wire wrap, and the
-        inside of the duct. The flow area is the inner area of the duct minus the area of the
-        pins and the wire.
-
-        To convert the inner hex pitch into a perimeter, first convert to side, then
-        multiply by 6.
-
-        p=sqrt(3)*s
-         l = 6*p/sqrt(3)
-        """
-
-        return 4.0 * self.getFlowAreaPerPin() / self.getWettedPerimeter()
+        raise NotImplementedError
 
     def adjustUEnrich(self, newEnrich):
         """
@@ -2043,6 +2016,39 @@ class HexBlock(Block):
                 )
             )
 
+    def getWettedPerimeter(self):
+        """Return wetted perimeter per pin with duct averaged in."""
+        duct = self.getComponent(Flags.DUCT)
+        clad = self.getComponent(Flags.CLAD)
+        wire = self.getComponent(Flags.WIRE)
+        if not duct or not clad:
+            raise ValueError(
+                "Wetted perimeter cannot be computed in {}. No duct or clad components exist.".format(
+                    self
+                )
+            )
+
+        return math.pi * (
+            clad.getDimension("od") + wire.getDimension("od")
+        ) + 6 * duct.getDimension("ip") / math.sqrt(3) / clad.getDimension("mult")
+
+    def getHydraulicDiameter(self):
+        """
+        Return the hydraulic diameter in this block in cm.
+
+        Hydraulic diameter is 4A/P where A is the flow area and P is the wetted perimeter.
+        In a hex assembly, the wetted perimeter includes the cladding, the wire wrap, and the
+        inside of the duct. The flow area is the inner area of the duct minus the area of the
+        pins and the wire.
+
+        To convert the inner hex pitch into a perimeter, first convert to side, then
+        multiply by 6.
+
+        p = sqrt(3)*s
+        l = 6*p/sqrt(3)
+        """
+        return 4.0 * self.getFlowAreaPerPin() / self.getWettedPerimeter()
+
 
 class CartesianBlock(Block):
 
@@ -2154,9 +2160,15 @@ class Point(Block):
             self.p[param] = 0.0
 
     def getVolume(self):
-        return (
-            1.0  # points have no volume scaling; point flux are not volume-integrated
-        )
+        """points have no volume scaling; point flux are not volume-integrated"""
+        return 1.0
 
     def getBurnupPeakingFactor(self):
-        return 1.0  # peaking makes no sense for points
+        """peaking makes no sense for points"""
+        return 1.0
+
+    def getWettedPerimeter(self):
+        return 0.0
+
+    def getHydraulicDiameter(self):
+        return 0.0

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -391,7 +391,6 @@ class Block_TestCase(unittest.TestCase):
         self.assertFalse(self.Block.hasFlags(Flags.PLENUM, exact=True))
 
     def test_hasFlags(self):
-
         self.Block.setType("feed fuel")
 
         cur = self.Block.hasFlags(Flags.FEED | Flags.FUEL)
@@ -401,7 +400,6 @@ class Block_TestCase(unittest.TestCase):
         self.assertFalse(cur)
 
     def test_setType(self):
-
         self.Block.setType("igniter fuel")
 
         self.assertEqual("igniter fuel", self.Block.getType())
@@ -415,7 +413,6 @@ class Block_TestCase(unittest.TestCase):
         self.assertFalse(self.Block.hasFlags(Flags.IGNITER | Flags.FUEL))
 
     def test_duplicate(self):
-
         Block2 = copy.deepcopy(self.Block)
         originalComponents = self.Block.getComponents()
         newComponents = Block2.getComponents()
@@ -566,7 +563,6 @@ class Block_TestCase(unittest.TestCase):
             self.assertAlmostEqual(cur, ref, places=places)
 
     def test_getNumberDensity(self):
-
         refDict = {
             "U235": 0.00275173784234,
             "U238": 0.0217358415457,
@@ -637,7 +633,6 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(cur, ref, places=places)
 
     def test_setMass(self):
-
         self.Block.setHeight(100.0)
 
         mass = 100.0
@@ -687,9 +682,7 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(cur, ref, places=places)
 
     def test_replaceBlockWithBlock(self):
-        r"""
-        Tests conservation of mass flag in replaceBlockWithBlock
-        """
+        r"""Tests conservation of mass flag in replaceBlockWithBlock"""
         block = self.Block
         ductBlock = block.__class__("duct")
         ductBlock.add(block.getComponent(Flags.COOLANT, exact=True))
@@ -1904,10 +1897,18 @@ class ThRZBlock_TestCase(unittest.TestCase):
         self.ThRZBlock.verifyBlockDims()
 
     def test_getThetaRZGrid(self):
+        """Since not applicable to ThetaRZ Grids"""
         b = self.ThRZBlock
         with self.assertRaises(NotImplementedError):
             b.autoCreateSpatialGrids()
-        # Since not applicable to Cartesian Grids.
+
+    def test_getWettedPerimeter(self):
+        with self.assertRaises(NotImplementedError):
+            _ = self.ThRZBlock.getWettedPerimeter()
+
+    def test_getHydraulicDiameter(self):
+        with self.assertRaises(NotImplementedError):
+            _ = self.ThRZBlock.getHydraulicDiameter()
 
 
 class CartesianBlock_TestCase(unittest.TestCase):
@@ -2003,19 +2004,33 @@ class CartesianBlock_TestCase(unittest.TestCase):
         self.assertAlmostEqual(sum(c.getArea() for c in cartBlock), rectTotalArea)
 
     def test_getCartesianGrid(self):
+        """Since not applicable to Cartesian Grids"""
         b = self.cartesianBlock
         with self.assertRaises(NotImplementedError):
             b.autoCreateSpatialGrids()
-        # Since not applicable to Cartesian Grids.
+
+    def test_getWettedPerimeter(self):
+        with self.assertRaises(NotImplementedError):
+            _ = self.cartesianBlock.getWettedPerimeter()
+
+    def test_getHydraulicDiameter(self):
+        with self.assertRaises(NotImplementedError):
+            _ = self.cartesianBlock.getHydraulicDiameter()
 
 
 class PointTests(unittest.TestCase):
     def setUp(self):
-        self.Point = blocks.Point()
+        self.point = blocks.Point()
 
     def test_getters(self):
-        self.assertEqual(1.0, self.Point.getVolume())
-        self.assertEqual(1.0, self.Point.getBurnupPeakingFactor())
+        self.assertEqual(1.0, self.point.getVolume())
+        self.assertEqual(1.0, self.point.getBurnupPeakingFactor())
+
+    def test_getWettedPerimeter(self):
+        self.assertEqual(0.0, self.point.getWettedPerimeter())
+
+    def test_getHydraulicDiameter(self):
+        self.assertEqual(0.0, self.point.getHydraulicDiameter())
 
 
 class MassConservationTests(unittest.TestCase):

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -80,18 +80,29 @@ class TestApps(unittest.TestCase):
         context.APP_NAME = "armi"
 
     def test_getParamRenames(self):
+        # a basic test of the method
         app = getApp()
         app.pluginManager.register(TestPlugin1)
         app.pluginManager.register(TestPlugin4)
         app._paramRenames = None  # need to implement better cache invalidation rules
 
         renames = app.getParamRenames()
+
         self.assertIn("oldType", renames)
         self.assertEqual(renames["oldType"], "type")
-
         self.assertIn("arealPD", renames)
         self.assertEqual(renames["arealPD"], "arealPowerDensity")
 
+        # test an invalid param manager situation
+        app._paramRenames[0][1] = -3
+        renames = app.getParamRenames()
+
+        self.assertIn("oldType", renames)
+        self.assertEqual(renames["oldType"], "type")
+        self.assertIn("arealPD", renames)
+        self.assertEqual(renames["arealPD"], "arealPowerDensity")
+
+        # test the exceptions that get raised
         app.pluginManager.register(TestPlugin2)
         app._paramRenames = None  # need to implement better cache invalidation rules
         with self.assertRaisesRegex(

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -23,6 +23,7 @@ Bug fixes
 #. Fixed issue with docs not correctly loading their Git submodule in TOX.
 #. Fixed issue with ``_swapFluxParams`` failing for assemblies with different blocks (`#566 <https://github.com/terrapower/armi/issues/566>`_)
 #. Multiple bug fixes in ``growToFullCore``.
+#. ``Block.getWettedPerim`` was moved to ``HexBlock``, as that was more accurate.
 #. TBD
 
 


### PR DESCRIPTION
## Description

The implementation of `getWettedPerim()` was really specific to `HexBlock`, though it was in the general `Block`. This was incorrect, and fixed here.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
