### PR TITLE
Fix - Yamlize docstrings are being forcably inherited

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -434,6 +434,6 @@ only use third-party Python libraries that have MIT or BSD licenses.
 .. |Build Status| image:: https://github.com/terrapower/armi/actions/workflows/unittests.yaml/badge.svg?branch=master
     :target: https://github.com/terrapower/armi/actions/workflows/unittests.yaml
 
-.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=master&kill_cache=9
+.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=master&kill_cache=7
     :target: https://coveralls.io/github/terrapower/armi?branch=master
 

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -150,8 +150,8 @@ class TestRunLog(unittest.TestCase):
         def returnNone(*args, **kwargs):
             return None
 
-        log.getDuplicatesFilter = returnNone
-        self.assertIsNone(log.getDuplicatesFilter())
+        log.logger.getDuplicatesFilter = returnNone
+        self.assertIsNone(log.logger.getDuplicatesFilter())
 
         # run the warning report
         log.warningReport()
@@ -161,9 +161,9 @@ class TestRunLog(unittest.TestCase):
         # test what was logged
         streamVal = stream.getvalue()
         self.assertIn(testName, streamVal, msg=streamVal)
-        self.assertNotIn("None Found", streamVal, msg=streamVal)
+        self.assertIn("None Found", streamVal, msg=streamVal)
         self.assertNotIn("invisible", streamVal, msg=streamVal)
-        self.assertEqual(streamVal.count(testName), 2, msg=streamVal)
+        self.assertEqual(streamVal.count(testName), 1, msg=streamVal)
 
     def test_closeLogging(self):
         """A basic test of the close() functionality"""

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -75,6 +75,15 @@ def autodoc_skip_member_handler(app, what, name, obj, skip, options):
     """Manually exclude certain methods/functions from docs"""
     # exclude special methods from unittest
     excludes = ["setUp", "setUpClass", "tearDown", "tearDownClass"]
+
+    try:
+        # special logic to fix inherited docstrings from yamlize.Attribute
+        s = str(obj).strip()
+        if s.startswith("<Attribute") and "_yamlized_" in s:
+            return True
+    except:
+        pass
+
     return name.startswith("_") or name in excludes
 
 


### PR DESCRIPTION
## Description

Generally, in our docs, we have solved a problem we were having: we were getting docstrings bleeding through from base classes. The only situation this hasn't been fixed for is where we use `Yamlize`. Particularly, subclasses of `yamlize.Object` have several `yamlize.Attribute`, which have terrible docstrings bleeding through from their base class.

After much puttering around, the only solution I can find is to omit these attributes from the docs entirely. This is perhaps not ideal, but at least the docs aren't _wrong_ any more.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
