### PR TITLE
Update unit tests to also pass in Python 3.10

### DIFF
--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -338,15 +338,15 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         """
         # get a baseline: show how the Setting object looks to start
         s1 = setting.Setting("testCopy", 765)
-        self.assertEquals(s1.name, "testCopy")
-        self.assertEquals(s1._value, 765)
+        self.assertEqual(s1.name, "testCopy")
+        self.assertEqual(s1._value, 765)
         self.assertTrue(hasattr(s1, "schema"))
         self.assertTrue(hasattr(s1, "_customSchema"))
 
         # show that copy(Setting) is working correctly
         s2 = copy.copy(s1)
-        self.assertEquals(s2._value, 765)
-        self.assertEquals(s2.name, "testCopy")
+        self.assertEqual(s2._value, 765)
+        self.assertEqual(s2.name, "testCopy")
         self.assertTrue(hasattr(s2, "schema"))
         self.assertTrue(hasattr(s2, "_customSchema"))
 
@@ -357,15 +357,15 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         # get a baseline: show how the Setting object looks to start
         s1 = setting.Setting("testCopy", 765)
         s1.value = 999
-        self.assertEquals(s1.name, "testCopy")
-        self.assertEquals(s1._value, 999)
+        self.assertEqual(s1.name, "testCopy")
+        self.assertEqual(s1._value, 999)
         self.assertTrue(hasattr(s1, "schema"))
         self.assertTrue(hasattr(s1, "_customSchema"))
 
         # show that copy(Setting) is working correctly
         s2 = copy.copy(s1)
-        self.assertEquals(s2._value, 999)
-        self.assertEquals(s2.name, "testCopy")
+        self.assertEqual(s2._value, 999)
+        self.assertEqual(s2.name, "testCopy")
         self.assertTrue(hasattr(s2, "schema"))
         self.assertTrue(hasattr(s2, "_customSchema"))
 

--- a/armi/tests/tutorials/c5g7-blueprints.yaml
+++ b/armi/tests/tutorials/c5g7-blueprints.yaml
@@ -65,8 +65,8 @@ custom isotopics:
         H: 6.70e-2
         O: 3.35E-2
         B: 2.87E-5
-        U235: 6e-8
-        U238: 6e-9
+        U235: 6.0e-8
+        U238: 6.0e-9
 # end-custom-isotopics
 blocks:
     uo2: &block_uo2

--- a/armi/utils/tests/test_gridGui.py
+++ b/armi/utils/tests/test_gridGui.py
@@ -44,15 +44,21 @@ If it outputs "x11", it should work (and if it outputs "wayland", it probably wo
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import asyncio
 import os
-import pytest
 import time
 import unittest
-import test.support
+
+import pytest
+
+try:
+    from test.support import import_module
+except ModuleNotFoundError:
+    # module was moved here in Python 3.10
+    from test.support.import_helper import import_module
 
 # wxpython is an optional dependency, and without it we cant do much of anything. This
 # should raise a unittest.SkipTest if it can't find wx, signalling to pytest to skip the
 # rest of the module. Neat!
-wx = test.support.import_module("wx")
+wx = import_module("wx")
 
 from armi import configure, getApp
 


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

This brings the armi unit test suite up to snuff with Python 3.10. All tests now pass without errors
in 3.10 as well as earlier supported versions of Python 3. 

Also got rid of some deprecation warnings. 

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
