### PR TITLE
Control rod assembly parameter renames

### DIFF
--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -196,9 +196,10 @@ def getAssemblyParameterDefinitions():
         )
 
         pb.defParam(
-            "crEndingElevation",
+            "crInsertedElevation",
             units="cm",
-            description="The final elevation of the bottom of the control material when fully inserted.",
+            description=("The final elevation of the bottom of the control material when fully inserted. Note that this should "
+                        "be considered a lower elevation than the ``crWithdrawnElevation`` by definition and modeling semantics."),
             categories=[parameters.Category.assignInBlueprints],
             saveToDB=True,
         )
@@ -211,9 +212,10 @@ def getAssemblyParameterDefinitions():
         )
 
         pb.defParam(
-            "crStartingElevation",
+            "crWithdrawnElevation",
             units="cm",
-            description="The initial starting elevation of the moveable section of a control rod assembly when fully withdrawn.",
+            description=("The initial starting elevation of the moveable section of a control rod assembly when fully withdrawn.  Note that this should "
+                         "be considered a higher elevation than the ``crInsertedElevation`` by definition and modeling semantics."),
             categories=[parameters.Category.assignInBlueprints],
             saveToDB=True,
         )

--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -198,8 +198,10 @@ def getAssemblyParameterDefinitions():
         pb.defParam(
             "crInsertedElevation",
             units="cm",
-            description=("The final elevation of the bottom of the control material when fully inserted. Note that this should "
-                        "be considered a lower elevation than the ``crWithdrawnElevation`` by definition and modeling semantics."),
+            description=(
+                "The final elevation of the bottom of the control material when fully inserted. Note that this should "
+                "be considered a lower elevation than the ``crWithdrawnElevation`` by definition and modeling semantics."
+            ),
             categories=[parameters.Category.assignInBlueprints],
             saveToDB=True,
         )
@@ -214,8 +216,10 @@ def getAssemblyParameterDefinitions():
         pb.defParam(
             "crWithdrawnElevation",
             units="cm",
-            description=("The initial starting elevation of the moveable section of a control rod assembly when fully withdrawn.  Note that this should "
-                         "be considered a higher elevation than the ``crInsertedElevation`` by definition and modeling semantics."),
+            description=(
+                "The initial starting elevation of the moveable section of a control rod assembly when fully withdrawn.  Note that this should "
+                "be considered a higher elevation than the ``crInsertedElevation`` by definition and modeling semantics."
+            ),
             categories=[parameters.Category.assignInBlueprints],
             saveToDB=True,
         )

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -14,6 +14,7 @@ What's new in ARMI
 #. Minor code re-org, moving math utilities into their own module.
 #. Removed the ``PyYaml`` dependency.
 #. Removed all bare ``import armi`` statements, for code clarity.
+#. Renamed control rod assembly parameters for generic implementations of control rod handling.
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

Control rod parameter renames from `crStartingElevation` and `crEndingElevation` to `crWithdrawnElevation` and `crInsertedElevation` for clarity in modeling.

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.
- [x] New or updated dependencies have been added to `setup.py`.
