### PR TITLE
Update/upgrade for component axial linkage

### DIFF
--- a/armi/reactor/components/basicShapes.py
+++ b/armi/reactor/components/basicShapes.py
@@ -71,6 +71,9 @@ class Circle(ShapedComponent):
     def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
         return max(self.getDimension("id", Tc, cold), self.getDimension("od", Tc, cold))
 
+    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+        return min(self.getDimension("id", Tc, cold), self.getDimension("od", Tc, cold))
+
     def getComponentArea(self, cold=False):
         """Computes the area for the circle component in cm^2."""
         idiam = self.getDimension("id", cold=cold)
@@ -126,6 +129,10 @@ class Hexagon(ShapedComponent):
 
     def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
         sideLength = self.getDimension("op", Tc, cold) / math.sqrt(3)
+        return 2.0 * sideLength
+
+    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+        sideLength = self.getDimension("ip", Tc, cold) / math.sqrt(3)
         return 2.0 * sideLength
 
     def getComponentArea(self, cold=False):
@@ -212,6 +219,11 @@ class Rectangle(ShapedComponent):
         lengthO = self.getDimension("lengthOuter", Tc, cold=cold)
         widthO = self.getDimension("widthOuter", Tc, cold=cold)
         return math.sqrt(widthO ** 2 + lengthO ** 2)
+
+    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+        lengthI = self.getDimension("lengthInner", Tc, cold=cold)
+        widthI = self.getDimension("widthInner", Tc, cold=cold)
+        return math.sqrt(widthI ** 2 + lengthI ** 2)
 
     def getComponentArea(self, cold=False):
         """Computes the area of the rectangle in cm^2."""
@@ -348,6 +360,10 @@ class Square(Rectangle):
     def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
         widthO = self.getDimension("widthOuter", Tc, cold=cold)
         return math.sqrt(widthO ** 2 + widthO ** 2)
+
+    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+        widthI = self.getDimension("widthInner", Tc, cold=cold)
+        return math.sqrt(widthI ** 2 + widthI ** 2)
 
     def getPitchData(self):
         """

--- a/armi/reactor/components/basicShapes.py
+++ b/armi/reactor/components/basicShapes.py
@@ -71,7 +71,7 @@ class Circle(ShapedComponent):
     def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
         return max(self.getDimension("id", Tc, cold), self.getDimension("od", Tc, cold))
 
-    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+    def getCircleInnerDiameter(self, Tc=None, cold=False):
         return min(self.getDimension("id", Tc, cold), self.getDimension("od", Tc, cold))
 
     def getComponentArea(self, cold=False):
@@ -131,7 +131,7 @@ class Hexagon(ShapedComponent):
         sideLength = self.getDimension("op", Tc, cold) / math.sqrt(3)
         return 2.0 * sideLength
 
-    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+    def getCircleInnerDiameter(self, Tc=None, cold=False):
         sideLength = self.getDimension("ip", Tc, cold) / math.sqrt(3)
         return 2.0 * sideLength
 
@@ -220,7 +220,7 @@ class Rectangle(ShapedComponent):
         widthO = self.getDimension("widthOuter", Tc, cold=cold)
         return math.sqrt(widthO ** 2 + lengthO ** 2)
 
-    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+    def getCircleInnerDiameter(self, Tc=None, cold=False):
         lengthI = self.getDimension("lengthInner", Tc, cold=cold)
         widthI = self.getDimension("widthInner", Tc, cold=cold)
         return math.sqrt(widthI ** 2 + lengthI ** 2)
@@ -361,7 +361,7 @@ class Square(Rectangle):
         widthO = self.getDimension("widthOuter", Tc, cold=cold)
         return math.sqrt(widthO ** 2 + widthO ** 2)
 
-    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+    def getCircleInnerDiameter(self, Tc=None, cold=False):
         widthI = self.getDimension("widthInner", Tc, cold=cold)
         return math.sqrt(widthI ** 2 + widthI ** 2)
 

--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -234,6 +234,11 @@ class Helix(ShapedComponent):
             "helixDiameter", Tc, cold=cold
         )
 
+    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+        return self.getDimension("id", Tc, cold) + self.getDimension(
+            "helixDiameter", Tc, cold=cold
+        )
+
     def getComponentArea(self, cold=False):
         """Computes the area for the helix in cm^2."""
         ap = self.getDimension("axialPitch", cold=cold)

--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -234,7 +234,7 @@ class Helix(ShapedComponent):
             "helixDiameter", Tc, cold=cold
         )
 
-    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+    def getCircleInnerDiameter(self, Tc=None, cold=False):
         return self.getDimension("id", Tc, cold) + self.getDimension(
             "helixDiameter", Tc, cold=cold
         )

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -783,6 +783,10 @@ class Component(composites.Composite, metaclass=ComponentType):
         """Abstract bounding circle method that should be overwritten by each shape subclass."""
         raise NotImplementedError
 
+    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+        """Abstract inner bounding circle method that should be overwritten by each shape subclass."""
+        raise NotImplementedError
+
     def dimensionIsLinked(self, key):
         """True if a the specified dimension is linked to another dimension."""
         return key in self.p and isinstance(self.p[key], _DimensionLink)

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -784,7 +784,15 @@ class Component(composites.Composite, metaclass=ComponentType):
         raise NotImplementedError
 
     def getCircleInnerDiameter(self, Tc=None, cold=False):
-        """Abstract inner bounding circle method that should be overwritten by each shape subclass."""
+        """Abstract inner circle method that should be overwritten by each shape subclass.
+
+        Notes
+        -----
+        The inner circle is meaningful for annular shapes, i.e., circle with non-zero ID,
+        hexagon with non-zero IP, etc. For shapes with corners (e.g., hexagon, rectangle, etc)
+        the inner circle intersects the corners of the inner bound, opposed to intersecting
+        the "flats".
+        """
         raise NotImplementedError
 
     def dimensionIsLinked(self, key):

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -783,7 +783,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         """Abstract bounding circle method that should be overwritten by each shape subclass."""
         raise NotImplementedError
 
-    def getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+    def getCircleInnerDiameter(self, Tc=None, cold=False):
         """Abstract inner bounding circle method that should be overwritten by each shape subclass."""
         raise NotImplementedError
 

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -481,6 +481,9 @@ def _determineLinked(componentA, componentB):
     - Requires that shapes have the getCircleInnerDiameter and getBoundingCircleOuterDiameter defined
     - For axial linkage to be True, components MUST be solids, the same Component Class, multiplicity, and meet inner
       and outer diameter requirements.
+    - When component dimensions are retrieved, cold=True to ensure that dimensions are evaluated
+      at cold/input temperatures. At temperature, solid-solid interfaces in ARMI may produce
+      slight overlaps due to thermal expansion. Handling these potential overlaps are out of scope.
 
     Returns
     -------
@@ -493,12 +496,12 @@ def _determineLinked(componentA, componentB):
         and (componentA.getDimension("mult") == componentB.getDimension("mult"))
     ):
         idA, odA = (
-            componentA.getCircleInnerDiameter(),
-            componentA.getBoundingCircleOuterDiameter(),
+            componentA.getCircleInnerDiameter(cold=True),
+            componentA.getBoundingCircleOuterDiameter(cold=True),
         )
         idB, odB = (
-            componentB.getCircleInnerDiameter(),
-            componentB.getBoundingCircleOuterDiameter(),
+            componentB.getCircleInnerDiameter(cold=True),
+            componentB.getBoundingCircleOuterDiameter(cold=True),
         )
 
         biggerID = max(idA, idB)

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -171,7 +171,9 @@ class AxialExpansionChanger:
                 for c in b:
                     growFrac = self.expansionData.getExpansionFactor(c)
                     runLog.debug(
-                        msg="      Component {0}, growFrac = {1:.4e}".format(c, growFrac)
+                        msg="      Component {0}, growFrac = {1:.4e}".format(
+                            c, growFrac
+                        )
                     )
                     if growFrac >= 0.0:
                         c.height = (1.0 + growFrac) * blockHeight
@@ -192,7 +194,9 @@ class AxialExpansionChanger:
                     c.ztop = c.zbottom + c.height
                     # redistribute block boundaries if on the target component
                     if self.expansionData.isTargetComponent(c):
-                        runLog.debug("      Component {0} is target component".format(c))
+                        runLog.debug(
+                            "      Component {0} is target component".format(c)
+                        )
                         b.p.ztop = c.ztop
 
             # see also b.setHeight()
@@ -417,7 +421,7 @@ class AssemblyAxialLinkage:
             key to access blocks containing linked components
         c : :py:class:`Component <armi.reactor.components.component.Component>` object
             component to determine axial linkage for
-        
+
         Raises
         ------
         RuntimeError
@@ -432,9 +436,7 @@ class AssemblyAxialLinkage:
                             errMsg = (
                                 "Multiple component axial linkages have been found for Component {0}; Block {1}."
                                 " This is indicative of an error in the blueprints! Linked components found are"
-                                "{2} and {3}".format(
-                                    c, b, lstLinkedC[ib], otherC
-                                )
+                                "{2} and {3}".format(c, b, lstLinkedC[ib], otherC)
                             )
                             runLog.error(msg=errMsg)
                             raise RuntimeError(errMsg)

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -487,6 +487,7 @@ def _determineLinked(componentA, componentB):
         biggerID = max(idA, idB)
         smallerOD = min(odA, odB)
         if biggerID >= smallerOD:
+            # one object fits inside the other
             linked = False
         else:
             linked = True

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -152,8 +152,12 @@ class AxialExpansionChanger:
         """
         mesh = [0.0]
         numOfBlocks = self.linked.a.countBlocksWithFlags()
+        runLog.debug(
+            "Printing component expansion information (growth percentage and 'target component')"
+            "for each block in assembly {0}.".format(self.linked.a)
+        )
         for ib, b in enumerate(self.linked.a):
-            runLog.debug(msg="Block {0}".format(b))
+            runLog.debug(msg="  Block {0}".format(b))
             if thermal:
                 blockHeight = b.p.heightBOL
             else:
@@ -167,7 +171,7 @@ class AxialExpansionChanger:
                 for c in b:
                     growFrac = self.expansionData.getExpansionFactor(c)
                     runLog.debug(
-                        msg="    Component {0}, growFrac = {1:.4e}".format(c, growFrac)
+                        msg="      Component {0}, growFrac = {1:.4e}".format(c, growFrac)
                     )
                     if growFrac >= 0.0:
                         c.height = (1.0 + growFrac) * blockHeight
@@ -188,7 +192,7 @@ class AxialExpansionChanger:
                     c.ztop = c.zbottom + c.height
                     # redistribute block boundaries if on the target component
                     if self.expansionData.isTargetComponent(c):
-                        runLog.debug("    Component {0} is target component".format(c))
+                        runLog.debug("      Component {0} is target component".format(c))
                         b.p.ztop = c.ztop
 
             # see also b.setHeight()

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -166,7 +166,9 @@ class AxialExpansionChanger:
             if ib < (numOfBlocks - 1):
                 for c in b:
                     growFrac = self.expansionData.getExpansionFactor(c)
-                    runLog.debug(msg="    Component {0}, growFrac = {1:.4e}".format(c,growFrac))
+                    runLog.debug(
+                        msg="    Component {0}, growFrac = {1:.4e}".format(c, growFrac)
+                    )
                     if growFrac >= 0.0:
                         c.height = (1.0 + growFrac) * blockHeight
                     else:

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -417,6 +417,11 @@ class AssemblyAxialLinkage:
             key to access blocks containing linked components
         c : :py:class:`Component <armi.reactor.components.component.Component>` object
             component to determine axial linkage for
+        
+        Raises
+        ------
+        RuntimeError
+            multiple candidate components are found to be axially linked to a component
         """
         lstLinkedC = [None, None]
         for ib, linkdBlk in enumerate(self.linkedBlocks[b]):
@@ -424,13 +429,15 @@ class AssemblyAxialLinkage:
                 for otherC in linkdBlk.getChildren():
                     if _determineLinked(c, otherC):
                         if lstLinkedC[ib] is not None:
-                            runLog.warning(
-                                msg="Multiple component axial linkages have been found for "
-                                "Component {0}; Block {1}. This Component will be axially linked "
-                                "to Component {2}; Block {3}.".format(
-                                    c, b, otherC, linkdBlk
+                            errMsg = (
+                                "Multiple component axial linkages have been found for Component {0}; Block {1}."
+                                " This is indicative of an error in the blueprints! Linked components found are"
+                                "{2} and {3}".format(
+                                    c, b, lstLinkedC[ib], otherC
                                 )
                             )
+                            runLog.error(msg=errMsg)
+                            raise RuntimeError(errMsg)
                         lstLinkedC[ib] = otherC
 
         self.linkedComponents[c] = lstLinkedC

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -421,7 +421,11 @@ class AssemblyAxialLinkage:
                     if _determineLinked(c, otherC):
                         if lstLinkedC[ib] is not None:
                             runLog.warning(
-                                msg="There is already something linked here!"
+                                msg="Multiple component axial linkages have been found for "
+                                "Component {0}; Block {1}. This Component will be axially linked "
+                                "to Component {2}; Block {3}.".format(
+                                    c, b, otherC, linkdBlk
+                                )
                             )
                         lstLinkedC[ib] = otherC
 

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -461,7 +461,7 @@ def _determineLinked(componentA, componentB):
 
     Notes
     -----
-    - Requires that shapes have the getBoundingCircleInnerDiameter and getBoundingCircleOuterDiameter defined
+    - Requires that shapes have the getCircleInnerDiameter and getBoundingCircleOuterDiameter defined
     - For axial linkage to be True, components MUST be solids, the same Component Class, multiplicity, and meet inner
       and outer diameter requirements.
 
@@ -476,11 +476,11 @@ def _determineLinked(componentA, componentB):
         and (componentA.getDimension("mult") == componentB.getDimension("mult"))
     ):
         idA, odA = (
-            componentA.getBoundingCircleInnerDiameter(),
+            componentA.getCircleInnerDiameter(),
             componentA.getBoundingCircleOuterDiameter(),
         )
         idB, odB = (
-            componentB.getBoundingCircleInnerDiameter(),
+            componentB.getCircleInnerDiameter(),
             componentB.getBoundingCircleOuterDiameter(),
         )
 

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -339,13 +339,14 @@ class TestDerivedShape(TestShapedComponent):
 
 class TestCircle(TestShapedComponent):
     componentCls = Circle
+    _id = 5.0
     _od = 10
     _coldTemp = 25.0
     componentDims = {
         "Tinput": _coldTemp,
         "Thot": 25.0,
         "od": _od,
-        "id": 5.0,
+        "id": _id,
         "mult": 1.5,
     }
 
@@ -383,6 +384,10 @@ class TestCircle(TestShapedComponent):
         ref = self._od
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
+
+    def test_getBoundingCircleInnerDiameter(self):
+        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
+        self.assertAlmostEqual(self._id, cur)
 
     def test_dimensionThermallyExpands(self):
         expandedDims = ["od", "id", "mult"]
@@ -540,6 +545,10 @@ class TestRectangle(TestShapedComponent):
         ref = math.sqrt(61.0)
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
+    
+    def test_getBoundingCircleInnerDiameter(self):
+        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
+        self.assertAlmostEqual(math.sqrt(25.0), cur)
 
     def test_getArea(self):
         outerL = self.component.getDimension("lengthOuter")
@@ -647,6 +656,11 @@ class TestSquare(TestShapedComponent):
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
+    def test_getBoundingCircleInnerDiameter(self):
+        ref = math.sqrt(8.0)
+        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
+        self.assertAlmostEqual(ref, cur)
+
     def test_getArea(self):
         outerW = self.component.getDimension("widthOuter")
         innerW = self.component.getDimension("widthInner")
@@ -744,6 +758,11 @@ class TestHexagon(TestShapedComponent):
     def test_getBoundingCircleOuterDiameter(self):
         ref = 2.0 * 10 / math.sqrt(3)
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
+        self.assertAlmostEqual(ref, cur)
+
+    def test_getBoundingCircleInnerDiameter(self):
+        ref = 2.0 * 5.0 / math.sqrt(3)
+        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
     def test_getArea(self):
@@ -902,6 +921,11 @@ class TestHelix(TestShapedComponent):
     def test_getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
         ref = 0.25 + 2.0
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
+        self.assertAlmostEqual(ref, cur)
+
+    def test_getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+        ref = 0.1 + 2.0
+        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
     def test_getArea(self):

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -545,7 +545,7 @@ class TestRectangle(TestShapedComponent):
         ref = math.sqrt(61.0)
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
-    
+
     def test_getBoundingCircleInnerDiameter(self):
         cur = self.component.getBoundingCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(math.sqrt(25.0), cur)

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -385,8 +385,8 @@ class TestCircle(TestShapedComponent):
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
-    def test_getBoundingCircleInnerDiameter(self):
-        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
+    def test_getCircleInnerDiameter(self):
+        cur = self.component.getCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(self._id, cur)
 
     def test_dimensionThermallyExpands(self):
@@ -546,8 +546,8 @@ class TestRectangle(TestShapedComponent):
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
-    def test_getBoundingCircleInnerDiameter(self):
-        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
+    def test_getCircleInnerDiameter(self):
+        cur = self.component.getCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(math.sqrt(25.0), cur)
 
     def test_getArea(self):
@@ -656,9 +656,9 @@ class TestSquare(TestShapedComponent):
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
-    def test_getBoundingCircleInnerDiameter(self):
+    def test_getCircleInnerDiameter(self):
         ref = math.sqrt(8.0)
-        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
+        cur = self.component.getCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
     def test_getArea(self):
@@ -760,9 +760,9 @@ class TestHexagon(TestShapedComponent):
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
-    def test_getBoundingCircleInnerDiameter(self):
+    def test_getCircleInnerDiameter(self):
         ref = 2.0 * 5.0 / math.sqrt(3)
-        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
+        cur = self.component.getCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
     def test_getArea(self):
@@ -923,9 +923,9 @@ class TestHelix(TestShapedComponent):
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
-    def test_getBoundingCircleInnerDiameter(self, Tc=None, cold=False):
+    def test_getCircleInnerDiameter(self, Tc=None, cold=False):
         ref = 0.1 + 2.0
-        cur = self.component.getBoundingCircleInnerDiameter(cold=True)
+        cur = self.component.getCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
     def test_getArea(self):


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description
The current methodology for determining component axial linkage was found to be error prone. The current approach requires that Components be the same class type and have an area with an absolute difference of 10^-3. For some cases, this can provide false positive linkage. To improve this, an overhaul of the methodology was undertaken. In this PR, this methodology is updated/upgraded to to account for the following: 1) Component classes must be solids, 2) the same class type, 3) have the same multiplicity, 4) and meet overlap criteria. A `runLog.warning` has also been added if a Component is found to be linked to multiple Components in a neighboring block.

The methodology can be found in `axialExpansionChanger.py::AssemblyAxialLinkage::_determineAxialLinkage`. Several relevant unit tests have been added to cover various expected cases - see `test_AxialExpansionChanger.py::TestLinkage`. Other unit tests have also been added to maintain coverage in `basicShapes.py` and `complexShapes.py`.  

<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.