### PR TITLE
Allow jumpRingTo to be equal to 1

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -990,7 +990,7 @@ class FuelHandler:
             chargeRing = maxRingInCore
         if jumpRingFrom is not None and not (1 < jumpRingFrom < maxRingInCore):
             raise ValueError(f"JumpRingFrom {jumpRingFrom} is not in the core.")
-        if jumpRingTo is not None and not (1 < jumpRingTo < maxRingInCore):
+        if jumpRingTo is not None and not (1 <= jumpRingTo < maxRingInCore):
             raise ValueError(f"JumpRingTo {jumpRingTo} is not in the core.")
 
         if chargeRing > dischargeRing and jumpRingTo is None:

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -544,6 +544,10 @@ class TestFuelHandler(ArmiTestHelper):
         schedule, widths = fh.buildRingSchedule(1, 9)
         self.assertEqual(schedule, [9, 8, 7, 6, 5, 4, 3, 2, 1])
 
+        # simple with no jumps
+        schedule, widths = fh.buildRingSchedule(9, 1, jumpRingTo=1)
+        self.assertEqual(schedule, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+
         # simple with 1 jump
         schedule, widths = fh.buildRingSchedule(9, 1, jumpRingFrom=6)
         self.assertEqual(schedule, [5, 4, 3, 2, 1, 6, 7, 8, 9])


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

Fix `ValueError` check for `jumpRingTo` to allow it to be equal to 1 (since the default for convergent shuffle is in fact 1). 

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [ ] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
