### PR TITLE
Adding Python 3.10 to our GH Actions unit testing

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, 3.10]
+        python: [3.7, 3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2
@@ -23,4 +23,4 @@ jobs:
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox
-        run: tox -e py,mpitest
+        run: tox -e test,mpitest

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: Install deps
         run: python -m pip install tox tox-gh-actions
       - name: Run Tox
-        run: tox -e py
+        run: tox -e test

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -182,7 +182,7 @@ templates_path = [".templates"]
 source_suffix = ".rst"
 
 # The top-level toctree document.
-master_doc = "index"
+root_doc = "index"
 
 # General information about the project.
 project = "ARMI"

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,10 @@ setenv =
     PYTHONPATH = {toxinidir}
     USERNAME = armi
 
+[testenv:test]
+commands =
+    pytest --ignore=armi/utils/tests/test_gridGui.py -n 4 armi
+
 [testenv:doc]
 whitelist_externals =
     /usr/bin/git


### PR DESCRIPTION
## Description

This PR runs our unit tests under Python 3.10 to our GH Actions builds. This will make sure that _every_ time we do a PR we are also testing Python 3.10.

I figure, since this is so easy to do, we can throw this in before our big "official" Python 3.10 support (which is coming soon).

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
