### PR TITLE
Setting the trackAssems default to False

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -99,7 +99,9 @@ class App:
     def version(self) -> str:
         """Grab the version of this app (defaults to ARMI version).
 
-        NOTE: This is designed to be over-ridable by Application developers.
+        Notes
+        -----
+        This is designed to be over-ridable by Application developers.
         """
         return meta.__version__
 

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -91,7 +91,9 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
     @property
     def atEOL(self):
         """
-        NOTE: This operator's atEOL method behaves very differently than other operators.
+        Notes
+        -----
+        This operator's atEOL method behaves very differently than other operators.
         The idea is that snapshots don't really have an EOL since they are independent of
         chrological order and may or may not contain the last time node from the load database.
         """

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -25,19 +25,14 @@ import unittest
 
 import numpy as np
 
-from armi.physics.fuelCycle import fuelHandlers
-from armi.physics.fuelCycle import settings
-from armi.reactor import assemblies
-from armi.reactor import blocks
-from armi.reactor import components
-from armi.reactor.tests import test_reactors
-from armi.tests import TEST_ROOT
-from armi.utils import directoryChangers
-from armi.reactor import grids
-from armi.reactor.flags import Flags
-from armi.tests import ArmiTestHelper
-from armi.settings import caseSettings
 from armi.physics import fuelCycle
+from armi.physics.fuelCycle import fuelHandlers, settings
+from armi.reactor import assemblies, blocks, components, grids
+from armi.reactor.flags import Flags
+from armi.reactor.tests import test_reactors
+from armi.settings import caseSettings
+from armi.tests import ArmiTestHelper, TEST_ROOT
+from armi.utils import directoryChangers
 
 
 class TestFuelHandler(ArmiTestHelper):
@@ -60,8 +55,10 @@ class TestFuelHandler(ArmiTestHelper):
         but none of these have any number densities.
         """
         self.o, self.r = test_reactors.loadTestReactor(
-            self.directoryChanger.destination, customSettings={"nCycles": 3}
+            self.directoryChanger.destination,
+            customSettings={"nCycles": 3, "trackAssems": True},
         )
+
         blockList = self.r.core.getBlocks()
         for bi, b in enumerate(blockList):
             b.p.flux = 5e10
@@ -324,6 +321,7 @@ class TestFuelHandler(ArmiTestHelper):
     def runShuffling(self, fh):
         """Shuffle fuel and write out a SHUFFLES.txt file."""
         fh.attachReactor(self.o, self.r)
+
         # so we don't overwrite the version-controlled armiRun-SHUFFLES.txt
         self.o.cs.caseTitle = "armiRun2"
         fh.interactBOL()

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -374,7 +374,7 @@ class AssemblyAxialLinkage:
         b : :py:class:`Block <armi.reactor.blocks.Block>` object
             block to determine axial linkage for
 
-        NOTES
+        Notes
         -----
         - block linkage is determined by matching ztop/zbottom (see below)
         - block linkage is stored in self.linkedBlocks[b]

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1614,7 +1614,6 @@ class Core(composites.Composite):
         -----
         createFreshFeed and createAssemblyOfType and this
         all need to be merged together somehow.
-
         """
         return self.createAssemblyOfType(assemType=self._freshFeedType)
 
@@ -1646,7 +1645,6 @@ class Core(composites.Composite):
         See Also
         --------
         armi.fuelHandler.doRepeatShuffle : uses this to repeat shuffling
-
         """
         a = self.parent.blueprints.constructAssem(
             cs or settings.getMasterCs(), name=assemType
@@ -1948,14 +1946,12 @@ class Core(composites.Composite):
 
         Parameters
         ----------
-
         target : float
             This is the fraction of the total reactor fuel flux compared to the flux in a
             specific assembly in a ring
 
         Returns
         -------
-
         targetRing, fraction of flux : tuple
             targetRing is the ring with the fraction of flux that best meets the target.
         """

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -651,36 +651,6 @@ class Core(composites.Composite):
         """
         return self.lib.numGroups
 
-    # NOTE: this method is never used
-    def countAssemblies(self, typeList, ring=None, fullCore=False):
-        """
-        Counts the number of assemblies of type in ring (or in full reactor)
-
-        Parameters
-        ----------
-        typeList : iterable, optional
-            Restruct counts to this assembly type.
-
-        rings : int
-            The reactor ring to find assemblies in
-
-        fullCore : bool, optional
-            If True, will consider the core symmetry. Default: False
-        """
-        assems = (a for a in self if a.hasFlags(typeList, exact=True))
-
-        if ring is not None:
-            assems = (a for a in assems if a.spatialLocator.getRingPos()[0] == ring)
-
-        if not fullCore:
-            return sum(1 for _a in assems)
-
-        pmult = self.powerMultiplier  # value is loop-independent
-
-        rings = (a.spatialLocator.getRingPos()[0] for a in assems)
-
-        return sum(1 if r == 1 else pmult for r in rings)
-
     def countBlocksWithFlags(self, blockTypeSpec, assemTypeSpec=None):
         """
         Return the total number of blocks in an assembly in the reactor that

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -405,18 +405,20 @@ class Core(composites.Composite):
         discharge : bool, optional
             Discharge the assembly, including adding it to the SFP. Default: True
 
-
         Originally, this held onto all assemblies in the spend fuel pool. However, having
-        this sitting in memory becomes constraining for large problems. It is more
+        this sitting in memory becomes constraining for large simulations. It is more
         memory-efficient to only save the assemblies that are required for detailed
         history tracking. In fact, there's no need to save the assembly object at all,
-        just have the history interface save the relevant parameters. This is an important
-        cleanup.
+        just have the history interface save the relevant parameters.
+
+        Notes
+        -----
+        Please expect this method will delete your assembly (instead of moving it to a
+        Spent Fuel Pool) unless you set the ``trackAssems`` to True in your settings file.
 
         See Also
         --------
         add : adds an assembly
-
         """
         paramDefs = set(parameters.ALL_DEFINITIONS)
         paramDefs.difference_update(set(parameters.forType(Core)))

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -216,7 +216,9 @@ class ReactorTests(unittest.TestCase):
 
 class HexReactorTests(ReactorTests):
     def setUp(self):
-        self.o, self.r = loadTestReactor(self.directoryChanger.destination)
+        self.o, self.r = loadTestReactor(
+            self.directoryChanger.destination, customSettings={"trackAssems": True}
+        )
 
     def test_getTotalParam(self):
         # verify that the block params are being read.

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -526,20 +526,6 @@ class HexReactorTests(ReactorTests):
         self.assertEqual(a1, a2)
         self.assertEqual(a1, a3)
 
-    def test_countAssemblies(self):
-        """Tests that the users definition of assemblies is preserved.
-
-        .. test:: Tests that the users definition of assembilies is preserved.
-            :id: TEST_REACTOR_3
-            :links: REQ_REACTOR
-        """
-        nFuel = self.r.core.countAssemblies(Flags.FUEL)
-        self.assertEqual(2, nFuel)
-        nFuel_r3 = self.r.core.countAssemblies(Flags.FUEL, ring=3)
-        self.assertEqual(1, nFuel_r3)
-        nFuel = self.r.core.countAssemblies(Flags.FUEL, fullCore=True)
-        self.assertEqual(6, nFuel)
-
     def test_restoreReactor(self):
         aListLength = len(self.r.core.getAssemblies())
         converter = self.r.core.growToFullCore(self.o.cs)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -519,6 +519,16 @@ class HexReactorTests(ReactorTests):
         nAssmWithBlanks = self.r.core.getNumAssembliesWithAllRingsFilledOut(nRings)
         self.assertEqual(77, nAssmWithBlanks)
 
+    def test_getNumEnergyGroups(self):
+        # this Core doesn't have a loaded ISOTXS library, so this test is minimally useful
+        with self.assertRaises(AttributeError):
+            self.r.core.getNumEnergyGroups()
+
+    def test_getMinimumPercentFluxInFuel(self):
+        # there is no flux in the test reactor YET, so this test is minimally useful
+        with self.assertRaises(ZeroDivisionError):
+            _targetRing, _fluxFraction = self.r.core.getMinimumPercentFluxInFuel()
+
     def test_getAssembly(self):
         a1 = self.r.core.getAssemblyWithAssemNum(assemNum=10)
         a2 = self.r.core.getAssembly(locationString="005-023")

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -59,7 +59,9 @@ class Settings:
     The settings object has a 1-to-1 correspondence with the ARMI settings input file.
     This file may be created by hand or by the GUI in submitter.py.
 
-    NOTE: The actual settings in any instance of this class are immutable.
+    Notes
+    -----
+    The actual settings in any instance of this class are immutable.
     """
 
     # Settings is not a singleton, but there is a globally
@@ -186,7 +188,9 @@ class Settings:
         """
         Return a copy of an actual Setting object, instead of just its value.
 
-        NOTE: This is used very rarely, try to organize your code to only need a Setting value.
+        Notes
+        -----
+        This is used very rarely, try to organize your code to only need a Setting value.
         """
         if key in self.__settings:
             return copy(self.__settings[key])
@@ -196,7 +200,11 @@ class Settings:
             raise NonexistentSetting(key)
 
     def __setitem__(self, key, val):
-        # TODO: This potentially allows for invisible settings mutations and should be removed.
+        """
+        Notes
+        -----
+        This potentially allows for invisible settings mutations.
+        """
         if key in self.__settings:
             self.__settings[key].setValue(val)
         else:
@@ -321,7 +329,9 @@ class Settings:
         """
         Central location to init logging verbosity
 
-        NOTE: This means that creating a Settings object sets the global logging
+        Notes
+        -----
+        This means that creating a Settings object sets the global logging
         level of the entire code base.
         """
         if context.MPI_RANK == 0:
@@ -395,13 +405,15 @@ class Settings:
         """Attempt to grab the module-level logger verbosities from the settings file,
         and then set their log levels (verbosities).
 
-        NOTE: This method is only meant to be called once per run.
-
         Parameters
         ----------
         force : bool, optional
             If force is False, don't overwrite the log verbosities if the logger already exists.
             IF this needs to be used mid-run, force=False is safer.
+
+        Notes
+        -----
+        This method is only meant to be called once per run.
         """
         # try to get the setting dict
         verbs = self["moduleVerbosity"]

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -658,8 +658,10 @@ def defineSettings() -> List[setting.Setting]:
             CONF_TRACK_ASSEMS,
             default=False,
             label="Save Discharged Assemblies",
-            description="Track assemblies for detailed fuel histories. Disable in case "
-            "you get memory errors.",
+            description="Track assemblies for detailed fuel histories. For instance, "
+            "assemblies are tracked after they come out of a reactor by putting them "
+            "in a Spent Fuel Pool. This might be necessary for your work, but it "
+            "certainly increases the memory usage of the program.",
         ),
         setting.Setting(
             CONF_VERBOSITY,

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -656,7 +656,7 @@ def defineSettings() -> List[setting.Setting]:
         ),
         setting.Setting(
             CONF_TRACK_ASSEMS,
-            default=True,
+            default=False,
             label="Save Discharged Assemblies",
             description="Track assemblies for detailed fuel histories. Disable in case "
             "you get memory errors.",

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -333,8 +333,11 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
 
     def test_copySetting(self):
         """Ensure that when we copy a Setting() object, the result is sound.
-        NOTE: In particuar, self.schema and self._customSchema on a Setting object are
-              removed by Setting.__getstate__, and that has been a problem in the past.
+
+        Notes
+        -----
+        In particuar, self.schema and self._customSchema on a Setting object are
+        removed by Setting.__getstate__, and that has been a problem in the past.
         """
         # get a baseline: show how the Setting object looks to start
         s1 = setting.Setting("testCopy", 765)

--- a/armi/utils/dynamicImporter.py
+++ b/armi/utils/dynamicImporter.py
@@ -26,7 +26,7 @@ def importEntirePackage(module):
 
     Notes
     -----
-    This method may only work for a flat directory?
+    This method may only work for a flat directory
     """
     modules = glob.glob(os.path.dirname(module.__file__) + "/*.py")
     names = [os.path.basename(f)[:-3] for f in modules]

--- a/armi/utils/dynamicImporter.py
+++ b/armi/utils/dynamicImporter.py
@@ -24,7 +24,9 @@ from armi import runLog
 def importEntirePackage(module):
     """Load every module in a package
 
-    NOTE: this method may only work for a flat directory?
+    Notes
+    -----
+    This method may only work for a flat directory?
     """
     modules = glob.glob(os.path.dirname(module.__file__) + "/*.py")
     names = [os.path.basename(f)[:-3] for f in modules]

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -16,6 +16,7 @@ What's new in ARMI
 #. Removed all bare ``import armi`` statements, for code clarity.
 #. Renamed control rod assembly parameters for generic implementations of control rod handling.
 #. Changed the default Git branch name to ``main``.
+#. Changed the default value of the ``trackAssems`` setting to ``False``.
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

As we have recently been having much discussion about memory, it is time to change the default value of `trackAssems` to False.

Really, this seems like the best option, though we should watch for how this affects downstream projects.

(ALSO: Sorry, I can't help myself. I also did two other cleanup activities as part of this PR: I removed a completely unused `countAssemblies()` method, and I fixed some RST formatting in our docs.)

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
