### PR TITLE
Let's not delete a file inside a loop

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,4 +1,4 @@
-name: Coverage
+name: Coverage1
 
 on: [push, pull_request]
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,4 +1,4 @@
-name: Coverage1
+name: Coverage
 
 on: [push, pull_request]
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2037,7 +2037,9 @@ class HexBlock(Block):
 
     def hasPinPitch(self):
         """Return True if the block has enough information to calculate pin pitch."""
-        return self.getComponent(Flags.CLAD) and self.getComponent(Flags.WIRE)
+        return (self.getComponent(Flags.CLAD) is not None) and (
+            self.getComponent(Flags.WIRE) is not None
+        )
 
     def getPinPitch(self, cold=False):
         """

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1549,6 +1549,14 @@ class Block_TestCase(unittest.TestCase):
         dims = self.block.getDimensions("od")
         self.assertIn(self.block.getComponent(Flags.FUEL).p.od, dims)
 
+    def test_getPlenumPin(self):
+        pin = self.block.getPlenumPin()
+        self.assertIsNone(pin)
+
+    def test_hasPinPitch(self):
+        hasPitch = self.block.hasPinPitch()
+        self.assertTrue(hasPitch)
+
 
 class Test_NegativeVolume(unittest.TestCase):
     def test_negativeVolume(self):

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -252,7 +252,7 @@ class MpiDistributeStateTests(unittest.TestCase):
 
 class MpiPathToolsTests(unittest.TestCase):
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
-    def xxxx_cleanPathMpi(self):
+    def test_cleanPathMpi(self):
         # """Simple tests of cleanPath(), in the MPI scenario"""
         # Test 0: File is not safe to delete, due to name pathing
         with TemporaryDirectoryChanger():
@@ -261,7 +261,7 @@ class MpiPathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(filePath0))
             with self.assertRaises(Exception):
-                pathTools.cleanPath(filePath0, mpiRank=0)
+                pathTools.cleanPath(filePath0, mpiRank=context.MPI_RANK)
 
         # Test 1: Delete a single file
         with TemporaryDirectoryChanger():
@@ -269,7 +269,7 @@ class MpiPathToolsTests(unittest.TestCase):
             open(filePath1, "w").write("something")
 
             self.assertTrue(os.path.exists(filePath1))
-            pathTools.cleanPath(filePath1, mpiRank=0)
+            pathTools.cleanPath(filePath1, mpiRank=context.MPI_RANK)
             self.assertFalse(os.path.exists(filePath1))
 
         # Test 2: Delete an empty directory
@@ -278,7 +278,7 @@ class MpiPathToolsTests(unittest.TestCase):
             os.mkdir(dir2)
 
             self.assertTrue(os.path.exists(dir2))
-            pathTools.cleanPath(dir2, mpiRank=0)
+            pathTools.cleanPath(dir2, mpiRank=context.MPI_RANK)
             self.assertFalse(os.path.exists(dir2))
 
         # Test 3: Delete a directory with two files inside
@@ -295,7 +295,7 @@ class MpiPathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(dir3))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file1.txt")))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file2.txt")))
-            pathTools.cleanPath(dir3, mpiRank=0)
+            pathTools.cleanPath(dir3, mpiRank=context.MPI_RANK)
             self.assertFalse(os.path.exists(dir3))
 
 

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -252,7 +252,7 @@ class MpiDistributeStateTests(unittest.TestCase):
 
 class MpiPathToolsTests(unittest.TestCase):
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
-    def xxxx_cleanPathMpi(self):
+    def test_cleanPathMpi(self):
         # """Simple tests of cleanPath(), in the MPI scenario"""
         with TemporaryDirectoryChanger():
             # TEST 0: File is not safe to delete, due to name pathing

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -252,7 +252,7 @@ class MpiDistributeStateTests(unittest.TestCase):
 
 class MpiPathToolsTests(unittest.TestCase):
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
-    def test_cleanPathMpi(self):
+    def xxxx_cleanPathMpi(self):
         # """Simple tests of cleanPath(), in the MPI scenario"""
         # Test 0: File is not safe to delete, due to name pathing
         with TemporaryDirectoryChanger():

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -252,8 +252,8 @@ class MpiDistributeStateTests(unittest.TestCase):
 
 class MpiPathToolsTests(unittest.TestCase):
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
-    def test_cleanPathMpi(self):
-        """Simple tests of cleanPath(), in the MPI scenario"""
+    def xxxx_cleanPathMpi(self):
+        #"""Simple tests of cleanPath(), in the MPI scenario"""
         # Test 0: File is not safe to delete, due to name pathing
         with TemporaryDirectoryChanger():
             filePath0 = "test0_cleanPathNoMpi"

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -253,7 +253,7 @@ class MpiDistributeStateTests(unittest.TestCase):
 class MpiPathToolsTests(unittest.TestCase):
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
     def xxxx_cleanPathMpi(self):
-        #"""Simple tests of cleanPath(), in the MPI scenario"""
+        # """Simple tests of cleanPath(), in the MPI scenario"""
         # Test 0: File is not safe to delete, due to name pathing
         with TemporaryDirectoryChanger():
             filePath0 = "test0_cleanPathNoMpi"

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -254,8 +254,8 @@ class MpiPathToolsTests(unittest.TestCase):
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
     def xxxx_cleanPathMpi(self):
         # """Simple tests of cleanPath(), in the MPI scenario"""
-        # Test 0: File is not safe to delete, due to name pathing
         with TemporaryDirectoryChanger():
+            # TEST 0: File is not safe to delete, due to name pathing
             filePath0 = "test0_cleanPathNoMpi"
             open(filePath0, "w").write("something")
 
@@ -263,8 +263,7 @@ class MpiPathToolsTests(unittest.TestCase):
             with self.assertRaises(Exception):
                 pathTools.cleanPath(filePath0, mpiRank=context.MPI_RANK)
 
-        # Test 1: Delete a single file
-        with TemporaryDirectoryChanger():
+            # TEST 1: Delete a single file
             filePath1 = "test1_cleanPathNoMpi_mongoose"
             open(filePath1, "w").write("something")
 
@@ -272,8 +271,7 @@ class MpiPathToolsTests(unittest.TestCase):
             pathTools.cleanPath(filePath1, mpiRank=context.MPI_RANK)
             self.assertFalse(os.path.exists(filePath1))
 
-        # Test 2: Delete an empty directory
-        with TemporaryDirectoryChanger():
+            # TEST 2: Delete an empty directory
             dir2 = "mongoose"
             os.mkdir(dir2)
 
@@ -281,8 +279,7 @@ class MpiPathToolsTests(unittest.TestCase):
             pathTools.cleanPath(dir2, mpiRank=context.MPI_RANK)
             self.assertFalse(os.path.exists(dir2))
 
-        # Test 3: Delete a directory with two files inside
-        with TemporaryDirectoryChanger():
+            # TEST 3: Delete a directory with two files inside
             # create directory
             dir3 = "mongoose"
             os.mkdir(dir3)

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -274,7 +274,7 @@ def cleanPath(path, mpiRank=0):
     maxLoops = 6
     waitTime = 0.5
     loopCounter = 0
-    while os.path.exists(path) and loopCounter < maxLoops:
+    while os.path.exists(path) or loopCounter < maxLoops:
         loopCounter += 1
         sleep(waitTime)
 

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -274,8 +274,10 @@ def cleanPath(path, mpiRank=0):
     maxLoops = 6
     waitTime = 0.5
     loopCounter = 0
-    while os.path.exists(path) or loopCounter < maxLoops:
+    while os.path.exists(path):
         loopCounter += 1
+        if loopCounter > maxLoops:
+            break
         sleep(waitTime)
 
     # Potentially, wait for all the processes to catch up.

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -219,7 +219,7 @@ def moduleAndAttributeExist(pathAttr):
     return moduleAttributeName in userSpecifiedModule.__dict__
 
 
-def cleanPath(path):
+def cleanPath(path, mpiRank=0):
     """Recursively delete a path.
 
     !!! careful with this !!! It can delete the entire cluster.
@@ -237,7 +237,6 @@ def cleanPath(path):
     -------
     success : bool
         True if file was deleted. False if it was not.
-
     """
     valid = False
     if not os.path.exists(path):
@@ -263,23 +262,25 @@ def cleanPath(path):
             "You tried to delete {0}, but it does not seem safe to do so.".format(path)
         )
 
-    for i in range(3):
-        try:
-            if os.path.exists(path) and os.path.isdir(path):
-                shutil.rmtree(path)
-            elif not os.path.isdir(path):
-                # it's just a file. Delete it.
-                os.remove(path)
-        except:
-            if i == 2:
-                pass
-            # in case the OS is behind or something
-            sleep(0.1)
+    # delete the file/directory from only one process
+    if context.MPI_RANK == mpiRank:
+        if os.path.exists(path) and os.path.isdir(path):
+            shutil.rmtree(path)
+        elif not os.path.isdir(path):
+            # it's just a file. Delete it.
+            os.remove(path)
 
-        sleep(0.3)
-        if not os.path.exists(path):
-            break
-        sleep(0.3)
+    # Potentially, wait for the deletion to finish.
+    maxLoops = 6
+    waitTime = 0.5
+    loopCounter = 0
+    while os.path.exists(path) and loopCounter < maxLoops:
+        loopCounter += 1
+        sleep(waitTime)
+
+    # Potentially, wait for all the processes to catch up.
+    if context.MPI_SIZE > 1:
+        context.MPI_COMM.barrier()
 
     if os.path.exists(path):
         return False

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -75,8 +75,8 @@ class PathToolsTests(unittest.TestCase):
     @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")
     def test_cleanPathNoMpi(self):
         """Simple tests of cleanPath(), in the no-MPI scenario"""
-        # Test 0: File is not safe to delete, due to name pathing
         with TemporaryDirectoryChanger():
+            # TEST 0: File is not safe to delete, due to name pathing
             filePath0 = "test0_cleanPathNoMpi"
             open(filePath0, "w").write("something")
 
@@ -84,8 +84,7 @@ class PathToolsTests(unittest.TestCase):
             with self.assertRaises(Exception):
                 pathTools.cleanPath(filePath0, mpiRank=0)
 
-        # Test 1: Delete a single file
-        with TemporaryDirectoryChanger():
+            # TEST 1: Delete a single file
             filePath1 = "test1_cleanPathNoMpi_mongoose"
             open(filePath1, "w").write("something")
 
@@ -93,8 +92,7 @@ class PathToolsTests(unittest.TestCase):
             pathTools.cleanPath(filePath1, mpiRank=0)
             self.assertFalse(os.path.exists(filePath1))
 
-        # Test 2: Delete an empty directory
-        with TemporaryDirectoryChanger():
+            # TEST 2: Delete an empty directory
             dir2 = "mongoose"
             os.mkdir(dir2)
 
@@ -102,8 +100,7 @@ class PathToolsTests(unittest.TestCase):
             pathTools.cleanPath(dir2, mpiRank=0)
             self.assertFalse(os.path.exists(dir2))
 
-        # Test 3: Delete a directory with two files inside
-        with TemporaryDirectoryChanger():
+            # TEST 3: Delete a directory with two files inside
             # create directory
             dir3 = "mongoose"
             os.mkdir(dir3)

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -16,11 +16,13 @@
 Unit tests for pathTools.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
-import unittest
 import os
 import types
+import unittest
 
+from armi import context
 from armi.utils import pathTools
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 THIS_DIR = os.path.dirname(__file__)
 
@@ -69,6 +71,53 @@ class PathToolsTests(unittest.TestCase):
         self.assertFalse(pathTools.moduleAndAttributeExist(thisFile + ":doesntExist"))
         self.assertTrue(pathTools.moduleAndAttributeExist(thisFile + ":THIS_DIR"))
         self.assertTrue(pathTools.moduleAndAttributeExist(thisFile + ":PathToolsTests"))
+
+    @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")
+    def test_cleanPathNoMpi(self):
+        """Simple tests of cleanPath(), in the no-MPI scenario"""
+        # Test 0: File is not safe to delete, due to name pathing
+        with TemporaryDirectoryChanger():
+            filePath0 = "test0_cleanPathNoMpi"
+            open(filePath0, "w").write("something")
+
+            self.assertTrue(os.path.exists(filePath0))
+            with self.assertRaises(Exception):
+                pathTools.cleanPath(filePath0, mpiRank=0)
+
+        # Test 1: Delete a single file
+        with TemporaryDirectoryChanger():
+            filePath1 = "test1_cleanPathNoMpi_mongoose"
+            open(filePath1, "w").write("something")
+
+            self.assertTrue(os.path.exists(filePath1))
+            pathTools.cleanPath(filePath1, mpiRank=0)
+            self.assertFalse(os.path.exists(filePath1))
+
+        # Test 2: Delete an empty directory
+        with TemporaryDirectoryChanger():
+            dir2 = "mongoose"
+            os.mkdir(dir2)
+
+            self.assertTrue(os.path.exists(dir2))
+            pathTools.cleanPath(dir2, mpiRank=0)
+            self.assertFalse(os.path.exists(dir2))
+
+        # Test 3: Delete a directory with two files inside
+        with TemporaryDirectoryChanger():
+            # create directory
+            dir3 = "mongoose"
+            os.mkdir(dir3)
+
+            # throw in a couple of simple text files
+            open(os.path.join(dir3, "file1.txt"), "w").write("something1")
+            open(os.path.join(dir3, "file2.txt"), "w").write("something2")
+
+            # delete the directory and test
+            self.assertTrue(os.path.exists(dir3))
+            self.assertTrue(os.path.exists(os.path.join(dir3, "file1.txt")))
+            self.assertTrue(os.path.exists(os.path.join(dir3, "file2.txt")))
+            pathTools.cleanPath(dir3, mpiRank=0)
+            self.assertFalse(os.path.exists(dir3))
 
 
 if __name__ == "__main__":

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -24,6 +24,7 @@ Bug fixes
 #. Fixed issue with ``_swapFluxParams`` failing for assemblies with different blocks (`#566 <https://github.com/terrapower/armi/issues/566>`_)
 #. Multiple bug fixes in ``growToFullCore``.
 #. ``Block.getWettedPerim`` was moved to ``HexBlock``, as that was more accurate.
+#. ``pathTools.cleanPath()`` is not much more linear, and handles the MPI use-case better.
 #. TBD
 
 


### PR DESCRIPTION
## Description

The old `pathTools()` would repeatedly delete the same file/directory inside a loop.  That seems suspect.

It also did not handle the situation well for when we want to delete a file/directory in an MPI or non-MPI scenario well.

This change to the method linearizes our file deletion, to only one delete call. It also gives the user control of whether or not this deletion should be MPI-safe or not.

This is in response to: https://github.com/terrapower/armi/issues/406

**NOTE**:
I also fixed a bug in the `HexBlock.hasPinPitch()`, which sometimes returned the Block itself, rather than just a boolean. That is, it's return type was internally inconsistent, and did not match `Block.hasPinPitch()`.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
