### PR TITLE
Axial expansion process load bug fix

### DIFF
--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -68,8 +68,6 @@ text representations of input and objects in the code.
 
 
 """
-from collections import OrderedDict
-import collections
 import copy
 import os
 import pathlib
@@ -86,15 +84,16 @@ from armi import context
 from armi import getPluginManager, getPluginManagerOrFail
 from armi import plugins
 from armi import runLog
-from armi import settings
 from armi.utils.customExceptions import InputError
-from armi.nucDirectory import elements
 from armi.nucDirectory import nuclideBases
 from armi.reactor import assemblies
 from armi.reactor import geometry
 from armi.reactor import systemLayoutInput
 from armi.scripts import migration
 from armi.utils import textProcessors
+
+from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
+from armi.reactor.flags import Flags
 
 # NOTE: using non-ARMI-standard imports because these are all a part of this package,
 # and using the module imports would make the attribute definitions extremely long
@@ -301,6 +300,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
         This method should not be called directly, but it is used in testing.
         """
+        axialExpChngr = AxialExpansionChanger(cs["detailedAxialExpansion"])
         if not self._prepped:
             self._assignTypeNums()
             for func in self._resolveFunctions:
@@ -311,6 +311,11 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
             for aDesign in self.assemDesigns:
                 a = aDesign.construct(cs, self)
+                if not cs["inputHeightsConsideredHot"]:
+                    if not a.hasFlags(Flags.CONTROL):
+                        axialExpChngr.setAssembly(a)
+                        axialExpChngr.expansionData.computeThermalExpansionFactors()
+                        axialExpChngr.axiallyExpandAssembly(thermal=True)
                 self._assembliesBySpecifier[aDesign.specifier] = a
                 self.assemblies[aDesign.name] = a
 

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -43,8 +43,6 @@ from armi import runLog
 from armi.reactor import geometry
 from armi.reactor import grids
 from armi.reactor.blueprints.gridBlueprint import Triplet
-from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
-from armi.reactor.flags import Flags
 
 
 class SystemBlueprint(yamlize.Object):
@@ -74,7 +72,6 @@ class SystemBlueprint(yamlize.Object):
         self.name = name
         self.gridName = gridName
         self.origin = origin
-        self.axialExpChngr = None
 
     @staticmethod
     def _resolveSystemType(typ: str):
@@ -130,7 +127,6 @@ class SystemBlueprint(yamlize.Object):
 
         runLog.info("Constructing the `{}`".format(self.name))
 
-        self.axialExpChngr = AxialExpansionChanger(cs["detailedAxialExpansion"])
         # TODO: We should consider removing automatic geom file migration.
         if geom is not None and self.name == "core":
             gridDesign = geom.toGridBlueprints("core")[0]
@@ -195,11 +191,6 @@ class SystemBlueprint(yamlize.Object):
         badLocations = set()
         for locationInfo, aTypeID in gridContents.items():
             newAssembly = bp.constructAssem(cs, specifier=aTypeID)
-            if not cs["inputHeightsConsideredHot"]:
-                if not newAssembly.hasFlags(Flags.CONTROL):
-                    self.axialExpChngr.setAssembly(newAssembly)
-                    self.axialExpChngr.expansionData.computeThermalExpansionFactors()
-                    self.axialExpChngr.axiallyExpandAssembly(thermal=True)
 
             i, j = locationInfo
             loc = container.spatialGrid[i, j, 0]

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -620,13 +620,13 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             {"inputHeightsConsideredHot": True},
         )
-        self.stdAssems = [a for a in r.core.getAssemblies()]
+        self.stdAssems = [a for a in r.core.getAssemblies(includeAll=True)]
 
         _oCold, rCold = loadTestReactor(
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             {"inputHeightsConsideredHot": False},
         )
-        self.testAssems = [a for a in rCold.core.getAssemblies()]
+        self.testAssems = [a for a in rCold.core.getAssemblies(includeAll=True)]
 
     def test_coldAssemblyHeight(self):
         """block heights are cold and should be expanded
@@ -664,7 +664,8 @@ def checkColdBlockHeight(bStd, bExp, assertType, strForAssertion):
     assertType(
         bStd.getHeight(),
         bExp.getHeight(),
-        msg="Std Block {0} ({1}) and Exp Block {2} ({3}) should have {4:s} heights!".format(
+        msg="Assembly: {0} -- Std Block {1} ({2}) and Exp Block {3} ({4}) should have {5:s} heights!".format(
+            bStd.parent,
             bStd,
             bStd.getHeight(),
             bExp,

--- a/armi/tests/detailedAxialExpansion/refSmallCoreGrid.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallCoreGrid.yaml
@@ -12,7 +12,7 @@ core:
         MC  PC  MC  MC  OC  SH
           IC  IC  MC  MC  OC
             IC  IC  MC  MC  SH
-          IC  LB  IC  MC  OC
+          IC  LA  IC  MC  OC
             IC  IC  SC  MC  SH
               LA  IC  MC  OC
             IC  IC  IC  MC  SH


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description
In #657, the ability to thermally expand assemblies at BOL was introduced. It was recently discovered that only assemblies placed in the core at BOL were expanded. However, there are use cases where one may define an assembly in the blueprints that may not be present at BOL and shuffled in later. To enable thermal expansion of such assemblies, the axial expansion changer in process load needed to be moved. 

Effects:
- Now _all_ assemblies, i.e., those in and out of the core at BOL, are thermally expanded at process load. 
- This actually results in an efficiency improvement as well. Instead of thermally expanded _every single_ assembly in a core grid, we only thermally expand each assembly type once and allow ARMI to place the thermally expanded assemblies where they are needed.

Changes:
1. copy-paste axial expansion logic from `armi/reactor/blueprints/reactorBlueprint.py` to `armi/reactor/blueprints/__init__.py`
2. Remove assembly type "LB" from core grid in `armi/tests/detailedAxialExpansion`
3. Add option `includeAll=True` into `test_AxialExpansionChanger.py` to ensure that _all_ assemblies defined in the blueprints are thermally expanded at process load. 
4. Sneaking in the removal of some unused imports in `armi/reactor/blueprints/__init__.py`

<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.