### PR TITLE
Return no diffs earlier in dbcompare if mean is 0

### DIFF
--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -420,7 +420,11 @@ def _diffSimpleData(
     try:
         # use mean to avoid some unnecessary infinities
         mean = (src[()] + ref[()]) / 2.0
-        diff = (src[()] - ref[()]) / mean
+        if mean.all() == 0:
+            # no diffs possible
+            return
+        else:
+            diff = (src[()] - ref[()]) / mean
     except TypeError:
         # Strings are persnickety
         if src.dtype.kind == ref.dtype.kind and src.dtype.kind in {"U", "S"}:


### PR DESCRIPTION
This only returns no diffs if ALL values in the mean array are 0.

<!-- Thanks in advance for you contribution! -->

## Description

Not sure this is necessary yet

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] The code is understandable and maintainable to people beyond the author.
- [ ] Tests have been added/updated to verify that the new or changed code works.
- [ ] There is no commented out code in this PR.
- [ ] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [ ] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
- [ ] New or updated dependencies have been added to `setup.py`.
