### PR TITLE
Remove pinPowers parameter from block module

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -186,58 +186,6 @@ def _getNeutronicsBlockParams():
         )
 
         pb.defParam(
-            "pinPowers",
-            units="W/cm",
-            description="""
-                The block-level pin linear power densities. pinPowers[i] represents the average linear power density of
-                pin i.  Power units are Watts/cm (Watts produced per cm of pin length).  The "ARMI pin ordering" is
-                used, which is counter-clockwise from 3 o'clock.  See TP1-1.9.31-RPT-0010 for more details.
-            """,
-            saveToDB=True,
-            default=None,
-        )
-
-        def pinPowersNeutron(self, value):
-            self._p_pinPowersNeutron = (
-                value
-                if value is None or isinstance(value, numpy.ndarray)
-                else numpy.array(value)
-            )
-
-        pb.defParam(
-            "pinPowersNeutron",
-            setter=pinPowersNeutron,
-            units="W/cm",
-            description="""
-                The block-level pin linear power densities from neutron-induced
-                interactions. pinPowersNeutron[i] represents the average linear power density of pin i
-                (from neutron heating). Power units are Watts/cm (Watts produced per cm of pin length).
-            """,
-            saveToDB=True,
-            default=None,
-        )
-
-        def pinPowersGamma(self, value):
-            self._p_pinPowersGamma = (
-                value
-                if value is None or isinstance(value, numpy.ndarray)
-                else numpy.array(value)
-            )
-
-        pb.defParam(
-            "pinPowersGamma",
-            setter=pinPowersGamma,
-            units="W/cm",
-            description="""
-                The block-level pin linear power densities from gamma heating.
-                pinPowersGamma[i] represents the average linear power density of pin i (from gamma
-                heating). Power units are Watts/cm (Watts produced per cm of pin length).",
-            """,
-            saveToDB=True,
-            default=None,
-        )
-
-        pb.defParam(
             "axialPowerProfile",
             units="",
             description="""

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1951,7 +1951,6 @@ class HexBlock(Block):
         return self._getPinCoordinatesHex()
 
     def _getPinCoordinatesHex(self):
-        """"""
         pinPitch = self.getPinPitch()
         if pinPitch is None:
             return []

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1574,11 +1574,7 @@ class HexBlock(Block):
         nPins = self.getNumPins()
         self.p.pinLocation = list(range(1, nPins + 1))
 
-    def setPinPowers(
-        self,
-        powers,
-        powerKeySuffix="",
-    ):
+    def setPinPowers(self, powers, powerKeySuffix=""):
         """
         Updates the pin linear power densities of this block for the current rotation.
         The linear densities are represented by the *linPowByPin* parameter.

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1577,7 +1577,6 @@ class HexBlock(Block):
     def setPinPowers(
         self,
         powers,
-        numPins,
         imax,
         jmax,
         removeSixCornerPins=False,
@@ -1594,10 +1593,6 @@ class HexBlock(Block):
             linear power density of pin i. The units of linear power density is watts/cm
             (i.e., watts produced per cm of pin length). The "ARMI pin ordering" must be
             be used, which is counter-clockwise from 3 o'clock.
-
-        numPins : int, required
-            Number of pins in the block. This parameter should probably be removed because it
-            can be derived from the block.
 
         imax: int, required
             Number of pin rings. This parameter should probably be removed because it
@@ -1620,6 +1615,8 @@ class HexBlock(Block):
         -----
         This method can handle assembly rotations by using the *pinLocation* parameter.
         """
+        numPins = self.getNumPins()
+
         powerKey = f"linPowByPin{powerKeySuffix}"
         self.p[powerKey] = numpy.zeros(numPins)
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1579,6 +1579,14 @@ class HexBlock(Block):
         Updates the pin linear power densities of this block for the current rotation.
         The linear densities are represented by the *linPowByPin* parameter.
 
+        It is assumed that :py:meth:`.initializePinLocations` has already been executed
+        for fueled blocks in order to access the *pinLocation* parameter. The
+        *pinLocation* parameter is not accessed for non-fueled blocks.
+
+        The *linPowByPin* parameter can be directly assigned to instead of using this
+        method if the multiplicity of the pins in the block is equal to the number of
+        pins in the block.
+
         Parameters
         ----------
         powers : list of floats, required
@@ -1601,12 +1609,9 @@ class HexBlock(Block):
         powerKey = f"linPowByPin{powerKeySuffix}"
         self.p[powerKey] = numpy.zeros(numPins)
 
-        # Loop through rings
+        # Loop through rings. The *pinLocation* parameter is only accessed for fueled
+        # blocks; it is assumed that non-fueled blocks do not use a rotation map.
         for pinNum in range(numPins):
-            # TODO: This appears to need fixing to account for blocks in fueled
-            # TODO: assemblies that contain elevations with pins but no fuel,
-            # TODO: such as for an axial shield. These blocks should still have
-            # TODO: powers that are eligible for rotation.
             if self.hasFlags(Flags.FUEL):
                 # -1 is needed in order to map from pinLocations to list index
                 pinLoc = self.p.pinLocation[pinNum] - 1

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1645,15 +1645,20 @@ class HexBlock(Block):
                 self.p[powerKey][pinNum] = linPow
                 pinNum += 1
 
-        # If using the *powerKeySuffix* parameter, we also need to set total power. If
-        # you were setting gamma power, the logic below assumes that the neutron powers
-        # have already been set.
+        # If using the *powerKeySuffix* parameter, we also need to set total power, which
+        # is sum of neutron and gamma powers. We assume that a solo gamma calculation
+        # to set total power does not make sense.
         if powerKeySuffix:
-            self.p.linPowByPin = (
-                self.p[f"linPowByPin{NEUTRON}"] + self.p[powerKey]
-                if powerKeySuffix == GAMMA
-                else self.p[powerKey]
-            )
+            if powerKeySuffix == GAMMA:
+                if self.p[f"linPowByPin{NEUTRON}"] is None:
+                    msg = (
+                        "Neutron power has not been set yet. Cannot set total power for "
+                        f"{self}."
+                    )
+                    raise UnboundLocalError(msg)
+                self.p.linPowByPin = self.p[f"linPowByPin{NEUTRON}"] + self.p[powerKey]
+            else:
+                self.p.linPowByPin = self.p[powerKey]
 
     def rotate(self, deg):
         """Function for rotating a block's spatially varying variables by a specified angle.

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1612,8 +1612,8 @@ class HexBlock(Block):
                 pinLoc = self.p.pinLocation[pinNum] - 1
             else:
                 pinLoc = pinNum
-            linPow = powers[pinLoc]
-            self.p[powerKey][pinNum] = linPow
+            pinLinPow = powers[pinLoc]
+            self.p[powerKey][pinNum] = pinLinPow
 
         # If using the *powerKeySuffix* parameter, we also need to set total power, which
         # is sum of neutron and gamma powers. We assume that a solo gamma calculation

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1580,7 +1580,6 @@ class HexBlock(Block):
         numPins,
         imax,
         jmax,
-        gamma=False,
         removeSixCornerPins=False,
         powerKeySuffix="",
     ):
@@ -1609,9 +1608,6 @@ class HexBlock(Block):
             is the number of pins in ring 2, and so on. This parameter should probably be
             removed because it can be derived from the block.
 
-        gamma: bool, optional
-            Currently unused
-
         removeSixCornerPins: bool, optional.
             Defaults to False
 
@@ -1624,7 +1620,8 @@ class HexBlock(Block):
         -----
         This method can handle assembly rotations by using the *pinLocation* parameter.
         """
-        self.p["linPowByPin" + powerKeySuffix] = numpy.zeros(numPins)
+        powerKey = f"linPowByPin{powerKeySuffix}"
+        self.p[powerKey] = numpy.zeros(numPins)
 
         # Loop through rings
         j0 = jmax[imax - 1] / 6
@@ -1645,8 +1642,18 @@ class HexBlock(Block):
                     else:
                         pinLoc = pinNum
                     linPow = powers[pinLoc]
-                self.p["linPowByPin" + powerKeySuffix][pinNum] = linPow
+                self.p[powerKey][pinNum] = linPow
                 pinNum += 1
+
+        # If using the *powerKeySuffix* parameter, we also need to set total power. If
+        # you were setting gamma power, the logic below assumes that the neutron powers
+        # have already been set.
+        if powerKeySuffix:
+            self.p.linPowByPin = (
+                self.p[f"linPowByPin{NEUTRON}"] + self.p[powerKey]
+                if powerKeySuffix == GAMMA
+                else self.p[powerKey]
+            )
 
     def rotate(self, deg):
         """Function for rotating a block's spatially varying variables by a specified angle.

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1579,7 +1579,6 @@ class HexBlock(Block):
         powers,
         imax,
         jmax,
-        removeSixCornerPins=False,
         powerKeySuffix="",
     ):
         """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1577,8 +1577,6 @@ class HexBlock(Block):
     def setPinPowers(
         self,
         powers,
-        imax,
-        jmax,
         powerKeySuffix="",
     ):
         """
@@ -1592,15 +1590,6 @@ class HexBlock(Block):
             linear power density of pin i. The units of linear power density is watts/cm
             (i.e., watts produced per cm of pin length). The "ARMI pin ordering" must be
             be used, which is counter-clockwise from 3 o'clock.
-
-        imax: int, required
-            Number of pin rings. This parameter should probably be removed because it
-            can be derived from the block.
-
-        jmax: list of ints, required
-            Number of pins per ring. Element 0 is the number of pins in ring 1, element 1
-            is the number of pins in ring 2, and so on. This parameter should probably be
-            removed because it can be derived from the block.
 
         powerKeySuffix: str, optional
             Must be either an empty string, :py:const:`NEUTRON <armi.physics.neutronics.const.NEUTRON>`,
@@ -1617,22 +1606,18 @@ class HexBlock(Block):
         self.p[powerKey] = numpy.zeros(numPins)
 
         # Loop through rings
-        pinNum = 0
-        for i in range(imax):
-            # Loop through positions in ring i
-            for j in range(jmax[i]):
-                # TODO: This appears to need fixing to account for blocks in fueled
-                # TODO: assemblies that contain elevations with pins but no fuel,
-                # TODO: such as for an axial shield. These blocks should still have
-                # TODO: powers that are eligible for rotation.
-                if self.hasFlags(Flags.FUEL):
-                    # -1 is needed in order to map from pinLocations to list index
-                    pinLoc = self.p.pinLocation[pinNum] - 1
-                else:
-                    pinLoc = pinNum
-                linPow = powers[pinLoc]
+        for pinNum in range(numPins):
+            # TODO: This appears to need fixing to account for blocks in fueled
+            # TODO: assemblies that contain elevations with pins but no fuel,
+            # TODO: such as for an axial shield. These blocks should still have
+            # TODO: powers that are eligible for rotation.
+            if self.hasFlags(Flags.FUEL):
+                # -1 is needed in order to map from pinLocations to list index
+                pinLoc = self.p.pinLocation[pinNum] - 1
+            else:
+                pinLoc = pinNum
+            linPow = powers[pinLoc]
             self.p[powerKey][pinNum] = linPow
-            pinNum += 1
 
         # If using the *powerKeySuffix* parameter, we also need to set total power, which
         # is sum of neutron and gamma powers. We assume that a solo gamma calculation

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1637,7 +1637,8 @@ class HexBlock(Block):
                 else:
                     # TODO: This appears to need fixing to account for blocks in fueled
                     # TODO: assemblies that contain elevations with pins but no fuel,
-                    # TODO: such as for an axial shield.
+                    # TODO: such as for an axial shield. These blocks should still have
+                    # TODO: powers that are eligible for rotation.
                     if self.hasFlags(Flags.FUEL):
                         # -1 is needed in order to map from pinLocations to list index
                         pinLoc = self.p.pinLocation[pinNum] - 1

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1966,12 +1966,15 @@ class HexBlock(Block):
         return self._getPinCoordinatesHex()
 
     def _getPinCoordinatesHex(self):
-        coordinates = []
-        numPins = self.getNumPins()
-        numPinRings = hexagon.numRingsToHoldNumCells(numPins)
+        """"""
         pinPitch = self.getPinPitch()
         if pinPitch is None:
             return []
+
+        coordinates = []
+        numPins = self.getNumPins()
+        numPinRings = hexagon.numRingsToHoldNumCells(numPins)
+
         # pin lattice is rotated 30 degrees from assembly lattice
         grid = grids.HexGrid.fromPitch(pinPitch, numPinRings, self, pointedEndUp=True)
         for ring in range(numPinRings):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1188,6 +1188,23 @@ class Block_TestCase(unittest.TestCase):
         neutronPowerKey = f"linPowByPin{NEUTRON}"
         gammaPowerKey = f"linPowByPin{GAMMA}"
 
+        # Try setting gamma power too early and then reset
+        with self.assertRaises(UnboundLocalError) as context:
+            self.block.setPinPowers(
+                gammaPower,
+                numPins,
+                imax,
+                jmax,
+                removeSixCornerPins=False,
+                powerKeySuffix=GAMMA,
+            )
+        errorMsg = (
+            "Neutron power has not been set yet. Cannot set total power for "
+            f"{self.block}."
+        )
+        self.assertTrue(errorMsg in str(context.exception))
+        self.block.p[gammaPowerKey] = None
+
         # Test with no powerKeySuffix
         self.block.setPinPowers(
             neutronPower, numPins, imax, jmax, removeSixCornerPins=False

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -16,10 +16,11 @@ r"""Tests blocks.py"""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,invalid-name,consider-using-f-string
 import copy
 import math
-import numpy
-from numpy.testing import assert_allclose
 import os
 import unittest
+
+import numpy
+from numpy.testing import assert_allclose
 
 from armi import materials, runLog, settings, tests
 from armi.nucDirectory import nucDir, nuclideBases

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1195,7 +1195,6 @@ class Block_TestCase(unittest.TestCase):
                 gammaPower,
                 imax,
                 jmax,
-                removeSixCornerPins=False,
                 powerKeySuffix=GAMMA,
             )
         errorMsg = (
@@ -1206,7 +1205,7 @@ class Block_TestCase(unittest.TestCase):
         self.block.p[gammaPowerKey] = None
 
         # Test with no powerKeySuffix
-        self.block.setPinPowers(neutronPower, imax, jmax, removeSixCornerPins=False)
+        self.block.setPinPowers(neutronPower, imax, jmax)
         assert_allclose(self.block.p[totalPowerKey], numpy.array(neutronPower))
         self.assertIsNone(self.block.p[neutronPowerKey])
         self.assertIsNone(self.block.p[gammaPowerKey])

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1215,7 +1215,6 @@ class Block_TestCase(unittest.TestCase):
             neutronPower,
             imax,
             jmax,
-            removeSixCornerPins=False,
             powerKeySuffix=NEUTRON,
         )
         assert_allclose(self.block.p[totalPowerKey], numpy.array(neutronPower))
@@ -1227,7 +1226,6 @@ class Block_TestCase(unittest.TestCase):
             gammaPower,
             imax,
             jmax,
-            removeSixCornerPins=False,
             powerKeySuffix=GAMMA,
         )
         assert_allclose(self.block.p[totalPowerKey], numpy.array(totalPower))

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1193,7 +1193,6 @@ class Block_TestCase(unittest.TestCase):
         with self.assertRaises(UnboundLocalError) as context:
             self.block.setPinPowers(
                 gammaPower,
-                numPins,
                 imax,
                 jmax,
                 removeSixCornerPins=False,
@@ -1207,9 +1206,7 @@ class Block_TestCase(unittest.TestCase):
         self.block.p[gammaPowerKey] = None
 
         # Test with no powerKeySuffix
-        self.block.setPinPowers(
-            neutronPower, numPins, imax, jmax, removeSixCornerPins=False
-        )
+        self.block.setPinPowers(neutronPower, imax, jmax, removeSixCornerPins=False)
         assert_allclose(self.block.p[totalPowerKey], numpy.array(neutronPower))
         self.assertIsNone(self.block.p[neutronPowerKey])
         self.assertIsNone(self.block.p[gammaPowerKey])
@@ -1217,7 +1214,6 @@ class Block_TestCase(unittest.TestCase):
         # Test with neutron powers
         self.block.setPinPowers(
             neutronPower,
-            numPins,
             imax,
             jmax,
             removeSixCornerPins=False,
@@ -1230,7 +1226,6 @@ class Block_TestCase(unittest.TestCase):
         # Test with gamma powers
         self.block.setPinPowers(
             gammaPower,
-            numPins,
             imax,
             jmax,
             removeSixCornerPins=False,

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1184,17 +1184,17 @@ class Block_TestCase(unittest.TestCase):
         imax = 9  # hexagonal rings of pins
         jmax = [max(1, 6 * i) for i in range(imax)]  # pins in each hexagonal ring
 
-        totalPower = "linPowByPin"
-        neutronPower = f"linPowByPin{NEUTRON}"
-        gammaPower = f"linPowByPin{GAMMA}"
+        totalPowerKey = "linPowByPin"
+        neutronPowerKey = f"linPowByPin{NEUTRON}"
+        gammaPowerKey = f"linPowByPin{GAMMA}"
 
         # Test with no powerKeySuffix
         self.block.setPinPowers(
             neutronPower, numPins, imax, jmax, removeSixCornerPins=False
         )
-        assert_allclose(self.block.p[totalPower], numpy.array(neutronPower))
-        self.assertIsNone(self.block.p[neutronPower])
-        self.assertIsNone(self.block.p[gammaPower])
+        assert_allclose(self.block.p[totalPowerKey], numpy.array(neutronPower))
+        self.assertIsNone(self.block.p[neutronPowerKey])
+        self.assertIsNone(self.block.p[gammaPowerKey])
 
         # Test with neutron powers
         self.block.setPinPowers(
@@ -1205,9 +1205,9 @@ class Block_TestCase(unittest.TestCase):
             removeSixCornerPins=False,
             powerKeySuffix=NEUTRON,
         )
-        assert_allclose(self.block.p[totalPower], numpy.array(neutronPower))
-        assert_allclose(self.block.p[neutronPower], numpy.array(neutronPower))
-        self.assertIsNone(self.block.p[gammaPower])
+        assert_allclose(self.block.p[totalPowerKey], numpy.array(neutronPower))
+        assert_allclose(self.block.p[neutronPowerKey], numpy.array(neutronPower))
+        self.assertIsNone(self.block.p[gammaPowerKey])
 
         # Test with gamma powers
         self.block.setPinPowers(
@@ -1218,9 +1218,9 @@ class Block_TestCase(unittest.TestCase):
             removeSixCornerPins=False,
             powerKeySuffix=GAMMA,
         )
-        assert_allclose(self.block.p[totalPower], numpy.array(totalPower))
-        assert_allclose(self.block.p[neutronPower], numpy.array(neutronPower))
-        assert_allclose(self.block.p[gammaPower], numpy.array(gammaPower))
+        assert_allclose(self.block.p[totalPowerKey], numpy.array(totalPower))
+        assert_allclose(self.block.p[neutronPowerKey], numpy.array(neutronPower))
+        assert_allclose(self.block.p[gammaPowerKey], numpy.array(gammaPower))
 
     def test_getComponentAreaFrac(self):
         def calcFracManually(names):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1182,8 +1182,6 @@ class Block_TestCase(unittest.TestCase):
         neutronPower = [10.0 * i for i in range(numPins)]
         gammaPower = [1.0 * i for i in range(numPins)]
         totalPower = [x + y for x, y in zip(neutronPower, gammaPower)]
-        imax = 9  # hexagonal rings of pins
-        jmax = [max(1, 6 * i) for i in range(imax)]  # pins in each hexagonal ring
 
         totalPowerKey = "linPowByPin"
         neutronPowerKey = f"linPowByPin{NEUTRON}"
@@ -1193,8 +1191,6 @@ class Block_TestCase(unittest.TestCase):
         with self.assertRaises(UnboundLocalError) as context:
             self.block.setPinPowers(
                 gammaPower,
-                imax,
-                jmax,
                 powerKeySuffix=GAMMA,
             )
         errorMsg = (
@@ -1205,7 +1201,7 @@ class Block_TestCase(unittest.TestCase):
         self.block.p[gammaPowerKey] = None
 
         # Test with no powerKeySuffix
-        self.block.setPinPowers(neutronPower, imax, jmax)
+        self.block.setPinPowers(neutronPower)
         assert_allclose(self.block.p[totalPowerKey], numpy.array(neutronPower))
         self.assertIsNone(self.block.p[neutronPowerKey])
         self.assertIsNone(self.block.p[gammaPowerKey])
@@ -1213,8 +1209,6 @@ class Block_TestCase(unittest.TestCase):
         # Test with neutron powers
         self.block.setPinPowers(
             neutronPower,
-            imax,
-            jmax,
             powerKeySuffix=NEUTRON,
         )
         assert_allclose(self.block.p[totalPowerKey], numpy.array(neutronPower))
@@ -1224,8 +1218,6 @@ class Block_TestCase(unittest.TestCase):
         # Test with gamma powers
         self.block.setPinPowers(
             gammaPower,
-            imax,
-            jmax,
             powerKeySuffix=GAMMA,
         )
         assert_allclose(self.block.p[totalPowerKey], numpy.array(totalPower))

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -28,10 +28,9 @@ from armi.physics.neutronics import NEUTRON, GAMMA
 from armi.reactor import blocks, components, geometry, grids
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_assemblies import makeTestAssembly
-from armi.tests import TEST_ROOT
+from armi.tests import ISOAA_PATH, TEST_ROOT
 from armi.utils import hexagon, units
 from armi.utils.units import MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
-from armi.tests import ISOAA_PATH
 
 
 def buildSimpleFuelBlock():


### PR DESCRIPTION
## Description

This pull request removes the `pinPowers` parameter from the framework. The history of this parameter is not clear, but after some investigating, I have concluded that this parameter is either not used anymore and has been replaced by `linPowByPin`.

`setPinPowers()` now only makes reference to `linPowByPin`.

I also judged that the `gamma` parameter for the method is redundant, since it can be derived from the `powerKeySuffix` parameter, so I removed that.

I did not see any testing for `linPowByPin`, so I also modified the `test_blocks.py` module to replace `pinPowers` testing with `linPowByPin` testing.

Finally, I have added a TODO in the method because there is a section of its behavior that is unclear to me. I am unable to make a decision of what to do about it on my own, so I decided to leave it alone and just add a note. A future pull request could address the TODO.

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
