### PR TITLE
update getPinToDuctGap to ignore holedHex

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1849,7 +1849,7 @@ class HexBlock(Block):
                 # getPinCenterFlatToFlat only works for hexes
                 # inner most duct might be circle or some other shape
                 duct = None
-            elif not isinstance(duct, components.HoledHexagon):
+            elif isinstance(duct, components.HoledHexagon):
                 # has no ip and is circular on inside so following
                 # code will not work
                 duct = None

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1849,6 +1849,10 @@ class HexBlock(Block):
                 # getPinCenterFlatToFlat only works for hexes
                 # inner most duct might be circle or some other shape
                 duct = None
+            elif not isinstance(duct, components.HoledHexagon):
+                # has no ip and is circular on inside so following
+                # code will not work
+                duct = None
         clad = self.getComponent(Flags.CLAD)
         if any(c is None for c in (duct, wire, clad)):
             return None


### PR DESCRIPTION
## Description

The current code cannot handle it since it has no `ip`.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [ ] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
