### PR TITLE
Improving code coverage and removing unused imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -434,6 +434,6 @@ only use third-party Python libraries that have MIT or BSD licenses.
 .. |Build Status| image:: https://github.com/terrapower/armi/actions/workflows/unittests.yaml/badge.svg?branch=master
     :target: https://github.com/terrapower/armi/actions/workflows/unittests.yaml
 
-.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=master&kill_cache=0
+.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=master&kill_cache=9
     :target: https://coveralls.io/github/terrapower/armi?branch=master
 

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -68,12 +68,10 @@ Specifying blocks and assemblies to track
 See :ref:`detail-assems`.
 
 """
-import re
-import os
 from collections import OrderedDict
 from typing import Tuple
+import re
 
-import numpy
 from matplotlib import pyplot
 import tabulate
 
@@ -81,9 +79,9 @@ from armi import interfaces
 from armi import runLog
 from armi import utils
 from armi import operators
-from armi.utils import textProcessors
 from armi.reactor.flags import Flags
 from armi.reactor import grids
+from armi.utils import textProcessors
 
 ORDER = 2 * interfaces.STACK_ORDER.BEFORE + interfaces.STACK_ORDER.BOOKKEEPING
 

--- a/armi/cli/reportsEntryPoint.py
+++ b/armi/cli/reportsEntryPoint.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pathlib
 import webbrowser
 
 from armi import getPluginManagerOrFail

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -19,6 +19,7 @@ import sys
 import unittest
 
 from armi.__main__ import main
+from armi.bookkeeping.visualization.entryPoint import VisFileEntryPoint
 from armi.cli.checkInputs import CheckInputEntryPoint, ExpandBlueprints
 from armi.cli.clone import CloneArmiRunCommandBatch, CloneSuiteCommand
 from armi.cli.compareCases import CompareCases, CompareSuites
@@ -91,6 +92,7 @@ class TestConvertDB(unittest.TestCase):
         cdb.parse_args(["/path/to/fake.h5"])
 
         self.assertEqual(cdb.name, "convert-db")
+        self.assertEqual(cdb.args.output_version, "3")
         self.assertIsNone(cdb.args.nodes)
 
         # Since the file is fake, invoke() should exit early.
@@ -99,6 +101,18 @@ class TestConvertDB(unittest.TestCase):
             with self.assertRaises(ValueError):
                 cdb.invoke()
             self.assertIn("Converting the", mock._outputStream)
+
+    def test_convertDbOutputVersion(self):
+        cdb = ConvertDB()
+        cdb.addOptions()
+        cdb.parse_args(["/path/to/fake.h5", "--output-version", "XtView"])
+        self.assertEqual(cdb.args.output_version, "2")
+
+    def test_convertDbOutputNodes(self):
+        cdb = ConvertDB()
+        cdb.addOptions()
+        cdb.parse_args(["/path/to/fake.h5", "--nodes", "(1,2)"])
+        self.assertEqual(cdb.args.nodes, [(1, 2)])
 
 
 class TestCopyDB(unittest.TestCase):
@@ -227,6 +241,16 @@ class TestRunSuiteCommand(unittest.TestCase):
 
         self.assertEqual(rs.name, "run-suite")
         self.assertIsNone(rs.settingsArgument)
+
+
+class TestVisFileEntryPointCommand(unittest.TestCase):
+    def test_visFileEntryPointBasics(self):
+        vf = VisFileEntryPoint()
+        vf.addOptions()
+        vf.parse_args(["/path/to/fake.h5"])
+
+        self.assertEqual(vf.name, "vis-file")
+        self.assertIsNone(vf.settingsArgument)
 
 
 if __name__ == "__main__":

--- a/armi/context.py
+++ b/armi/context.py
@@ -26,7 +26,6 @@ import enum
 import gc
 import getpass
 import os
-import shutil
 import sys
 import time
 

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -14,7 +14,6 @@
 
 """Test the Lattice Interface"""
 
-import os
 import unittest
 
 from armi.physics.neutronics.latticePhysics.latticePhysicsInterface import (

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -14,7 +14,6 @@
 
 """Test the Lattice Physics Writer"""
 
-import os
 import unittest
 
 from armi.physics.neutronics.const import CONF_CROSS_SECTION

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -31,7 +31,6 @@ See Also: :doc:`/developer/index`.
 """
 import collections
 import itertools
-import math
 import timeit
 from typing import Dict, Optional, Type, Tuple, List, Union
 

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -21,7 +21,9 @@ from armi import runLog
 from armi import settings
 from armi.nucDirectory import nucDir, nuclideBases
 from armi import utils
-
+from armi.physics.neutronics.fissionProductModel.tests.test_lumpedFissionProduct import (
+    getDummyLFPFile,
+)
 from armi.reactor import components
 from armi.reactor import composites
 from armi.reactor import assemblies
@@ -30,7 +32,6 @@ from armi.reactor import grids
 from armi.reactor.blueprints import assemblyBlueprint
 from armi.reactor import parameters
 from armi.reactor.flags import Flags
-
 from armi.reactor.tests.test_blocks import loadTestBlock
 
 
@@ -212,6 +213,39 @@ class TestCompositePattern(unittest.TestCase):
         self.assertAlmostEqual(self.container.getVolume(), 0)
         self.container._updateVolume()
         self.assertAlmostEqual(self.container.getVolume(), 0)
+
+    def test_expandLFPs(self):
+        # simple test, with no lumped fission product mappings
+        numDens = {"NA23": 1.0}
+        numDens = self.container._expandLFPs(numDens)
+        self.assertEqual(len(numDens), 1)
+
+        # set the lumped fission product mapping
+        fpd = getDummyLFPFile()
+        lfps = fpd.createLFPsFromFile()
+        self.container.setLumpedFissionProducts(lfps)
+
+        # get back the lumped fission product mapping, just to check
+        lfp = self.container.getLumpedFissionProductCollection()
+        self.assertEqual(len(lfp), 3)
+        self.assertIn("LFP35", lfp)
+        self.assertIn("LFP38", lfp)
+        self.assertIn("LFP39", lfp)
+
+        # quick test WITH some lumped fission products in the mix
+        numDens = {"NA23": 1.0, "LFP35": 2.0}
+        numDens = self.container._expandLFPs(numDens)
+        self.assertEqual(len(numDens), 9)
+        self.assertEqual(numDens["MO99"], 0)
+
+    def test_getIntegratedMgFlux(self):
+        mgFlux = self.container.getIntegratedMgFlux()
+        self.assertEqual(mgFlux, [0.0])
+
+    def test_getReactionRates(self):
+        rRates = self.container.getReactionRates("U235")
+        self.assertEqual(len(rRates), 6)
+        self.assertEqual(sum([r for r in rRates.values()]), 0)
 
 
 class TestCompositeTree(unittest.TestCase):

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -16,15 +16,12 @@
 :py:class:`~armi.settings.caseSettings.Settings`, and the contained
 :py:class:`~armi.settings.setting.Setting`.
 """
-import ast
+from typing import Dict, Tuple, Set
 import collections
 import datetime
 import enum
 import os
-import re
-from typing import Dict, Tuple, Set
 import sys
-import warnings
 
 from ruamel.yaml import YAML
 import ruamel.yaml.comments

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -118,6 +118,29 @@ class TestApps(unittest.TestCase):
         ):
             app.getParamRenames()
 
+    def test_getParamRenamesInvalids(self):
+        # a basic test of the method
+        app = getApp()
+        app.pluginManager.register(TestPlugin1)
+        app.pluginManager.register(TestPlugin4)
+        app._paramRenames = None  # need to implement better cache invalidation rules
+
+        renames = app.getParamRenames()
+
+        self.assertIn("oldType", renames)
+        self.assertEqual(renames["oldType"], "type")
+        self.assertIn("arealPD", renames)
+        self.assertEqual(renames["arealPD"], "arealPowerDensity")
+
+        # test the strange, invalid case
+        self.assertIsNotNone(app._paramRenames)
+        app._pm._counter = -1
+        renames = app.getParamRenames()
+        self.assertIn("oldType", renames)
+        self.assertEqual(renames["oldType"], "type")
+        self.assertIn("arealPD", renames)
+        self.assertEqual(renames["arealPD"], "arealPowerDensity")
+
     def test_version(self):
         app = getApp()
         ver = app.version

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -26,10 +26,7 @@ mpiexec.exe -n 2 python -m pytest armi/tests/test_mpiFeatures.py
 # pylint: disable=abstract-method,no-self-use,unused-argument
 from distutils.spawn import find_executable
 import os
-import subprocess
 import unittest
-
-import pytest
 
 from armi import context
 from armi import mpiActions

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -370,6 +370,20 @@ class TestRunLogger(unittest.TestCase):
         self.rl.allowStopDuplicates()
         self.assertEqual(len(self.rl.filters), 1)
 
+    def test_write(self):
+        # divert the logging to a stream, to make testing easier
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        self.rl.handlers = [handler]
+
+        # log some things
+        testName = "test_write"
+        self.rl.write(testName)
+
+        # test what was logged
+        streamVal = stream.getvalue()
+        self.assertIn(testName, streamVal, msg=streamVal)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -342,10 +342,9 @@ class TestRunLog(unittest.TestCase):
         with TemporaryDirectoryChanger():
             logDir = "test_createLogDir"
             self.assertFalse(os.path.exists(logDir))
-            runLog.createLogDir(logDir)
-            self.assertTrue(os.path.exists(logDir))
-            runLog.createLogDir(logDir)
-            self.assertTrue(os.path.exists(logDir))
+            for _ in range(10):
+                runLog.createLogDir(logDir)
+                self.assertTrue(os.path.exists(logDir))
 
 
 class TestRunLogger(unittest.TestCase):

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -349,7 +349,6 @@ class TestRunLog(unittest.TestCase):
 
 class TestRunLogger(unittest.TestCase):
     def setUp(self):
-        # pass
         self.rl = runLog.RunLogger("ARMI|things_and_stuff|0")
 
     def test_getDuplicatesFilter(self):
@@ -358,6 +357,18 @@ class TestRunLogger(unittest.TestCase):
 
         self.rl.filters = []
         self.assertIsNone(self.rl.getDuplicatesFilter())
+
+    def test_allowStopDuplicates(self):
+        # the usual case, where the DeduplicateFilter already exists
+        self.assertEqual(len(self.rl.filters), 1)
+        self.rl.allowStopDuplicates()
+        self.assertEqual(len(self.rl.filters), 1)
+
+        # the unusual case, where the DeduplicateFilter isn't there
+        self.rl.filters = []
+        self.assertEqual(len(self.rl.filters), 0)
+        self.rl.allowStopDuplicates()
+        self.assertEqual(len(self.rl.filters), 1)
 
 
 if __name__ == "__main__":

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -44,9 +44,7 @@ The grid editor may be invoked with the :py:mod:`armi.cli.gridGui` entry point::
   in computer graphics.
 
 """
-
 import colorsys
-import copy
 import enum
 import io
 import os
@@ -69,7 +67,6 @@ from armi.reactor import geometry
 from armi.reactor import grids
 from armi.reactor import blueprints
 from armi.reactor.flags import Flags
-import armi.reactor.blueprints
 from armi.reactor.blueprints import Blueprints, gridBlueprint, migrate
 from armi.reactor.blueprints.gridBlueprint import GridBlueprint, saveToStream
 from armi.reactor.blueprints.assemblyBlueprint import AssemblyBlueprint

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -16,7 +16,6 @@ r""" Testing some utility functions
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,too-many-public-methods,invalid-name
 from collections import defaultdict
-import math
 import unittest
 
 import numpy as np


### PR DESCRIPTION
## Description

Currently, if you run the ARMI unit tests 10 times in a row you get 10 slightly different code coverages.

This PR attempts to close the gap, so that no longer happens.

Also, I removed a bunch of unused imports.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
