### PR TITLE
Moving comments to use the word primary

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -173,7 +173,7 @@ def init(choice=None, fName=None, cs=None):
     try:
         return armiCase.initializeOperator()
     except:  # Catch any and all errors. Naked exception on purpose.
-        # Concatenate errors to the master log file.
+        # Concatenate errors to the primary log file.
         runLog.close()
         raise
 

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -293,7 +293,7 @@ class DatabaseInterface(interfaces.Interface):
         """
         Reconnect to pre-existing database.
 
-        DB is created and managed by the master node only but we can still connect to it
+        DB is created and managed by the primary node only but we can still connect to it
         from workers to enable things like history tracking.
         """
         if context.MPI_RANK > 0:

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -372,7 +372,7 @@ class Case:
 
         with o:
             if self.cs["trace"] and context.MPI_RANK == 0:
-                # only trace master node.
+                # only trace primary node.
                 tracer = trace.Trace(ignoredirs=[sys.prefix, sys.exec_prefix], trace=1)
                 tracer.runctx("o.operate()", globals(), locals())
             else:

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -231,7 +231,7 @@ class ArmiCLI:
 
 
 def splash():
-    """Emit a the active App's splash text to the runLog for the master node."""
+    """Emit a the active App's splash text to the runLog for the primary node."""
     from armi import getApp  # pylint: disable=import-outside-toplevel
 
     app = getApp()

--- a/armi/context.py
+++ b/armi/context.py
@@ -99,7 +99,7 @@ Mode.setMode(CURRENT_MODE)
 
 MPI_COMM = None
 # MPI_RANK represents the index of the CPU that is running.
-# 0 is typically the master CPU, while 1+ are typically workers.
+# 0 is typically the primary CPU, while 1+ are typically workers.
 # MPI_SIZE is the total number of CPUs
 MPI_RANK = 0
 MPI_SIZE = 1

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -204,7 +204,7 @@ class Interface:
 
         Notes
         -----
-        This runs on all worker nodes as well as the master.
+        This runs on all worker nodes as well as the primary.
         """
         self.r = r
         self.cs = o.cs
@@ -316,7 +316,7 @@ class Interface:
         pass
 
     def interactDistributeState(self):
-        """Called after this interface is copied to a different (non-master) MPI node."""
+        """Called after this interface is copied to a different (non-primary) MPI node."""
         pass
 
     def isRequestedDetailPoint(self, cycle=None, node=None):

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -497,14 +497,16 @@ class Operator:  # pylint: disable=too-many-public-methods
         cs = settings.getMasterCs()
         wrong = (self.cs is not cs) or any((i.cs is not cs) for i in self.interfaces)
         if wrong:
-            msg = ["Master cs ID is {}".format(id(cs))]
+            msg = ["Primay cs ID is {}".format(id(cs))]
             for i in self.interfaces:
                 msg.append("{:30s} has cs ID: {:12d}".format(str(i), id(i.cs)))
             msg.append("{:30s} has cs ID: {:12d}".format(str(self), id(self.cs)))
             raise RuntimeError("\n".join(msg))
 
         runLog.debug(
-            "Reactors, operators, and interfaces all share master cs: {}".format(id(cs))
+            "Reactors, operators, and interfaces all share primary cs: {}".format(
+                id(cs)
+            )
         )
 
     def interactAllInit(self):

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -163,7 +163,7 @@ class SystemBlueprint(yamlize.Object):
         )
         system.spatialLocator = spatialLocator
         if context.MPI_RANK != 0:
-            # on non-master nodes we don't bother building up the assemblies
+            # on non-primary nodes we don't bother building up the assemblies
             # because they will be populated with DistributeState.
             return None
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1309,7 +1309,7 @@ class Core(composites.Composite):
         assemblyLevel : bool, optional
             If True, will find assemblies rather than blocks
         locContents : dict, optional
-            A master lookup table with location string keys and block/assembly values
+            A lookup table with location string keys and block/assembly values
             useful if you want to call this function many times and would like a speedup.
 
         Returns
@@ -1834,7 +1834,7 @@ class Core(composites.Composite):
 
         See Also
         --------
-        processLoading : sets up the master mesh that this perturbs.
+        processLoading : sets up the primary mesh that this perturbs.
         """
         # most of the time, we want fuel, but they should mostly have the same number of blocks
         # if this becomes a problem, we might find either the
@@ -2078,7 +2078,7 @@ class Core(composites.Composite):
         Parameters
         ----------
         mats : iterable or Material
-            List (or single) of materials to scan the full core for, accumulating a master nuclide list
+            List (or single) of materials to scan the full core for, accumulating a nuclide list
 
         Returns
         -------
@@ -2095,7 +2095,6 @@ class Core(composites.Composite):
         If you need to know the nuclides in a fuel pin, you can't just use the sample returned
         from getDominantMaterial, because it may be a fresh fuel material (U and Zr) even though
         there are burned materials elsewhere (with U, Zr, Pu, LFP, etc.).
-
         """
         if not isinstance(mats, list):
             # single material passed in

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -61,7 +61,7 @@ def buildOperatorOfEmptyHexBlocks(customSettings=None):
 
     customSettings["db"] = False  # stop use of database
     cs = cs.modified(newSettings=customSettings)
-    settings.setMasterCs(cs)  # reset so everything matches master
+    settings.setMasterCs(cs)  # reset so everything matches the primary Cs
 
     r = tests.getEmptyHexReactor()
     r.core.setOptionsFromCs(cs)

--- a/armi/settings/__init__.py
+++ b/armi/settings/__init__.py
@@ -159,7 +159,7 @@ def getMasterCs():
     """
     Return the global case-settings object (cs).
 
-    This can be called at any time to create or obtain the master Cs, a module-level CS
+    This can be called at any time to create or obtain the primary Cs, a module-level CS
     intended to be shared by many other objects.
 
     It can have multiple instances in multiprocessing cases.
@@ -178,9 +178,9 @@ def getMasterCs():
 
 def setMasterCs(cs):
     """
-    Set the master Cs to be the one that is passed in.
+    Set the primary Cs to be the one that is passed in.
 
     These are kept track of independently on a PID basis to allow independent multiprocessing.
     """
     Settings.instance = cs
-    runLog.debug("Master cs set to {} with ID: {}".format(cs, id(cs)))
+    runLog.debug("Primary cs set to {} with ID: {}".format(cs, id(cs)))

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -22,7 +22,7 @@ the environment setup, and hundreds of other things.
 A settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to
 create this settings file, which is then loaded by an ARMI process on the cluster.
 
-A master case settings is created as ``masterCs``
+A primay case settings is created as ``masterCs``
 
 """
 import io

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -330,7 +330,7 @@ def defineSettings() -> List[setting.Setting]:
             CONF_BRANCH_VERBOSITY,
             default="error",
             label="Worker Log Verbosity",
-            description="Verbosity of the non-master MPI nodes",
+            description="Verbosity of the non-primary MPI nodes",
             options=[
                 "debug",
                 "extra",
@@ -664,7 +664,7 @@ def defineSettings() -> List[setting.Setting]:
         setting.Setting(
             CONF_VERBOSITY,
             default="info",
-            label="Master Log Verbosity",
+            label="Primary Log Verbosity",
             description="How verbose the output will be",
             options=[
                 "debug",

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -99,7 +99,7 @@ class MpiOperatorTests(unittest.TestCase):
         self.o.operate()
 
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
-    def test_masterException(self):
+    def test_primaryException(self):
         self.o.removeAllInterfaces()
         failer = FailingInterface1(self.o.r, self.o.cs)
         self.o.addInterface(failer)
@@ -110,7 +110,7 @@ class MpiOperatorTests(unittest.TestCase):
             self.o.operate()
 
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
-    def test_masterCritical(self):
+    def test_primaryCritical(self):
         self.o.removeAllInterfaces()
         failer = FailingInterface2(self.o.r, self.o.cs)
         self.o.addInterface(failer)

--- a/doc/user/assorted_guide.rst
+++ b/doc/user/assorted_guide.rst
@@ -6,8 +6,8 @@ selects the one that is preferred by the user before going on to the
 next time step. A branch search involves several methods.
 
 A branch search starts when the :py:meth:`branchSearch <armi.operators.Operator.branchSearch>`
-method is called on the master node. It backs up the reactor state and that
-of all the interfaces to allow the master node to participate in the branch search.
+method is called on the primary node. It backs up the reactor state and that
+of all the interfaces to allow the primary node to participate in the branch search.
 It then calls :py:meth:`spawnCritShuffleSearch <armi.operators.Operator.spawnCritShuffleSearch>`
 and restores the original reactor after the branch search is complete.
 
@@ -18,10 +18,10 @@ calls :py:meth:`runCritShuffleSearch <armi.operators.OperatorMPI.runCritShuffleS
 to actually do the runs, and finally wraps up and chooses the best case.
 
 The :py:meth:`runCritShuffleSearch <armi.operators.OperatorMPI.runCritShuffleSearch>`
-only runs on the master node as well. It distributes the current reactor and
+only runs on the primary node as well. It distributes the current reactor and
 interface state to all MPI processes and then broadcasts the command
 to inform the MPI nodes to prepare to do a branch search (with the ``rebusShuffle``
-command). On the master and all the workers, the
+command). On the primary and all the workers, the
 :py:meth:`armi.operators.OperatorMPI.runShuffleBranch` method is called at the same
 time to run the neutronics cases.
 

--- a/doc/user/outputs/stdout.rst
+++ b/doc/user/outputs/stdout.rst
@@ -17,7 +17,7 @@ results are.  Here is an excerpt::
         [xtra] Cross section group manager summary
 
 In a standard run, the various interfaces will loop through and print out messages according to the `verbosity`
-setting. In multi-processing runs, the **stdout** shows messages from the master node first and then shows information
+setting. In multi-processing runs, the **stdout** shows messages from the primary node first and then shows information
 from all other nodes below (with verbosity set by the `branchVerbosity` setting). Sometimes a user will want to set the
 verbosity of just one module (.py file) in the code higher than the rest of ARMI, to do so they can set up a custom
 logger by placing this line at the top of the file::
@@ -40,5 +40,4 @@ Some Linux users tend to use the **tail** command to monitor the progress of an 
     tail -f myRun.stdout
 
 This provides live information on the progress.
-
 


### PR DESCRIPTION
## Description

This PR doesn't not fix the "getMasterCs()" method, or the language in our MPI code. But it solves the easy parts of moving our comments and docstrings to use the word "primary".

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
