### PR TITLE
Allow components to have children in support of particle fuel modeling

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -751,6 +751,30 @@ class Block(composites.Composite):
             # on the interface stack.
             self.p.pdensDecay *= frac
 
+    def updateComponentGroupMults(self):
+        """
+        Update component group mults.
+
+        They were temporarily set to the desired blend fraction during component
+        construction. This derives the actual multiplicity based on the target
+        blend fraction.
+
+        Note that the blend fractions are applied to the hot thermally-expanded
+        dimensions.
+        """
+        for c in self.getChildren():
+            if len(c) > 1:
+                backgroundVol = c.getVolume()
+                # expect all mults to be temporarily set to blend frac from blueprints
+                blendFrac = c[0].p.mult
+                # remove scaling by mult=blendFrac here
+                childVol = sum(subchild.getVolume() / blendFrac for subchild in c)
+                # mult should be such that subchild/backgroundVol = blendFrac
+                # so subchild * blendFrac * newMult = blendFrac * backgroundVol
+                newMult = blendFrac * backgroundVol / childVol
+                for subchild in c:
+                    subchild.setDimension("mult", newMult)
+
     def completeInitialLoading(self, bolBlock=None):
         """
         Does some BOL bookkeeping to track things like BOL HM density for burnup tracking.

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1950,11 +1950,15 @@ class HexBlock(Block):
 
         ringNumber = hexagon.numRingsToHoldNumCells(self.getNumPins())
         # For the below to work, there must not be multiple wire or multiple clad types.
+        pitch = self.getPinPitch(cold=True)
+        if pitch is None:
+            raise ValueError(
+                f"Could not create spatialGrid for block {self.p.type} "
+                "because the pin pitch was not detected."
+            )
         # note that it's the pointed end of the cell hexes that are up (but the
         # macro shape of the pins forms a hex with a flat top fitting in the assembly)
-        grid = grids.HexGrid.fromPitch(
-            self.getPinPitch(cold=True), numRings=0, pointedEndUp=True
-        )
+        grid = grids.HexGrid.fromPitch(pitch, numRings=0, pointedEndUp=True)
         spatialLocators = grids.MultiIndexLocation(grid=self.spatialGrid)
         numLocations = 0
         for ring in range(ringNumber):

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -101,6 +101,7 @@ class BlockBlueprint(yamlize.KeyedList):
             Top layer groups the by-block material modifications under the `byBlock` key
             and the by-component material modifications under the component's name.
             The inner dict under each key contains material modification names and values.
+
         """
         runLog.debug("Constructing block {}".format(self.name))
         components = collections.OrderedDict()
@@ -194,6 +195,11 @@ class BlockBlueprint(yamlize.KeyedList):
                 b.autoCreateSpatialGrids()
             except (ValueError, NotImplementedError) as e:
                 runLog.warning(str(e), single=True)
+
+        # now that components are in blocks we have heights and can actually
+        # compute the mults of the component groups.
+        b.updateComponentGroupMults()
+
         return b
 
     def _checkByComponentMaterialInput(self, materialInput):

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -180,13 +180,13 @@ class ComponentBlueprint(yamlize.Object):
             if self.blends:
                 # build a blended object
                 for groupName, blendFrac in zip(self.blends, self.blendFracs):
-                    # blendFrac is a volume fraction, and so we need to adjust the multiplicities 
+                    # blendFrac is a volume fraction, and so we need to adjust the multiplicities
                     # so that the background component and the child group match up
                     # The area of the background component will be fully determined by its dims and mult.
                     # but internally, its number densities and volumes need to be set to match
                     # the blendFrac
                     group = blueprint.componentGroups[groupName]
-                    # strip off the blend/blendFrac args since they aren't valid on any 
+                    # strip off the blend/blendFrac args since they aren't valid on any
                     # specific shape's constructor
                     del kwargs["blends"]
                     del kwargs["blendFracs"]
@@ -194,10 +194,14 @@ class ComponentBlueprint(yamlize.Object):
                     constructedObject = components.factory(shape, [], kwargs)
                     # build the child objects
                     for groupedComponent in group:
-                        componentDesign = blueprint.componentDesigns[groupedComponent.name]
+                        componentDesign = blueprint.componentDesigns[
+                            groupedComponent.name
+                        ]
                         component = componentDesign.construct(blueprint, matMods=dict())
                         # override free component multiplicity if it's set based on the group definition
-                        component.setDimension("mult", groupedComponent.mult*blendFrac)
+                        component.setDimension(
+                            "mult", groupedComponent.mult * blendFrac
+                        )
                         _setComponentFlags(component, self.flags, blueprint)
                         insertDepletableNuclideKeys(component, blueprint)
                         constructedObject.add(component)

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -198,10 +198,10 @@ class ComponentBlueprint(yamlize.Object):
                             groupedComponent.name
                         ]
                         component = componentDesign.construct(blueprint, matMods=dict())
-                        # override free component multiplicity if it's set based on the group definition
-                        component.setDimension(
-                            "mult", groupedComponent.mult * blendFrac
-                        )
+                        # temporarily set grouped component mults to the blend fraction
+                        # these will be updated based on parent component volume
+                        # during block construction
+                        component.setDimension("mult", blendFrac)
                         _setComponentFlags(component, self.flags, blueprint)
                         insertDepletableNuclideKeys(component, blueprint)
                         constructedObject.add(component)

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -199,7 +199,7 @@ class ComponentBlueprint(yamlize.Object):
                         # override free component multiplicity if it's set based on the group definition
                         component.setDimension("mult", groupedComponent.mult*blendFrac)
                         _setComponentFlags(component, self.flags, blueprint)
-                        _insertDepletableNuclideKeys(component, blueprint)
+                        insertDepletableNuclideKeys(component, blueprint)
                         constructedObject.add(component)
                     children = {c.name: c for c in constructedObject.getChildren()}
                     for child in children.values():

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -193,10 +193,18 @@ class ComponentBlueprint(yamlize.Object):
                     # build the background object
                     constructedObject = components.factory(shape, [], kwargs)
                     # build the child objects
+                    # all grouped components have to be input with the same mult for now
+                    inputMult = None
                     for groupedComponent in group:
                         componentDesign = blueprint.componentDesigns[
                             groupedComponent.name
                         ]
+                        if inputMult is None:
+                            inputMult = componentDesign.mult 
+                        if componentDesign.mult != inputMult:
+                            raise ValueError(
+                                f"Grouped components must all have the same input mult of {inputMult}"
+                            )
                         component = componentDesign.construct(blueprint, matMods=dict())
                         # temporarily set grouped component mults to the blend fraction
                         # these will be updated based on parent component volume

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -626,14 +626,16 @@ class Component(composites.Composite, metaclass=ComponentType):
         """
         
         if self._children:
-            childDens = composites.Composite.getNuclideNumberDensities(self, nucNames)
+            childDens = dict(zip(nucNames, composites.Composite.getNuclideNumberDensities(self, nucNames)))
+            # get volume of children by using the composite method which loops over all children
             childVol = composites.Composite.getVolume(self)
+            # get self volume by calling the shape-specific volume method of the background shape
             totalVol = self.getVolume()
             childFrac = childVol / totalVol
             selfFrac = 1.0 - childFrac
             return [
                 self.p.numberDensities.get(nucName, 0.0) * selfFrac
-                + childDens.get(nucName, 0, 0) * childFrac
+                + childDens.get(nucName, 0.0) * childFrac
                 for nucName in nucNames
             ]
         else:
@@ -1027,7 +1029,9 @@ class Component(composites.Composite, metaclass=ComponentType):
 
     def iterComponents(self, typeSpec=None, exact=False):
         if self._children:
-            return composites.Composite.iterComponents(self, typeSpec, exact)
+            # import pdb; pdb.set_trace()
+            return iter(composites.Composite.iterComponents(self, typeSpec, exact))
+            #print(self, list(comps))
         else:
             if self.hasFlags(typeSpec, exact):
                 yield self

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -624,9 +624,14 @@ class Component(composites.Composite, metaclass=ComponentType):
         Component ndens is unique in that it combines its own actual composition
         with that of its potential children
         """
-        
+
         if self._children:
-            childDens = dict(zip(nucNames, composites.Composite.getNuclideNumberDensities(self, nucNames)))
+            childDens = dict(
+                zip(
+                    nucNames,
+                    composites.Composite.getNuclideNumberDensities(self, nucNames),
+                )
+            )
             # get volume of children by using the composite method which loops over all children
             childVol = composites.Composite.getVolume(self)
             # get self volume by calling the shape-specific volume method of the background shape
@@ -639,10 +644,8 @@ class Component(composites.Composite, metaclass=ComponentType):
                 for nucName in nucNames
             ]
         else:
-            return [
-                self.p.numberDensities.get(nucName, 0.0)
-                for nucName in nucNames
-            ]
+            return [self.p.numberDensities.get(nucName, 0.0) for nucName in nucNames]
+
     def setName(self, name):
         """Components use name for type and name."""
         composites.Composite.setName(self, name)
@@ -1028,10 +1031,17 @@ class Component(composites.Composite, metaclass=ComponentType):
             )
 
     def iterComponents(self, typeSpec=None, exact=False):
+        """
+        Yield the component or its direct child components.
+
+        Notes
+        -----
+        This could probably be made recursive to allow arbitrary depth, but it's more complex
+        """
         if self._children:
-            # import pdb; pdb.set_trace()
-            return iter(composites.Composite.iterComponents(self, typeSpec, exact))
-            #print(self, list(comps))
+            for child in self._children:
+                if self.hasFlags(typeSpec, exact):
+                    yield child
         else:
             if self.hasFlags(typeSpec, exact):
                 yield self

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1237,7 +1237,13 @@ class ArmiObject(metaclass=CompositeModelType):
         return self.getNuclideNumberDensities([nucName])[0]
 
     def getNuclideNumberDensities(self, nucNames):
-        """Return a list of number densities in atoms/barn-cm for the nuc names requested."""
+        """
+        Return a list of number densities in atoms/barn-cm for the nuc names requested.
+
+        See Also
+        --------
+        getNumberDensities: Gets all number densities as a dict rather than a list
+        """
         volumes = numpy.array(
             [
                 c.getVolume() / (c.parent.getSymmetryFactor() if c.parent else 1.0)
@@ -1284,6 +1290,10 @@ class ArmiObject(metaclass=CompositeModelType):
         -------
         numberDensities : dict
             nucName keys, number density values (atoms/bn-cm)
+
+        See Also
+        --------
+        getNuclideNumberDensities: Gets a list of number densities based on a list of nuclide names
         """
         numberDensities = self._getNdensHelper()
         if expandFissionProducts:

--- a/armi/tests/refTriso-bp.yaml
+++ b/armi/tests/refTriso-bp.yaml
@@ -4,7 +4,7 @@ blocks:
         fuel: &component_fuel_fuel
             shape: Hexagon
             material: UZr
-            Tinput: 25.0
+            Tinput: 600.0
             Thot: 600.0
             ip: 0.0
             mult: 1.0
@@ -17,15 +17,15 @@ blocks:
             blendFracs: 
               - 0.350
             material: Graphite
-            Tinput: 25.0
+            Tinput: 600.0
             Thot: 600.0
             mult: 20.0 
             id: 0.0
             od: 1.2446
         duct: 
             shape: Hexagon
-            material: UZr
-            Tinput: 25.0
+            material: HT9
+            Tinput: 600.0
             Thot: 600.0
             ip: 9.0
             mult: 1.0
@@ -41,7 +41,7 @@ components:
     kernel:
         shape: Sphere
         material: UZr
-        Tinput: 25.0
+        Tinput: 600.0
         Thot: 600.0
         id: 0.0
         mult: 1.0
@@ -49,7 +49,7 @@ components:
     buffer:
         shape: Sphere
         material: Graphite
-        Tinput: 25.0
+        Tinput: 600.0
         Thot: 600.0
         id: kernel.od
         mult: 1.0
@@ -57,7 +57,7 @@ components:
     ipyc:
         shape: Sphere
         material: Graphite
-        Tinput: 25.0
+        Tinput: 600.0
         Thot: 600.0
         id: buffer.od
         mult: 1.0
@@ -65,7 +65,7 @@ components:
     sic:
         shape: Sphere
         material: SiC
-        Tinput: 25.0
+        Tinput: 600.0
         Thot: 600.0
         id: ipyc.od
         mult: 1.0
@@ -73,7 +73,7 @@ components:
     opyc:
         shape: Sphere
         material: Graphite
-        Tinput: 25.0
+        Tinput: 600.0
         Thot: 600.0
         id: sic.od
         mult: 1.0
@@ -82,15 +82,15 @@ components:
 component groups:
     triso particle:
       kernel:
-        mult: 1000
+        mult: 1
       buffer:
-        mult: 1000
+        mult: 1
       ipyc:
-        mult: 1000
+        mult: 1
       sic:
-        mult: 1000
+        mult: 1
       opyc:
-        mult: 1000
+        mult: 1
         
 
 assemblies:

--- a/armi/tests/refTriso-bp.yaml
+++ b/armi/tests/refTriso-bp.yaml
@@ -15,16 +15,16 @@ blocks:
             blends: 
               - triso particle
             blendFracs: 
-              - 0.350
+              - 0.70
             material: Graphite
             Tinput: 600.0
             Thot: 600.0
-            mult: 20.0 
+            mult: 2
             id: 0.0
             od: 1.2446
         duct: 
             shape: Hexagon
-            material: HT9
+            material: Cu
             Tinput: 600.0
             Thot: 600.0
             ip: 9.0
@@ -32,7 +32,7 @@ blocks:
             op: 10.0
         coolant: 
             shape: DerivedShape
-            material: Graphite
+            material: NaCl
             Tinput: 25.0
             Thot: 600.0
 
@@ -48,7 +48,7 @@ components:
         od: 0.010625
     buffer:
         shape: Sphere
-        material: Graphite
+        material: Lead
         Tinput: 600.0
         Thot: 600.0
         id: kernel.od
@@ -56,7 +56,7 @@ components:
         od: 0.015625
     ipyc:
         shape: Sphere
-        material: Graphite
+        material: Lead
         Tinput: 600.0
         Thot: 600.0
         id: buffer.od
@@ -64,7 +64,7 @@ components:
         od: 0.017375
     sic:
         shape: Sphere
-        material: SiC
+        material: Lead
         Tinput: 600.0
         Thot: 600.0
         id: ipyc.od
@@ -72,7 +72,7 @@ components:
         od: 0.019125
     opyc:
         shape: Sphere
-        material: Graphite
+        material: Lead
         Tinput: 600.0
         Thot: 600.0
         id: sic.od
@@ -91,7 +91,7 @@ component groups:
         mult: 1
       opyc:
         mult: 1
-        
+
 
 assemblies:
     fuel a: &assembly_a
@@ -143,3 +143,17 @@ grids:
                     IC  IC  IC  OC
                   IC  IC  IC  IC  OC
         symmetry: third periodic
+
+nuclide flags:
+    B: &nuc_flags {burn: false, xs: true}
+    C: *nuc_flags
+    PB: *nuc_flags
+    ZR: *nuc_flags
+    U235: *nuc_flags
+    U238: *nuc_flags
+    CU63: *nuc_flags
+    CU65: *nuc_flags
+    CL35: *nuc_flags
+    CL37: *nuc_flags
+    CL37: *nuc_flags
+    NA23: *nuc_flags

--- a/armi/tests/refTriso-bp.yaml
+++ b/armi/tests/refTriso-bp.yaml
@@ -12,11 +12,14 @@ blocks:
     fuel2: &block_fuel2
         triso compact: 
             shape: Circle
-            blend: triso particle
-            blend frac: 0.350
+            blends: 
+              - triso particle
+            blendFracs: 
+              - 0.350
             material: Graphite
             Tinput: 25.0
             Thot: 600.0
+            mult: 20.0 
             id: 0.0
             od: 1.2446
         duct: 
@@ -79,15 +82,15 @@ components:
 component groups:
     triso particle:
       kernel:
-        mult: 1
+        mult: 1000
       buffer:
-        mult: 1
+        mult: 1000
       ipyc:
-        mult: 1
+        mult: 1000
       sic:
-        mult: 1
+        mult: 1000
       opyc:
-        mult: 1
+        mult: 1000
         
 
 assemblies:

--- a/armi/tests/refTriso-bp.yaml
+++ b/armi/tests/refTriso-bp.yaml
@@ -1,0 +1,142 @@
+# A full blueprint file that contains assems made with ComponentGroups
+blocks:
+    fuel: &block_fuel
+        fuel: &component_fuel_fuel
+            shape: Hexagon
+            material: UZr
+            Tinput: 25.0
+            Thot: 600.0
+            ip: 0.0
+            mult: 1.0
+            op: 10.0
+    fuel2: &block_fuel2
+        triso compact: 
+            shape: Circle
+            blend: triso particle
+            blend frac: 0.350
+            material: Graphite
+            Tinput: 25.0
+            Thot: 600.0
+            id: 0.0
+            od: 1.2446
+        duct: 
+            shape: Hexagon
+            material: UZr
+            Tinput: 25.0
+            Thot: 600.0
+            ip: 9.0
+            mult: 1.0
+            op: 10.0
+        coolant: 
+            shape: DerivedShape
+            material: Graphite
+            Tinput: 25.0
+            Thot: 600.0
+
+components:
+    # triso dims from Table 4 in TRISO benchmark
+    kernel:
+        shape: Sphere
+        material: UZr
+        Tinput: 25.0
+        Thot: 600.0
+        id: 0.0
+        mult: 1.0
+        od: 0.010625
+    buffer:
+        shape: Sphere
+        material: Graphite
+        Tinput: 25.0
+        Thot: 600.0
+        id: kernel.od
+        mult: 1.0
+        od: 0.015625
+    ipyc:
+        shape: Sphere
+        material: Graphite
+        Tinput: 25.0
+        Thot: 600.0
+        id: buffer.od
+        mult: 1.0
+        od: 0.017375
+    sic:
+        shape: Sphere
+        material: SiC
+        Tinput: 25.0
+        Thot: 600.0
+        id: ipyc.od
+        mult: 1.0
+        od: 0.019125
+    opyc:
+        shape: Sphere
+        material: Graphite
+        Tinput: 25.0
+        Thot: 600.0
+        id: sic.od
+        mult: 1.0
+        od: 0.021125
+
+component groups:
+    triso particle:
+      kernel:
+        mult: 1
+      buffer:
+        mult: 1
+      ipyc:
+        mult: 1
+      sic:
+        mult: 1
+      opyc:
+        mult: 1
+        
+
+assemblies:
+    fuel a: &assembly_a
+        specifier: IC
+        blocks: [*block_fuel]
+        height: [1.0]
+        axial mesh points: [1]
+        xs types: [A]
+    fuel c: &assembly_c
+        specifier: OC
+        blocks: [*block_fuel2]
+        height: [1.0]
+        axial mesh points: [1]
+        xs types: [A]
+systems:
+    core:
+        grid name: core
+        origin:
+            x: 0.0
+            y: 0.0
+            z: 0.0
+grids:
+    pins:
+        geom: cartesian
+        lattice map: |
+            2 2 2 2 2
+            2 1 1 1 2
+            2 1 3 1 2
+            2 3 1 1 2
+            2 2 2 2 2
+    core:
+        geom: hex
+        lattice map: |
+          -   -   OC
+            -   OC  OC
+          -   OC  OC  OC
+            OC  OC  OC  OC
+              OC  IC  OC  OC
+            OC  IC  IC  OC  OC
+              IC  IC  IC  OC  OC
+                IC  IC  IC  OC  OC
+              IC  IC  IC  IC  OC  OC
+                IC  IC  IC  IC  OC
+                  IC  IC  IC  IC  OC
+                IC  IC  IC  IC  OC
+                  IC  IC  IC  IC  OC
+                    IC  IC  IC  OC
+                  IC  IC  IC  IC  OC
+                    IC  IC  IC  OC
+                  IC  IC  IC  IC  OC
+        symmetry: third periodic

--- a/armi/tests/refTriso-settings.yaml
+++ b/armi/tests/refTriso-settings.yaml
@@ -1,0 +1,18 @@
+metadata:
+  version: uncontrolled
+settings:
+  buGroups:
+    - 100
+  burnSteps: 2
+  comment: Test input with TRISO fuel. UNDER DEVELOPMENT!
+  cycleLength: 2000.0
+  db: true
+  loadingFile: refTriso-bp.yaml
+  genReports: false
+  moduleVerbosity:
+    armi.reactor.reactors: info
+  nCycles: 6
+  numCoupledIterations: 0
+  power: 350.0e6
+  summarizeAssemDesign: false
+  verbosity: extra

--- a/armi/tests/test_trisoGeomCase.py
+++ b/armi/tests/test_trisoGeomCase.py
@@ -19,6 +19,7 @@ This test is intended to grow into a test of a TRISO fuel case as the capabiliti
 to support TRISO are added. It does not yet represent real TRISO.
 """
 import unittest
+import math
 
 from armi.utils import directoryChangers
 from armi.tests import TEST_ROOT
@@ -56,10 +57,26 @@ class ComponentGroupReactorTests(unittest.TestCase):
         """
         Make sure composition is blended as expected
         """
-        triso = self.o.r.core[-1][0][0]
-        self.assertEqual(len(list(triso.iterComponents())), 5)
-        self.assertGreater(triso.getMass("U235"), 0.0)
-        self.assertGreater(triso.getMass("C"), 0.0)
+        trisoBlock = self.o.r.core[-1][0]
+        trisoComponent = trisoBlock[0]
+        self.assertEqual(len(list(trisoComponent.iterComponents())), 5)
+        self.assertGreater(trisoComponent.getMass("U235"), 0.0)
+        self.assertGreater(trisoComponent.getMass("C"), 0.0)
+
+        uraniumMass = trisoBlock.getMass("U")
+        # compute triso compact volume from blueprints dimensions
+        blockHeight = trisoBlock.getHeight()
+
+        # expected volume of all kernels in 1 block
+        trisoVolume = blockHeight * math.pi * 1.2466 ** 2 / 4.0 * 20 * 0.350
+
+        # u vol frac within one kernel
+        uraniumFrac = 0.010625 ** 3 / 0.021125 ** 3
+
+        # UZr is 15 g/cc with 90% U
+        expectedMass = 15.6 * 0.9 * trisoVolume * uraniumFrac
+        diff = abs(uraniumMass - expectedMass) / uraniumMass
+        self.assertLess(diff, 0.01)
 
     def test_db(self):
         """Show that this kind of reactor configuration can write and load from DB"""

--- a/armi/tests/test_trisoGeomCase.py
+++ b/armi/tests/test_trisoGeomCase.py
@@ -1,0 +1,78 @@
+# Copyright 2022 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests that a case with Component Groups can load, write to DB, and then read from DB.
+
+This test is intended to grow into a test of a TRISO fuel case as the capabilities
+to support TRISO are added. It does not yet represent real TRISO.
+"""
+import unittest
+
+from armi.utils import directoryChangers
+from armi.tests import TEST_ROOT
+from armi.reactor.flags import Flags
+from armi.reactor import geometry
+from armi import settings
+from armi.reactor import reactors
+from armi import operators
+from armi.bookkeeping import db
+
+TEST_NAME = "refTriso-settings.yaml"
+
+
+class ComponentGroupReactorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.directoryChanger = directoryChangers.DirectoryChanger(TEST_ROOT)
+        cls.directoryChanger.open()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.directoryChanger.close()
+
+    def setUp(self):
+        """
+        Use the related setup in the testFuelHandlers module.
+        """
+        cs = settings.Settings(fName=TEST_NAME)
+        self.o = operators.factory(cs)
+        self.r = reactors.loadFromCs(cs)
+        settings.setMasterCs(cs)
+        self.o.initializeInterfaces(self.r)
+
+    def test_db(self):
+        """Show that this kind of reactor configuration can write and load from DB"""
+        # set some state
+        assem = self.o.r.core.childrenByLocator[self.o.r.core.spatialGrid[8, 0, 0]]
+        block = assem[0]
+        block.p.flux = 1e15
+
+        # write
+        dbi = self.o.getInterface("database")
+        dbi.initDB()
+        dbi.database.writeToDB(self.o.r)
+
+        # read
+        dbo = db.databaseFactory(TEST_NAME.replace(".yaml", ".h5"))
+        with dbo:
+            r = dbo.load(0, 0)
+
+        # verify
+        self.assertEqual(r.core.geomType, geometry.GeomType.HEX)
+
+
+if __name__ == "__main__":
+    # import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/armi/tests/test_trisoGeomCase.py
+++ b/armi/tests/test_trisoGeomCase.py
@@ -52,6 +52,15 @@ class ComponentGroupReactorTests(unittest.TestCase):
         settings.setMasterCs(cs)
         self.o.initializeInterfaces(self.r)
 
+    def test_particleFuel(self):
+        """
+        Make sure composition is blended as expected
+        """
+        triso = self.o.r.core[-1][0][0]
+        self.assertEqual(len(list(triso.iterComponents())), 5)
+        self.assertGreater(triso.getMass("U235"), 0.0)
+        self.assertGreater(triso.getMass("C"), 0.0)
+
     def test_db(self):
         """Show that this kind of reactor configuration can write and load from DB"""
         # set some state
@@ -65,7 +74,7 @@ class ComponentGroupReactorTests(unittest.TestCase):
         dbi.database.writeToDB(self.o.r)
 
         # read
-        dbo = db.databaseFactory(TEST_NAME.replace(".yaml", ".h5"))
+        dbo = db.databaseFactory(TEST_NAME.replace(".yaml", ".h5"), permission="r")
         with dbo:
             r = dbo.load(0, 0)
 


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

This changes the ARMI data model to allow components to have children. It also adds a input
capability to allow users to input particle type fuel (e.g. TRISO).

This is a proof-of-concept at the moment, intended for getting feedback from @drewj-usnctech 
wrt #477 . 

Mostly, take a look at the input file and let us know if it satisfies the need. We will need
to add more testing and documentation to verify that everything is working 
and explained. 

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
