### PR TITLE
`getCircleInnerDiameter()` on holed components

### DIFF
--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -77,6 +77,19 @@ class HoledHexagon(basicShapes.Hexagon):
         area = mult * (hexArea - circularArea)
         return area
 
+    def getCircleInnerDiameter(self, Tc=None, cold=False):
+        """
+        For the special case of only one single hole, returns the
+        diameter of that hole.
+
+        For any other case, returns 0.0 because an "circle inner diameter" becomes
+        undefined.
+        """
+        if self.getDimension("nHoles") == 1:
+            return self.getDimension("holeOD", Tc, cold)
+        else:
+            return 0.0
+
 
 class HoledRectangle(basicShapes.Rectangle):
     """Rectangle with one circular hole in it."""
@@ -130,6 +143,12 @@ class HoledRectangle(basicShapes.Rectangle):
         area = mult * (rectangleArea - circularArea)
         return area
 
+    def getCircleInnerDiameter(self, Tc=None, cold=False):
+        """
+        Returns the ``holeOD``.
+        """
+        return self.getDimension("holeOD", Tc, cold)
+
 
 class HoledSquare(basicShapes.Square):
     """Square with one circular hole in it."""
@@ -175,6 +194,12 @@ class HoledSquare(basicShapes.Square):
         mult = self.getDimension("mult")
         area = mult * (rectangleArea - circularArea)
         return area
+
+    def getCircleInnerDiameter(self, Tc=None, cold=False):
+        """
+        Returns the ``holeOD``.
+        """
+        return self.getDimension("holeOD", Tc, cold)
 
 
 class Helix(ShapedComponent):

--- a/armi/reactor/components/componentParameters.py
+++ b/armi/reactor/components/componentParameters.py
@@ -156,9 +156,9 @@ def getHoledHexagonParameterDefinitions():
 
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
-        pb.defParam("holeOD", units="?", description="?")
+        pb.defParam("holeOD", units="cm", description="Diameter of interior hole(s)")
 
-        pb.defParam("nHoles", units="?", description="?")
+        pb.defParam("nHoles", units="cm", description="Number of interior holes")
 
     return pDefs
 
@@ -168,7 +168,7 @@ def getHoledRectangleParameterDefinitions():
 
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
-        pb.defParam("holeOD", units="?", description="?")
+        pb.defParam("holeOD", units="cm", description="Diameter of interior hole")
 
     return pDefs
 

--- a/armi/reactor/components/componentParameters.py
+++ b/armi/reactor/components/componentParameters.py
@@ -158,7 +158,9 @@ def getHoledHexagonParameterDefinitions():
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("holeOD", units="cm", description="Diameter of interior hole(s)")
 
-        pb.defParam("nHoles", units=units.UNITLESS, description="Number of interior holes")
+        pb.defParam(
+            "nHoles", units=units.UNITLESS, description="Number of interior holes"
+        )
 
     return pDefs
 

--- a/armi/reactor/components/componentParameters.py
+++ b/armi/reactor/components/componentParameters.py
@@ -158,7 +158,7 @@ def getHoledHexagonParameterDefinitions():
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("holeOD", units="cm", description="Diameter of interior hole(s)")
 
-        pb.defParam("nHoles", units="cm", description="Number of interior holes")
+        pb.defParam("nHoles", units=units.UNITLESS, description="Number of interior holes")
 
     return pDefs
 

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -826,6 +826,26 @@ class TestHoledHexagon(TestShapedComponent):
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
 
+    def test_getCircleInnerDiameter(self):
+        ref = 0  # there are multiple holes, so the function should return 0
+        cur = self.component.getCircleInnerDiameter(cold=True)
+        self.assertEqual(ref, cur)
+
+        # make and test another one with just 1 hole
+        simpleHoledHexagon = HoledHexagon(
+            'hex',
+            "Void",
+            self.componentDims["Tinput"],
+            self.componentDims["Thot"],
+            self.componentDims["op"],
+            self.componentDims["holeOD"],
+            nHoles=1,
+        )
+        self.assertEqual(
+            self.componentDims["holeOD"],
+            simpleHoledHexagon.getCircleInnerDiameter(cold=True),
+        )
+
     def test_getArea(self):
         op = self.component.getDimension("op")
         odHole = self.component.getDimension("holeOD")
@@ -884,6 +904,11 @@ class TestHoledRectangle(TestShapedComponent):
         cur = self.component.getBoundingCircleOuterDiameter()
         self.assertAlmostEqual(ref, cur)
 
+    def test_getCircleInnerDiameter(self):
+        ref = self.componentDims["holeOD"]
+        cur = self.component.getCircleInnerDiameter(cold=True)
+        self.assertEqual(ref, cur)
+
     def test_getArea(self):
         rectArea = self.length * self.width
         odHole = self.component.getDimension("holeOD")
@@ -924,6 +949,11 @@ class TestHoledSquare(TestHoledRectangle):
 
     def test_thermallyExpands(self):
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
+
+    def test_getCircleInnerDiameter(self):
+        ref = self.componentDims["holeOD"]
+        cur = self.component.getCircleInnerDiameter(cold=True)
+        self.assertEqual(ref, cur)
 
 
 class TestHelix(TestShapedComponent):

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -833,7 +833,7 @@ class TestHoledHexagon(TestShapedComponent):
 
         # make and test another one with just 1 hole
         simpleHoledHexagon = HoledHexagon(
-            'hex',
+            "hex",
             "Void",
             self.componentDims["Tinput"],
             self.componentDims["Thot"],


### PR DESCRIPTION
## Description

Add a `getCircleInnerDiameter()` method to all Holed components. This is in response to #755 .

Also filled out the relevant component parameter definitions.

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.