### PR TITLE
Making component naming conventions more clear

### DIFF
--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -298,9 +298,18 @@ class Component(composites.Composite, metaclass=ComponentType):
                     linkedKey = match.group(2)
                     self.p[dimName] = _DimensionLink((comp, linkedKey))
                 except:
-                    raise KeyError(
-                        "Bad component link `{}` defined as `{}`".format(dimName, value)
-                    )
+                    if value.count(".") > 1:
+                        raise ValueError(
+                            "Component names should not have periods in them: `{}`".format(
+                                value
+                            )
+                        )
+                    else:
+                        raise KeyError(
+                            "Bad component link `{}` defined as `{}`".format(
+                                dimName, value
+                            )
+                        )
 
     def setLink(self, key, otherComp, otherCompKey):
         """Set the dimension link."""

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -429,6 +429,24 @@ class TestCircle(TestShapedComponent):
         cur = gap.getArea()
         self.assertAlmostEqual(cur, ref)
 
+    def test_badComponentName(self):
+        """This shows that resolveLinkedDims cannot support names with periods in them"""
+        nPins = 12
+        fuelDims = {"Tinput": 25.0, "Thot": 430.0, "od": 0.9, "id": 0.0, "mult": nPins}
+        cladDims = {"Tinput": 25.0, "Thot": 430.0, "od": 1.1, "id": 1.0, "mult": nPins}
+        fuel = Circle("fuel", "UZr", **fuelDims)
+        clad = Circle("clad_4.2.3", "HT9", **cladDims)
+        gapDims = {
+            "Tinput": 25.0,
+            "Thot": 430.0,
+            "od": "clad_4.2.3.id",
+            "id": "fuel.od",
+            "mult": nPins,
+        }
+        gapDims["components"] = {"clad_4.2.3": clad, "fuel": fuel}
+        with self.assertRaises(ValueError):
+            gap = Circle("gap", "Void", **gapDims)
+
     def test_componentInteractionsLinkingBySubtraction(self):
         r"""Tests linking of components by subtraction."""
         nPins = 217

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -3,7 +3,7 @@ Tooling and Infrastructure
 
 Good Commit Messages
 --------------------
-The ARMI project follows a few basic rools for "good" commit messages:
+The ARMI project follows a few basic rules for "good" commit messages:
 
 * The purpose of the message is to explain to the changes you made to a stranger 5 years from now.
 * Keep your writing short and to the point.

--- a/doc/user/inputs/blueprints.rst
+++ b/doc/user/inputs/blueprints.rst
@@ -128,7 +128,9 @@ Here we have provided the following information:
 
 Component name
     The component name (``fuel``) is specified at the top. Some physics kernels interpret names specially, so
-    pay attention to any naming conventions.
+    pay attention to any naming conventions. As a general rule, you can expect that people will be doing regex
+    on your name, so you should not use any of these characters in your component names:
+    ``. ^ $ * + ? { } [ ] \ | ( ) :``. 
 
 shape
     The shape will be extruded to the length specified in the ``assemblies`` input section below. ARMI contains


### PR DESCRIPTION
## Description

As it happens, component names are parsed by Python regex, so you cannot use any regex identifiers in component names:

> . ^ $ * + ? { } [ ] \ | ( )

And component names are used in YAML, so it would be best to keep `:` out of the names as well.

This PR adds these component-naming convention rules to the docs, and improved the clarity of one of the error messages in `components.py`.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
