### PR TITLE
Cleanup composite.getComponent

### DIFF
--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -22,6 +22,7 @@ from armi.interfaces import Interface
 from armi.operators.operator import Operator
 from armi.reactor.tests import test_reactors
 from armi.settings.caseSettings import Settings
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class InterfaceA(Interface):
@@ -110,6 +111,11 @@ class OperatorTests(unittest.TestCase):
         # validate the method works
         cs = o.setStateToDefault(o.cs)
         self.assertEqual(cs["runType"], "Standard")
+
+    def test_snapshotRequest(self):
+        o, _r = test_reactors.loadTestReactor()
+        with TemporaryDirectoryChanger():
+            o.snapshotRequest(0, 1)
 
 
 class CyclesSettingsTests(unittest.TestCase):

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -66,13 +66,10 @@ class OperatorTests(unittest.TestCase):
         # 3) Also if another class not a subclass has the same function,
         #    raise an error
         interfaceC = InterfaceC(r, self.cs)
-
         self.assertRaises(RuntimeError, o.addInterface, interfaceC)
 
         # 4) Check adding a different function Interface
-
         interfaceC.function = "C"
-
         o.addInterface(interfaceC)
         self.assertEqual(o.getInterface("Second"), interfaceB)
         self.assertEqual(o.getInterface("Third"), interfaceC)
@@ -89,6 +86,14 @@ class OperatorTests(unittest.TestCase):
         o, r = test_reactors.loadTestReactor()
         self.assertTrue(o.interfaceIsActive("main"))
         self.assertFalse(o.interfaceIsActive("Fake-o"))
+
+    def test_loadState(self):
+        """The loadTestReactor() test tool does not have any history in the DB to load from"""
+        o, r = test_reactors.loadTestReactor()
+
+        # a first, simple test that this method fails correctly
+        with self.assertRaises(RuntimeError):
+            o.loadState(0, 1)
 
 
 class CyclesSettingsTests(unittest.TestCase):

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -85,6 +85,11 @@ class OperatorTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             o._checkCsConsistency()
 
+    def test_interfaceIsActive(self):
+        o, r = test_reactors.loadTestReactor()
+        self.assertTrue(o.interfaceIsActive("main"))
+        self.assertFalse(o.interfaceIsActive("Fake-o"))
+
 
 class CyclesSettingsTests(unittest.TestCase):
     """

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -75,7 +75,7 @@ class OperatorTests(unittest.TestCase):
         self.assertEqual(o.getInterface("Third"), interfaceC)
 
     def test_checkCsConsistency(self):
-        o, r = test_reactors.loadTestReactor()
+        o, _r = test_reactors.loadTestReactor()
         o._checkCsConsistency()  # passes without error
 
         o.cs = o.cs.modified(newSettings={"nCycles": 66})
@@ -83,17 +83,33 @@ class OperatorTests(unittest.TestCase):
             o._checkCsConsistency()
 
     def test_interfaceIsActive(self):
-        o, r = test_reactors.loadTestReactor()
+        o, _r = test_reactors.loadTestReactor()
         self.assertTrue(o.interfaceIsActive("main"))
         self.assertFalse(o.interfaceIsActive("Fake-o"))
 
     def test_loadState(self):
         """The loadTestReactor() test tool does not have any history in the DB to load from"""
-        o, r = test_reactors.loadTestReactor()
+        o, _r = test_reactors.loadTestReactor()
 
         # a first, simple test that this method fails correctly
         with self.assertRaises(RuntimeError):
             o.loadState(0, 1)
+
+    def test_couplingIsActive(self):
+        o, _r = test_reactors.loadTestReactor()
+        self.assertFalse(o.couplingIsActive())
+
+    def test_setStateToDefault(self):
+        o, _r = test_reactors.loadTestReactor()
+
+        # reset the runType for testing
+        self.assertEqual(o.cs["runType"], "Standard")
+        o.cs = o.cs.modified(newSettings={"runType": "fake"})
+        self.assertEqual(o.cs["runType"], "fake")
+
+        # validate the method works
+        cs = o.setStateToDefault(o.cs)
+        self.assertEqual(cs["runType"], "Standard")
 
 
 class CyclesSettingsTests(unittest.TestCase):

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2448,9 +2448,7 @@ class ArmiObject(metaclass=CompositeModelType):
         else:
             return components[0]
 
-    def getComponent(
-        self, typeSpec: TypeSpec, exact=False, returnNull=False, quiet=False
-    ):
+    def getComponent(self, typeSpec: TypeSpec, exact=False, quiet=False):
         """
         Get a particular component from this object.
 
@@ -2470,7 +2468,6 @@ class ArmiObject(metaclass=CompositeModelType):
         Returns
         -------
         Component : The component that matches the critera or None
-
         """
         results = self.getComponents(typeSpec, exact=exact)
         if len(results) == 1:

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -387,6 +387,16 @@ class TestCompositeTree(unittest.TestCase):
 
         self.assertEqual(fuelMass, a.getFuelMass())
 
+    def test_getNeutronEnergyDepositionConstants(self):
+        """Until we improve test architecture, this test can not be more interesting"""
+        with self.assertRaises(RuntimeError):
+            _x = self.r.core.getNeutronEnergyDepositionConstants()
+
+    def test_getGammaEnergyDepositionConstants(self):
+        """Until we improve test architecture, this test can not be more interesting"""
+        with self.assertRaises(RuntimeError):
+            _x = self.r.core.getGammaEnergyDepositionConstants()
+
     def test_getChildrenIncludeMaterials(self):
         """Test that the ``StateRetainer`` retains material properties when they are modified."""
         cs = settings.Settings()

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -390,11 +390,13 @@ class TestCompositeTree(unittest.TestCase):
     def test_getNeutronEnergyDepositionConstants(self):
         """Until we improve test architecture, this test can not be more interesting"""
         with self.assertRaises(RuntimeError):
+            # fails because this test reactor does not have a cross-section library
             _x = self.r.core.getNeutronEnergyDepositionConstants()
 
     def test_getGammaEnergyDepositionConstants(self):
         """Until we improve test architecture, this test can not be more interesting"""
         with self.assertRaises(RuntimeError):
+            # fails because this test reactor does not have a cross-section library
             _x = self.r.core.getGammaEnergyDepositionConstants()
 
     def test_getChildrenIncludeMaterials(self):


### PR DESCRIPTION
## Description

This PR cleans up the `Composite.getComponent()` method, by removing an unused parameter.

I also threw in some code coverage for various things, just on general principles.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
