### PR TITLE
Fix MPI hanging bug.

### DIFF
--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -174,6 +174,7 @@ class MainInterface(interfaces.Interface):
             node = int(snapText[3:])
             newFolder = "snapShot{0}_{1}".format(cycle, node)
             utils.pathTools.cleanPath(newFolder)
+            context.waitAll()
 
         # delete database if it's SQLlite
         # no need to delete because the database won't have copied it back if using fastpath.
@@ -181,8 +182,12 @@ class MainInterface(interfaces.Interface):
         # clean temp directories.
         if os.path.exists("shuffleBranches"):
             utils.pathTools.cleanPath("shuffleBranches")
+            context.waitAll()
+            # Potentially, wait for all the processes to catch up.
+
         if os.path.exists("failedRuns"):
             utils.pathTools.cleanPath("failedRuns")
+            context.waitAll()
 
     # pylint: disable=no-self-use
     def cleanLastCycleFiles(self):

--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -23,7 +23,6 @@ import os
 import re
 import itertools
 
-from armi import context
 from armi import interfaces
 from armi import runLog
 from armi import utils
@@ -174,16 +173,16 @@ class MainInterface(interfaces.Interface):
             cycle = int(snapText[0:3])
             node = int(snapText[3:])
             newFolder = "snapShot{0}_{1}".format(cycle, node)
-            utils.pathTools.cleanPath(newFolder, context.MPI_RANK)
+            utils.pathTools.cleanPath(newFolder)
 
         # delete database if it's SQLlite
         # no need to delete because the database won't have copied it back if using fastpath.
 
         # clean temp directories.
         if os.path.exists("shuffleBranches"):
-            utils.pathTools.cleanPath("shuffleBranches", context.MPI_RANK)
+            utils.pathTools.cleanPath("shuffleBranches")
         if os.path.exists("failedRuns"):
-            utils.pathTools.cleanPath("failedRuns", context.MPI_RANK)
+            utils.pathTools.cleanPath("failedRuns")
 
     # pylint: disable=no-self-use
     def cleanLastCycleFiles(self):

--- a/armi/context.py
+++ b/armi/context.py
@@ -288,7 +288,7 @@ def waitAll() -> None:
     """
     If there are parallel processes running, wait for all to catch up to the checkpoint.
     """
-    if MPI_SIZE > 1 and MPI_DISTRIBUTABLE:
+    if MPI_SIZE > 1 and (MPI_DISTRIBUTABLE or not MPI_RANK == 0):
         MPI_COMM.barrier()
 
 

--- a/armi/context.py
+++ b/armi/context.py
@@ -147,7 +147,7 @@ if MPI_NODENAMES.index(MPI_NODENAME) == MPI_RANK:
 if MPI_COMM is not None:
     MPI_COMM.barrier()  # make sure app data exists before workers proceed.
 
-MPI_DISTRIBUTABLE = MPI_RANK == 0 and MPI_SIZE > 1
+MPI_DISTRIBUTABLE = MPI_SIZE > 1
 
 _FAST_PATH = os.path.join(os.getcwd())
 """
@@ -288,7 +288,7 @@ def waitAll() -> None:
     """
     If there are parallel processes running, wait for all to catch up to the checkpoint.
     """
-    if MPI_SIZE > 1 and (MPI_DISTRIBUTABLE or not MPI_RANK == 0):
+    if MPI_SIZE > 1 and MPI_DISTRIBUTABLE:
         MPI_COMM.barrier()
 
 

--- a/armi/context.py
+++ b/armi/context.py
@@ -238,7 +238,7 @@ def cleanTempDirs(olderThanDays=None):
                 file=sys.stdout,
             )
         try:
-            cleanPath(_FAST_PATH, mpiRank=MPI_RANK, barrier=False)
+            cleanPath(_FAST_PATH, mpiRank=MPI_RANK)
         except Exception as error:  # pylint: disable=broad-except
             for outputStream in (sys.stderr, sys.stdout):
                 if printMsg:
@@ -279,9 +279,17 @@ def cleanAllArmiTempDirs(olderThanDays: int) -> None:
             runIsOldAndLikleyComplete = (now - dateOfFolder) > gracePeriod
             if runIsOldAndLikleyComplete or fromThisRun:
                 # Delete old files
-                cleanPath(dirPath, mpiRank=MPI_RANK, barrier=False)
+                cleanPath(dirPath, mpiRank=MPI_RANK)
         except:  # pylint: disable=bare-except
             pass
+
+
+def waitAll() -> None:
+    """
+    If there are parallel processes running, wait for all to catch up to the checkpoint.
+    """
+    if MPI_SIZE > 1 and MPI_DISTRIBUTABLE:
+        MPI_COMM.barrier()
 
 
 def disconnectAllHdfDBs() -> None:

--- a/armi/context.py
+++ b/armi/context.py
@@ -238,7 +238,7 @@ def cleanTempDirs(olderThanDays=None):
                 file=sys.stdout,
             )
         try:
-            cleanPath(_FAST_PATH, mpiRank=MPI_RANK)
+            cleanPath(_FAST_PATH, mpiRank=MPI_RANK, barrier=False)
         except Exception as error:  # pylint: disable=broad-except
             for outputStream in (sys.stderr, sys.stdout):
                 if printMsg:

--- a/armi/context.py
+++ b/armi/context.py
@@ -238,7 +238,7 @@ def cleanTempDirs(olderThanDays=None):
                 file=sys.stdout,
             )
         try:
-            cleanPath(_FAST_PATH, MPI_RANK)
+            cleanPath(_FAST_PATH)
         except Exception as error:  # pylint: disable=broad-except
             for outputStream in (sys.stderr, sys.stdout):
                 if printMsg:
@@ -279,7 +279,7 @@ def cleanAllArmiTempDirs(olderThanDays: int) -> None:
             runIsOldAndLikleyComplete = (now - dateOfFolder) > gracePeriod
             if runIsOldAndLikleyComplete or fromThisRun:
                 # Delete old files
-                cleanPath(dirPath, MPI_RANK, barrier=False)
+                cleanPath(dirPath, barrier=False)
         except:  # pylint: disable=bare-except
             pass
 

--- a/armi/context.py
+++ b/armi/context.py
@@ -238,7 +238,7 @@ def cleanTempDirs(olderThanDays=None):
                 file=sys.stdout,
             )
         try:
-            cleanPath(_FAST_PATH)
+            cleanPath(_FAST_PATH, mpiRank=MPI_RANK)
         except Exception as error:  # pylint: disable=broad-except
             for outputStream in (sys.stderr, sys.stdout):
                 if printMsg:
@@ -279,7 +279,7 @@ def cleanAllArmiTempDirs(olderThanDays: int) -> None:
             runIsOldAndLikleyComplete = (now - dateOfFolder) > gracePeriod
             if runIsOldAndLikleyComplete or fromThisRun:
                 # Delete old files
-                cleanPath(dirPath, barrier=False)
+                cleanPath(dirPath, mpiRank=MPI_RANK, barrier=False)
         except:  # pylint: disable=bare-except
             pass
 

--- a/armi/context.py
+++ b/armi/context.py
@@ -279,7 +279,7 @@ def cleanAllArmiTempDirs(olderThanDays: int) -> None:
             runIsOldAndLikleyComplete = (now - dateOfFolder) > gracePeriod
             if runIsOldAndLikleyComplete or fromThisRun:
                 # Delete old files
-                cleanPath(dirPath, MPI_RANK)
+                cleanPath(dirPath, MPI_RANK, barrier=False)
         except:  # pylint: disable=bare-except
             pass
 

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -400,7 +400,7 @@ class DistributionAction(MpiAction):
 
         Notes
         =====
-        Two things about this method make it non-recursiv
+        Two things about this method make it non-recursive
         """
         canDistribute = context.MPI_DISTRIBUTABLE
         mpiComm = context.MPI_COMM
@@ -424,11 +424,11 @@ class DistributionAction(MpiAction):
         try:
             action = mpiComm.scatter(self._actions, root=0)
             # create a new communicator that only has these specific dudes running
-            context.MPI_DISTRIBUTABLE = False
             hasAction = action is not None
             context.MPI_COMM = mpiComm.Split(int(hasAction))
             context.MPI_RANK = context.MPI_COMM.Get_rank()
             context.MPI_SIZE = context.MPI_COMM.Get_size()
+            context.MPI_DISTRIBUTABLE = context.MPI_RANK == 0 and context.MPI_SIZE > 1
             context.MPI_NODENAMES = context.MPI_COMM.allgather(context.MPI_NODENAME)
             if hasAction:
                 actionResult = action.invoke(self.o, self.r, self.cs)

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -362,7 +362,10 @@ def runActionsInSerial(o, r, cs, actions):
     for aa, action in enumerate(actions):
         action.serial = True
         runLog.extra("Running action {} of {}: {}".format(aa + 1, numActions, action))
-        results.append(action.invoke(o, r, cs))
+        distrib = DistributionAction(action)
+        distrib.broadcast()
+        results.append(distrib.invoke(o, r, cs))
+        #results.append(action.invoke(o, r, cs))
         action.serial = False  # return to original state
     return results
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -1010,7 +1010,6 @@ class Operator:  # pylint: disable=too-many-public-methods
         if os.path.exists(newFolder):
             runLog.important("Deleting existing snapshot data in {0}".format(newFolder))
             pathTools.cleanPath(newFolder)  # careful with cleanPath!
-            context.waitAll()
             # give it a minute.
             time.sleep(1)
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -1010,6 +1010,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         if os.path.exists(newFolder):
             runLog.important("Deleting existing snapshot data in {0}".format(newFolder))
             pathTools.cleanPath(newFolder)  # careful with cleanPath!
+            context.waitAll()
             # give it a minute.
             time.sleep(1)
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -1009,7 +1009,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         newFolder = "snapShot{0}_{1}".format(cycle, node)
         if os.path.exists(newFolder):
             runLog.important("Deleting existing snapshot data in {0}".format(newFolder))
-            pathTools.cleanPath(newFolder, context.MPI_RANK)  # careful with cleanPath!
+            pathTools.cleanPath(newFolder)  # careful with cleanPath!
             # give it a minute.
             time.sleep(1)
 

--- a/armi/tests/armiRun.yaml
+++ b/armi/tests/armiRun.yaml
@@ -55,6 +55,7 @@ settings:
   refType: inner igniter fuel
   reloadDBName: reloadingDB.h5
   shuffleLogic: refSmallReactorShuffleLogic.py
+  smallRun: true
   summarizeAssemDesign: false
   targetK: 1.002
   transientForSensitivity: ''

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -258,14 +258,14 @@ class MpiPathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(filePath0))
             with self.assertRaises(Exception):
-                pathTools.cleanPath(filePath0)
+                pathTools.cleanPath(filePath0, mpiRank=context.MPI_RANK)
 
             # TEST 1: Delete a single file
             filePath1 = "test1_cleanPathNoMpi_mongoose"
             open(filePath1, "w").write("something")
 
             self.assertTrue(os.path.exists(filePath1))
-            pathTools.cleanPath(filePath1)
+            pathTools.cleanPath(filePath1, mpiRank=context.MPI_RANK)
             self.assertFalse(os.path.exists(filePath1))
 
             # TEST 2: Delete an empty directory
@@ -273,7 +273,7 @@ class MpiPathToolsTests(unittest.TestCase):
             os.mkdir(dir2)
 
             self.assertTrue(os.path.exists(dir2))
-            pathTools.cleanPath(dir2)
+            pathTools.cleanPath(dir2, mpiRank=context.MPI_RANK)
             self.assertFalse(os.path.exists(dir2))
 
             # TEST 3: Delete a directory with two files inside

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -28,7 +28,6 @@ from distutils.spawn import find_executable
 import os
 import unittest
 
-from armi import context
 from armi import mpiActions
 from armi import settings
 from armi.interfaces import Interface
@@ -258,14 +257,14 @@ class MpiPathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(filePath0))
             with self.assertRaises(Exception):
-                pathTools.cleanPath(filePath0, mpiRank=context.MPI_RANK)
+                pathTools.cleanPath(filePath0)
 
             # TEST 1: Delete a single file
             filePath1 = "test1_cleanPathNoMpi_mongoose"
             open(filePath1, "w").write("something")
 
             self.assertTrue(os.path.exists(filePath1))
-            pathTools.cleanPath(filePath1, mpiRank=context.MPI_RANK)
+            pathTools.cleanPath(filePath1)
             self.assertFalse(os.path.exists(filePath1))
 
             # TEST 2: Delete an empty directory
@@ -273,7 +272,7 @@ class MpiPathToolsTests(unittest.TestCase):
             os.mkdir(dir2)
 
             self.assertTrue(os.path.exists(dir2))
-            pathTools.cleanPath(dir2, mpiRank=context.MPI_RANK)
+            pathTools.cleanPath(dir2)
             self.assertFalse(os.path.exists(dir2))
 
             # TEST 3: Delete a directory with two files inside
@@ -289,7 +288,7 @@ class MpiPathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(dir3))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file1.txt")))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file2.txt")))
-            pathTools.cleanPath(dir3, mpiRank=context.MPI_RANK)
+            pathTools.cleanPath(dir3)
             self.assertFalse(os.path.exists(dir3))
 
 

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -28,6 +28,7 @@ from distutils.spawn import find_executable
 import os
 import unittest
 
+from armi import context
 from armi import mpiActions
 from armi import settings
 from armi.interfaces import Interface

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -292,7 +292,7 @@ class MpiPathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(dir3))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file1.txt")))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file2.txt")))
-            pathTools.cleanPath(dir3)
+            pathTools.cleanPath(dir3, mpiRank=context.MPI_RANK)
             context.waitAll()
             self.assertFalse(os.path.exists(dir3))
 

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -259,6 +259,7 @@ class MpiPathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(filePath0))
             with self.assertRaises(Exception):
                 pathTools.cleanPath(filePath0, mpiRank=context.MPI_RANK)
+            context.waitAll()
 
             # TEST 1: Delete a single file
             filePath1 = "test1_cleanPathNoMpi_mongoose"
@@ -266,6 +267,7 @@ class MpiPathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(filePath1))
             pathTools.cleanPath(filePath1, mpiRank=context.MPI_RANK)
+            context.waitAll()
             self.assertFalse(os.path.exists(filePath1))
 
             # TEST 2: Delete an empty directory
@@ -274,6 +276,7 @@ class MpiPathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(dir2))
             pathTools.cleanPath(dir2, mpiRank=context.MPI_RANK)
+            context.waitAll()
             self.assertFalse(os.path.exists(dir2))
 
             # TEST 3: Delete a directory with two files inside
@@ -290,6 +293,7 @@ class MpiPathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(dir3, "file1.txt")))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file2.txt")))
             pathTools.cleanPath(dir3)
+            context.waitAll()
             self.assertFalse(os.path.exists(dir3))
 
 

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -268,6 +268,7 @@ class TemporaryDirectoryChanger(DirectoryChanger):
                     "That is, if you create a directory with a name starting with a period, the "
                     "TempDirChanger will not be able to clean it (for instance, a '.git' dir)."
                 )
+        context.waitAll()
 
 
 class ForcedCreationDirectoryChanger(DirectoryChanger):

--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -167,7 +167,7 @@ def deleteCache(cachedFolder):
     """
     if "Output_Cache" not in cachedFolder:
         raise RuntimeError("Cache location must contain safeword: `Output_Cache`.")
-    cleanPath(cachedFolder, context.MPI_RANK)
+    cleanPath(cachedFolder)
 
 
 def cacheCall(

--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -168,6 +168,7 @@ def deleteCache(cachedFolder):
     if "Output_Cache" not in cachedFolder:
         raise RuntimeError("Cache location must contain safeword: `Output_Cache`.")
     cleanPath(cachedFolder)
+    context.waitAll()
 
 
 def cacheCall(

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -240,7 +240,7 @@ def cleanPath(path, mpiRank=0):
     """
     valid = False
     if not os.path.exists(path):
-        if context.MPI_SIZE > 1:
+        if context.MPI_SIZE > 1 and context.MPI_DISTRIBUTABLE:
             context.MPI_COMM.barrier()
         return True
 
@@ -283,7 +283,7 @@ def cleanPath(path, mpiRank=0):
         sleep(waitTime)
 
     # Potentially, wait for all the processes to catch up.
-    if context.MPI_SIZE > 1:
+    if context.MPI_SIZE > 1 and context.MPI_DISTRIBUTABLE:
         context.MPI_COMM.barrier()
 
     if os.path.exists(path):

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -219,7 +219,7 @@ def moduleAndAttributeExist(pathAttr):
     return moduleAttributeName in userSpecifiedModule.__dict__
 
 
-def cleanPath(path, mpiRank=0):
+def cleanPath(path, mpiRank=0, barrier=True):
     """Recursively delete a path.
 
     !!! careful with this !!! It can delete the entire cluster.
@@ -240,7 +240,7 @@ def cleanPath(path, mpiRank=0):
     """
     valid = False
     if not os.path.exists(path):
-        if context.MPI_SIZE > 1 and context.MPI_DISTRIBUTABLE:
+        if context.MPI_SIZE > 1 and context.MPI_DISTRIBUTABLE and barrier:
             context.MPI_COMM.barrier()
         return True
 
@@ -283,7 +283,7 @@ def cleanPath(path, mpiRank=0):
         sleep(waitTime)
 
     # Potentially, wait for all the processes to catch up.
-    if context.MPI_SIZE > 1 and context.MPI_DISTRIBUTABLE:
+    if context.MPI_SIZE > 1 and context.MPI_DISTRIBUTABLE and barrier:
         context.MPI_COMM.barrier()
 
     if os.path.exists(path):

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -219,7 +219,7 @@ def moduleAndAttributeExist(pathAttr):
     return moduleAttributeName in userSpecifiedModule.__dict__
 
 
-def cleanPath(path, mpiRank=0, barrier=True):
+def cleanPath(path, mpiRank=0):
     """Recursively delete a path.
 
     !!! careful with this !!! It can delete the entire cluster.
@@ -240,8 +240,6 @@ def cleanPath(path, mpiRank=0, barrier=True):
     """
     valid = False
     if not os.path.exists(path):
-        if context.MPI_SIZE > 1 and context.MPI_DISTRIBUTABLE and barrier:
-            context.MPI_COMM.barrier()
         return True
 
     for validPath in [
@@ -281,10 +279,6 @@ def cleanPath(path, mpiRank=0, barrier=True):
         if loopCounter > maxLoops:
             break
         sleep(waitTime)
-
-    # Potentially, wait for all the processes to catch up.
-    if context.MPI_SIZE > 1 and context.MPI_DISTRIBUTABLE and barrier:
-        context.MPI_COMM.barrier()
 
     if os.path.exists(path):
         return False

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -83,6 +83,7 @@ class PathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(filePath0))
             with self.assertRaises(Exception):
                 pathTools.cleanPath(filePath0, mpiRank=0)
+                context.waitAll()
 
             # TEST 1: Delete a single file
             filePath1 = "test1_cleanPathNoMpi_mongoose"
@@ -90,6 +91,7 @@ class PathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(filePath1))
             pathTools.cleanPath(filePath1, mpiRank=0)
+            context.waitAll()
             self.assertFalse(os.path.exists(filePath1))
 
             # TEST 2: Delete an empty directory
@@ -98,6 +100,7 @@ class PathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(dir2))
             pathTools.cleanPath(dir2, mpiRank=0)
+            context.waitAll()
             self.assertFalse(os.path.exists(dir2))
 
             # TEST 3: Delete a directory with two files inside
@@ -114,6 +117,7 @@ class PathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(dir3, "file1.txt")))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file2.txt")))
             pathTools.cleanPath(dir3, mpiRank=0)
+            context.waitAll()
             self.assertFalse(os.path.exists(dir3))
 
 


### PR DESCRIPTION
## Description

Making the fix from #688 more robust. There are some situations where `MPI_SIZE` can be greater than 1, but `MPI_DISTRIBUTABLE` is `False` and only the rank 0 process has called `cleanPath()`. This code prevents the code from getting to an infinite MPI barrier in that situation.

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed: N/A

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
