### PR TITLE
adding THaverageSlugTemp parameter

### DIFF
--- a/armi/physics/thermalHydraulics/parameters.py
+++ b/armi/physics/thermalHydraulics/parameters.py
@@ -334,6 +334,13 @@ def _getBlockParams():
         )
 
         pb.defParam(
+            "THaverageSlugTemp",
+            units=units.DEGC,
+            description="The nominal average (non-fuel) slug/pin temperature in the block, which should be used for neutronic and TH feedback.",
+            location=ParamLocation.AVERAGE,
+        )
+
+        pb.defParam(
             "THcoolantAverageT",
             units=units.DEGC,
             description="Flow-based average of the inlet and outlet coolant temperatures.",


### PR DESCRIPTION
A T/H parameter that is useful for storing temperatures of the slugs/pins for non-fuel geometries.

@dlangewisch

<!-- Thanks in advance for you contribution! -->

## Description

<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.