### PR TITLE
Adding `load pad` flag

### DIFF
--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -258,6 +258,7 @@ class Flags(Flag):
     WIRE = auto()
     COOLANT = auto()
     INTERCOOLANT = auto()
+    LOAD_PAD = auto()
     ACLP = auto()  # above core load pad
     SKID = auto()
     VOID = auto()
@@ -330,6 +331,7 @@ _CONVERSIONS = {
     re.compile(r"\bGRID\b"): Flags.GRID_PLATE,
     re.compile(r"\bINLET\s+NOZZLE\b"): Flags.INLET_NOZZLE,
     re.compile(r"\bNOZZLE\b"): Flags.INLET_NOZZLE,
+    re.compile(r"\bLOAD\s+PAD\b"): Flags.LOAD_PAD,
     re.compile(r"\bHANDLING\s+SOCKET\b"): Flags.HANDLING_SOCKET,
     re.compile(r"\bGUIDE\s+TUBE\b"): Flags.GUIDE_TUBE,
     re.compile(r"\bFISSION\s+CHAMBER\b"): Flags.FISSION_CHAMBER,


### PR DESCRIPTION
## Description

The new `load pad` flag is needed for mechanical modeling, to adding with load pads within a moving control bundle.

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.
