### PR TITLE
Fixing error in docs - MAX_Z bounds were not enforced

### DIFF
--- a/doc/gallery-src/framework/run_materials.py
+++ b/doc/gallery-src/framework/run_materials.py
@@ -21,7 +21,6 @@ contents. Some have temperature dependent properties, but some don't. You can pr
 your own proprietary material properties via a plugin.
 
 More info about the materials here: :py:mod:`armi.materials`.
-
 """
 import numpy as np
 import matplotlib.pyplot as plt
@@ -29,7 +28,7 @@ import matplotlib.pyplot as plt
 from armi import configure, materials
 from armi.nucDirectory import nuclideBases
 
-MAX_Z = 96  # stop at Curium
+MAX_Z = 98  # stop at Californium
 
 configure(permissive=True)
 
@@ -45,7 +44,11 @@ for mi, matCls in enumerate(mats):
     for nucName, frac in m.p.massFrac.items():
         nb = nuclideBases.byName[nucName]
         idx = mi, nb.z - 1
-        zVals[idx] += frac
+        try:
+            zVals[idx] += frac
+        except IndexError:
+            # respect the MAX_Z bounds
+            pass
 
 fig, ax = plt.subplots(figsize=(16, 12))
 im = ax.imshow(zVals, cmap="YlGn")


### PR DESCRIPTION
## Description

We have this little helper script in the docs that plots all of our materials. Hurray. 

Well, we added Californium to our materials today, but it turns out the doc script was not prepared for that.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
