### PR TITLE
Move block getPinCoordinates from HexBlock to Block

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1529,6 +1529,32 @@ class Block(composites.Composite):
         """
         raise NotImplementedError
 
+    def getPinCoordinates(self):
+        """
+        Compute the local centroid coordinates of any pins in this block.
+
+        The pins must have a CLAD-flagged component for this to work.
+
+        Returns
+        -------
+        localCoordinates : list
+            list of (x,y,z) pairs representing each pin in the order they are listed as children
+
+        Notes
+        -----
+        This assumes hexagonal pin lattice and needs to be upgraded once more generic geometry
+        options are needed. Only works if pins have clad.
+        """
+        coords = []
+        for clad in self.getChildrenWithFlags(Flags.CLAD):
+            if isinstance(clad.spatialLocator, grids.MultiIndexLocation):
+                coords.extend(
+                    [locator.getLocalCoordinates() for locator in clad.spatialLocator]
+                )
+            else:
+                coords.append(clad.spatialLocator.getLocalCoordinates())
+        return coords
+
 
 class HexBlock(Block):
 
@@ -1928,31 +1954,6 @@ class HexBlock(Block):
                     return 2.0
         return 1.0
 
-    def getPinCoordinates(self):
-        """
-        Compute the local centroid coordinates of any pins in this block.
-
-        The pins must have a CLAD-flagged component for this to work.
-
-        Returns
-        -------
-        localCoordinates : list
-            list of (x,y,z) pairs representing each pin in the order they are listed as children
-
-        Notes
-        -----
-        This assumes hexagonal pin lattice and needs to be upgraded once more generic geometry
-        options are needed. Only works if pins have clad.
-        """
-        coords = []
-        for clad in self.getChildrenWithFlags(Flags.CLAD):
-            if isinstance(clad.spatialLocator, grids.MultiIndexLocation):
-                coords.extend(
-                    [locator.getLocalCoordinates() for locator in clad.spatialLocator]
-                )
-            else:
-                coords.append(clad.spatialLocator.getLocalCoordinates())
-        return coords
 
     def autoCreateSpatialGrids(self):
         """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1954,7 +1954,6 @@ class HexBlock(Block):
                     return 2.0
         return 1.0
 
-
     def autoCreateSpatialGrids(self):
         """
         Given a block without a spatialGrid, create a spatialGrid and give its children
@@ -1976,10 +1975,7 @@ class HexBlock(Block):
         ------
         ValueError
             If the multiplicities of the block are not only 1 or N or if generated ringNumber leads to more positions than necessary.
-
-
         """
-
         # Check multiplicities...
         mults = {c.getDimension("mult") for c in self.iterComponents()}
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -794,6 +794,12 @@ class HexReactorTests(ReactorTests):
         self.assertEqual(0, len(self.r.core.blocksByName))
         self.assertEqual(0, len(self.r.core.assembliesByName))
 
+    def test_pinCoordsAllBlocks(self):
+        """Make sure all blocks can get pin coords."""
+        for b in self.r.core.getBlocks():
+            coords = b.getPinCoordinates()
+            self.assertGreater(len(coords), -1)
+
 
 class CartesianReactorTests(ReactorTests):
     def setUp(self):


### PR DESCRIPTION
Minor change that shouldn't impact anyone but anticipates more pin-detailed Cartesian cases later:

Moving `getPinCoordinates()` from `HexBlock` to `Block`.