### PR TITLE
Remove duplicate, incorrect setting of core `power` parameter

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -155,7 +155,7 @@ class TestCompareDB3(unittest.TestCase):
 
         # end-to-end validation that comparing a photocopy database works
         diffs = compareDatabases(dbs[0]._fullPath, dbs[1]._fullPath)
-        self.assertEqual(len(diffs.diffs), 459)
+        self.assertEqual(len(diffs.diffs), 456)
         self.assertEqual(diffs.nDiffs(), 3)
 
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2216,8 +2216,6 @@ class Core(composites.Composite):
             "=========== Initializing Mesh, Assembly Zones, and Nuclide Categories =========== "
         )
 
-        self.p.power = cs["power"]
-
         for b in self.getBlocks():
             if b.p.molesHmBOL > 0.0:
                 break


### PR DESCRIPTION
## Description

In [`processLoading`](https://github.com/terrapower/armi/blob/00f738f16cc5b6d028c19083b43cdacca44f7aa1/armi/reactor/reactors.py#L2198), the core's `power` parameter is set. This is not necessary, as core power is already set both within the operator while stepping through time and during restarts.

But the real problem here is that power is being set _incorrectly_ during `processLoading`. Specifically, the value being used does not account for the `powerFraction(s)` setting. So right now, it always sets the power to the _rated_ power. This becomes apparent during restart cases when `powerFraction(s)` is non-unity, and then the code fails during [`NeutronicsUniformMeshConverter._checkConversion`](https://github.com/terrapower/armi/blob/d04e1be8937c44e506dfcd5ff25459fca24af6cf/armi/reactor/converters/uniformMesh.py#L371) (thank god for that little function, it's caught a number of bugs recently!).

This PR:
1. Fixes this problem by removing the setting of `core.p.power` from within `processLoading`
2. Adds unit tests to confirm that the changes don't break the code
3. Repairs a unit test that was broken by the change

I also have been using this updated code in my personal runs (both restart and standard) and it seems to have fixed the problem without breaking anything else.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.