### PR TITLE
Fixing bug in memory profiler

### DIFF
--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -112,8 +112,6 @@ class MemoryProfiler(interfaces.Interface):
         r"""
         Print out some information to stdout about the memory usage of ARMI.
 
-        Makes use of the asizeof utility.
-
         Useful when the debugMem setting is set to True.
 
         Turn these on as appropriate to find all your problems.
@@ -319,7 +317,6 @@ class InstanceCounter:
         self.ids.add(itemId)
         if self.reportSize:
             try:
-                # self.memSize += asizeof(item)
                 self.memSize += sys.getsizeof(item)
             except:
                 self.memSize = float("nan")

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -130,23 +130,22 @@ class MemoryProfiler(interfaces.Interface):
     def _reactorAssemblyTrackingBreakdown(self):
         runLog.important("Reactor attribute ArmiObject tracking count")
         for attrName, attrObj in self.r.core.__dict__.items():
-            if (
-                isinstance(attrObj, list)
-                and attrObj
-                and isinstance(attrObj[0], ArmiObject)
+            if not attrObj:
+                continue
+
+            if isinstance(attrObj, list) and isinstance(attrObj[0], ArmiObject):
+                runLog.important(
+                    "List {:30s} has {:4d} ArmiObjects".format(attrName, len(attrObj))
+                )
+
+            if isinstance(attrObj, dict) and isinstance(
+                list(attrObj.values())[0], ArmiObject
             ):
                 runLog.important(
-                    "List {:30s} has {:4d} assemblies".format(attrName, len(attrObj))
+                    "Dict {:30s} has {:4d} ArmiObjects".format(attrName, len(attrObj))
                 )
-            if (
-                isinstance(attrObj, dict)
-                and attrObj
-                and isinstance(list(attrObj.values())[0], ArmiObject)
-            ):
-                runLog.important(
-                    "Dict {:30s} has {:4d} assemblies".format(attrName, len(attrObj))
-                )
-        runLog.important("SFP has {:4d} assemblies".format(len(self.r.core.sfp)))
+
+        runLog.important("SFP has {:4d} ArmiObjects".format(len(self.r.core.sfp)))
 
     def checkForDuplicateObjectsOnArmiModel(self, attrName, refObject):
         """Scans thorugh ARMI model for duplicate objects"""

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -64,6 +64,21 @@ class TestMemoryProfiler(unittest.TestCase):
             # do some basic testing
             self.assertIn("End Memory Usage Report", mock._outputStream)
 
+    def test_printFullMemoryBreakdown(self):
+        with mockRunLogs.BufferLog() as mock:
+            # we should start with a clean slate
+            self.assertEqual("", mock._outputStream)
+            runLog.LOG.startLog("test_displayMemUsage")
+            runLog.LOG.setVerbosity(logging.INFO)
+
+            # we should start at info level, and that should be working correctly
+            self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
+            self.memPro._printFullMemoryBreakdown(startsWith="", reportSize=True)
+
+            # do some basic testing
+            self.assertIn("UNIQUE_INSTANCE_COUNT", mock._outputStream)
+            self.assertIn(" MB", mock._outputStream)
+
     def test_getReferrers(self):
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate

--- a/armi/tests/refTestCartesian.yaml
+++ b/armi/tests/refTestCartesian.yaml
@@ -24,7 +24,6 @@ settings:
   max2SigmaCladIDT: 630.0
   maxFlowZones: 12
   maxRegionDensityIterations: 5
-  outputCOBRAPinPeakingFactors: false
   outputFileExtension: png
   percentNaReduction: 10.0
   power: 400000000.0

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -26,6 +26,7 @@ Bug fixes
 #. Multiple bug fixes in ``growToFullCore``.
 #. ``Block.getWettedPerim`` was moved to ``HexBlock``, as that was more accurate.
 #. ``pathTools.cleanPath()`` is not much more linear, and handles the MPI use-case better.
+#. Fixed bugs in the ARMI memory profiler.
 #. TBD
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
         "pillow",
         "pluggy",
         "pyevtk",
-        "pympler",
         "scipy",
         "tabulate",
         "voluptuous",


### PR DESCRIPTION
## Description

Upon trying to use `memory_profiler.py` to debug a problem a user reported it was broken. Indeed, it appeared to have a couple of bugs in it.  Furthermore, at least in Python 3.x, the third-party tool `pympler.asizeof()` was so slow as to be entirely unusualble.

To this end, I have fixed a couple of bugs in `memory_profiler.py` and removed all references to `pympler`.

My guess is that the Python standard library `sys.getsizeof()` method will under-report memory usage a bit. BUT it does work, and it works fast, without failure. So that's still a big win.

Also, I was able to delete a bunch of unused code.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
- [X] New or updated dependencies have been added to `setup.py`.
