### PR TITLE
Add `core.p.referenceBlockAxialMesh` and adjust `core.createAssemblyOfType()`

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -155,7 +155,7 @@ class TestCompareDB3(unittest.TestCase):
 
         # end-to-end validation that comparing a photocopy database works
         diffs = compareDatabases(dbs[0]._fullPath, dbs[1]._fullPath)
-        self.assertEqual(len(diffs.diffs), 456)
+        self.assertEqual(len(diffs.diffs), 459)
         self.assertEqual(diffs.nDiffs(), 3)
 
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -218,9 +218,9 @@ def defineCoreParameters():
     with pDefs.createBuilder(default=0.0, location="N/A") as pb:
 
         pb.defParam(
-            "currentGeometryAxialMesh",
+            "referenceBlockAxialMesh",
             units="cm",
-            description="Current core axial mesh.",
+            description="The axial block boundaries that assemblies should conform to in a uniform mesh case.",
             default=None,
         )
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -218,6 +218,13 @@ def defineCoreParameters():
     with pDefs.createBuilder(default=0.0, location="N/A") as pb:
 
         pb.defParam(
+            "currentGeometryAxialMesh",
+            units="cm",
+            description="Current core axial mesh.",
+            default=None,
+        )
+
+        pb.defParam(
             "breedingRatio2",
             units="N/A",
             description="Ratio of fissile Burned and discharged to fissile discharged",

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -216,6 +216,7 @@ class Core(composites.Composite):
         self._automaticVariableMesh = False
         self._minMeshSizeRatio = 0.15
         self._inputHeightsConsideredHot = True
+        self._detailedAxialExpansion = False
 
     def setOptionsFromCs(self, cs):
         # these are really "user modifiable modeling constants"
@@ -227,6 +228,7 @@ class Core(composites.Composite):
         self._automaticVariableMesh = cs["automaticVariableMesh"]
         self._minMeshSizeRatio = cs["minMeshSizeRatio"]
         self._inputHeightsConsideredHot = cs["inputHeightsConsideredHot"]
+        self._detailedAxialExpansion = cs["detailedAxialExpansion"]
 
     def __getstate__(self):
         """Applies a settings and parent to the core and components."""
@@ -1688,6 +1690,12 @@ class Core(composites.Composite):
                     # therefore breaks the burnup metric.
                     b.adjustUEnrich(enrich)
 
+        if not self._detailedAxialExpansion:
+            # if detailedAxialExpansion: False, make sure that the assembly being created has the correct core mesh
+            a.setBlockMesh(
+                self.p.currentGeometryAxialMesh[1:], conserveMassFlag="auto"
+            )  # pass [1:] to skip 0.0
+
         return a
 
     def saveAllFlux(self, fName="allFlux.txt"):
@@ -2221,6 +2229,9 @@ class Core(composites.Composite):
                 "Please make sure that this is intended and not a input error."
             )
 
+        self.p.currentGeometryAxialMesh = self.findAllAxialMeshPoints(
+            applySubMesh=False
+        )
         self.p.axialMesh = self.findAllAxialMeshPoints()
         refAssem = self.refAssem
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1693,7 +1693,7 @@ class Core(composites.Composite):
         if not self._detailedAxialExpansion:
             # if detailedAxialExpansion: False, make sure that the assembly being created has the correct core mesh
             a.setBlockMesh(
-                self.p.currentGeometryAxialMesh[1:], conserveMassFlag="auto"
+                self.p.referenceBlockAxialMesh[1:], conserveMassFlag="auto"
             )  # pass [1:] to skip 0.0
 
         return a
@@ -2229,9 +2229,7 @@ class Core(composites.Composite):
                 "Please make sure that this is intended and not a input error."
             )
 
-        self.p.currentGeometryAxialMesh = self.findAllAxialMeshPoints(
-            applySubMesh=False
-        )
+        self.p.referenceBlockAxialMesh = self.findAllAxialMeshPoints(applySubMesh=False)
         self.p.axialMesh = self.findAllAxialMeshPoints()
         refAssem = self.refAssem
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -740,6 +740,13 @@ class HexReactorTests(ReactorTests):
         aNew = self.r.core.createAssemblyOfType(aOld.getType())
         self.assertAlmostEqual(aOld.getMass(), aNew.getMass())
 
+        # test axial mesh alignment
+        aNewMesh = aNew.getAxialMesh()
+        for i, meshValue in enumerate(aNewMesh):
+            self.assertAlmostEqual(
+                meshValue, self.r.core.p.currentGeometryAxialMesh[i + 1]
+            )  # use i+1 to skip 0.0
+
         # creation with modified enrichment
         aNew2 = self.r.core.createAssemblyOfType(aOld.getType(), 0.195)
         fuelBlock = aNew2.getFirstBlock(Flags.FUEL)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -744,7 +744,7 @@ class HexReactorTests(ReactorTests):
         aNewMesh = aNew.getAxialMesh()
         for i, meshValue in enumerate(aNewMesh):
             self.assertAlmostEqual(
-                meshValue, self.r.core.p.currentGeometryAxialMesh[i + 1]
+                meshValue, self.r.core.p.referenceBlockAxialMesh[i + 1]
             )  # use i+1 to skip 0.0
 
         # creation with modified enrichment


### PR DESCRIPTION
Summary:
- adding a `reactor.core` parameter to store the geometric axial mesh (_not_ the neutronics mesh that is currently stored on `reactor.core.axialMesh`). This new parameter is: `core.p.currentGeometryAxialMesh`
- if `detailedAxialExpansion: False`, ensuring that when new assemblies are created from blueprint assemblies that the geometric block mesh on the assembly is set to align with the `core.p.currentGeometryAxialMesh`.

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.