### PR TITLE
Ensure same domain when converting geometry.

### DIFF
--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -349,9 +349,6 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
 
     def test_initNewFullReactor(self):
         """Test that initNewReactor will growToFullCore if necessary."""
-
-    def test_blueprintCopy(self):
-        """Ensure that necessary blueprint attributes are set"""
         # Perform reactor conversion
         changer = geometryConverters.ThirdCoreHexToFullCoreChanger(self.o.cs)
         changer.convert(self.r)

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -27,6 +27,7 @@ from armi.reactor import geometry
 from armi.reactor import grids
 from armi.tests import TEST_ROOT
 from armi.reactor.converters import geometryConverters
+from armi.reactor.converters import uniformMesh
 from armi.reactor.tests.test_reactors import loadTestReactor
 from armi.reactor.flags import Flags
 from armi.utils import directoryChangers
@@ -345,6 +346,23 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
             ),
         )
         self.assertFalse(self.r.core.isFullCore)
+
+    def test_initNewFullReactor(self):
+        """Test that initNewReactor will growToFullCore if necessary."""
+
+    def test_blueprintCopy(self):
+        """Ensure that necessary blueprint attributes are set"""
+        # Perform reactor conversion
+        changer = geometryConverters.ThirdCoreHexToFullCoreChanger(self.o.cs)
+        changer.convert(self.r)
+
+        converter = uniformMesh.NeutronicsUniformMeshConverter()
+        newR = converter.initNewReactor(self.r)
+
+        # Check the full core conversion is successful
+        self.assertTrue(self.r.core.isFullCore)
+        self.assertTrue(newR.core.isFullCore)
+        self.assertEqual(newR.core.symmetry.domain, geometry.DomainType.FULL_CORE)
 
     def test_skipGrowToFullCoreWhenAlreadyFullCore(self):
         """Test that hex core is not modified when third core to full core changer is called on an already full core geometry."""

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -126,6 +126,11 @@ class UniformMeshGeometryConverter(GeometryConverter):
         coreDesign.construct(sourceReactor.o.cs, bp, newReactor, loadAssems=False)
         newReactor.core.lib = sourceReactor.core.lib
         newReactor.core.setPitchUniform(sourceReactor.core.getAssemblyPitch())
+
+        # check if the sourceReactor has been modified from the blueprints
+        if sourceReactor.core.isFullCore and not newReactor.core.isFullCore:
+            geometryConverter = newReactor.core.growToFullCore(sourceReactor.o.cs)
+
         return newReactor
 
     def _computeAverageAxialMesh(self):


### PR DESCRIPTION
## Description

`initNewReactor` creates a `newReactor` from a `sourceReactor`'s blueprints. Sometimes the `sourceReactor` has been expanded from `THIRD` to `FULL` core geometry, but the blueprints do not reflect this change. This code change ensures that the `newReactor` is also expanded to full core if the `sourceReactor` has been expanded.

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.
