### PR TITLE
Fix the hex orientation of pin locations.

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1935,6 +1935,8 @@ class HexBlock(Block):
         """
         Compute the local centroid coordinates of any pins in this block.
 
+        The pins must have a CLAD-flagged component for this to work.
+
         Returns
         -------
         localCoordinates : list
@@ -1952,7 +1954,7 @@ class HexBlock(Block):
                     [locator.getLocalCoordinates() for locator in clad.spatialLocator]
                 )
             else:
-                coords.append(locator.getLocalCoordinates())
+                coords.append(clad.spatialLocator.getLocalCoordinates())
         return coords
 
     def autoCreateSpatialGrids(self):
@@ -1969,6 +1971,8 @@ class HexBlock(Block):
         -----
         If the block meets all the conditions, we gather all components to either be a multiIndexLocation containing all
         of the pin positions, otherwise, locator is the center (0,0).
+
+        Also, this only works on blocks that have 'flat side up'.
 
         Raises
         ------

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1693,6 +1693,10 @@ class HexBlock_TestCase(unittest.TestCase):
         self.assertTrue(self.HexBlock.hasFlags(Flags.INTERCOOLANT))
 
     def test_getPinCoords(self):
+        blockPitch = self.HexBlock.getPitch()
+        pinPitch = self.HexBlock.getPinPitch()
+        nPins = self.HexBlock.getNumPins()
+        side = hexagon.side(blockPitch)
         xyz = self.HexBlock.getPinCoordinates()
         x, y, _z = zip(*xyz)
         self.assertAlmostEqual(
@@ -1700,6 +1704,24 @@ class HexBlock_TestCase(unittest.TestCase):
         )  # first two pins should be side by side on top.
         self.assertNotAlmostEqual(x[1], x[2])
         self.assertEqual(len(xyz), self.HexBlock.getNumPins())
+
+        # ensure all pins are within the proper bounds of a
+        # flats-up oriented hex block
+        self.assertLess(max(y), blockPitch / 2.0)
+        self.assertGreater(min(y), -blockPitch / 2.0)
+        self.assertLess(max(x), side)
+        self.assertGreater(min(x), -side)
+
+        # center pin should be at 0
+        mags = [(xi ** 2 + yi ** 2, (xi, yi)) for xi, yi, zi in xyz]
+        _centerMag, (cx, cy) = min(mags)
+        self.assertAlmostEqual(cx, 0.0)
+        self.assertAlmostEqual(cy, 0.0)
+
+        # extreme pin should be at proper radius
+        cornerMag, (cx, cy) = max(mags)
+        nRings = hexagon.numRingsToHoldNumCells(nPins) - 1
+        self.assertAlmostEqual(math.sqrt(cornerMag), nRings * pinPitch)
 
     def test_getPitchHomogenousBlock(self):
         """
@@ -1844,7 +1866,7 @@ class HexBlock_TestCase(unittest.TestCase):
         # add a wire only some places in the block, so grid should not be created.
         wire = components.Helix("wire", "HT9", **wireDims)
         self.HexBlock.add(wire)
-        self.HexBlock.spatialGrid = None # clear existing
+        self.HexBlock.spatialGrid = None  # clear existing
         with self.assertRaises(ValueError):
             self.HexBlock.autoCreateSpatialGrids()
 


### PR DESCRIPTION
The pin locations in a hex block were rotated 30 degrees from where they
should be. This was discovered when plotting pin-level assembly plots
and they were all sticking out the edges. The major confusion comes in
from the fact that even though pointed end up  doesn't seem right when
you look at the pins, if you look at the little outline hexes
surrounding each pin then you can see that indeed the pointed end is
supposed to be up in this case.

This could impact results for anyone using auto-generated pin-level
grids and using the pin-wise pin coordinates.

Before: 
![image](https://user-images.githubusercontent.com/53948397/175141840-6b662c73-2be4-4ca4-96a6-9db96250e854.png)

After: 
![Screenshot from 2022-06-22 23-20-36](https://user-images.githubusercontent.com/53948397/175141895-bf5cda13-4c2d-48b2-a970-42d92d7df51f.png)

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [ ] Documentation added/updated in the `doc` folder.
