### PR TITLE
updating docstring for applicable assembly-types

### DIFF
--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -23,14 +23,18 @@ class AxialExpansionChanger:
     """
     Axially expand or contract assemblies or an entire core.
 
-    Useful for fuel performance, thermal expansion, reactivity coefficients, etc.
-
     Attributes
     ----------
     linked : :py:class:`AssemblyAxialLinkage` object.
         establishes object containing axial linkage information
     expansionData : :py:class:`ExpansionData <armi.reactor.converters.axialExpansionChanger.ExpansionData>` object.
         establishes object to store and access relevant expansion data
+
+    Notes
+    -----
+    - Is designed to work with general, vertically oriented, pin-type assembly designs. It is not set up to account
+      for any other assembly type.
+    - Useful for fuel performance, thermal expansion, reactivity coefficients, etc.
     """
 
     def __init__(self, converterSettings: dict):


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description
Axial expansion changer is only designed to work with vertically oriented, pin-type assemblies. Just adding a note to explicitly say so.
<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.
