### PR TITLE
Fixes to doc building in Python 3.10

### DIFF
--- a/armi/utils/tests/test_gridGui.py
+++ b/armi/utils/tests/test_gridGui.py
@@ -51,7 +51,7 @@ import pytest
 
 try:
     from test.support import import_module
-except ModuleNotFoundError:
+except ImportError:
     # module was moved here in Python 3.10
     from test.support.import_helper import import_module
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,6 +49,8 @@ from armi import meta
 from armi.bookkeeping import tests as bookkeepingTests
 from armi.utils.dochelpers import *
 
+context.Mode.setMode(context.Mode.BATCH)
+
 # Configure the baseline framework "App" for framework doc building
 armi_configure(apps.App())
 disableFutureConfigures()

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -33,3 +33,4 @@ for b in reactor.core.getBlocks():
     b.p.pdens = x ** 2 + y ** 2 + z ** 2
 
 plotting.plotFaceMap(reactor.core, param="pdens", labelFmt="{0:.1e}")
+plotting.close()


### PR DESCRIPTION
These come from building the documentation, including the gallery and
tutorials, in Python 3.10. A few issues that showed up were:

* the doc build hung on a prompt, so I set it explicitly to BATCH
  mode
* The reactor facemap gallery example hung forever, so I added
  an explicit matplotlib close() to the gallery
* My recent unit test change didn't always work so I set it to
  be the more general ImportError exception.

All docs and galleries and tutorials build just fine in Python 3.10
now.

<!-- Thanks in advance for you contribution! -->

<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
