### PR TITLE
Again move axial exp process load

### DIFF
--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -92,9 +92,6 @@ from armi.reactor import systemLayoutInput
 from armi.scripts import migration
 from armi.utils import textProcessors
 
-from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
-from armi.reactor.flags import Flags
-
 # NOTE: using non-ARMI-standard imports because these are all a part of this package,
 # and using the module imports would make the attribute definitions extremely long
 # without adding detail
@@ -300,7 +297,6 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
         This method should not be called directly, but it is used in testing.
         """
-        axialExpChngr = AxialExpansionChanger(cs["detailedAxialExpansion"])
         if not self._prepped:
             self._assignTypeNums()
             for func in self._resolveFunctions:
@@ -311,11 +307,6 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
             for aDesign in self.assemDesigns:
                 a = aDesign.construct(cs, self)
-                if not cs["inputHeightsConsideredHot"]:
-                    if not a.hasFlags(Flags.CONTROL):
-                        axialExpChngr.setAssembly(a)
-                        axialExpChngr.expansionData.computeThermalExpansionFactors()
-                        axialExpChngr.axiallyExpandAssembly(thermal=True)
                 self._assembliesBySpecifier[aDesign.specifier] = a
                 self.assemblies[aDesign.name] = a
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2237,8 +2237,8 @@ class Core(composites.Composite):
 
         """
         if not cs["inputHeightsConsideredHot"]:
-            runLog.info(
-                "Axially expanding all (except control) assemblies from Tinput to Thot."
+            runLog.header(
+                "=========== Axially expanding all (except control) assemblies from Tinput to Thot ==========="
             )
             axialExpChngr = AxialExpansionChanger(cs["detailedAxialExpansion"])
             for a in self.getAssemblies(includeAll=True):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -55,6 +55,7 @@ from armi.utils import createFormattedStrWithDelimiter, units
 from armi.utils import directoryChangers
 from armi.utils.iterables import Sequence
 from armi.utils.mathematics import average1DWithinTolerance
+from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 
 # init logger
 runLog = logging.getLogger(__name__)
@@ -2235,6 +2236,17 @@ class Core(composites.Composite):
         updateAxialMesh : Perturbs the axial mesh originally set up here.
 
         """
+        if not cs["inputHeightsConsideredHot"]:
+            runLog.info(
+                "Axially expanding all (except control) assemblies from Tinput to Thot."
+            )
+            axialExpChngr = AxialExpansionChanger(cs["detailedAxialExpansion"])
+            for a in self.getAssemblies(includeAll=True):
+                if not a.hasFlags(Flags.CONTROL):
+                    axialExpChngr.setAssembly(a)
+                    axialExpChngr.expansionData.computeThermalExpansionFactors()
+                    axialExpChngr.axiallyExpandAssembly(thermal=True)
+
         runLog.header(
             "=========== Initializing Mesh, Assembly Zones, and Nuclide Categories =========== "
         )


### PR DESCRIPTION
Kudos to @john-science for the solid suggestion on a Friday afternoon!

It's not ideal to require the axial expansion changer to _always_ initiate when blueprints are read. It's a very `Core` specific task and should live closer to where it is appropriately used. E.g., a user may not always define/want a `Core` in their blueprints (e.g., spent fuel pool analyses). So this commit moves it off of `armi/reactor/blueprints/__init__.py` and onto `armi/reactor/reactors.py::Core::processLoading` - and even more specifically, only if `inputHeightsConsideredHot = False`. 

<!-- Thanks in advance for you contribution! -->

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.