### PR TITLE
Fixing removeAssembliesInRing for circular hex reactors

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -435,12 +435,26 @@ class Core(composites.Composite):
         else:
             self._removeListFromAuxiliaries(a1)
 
-    def removeAssembliesInRing(self, ringNum):
+    def removeAssembliesInRing(self, ringNum, forceHexRing=False):
         """
         Removes all of the assemblies in a given ring
+
+        Parameters
+        ----------
+        ringNum : int
+            The ring to remove
+
+        forceHexRing : bool, optional
+            If you want to remove a circular ring from a square or hex reactor.
         """
-        for a in self.getAssembliesInRing(ringNum):
+        if forceHexRing:
+            assems = self.getAssembliesInSquareOrHexRing(ringNum)
+        else:
+            assems = self.getAssembliesInRing(ringNum)
+
+        for a in assems:
             self.removeAssembly(a)
+
         self.processLoading(settings.getMasterCs())
 
     def _removeListFromAuxiliaries(self, assembly):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -445,7 +445,8 @@ class Core(composites.Composite):
             The ring to remove
 
         forceHexRing : bool, optional
-            If you want to remove a circular ring from a square or hex reactor.
+            True ~ if you want to remove assemblies in square or hex ring from a squre or hex reactor.
+            False ~ if you want to remove assemblies in a circular ring.
         """
         if forceHexRing:
             assems = self.getAssembliesInSquareOrHexRing(ringNum)

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -435,7 +435,7 @@ class Core(composites.Composite):
         else:
             self._removeListFromAuxiliaries(a1)
 
-    def removeAssembliesInRing(self, ringNum, forceHexRing=False):
+    def removeAssembliesInRing(self, ringNum, overrideCircularRingMode=False):
         """
         Removes all of the assemblies in a given ring
 
@@ -444,16 +444,17 @@ class Core(composites.Composite):
         ringNum : int
             The ring to remove
 
-        forceHexRing : bool, optional
-            True ~ if you want to remove assemblies in square or hex ring from a squre or hex reactor.
-            False ~ if you want to remove assemblies in a circular ring.
-        """
-        if forceHexRing:
-            assems = self.getAssembliesInSquareOrHexRing(ringNum)
-        else:
-            assems = self.getAssembliesInRing(ringNum)
+        overrideCircularRingMode : bool, optional
+            False ~ default: use circular/square/hex rings, just as the reactor defines them
+            True ~ If you know you don't want to use the circular ring mode, and instead want square or hex.
 
-        for a in assems:
+        See Also
+        --------
+        getAssembliesInRing : definition of a ring
+        """
+        for a in self.getAssembliesInRing(
+            ringNum, overrideCircularRingMode=overrideCircularRingMode
+        ):
             self.removeAssembly(a)
 
         self.processLoading(settings.getMasterCs())
@@ -731,7 +732,12 @@ class Core(composites.Composite):
             return float("inf")
 
     def getAssembliesInRing(
-        self, ring, typeSpec=None, exactType=False, exclusions=None
+        self,
+        ring,
+        typeSpec=None,
+        exactType=False,
+        exclusions=None,
+        overrideCircularRingMode=False,
     ):
         """
         Returns the assemblies in a specified ring. Definitions of rings can change
@@ -754,13 +760,16 @@ class Core(composites.Composite):
         exclusions : list of assemblies
             list of assemblies that are not to be considered
 
+        overrideCircularRingMode : bool, optional
+            False ~ default: use circular/square/hex rings, just as the reactor defines them
+            True ~ If you know you don't want to use the circular ring mode, and instead want square or hex.
+
         Returns
         -------
         aList : list of assemblies
             A list of assemblies that match the criteria within the ring
-
         """
-        if self._circularRingMode:
+        if self._circularRingMode and not overrideCircularRingMode:
             getter = self.getAssembliesInCircularRing
         else:
             getter = self.getAssembliesInSquareOrHexRing

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -725,6 +725,21 @@ class HexReactorTests(ReactorTests):
             self.assertNotEqual(aLoc[i], a.spatialLocator)
             self.assertEqual(a.spatialLocator.grid, self.r.core.sfp.spatialGrid)
 
+    def test_removeAssembliesInRingByCount(self):
+        self.assertEqual(self.r.core.getNumRings(), 9)
+        self.r.core.removeAssembliesInRing(9)
+        self.assertEqual(self.r.core.getNumRings(), 8)
+
+    def test_removeAssembliesInRingHex(self):
+        """
+        Since the test reactor is hex, we need to use the forceHexRing option
+        to remove assemblies from it.
+        """
+        self.assertEqual(self.r.core.getNumRings(), 9)
+        for ringNum in range(6, 10):
+            self.r.core.removeAssembliesInRing(ringNum, forceHexRing=True)
+        self.assertEqual(self.r.core.getNumRings(), 5)
+
     def test_getNozzleTypes(self):
         nozzleTypes = self.r.core.getNozzleTypes()
         expectedTypes = ["Inner", "Outer", "lta", "Default"]

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -732,12 +732,12 @@ class HexReactorTests(ReactorTests):
 
     def test_removeAssembliesInRingHex(self):
         """
-        Since the test reactor is hex, we need to use the forceHexRing option
+        Since the test reactor is hex, we need to use the overrideCircularRingMode option
         to remove assemblies from it.
         """
         self.assertEqual(self.r.core.getNumRings(), 9)
         for ringNum in range(6, 10):
-            self.r.core.removeAssembliesInRing(ringNum, forceHexRing=True)
+            self.r.core.removeAssembliesInRing(ringNum, overrideCircularRingMode=True)
         self.assertEqual(self.r.core.getNumRings(), 5)
 
     def test_getNozzleTypes(self):


### PR DESCRIPTION
## Description

There is some confusing language in ARMI that you can remove a "circular" ring of assemblies from a "hexagonal" reactor.

While the method `removeAssembliesinSquareOrHexRing()` does exist, it seems likely that people will keep trying to use `removeAssembliesInRing()` and running into the problem in [this ticket](https://github.com/terrapower/armi/issues/750).

As such, this PR fixes the issue.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
