### PR TITLE
Fix description of reactor `power` parameter

### DIFF
--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -548,7 +548,7 @@ def defineCoreParameters():
         pb.defParam(
             "power",
             units="W",
-            description="Rated thermal power of the reactor core. Corresponds to the "
+            description="Thermal power of the reactor core. Corresponds to the "
             "nuclear power generated in the core.",
         )
 


### PR DESCRIPTION
The reactor power is not necessarily the "rated" value, as the reactor can change power between steps and cycles.  See, for instance, here where the `power` parameter is updated based on the power fractions:

https://github.com/terrapower/armi/blob/1bd3050bbe4a823ee4725acb307f134f2f870f7d/armi/operators/operator.py#L349-L352

Rated power can instead be obtained from the case settings.

<!-- Thanks in advance for you contribution! -->

## Description

<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
