### PR TITLE
Get Previous Time Node Bug Fix

### DIFF
--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -422,7 +422,7 @@ def getPreviousTimeNode(cycle, node, cs):
     else:
         nodesPerCycle = getNodesPerCycle(cs)
         nodesInLastCycle = nodesPerCycle[cycle - 1]
-        indexOfLastNode = nodesInLastCycle - 1 # zero based indexing for nodes
+        indexOfLastNode = nodesInLastCycle - 1  # zero based indexing for nodes
         return (cycle - 1, indexOfLastNode)
 
 

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -420,10 +420,10 @@ def getPreviousTimeNode(cycle, node, cs):
     if node != 0:
         return (cycle, node - 1)
     else:
-        # index starts at zero, so the last node in a cycle is equal to the number of
-        # burn steps.
         nodesPerCycle = getNodesPerCycle(cs)
-        return (cycle - 1, nodesPerCycle[cycle - 1])
+        nodesInLastCycle = nodesPerCycle[cycle - 1]
+        indexOfLastNode = nodesInLastCycle - 1 # zero based indexing for nodes
+        return (cycle - 1, indexOfLastNode)
 
 
 def tryPickleOnAllContents(obj, ignore=None, path=None, verbose=False):

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -355,7 +355,7 @@ settings:
             getPreviousTimeNode(0, 0, "foo")
         self.assertEqual(getPreviousTimeNode(1, 1, self.standaloneSimpleCS), (1, 0))
         self.assertEqual(getPreviousTimeNode(1, 0, self.standaloneSimpleCS), (0, 3))
-        self.assertEqual(getPreviousTimeNode(1, 0, self.standaloneDetailedCS), (0, 2))
+        self.assertEqual(getPreviousTimeNode(1, 0, self.standaloneDetailedCS), (0, 3))
         self.assertEqual(getPreviousTimeNode(2, 4, self.standaloneDetailedCS), (2, 3))
 
     def test_getCumulativeNodeNum(self):

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -353,8 +353,9 @@ settings:
     def test_getPreviousTimeNode(self):
         with self.assertRaises(ValueError):
             getPreviousTimeNode(0, 0, "foo")
-
-        self.assertEqual(getPreviousTimeNode(1, 0, self.standaloneDetailedCS), (0, 4))
+        self.assertEqual(getPreviousTimeNode(1, 1, self.standaloneSimpleCS), (1, 0))
+        self.assertEqual(getPreviousTimeNode(1, 0, self.standaloneSimpleCS), (0, 3))
+        self.assertEqual(getPreviousTimeNode(1, 0, self.standaloneDetailedCS), (0, 2))
         self.assertEqual(getPreviousTimeNode(2, 4, self.standaloneDetailedCS), (2, 3))
 
     def test_getCumulativeNodeNum(self):


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

Fixed a bug in getPreviousTimeNode that caused the node value to be high by 1 when looking
at the last node of a previous cycle.

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
