### PR TITLE
New nozzleType parameter in blueprints

### DIFF
--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -297,6 +297,16 @@ def getAssemblyParameterDefinitions():
             saveToDB=True,
         )
 
+        pb.defParam(
+            "nozzleType",
+            units="None",
+            description="nozzle type for assembly",
+            location="?",
+            default="Default",
+            saveToDB=True,
+            categories=[parameters.Category.assignInBlueprints],
+        )
+
     with pDefs.createBuilder(default=0.0) as pb:
 
         pb.defParam("Pos", units="?", description="?", location="?")

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1066,7 +1066,7 @@ class Core(composites.Composite):
 
     def getNozzleTypes(self):
         nozzleList = list(set(a.p.nozzleType for a in self.getAssemblies()))
-        return { nozzleType: i for i, nozzleType in enumerate(sorted(nozzleList)) }
+        return {nozzleType: i for i, nozzleType in enumerate(sorted(nozzleList))}
 
     def getBlockByName(self, name):
         """

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1064,6 +1064,10 @@ class Core(composites.Composite):
 
         return assems
 
+    def getNozzleTypes(self):
+        nozzleList = list(set(a.p.nozzleType for a in self.getAssemblies()))
+        return { nozzleType: i for i, nozzleType in enumerate(sorted(nozzleList)) }
+
     def getBlockByName(self, name):
         """
         Finds a block based on its name.

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1065,7 +1065,24 @@ class Core(composites.Composite):
         return assems
 
     def getNozzleTypes(self):
-        nozzleList = list(set(a.p.nozzleType for a in self.getAssemblies()))
+        """
+        Get a dictionary of all of the assembly ``nozzleType``s in the core.
+
+        Returns
+        -------
+            nozzles : dict
+            A dictionary of ``{nozzleType: nozzleID}`` pairs, where the nozzleIDs are
+            numbers corresponding to the alphabetical order of the ``nozzleType`` names.
+
+        Notes
+        -----
+        Getting the ``nozzleID`` by alphabetical order could cause a problem if a new
+        ``nozzleType`` is added during a run. This problem should not occur with the
+        ``includeBolAssems=True`` argument provided.
+        """
+        nozzleList = list(
+            set(a.p.nozzleType for a in self.getAssemblies(includeBolAssems=True))
+        )
         return {nozzleType: i for i, nozzleType in enumerate(sorted(nozzleList))}
 
     def getBlockByName(self, name):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1070,7 +1070,7 @@ class Core(composites.Composite):
 
         Returns
         -------
-            nozzles : dict
+        nozzles : dict
             A dictionary of ``{nozzleType: nozzleID}`` pairs, where the nozzleIDs are
             numbers corresponding to the alphabetical order of the ``nozzleType`` names.
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -732,8 +732,7 @@ class HexReactorTests(ReactorTests):
         expectedTypes = ["Inner", "Outer", "lta", "Default"]
         for nozzle in nozzleTypes:
             self.assertTrue(
-                nozzle in expectedTypes,
-                f"nozzleType {nozzle} not in {expectedTypes}"
+                nozzle in expectedTypes, f"nozzleType {nozzle} not in {expectedTypes}"
             )
 
     def test_createAssemblyOfType(self):

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -727,6 +727,15 @@ class HexReactorTests(ReactorTests):
             self.assertNotEqual(aLoc[i], a.spatialLocator)
             self.assertEqual(a.spatialLocator.grid, self.r.core.sfp.spatialGrid)
 
+    def test_getNozzleTypes(self):
+        nozzleTypes = self.r.core.getNozzleTypes()
+        expectedTypes = ["Inner", "Outer", "lta", "Default"]
+        for nozzle in nozzleTypes:
+            self.assertTrue(
+                nozzle in expectedTypes,
+                f"nozzleType {nozzle} not in {expectedTypes}"
+            )
+
     def test_createAssemblyOfType(self):
         """Test creation of new assemblies."""
         # basic creation

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -195,10 +195,10 @@ class Zones_InReactor(unittest.TestCase):
         cs = cs.modified(newSettings=newSettings)
         zonez = zones.buildZones(r.core, cs)
 
-        self.assertEqual(len(list(zonez)), 2)
-        self.assertIn("008-040", zonez["zone0"])
-        self.assertIn("005-023", zonez["zone0"])
-        self.assertIn("003-002", zonez["ltazone0"])
+        self.assertEqual(len(list(zonez)), 3)
+        self.assertIn("008-040", zonez["zone0-Outer"])
+        self.assertIn("005-023", zonez["zone0-Inner"])
+        self.assertIn("003-002", zonez["zone0-lta"])
 
     def test_removeZone(self):
         o, r = self.o, self.r

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -195,10 +195,11 @@ class Zones_InReactor(unittest.TestCase):
         cs = cs.modified(newSettings=newSettings)
         zonez = zones.buildZones(r.core, cs)
 
-        self.assertEqual(len(list(zonez)), 3)
+        self.assertEqual(len(list(zonez)), 4)
         self.assertIn("008-040", zonez["zone0-Outer"])
         self.assertIn("005-023", zonez["zone0-Inner"])
         self.assertIn("003-002", zonez["zone0-lta"])
+        self.assertIn("009-001", zonez["zone0-Default"])
 
     def test_removeZone(self):
         o, r = self.o, self.r

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -465,7 +465,7 @@ def _buildZonesByOrifice(core, cs):
 
     # first get all different orifice setting zones
     for a in core.getAssembliesOfType(Flags.FUEL):
-        orificeSetting = "zone" + str(a.p.THorificeZone) + "-" + str(a.p.NozzleType)
+        orificeSetting = "zone" + str(a.p.THorificeZone) + "-" + str(a.p.nozzleType)
         b = a.getFirstBlock(Flags.FUEL)
         cFuel = b.getComponent(Flags.FUEL)
         fuelMaterial = cFuel.getProperties()
@@ -478,7 +478,7 @@ def _buildZonesByOrifice(core, cs):
 
     # now put FAs of the same orifice zone in to one channel
     for a in core.getAssembliesOfType(Flags.FUEL):
-        orificeSetting = "zone" + str(a.p.THorificeZone) + "-" + str(a.p.NozzleType)
+        orificeSetting = "zone" + str(a.p.THorificeZone) + "-" + str(a.p.nozzleType)
         b = a.getFirstBlock(Flags.FUEL)
         cFuel = b.getComponent(Flags.FUEL)
         fuelMaterial = cFuel.getProperties()

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -469,8 +469,6 @@ def _buildZonesByOrifice(core, cs):
         b = a.getFirstBlock(Flags.FUEL)
         cFuel = b.getComponent(Flags.FUEL)
         fuelMaterial = cFuel.getProperties()
-        #if "lta" in a.getType():
-        #    orificeSetting = "lta" + str((orificeSetting))
         if "Oxide" in fuelMaterial.getName():
             orificeSetting = "Oxide" + str((orificeSetting))
         if orificeSetting not in orificeZones.names:
@@ -482,13 +480,8 @@ def _buildZonesByOrifice(core, cs):
         b = a.getFirstBlock(Flags.FUEL)
         cFuel = b.getComponent(Flags.FUEL)
         fuelMaterial = cFuel.getProperties()
-        # get channel for lta
-        #if "lta" in a.getType():
-        #    orificeZones["lta" + str(orificeSetting)].append(a.getLocation())
-        # account for oxide fuel
         if "Oxide" in fuelMaterial.getName():
             orificeZones["Oxide" + str(orificeSetting)].append(a.getLocation())
-        # account for LTA
         else:
             orificeZones[orificeSetting].append(a.getLocation())
 

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -464,26 +464,15 @@ def _buildZonesByOrifice(core, cs):
     orificeZones = Zones(core, cs)
 
     # first get all different orifice setting zones
-    for a in core.getAssembliesOfType(Flags.FUEL):
+    for a in core.getAssemblies():
         orificeSetting = "zone" + str(a.p.THorificeZone) + "-" + str(a.p.nozzleType)
-        b = a.getFirstBlock(Flags.FUEL)
-        cFuel = b.getComponent(Flags.FUEL)
-        fuelMaterial = cFuel.getProperties()
-        if "Oxide" in fuelMaterial.getName():
-            orificeSetting = "Oxide" + str((orificeSetting))
         if orificeSetting not in orificeZones.names:
             orificeZones.add(Zone(orificeSetting))
 
     # now put FAs of the same orifice zone in to one channel
-    for a in core.getAssembliesOfType(Flags.FUEL):
+    for a in core.getAssemblies():
         orificeSetting = "zone" + str(a.p.THorificeZone) + "-" + str(a.p.nozzleType)
-        b = a.getFirstBlock(Flags.FUEL)
-        cFuel = b.getComponent(Flags.FUEL)
-        fuelMaterial = cFuel.getProperties()
-        if "Oxide" in fuelMaterial.getName():
-            orificeZones["Oxide" + str(orificeSetting)].append(a.getLocation())
-        else:
-            orificeZones[orificeSetting].append(a.getLocation())
+        orificeZones[orificeSetting].append(a.getLocation())
 
     return orificeZones
 

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -465,28 +465,28 @@ def _buildZonesByOrifice(core, cs):
 
     # first get all different orifice setting zones
     for a in core.getAssembliesOfType(Flags.FUEL):
-        orificeSetting = "zone" + str(a.p.THorificeZone)
+        orificeSetting = "zone" + str(a.p.THorificeZone) + "-" + str(a.p.NozzleType)
         b = a.getFirstBlock(Flags.FUEL)
         cFuel = b.getComponent(Flags.FUEL)
         fuelMaterial = cFuel.getProperties()
-        if "lta" in a.getType():
-            orificeSetting = "lta" + str((orificeSetting))
-        elif "Oxide" in fuelMaterial.getName():
+        #if "lta" in a.getType():
+        #    orificeSetting = "lta" + str((orificeSetting))
+        if "Oxide" in fuelMaterial.getName():
             orificeSetting = "Oxide" + str((orificeSetting))
         if orificeSetting not in orificeZones.names:
             orificeZones.add(Zone(orificeSetting))
 
     # now put FAs of the same orifice zone in to one channel
     for a in core.getAssembliesOfType(Flags.FUEL):
-        orificeSetting = "zone" + str(a.p.THorificeZone)
+        orificeSetting = "zone" + str(a.p.THorificeZone) + "-" + str(a.p.NozzleType)
         b = a.getFirstBlock(Flags.FUEL)
         cFuel = b.getComponent(Flags.FUEL)
         fuelMaterial = cFuel.getProperties()
         # get channel for lta
-        if "lta" in a.getType():
-            orificeZones["lta" + str(orificeSetting)].append(a.getLocation())
+        #if "lta" in a.getType():
+        #    orificeZones["lta" + str(orificeSetting)].append(a.getLocation())
         # account for oxide fuel
-        elif "Oxide" in fuelMaterial.getName():
+        if "Oxide" in fuelMaterial.getName():
             orificeZones["Oxide" + str(orificeSetting)].append(a.getLocation())
         # account for LTA
         else:

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -458,7 +458,7 @@ def _buildZonesByOrifice(core, cs):
 
     Notes
     -----
-    Orifice coefficients are determined by a combinatio of the
+    Orifice coefficients are determined by a combination of the
     ``THorificeZone`` and ``nozzleType`` parameters. Each combination of
     ``THorificeZone`` and ``nozzleType`` is treated as a unique ``Zone``.
     """

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -458,7 +458,9 @@ def _buildZonesByOrifice(core, cs):
 
     Notes
     -----
-    It separate oxide and LTA assembly into their own zones
+    Orifice coefficients are determined by a combinatio of the
+    ``THorificeZone`` and ``nozzleType`` parameters. Each combination of
+    ``THorificeZone`` and ``nozzleType`` is treated as a unique ``Zone``.
     """
     runLog.extra("Building Zones by Orifice zone")
     orificeZones = Zones(core, cs)

--- a/armi/tests/refSmallReactorBase.yaml
+++ b/armi/tests/refSmallReactorBase.yaml
@@ -371,6 +371,7 @@ assemblies:
             U235_wt_frac: &igniter_fuel_u235_wt_frac ['', 0.11, 0.11, 0.11, '']
             ZR_wt_frac: &igniter_fuel_zr_wt_frac ['', 0.06, 0.06, 0.06, '']
         xs types: &igniter_fuel_xs_types [A, A, A, A, A]
+        nozzleType: Inner
     middle fuel:
         specifier: MC
         blocks: [*block_grid_plate, *block_fuel2, *block_fuel2, *block_fuel2, *block_plenum]
@@ -392,6 +393,7 @@ assemblies:
             U235_wt_frac: &lta_fuel_u235_wt_frac ['', 0.2, 0.2, 0.2, '']
             ZR_wt_frac: &lta_fuel_zr_wt_frac ['', 0.07, 0.07, 0.06, '']
         xs types: *igniter_fuel_xs_types
+        nozzleType: lta
     lta fuel b:
         specifier: LB
         blocks: [*block_grid_plate, *block_lta2_fuel, *block_lta2_fuel, *block_lta2_fuel, *block_plenum]
@@ -401,6 +403,7 @@ assemblies:
             U235_wt_frac: *lta_fuel_u235_wt_frac
             ZR_wt_frac: *lta_fuel_zr_wt_frac
         xs types: *igniter_fuel_xs_types
+        nozzleType: lta
     feed fuel:
         specifier: OC
         blocks: *igniter_fuel_blocks
@@ -410,6 +413,7 @@ assemblies:
             U235_wt_frac: *igniter_fuel_u235_wt_frac
             ZR_wt_frac: *igniter_fuel_zr_wt_frac
         xs types: *igniter_fuel_xs_types
+        nozzleType: Outer
     primary control:
         specifier: PC
         blocks: [*block_grid_plate, *block_duct, *block_control, *block_plenum, *block_duct]

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -98,7 +98,6 @@ FLAG_STYLES = {
     # WHITE (same as above, this will just lighten anything that it accompanies)
     Flags.MIDDLE: (numpy.array([1.0, 1.0, 1.0]), None),
     Flags.ANNULAR: (numpy.array([1.0, 1.0, 1.0]), None),
-
     Flags.IGNITER: (numpy.array([0.2, 0.2, 0.2]), None),
     Flags.STARTER: (numpy.array([0.4, 0.4, 0.4]), None),
     Flags.FEED: (numpy.array([0.6, 0.6, 0.6]), None),

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -98,6 +98,11 @@ FLAG_STYLES = {
     # WHITE (same as above, this will just lighten anything that it accompanies)
     Flags.MIDDLE: (numpy.array([1.0, 1.0, 1.0]), None),
     Flags.ANNULAR: (numpy.array([1.0, 1.0, 1.0]), None),
+
+    Flags.IGNITER: (numpy.array([0.2, 0.2, 0.2]), None),
+    Flags.STARTER: (numpy.array([0.4, 0.4, 0.4]), None),
+    Flags.FEED: (numpy.array([0.6, 0.6, 0.6]), None),
+    Flags.DRIVER: (numpy.array([0.8, 0.8, 0.8]), None),
 }
 
 # RGB weights for calculating luminance. We use this to decide whether we should put

--- a/doc/user/inputs/blueprints.rst
+++ b/doc/user/inputs/blueprints.rst
@@ -283,7 +283,7 @@ Historically, flags have also been used to describe directly `what should be don
 an object in the reactor model. For instance, an object with the ``DEPLETABLE`` flag set
 will participate in isotopic depletion analysis, whereas objects without the
 ``DEPLETION`` flag set will not. This has led to a lot of confusion, as the meaning of
-various flags is burried deep within the code, and can conflict from place to place. We
+various flags is buried deep within the code, and can conflict from place to place. We
 are trying to align around a `what something is` interpretation, and bind those to
 specific behaviors with settings. For more details, see :py:mod:`armi.reactor.flags`.
 
@@ -328,6 +328,7 @@ A complete definition of an inner-core assembly may be seen below::
                 material modifications:
                     U235_wt_frac: ['', '', 0.001, 0.002, 0.03, '']
                     ZR_wt_frac: ['', '', 0.1, 0.1, 0.1, 0.1]
+                nozzleType: Inner
                 xs types: [A, B, C, D, E, F]
 
 .. note:: While component dimensions are entered as cold dimensions, axial heights must
@@ -379,6 +380,11 @@ material modifications
   enrichment (mass frac.), zirconium mass frac, and any additional options required to fully define
   the material loaded in the component.  The material definitions in the material library define
   valid modifications for them.
+
+nozzleType
+  This is a string that identifies what type of inlet nozzle an assembly has. This parameter could
+  be used in an implementation of a thermal-hydraulics solver with flow orificing to apply
+  different pressure loss coefficients and/or flow rates to different types of assemblies.
 
   .. exec::
       from armi.materials import Material


### PR DESCRIPTION
## Description

Different assemblies in the core can be manufactured with different nozzle types that can affect the coolant flow distribution within the core. This PR adds a parameter `nozzleType` that can be defined in the assembly blueprint. This parameter can be queried by T/H and orificing code to assist with modeling.

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.
