### PR TITLE
Fix centering in the Cartesian test case.

### DIFF
--- a/armi/tests/refSmallCartesian.yaml
+++ b/armi/tests/refSmallCartesian.yaml
@@ -282,8 +282,8 @@ systems:
     core:
         grid name: core
         origin:
-            x: -65.0
-            y: -65.0
+            x: 0.0
+            y: 0.0
             z: 0.0
 
 grids:


### PR DESCRIPTION
The center for refSmallCartesian should be at 0,0,0.  As it was, the
Fuel management in a LWR gallery example had negative burnups, which,
though manufactured as a demo, were confusing. This this change, the
gallery example is again a typical full core case.

Sidenote: first commit from an airplane?

[Before fix](https://terrapower.github.io/armi/gallery/framework/run_fuelManagement.html#sphx-glr-gallery-framework-run-fuelmanagement-py): 

![image](https://user-images.githubusercontent.com/53948397/174550671-b56ac417-71ef-4792-af83-181b69641728.png)

After fix: 
![image](https://user-images.githubusercontent.com/53948397/174551848-e4a80d34-34ae-46e0-a43e-91cb941a2b0f.png)


- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
