### PR TITLE
Fix setting the target component in axialExpansion

### DIFF
--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -670,7 +670,7 @@ class ExpansionData:
         Notes
         -----
         - if flagOfInterest is None, finds the component within b that contains flags that
-          are defined in a preferred order of flags, or barring that, in b.p.flags 
+          are defined in a preferred order of flags, or barring that, in b.p.flags
         - if flagOfInterest is not None, finds the component that contains the flagOfInterest.
 
         Raises
@@ -691,13 +691,13 @@ class ExpansionData:
             ]
             for targetFlag in targetFlagsInPreferedOrder:
                 componentWFlag = [c for c in b.getChildren() if c.hasFlags(targetFlag)]
-                if componentWFlag != []:  # or just `if componentWFlag`
+                if componentWFlag != []:
                     break
+            # some blocks/components are not included in the above list but should still be found
+            if not componentWFlag:
+                componentWFlag = [c for c in b.getChildren() if c.p.flags in b.p.flags]
         else:
             componentWFlag = [c for c in b.getChildren() if c.hasFlags(flagOfInterest)]
-        # some blocks/components are not included in the above list but should still be found
-        if not componentWFlag:
-            componentWFlag = [c for c in b.getChildren() if c.p.flags in b.p.flags]
         if len(componentWFlag) == 0:
             raise RuntimeError("No target component found!\n   Block {0}".format(b))
         if len(componentWFlag) > 1:

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -682,10 +682,6 @@ class ExpansionData:
         """
 
         if flagOfInterest is None:
-            componentWFlag = [c for c in b.getChildren() if c.p.flags in b.p.flags]
-        else:
-            componentWFlag = [c for c in b.getChildren() if c.hasFlags(flagOfInterest)]
-        if len(componentWFlag) > 1:
             # Follow expansion of most neutronically important component, fuel first then control/poison
             targetFlagsInPreferedOrder = [
                 Flags.FUEL,
@@ -694,11 +690,14 @@ class ExpansionData:
                 Flags.SHIELD,
             ]
             for targetFlag in targetFlagsInPreferedOrder:
-                for c in componentWFlag:
-                    if targetFlag in c.p.flags:
-                        componentWFlag = [c]
-                    if len(componentWFlag) == 1:
-                        break
+                componentWFlag = [c for c in b.getChildren() if c.hasFlags(targetFlag)]
+                if componentWFlag != []:  # or just `if componentWFlag`
+                    break
+        else:
+            componentWFlag = [c for c in b.getChildren() if c.hasFlags(flagOfInterest)]
+        # some blocks/components are not included in the above list but should still be found
+        if not componentWFlag:
+            componentWFlag = [c for c in b.getChildren() if c.p.flags in b.p.flags]
         if len(componentWFlag) == 0:
             raise RuntimeError("No target component found!\n   Block {0}".format(b))
         if len(componentWFlag) > 1:

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -680,10 +680,25 @@ class ExpansionData:
         RuntimeError
             multiple target components found
         """
+
         if flagOfInterest is None:
             componentWFlag = [c for c in b.getChildren() if c.p.flags in b.p.flags]
         else:
             componentWFlag = [c for c in b.getChildren() if c.hasFlags(flagOfInterest)]
+        if len(componentWFlag) > 1:
+            # Follow expansion of most neutronically important component, fuel first then control/poison
+            targetFlagsInPreferedOrder = [
+                Flags.FUEL,
+                Flags.CONTROL,
+                Flags.POISON,
+                Flags.SHIELD,
+            ]
+            for targetFlag in targetFlagsInPreferedOrder:
+                for c in componentWFlag:
+                    if targetFlag in c.p.flags:
+                        componentWFlag = [c]
+                    if len(componentWFlag) == 1:
+                        break
         if len(componentWFlag) == 0:
             raise RuntimeError("No target component found!\n   Block {0}".format(b))
         if len(componentWFlag) > 1:

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -670,7 +670,7 @@ class ExpansionData:
         Notes
         -----
         - if flagOfInterest is None, finds the component within b that contains flags that
-          are defined in b.p.flags
+          are defined in a preferred order of flags, or barring that, in b.p.flags 
         - if flagOfInterest is not None, finds the component that contains the flagOfInterest.
 
         Raises

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -18,6 +18,13 @@ from numpy import array
 from armi import runLog
 from armi.reactor.flags import Flags
 
+TARGET_FLAGS_IN_PREFERRED_ORDER = [
+    Flags.FUEL,
+    Flags.CONTROL,
+    Flags.POISON,
+    Flags.SHIELD,
+]
+
 
 class AxialExpansionChanger:
     """
@@ -683,13 +690,7 @@ class ExpansionData:
 
         if flagOfInterest is None:
             # Follow expansion of most neutronically important component, fuel first then control/poison
-            targetFlagsInPreferedOrder = [
-                Flags.FUEL,
-                Flags.CONTROL,
-                Flags.POISON,
-                Flags.SHIELD,
-            ]
-            for targetFlag in targetFlagsInPreferedOrder:
+            for targetFlag in TARGET_FLAGS_IN_PREFERRED_ORDER:
                 componentWFlag = [c for c in b.getChildren() if c.hasFlags(targetFlag)]
                 if componentWFlag != []:
                     break

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -531,7 +531,8 @@ class TestExceptions(Base, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_specifyTargetComponentBlockWithMultipleFlags(self):
-        # build block for testing
+        # build a block that has two flags as well as a component matching each
+        # flag
         b = HexBlock("fuel poison", height=10.0)
         fuelDims = {"Tinput": 25.0, "Thot": 600.0, "od": 0.9, "id": 0.5, "mult": 200.0}
         poisonDims = {"Tinput": 25.0, "Thot": 400.0, "od": 0.5, "id": 0.0, "mult": 10.0}

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -530,6 +530,20 @@ class TestExceptions(Base, unittest.TestCase):
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
 
+    def test_specifyTargetComponentBlockWithMultipleFlags(self):
+        # build block for testing
+        b = HexBlock("fuel poison", height=10.0)
+        fuelDims = {"Tinput": 25.0, "Thot": 600.0, "od": 0.9, "id": 0.5, "mult": 200.0}
+        poisonDims = {"Tinput": 25.0, "Thot": 400.0, "od": 0.5, "id": 0.0, "mult": 10.0}
+        fuel = Circle("fuel", "FakeMat", **fuelDims)
+        poison = Circle("poison", "FakeMat", **poisonDims)
+        b.add(fuel)
+        b.add(poison)
+        try:
+            self.obj.expansionData.specifyTargetComponent(b)
+        except RuntimeError:
+            self.fail()
+
     def test_isFuelLocked(self):
         b_TwoFuel = HexBlock("fuel", height=10.0)
         fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.76, "id": 0.00, "mult": 127.0}


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

If more than one flag is in a block definition, the `specifyTargetComponent` method would fail with a Runtime error. The proposed fix is to loop the through a list of flags in order of importance break the loop once one of those flags matches. Still, this list of flags is incomplete so it is possible that `componentWFlag` would remain empty. In this case the original behavior is retained. 

The unit test is a little redundant (testing that a RuntimeError is not raised, which is implicit in testing?) but I felt it important to be explicit there. Definitely willing to do something different. 

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.
