### PR TITLE
Removing defunct "geom" reference

### DIFF
--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -139,7 +139,7 @@ class MainInterface(interfaces.Interface):
                 pass
             else:
                 with Database3(self.cs["reloadDBName"], "r") as db:
-                    r = db.load(cycle, node, self.cs, self.r.blueprints, self.r.geom)
+                    r = db.load(cycle, node, self.cs, self.r.blueprints)
 
                 self.o.reattach(r, self.cs)
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -124,9 +124,7 @@ def loadFromCs(cs):
 
 
 def factory(cs, bp, geom: Optional[systemLayoutInput.SystemLayoutInput] = None):
-    """
-    Build a reactor from input settings, blueprints and geometry.
-    """
+    """Build a reactor from input settings, blueprints and geometry."""
     from armi.reactor import blueprints
 
     runLog.header("=========== Constructing Reactor and Verifying Inputs ===========")
@@ -185,10 +183,6 @@ class Core(composites.Composite):
         ----------
         name : str
             Name of the object. Flags will inherit from this.
-        geom : SystemLayoutInput object
-            Contains face-map
-        cs : CaseSettings object, optional
-            the calculation settings dictionary
         """
         composites.Composite.__init__(self, name)
         self.p.flags = Flags.fromStringIgnoreErrors(name)


### PR DESCRIPTION
## Description

Fixing bug #726 . `Reactor.geom` no longer exists.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
