### PR TITLE
`updateGlobalAssemblyNum` called twice during `loadState`

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -423,7 +423,9 @@ class DatabaseInterface(interfaces.Interface):
                         cs=self.cs,
                         bp=self.r.blueprints,
                         allowMissing=True,
+                        updateGlobalAssemNum=updateGlobalAssemNum,
                     )
+                    self.o.reattach(newR, self.cs)
                     break
         else:
             # reactor was never set so fail
@@ -438,11 +440,6 @@ class DatabaseInterface(interfaces.Interface):
                     getH5GroupName(cycle, timeNode, timeStepName)
                 )
             )
-
-        if updateGlobalAssemNum:
-            updateGlobalAssemblyNum(newR)
-
-        self.o.reattach(newR, self.cs)
 
     def getHistory(
         self,
@@ -1080,7 +1077,14 @@ class Database3(database.Database):
         shutil.copy(self._fullPath, self._fileName)
 
     def load(
-        self, cycle, node, cs=None, bp=None, statePointName=None, allowMissing=False
+        self,
+        cycle,
+        node,
+        cs=None,
+        bp=None,
+        statePointName=None,
+        allowMissing=False,
+        updateGlobalAssemNum=True,
     ):
         """Load a new reactor from (cycle, node).
 
@@ -1105,6 +1109,9 @@ class Database3(database.Database):
         allowMissing : bool
             Whether to emit a warning, rather than crash if reading a database
             with undefined parameters. Default False.
+        updateGlobalAssemNum : bool
+            Whether to update the global assembly number to the value stored in
+            r.core.p.maxAssemNum. Default True.
 
         Returns
         -------
@@ -1140,8 +1147,9 @@ class Database3(database.Database):
         )
         root = comps[0][0]
 
-        # ensure the max assembly number is correct
-        updateGlobalAssemblyNum(root)
+        # ensure the max assembly number is correct, unless the user says no
+        if updateGlobalAssemNum:
+            updateGlobalAssemblyNum(root)
 
         # usually a reactor object
         return root

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -270,6 +270,28 @@ class TestDatabase3(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.db.fileName = "whatever.h5"
 
+    def test_load_updateGlobalAssemNum(self):
+        from armi.reactor import assemblies
+        from armi.reactor.assemblies import resetAssemNumCounter
+
+        self.makeShuffleHistory()
+
+        resetAssemNumCounter()
+        self.assertEqual(assemblies._assemNum, 0)
+
+        # there will 77 assemblies added to the newly created core
+        self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=False)
+        self.assertEqual(assemblies._assemNum, 77)
+
+        # now do the same call again and show that the global _assemNum just keeps going up
+        self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=False)
+        self.assertEqual(assemblies._assemNum, 77 * 2)
+
+        # now load but also updateGlobalAssemNum and show that it updates to the value
+        # stored in self.r.p.maxAssemNum plus 1
+        self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=True)
+        self.assertEqual(assemblies._assemNum, self.r.core.p.maxAssemNum + 1)
+
     def test_history(self):
         self.makeShuffleHistory()
 


### PR DESCRIPTION
## Description

In response to #690 .

The duplicate call has been removed and another input option `updateGlobalAssemNum` has been added to `loadState` so that it can be passed along to `load`. This way both calls are consistent and `updateGlobalAssemblyNum` doesn't need to be called within `loadState` itself.

The default value of `updateGlobalAssemNum` is `True` so that the previous behavior is maintained by default.

Tests have been added as well.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.