### PR TITLE
Removing unused variables

### DIFF
--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -134,7 +134,7 @@ class TestCaseSuiteDependencies(unittest.TestCase):
     def test_clone(self):
         """if you pass an invalid path, the clone can't happen, but it won't do any damage either"""
         with self.assertRaises(RuntimeError):
-            clone = self.suite.clone("test_clone")
+            _clone = self.suite.clone("test_clone")
 
     def test_dependenciesWithObscurePaths(self):
         """

--- a/armi/cli/reportsEntryPoint.py
+++ b/armi/cli/reportsEntryPoint.py
@@ -113,7 +113,7 @@ class ReportsEntryPoint(entryPoint.EntryPoint):
                         blueprint = db.loadBlueprints()
                     r = reactors.factory(cs, blueprint)
                     report.title = r.name
-                    pluginContent = getPluginManagerOrFail().hook.getReportContents(
+                    _pc = getPluginManagerOrFail().hook.getReportContents(
                         r=r,
                         cs=cs,
                         report=report,

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -1502,7 +1502,7 @@ assemblies:
     def test_class1Class2_class1_wt_frac(self):
         # should error because class1_wt_frac not in (0,1)
         with self.assertRaises(ValueError):
-            a = self.loadAssembly(
+            _a = self.loadAssembly(
                 """
         material modifications:
             class1_wt_frac: [2.0]
@@ -1514,7 +1514,7 @@ assemblies:
     def test_class1Class2_classX_custom_isotopics(self):
         # should error because class1_custom_isotopics doesn't exist
         with self.assertRaises(KeyError):
-            a = self.loadAssembly(
+            _a = self.loadAssembly(
                 """
         material modifications:
             class1_wt_frac: [0.5]

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -474,8 +474,8 @@ class TestFuelHandler(ArmiTestHelper):
         self.assertEqual(b.getRotationNum(), rotNum + 2)
 
     def test_linPowByPin(self):
-        fh = fuelHandlers.FuelHandler(self.o)
-        hist = self.o.getInterface("history")
+        _fh = fuelHandlers.FuelHandler(self.o)
+        _hist = self.o.getInterface("history")
         newSettings = {"assemblyRotationStationary": True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
@@ -488,8 +488,8 @@ class TestFuelHandler(ArmiTestHelper):
         self.assertEqual(type(b.p.linPowByPin), np.ndarray)
 
     def test_linPowByPinNeutron(self):
-        fh = fuelHandlers.FuelHandler(self.o)
-        hist = self.o.getInterface("history")
+        _fh = fuelHandlers.FuelHandler(self.o)
+        _hist = self.o.getInterface("history")
         newSettings = {"assemblyRotationStationary": True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
@@ -502,8 +502,8 @@ class TestFuelHandler(ArmiTestHelper):
         self.assertEqual(type(b.p.linPowByPinNeutron), np.ndarray)
 
     def test_linPowByPinGamma(self):
-        fh = fuelHandlers.FuelHandler(self.o)
-        hist = self.o.getInterface("history")
+        _fh = fuelHandlers.FuelHandler(self.o)
+        _hist = self.o.getInterface("history")
         newSettings = {"assemblyRotationStationary": True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -42,7 +42,7 @@ class TestLatticePhysicsInterface(unittest.TestCase):
     def test_LatticePhysicsInterface(self):
         """Super basic test of the LatticePhysicsInterface"""
         cs = Settings()
-        o, r = loadTestReactor()
+        _o, r = loadTestReactor()
         i = LatticeInterfaceTester(r, cs)
 
         self.assertEqual(i._HEX_MODEL.strip(), "hex")

--- a/armi/physics/neutronics/tests/test_crossSectionTable.py
+++ b/armi/physics/neutronics/tests/test_crossSectionTable.py
@@ -47,7 +47,7 @@ class TestCrossSectionTable(unittest.TestCase):
         self.assertIn("mcnpId", xSecTable[-1])
 
     def test_isotopicDepletionInterface(self):
-        o, r = loadTestReactor()
+        _o, r = loadTestReactor()
         cs = Settings()
 
         aid = idi.AbstractIsotopicDepleter(r, cs)

--- a/armi/physics/neutronics/tests/test_macroXSGenerationInterface.py
+++ b/armi/physics/neutronics/tests/test_macroXSGenerationInterface.py
@@ -25,7 +25,7 @@ from armi.settings import Settings
 class TestMacroXSGenerationInterface(unittest.TestCase):
     def test_macroXSGenerationInterface(self):
         cs = Settings()
-        o, r = loadTestReactor()
+        _o, r = loadTestReactor()
         i = MacroXSGenerationInterface(r, cs)
 
         self.assertIsNone(i.macrosLastBuiltAt)

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -561,7 +561,6 @@ def saveToStream(stream, bluep, full=False, tryMap=False):
             continue
 
         if gridDesign.readFromLatticeMap or tryMap:
-            geomType = geometry.GeomType.fromStr(gridDesign.geom)
             symmetry = geometry.SymmetryType.fromStr(gridDesign.symmetry)
 
             aMap = asciimaps.asciiMapFromGeomAndDomain(

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -378,7 +378,7 @@ class TestGridBlueprintsSection(unittest.TestCase):
     def test_simpleReadLatticeMap(self):
         # Cartesian full, even/odd hybrid
         gridDesign4 = self.grids["sfp even"]
-        grid = gridDesign4.construct()
+        _grid = gridDesign4.construct()
 
         # test that we can correctly save this to a YAML
         bp = Blueprints.load(FULL_BP)
@@ -413,7 +413,7 @@ class TestGridBlueprintsSection(unittest.TestCase):
     def test_simpleReadNoLatticeMap(self):
         # Cartesian full, even/odd hybrid
         gridDesign4 = self.grids["sfp even"]
-        grid = gridDesign4.construct()
+        _grid = gridDesign4.construct()
 
         # test that we can correctly save this to a YAML
         bp = Blueprints.load(FULL_BP_GRID)

--- a/armi/reactor/blueprints/tests/test_materialModifications.py
+++ b/armi/reactor/blueprints/tests/test_materialModifications.py
@@ -134,7 +134,7 @@ assemblies:
 
     def test_invalid_component_modification(self):
         with self.assertRaises(ValueError):
-            a = self.loadUZrAssembly(
+            _a = self.loadUZrAssembly(
                 """
         material modifications:
             by component:

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -169,7 +169,7 @@ class TestHexToRZConverter(unittest.TestCase):
         self._checkNuclideMasses(expectedMassDict, newR)
         self._checkBlockAtMeshPoint(geomConv)
         self._checkReactorMeshCoordinates(geomConv)
-        figs = geomConv.plotConvertedReactor()
+        _figs = geomConv.plotConvertedReactor()
         with directoryChangers.TemporaryDirectoryChanger():
             geomConv.plotConvertedReactor("fname")
 

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -129,7 +129,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         # check if the sourceReactor has been modified from the blueprints
         if sourceReactor.core.isFullCore and not newReactor.core.isFullCore:
-            geometryConverter = newReactor.core.growToFullCore(sourceReactor.o.cs)
+            _geometryConverter = newReactor.core.growToFullCore(sourceReactor.o.cs)
 
         return newReactor
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -449,7 +449,7 @@ class Block_TestCase(unittest.TestCase):
         ref = "B"
         self.assertEqual(cur, ref)
 
-        oldBuGroups = self.cs["buGroups"]
+        _oldBuGroups = self.cs["buGroups"]
         newSettings = {"buGroups": [100]}
         self.cs = self.cs.modified(newSettings=newSettings)
 

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -445,7 +445,7 @@ class TestCircle(TestShapedComponent):
         }
         gapDims["components"] = {"clad_4.2.3": clad, "fuel": fuel}
         with self.assertRaises(ValueError):
-            gap = Circle("gap", "Void", **gapDims)
+            _gap = Circle("gap", "Void", **gapDims)
 
     def test_componentInteractionsLinkingBySubtraction(self):
         r"""Tests linking of components by subtraction."""

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -247,7 +247,7 @@ class SettingsReader:
                 self.invalidSettings.add(settingName)
             else:
                 # apply validations
-                settingObj = self.cs.getSetting(settingName)
+                _settingObj = self.cs.getSetting(settingName)
 
                 # The value is automatically coerced into the expected type
                 # when set using either the default or user-defined schema

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -329,7 +329,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
 
         # prove that successive applications of "modified" don't fail
         cs3 = cs2.modified(newSettings={"numberofGenericParams": 7})
-        cs4 = cs3.modified(newSettings={"somethingElse": 123})
+        _cs4 = cs3.modified(newSettings={"somethingElse": 123})
 
     def test_copySetting(self):
         """Ensure that when we copy a Setting() object, the result is sound.

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -135,10 +135,8 @@ class DirectoryChanger:
         entire directory to aid in debugging. Typically this is only called if
         ``dumpOnException`` is True.
         """
-        initialPath = self.destination
         folderName = os.path.split(self.destination)[1]
         recoveryPath = os.path.join(self.initial, f"dump-{folderName}")
-        fileList = os.listdir(self.destination)
         shutil.copytree(self.destination, recoveryPath)
 
     @staticmethod


### PR DESCRIPTION
## Description

This is just a cleanup PR. I went through the code and removed a ton of unused variables.

For testing situations and such, I follow the Python convention that purposefully unused variables should start with an underscore.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
