### PR TITLE
Update 1D block converter to prevent negative area components.

### DIFF
--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -588,8 +588,8 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             # altogether. If not skipped, the conversion process still works, but this would
             # result in one or more rings having an outer diameter than is smaller than the
             # inner diameter.
-            #             if c.getArea() < 0.0:
-            #                 continue
+            if c.getArea() < 0.0:
+                continue
 
             if (
                 self._sourceBlock.getNumComponents(c.p.flags)

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -518,7 +518,6 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
                         driverFuelBlock
                     )
                 )
-
         self.pinPitch = sourceBlock.getPinPitch()
         self.mergeIntoClad = mergeIntoClad or []
         self.interRingComponent = sourceBlock.getComponent(Flags.COOLANT, exact=True)
@@ -547,6 +546,13 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             self._buildNthRing(pinComponents, ring)
         self._buildNonPinRings(nonPins)
         self._addDriverFuelRings()
+
+        for comp in self.convertedBlock.getComponents():
+            assert comp.getArea() >= 0.0, (
+                f"{comp} in {self.convertedBlock} has a negative area of {comp.getArea()}. "
+                "Negative areas are not supported."
+            )
+
         return self.convertedBlock
 
     def _dissolveComponents(self):
@@ -566,12 +572,25 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
         """
         Figure out which components are in each pin ring and which are not.
 
+        Notes
+        -----
         Assumption is that anything with multiplicity equal to numPins is a pin (clad, wire, bond, etc.)
-        Non-pins will include things like coolant, duct, interduct, whatever else.
+        Non-pins will include things like coolant, duct, interduct, etc.
+
+        This skips components that have a negative area, which can exist if a user implements a linked
+        component containing void or non-solid materials (e.g., gaps)
         """
         pinComponents, nonPins = [], []
 
         for c in self._sourceBlock:
+
+            # If the area of the component is negative than this component should be skipped
+            # altogether. If not skipped, the conversion process still works, but this would
+            # result in one or more rings having an outer diameter than is smaller than the
+            # inner diameter.
+            #             if c.getArea() < 0.0:
+            #                 continue
+
             if (
                 self._sourceBlock.getNumComponents(c.p.flags)
                 == self._sourceBlock.getNumPins()

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -19,6 +19,7 @@ import os
 import numpy
 
 from armi.reactor.converters import blockConverters
+from armi.reactor import blocks
 from armi.reactor import components
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_blocks import loadTestBlock
@@ -163,6 +164,34 @@ class TestBlockConverter(unittest.TestCase):
             hexagon.numPositionsInRing,
         )
 
+    def test_convertHexWithFuelDriverOnNegativeComponentAreaBlock(self):
+        """
+        Tests the conversion of a control block with linked components, where
+        a component contains a negative area due to thermal expansion.
+        """
+        driverBlock = (
+            loadTestReactor(TEST_ROOT)[1]
+            .core.getAssemblies(Flags.FUEL)[2]
+            .getFirstBlock(Flags.FUEL)
+        )
+
+        block = buildControlBlockWithLinkedNegativeAreaComponent()
+        areas = [c.getArea() for c in block]
+
+        # Check that a negative area component exists.
+        self.assertLess(min(areas), 0.0)
+
+        driverBlock.spatialGrid = None
+        block.spatialGrid = grids.HexGrid.fromPitch(1.0)
+
+        converter = blockConverters.HexComponentsToCylConverter(
+            block, driverFuelBlock=driverBlock, numExternalRings=2
+        )
+        convertedBlock = converter.convert()
+        # The area is increased because the negative area components are
+        # removed.
+        self.assertGreater(convertedBlock.getArea(), block.getArea())
+
     def test_convertCartesianLatticeWithFuelDriver(self):
         """Test conversion with fuel driver."""
         r = loadTestReactor(TEST_ROOT, inputFileName="zpprTest.yaml")[1]
@@ -286,6 +315,65 @@ def _buildJoyoFuel():
         mult=91,
     )
     return fuel, clad
+
+
+def buildControlBlockWithLinkedNegativeAreaComponent():
+    """
+    Return a block that contains a bond component that resolves to a negative area
+    once the fuel and clad thermal expansion have occurred.
+    """
+    b = blocks.HexBlock("control", height=10.0)
+
+    controlDims = {"Tinput": 25.0, "Thot": 600, "od": 0.77, "id": 0.00, "mult": 127.0}
+    bondDims = {
+        "Tinput": 600,
+        "Thot": 600,
+        "od": "clad.id",
+        "id": "control.od",
+        "mult": 127.0,
+    }
+    cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.77, "mult": 127.0}
+    wireDims = {
+        "Tinput": 25.0,
+        "Thot": 450,
+        "od": 0.1,
+        "id": 0.0,
+        "mult": 127.0,
+        "axialPitch": 30.0,
+        "helixDiameter": 0.9,
+    }
+    ductDims = {"Tinput": 25.0, "Thot": 400, "op": 16, "ip": 15.3, "mult": 1.0}
+    intercoolantDims = {
+        "Tinput": 400,
+        "Thot": 400,
+        "op": 17.0,
+        "ip": ductDims["op"],
+        "mult": 1.0,
+    }
+    coolDims = {"Tinput": 25.0, "Thot": 400}
+
+    control = components.Circle("control", "UZr", **controlDims)
+    clad = components.Circle("clad", "HT9", **cladDims)
+    # This sets up the linking of the bond to the fuel and the clad components.
+    bond = components.Circle(
+        "bond", "Sodium", components={"control": control, "clad": clad}, **bondDims
+    )
+    wire = components.Helix("wire", "HT9", **wireDims)
+    duct = components.Hexagon("duct", "HT9", **ductDims)
+    coolant = components.DerivedShape("coolant", "Sodium", **coolDims)
+    intercoolant = components.Hexagon("intercoolant", "Sodium", **intercoolantDims)
+
+    b.add(control)
+    b.add(bond)
+    b.add(clad)
+    b.add(wire)
+    b.add(duct)
+    b.add(coolant)
+    b.add(intercoolant)
+
+    b.getVolumeFractions()  # TODO: remove, should be no-op when removed self.cached
+
+    return b
 
 
 if __name__ == "__main__":

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -277,7 +277,7 @@ def _buildJoyoFuel():
         mult=91,
     )
     clad = components.Circle(
-        name="fuel",
+        name="clad",
         material="HT9",
         Tinput=20.0,
         Thot=20.0,


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description

<!-- Please include a summary of the change and link to any related GitHub Issues.-->

The `HexComponentsToCylConverter` class is updated in this to properly handle and check for
negative area components after the conversion has occurred. This is a scenario that was previously
not handled and can occur when the user implements a block design in the blueprints where
two solid components are connected with a "gap-like" component and then have overlaps due
to thermal expansion. This "gap-like" component can be named anything and can either have
`Void` or some `Liquid` material type. `Void` components explicitly named "gap" are already handled
correctly, but that logic was not sufficient to also handle negative area components in edge modeling
cases.

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.
- [x] New or updated dependencies have been added to `setup.py`.
