### PR TITLE
Making min/max temperatures for Material curves more discoverable

### DIFF
--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -43,6 +43,8 @@ class Alloy200(Material):
         "TRefa": 20,  # Constants for thermal expansion
     }
 
+    propertyValidTemperature = {"linear expansion": ((73.15, 1273.15), "K")}
+
     referenceMaxPercentImpurites = [
         ("C", 0.15),
         ("MN", 0.35),
@@ -99,7 +101,8 @@ class Alloy200(Material):
             instantaneous coefficient of thermal expansion of Alloy 200 (1/C)
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(73.15, 1273.15, Tk, "linear expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
         return interp(Tk, self.linearExpansionTableK, self.linearExpansionTable)
 
     def setDefaultMassFracs(self):

--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -15,9 +15,10 @@
 """
 Alloy-200 are wrought commercially pure nickel.
 """
+from numpy import interp
 
 from armi.materials.material import Material
-from armi.utils.units import getTc
+from armi.utils.units import getTk
 
 
 class Alloy200(Material):
@@ -51,26 +52,35 @@ class Alloy200(Material):
         ("FE", 0.40),
     ]
 
-    def linearExpansionPercent(self, Tk=None, Tc=None):
-        r"""
-        Returns percent linear thermal expansion of Alloy 200
+    linearExpansionTableK = [
+        73.15,
+        173.15,
+        373.15,
+        473.15,
+        573.15,
+        673.15,
+        773.15,
+        873.15,
+        973.15,
+        1073.15,
+        1173.15,
+        1273.15,
+    ]
 
-        Parameters
-        ----------
-        Tk : float, optional
-            temperature in degrees Kelvin
-        Tc : float, optional
-            temperature in degrees Celsius
-
-        Returns
-        -------
-        linearExpansionPercent : float
-            percent linear thermal expansion of Alloy 200 (%)
-        """
-        Tc = getTc(Tc, Tk)
-        self.checkTempRange(-200, 1000, Tc, "linear expansion percent")
-        linearExpansionPercent = self.calcLinearExpansionPercentMetal(T=Tc)
-        return linearExpansionPercent
+    linearExpansionTable = [
+        10.1e-6,
+        11.3e-6,
+        13.3e-6,
+        13.9e-6,
+        14.3e-6,
+        14.8e-6,
+        15.2e-6,
+        15.6e-6,
+        15.8e-6,
+        16.2e-6,
+        16.5e-6,
+        16.7e-6,
+    ]
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""
@@ -88,10 +98,9 @@ class Alloy200(Material):
         linearExpansion : float
             instantaneous coefficient of thermal expansion of Alloy 200 (1/C)
         """
-        Tc = getTc(Tc, Tk)
-        self.checkTempRange(-200, 1000, Tc, "linear expansion")
-        linearExpansion = self.calcLinearExpansionMetal(T=Tc)
-        return linearExpansion
+        Tk = getTk(Tc, Tk)
+        self.checkTempRange(73.15, 1273.15, Tk, "linear expansion")
+        return interp(Tk, self.linearExpansionTableK, self.linearExpansionTable)
 
     def setDefaultMassFracs(self):
         """

--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -116,5 +116,4 @@ class Alloy200(Material):
             nickleMassFrac -= assumedMassFrac
 
         self.setMassFrac("NI", nickleMassFrac)
-
         self.p.refDens = 8.9

--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -101,8 +101,7 @@ class Alloy200(Material):
             instantaneous coefficient of thermal expansion of Alloy 200 (1/C)
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
+        self.checkPropertyTempRange("linear expansion", Tk)
 
         return interp(Tk, self.linearExpansionTableK, self.linearExpansionTable)
 

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -175,8 +175,7 @@ class B4C(material.Material):
     def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
         """Boron carbide expansion. Very preliminary"""
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tc)
         deltaT = Tc - 25
         dLL = deltaT * 4.5e-6
         return dLL * 100

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -26,6 +26,8 @@ class B4C(material.Material):
     name = "B4C"
     enrichedNuclide = "B10"
 
+    propertyValidTemperature = {"linear expansion percent": ((25, 500), "C")}
+
     def applyInputParams(
         self, B10_wt_frac=None, theoretical_density=None, TD_frac=None, *args, **kwargs
     ):
@@ -173,7 +175,8 @@ class B4C(material.Material):
     def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
         """Boron carbide expansion. Very preliminary"""
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(25, 500, Tc, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
         deltaT = Tc - 25
-        dLL = deltaT * 4.5e-6 * 100  # percent
-        return dLL
+        dLL = deltaT * 4.5e-6
+        return dLL * 100

--- a/armi/materials/be9.py
+++ b/armi/materials/be9.py
@@ -29,6 +29,7 @@ class Be9(Material):
 
     name = "Be-9"
     thermalScatteringLaws = (tsl.byNbAndCompound[nb.byName["BE"], tsl.BE_METAL],)
+    propertyValidTemperature = {"linear expansion percent": ((50, 1560.0), "K")}
 
     def setDefaultMassFracs(self):
         self.setMassFrac("BE9", 1.0)
@@ -43,5 +44,6 @@ class Be9(Material):
         which is in turn based on Fusion Engineering and Design . FEDEEE 5(2), 141-234 (1987)
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(50, 1560.0, Tk, "linear expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
         return 1e-4 * (8.4305 + 1.1464e-2 * Tk - 2.9752e-6 * Tk ** 2)

--- a/armi/materials/be9.py
+++ b/armi/materials/be9.py
@@ -44,6 +44,5 @@ class Be9(Material):
         which is in turn based on Fusion Engineering and Design . FEDEEE 5(2), 141-234 (1987)
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tk)
         return 1e-4 * (8.4305 + 1.1464e-2 * Tk - 2.9752e-6 * Tk ** 2)

--- a/armi/materials/californium.py
+++ b/armi/materials/californium.py
@@ -25,3 +25,12 @@ from armi.materials.material import Material
 class Californium(Material):
 
     name = "Californium"
+
+    def setDefaultMassFracs(self):
+        self.setMassFrac("CF252", 1.0)
+
+    def density(self, Tk=None, Tc=None):
+        """
+        https://en.wikipedia.org/wiki/Californium
+        """
+        return 15.1  # g/cm3

--- a/armi/materials/copper.py
+++ b/armi/materials/copper.py
@@ -23,6 +23,8 @@ from armi.materials.material import Material
 class Cu(Material):
     name = "Cu"
 
+    propertyValidTemperature = {"linear expansion percent": ((40.43, 788.83), "K")}
+
     def setDefaultMassFracs(self):
         self.setMassFrac("CU63", 0.6915)
         self.setMassFrac("CU65", 0.3085)
@@ -41,5 +43,6 @@ class Cu(Material):
         Properties of High Performance Rocket Nozzle Materials (NASA CR - 134806)
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(40.43, 788.83, Tk, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
         return 5.0298e-07 * Tk ** 2 + 1.3042e-03 * Tk - 4.3097e-01

--- a/armi/materials/copper.py
+++ b/armi/materials/copper.py
@@ -43,6 +43,5 @@ class Cu(Material):
         Properties of High Performance Rocket Nozzle Materials (NASA CR - 134806)
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tk)
         return 5.0298e-07 * Tk ** 2 + 1.3042e-03 * Tk - 4.3097e-01

--- a/armi/materials/cs.py
+++ b/armi/materials/cs.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
-Cesium.
+Cesium
 """
 
 from armi.materials.material import Material
+from armi.utils.units import getTk
 
 
 class Cs(Material):
@@ -31,4 +31,11 @@ class Cs(Material):
         """
         https://en.wikipedia.org/wiki/Caesium
         """
-        return 1.843  # g/cm3
+        Tk = getTk(Tc, Tk)
+        if Tk < self.meltingPoint():
+            return 1.93  # g/cm3
+        else:
+            return 1.843  # g/cm3
+
+    def meltingPoint(self):
+        return 301.7  # K

--- a/armi/materials/cs.py
+++ b/armi/materials/cs.py
@@ -23,3 +23,12 @@ from armi.materials.material import Material
 class Cs(Material):
 
     name = "Cesium"
+
+    def setDefaultMassFracs(self):
+        self.setMassFrac("CS133", 1.0)
+
+    def density(self, Tk=None, Tc=None):
+        """
+        https://en.wikipedia.org/wiki/Caesium
+        """
+        return 1.843  # g/cm3

--- a/armi/materials/custom.py
+++ b/armi/materials/custom.py
@@ -31,7 +31,6 @@ class Custom(Material):
 
     name = "Custom Material"
     enrichedNuclide = "U235"
-    correctDensityAfterApplyInputParams = False
 
     def __init__(self):
         """

--- a/armi/materials/graphite.py
+++ b/armi/materials/graphite.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Graphite is often used as a moderator in gas-cooled nuclear reactors.
 """

--- a/armi/materials/hastelloyN.py
+++ b/armi/materials/hastelloyN.py
@@ -41,8 +41,6 @@ class HastelloyN(Material):
         "salts in the temperature range of 704 to 871C (1300 to 1600F)"
     )
 
-    # Dictionary of valid temperatures (in C) over which the property models are valid in the format
-    # 'Property_Name': ((Temperature_Lower_Limit, Temperature_Upper_Limit), Temperature_Units)
     propertyValidTemperature = {
         "thermal conductivity": ((473.15, 973.15), "K"),
         "heat capacity": ((373.15, 973.15), "K"),
@@ -88,14 +86,11 @@ class HastelloyN(Material):
         Returns
         -------
         Hastelloy N thermal conductivity (W/m-K)
-
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        (TLowerLimit, TUpperLimit) = self.propertyValidTemperature[
-            "thermal conductivity"
-        ][0]
-        self.checkTempRange(TLowerLimit, TUpperLimit, Tk, "thermal conductivity")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
         return 1.92857e-05 * Tc ** 2 + 3.12857e-03 * Tc + 1.17743e01  # W/m-K
 
     def heatCapacity(self, Tk=None, Tc=None):
@@ -118,8 +113,8 @@ class HastelloyN(Material):
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        (TLowerLimit, TUpperLimit) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(TLowerLimit, TUpperLimit, Tk, "heat capacity")
+        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "heat capacity")
         return (
             +3.19981e02
             + 2.47421e00 * Tc
@@ -169,8 +164,6 @@ class HastelloyN(Material):
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        (TLowerLimit, TUpperLimit) = self.propertyValidTemperature["thermal expansion"][
-            0
-        ]
-        self.checkTempRange(TLowerLimit, TUpperLimit, Tk, "thermal expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "thermal expansion")
         return 2.60282e-12 * Tc ** 2 + 7.69859e-10 * Tc + 1.21036e-05

--- a/armi/materials/hastelloyN.py
+++ b/armi/materials/hastelloyN.py
@@ -88,8 +88,7 @@ class HastelloyN(Material):
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tk)
         return 1.92857e-05 * Tc ** 2 + 3.12857e-03 * Tc + 1.17743e01  # W/m-K
 
     def heatCapacity(self, Tk=None, Tc=None):
@@ -108,12 +107,10 @@ class HastelloyN(Material):
         Returns
         -------
         Hastelloy N specific heat capacity (J/kg-C)
-
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "heat capacity")
+        self.checkPropertyTempRange("heat capacity", Tk)
         return (
             +3.19981e02
             + 2.47421e00 * Tc
@@ -138,7 +135,6 @@ class HastelloyN(Material):
         Returns
         -------
         %dLL(T) in m/m/K
-
         """
         Tc = getTc(Tc, Tk)
         refTempC = getTc(Tk=self.p.refTempK)
@@ -159,10 +155,8 @@ class HastelloyN(Material):
         Returns
         -------
         mean coefficient of thermal expansion in m/m/C
-
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "thermal expansion")
+        self.checkPropertyTempRange("thermal expansion", Tk)
         return 2.60282e-12 * Tc ** 2 + 7.69859e-10 * Tc + 1.21036e-05

--- a/armi/materials/hastelloyN.py
+++ b/armi/materials/hastelloyN.py
@@ -33,7 +33,6 @@ class HastelloyN(Material):
 
     """
     name = "HastelloyN"
-    type = "Structural"
 
     materialIntro = (
         "Hastelloy N alloy is a nickel-base alloy that was invented at Oak RIdge National Laboratories "

--- a/armi/materials/ht9.py
+++ b/armi/materials/ht9.py
@@ -66,8 +66,7 @@ class HT9(materials.Material):
         The ref gives dL/L0 in percent and is valid from 293 - 1050 K.
         """
         tk = units.getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, tk, "linear expansion")
+        self.checkPropertyTempRange("linear expansion", tk)
         return -0.16256 + 1.62307e-4 * tk + 1.42357e-6 * tk ** 2 - 5.50344e-10 * tk ** 3
 
     def thermalConductivity(self, Tk=None, Tc=None):

--- a/armi/materials/ht9.py
+++ b/armi/materials/ht9.py
@@ -39,6 +39,8 @@ class HT9(materials.Material):
 
     name = "HT9"
 
+    propertyValidTemperature = {"linear expansion": ((293, 1050), "K")}
+
     def setDefaultMassFracs(self):
         """
         HT9 mass fractions
@@ -64,7 +66,8 @@ class HT9(materials.Material):
         The ref gives dL/L0 in percent and is valid from 293 - 1050 K.
         """
         tk = units.getTk(Tc, Tk)
-        self.checkTempRange(293, 1050, tk, "linear expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, tk, "linear expansion")
         return -0.16256 + 1.62307e-4 * tk + 1.42357e-6 * tk ** 2 - 5.50344e-10 * tk ** 3
 
     def thermalConductivity(self, Tk=None, Tc=None):

--- a/armi/materials/inconel600.py
+++ b/armi/materials/inconel600.py
@@ -95,8 +95,7 @@ class Inconel600(Material):
             thermal conductivity in W/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tc)
         thermalCond = 3.4938e-6 * Tc ** 2 + 1.3403e-2 * Tc + 14.572
         return thermalCond  # W/m-C
 
@@ -136,8 +135,7 @@ class Inconel600(Material):
             heat capacity in J/kg/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "heat capacity")
+        self.checkPropertyTempRange("heat capacity", Tc)
         heatCapacity = 7.4021e-6 * Tc ** 2 + 0.20573 * Tc + 441.3
         return heatCapacity  # J/kg-C
 
@@ -199,8 +197,7 @@ class Inconel600(Material):
         linExpPercent in %-m/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tc)
         linExpPercent = 3.722e-7 * Tc ** 2 + 1.303e-3 * Tc - 2.863e-2
         return linExpPercent
 
@@ -228,7 +225,6 @@ class Inconel600(Material):
         linExp in m/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion")
+        self.checkPropertyTempRange("linear expansion", Tc)
         linExp = 7.444e-9 * Tc + 1.303e-5
         return linExp

--- a/armi/materials/inconel600.py
+++ b/armi/materials/inconel600.py
@@ -17,12 +17,18 @@ Inconel600
 """
 import numpy
 
-from armi.utils.units import getTc
 from armi.materials.material import Material
+from armi.utils.units import getTc
 
 
 class Inconel600(Material):
     name = "Inconel600"
+    propertyValidTemperature = {
+        "heat capacity": ((20, 900), "C"),
+        "linear expansion": ((21.0, 900.0), "C"),
+        "linear expansion percent": ((21.0, 900.0), "C"),
+        "thermal conductivity": ((20.0, 800.0), "C"),
+    }
     references = {
         "mass fractions": "http://www.specialmetals.com/documents/Inconel%20alloy%20600.pdf",
         "density": "http://www.specialmetals.com/documents/Inconel%20alloy%20600.pdf",
@@ -67,7 +73,6 @@ class Inconel600(Material):
         Returns
         -------
         list of length 'power' containing the polynomial fit coefficients for thermal conductivity.
-
         """
         Tc = [20.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0]
         k = [14.9, 15.9, 17.3, 19.0, 20.5, 22.1, 23.9, 25.7, 27.5]
@@ -88,10 +93,10 @@ class Inconel600(Material):
         -------
         thermalCond : float
             thermal conductivity in W/m/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(20.0, 800.0, Tc, "thermal conductivity")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "thermal conductivity")
         thermalCond = 3.4938e-6 * Tc ** 2 + 1.3403e-2 * Tc + 14.572
         return thermalCond  # W/m-C
 
@@ -109,7 +114,6 @@ class Inconel600(Material):
         Returns
         -------
         list of length 'power' containing the polynomial fit coefficients for heat capacity.
-
         """
         Tc = [20.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0]
         cp = [444.0, 465.0, 486.0, 502.0, 519.0, 536.0, 578.0, 595.0, 611.0, 628.0]
@@ -130,10 +134,10 @@ class Inconel600(Material):
         -------
         heatCapacity : float
             heat capacity in J/kg/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(20, 900, Tc, "heat capacity")
+        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "heat capacity")
         heatCapacity = 7.4021e-6 * Tc ** 2 + 0.20573 * Tc + 441.3
         return heatCapacity  # J/kg-C
 
@@ -153,7 +157,6 @@ class Inconel600(Material):
         Returns
         -------
         list of length 'power' containing the polynomial fit coefficients for linearExpansionPercent
-
         """
         refTempC = getTc(None, Tk=self.p.refTempK)
         Tc = [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0]
@@ -194,11 +197,10 @@ class Inconel600(Material):
         Returns
         -------
         linExpPercent in %-m/m/C
-
         """
         Tc = getTc(Tc, Tk)
-
-        self.checkTempRange(21.0, 900.0, Tc, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
         linExpPercent = 3.722e-7 * Tc ** 2 + 1.303e-3 * Tc - 2.863e-2
         return linExpPercent
 
@@ -224,9 +226,9 @@ class Inconel600(Material):
         Returns
         -------
         linExp in m/m/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(21.0, 900.0, Tc, "linear expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion")
         linExp = 7.444e-9 * Tc + 1.303e-5
         return linExp

--- a/armi/materials/inconel625.py
+++ b/armi/materials/inconel625.py
@@ -23,6 +23,12 @@ from armi.materials.material import Material
 
 class Inconel625(Material):
     name = "Inconel625"
+    propertyValidTemperature = {
+        "heat capacity": ((221.0, 1093.0), "C"),
+        "linear expansion": ((21.0, 927.0), "C"),
+        "linear expansion percent": ((21.0, 927.0), "C"),
+        "thermal conductivity": ((21.0, 982.0), "C"),
+    }
     references = {
         "mass fractions": "http://www.specialmetals.com/assets/documents/alloys/inconel/inconel-alloy-625.pdf",
         "density": "http://www.specialmetals.com/assets/documents/alloys/inconel/inconel-alloy-625.pdf",
@@ -72,7 +78,6 @@ class Inconel625(Material):
         Returns
         -------
         list of length 'power' containing the polynomial fit coefficients for thermal conductivity.
-
         """
         Tc = [21.0, 38.0, 93.0, 204.0, 316.0, 427.0, 538.0, 649.0, 760.0, 871.0, 982.0]
         k = [9.8, 10.1, 10.8, 12.5, 14.1, 15.7, 17.5, 19.0, 20.8, 22.8, 25.2]
@@ -93,10 +98,10 @@ class Inconel625(Material):
         -------
         thermalCond : float
             thermal conductivity in W/m/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(21.0, 982.0, Tc, "thermal conductivity")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "thermal conductivity")
         thermalCond = 2.7474e-6 * Tc ** 2 + 0.012907 * Tc + 9.62532
         return thermalCond  # W/m-C
 
@@ -114,7 +119,6 @@ class Inconel625(Material):
         Returns
         -------
         list of length 'power' containing the polynomial fit coefficients for heat capacity.
-
         """
         Tc = [
             21.0,
@@ -159,10 +163,10 @@ class Inconel625(Material):
         -------
         heatCapacity : float
             heat capacity in J/kg/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(21.0, 1093.0, Tc, "heat capacity")
+        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "heat capacity")
         heatCapacity = -5.3777e-6 * Tc ** 2 + 0.25 * Tc + 404.26
         return heatCapacity  # J/kg-C
 
@@ -182,7 +186,6 @@ class Inconel625(Material):
         Returns
         -------
         list of length 'power' containing the polynomial fit coefficients for linearExpansionPercent
-
         """
         refTempC = getTc(None, Tk=self.p.refTempK)
         Tc = [93.0, 204.0, 316.0, 427.0, 538.0, 649.0, 760.0, 871.0, 927.0]
@@ -223,10 +226,10 @@ class Inconel625(Material):
         Returns
         -------
         linExpPercent in %-m/m/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(21.0, 927.0, Tc, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
         linExpPercent = 5.083e-7 * Tc ** 2 + 1.125e-3 * Tc - 1.804e-2
         return linExpPercent
 
@@ -252,9 +255,9 @@ class Inconel625(Material):
         Returns
         -------
         linExp in m/m/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(21.0, 927.0, Tc, "linear expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion")
         linExp = 1.0166e-8 * Tc + 1.125e-5
         return linExp

--- a/armi/materials/inconel625.py
+++ b/armi/materials/inconel625.py
@@ -100,8 +100,7 @@ class Inconel625(Material):
             thermal conductivity in W/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tc)
         thermalCond = 2.7474e-6 * Tc ** 2 + 0.012907 * Tc + 9.62532
         return thermalCond  # W/m-C
 
@@ -165,8 +164,7 @@ class Inconel625(Material):
             heat capacity in J/kg/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "heat capacity")
+        self.checkPropertyTempRange("heat capacity", Tc)
         heatCapacity = -5.3777e-6 * Tc ** 2 + 0.25 * Tc + 404.26
         return heatCapacity  # J/kg-C
 
@@ -228,8 +226,7 @@ class Inconel625(Material):
         linExpPercent in %-m/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tc)
         linExpPercent = 5.083e-7 * Tc ** 2 + 1.125e-3 * Tc - 1.804e-2
         return linExpPercent
 
@@ -257,7 +254,6 @@ class Inconel625(Material):
         linExp in m/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion")
+        self.checkPropertyTempRange("linear expansion", Tc)
         linExp = 1.0166e-8 * Tc + 1.125e-5
         return linExp

--- a/armi/materials/inconel800.py
+++ b/armi/materials/inconel800.py
@@ -65,7 +65,6 @@ class Inconel800(Material):
         Returns
         -------
         %dLL(T) in m/m/K
-
         """
         Tc = getTc(Tc, Tk)
         refTempC = getTc(Tk=self.p.refTempK)
@@ -86,13 +85,10 @@ class Inconel800(Material):
         Returns
         -------
         mean coefficient of thermal expansion in m/m/C
-
         """
         Tc = getTc(Tc, Tk)
-        (TLowerLimit, TUpperLimit) = self.propertyValidTemperature["thermal expansion"][
-            0
-        ]
-        self.checkTempRange(TLowerLimit, TUpperLimit, Tc, "thermal expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "thermal expansion")
         return (
             2.52525e-14 * Tc ** 3
             - 3.77814e-11 * Tc ** 2

--- a/armi/materials/inconel800.py
+++ b/armi/materials/inconel800.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Incoloy 800."""
+"""Incoloy 800"""
 
 from armi.utils.units import getTc
 from armi.materials.material import Material
@@ -87,8 +87,7 @@ class Inconel800(Material):
         mean coefficient of thermal expansion in m/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "thermal expansion")
+        self.checkPropertyTempRange("thermal expansion", Tc)
         return (
             2.52525e-14 * Tc ** 3
             - 3.77814e-11 * Tc ** 2

--- a/armi/materials/inconelX750.py
+++ b/armi/materials/inconelX750.py
@@ -23,6 +23,12 @@ from armi.materials.material import Material
 
 class InconelX750(Material):
     name = "InconelX750"
+    propertyValidTemperature = {
+        "heat capacity": ((-18.0, 1093.0), "C"),
+        "linear expansion": ((21.1, 982.2), "C"),
+        "linear expansion percent": ((21.1, 982.2), "C"),
+        "thermal conductivity": ((-156.7, 871.1), "C"),
+    }
     references = {
         "mass fractions": "http://www.specialmetals.com/documents/Inconel%20alloy%20X-750.pdf",
         "density": "http://www.specialmetals.com/documents/Inconel%20alloy%20X-750.pdf",
@@ -71,7 +77,6 @@ class InconelX750(Material):
         Returns
         -------
         list of length 'power' containing the polynomial fit coefficients for thermal conductivity.
-
         """
         Tc = [
             -156.7,
@@ -118,10 +123,10 @@ class InconelX750(Material):
         -------
         thermalCond : float
             thermal conductivity in W/m/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(-156.7, 871.1, Tc, "thermal conductivity")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "thermal conductivity")
         thermalCond = 1.4835e-6 * Tc ** 2 + 1.2668e-2 * Tc + 11.632
         return thermalCond  # W/m-C
 
@@ -139,7 +144,6 @@ class InconelX750(Material):
         Returns
         -------
         list of length 'power' containing the polynomial fit coefficients for heat capacity.
-
         """
         Tc = [21.1, 93.3, 204.4, 315.6, 426.7, 537.8, 648.9, 760.0, 871.1]
         cp = [431.2, 456.4, 485.7, 502.4, 523.4, 544.3, 573.6, 632.2, 715.9]
@@ -163,7 +167,8 @@ class InconelX750(Material):
 
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(-18.0, 1093.0, Tc, "heat capacity")
+        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "heat capacity")
         heatCapacity = (
             9.2261e-7 * Tc ** 3 - 9.6368e-4 * Tc ** 2 + 4.7778e-1 * Tc + 420.55
         )
@@ -185,7 +190,6 @@ class InconelX750(Material):
         Returns
         -------
         list of length 'power' containing the polynomial fit coefficients for linearExpansionPercent
-
         """
         refTempC = getTc(None, Tk=self.p.refTempK)
         Tc = [93.3, 204.4, 315.6, 426.7, 537.8, 648.9, 760.0, 871.1, 982.2]
@@ -226,10 +230,10 @@ class InconelX750(Material):
         Returns
         -------
         linExpPercent in %-m/m/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(21.1, 982.2, Tc, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
         linExpPercent = 6.8378e-7 * Tc ** 2 + 1.056e-3 * Tc - 1.3161e-2
         return linExpPercent
 
@@ -255,9 +259,9 @@ class InconelX750(Material):
         Returns
         -------
         linExp in m/m/C
-
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(21.1, 982.2, Tc, "linear expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion")
         linExp = 1.36756e-8 * Tc + 1.056e-5
         return linExp

--- a/armi/materials/inconelX750.py
+++ b/armi/materials/inconelX750.py
@@ -125,8 +125,7 @@ class InconelX750(Material):
             thermal conductivity in W/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tc)
         thermalCond = 1.4835e-6 * Tc ** 2 + 1.2668e-2 * Tc + 11.632
         return thermalCond  # W/m-C
 
@@ -164,11 +163,9 @@ class InconelX750(Material):
         -------
         heatCapacity : float
             heat capacity in J/kg/C
-
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "heat capacity")
+        self.checkPropertyTempRange("heat capacity", Tc)
         heatCapacity = (
             9.2261e-7 * Tc ** 3 - 9.6368e-4 * Tc ** 2 + 4.7778e-1 * Tc + 420.55
         )
@@ -232,8 +229,7 @@ class InconelX750(Material):
         linExpPercent in %-m/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tc)
         linExpPercent = 6.8378e-7 * Tc ** 2 + 1.056e-3 * Tc - 1.3161e-2
         return linExpPercent
 
@@ -261,7 +257,6 @@ class InconelX750(Material):
         linExp in m/m/C
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion")
+        self.checkPropertyTempRange("linear expansion", Tc)
         linExp = 1.36756e-8 * Tc + 1.056e-5
         return linExp

--- a/armi/materials/lead.py
+++ b/armi/materials/lead.py
@@ -34,8 +34,7 @@ class Lead(material.Fluid):
         NOT BASED ON MEASUREMENT.
         Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["volumetric expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "volumetric expansion")
+        self.checkPropertyTempRange("volumetric expansion", Tk)
 
         return 1.0 / (9516.9 - Tk)
 
@@ -46,15 +45,13 @@ class Lead(material.Fluid):
     def density(self, Tk=None, Tc=None):
         r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "density")
+        self.checkPropertyTempRange("density", Tk)
 
         return 11.367 - 0.0011944 * Tk  # pre-converted from kg/m^3 to g/cc
 
     def heatCapacity(self, Tk=None, Tc=None):
         r"""heat ccapacity in J/kg/K from Sobolev"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "heat capacity")
+        self.checkPropertyTempRange("heat capacity", Tk)
 
         return 162.9 - 3.022e-2 * Tk + 8.341e-6 * Tk ** 2

--- a/armi/materials/lead.py
+++ b/armi/materials/lead.py
@@ -23,13 +23,19 @@ from armi.materials import material
 class Lead(material.Fluid):
     r"""Natural lead"""
     name = "Lead"
+    propertyValidTemperature = {
+        "density": ((600, 1700), "K"),
+        "heat capacity": ((600, 1500), "K"),
+        "volumetric expansion": ((600, 1700), "K"),
+    }
 
     def volumetricExpansion(self, Tk=None, Tc=None):
         r"""volumetric expansion inferred from density.
         NOT BASED ON MEASUREMENT.
         Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(600, 1700, Tk, "volumetric expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["volumetric expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "volumetric expansion")
 
         return 1.0 / (9516.9 - Tk)
 
@@ -40,13 +46,15 @@ class Lead(material.Fluid):
     def density(self, Tk=None, Tc=None):
         r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(600, 1700, Tk, "density")
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "density")
 
         return 11.367 - 0.0011944 * Tk  # pre-converted from kg/m^3 to g/cc
 
     def heatCapacity(self, Tk=None, Tc=None):
         r"""heat ccapacity in J/kg/K from Sobolev"""
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(600, 1500, Tk, "heat capacity")
+        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "heat capacity")
 
         return 162.9 - 3.022e-2 * Tk + 8.341e-6 * Tk ** 2

--- a/armi/materials/leadBismuth.py
+++ b/armi/materials/leadBismuth.py
@@ -43,8 +43,7 @@ class LeadBismuth(material.Fluid):
     def density(self, Tk=None, Tc=None):
         r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "density")
+        self.checkPropertyTempRange("density", Tk)
 
         return 11.096 - 0.0013236 * Tk  # pre-converted from kg/m^3 to g/cc
 
@@ -52,16 +51,14 @@ class LeadBismuth(material.Fluid):
         r"""dynamic viscosity in Pa-s from Sobolev. Accessed online at
         http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["dynamic visc"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "dynamic visc")
+        self.checkPropertyTempRange("dynamic visc", Tk)
 
         return 4.94e-4 * math.exp(754.1 / Tk)
 
     def heatCapacity(self, Tk=None, Tc=None):
         r"""heat ccapacity in J/kg/K from Sobolev. Expected acuracy 5%"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "heat capacity")
+        self.checkPropertyTempRange("heat capacity", Tk)
 
         return 159 - 2.72e-2 * Tk + 7.12e-6 * Tk ** 2
 
@@ -69,8 +66,7 @@ class LeadBismuth(material.Fluid):
         r"""thermal conductivity in W/m/K from Sobolev. Accessed online at
         http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tk)
 
         return 2.45 * Tk / (86.334 + 0.0511 * Tk)
 
@@ -79,7 +75,6 @@ class LeadBismuth(material.Fluid):
         NOT BASED ON MEASUREMENT.
         Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["volumetric expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "volumetric expansion")
+        self.checkPropertyTempRange("volumetric expansion", Tk)
 
         return 1.0 / (8383.2 - Tk)

--- a/armi/materials/leadBismuth.py
+++ b/armi/materials/leadBismuth.py
@@ -27,6 +27,13 @@ from armi.materials import material
 class LeadBismuth(material.Fluid):
     r"""Lead bismuth eutectic"""
     name = "Lead Bismuth"
+    propertyValidTemperature = {
+        "density": ((400, 1300), "K"),
+        "dynamic visc": ((400, 1100), "K"),
+        "heat capacity": ((400, 1100), "K"),
+        "thermal conductivity": ((400, 1100), "K"),
+        "volumetric expansion": ((400, 1300), "K"),
+    }
 
     def setDefaultMassFracs(self):
         r"""mass fractions"""
@@ -36,38 +43,43 @@ class LeadBismuth(material.Fluid):
     def density(self, Tk=None, Tc=None):
         r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(400, 1300, Tk, "density")
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "density")
 
         return 11.096 - 0.0013236 * Tk  # pre-converted from kg/m^3 to g/cc
+
+    def dynamicVisc(self, Tk=None, Tc=None):
+        r"""dynamic viscosity in Pa-s from Sobolev. Accessed online at
+        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12"""
+        Tk = getTk(Tc, Tk)
+        (Tmin, Tmax) = self.propertyValidTemperature["dynamic visc"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "dynamic visc")
+
+        return 4.94e-4 * math.exp(754.1 / Tk)
+
+    def heatCapacity(self, Tk=None, Tc=None):
+        r"""heat ccapacity in J/kg/K from Sobolev. Expected acuracy 5%"""
+        Tk = getTk(Tc, Tk)
+        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "heat capacity")
+
+        return 159 - 2.72e-2 * Tk + 7.12e-6 * Tk ** 2
+
+    def thermalConductivity(self, Tk=None, Tc=None):
+        r"""thermal conductivity in W/m/K from Sobolev. Accessed online at
+        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12"""
+        Tk = getTk(Tc, Tk)
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
+
+        return 2.45 * Tk / (86.334 + 0.0511 * Tk)
 
     def volumetricExpansion(self, Tk=None, Tc=None):
         r"""volumetric expansion inferred from density.
         NOT BASED ON MEASUREMENT.
         Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(400, 1300, Tk, "volumetric expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["volumetric expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "volumetric expansion")
 
         return 1.0 / (8383.2 - Tk)
-
-    def heatCapacity(self, Tk=None, Tc=None):
-        r"""heat ccapacity in J/kg/K from Sobolev. Expected acuracy 5%"""
-        Tk = getTk(Tc, Tk)
-        self.checkTempRange(400, 1100, Tk, "heat capacity")
-
-        return 159 - 2.72e-2 * Tk + 7.12e-6 * Tk ** 2
-
-    def dynamicVisc(self, Tk=None, Tc=None):
-        r"""dynamic viscosity in Pa-s from Sobolev. Accessed online at
-        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12"""
-        Tk = getTk(Tc, Tk)
-        self.checkTempRange(400, 1100, Tk, "heat capacity")
-
-        return 4.94e-4 * math.exp(754.1 / Tk)
-
-    def thermalConductivity(self, Tk=None, Tc=None):
-        r"""thermal conductivity in W/m/K from Sobolev. Accessed online at
-        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12"""
-        Tk = getTk(Tc, Tk)
-        self.checkTempRange(400, 1100, Tk, "heat capacity")
-
-        return 2.45 * Tk / (86.334 + 0.0511 * Tk)

--- a/armi/materials/lithium.py
+++ b/armi/materials/lithium.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Lithium.
 

--- a/armi/materials/magnesium.py
+++ b/armi/materials/magnesium.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 """
-Magnesium.
+Magnesium
 """
 
-from armi.utils.units import C_TO_K
 from armi.materials import material
+from armi.utils.units import getTk
 
 
 class Magnesium(material.Fluid):
     name = "Magnesium"
+    propertyValidTemperature = {"density": ((923, 1390), "K")}
 
     def setDefaultMassFracs(self):
         self.setMassFrac("MG", 1.0)
@@ -29,7 +30,7 @@ class Magnesium(material.Fluid):
     def density(self, Tk=None, Tc=None):
         r"""returns mass density of magnesium in g/cc
         The Liquid Temperature Range, Density and Constants of Magnesium. P.J. McGonigal. Temple University 1961."""
-        self.checkTempRange(923, 1390, Tk, "density")
-        if not Tk and Tc:
-            Tk = Tc + C_TO_K
+        Tk = getTk(Tc, Tk)
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "density")
         return 1.59 - 0.00026 * (Tk - 924.0)

--- a/armi/materials/magnesium.py
+++ b/armi/materials/magnesium.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Magnesium
-"""
+"""Magnesium"""
 
 from armi.materials import material
 from armi.utils.units import getTk
@@ -31,6 +29,6 @@ class Magnesium(material.Fluid):
         r"""returns mass density of magnesium in g/cc
         The Liquid Temperature Range, Density and Constants of Magnesium. P.J. McGonigal. Temple University 1961."""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "density")
+        self.checkPropertyTempRange("density", Tk)
+
         return 1.59 - 0.00026 * (Tk - 924.0)

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -51,7 +51,7 @@ class Material(composites.Leaf):
     # Indication of where the material is loaded from (may be plugin name)
     DATA_SOURCE = "ARMI"
 
-    # TODO
+    # String identifying the material
     name = "Material"
 
     # The literature references {property : citation}
@@ -59,9 +59,6 @@ class Material(composites.Leaf):
 
     # Name of enriched nuclide to be interpreted by enrichment modification methods
     enrichedNuclide = None
-
-    # TODO
-    correctDensityAfterApplyInputParams = True
 
     # Constants that may be used in intepolation functions for property lookups"
     modelConst = {}

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -554,9 +554,7 @@ class Material(composites.Leaf):
 
         label : str
             The name of the function or property that is being checked.
-
         """
-
         if not minV <= val <= maxV:
             msg = "Temperature {0} out of range ({1} to {2}) for {3} {4}".format(
                 val, minV, maxV, self.name, label
@@ -586,7 +584,6 @@ class Material(composites.Leaf):
         rhoCP : float
             Calculated value for the HT9 density* heat capacity
             unit (J/m^3-K)
-
         """
         Tc = getTc(Tc, Tk)
 

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -45,26 +45,34 @@ class Material(composites.Leaf):
     A material is made up of elements or isotopes. It has bulk properties like mass density.
     """
 
+    # State parameter definitions
     pDefs = materialParameters.getMaterialParameterDefinitions()
-    """State parameter definitions"""
 
+    # Indication of where the material is loaded from (may be plugin name)
     DATA_SOURCE = "ARMI"
-    """Indication of where the material is loaded from (may be plugin name)"""
 
+    # TODO
     name = "Material"
-    references = {}  # property : citation
-    """The literature references."""
 
+    # The literature references {property : citation}
+    references = {}
+
+    # Name of enriched nuclide to be interpreted by enrichment modification methods
     enrichedNuclide = None
-    """Name of enriched nuclide to be interpreted by enrichment modification methods"""
+
+    # TODO
     correctDensityAfterApplyInputParams = True
 
+    # Constants that may be used in intepolation functions for property lookups"
     modelConst = {}
-    """Constants that may be used in intepolation functions for property lookups"""
 
+    # Dictionary of valid temperatures over which the property models are valid in the format
+    # 'Property Name': ((Temperature_Lower_Limit, Temperature_Upper_Limit), Temperature_Units)
+    propertyValidTemperature = {}
+
+    # A tuple of :py:class:`~armi.nucDirectory.thermalScattering.ThermalScattering` instances
+    # with information about thermal scattering.
     thermalScatteringLaws = ()
-    """A tuple of :py:class:`~armi.nucDirectory.thermalScattering.ThermalScattering` instances 
-    with information about thermal scattering."""
 
     def __init__(self):
         composites.Leaf.__init__(self, self.__class__.name)

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -45,31 +45,31 @@ class Material(composites.Leaf):
     A material is made up of elements or isotopes. It has bulk properties like mass density.
     """
 
-    # State parameter definitions
     pDefs = materialParameters.getMaterialParameterDefinitions()
+    """State parameter definitions"""
 
-    # Indication of where the material is loaded from (may be plugin name)
     DATA_SOURCE = "ARMI"
+    """Indication of where the material is loaded from (may be plugin name)"""
 
-    # String identifying the material
     name = "Material"
+    """String identifying the material"""
 
-    # The literature references {property : citation}
     references = {}
+    """The literature references {property : citation}"""
 
-    # Name of enriched nuclide to be interpreted by enrichment modification methods
     enrichedNuclide = None
+    """Name of enriched nuclide to be interpreted by enrichment modification methods"""
 
-    # Constants that may be used in intepolation functions for property lookups"
     modelConst = {}
+    """Constants that may be used in intepolation functions for property lookups"""
 
-    # Dictionary of valid temperatures over which the property models are valid in the format
-    # 'Property Name': ((Temperature_Lower_Limit, Temperature_Upper_Limit), Temperature_Units)
     propertyValidTemperature = {}
+    """Dictionary of valid temperatures over which the property models are valid in the format
+    'Property Name': ((Temperature_Lower_Limit, Temperature_Upper_Limit), Temperature_Units)"""
 
-    # A tuple of :py:class:`~armi.nucDirectory.thermalScattering.ThermalScattering` instances
-    # with information about thermal scattering.
     thermalScatteringLaws = ()
+    """A tuple of :py:class:`~armi.nucDirectory.thermalScattering.ThermalScattering` instances
+    with information about thermal scattering."""
 
     def __init__(self):
         composites.Leaf.__init__(self, self.__class__.name)
@@ -137,7 +137,6 @@ class Material(composites.Leaf):
         See Also
         --------
         linearExpansion : handle instantaneous thermal expansion coefficients
-
         """
         return 0.0
 
@@ -449,15 +448,11 @@ class Material(composites.Leaf):
         return 0.0
 
     def yieldStrength(self, Tk: float = None, Tc: float = None) -> float:
-        r"""
-        returns yield strength at given T in MPa
-        """
+        r"""returns yield strength at given T in MPa"""
         return self.p.yieldStrength
 
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
-        r"""
-        thermal conductivity in given T in K
-        """
+        r"""thermal conductivity in given T in K"""
         return self.p.thermalConductivity
 
     def getProperty(
@@ -544,25 +539,44 @@ class Material(composites.Leaf):
     def getMassFracCopy(self):
         return copy.deepcopy(self.p.massFrac)
 
-    def checkTempRange(self, minV, maxV, val, label=""):
+    def checkPropertyTempRange(self, label, val):
+        r"""Checks if the given property / value combination fall between the min and max valid
+        temperatures provided in the propertyValidTemperature object.
+
+        Parameters
+        ----------
+        label : str
+            The name of the function or property that is being checked.
+
+        val : float
+            The value to check whether it is between minT and maxT.
+
+        Notes
+        -----
+        This was designed as a convience method for ``checkTempRange``.
+        """
+        (minT, maxT) = self.propertyValidTemperature[label][0]
+        self.checkTempRange(minT, maxT, val, label)
+
+    def checkTempRange(self, minT, maxT, val, label=""):
         r"""
-        Checks if the given temperature (val) is between the minV and maxV temperature limits supplied.
+        Checks if the given temperature (val) is between the minT and maxT temperature limits supplied.
         Label identifies what material type or element is being evaluated in the check.
 
         Parameters
         ----------
-        minV, maxV : float
+        minT, maxT : float
             The minimum and maximum values that val is allowed to have.
 
         val : float
-            The value to check whether it is between minV and maxV.
+            The value to check whether it is between minT and maxT.
 
         label : str
             The name of the function or property that is being checked.
         """
-        if not minV <= val <= maxV:
+        if not minT <= val <= maxT:
             msg = "Temperature {0} out of range ({1} to {2}) for {3} {4}".format(
-                val, minV, maxV, self.name, label
+                val, minT, maxT, self.name, label
             )
             if FAIL_ON_RANGE or numpy.isnan(val):
                 runLog.error(msg)

--- a/armi/materials/mgO.py
+++ b/armi/materials/mgO.py
@@ -22,11 +22,28 @@ from armi.materials.material import Material
 class MgO(Material):
     r"""MagnesiumOxide"""
     name = "MgO"
+    propertyValidTemperature = {
+        "density": ((273, 1273), "K"),
+        "linear expansion percent": ((273.15, 1273.15), "K"),
+    }
 
     def setDefaultMassFracs(self):
         r"""mass fractions"""
         self.setMassFrac("MG", 0.603035897)
         self.setMassFrac("O16", 0.396964103)
+
+    def density(self, Tk=None, Tc=None):
+        """same reference as linear expansion. Table II.
+        Reference density is from Wolfram Alpha At STP (273 K)"""
+        Tk = getTk(Tc, Tk)
+        rho0 = 3.58
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "density")
+        dLL = self.linearExpansionPercent(Tk=Tk)
+
+        dRho = (1 - (1 + dLL) ** 3) / (1 + dLL) ** 3
+        density = rho0 * (1 + dRho)
+        return density
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         """THE COEFFICIENT OF EXPANSION OF MAGNESIUM OXIDE
@@ -36,20 +53,8 @@ class MgO(Material):
 
         This is based on a 3rd order polynomial fit of the data in Table I.
         """
-        # Note: This is in C! Others are mostly in K. Depends on reference.
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(273.15, 1273.15, Tk, "deltaL")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
         return 1.0489e-5 * Tc + 6.0458e-9 * Tc ** 2 - 2.6875e-12 * Tc ** 3
-
-    def density(self, Tk=None, Tc=None):
-        """same reference as linear expansion. Table II.
-        Reference density is from Wolfram Alpha At STP (273 K)"""
-        Tk = getTk(Tc, Tk)
-        rho0 = 3.58
-        self.checkTempRange(273, 1273, Tk, "density")
-        dLL = self.linearExpansionPercent(Tk=Tk)
-
-        dRho = (1 - (1 + dLL) ** 3) / (1 + dLL) ** 3
-        density = rho0 * (1 + dRho)
-        return density

--- a/armi/materials/mgO.py
+++ b/armi/materials/mgO.py
@@ -37,8 +37,7 @@ class MgO(Material):
         Reference density is from Wolfram Alpha At STP (273 K)"""
         Tk = getTk(Tc, Tk)
         rho0 = 3.58
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "density")
+        self.checkPropertyTempRange("density", Tk)
         dLL = self.linearExpansionPercent(Tk=Tk)
 
         dRho = (1 - (1 + dLL) ** 3) / (1 + dLL) ** 3
@@ -55,6 +54,5 @@ class MgO(Material):
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tk)
         return 1.0489e-5 * Tc + 6.0458e-9 * Tc ** 2 - 2.6875e-12 * Tc ** 3

--- a/armi/materials/molybdenum.py
+++ b/armi/materials/molybdenum.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Molybdenum
 """

--- a/armi/materials/mox.py
+++ b/armi/materials/mox.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Mixed-oxide (MOX) ceramic fuel.
 
@@ -113,7 +112,6 @@ class MOX(UraniumOxide):
         return massFracPuO2 * molweightUO2 / massFracUO2 / molweightPuO2
 
     def setDefaultMassFracs(self):
-
         r"""UO2 + PuO2 mixture mass fractions.
 
         Pu238: 238.0495599 g/mol

--- a/armi/materials/mox.py
+++ b/armi/materials/mox.py
@@ -21,6 +21,7 @@ A definitive source for these properties is [#ornltm20002]_.
     Oak Ridge National Laboratory. ORNL/TM-2000/351 https://rsicc.ornl.gov/fmdp/tm2000-351.pdf
 
 """
+from armi import runLog
 from armi.materials.uraniumOxide import UraniumOxide
 from armi.materials import material
 from armi.nucDirectory import nucDir

--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -28,8 +28,9 @@ class Potassium(material.Fluid):
     """
 
     name = "Potassium"
+    propertyValidTemperature = {"density": ((63.38, 759), "K")}
 
-    def density(self, Tk=None, Tc=None, check_range=True):
+    def density(self, Tk=None, Tc=None):
         r"""
         Calculates the density of molten Potassium in g/cc
         From Foust, O.J. Sodium-NaK Engineering Handbook Vol. 1. New York: Gordon and Breach, 1972.
@@ -37,6 +38,6 @@ class Potassium(material.Fluid):
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        if check_range:
-            self.checkTempRange(63.38, 759, Tk, "density")
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "density")
         return 0.8415 - 2.172e-4 * Tc - 2.70e-8 * Tc ** 2 + 4.77e-12 * Tc ** 3

--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Potassium
-"""
+"""Potassium"""
 
 from armi.utils.units import getTc, getTk
 from armi.materials import material
@@ -38,6 +36,5 @@ class Potassium(material.Fluid):
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "density")
+        self.checkPropertyTempRange("density", Tk)
         return 0.8415 - 2.172e-4 * Tc - 2.70e-8 * Tc ** 2 + 4.77e-12 * Tc ** 3

--- a/armi/materials/scandiumOxide.py
+++ b/armi/materials/scandiumOxide.py
@@ -39,6 +39,5 @@ class Sc2O3(Material):
         From Table 4 of "Thermal Expansion and Phase Inversion of Rare-Earth Oxides.
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tk)
         return 2.6045e-07 * Tk ** 2 + 4.6374e-04 * Tk - 1.4696e-01

--- a/armi/materials/scandiumOxide.py
+++ b/armi/materials/scandiumOxide.py
@@ -21,6 +21,8 @@ from armi.materials.material import Material
 class Sc2O3(Material):
     name = "Sc2O3"
 
+    propertyValidTemperature = {"linear expansion percent": ((273.15, 1573.15), "K")}
+
     def setDefaultMassFracs(self):
         self.setMassFrac("SC45", 0.6520)
         self.setMassFrac("O16", 0.3480)
@@ -37,5 +39,6 @@ class Sc2O3(Material):
         From Table 4 of "Thermal Expansion and Phase Inversion of Rare-Earth Oxides.
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(273.15, 1573.15, Tk, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
         return 2.6045e-07 * Tk ** 2 + 4.6374e-04 * Tk - 1.4696e-01

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -82,20 +82,17 @@ class SiC(Material):
 
     def heatCapacity(self, Tc=None, Tk=None):
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "heat capacity")
+        self.checkPropertyTempRange("heat capacity", Tc)
         return 1110 + 0.15 * Tc - 425 * math.exp(-0.003 * Tc)
 
     def cumulativeLinearExpansion(self, Tk=None, Tc=None):
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["cumulative linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "cumulative linear expansion")
+        self.checkPropertyTempRange("cumulative linear expansion", Tc)
         return (4.22 + 8.33e-4 * Tc - 3.51 * math.exp(-0.00527 * Tc)) * 1.0e-6
 
     def density(self, Tc=None, Tk=None):
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "density")
+        self.checkPropertyTempRange("density", Tc)
         rho0 = 3.16
         Tc0 = 0.0
         cA = self.cumulativeLinearExpansion(Tc=Tc)
@@ -103,6 +100,5 @@ class SiC(Material):
 
     def thermalConductivity(self, Tc=None, Tk=None):
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tc)
         return (52000 * math.exp(-1.24e-5 * Tc)) / (Tc + 437)

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -46,8 +46,6 @@ class SiC(Material):
         ],
     }
 
-    type = "Structural"
-
     propertyEquation = {
         "heat capacity": "1110 + 0.15*Tc - 425*math.exp(-0.003*Tc)",
         "cumulative linear expansion": "(4.22 + 8.33E-4*Tc-3.51*math.exp(-0.00527*Tc))*1.0E-6",

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -18,14 +18,14 @@ Silicon Carbide
 
 import math
 
-from armi.utils.units import getTc
 from armi.materials.material import Material
-from armi.nucDirectory import thermalScattering as tsl
 from armi.nucDirectory import nuclideBases as nb
+from armi.nucDirectory import thermalScattering as tsl
+from armi.utils.units import getTc
 
 
 class SiC(Material):
-    r""" """
+    r"""Silicon Carbide"""
     name = "Silicon Carbide"
     thermalScatteringLaws = (
         tsl.byNbAndCompound[nb.byName["C"], tsl.SIC],
@@ -64,9 +64,9 @@ class SiC(Material):
     propertyNotes = {}
 
     propertyValidTemperature = {
-        "heat capacity": ((0, 2000), "C"),
         "cumulative linear expansion": ((0, 1500), "C"),
         "density": ((0, 1500), "C"),
+        "heat capacity": ((0, 2000), "C"),
         "thermal conductivity": ((0, 2000), "C"),
     }
 

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -84,22 +84,20 @@ class SiC(Material):
 
     def heatCapacity(self, Tc=None, Tk=None):
         Tc = getTc(Tc, Tk)
-        (TLowerLimit, TUpperLimit) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(TLowerLimit, TUpperLimit, Tc, "heat capacity")
+        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "heat capacity")
         return 1110 + 0.15 * Tc - 425 * math.exp(-0.003 * Tc)
 
     def cumulativeLinearExpansion(self, Tk=None, Tc=None):
         Tc = getTc(Tc, Tk)
-        (TLowerLimit, TUpperLimit) = self.propertyValidTemperature[
-            "cumulative linear expansion"
-        ][0]
-        self.checkTempRange(TLowerLimit, TUpperLimit, Tc, "cumulative linear expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["cumulative linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "cumulative linear expansion")
         return (4.22 + 8.33e-4 * Tc - 3.51 * math.exp(-0.00527 * Tc)) * 1.0e-6
 
     def density(self, Tc=None, Tk=None):
         Tc = getTc(Tc, Tk)
-        (TLowerLimit, TUpperLimit) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(TLowerLimit, TUpperLimit, Tc, "density")
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "density")
         rho0 = 3.16
         Tc0 = 0.0
         cA = self.cumulativeLinearExpansion(Tc=Tc)
@@ -107,8 +105,6 @@ class SiC(Material):
 
     def thermalConductivity(self, Tc=None, Tk=None):
         Tc = getTc(Tc, Tk)
-        (TLowerLimit, TUpperLimit) = self.propertyValidTemperature[
-            "thermal conductivity"
-        ][0]
-        self.checkTempRange(TLowerLimit, TUpperLimit, Tc, "thermal conductivity")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "thermal conductivity")
         return (52000 * math.exp(-1.24e-5 * Tc)) / (Tc + 437)

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Simple sodium material."""
+"""Simple sodium material"""
 
 from armi.materials import material
 from armi import runLog
@@ -67,8 +67,7 @@ class Sodium(material.Fluid):
         """
         Tk = getTk(Tc, Tk)
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "density")
+        self.checkPropertyTempRange("density", Tc)
 
         if (Tc is not None) and (Tc <= 97.72):
             runLog.warning(
@@ -101,8 +100,7 @@ class Sodium(material.Fluid):
         From [ANL-RE-95-2]_, Table 1.1-2.
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["enthalpy"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "enthalpy")
+        self.checkPropertyTempRange("enthalpy", Tk)
         enthalpy = (
             -365.77
             + 1.6582 * Tk
@@ -133,8 +131,7 @@ class Sodium(material.Fluid):
 
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tk)
         thermalConductivity = (
             124.67 - 0.11381 * Tk + 5.5226e-5 * Tk ** 2 - 1.1842e-8 * Tk ** 3
         )

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -36,12 +36,18 @@ class Sodium(material.Fluid):
 
     name = "Sodium"
 
+    propertyValidTemperature = {
+        "density": ((97.85, 2230.55), "C"),
+        "enthalpy": ((371.0, 2000.0), "K"),
+        "thermal conductivity": ((3715, 1500), "K"),
+    }
+
     def setDefaultMassFracs(self):
         """It's just sodium"""
         self.setMassFrac("NA", 1.0)
         self.p.refDens = 0.968
 
-    def density(self, Tk=None, Tc=None, check_range=True):
+    def density(self, Tk=None, Tc=None):
         """
         Returns density of Sodium in g/cc.
 
@@ -53,9 +59,6 @@ class Sodium(material.Fluid):
             temperature in degrees Kelvin
         Tc : float, optional
             temperature in degrees Celsius
-        check_range : Boolean, optional
-            Set check_range=False to avoid "zillions" of print-out warnings that occur if
-            the input temperature (Tc or Tk) is out of the applicability range of properties.
 
         Returns
         -------
@@ -64,10 +67,10 @@ class Sodium(material.Fluid):
         """
         Tk = getTk(Tc, Tk)
         Tc = getTc(Tc, Tk)
-        if check_range:
-            self.checkTempRange(97.85, 2230.55, Tc, "density")
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "density")
 
-        if check_range and (Tc is not None) and (Tc <= 97.72):
+        if (Tc is not None) and (Tc <= 97.72):
             runLog.warning(
                 "Sodium frozen at Tc: {0}".format(Tc),
                 label="Sodium frozen at Tc={0}".format(Tc),
@@ -98,7 +101,8 @@ class Sodium(material.Fluid):
         From [ANL-RE-95-2]_, Table 1.1-2.
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(371.0, 2000.0, Tk, "enthalpy")
+        (Tmin, Tmax) = self.propertyValidTemperature["enthalpy"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "enthalpy")
         enthalpy = (
             -365.77
             + 1.6582 * Tk
@@ -129,7 +133,8 @@ class Sodium(material.Fluid):
 
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(3715, 1500, Tk, "thermal conductivity")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
         thermalConductivity = (
             124.67 - 0.11381 * Tk + 5.5226e-5 * Tk ** 2 - 1.1842e-8 * Tk ** 3
         )

--- a/armi/materials/sodiumChloride.py
+++ b/armi/materials/sodiumChloride.py
@@ -18,8 +18,8 @@ Sodium Chloride salt
 .. note:: This is a very basic description of this material.
 
 """
-from armi.utils.units import getTk
 from armi.materials.material import Material
+from armi.utils.units import getTk
 
 
 class NaCl(Material):

--- a/armi/materials/sulfur.py
+++ b/armi/materials/sulfur.py
@@ -61,8 +61,7 @@ class Sulfur(material.Fluid):
     def density(self, Tk=None, Tc=None):
         r"""P. Espeau, R. Ceolin "density of molten sulfur in the 334-508K range" """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "density")
+        self.checkPropertyTempRange("density", Tk)
 
         return (2.18835 - 0.00098187 * Tk) * (self.fullDensFrac)
 
@@ -71,6 +70,6 @@ class Sulfur(material.Fluid):
         This is just a two-point interpolation."""
         Tk = getTk(Tc, Tk)
         (Tmin, Tmax) = self.propertyValidTemperature["volumetric expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "volumetric expansion")
+        self.checkPropertyTempRange("volumetric expansion", Tk)
 
         return linearInterpolation(x0=334, y0=5.28e-4, x1=430, y1=5.56e-4, targetX=Tk)

--- a/armi/materials/sulfur.py
+++ b/armi/materials/sulfur.py
@@ -17,13 +17,18 @@ Sulfur
 """
 
 from armi import runLog
+from armi.materials import material
 from armi.utils.mathematics import linearInterpolation
 from armi.utils.units import getTk
-from armi.materials import material
 
 
 class Sulfur(material.Fluid):
     name = "Sulfur"
+
+    propertyValidTemperature = {
+        "density": ((334, 430), "K"),
+        "volumetric expansion": ((334, 430), "K"),
+    }
 
     def applyInputParams(self, sulfur_density_frac=None, TD_frac=None):
         if sulfur_density_frac is not None:
@@ -56,8 +61,8 @@ class Sulfur(material.Fluid):
     def density(self, Tk=None, Tc=None):
         r"""P. Espeau, R. Ceolin "density of molten sulfur in the 334-508K range" """
         Tk = getTk(Tc, Tk)
-
-        self.checkTempRange(334, 430, Tk, "density")
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "density")
 
         return (2.18835 - 0.00098187 * Tk) * (self.fullDensFrac)
 
@@ -65,6 +70,7 @@ class Sulfur(material.Fluid):
         r"""P. Espeau, R. Ceolin "density of molten sulfur in the 334-508K range"
         This is just a two-point interpolation."""
         Tk = getTk(Tc, Tk)
+        (Tmin, Tmax) = self.propertyValidTemperature["volumetric expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "volumetric expansion")
 
-        self.checkTempRange(334, 430, Tk, "volumetric expansion")
         return linearInterpolation(x0=334, y0=5.28e-4, x1=430, y1=5.56e-4, targetX=Tk)

--- a/armi/materials/tZM.py
+++ b/armi/materials/tZM.py
@@ -23,6 +23,7 @@ from armi.utils.units import getTc
 
 class TZM(Material):
     name = "TZM"
+    propertyValidTemperature = {"linear expansion percent": ((21.11, 1382.22), "C")}
     references = {
         "linear expansion percent": "Report on the Mechanical and Thermal Properties of Tungsten and TZM Sheet Produced \
                    in the Refractory Metal Sheet Rolling Program, Part 1 to Bureau of Naval Weapons Contract No. N600(19)-59530, \
@@ -87,5 +88,7 @@ class TZM(Material):
         See Table viii-b, Appendix B, page 181.
         """
         Tc = getTc(Tc, Tk)
-        self.checkTempRange(21.11, 1382.22, Tc, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
+
         return interp(Tc, self.temperatureC, self.percentThermalExpansion)

--- a/armi/materials/tZM.py
+++ b/armi/materials/tZM.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-TZM
-"""
+"""TZM"""
 from numpy import interp
 
 from armi.materials.material import Material
@@ -88,7 +86,6 @@ class TZM(Material):
         See Table viii-b, Appendix B, page 181.
         """
         Tc = getTc(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tc, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tc)
 
         return interp(Tc, self.temperatureC, self.percentThermalExpansion)

--- a/armi/materials/tantalum.py
+++ b/armi/materials/tantalum.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """Tantalum"""
 
 from armi.materials.material import Material

--- a/armi/materials/tests/test_b4c.py
+++ b/armi/materials/tests/test_b4c.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Tests for boron carbide.
+Tests for boron carbide
 """
 
 import unittest
 
-from armi.materials.b4c import B4C
-from armi.materials.b4c import DEFAULT_THEORETICAL_DENSITY_FRAC
+from armi.materials.b4c import B4C, DEFAULT_THEORETICAL_DENSITY_FRAC
 from armi.materials.tests.test_materials import _Material_Test
 
 
@@ -49,6 +48,9 @@ class B4C_TestCase(_Material_Test, unittest.TestCase):
 
         reduced = self.B4C_both.density(500)
         self.assertAlmostEqual(ref * 0.4 / DEFAULT_THEORETICAL_DENSITY_FRAC, reduced)
+
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
 if __name__ == "__main__":

--- a/armi/materials/tests/test_be9.py
+++ b/armi/materials/tests/test_be9.py
@@ -29,6 +29,9 @@ class Test_Be9(test_materials._Material_Test, unittest.TestCase):
         delta = ref * 0.001
         self.assertAlmostEqual(cur, ref, delta=delta)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/materials/tests/test_graphite.py
+++ b/armi/materials/tests/test_graphite.py
@@ -40,6 +40,9 @@ class Graphite_TestCase(unittest.TestCase):
         ref = 2.149009
         self.assertAlmostEqual(cur, ref, accuracy)
 
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/materials/tests/test_lithium.py
+++ b/armi/materials/tests/test_lithium.py
@@ -76,6 +76,9 @@ class Lithium_TestCase(_Material_Test, unittest.TestCase):
         cur = 3570.0
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -97,6 +97,9 @@ class Magnesium_TestCase(_Material_Test, unittest.TestCase):
         delta = ref * 0.05
         self.assertAlmostEqual(cur, ref, delta=delta)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class MagnesiumOxide_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.MgO
@@ -121,6 +124,9 @@ class MagnesiumOxide_TestCase(_Material_Test, unittest.TestCase):
         ref = 0.0049909
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class Molybdenum_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Molybdenum
@@ -136,6 +142,12 @@ class Molybdenum_TestCase(_Material_Test, unittest.TestCase):
         delta = ref * 0.0001
         self.assertAlmostEqual(cur, ref, delta=delta)
 
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
 
 class NaCl_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.NaCl
@@ -149,6 +161,9 @@ class NaCl_TestCase(_Material_Test, unittest.TestCase):
         ref = 2.050604
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
 
 class NiobiumZirconium_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.NZ
@@ -161,6 +176,9 @@ class NiobiumZirconium_TestCase(_Material_Test, unittest.TestCase):
         cur = self.mat.density(Tk=1390)
         ref = 8.66
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
+
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
 
 
 class Potassium_TestCase(_Material_Test, unittest.TestCase):
@@ -181,6 +199,9 @@ class Potassium_TestCase(_Material_Test, unittest.TestCase):
         ref = 0.732
         delta = ref * 0.001
         self.assertAlmostEqual(cur, ref, delta=delta)
+
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
 class ScandiumOxide_TestCase(_Material_Test, unittest.TestCase):
@@ -203,6 +224,9 @@ class ScandiumOxide_TestCase(_Material_Test, unittest.TestCase):
         cur = self.mat.linearExpansionPercent(Tc=400)
         ref = 0.28322
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
+
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
 class Sodium_TestCase(_Material_Test, unittest.TestCase):
@@ -252,6 +276,9 @@ class Sodium_TestCase(_Material_Test, unittest.TestCase):
         delta = ref * 0.001
         self.assertAlmostEqual(cur, ref, delta=delta)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class Tantalum_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Tantalum
@@ -264,6 +291,9 @@ class Tantalum_TestCase(_Material_Test, unittest.TestCase):
         cur = self.mat.density(Tc=300)
         ref = 16.6
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
+
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
 
 
 class ThoriumUraniumMetal_TestCase(_Material_Test, unittest.TestCase):
@@ -301,6 +331,9 @@ class ThoriumUraniumMetal_TestCase(_Material_Test, unittest.TestCase):
         ref = 11.9e-6
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
 
 class Uranium_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Uranium
@@ -325,6 +358,9 @@ class Uranium_TestCase(_Material_Test, unittest.TestCase):
         cur = self.mat.thermalConductivity(Tc=900)
         ref = 48.524507909207507339033327298
         self.assertAlmostEqual(cur, ref, delta=10e-10)
+
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
 class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
@@ -472,6 +508,9 @@ class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
         for key in self.mat.p.massFrac.keys():
             self.assertEqual(duplicateMassFrac[key], self.mat.p.massFrac[key])
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class Thorium_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Thorium
@@ -506,6 +545,9 @@ class Thorium_TestCase(_Material_Test, unittest.TestCase):
         accuracy = 4
         self.assertAlmostEqual(cur, ref, accuracy)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class ThoriumOxide_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.ThoriumOxide
@@ -534,6 +576,9 @@ class ThoriumOxide_TestCase(_Material_Test, unittest.TestCase):
         accuracy = 4
         self.assertAlmostEqual(cur, ref, accuracy)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class Void_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Void
@@ -548,6 +593,9 @@ class Void_TestCase(_Material_Test, unittest.TestCase):
         cur = self.mat.linearExpansion(400)
         ref = 0.0
         self.assertEqual(cur, ref)
+
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
 
 
 class Lead_TestCase(_Material_Test, unittest.TestCase):
@@ -598,6 +646,9 @@ class Lead_TestCase(_Material_Test, unittest.TestCase):
         ref = 138.647
         delta = ref * 0.05
         self.assertAlmostEqual(cur, ref, delta=delta)
+
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
 class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
@@ -663,6 +714,9 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
         cur = 0.0024316
         self.assertAlmostEqual(ref, cur, delta=ref * 0.001)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class Sulfur_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Sulfur
@@ -683,6 +737,9 @@ class Sulfur_TestCase(_Material_Test, unittest.TestCase):
         ref = 5.28e-4
         accuracy = 4
         self.assertAlmostEqual(cur, ref, accuracy)
+
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
 class Zr_TestCase(_Material_Test, unittest.TestCase):
@@ -792,6 +849,9 @@ class Zr_TestCase(_Material_Test, unittest.TestCase):
             self.assertAlmostEqual(self.mat.density(Tc=Tc), expectedDensityValues[i])
             self.assertAlmostEqual(self.mat.density(Tk=Tk), expectedDensityValues[i])
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class Inconel_TestCase(_Material_Test, unittest.TestCase):
     def setUp(self):
@@ -839,6 +899,12 @@ class Inconel_TestCase(_Material_Test, unittest.TestCase):
                 cur, ref
             )
             self.assertAlmostEqual(cur, ref, delta=10e-7, msg=errorMsg)
+
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.Inconel.propertyValidTemperature), 0)
+        self.assertGreater(len(self.Inconel800.propertyValidTemperature), 0)
+        self.assertEqual(len(self.InconelPE16.propertyValidTemperature), 0)
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
 
 
 class Inconel600_TestCase(_Material_Test, unittest.TestCase):
@@ -957,6 +1023,9 @@ class Inconel600_TestCase(_Material_Test, unittest.TestCase):
         ref = self.mat.heatCapacity(Tc=200)
         cur = 482.742084
         self.assertAlmostEqual(ref, cur, delta=cur * 0.001)
+
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
 class Inconel625_TestCase(_Material_Test, unittest.TestCase):
@@ -1095,6 +1164,9 @@ class Inconel625_TestCase(_Material_Test, unittest.TestCase):
         cur = 454.044892
         self.assertAlmostEqual(ref, cur, delta=cur * 0.001)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class InconelX750_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.InconelX750
@@ -1230,6 +1302,9 @@ class InconelX750_TestCase(_Material_Test, unittest.TestCase):
         cur = 484.93968
         self.assertAlmostEqual(ref, cur, delta=cur * 0.001)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class Alloy200_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Alloy200
@@ -1251,6 +1326,9 @@ class Alloy200_TestCase(_Material_Test, unittest.TestCase):
     def test_propertyValidTemperature(self):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class CaH2_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.CaH2
@@ -1264,6 +1342,9 @@ class CaH2_TestCase(_Material_Test, unittest.TestCase):
         ref = self.mat.density(Tc=300)
         self.assertAlmostEqual(cur, ref, ref * 0.01)
 
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
 
 class Hafnium_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Hafnium
@@ -1276,6 +1357,9 @@ class Hafnium_TestCase(_Material_Test, unittest.TestCase):
 
         ref = self.mat.density(Tc=300)
         self.assertAlmostEqual(cur, ref, ref * 0.01)
+
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
 
 
 class HastelloyN_TestCase(_Material_Test, unittest.TestCase):
@@ -1364,6 +1448,9 @@ class HastelloyN_TestCase(_Material_Test, unittest.TestCase):
             )
             self.assertAlmostEqual(cur, ref, delta=10e-7, msg=errorMsg)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class TZM_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.TZM
@@ -1420,6 +1507,9 @@ class TZM_TestCase(_Material_Test, unittest.TestCase):
             )
             self.assertAlmostEqual(cur, ref, delta=10e-3, msg=errorMsg)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class YttriumOxide_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Y2O3
@@ -1442,6 +1532,9 @@ class YttriumOxide_TestCase(_Material_Test, unittest.TestCase):
         cur = 0.0696622
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class ZincOxide_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.ZnO
@@ -1463,6 +1556,9 @@ class ZincOxide_TestCase(_Material_Test, unittest.TestCase):
         ref = self.mat.linearExpansionPercent(Tc=100)
         cur = -99670.4933
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
+
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
 class FuelMaterial_TestCase(unittest.TestCase):

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -1248,6 +1248,9 @@ class Alloy200_TestCase(_Material_Test, unittest.TestCase):
         cur = 15.6e-6
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 class CaH2_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.CaH2

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -83,6 +83,38 @@ class MaterialFindingTests(unittest.TestCase):
             )
 
 
+class Californium_TestCase(_Material_Test, unittest.TestCase):
+    MAT_CLASS = materials.Californium
+
+    def test_density(self):
+        ref = 15.1
+
+        cur = self.mat.density(923)
+        self.assertAlmostEqual(cur, ref, delta=ref * 0.05)
+
+        cur = self.mat.density(1390)
+        self.assertAlmostEqual(cur, ref, delta=ref * 0.05)
+
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
+
+class Cesium_TestCase(_Material_Test, unittest.TestCase):
+    MAT_CLASS = materials.Cs
+
+    def test_density(self):
+        cur = self.mat.density(250)
+        ref = 1.93
+        self.assertAlmostEqual(cur, ref, delta=ref * 0.05)
+
+        cur = self.mat.density(450)
+        ref = 1.843
+        self.assertAlmostEqual(cur, ref, delta=ref * 0.05)
+
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
+
 class Magnesium_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Magnesium
 
@@ -510,6 +542,11 @@ class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
 
     def test_propertyValidTemperature(self):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
+    def test_adjustTD(self):
+        self.assertEqual(self.mat.theoreticalDensityFrac, 1.0)
+        self.mat.adjustTD(0.123)
+        self.assertEqual(self.mat.theoreticalDensityFrac, 0.123)
 
 
 class Thorium_TestCase(_Material_Test, unittest.TestCase):

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -1238,6 +1238,16 @@ class Alloy200_TestCase(_Material_Test, unittest.TestCase):
         """Assert alloy 200 has more than 99% nickle per its spec"""
         self.assertGreater(self.mat.p.massFrac["NI"], 0.99)
 
+    def test_linearExpansion(self):
+        ref = self.mat.linearExpansion(Tc=100)
+        cur = 13.3e-6
+        self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
+
+    def test_linearExpansion(self):
+        ref = self.mat.linearExpansion(Tk=873.15)
+        cur = 15.6e-6
+        self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
+
 
 class CaH2_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.CaH2

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -177,8 +177,27 @@ class Molybdenum_TestCase(_Material_Test, unittest.TestCase):
     def test_propertyValidTemperature(self):
         self.assertEqual(len(self.mat.propertyValidTemperature), 0)
 
-    def test_propertyValidTemperature(self):
-        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
+class MOX_TestCase(_Material_Test, unittest.TestCase):
+    MAT_CLASS = materials.MOX
+
+    def test_density(self):
+        cur = self.mat.density(333)
+        ref = 10.926
+        delta = ref * 0.0001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+    def test_getMassFracPuO2(self):
+        ref = 0.176067
+        self.assertAlmostEqual(self.mat.getMassFracPuO2(), ref, delta=ref * 0.001)
+
+    def test_getMolFracPuO2(self):
+        ref = 0.209
+        self.assertAlmostEqual(self.mat.getMolFracPuO2(), ref, delta=ref * 0.001)
+
+    def test_getMolFracPuO2(self):
+        ref = 2996.788765
+        self.assertAlmostEqual(self.mat.meltingPoint(), ref, delta=ref * 0.001)
 
 
 class NaCl_TestCase(_Material_Test, unittest.TestCase):

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -383,7 +383,7 @@ class ThoriumUraniumMetal_TestCase(_Material_Test, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
     def test_propertyValidTemperature(self):
-        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+        self.assertEqual(len(self.mat.propertyValidTemperature), 1)
 
 
 class Uranium_TestCase(_Material_Test, unittest.TestCase):

--- a/armi/materials/tests/test_sic.py
+++ b/armi/materials/tests/test_sic.py
@@ -46,6 +46,9 @@ class Test_SiC(test_materials._Material_Test, unittest.TestCase):
         ref = 1330.27867
         self.assertAlmostEqual(cur, ref, delta=delta)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/materials/tests/test_sulfur.py
+++ b/armi/materials/tests/test_sulfur.py
@@ -49,6 +49,9 @@ class Sulfur_TestCase(_Material_Test, unittest.TestCase):
         reduced = self.Sulfur_both.density(500)
         self.assertAlmostEqual(ref * 0.4, reduced)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/materials/tests/test_thoriumOxide.py
+++ b/armi/materials/tests/test_thoriumOxide.py
@@ -40,6 +40,9 @@ class ThoriumOxide_TestCase(_Material_Test, unittest.TestCase):
     def test_linearExpansionPercent(self):
         self.assertAlmostEqual(self.mat.linearExpansionPercent(Tk=500), 0.195334)
 
+    def test_propertyValidTemperature(self):
+        self.assertGreater(len(self.mat.propertyValidTemperature), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/materials/tests/test_uZr.py
+++ b/armi/materials/tests/test_uZr.py
@@ -29,6 +29,9 @@ class UZR_TestCase(test_materials._Material_Test, unittest.TestCase):
         delta = ref * 0.01
         self.assertAlmostEqual(cur, ref, delta=delta)
 
+    def test_propertyValidTemperature(self):
+        self.assertEqual(len(self.mat.propertyValidTemperature), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/materials/tests/test_water.py
+++ b/armi/materials/tests/test_water.py
@@ -200,5 +200,4 @@ class Test_Water(unittest.TestCase):
 
 
 if __name__ == "__main__":
-
     unittest.main()

--- a/armi/materials/tests/test_water.py
+++ b/armi/materials/tests/test_water.py
@@ -30,7 +30,6 @@ class Test_Water(unittest.TestCase):
         Reproduce verification results from IAPWS-IF97 for water at 0C
         http://www.iapws.org/relguide/supsat.pdf
         """
-
         water = SaturatedWater()
         steam = SaturatedSteam()
 
@@ -191,6 +190,13 @@ class Test_Water(unittest.TestCase):
             massFracH = water.getMassFrac("H")
             self.assertAlmostEqual(massFracO, 0.888, places=3)
             self.assertAlmostEqual(massFracO + massFracH, 1.0)
+
+    def test_propertyValidTemperature(self):
+        water = SaturatedWater()
+        self.assertEqual(len(water.propertyValidTemperature), 0)
+
+        steam = SaturatedSteam()
+        self.assertEqual(len(steam.propertyValidTemperature), 0)
 
 
 if __name__ == "__main__":

--- a/armi/materials/thU.py
+++ b/armi/materials/thU.py
@@ -29,6 +29,7 @@ from armi import runLog
 class ThU(material.Material):
     name = "ThU"
     enrichedNuclide = "U233"
+    propertyValidTemperature = {"linear expansion": ((30, 600), "K")}
 
     def getEnrichment(self):
         return self.getMassFrac("U233") / (
@@ -47,14 +48,13 @@ class ThU(material.Material):
         self.setMassFrac("U233", 0.0)
 
     def density(self, Tk=None, Tc=None):
-        Tk = getTk(Tc, Tk)
         """g/cc from IAEA TE 1450"""
         return 11.68
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""m/m/K from IAEA TE 1450"""
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(30, 600, Tk, "linear expansionn")
+        self.checkPropertyTempRange("linear expansion", Tk)
         return 11.9e-6
 
     def thermalConductivity(self, Tk=None, Tc=None):

--- a/armi/materials/thorium.py
+++ b/armi/materials/thorium.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Thorium Metal
 
@@ -21,29 +20,30 @@ Data is from [#IAEA-TECDOCT-1450]_.
 .. [#IAEA-TECDOCT-1450] Thorium fuel cycle -- Potential benefits and challenges, IAEA-TECDOC-1450 (2005).
     https://www-pub.iaea.org/mtcd/publications/pdf/te_1450_web.pdf
 """
-from armi.utils.units import getTk
 from armi.materials.material import Material
+from armi.utils.units import getTk
 
 
 class Thorium(Material):
     name = "Thorium metal"
+    propertyValidTemperature = {"linear expansion": ((30, 600), "K")}
 
     def setDefaultMassFracs(self):
         self.setMassFrac("TH232", 1.0)
 
     def density(self, Tk=None, Tc=None):
-        Tk = getTk(Tc, Tk)
         return 11.68
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""m/m/K from IAEA TECDOC 1450"""
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(30, 600, Tk, "linear expansionn")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
+
         return 11.9e-6
 
     def thermalConductivity(self, Tk=None, Tc=None):
         r"""W/m-K from IAEA TE 1450"""
-        Tk = getTk(Tc, Tk)
         return 43.1
 
     def meltingPoint(self):

--- a/armi/materials/thorium.py
+++ b/armi/materials/thorium.py
@@ -37,8 +37,7 @@ class Thorium(Material):
     def linearExpansion(self, Tk=None, Tc=None):
         r"""m/m/K from IAEA TECDOC 1450"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
+        self.checkPropertyTempRange("linear expansion", Tk)
 
         return 11.9e-6
 

--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Thorium Oxide solid ceramic.
 
@@ -28,6 +27,7 @@ from armi.materials.material import FuelMaterial
 
 class ThoriumOxide(FuelMaterial):
     name = "ThO2"
+    propertyValidTemperature = {"linear expansion": ((298, 1223), "K")}
     theoreticalDensityFrac = 1.0
 
     def adjustTD(self, val):
@@ -76,13 +76,14 @@ class ThoriumOxide(FuelMaterial):
 
     def density(self, Tk=None, Tc=None):
         """g/cc from IAEA TE 1450"""
-        Tk = getTk(Tc, Tk)
         return 10.00 * self.getTD()
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""m/m/K from IAEA TE 1450"""
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(298, 1223, Tk, "linear expansionn")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
+
         return 9.67e-6
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
@@ -92,11 +93,11 @@ class ThoriumOxide(FuelMaterial):
         """
         Tk = getTk(Tc=Tc, Tk=Tk)
         linearExpansionCoef = self.linearExpansion(Tk=Tk)
+
         return 100 * (linearExpansionCoef * (Tk - 298))
 
     def thermalConductivity(self, Tk=None, Tc=None):
         r"""W/m-K from IAEA TE 1450"""
-        Tk = getTk(Tc, Tk)
         return 6.20
 
     def meltingPoint(self):

--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -20,7 +20,7 @@ Data is from [#IAEA-TECDOCT-1450]_.
 .. [#IAEA-TECDOCT-1450] Thorium fuel cycle -- Potential benefits and challenges, IAEA-TECDOC-1450 (2005).
     https://www-pub.iaea.org/mtcd/publications/pdf/te_1450_web.pdf
 """
-
+from armi import runLog
 from armi.utils.units import getTk
 from armi.materials.material import FuelMaterial
 

--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -81,8 +81,7 @@ class ThoriumOxide(FuelMaterial):
     def linearExpansion(self, Tk=None, Tc=None):
         r"""m/m/K from IAEA TE 1450"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
+        self.checkPropertyTempRange("linear expansion", Tk)
 
         return 9.67e-6
 

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Uranium Thorium Zirconium alloy metal
 """
@@ -72,7 +71,6 @@ class UThZr(Material):
         # use vegard's law to mix densities by weight fraction at 50C
         # uzr0 = 1.0/(zrFrac/zr0+(1-zrFrac)/u0)
         uThZr0 = 1.0 / (zrFrac / zr0 + (uFrac) / u0 + thFrac / th0)
-        # runLog.debug('Cold density: {0} g/cc'.format(uzr0))
 
         dLL = self.linearExpansionPercent(Tk=Tk)
 

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -48,8 +48,7 @@ class Uranium(Material):
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
         """The thermal conductivity of pure U in W-m/K."""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tk)
 
         kU = 21.73 + (0.01591 * Tk) + (0.000005907 * Tk ** 2)
         return kU

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -48,9 +48,7 @@ class Uranium(Material):
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
         """The thermal conductivity of pure U in W-m/K."""
         Tk = getTk(Tc, Tk)
-        (TLowerLimit, TUpperLimit) = self.propertyValidTemperature[
-            "thermal conductivity"
-        ][0]
-        self.checkTempRange(TLowerLimit, TUpperLimit, Tk, "thermal conductivity")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
         kU = 21.73 + (0.01591 * Tk) + (0.000005907 * Tk ** 2)
         return kU

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Uranium metal
 
@@ -21,23 +20,20 @@ Much info is from [AAAFuels]_.
 .. [AAAFuels]  Kim, Y S, and Hofman, G L. AAA fuels handbook.. United States: N. p., 2003. Web. doi:10.2172/822554. .
 """
 
-from armi.utils.units import getTk
 from armi.materials.material import Material
+from armi.utils.units import getTk
 
 
 class Uranium(Material):
     name = "Uranium"
-    references = {
-        "thermal conductivity": ["AAA Fuels Handbook by YS Kim and G.L. Hofman, ANL"]
-    }
 
     materialIntro = ""
-
-    propertyUnits = {"thermal conductivity": "W/m-K"}
 
     propertyNotes = {"thermal conductivity": ""}
 
     propertyRawData = {"thermal conductivity": ""}
+
+    propertyUnits = {"thermal conductivity": "W/m-K"}
 
     propertyEquation = {
         "thermal conductivity": "21.73 + 0.01591T + 5.907&#215;10<super>-6</super>T<super>2</super>"
@@ -45,10 +41,15 @@ class Uranium(Material):
 
     propertyValidTemperature = {"thermal conductivity": ((255.4, 1173.2), "K")}
 
+    references = {
+        "thermal conductivity": ["AAA Fuels Handbook by YS Kim and G.L. Hofman, ANL"]
+    }
+
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
         """The thermal conductivity of pure U in W-m/K."""
         Tk = getTk(Tc, Tk)
         (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
         self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
+
         kU = 21.73 + (0.01591 * Tk) + (0.000005907 * Tk ** 2)
         return kU

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -22,8 +22,8 @@ uses data from [#ornltm2000]_.
 .. [#ornltm2000] Thermophysical Properties of MOX and UO2 Fuels Including the Effects of Irradiation. S.G. Popov,
     et.al. Oak Ridge National Laboratory. ORNL/TM-2000/351 https://rsicc.ornl.gov/fmdp/tm2000-351.pdf
 """
-import math
 import collections
+import math
 
 from numpy import interp
 

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -156,7 +156,7 @@ class UraniumOxide(material.FuelMaterial):
         Polynomial line fit to data from [#ornltm2000]_ on page 11.
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(300, 3100, Tk, "thermal conductivity")
+        self.checkTempRange(300, 3100, Tk, "density")
         return (-1.01147e-7 * Tk ** 2 - 1.29933e-4 * Tk + 1.09805e1) * self.getTD()
 
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
@@ -167,7 +167,7 @@ class UraniumOxide(material.FuelMaterial):
         simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(300, 3000, Tk, "density")
+        self.checkTempRange(300, 3000, Tk, "thermal conductivity")
         return interp(Tk, self.thermalConductivityTableK, self.thermalConductivityTable)
 
     def linearExpansion(self, Tk: float = None, Tc: float = None) -> float:

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -169,8 +169,7 @@ class UraniumOxide(material.FuelMaterial):
         Polynomial line fit to data from [#ornltm2000]_ on page 11.
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "density")
+        self.checkPropertyTempRange("density", Tk)
 
         return (-1.01147e-7 * Tk ** 2 - 1.29933e-4 * Tk + 1.09805e1) * self.getTD()
 
@@ -181,8 +180,7 @@ class UraniumOxide(material.FuelMaterial):
         From Section 4.3 in  [#ornltm2000]_
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "heat capacity")
+        self.checkPropertyTempRange("heat capacity", Tk)
 
         hcc = self.heatCapacityConstants
         # eq 4.2
@@ -203,8 +201,7 @@ class UraniumOxide(material.FuelMaterial):
         Curve fit from data in [#ornltm2000]_
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
+        self.checkPropertyTempRange("linear expansion", Tk)
 
         return 1.06817e-12 * Tk ** 2 - 1.37322e-9 * Tk + 1.02863e-5
 
@@ -215,8 +212,7 @@ class UraniumOxide(material.FuelMaterial):
         From Section 3.3 of [#ornltm2000]_
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tk)
 
         if Tk >= 273.0 and Tk < 923.0:
             return (
@@ -235,8 +231,7 @@ class UraniumOxide(material.FuelMaterial):
         simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tk)
 
         return interp(Tk, self.thermalConductivityTableK, self.thermalConductivityTable)
 

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Uranium Oxide properties. 
 
@@ -27,11 +26,11 @@ import math
 
 from numpy import interp
 
-from armi.utils.units import getTk
-from armi.materials import material
 from armi import runLog
-from armi.nucDirectory import thermalScattering as tsl
+from armi.materials import material
 from armi.nucDirectory import nuclideBases as nb
+from armi.nucDirectory import thermalScattering as tsl
+from armi.utils.units import getTk
 
 
 HeatCapacityConstants = collections.namedtuple(
@@ -41,20 +40,41 @@ HeatCapacityConstants = collections.namedtuple(
 
 class UraniumOxide(material.FuelMaterial):
     name = "Uranium Oxide"
-    thermalScatteringLaws = (
-        tsl.byNbAndCompound[nb.byName["U"], tsl.UO2],
-        tsl.byNbAndCompound[nb.byName["O"], tsl.UO2],
+
+    enrichedNuclide = "U235"
+
+    # ORNL/TM-2000/351 section 4.3
+    heatCapacityConstants = HeatCapacityConstants(
+        c1=302.27, c2=8.463e-3, c3=8.741e7, theta=548.68, Ea=18531.7
     )
+
+    __meltingPoint = 3123.0
+
+    propertyUnits = {"heat capacity": "J/mol-K"}
+
+    propertyValidTemperature = {
+        "density": ((300, 3100), "K"),
+        "heat capacity": ((298.15, 3120), "K"),
+        "linear expansion": ((273, 3120), "K"),
+        "linear expansion percent": ((273, __meltingPoint), "K"),
+        "thermal conductivity": ((300, 3000), "K"),
+    }
+
     references = {
         "thermal conductivity": "Thermal conductivity of uranium dioxide by nonequilibrium molecular dynamics simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999",
         "linear expansion": "Thermophysical Properties of MOX and UO2 Fuels Including the Effects of Irradiation. S.G. Popov, et.al. Oak Ridge National Laboratory. ORNL/TM-2000/351",
         "heat capacity": "ORNL/TM-2000/351",
     }
-    propertyUnits = {"heat capacity": "J/mol-K"}
 
     theoreticalDensityFrac = 1.0  # Default value
-    """Thermal conductivity values taken from:
-    Thermal conductivity of uranium dioxide by nonequilibrium molecular dynamics simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999"""
+
+    thermalScatteringLaws = (
+        tsl.byNbAndCompound[nb.byName["U"], tsl.UO2],
+        tsl.byNbAndCompound[nb.byName["O"], tsl.UO2],
+    )
+
+    # Thermal conductivity values taken from:
+    # Thermal conductivity of uranium dioxide by nonequilibrium molecular dynamics simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999
     thermalConductivityTableK = [
         300,
         600,
@@ -80,13 +100,6 @@ class UraniumOxide(material.FuelMaterial):
         1.847,
         1.718,
     ]
-
-    # ORNL/TM-2000/351 section 4.3
-    heatCapacityConstants = HeatCapacityConstants(
-        c1=302.27, c2=8.463e-3, c3=8.741e7, theta=548.68, Ea=18531.7
-    )
-
-    enrichedNuclide = "U235"
 
     def adjustTD(self, val: float) -> None:
         self.theoreticalDensityFrac = val
@@ -147,7 +160,7 @@ class UraniumOxide(material.FuelMaterial):
 
         From [#ornltm2000]_.
         """
-        return 3123.0
+        return self.__meltingPoint
 
     def density(self, Tk: float = None, Tc: float = None) -> float:
         """
@@ -156,45 +169,10 @@ class UraniumOxide(material.FuelMaterial):
         Polynomial line fit to data from [#ornltm2000]_ on page 11.
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(300, 3100, Tk, "density")
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "density")
+
         return (-1.01147e-7 * Tk ** 2 - 1.29933e-4 * Tk + 1.09805e1) * self.getTD()
-
-    def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
-        """
-        Thermal conductivity
-
-        Ref: Thermal conductivity of uranium dioxide by nonequilibrium molecular dynamics
-        simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999
-        """
-        Tk = getTk(Tc, Tk)
-        self.checkTempRange(300, 3000, Tk, "thermal conductivity")
-        return interp(Tk, self.thermalConductivityTableK, self.thermalConductivityTable)
-
-    def linearExpansion(self, Tk: float = None, Tc: float = None) -> float:
-        """
-        Linear expansion coefficient.
-
-        Curve fit from data in [#ornltm2000]_"""
-        Tk = getTk(Tc, Tk)
-        self.checkTempRange(273, 3120, Tk, "linear expansion")
-        return 1.06817e-12 * Tk ** 2 - 1.37322e-9 * Tk + 1.02863e-5
-
-    def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
-        """
-        Return dL/L
-
-        From Section 3.3 of [#ornltm2000]_
-        """
-        Tk = getTk(Tc, Tk)
-        self.checkTempRange(273, self.meltingPoint(), Tk, "linear expansion percent")
-        if Tk >= 273.0 and Tk < 923.0:
-            return (
-                -2.66e-03 + 9.802e-06 * Tk - 2.705e-10 * Tk ** 2 + 4.391e-13 * Tk ** 3
-            ) * 100.0
-        else:
-            return (
-                -3.28e-03 + 1.179e-05 * Tk - 2.429e-09 * Tk ** 2 + 1.219e-12 * Tk ** 3
-            ) * 100.0
 
     def heatCapacity(self, Tk: float = None, Tc: float = None) -> float:
         """
@@ -203,7 +181,9 @@ class UraniumOxide(material.FuelMaterial):
         From Section 4.3 in  [#ornltm2000]_
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(298.15, 3120, Tk, "heat capacity")
+        (Tmin, Tmax) = self.propertyValidTemperature["heat capacity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "heat capacity")
+
         hcc = self.heatCapacityConstants
         # eq 4.2
         specificHeatCapacity = (
@@ -215,6 +195,50 @@ class UraniumOxide(material.FuelMaterial):
             + hcc.c3 * hcc.Ea * math.exp(-hcc.Ea / Tk) / Tk ** 2
         )
         return specificHeatCapacity
+
+    def linearExpansion(self, Tk: float = None, Tc: float = None) -> float:
+        """
+        Linear expansion coefficient.
+
+        Curve fit from data in [#ornltm2000]_
+        """
+        Tk = getTk(Tc, Tk)
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
+
+        return 1.06817e-12 * Tk ** 2 - 1.37322e-9 * Tk + 1.02863e-5
+
+    def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
+        """
+        Return dL/L
+
+        From Section 3.3 of [#ornltm2000]_
+        """
+        Tk = getTk(Tc, Tk)
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+
+        if Tk >= 273.0 and Tk < 923.0:
+            return (
+                -2.66e-03 + 9.802e-06 * Tk - 2.705e-10 * Tk ** 2 + 4.391e-13 * Tk ** 3
+            ) * 100.0
+        else:
+            return (
+                -3.28e-03 + 1.179e-05 * Tk - 2.429e-09 * Tk ** 2 + 1.219e-12 * Tk ** 3
+            ) * 100.0
+
+    def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
+        """
+        Thermal conductivity
+
+        Ref: Thermal conductivity of uranium dioxide by nonequilibrium molecular dynamics
+        simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999
+        """
+        Tk = getTk(Tc, Tk)
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
+
+        return interp(Tk, self.thermalConductivityTableK, self.thermalConductivityTable)
 
 
 class UO2(UraniumOxide):

--- a/armi/materials/void.py
+++ b/armi/materials/void.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 """
 Void material.
 

--- a/armi/materials/water.py
+++ b/armi/materials/water.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# cython: profile=False
 import math
 
-from armi.utils.units import getTk
-from armi.nucDirectory import elements
 from armi.materials.material import Fluid
-from armi.utils import units
-from armi.nucDirectory import thermalScattering as tsl
+from armi.nucDirectory import elements
 from armi.nucDirectory import nuclideBases as nb
+from armi.nucDirectory import thermalScattering as tsl
+from armi.utils import units
+from armi.utils.units import getTk
 
 
 class Water(Fluid):
-
     """
     Water
 
@@ -122,7 +120,6 @@ class Water(Fluid):
         IAPWS-IF97 is now the international standard for calculations in the
         steam power industry
         """
-
         tau = self.tau(Tc=Tc, Tk=Tk)
         T_ratio = self.TEMPERATURE_CRITICAL_K / getTk(Tc=Tc, Tk=Tk)
 
@@ -321,7 +318,6 @@ class Water(Fluid):
 
 
 class SaturatedWater(Water):
-
     """
     Saturated Water
 

--- a/armi/materials/yttriumOxide.py
+++ b/armi/materials/yttriumOxide.py
@@ -14,12 +14,14 @@
 
 """Yttrium Oxide"""
 
-from armi.utils.units import getTk
 from armi.materials.material import Material
+from armi.utils.units import getTk
 
 
 class Y2O3(Material):
     name = "Y2O3"
+
+    propertyValidTemperature = {"linear expansion percent": ((273.15, 1573.15), "K")}
 
     def setDefaultMassFracs(self):
         self.setMassFrac("Y89", 0.7875)
@@ -37,5 +39,7 @@ class Y2O3(Material):
         From Table 5 of "Thermal Expansion and Phase Inversion of Rare-Earth Oxides.
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(273.15, 1573.15, Tk, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+
         return 1.4922e-07 * Tk ** 2 + 6.2448e-04 * Tk - 1.8414e-01

--- a/armi/materials/yttriumOxide.py
+++ b/armi/materials/yttriumOxide.py
@@ -39,7 +39,6 @@ class Y2O3(Material):
         From Table 5 of "Thermal Expansion and Phase Inversion of Rare-Earth Oxides.
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tk)
 
         return 1.4922e-07 * Tk ** 2 + 6.2448e-04 * Tk - 1.8414e-01

--- a/armi/materials/zincOxide.py
+++ b/armi/materials/zincOxide.py
@@ -14,12 +14,14 @@
 
 """Zinc Oxide"""
 
-from armi.utils.units import getTk
 from armi.materials.material import Material
+from armi.utils.units import getTk
 
 
 class ZnO(Material):
     name = "ZnO"
+
+    propertyValidTemperature = {"linear expansion percent": ((10.12, 1491.28), "K")}
 
     def setDefaultMassFracs(self):
         self.setMassFrac("ZN", 0.8034)
@@ -38,7 +40,9 @@ class ZnO(Material):
         Zinc Oxide: Fundamentals, Materials and Device Technology
         """
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(10.12, 1491.28, Tk, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+
         return (
             -1.9183e-03 * Tk ** 3 + 6.5944e-07 * Tk ** 2 + 5.2992e-05 * Tk - 5.2631e-02
         )

--- a/armi/materials/zincOxide.py
+++ b/armi/materials/zincOxide.py
@@ -40,8 +40,7 @@ class ZnO(Material):
         Zinc Oxide: Fundamentals, Materials and Device Technology
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tk)
 
         return (
             -1.9183e-03 * Tk ** 3 + 6.5944e-07 * Tk ** 2 + 5.2992e-05 * Tk - 5.2631e-02

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -18,14 +18,22 @@ Zirconium metal
 
 from numpy import interp
 
-from armi.utils.units import getTk, getTc
 from armi.materials.material import Material
+from armi.utils.units import getTk
 
 
 class Zr(Material):
     """Metallic zirconium"""
 
     name = "Zirconium"
+
+    propertyValidTemperature = {
+        "density": ((293, 1800), "K"),
+        "linear expansion": ((293, 1800), "K"),
+        "linear expansion percent": ((293, 1800), "K"),
+        "thermal conductivity": ((298, 2000), "K"),
+    }
+
     references = {
         "density": "AAA Materials Handbook 45803",
         "thermal conductivity": "AAA Fuels handbook. ANL",
@@ -81,9 +89,9 @@ class Zr(Material):
 
     def _computeReferenceDensity(self, Tk=None, Tc=None):
         r"""AAA Materials Handbook 45803"""
-        Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(293, 1800, Tk, "density")
+        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "density")
 
         if Tk < 1135:
             return -3.29256e-8 * Tk ** 2 - 9.67145e-5 * Tk + 6.60176
@@ -96,9 +104,9 @@ class Zr(Material):
 
         Reference: AAA Fuels handbook. ANL.
         """
-        Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(298, 2000, Tk, "thermal conductivity")
+        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
         return 8.853 + (0.007082 * Tk) + (0.000002533 * Tk ** 2) + (2992.0 / Tk)
 
     def linearExpansion(self, Tk=None, Tc=None):
@@ -109,9 +117,9 @@ class Zr(Material):
 
         See page 400
         """
-        Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(293, 1800, Tk, "linear expansion")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
         return interp(Tk, self.linearExpansionTableK, self.linearExpansionTable)
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
@@ -122,9 +130,9 @@ class Zr(Material):
 
         See page 400
         """
-        Tc = getTc(Tc, Tk)
         Tk = getTk(Tc, Tk)
-        self.checkTempRange(293, 1800, Tk, "linear expansion percent")
+        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
+        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
 
         if Tk >= 293 and Tk < 1137:
             return (

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -90,8 +90,7 @@ class Zr(Material):
     def _computeReferenceDensity(self, Tk=None, Tc=None):
         r"""AAA Materials Handbook 45803"""
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["density"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "density")
+        self.checkPropertyTempRange("density", Tk)
 
         if Tk < 1135:
             return -3.29256e-8 * Tk ** 2 - 9.67145e-5 * Tk + 6.60176
@@ -105,8 +104,7 @@ class Zr(Material):
         Reference: AAA Fuels handbook. ANL.
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["thermal conductivity"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "thermal conductivity")
+        self.checkPropertyTempRange("thermal conductivity", Tk)
         return 8.853 + (0.007082 * Tk) + (0.000002533 * Tk ** 2) + (2992.0 / Tk)
 
     def linearExpansion(self, Tk=None, Tc=None):
@@ -118,8 +116,7 @@ class Zr(Material):
         See page 400
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion")
+        self.checkPropertyTempRange("linear expansion", Tk)
         return interp(Tk, self.linearExpansionTableK, self.linearExpansionTable)
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
@@ -131,8 +128,7 @@ class Zr(Material):
         See page 400
         """
         Tk = getTk(Tc, Tk)
-        (Tmin, Tmax) = self.propertyValidTemperature["linear expansion percent"][0]
-        self.checkTempRange(Tmin, Tmax, Tk, "linear expansion percent")
+        self.checkPropertyTempRange("linear expansion percent", Tk)
 
         if Tk >= 293 and Tk < 1137:
             return (

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -29,6 +29,7 @@ Bug fixes
 #. ``Block.getWettedPerim`` was moved to ``HexBlock``, as that was more accurate.
 #. ``pathTools.cleanPath()`` is not much more linear, and handles the MPI use-case better.
 #. Fixed bugs in the ARMI memory profiler.
+#. Fixed linear expansion in ``Alloy200``.
 #. TBD
 
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -17,6 +17,7 @@ What's new in ARMI
 #. Renamed control rod assembly parameters for generic implementations of control rod handling.
 #. Changed the default Git branch name to ``main``.
 #. Changed the default value of the ``trackAssems`` setting to ``False``.
+#. Made the min/max temperatures of ``Material`` curves discoverable.
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

The [problem people were having](https://github.com/terrapower/armi/issues/715), that this PR attempts to address, is that in our material definitions, we have a _lot_ of hidden numbers, for instance, the min/max values that a temperature-dependent curve is valid over:

https://github.com/terrapower/armi/blob/cec12c998a9579f0c21fd2fbd1f863767a06fa52/armi/materials/ht9.py#L60-L68

There was already a solution for this for half-a-dozen materials in ARMI:

https://github.com/terrapower/armi/blob/cec12c998a9579f0c21fd2fbd1f863767a06fa52/armi/materials/siC.py#L68-L73

And:

https://github.com/terrapower/armi/blob/cec12c998a9579f0c21fd2fbd1f863767a06fa52/armi/materials/siC.py#L85-L89

This PR just extends this solution to all ARMI materials with temperature-dependent curves. The goal here is to solve the complaint/request by making ARMI materials:

1. More discoverable
2. More consistent

---

## Checklist

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.
- [x] Documentation added/updated in the `doc` folder.
