### PR TITLE
Renaming default branch to main

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
@@ -33,6 +33,6 @@ jobs:
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           repository-name: ${{ github.repository_owner }}/terrapower.github.io
-          branch: master
+          branch: main
           folder: doc/_build/html
           target-folder: armi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Any contribution must pass all included unit tests. The tests are built and run 
 
 ## Submitting changes
 
-Please send a [GitHub Pull Request to the ARMI master branch](https://github.com/terrapower/armi/pull/new/master) with a clear
+Please send a [GitHub Pull Request to the ARMI main branch](https://github.com/terrapower/armi/pull/new/main) with a clear
 list of what you've done (read more about [pull requests](http://help.github.com/pull-requests/)).  Please follow our
 coding conventions (below) and make sure all of your commits are atomic (one feature per commit).
 

--- a/README.rst
+++ b/README.rst
@@ -431,9 +431,9 @@ only use third-party Python libraries that have MIT or BSD licenses.
 
 --------------
 
-.. |Build Status| image:: https://github.com/terrapower/armi/actions/workflows/unittests.yaml/badge.svg?branch=master
+.. |Build Status| image:: https://github.com/terrapower/armi/actions/workflows/unittests.yaml/badge.svg?branch=main
     :target: https://github.com/terrapower/armi/actions/workflows/unittests.yaml
 
-.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=master&kill_cache=7
-    :target: https://coveralls.io/github/terrapower/armi?branch=master
+.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=main&kill_cache=7
+    :target: https://coveralls.io/github/terrapower/armi?branch=main
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -181,7 +181,7 @@ templates_path = [".templates"]
 # The suffix of source filenames.
 source_suffix = ".rst"
 
-# The master toctree document.
+# The top-level toctree document.
 master_doc = "index"
 
 # General information about the project.
@@ -273,7 +273,7 @@ html_context = {
     "display_github": True,  # Integrate GitHub
     "github_user": "terrapower",  # Username
     "github_repo": "armi",  # Repo name
-    "github_version": "master",  # Version
+    "github_version": "main",  # Version
     "conf_py_path": "/doc/",  # Path in the checkout to the docs root
 }
 

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -83,7 +83,7 @@ Every release should follow this process:
 1. Ensure all unit tests pass and the documentation is building correctly.
 2. Bump the ``__version__`` string in ``armi/meta.py``.
 3. Add release notes to the documentation:
-   `here <https://github.com/terrapower/armi/tree/master/doc/release>`__.
+   `here <https://github.com/terrapower/armi/tree/main/doc/release>`__.
 4. Tag the commit after it goes into the repo:
   - From this commit: ``git tag -a 1.0.0 -m "Release v1.0.0"``
   - Or from another commit: ``git tag <commit-hash> 1.0.0 -m "Release v1.0.0"``

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -15,6 +15,7 @@ What's new in ARMI
 #. Removed the ``PyYaml`` dependency.
 #. Removed all bare ``import armi`` statements, for code clarity.
 #. Renamed control rod assembly parameters for generic implementations of control rod handling.
+#. Changed the default Git branch name to ``main``.
 #. TBD
 
 Bug fixes

--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -69,7 +69,7 @@ install it with ``pip``, which will automatically discover and install the
 dependencies. This is useful for quick evaluations or to use it as a dependency
 in another project::
 
-   	(armi-venv) $ pip install https://github.com/terrapower/armi/archive/master.zip
+   	(armi-venv) $ pip install https://github.com/terrapower/armi/archive/main.zip
 
 Option 2: Install as a repository (for developers)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

Okay, this is it. This is the key push. We are renaming our `master` branch to `main`.

I should note, that for a week or two, I am leaving the defunct `master` branch in the repo, just so everyone's build tools don't immediately fail. BUT the default branch name IS called `main` already. So this PR just fixes our docs and GH Actions to match.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
