### PR TITLE
Add ability to define User Plugins in environmental variable that load at init

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -188,16 +188,20 @@ def getDefaultPlugins() -> List[Type[plugins.ArmiPlugin]]:
     from armi import cli
     from armi import bookkeeping
     from armi.physics import fuelCycle
+    from armi.physics import fuelPerformance
     from armi.physics import neutronics
     from armi.physics import safety
+    from armi.physics import thermalHydraulics
     from armi import reactor
 
     defaultPlugins = [
         cli.EntryPointsPlugin,
         bookkeeping.BookkeepingPlugin,
         fuelCycle.FuelHandlerPlugin,
+        fuelPerformance.FuelPerformancePlugin,
         neutronics.NeutronicsPlugin,
         safety.SafetyPlugin,
+        thermalHydraulics.ThermalHydraulicsPlugin,
         reactor.ReactorPlugin,
     ]
 

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -119,16 +119,12 @@ class App:
         OSs.
         """
         userPluginInput = os.environ.get("ARMI_USER_PLUGINS", "")
-        print(userPluginInput)
         if not userPluginInput:
             return
         for pluginSpec in userPluginInput.split(","):
-            print(pluginSpec)
             names = pluginSpec.split(".")
-            print(names)
             modPath = ".".join(names[:-1])
             clsName = names[-1]
-            print(modPath, clsName)
             mod = importlib.import_module(modPath)
             plugin = getattr(mod, clsName)
             self._pm.register(plugin)

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -71,30 +71,18 @@ class App:
         For a description of the things that an ARMI plugin can do, see the
         :py:mod:`armi.plugins` module.
         """
-        from armi import cli
-        from armi import bookkeeping
-        from armi.physics import fuelCycle
-        from armi.physics import fuelPerformance
-        from armi.physics import neutronics
-        from armi.physics import safety
-        from armi.physics import thermalHydraulics
-        from armi import reactor
-
         self._pm = plugins.getNewPluginManager()
-        for plugin in (
-            cli.EntryPointsPlugin,
-            bookkeeping.BookkeepingPlugin,
-            fuelCycle.FuelHandlerPlugin,
-            fuelPerformance.FuelPerformancePlugin,
-            neutronics.NeutronicsPlugin,
-            safety.SafetyPlugin,
-            thermalHydraulics.ThermalHydraulicsPlugin,
-            reactor.ReactorPlugin,
-        ):
-            self._pm.register(plugin)
+
+        self._registerFrameworkPlugins()
 
         self._paramRenames: Optional[Tuple[Dict[str, str], int]] = None
 
+    def _registerFrameworkPlugins(self):
+        """Register all the hard-coded Framework plugins."""
+        from armi import getDefaultPlugins  # avoid circular import
+
+        for plugin in getDefaultPlugins():
+            self._pm.register(plugin)
     @property
     def version(self) -> str:
         """Grab the version of this app (defaults to ARMI version).

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -15,11 +15,13 @@
 """Tests for the App class."""
 import copy
 import unittest
+import os
 
 from armi import cli
 from armi import configure
 from armi import context
 from armi import getApp
+from armi import apps
 from armi import getDefaultPluginManager
 from armi import meta
 from armi import plugins
@@ -173,3 +175,20 @@ class TestArmi(unittest.TestCase):
     def test_main(self):
         with self.assertRaises(SystemExit):
             main()
+
+
+class UserPlugin1:
+    pass
+
+
+class TestAppWithUserPlugins(unittest.TestCase):
+    """Test the ability to load in userplugins"""
+
+    def test_userPlugin(self):
+
+        os.environ["ARMI_USER_PLUGINS"] = "armi.tests.test_apps.UserPlugin1"
+        app = apps.App()
+        configure(app, permissive=True)
+
+        ver = app.version
+        self.assertIn("userplugin", ver)

--- a/doc/developer/making_armi_based_apps.rst
+++ b/doc/developer/making_armi_based_apps.rst
@@ -99,8 +99,20 @@ somehow in a cohesive package. Packaging Python projects is beyond the scope of 
 document, but see `this page <https://docs.python-guide.org/writing/structure/>`_ for
 some guidance.
 
-Once you have a plugin together, continue reading to see how to plug it into the ARMI
-Framework as part of an Application.
+Once you have a plugin together, you may either rest it out as a User Plugin
+or (highly recommended) build an ARMI-based Application. 
+
+Activating your Plugin as a User Plugin
+---------------------------------------
+You may activate one or more Plugins as User Plugins by referring to them
+on an environmental variable called ``ARMI_USER_PLUGINS``. The Plugin code
+must reside in a location that is importable (e.g. in your ``PYTHONPATH``). 
+The format for the value of the varaible may be found in :py:meth:`armi.apps.App._registerUserPlugins`.
+
+This capability is intended to be useful for early prototyping and testing. 
+
+Continue reading to see how to plug it into the ARMI Framework as part of an
+Application as recommended.
 
 -----------------------
 ARMI-Based Applications


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

<!-- Please include a summary of the change and link to any related GitHub Issues.-->
Fixes #569 
---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
