### PR TITLE
Fixing broken Alloy200 methods

### DIFF
--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -15,9 +15,10 @@
 """
 Alloy-200 are wrought commercially pure nickel.
 """
+from numpy import interp
 
 from armi.materials.material import Material
-from armi.utils.units import getTc
+from armi.utils.units import getTk
 
 
 class Alloy200(Material):
@@ -51,26 +52,35 @@ class Alloy200(Material):
         ("FE", 0.40),
     ]
 
-    def linearExpansionPercent(self, Tk=None, Tc=None):
-        r"""
-        Returns percent linear thermal expansion of Alloy 200
+    linearExpansionTableK = [
+        73.15,
+        173.15,
+        373.15,
+        473.15,
+        573.15,
+        673.15,
+        773.15,
+        873.15,
+        973.15,
+        1073.15,
+        1173.15,
+        1273.15,
+    ]
 
-        Parameters
-        ----------
-        Tk : float, optional
-            temperature in degrees Kelvin
-        Tc : float, optional
-            temperature in degrees Celsius
-
-        Returns
-        -------
-        linearExpansionPercent : float
-            percent linear thermal expansion of Alloy 200 (%)
-        """
-        Tc = getTc(Tc, Tk)
-        self.checkTempRange(-200, 1000, Tc, "linear expansion percent")
-        linearExpansionPercent = self.calcLinearExpansionPercentMetal(T=Tc)
-        return linearExpansionPercent
+    linearExpansionTable = [
+        10.1e-6,
+        11.3e-6,
+        13.3e-6,
+        13.9e-6,
+        14.3e-6,
+        14.8e-6,
+        15.2e-6,
+        15.6e-6,
+        15.8e-6,
+        16.2e-6,
+        16.5e-6,
+        16.7e-6,
+    ]
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""
@@ -88,10 +98,9 @@ class Alloy200(Material):
         linearExpansion : float
             instantaneous coefficient of thermal expansion of Alloy 200 (1/C)
         """
-        Tc = getTc(Tc, Tk)
-        self.checkTempRange(-200, 1000, Tc, "linear expansion")
-        linearExpansion = self.calcLinearExpansionMetal(T=Tc)
-        return linearExpansion
+        Tk = getTk(Tc, Tk)
+        self.checkTempRange(73.15, 1273.15, Tk, "linear expansion")
+        return interp(Tk, self.linearExpansionTableK, self.linearExpansionTable)
 
     def setDefaultMassFracs(self):
         """

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -554,9 +554,7 @@ class Material(composites.Leaf):
 
         label : str
             The name of the function or property that is being checked.
-
         """
-
         if not minV <= val <= maxV:
             msg = "Temperature {0} out of range ({1} to {2}) for {3} {4}".format(
                 val, minV, maxV, self.name, label
@@ -586,7 +584,6 @@ class Material(composites.Leaf):
         rhoCP : float
             Calculated value for the HT9 density* heat capacity
             unit (J/m^3-K)
-
         """
         Tc = getTc(Tc, Tk)
 

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -1238,6 +1238,16 @@ class Alloy200_TestCase(_Material_Test, unittest.TestCase):
         """Assert alloy 200 has more than 99% nickle per its spec"""
         self.assertGreater(self.mat.p.massFrac["NI"], 0.99)
 
+    def test_linearExpansion(self):
+        ref = self.mat.linearExpansion(Tc=100)
+        cur = 13.3e-6
+        self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
+
+    def test_linearExpansion(self):
+        ref = self.mat.linearExpansion(Tk=873.15)
+        cur = 15.6e-6
+        self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
+
 
 class CaH2_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.CaH2

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -22,8 +22,8 @@ uses data from [#ornltm2000]_.
 .. [#ornltm2000] Thermophysical Properties of MOX and UO2 Fuels Including the Effects of Irradiation. S.G. Popov,
     et.al. Oak Ridge National Laboratory. ORNL/TM-2000/351 https://rsicc.ornl.gov/fmdp/tm2000-351.pdf
 """
-import math
 import collections
+import math
 
 from numpy import interp
 

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -156,7 +156,7 @@ class UraniumOxide(material.FuelMaterial):
         Polynomial line fit to data from [#ornltm2000]_ on page 11.
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(300, 3100, Tk, "thermal conductivity")
+        self.checkTempRange(300, 3100, Tk, "density")
         return (-1.01147e-7 * Tk ** 2 - 1.29933e-4 * Tk + 1.09805e1) * self.getTD()
 
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
@@ -167,7 +167,7 @@ class UraniumOxide(material.FuelMaterial):
         simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(300, 3000, Tk, "density")
+        self.checkTempRange(300, 3000, Tk, "thermal conductivity")
         return interp(Tk, self.thermalConductivityTableK, self.thermalConductivityTable)
 
     def linearExpansion(self, Tk: float = None, Tc: float = None) -> float:

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -29,6 +29,7 @@ Bug fixes
 #. ``Block.getWettedPerim`` was moved to ``HexBlock``, as that was more accurate.
 #. ``pathTools.cleanPath()`` is not much more linear, and handles the MPI use-case better.
 #. Fixed bugs in the ARMI memory profiler.
+#. Fixed linear expansion in ``Alloy200``.
 #. TBD
 
 


### PR DESCRIPTION
## Description

Alloy200 appears to have had broken linear expansion for a few years. Essentially, it called a couple methods that don't exist:

* `calcLinearExpansionMetal()`
* `calcLinearExpansionPercentMetal()`

Easy enough to fix, as there is a good reference listed in the docstring.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [X] Documentation added/updated in the `doc` folder.
