### PR TITLE
Enable Users To Explicitly Specify Target Component for Axial Expansion

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1532,12 +1532,12 @@ class Block(composites.Composite):
 
     def setTargetComponent(self, targetComponent):
         """sets the targetComponent for the axial expansion changer
-        
+
         Parameter
         ---------
         targetComponent: :py:class:`Component <armi.reactor.components.component.Component>` object
             component specified to be target component for axial expansion changer
-        
+
         See Also
         --------
         armi.reactor.converters.axialExpansionChanger.py::ExpansionData::_setTargetComponents

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -97,7 +97,7 @@ class Block(composites.Composite):
 
         self.points = []
         self.macros = None
-        self.targetComponent = None
+        self.axialExpTargetComponent = None
 
         # flag to indicated when DerivedShape children must be updated.
         self.derivedMustUpdate = False
@@ -1530,7 +1530,7 @@ class Block(composites.Composite):
         """
         raise NotImplementedError
 
-    def setTargetComponent(self, targetComponent):
+    def setAxialExpTargetComp(self, targetComponent):
         """sets the targetComponent for the axial expansion changer
 
         Parameter
@@ -1542,7 +1542,7 @@ class Block(composites.Composite):
         --------
         armi.reactor.converters.axialExpansionChanger.py::ExpansionData::_setTargetComponents
         """
-        self.targetComponent = targetComponent
+        self.axialExpTargetComponent = targetComponent
 
     def getPinCoordinates(self):
         """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -97,6 +97,7 @@ class Block(composites.Composite):
 
         self.points = []
         self.macros = None
+        self.targetComponent = None
 
         # flag to indicated when DerivedShape children must be updated.
         self.derivedMustUpdate = False
@@ -1537,6 +1538,19 @@ class Block(composites.Composite):
         """
         raise NotImplementedError
 
+    def setTargetComponent(self, targetComponent):
+        """sets the targetComponent for the axial expansion changer
+        
+        Parameter
+        ---------
+        targetComponent: :py:class:`Component <armi.reactor.components.component.Component>` object
+            component specified to be target component for axial expansion changer
+        
+        See Also
+        --------
+        armi.reactor.converters.axialExpansionChanger.py::ExpansionData::_setTargetComponents
+        """
+        self.targetComponent = targetComponent
 
 class HexBlock(Block):
 

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -46,6 +46,7 @@ class BlockBlueprint(yamlize.KeyedList):
     name = yamlize.Attribute(key="name", type=str)
     gridName = yamlize.Attribute(key="grid name", type=str, default=None)
     flags = yamlize.Attribute(type=str, default=None)
+    targetComponent = yamlize.Attribute(type=str, default=None)
     _geomOptions = _configureGeomOptions()
 
     def _getBlockClass(self, outerComponent):
@@ -168,6 +169,19 @@ class BlockBlueprint(yamlize.KeyedList):
             flags = Flags.fromString(self.flags)
 
         b.setType(self.name, flags)
+
+        if self.targetComponent is not None:
+            try:
+                b.setTargetComponent(components[self.targetComponent])
+            except KeyError:
+                raise RuntimeError(
+                    "Block {0} --> target component {1}, specified in the blueprints does not "
+                    "match any component names. Revise target component in blueprints "
+                    "to match the name of a component and retry.".format(
+                        b, self.targetComponent,
+                    )
+                )
+
         for c in components.values():
             b.add(c)
         b.p.nPins = b.getNumPins()

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -46,7 +46,7 @@ class BlockBlueprint(yamlize.KeyedList):
     name = yamlize.Attribute(key="name", type=str)
     gridName = yamlize.Attribute(key="grid name", type=str, default=None)
     flags = yamlize.Attribute(type=str, default=None)
-    targetComponent = yamlize.Attribute(
+    axialExpTargetComponent = yamlize.Attribute(
         key="axial expansion target component", type=str, default=None
     )
     _geomOptions = _configureGeomOptions()
@@ -172,18 +172,18 @@ class BlockBlueprint(yamlize.KeyedList):
 
         b.setType(self.name, flags)
 
-        if self.targetComponent is not None:
+        if self.axialExpTargetComponent is not None:
             try:
-                b.setTargetComponent(components[self.targetComponent])
-            except KeyError:
+                b.setAxialExpTargetComp(components[self.axialExpTargetComponent])
+            except KeyError as noMatchingComponent:
                 raise RuntimeError(
-                    "Block {0} --> target component {1} specified in the blueprints does not "
-                    "match any component names. Revise target component in blueprints "
+                    "Block {0} --> axial expansion target component {1} specified in the blueprints does not "
+                    "match any component names. Revise axial expansion target component in blueprints "
                     "to match the name of a component and retry.".format(
                         b,
-                        self.targetComponent,
+                        self.axialExpTargetComponent,
                     )
-                )
+                ) from noMatchingComponent
 
         for c in components.values():
             b.add(c)

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -46,7 +46,9 @@ class BlockBlueprint(yamlize.KeyedList):
     name = yamlize.Attribute(key="name", type=str)
     gridName = yamlize.Attribute(key="grid name", type=str, default=None)
     flags = yamlize.Attribute(type=str, default=None)
-    targetComponent = yamlize.Attribute(type=str, default=None)
+    targetComponent = yamlize.Attribute(
+        key="axial expansion target component", type=str, default=None
+    )
     _geomOptions = _configureGeomOptions()
 
     def _getBlockClass(self, outerComponent):
@@ -175,10 +177,11 @@ class BlockBlueprint(yamlize.KeyedList):
                 b.setTargetComponent(components[self.targetComponent])
             except KeyError:
                 raise RuntimeError(
-                    "Block {0} --> target component {1}, specified in the blueprints does not "
+                    "Block {0} --> target component {1} specified in the blueprints does not "
                     "match any component names. Revise target component in blueprints "
                     "to match the name of a component and retry.".format(
-                        b, self.targetComponent,
+                        b,
+                        self.targetComponent,
                     )
                 )
 

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -202,7 +202,7 @@ class AxialExpansionChanger:
                     c.ztop = c.zbottom + c.height
                     # redistribute block boundaries if on the target component
                     if self.expansionData.isTargetComponent(c):
-                        if b.targetComponent is None:
+                        if b.axialExpTargetComponent is None:
                             runLog.debug(
                                 "      Component {0} is target component (inferred)".format(
                                     c
@@ -672,8 +672,8 @@ class ExpansionData:
             target components should be determined on the fly.
         """
         for b in self._a:
-            if b.targetComponent is not None:
-                self._componentDeterminesBlockHeight[b.targetComponent] = True
+            if b.axialExpTargetComponent is not None:
+                self._componentDeterminesBlockHeight[b.axialExpTargetComponent] = True
             elif b.hasFlags(Flags.PLENUM) or b.hasFlags(Flags.ACLP):
                 self.determineTargetComponent(b, Flags.CLAD)
             elif b.hasFlags(Flags.DUMMY):

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -202,9 +202,18 @@ class AxialExpansionChanger:
                     c.ztop = c.zbottom + c.height
                     # redistribute block boundaries if on the target component
                     if self.expansionData.isTargetComponent(c):
-                        runLog.debug(
-                            "      Component {0} is target component".format(c)
-                        )
+                        if b.targetComponent is None:
+                            runLog.debug(
+                                "      Component {0} is target component (inferred)".format(
+                                    c
+                                )
+                            )
+                        else:
+                            runLog.debug(
+                                "      Component {0} is target component (blueprints defined)".format(
+                                    c
+                                )
+                            )
                         b.p.ztop = c.ztop
 
             # see also b.setHeight()

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -656,10 +656,16 @@ class ExpansionData:
     def _setTargetComponents(self, setFuel):
         """sets target component for each block
 
-        - To-Do: allow users to specify target component for a block in settings
+        Parameters
+        ----------
+        setFuel : bool
+            boolean to determine if fuel block should have its target component set. Useful for when
+            target components should be determined on the fly.
         """
         for b in self._a:
-            if b.hasFlags(Flags.PLENUM) or b.hasFlags(Flags.ACLP):
+            if b.targetComponent is not None:
+                self._componentDeterminesBlockHeight[b.targetComponent] = True
+            elif b.hasFlags(Flags.PLENUM) or b.hasFlags(Flags.ACLP):
                 self.specifyTargetComponent(b, Flags.CLAD)
             elif b.hasFlags(Flags.DUMMY):
                 self.specifyTargetComponent(b, Flags.COOLANT)

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -675,15 +675,15 @@ class ExpansionData:
             if b.targetComponent is not None:
                 self._componentDeterminesBlockHeight[b.targetComponent] = True
             elif b.hasFlags(Flags.PLENUM) or b.hasFlags(Flags.ACLP):
-                self.specifyTargetComponent(b, Flags.CLAD)
+                self.determineTargetComponent(b, Flags.CLAD)
             elif b.hasFlags(Flags.DUMMY):
-                self.specifyTargetComponent(b, Flags.COOLANT)
+                self.determineTargetComponent(b, Flags.COOLANT)
             elif setFuel and b.hasFlags(Flags.FUEL):
                 self._isFuelLocked(b)
             else:
-                self.specifyTargetComponent(b)
+                self.determineTargetComponent(b)
 
-    def specifyTargetComponent(self, b, flagOfInterest=None):
+    def determineTargetComponent(self, b, flagOfInterest=None):
         """appends target component to self._componentDeterminesBlockHeight
 
         Parameters

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -609,6 +609,31 @@ class TestSpecifyTargetComponent(unittest.TestCase):
                 fuel
             ),
         )
+    
+    def test_specifyTargetComponet_BlueprintSpecifed(self):
+        b = HexBlock("SodiumBlock", height=10.0)
+        sodiumDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
+        dummy = Hexagon("coolant", "Sodium", **sodiumDims)
+        b.add(dummy)
+        b.getVolumeFractions()
+        b.setType("SodiumBlock")
+
+        # check for no target component found
+        with self.assertRaises(RuntimeError) as cm:
+            self.obj.expansionData.specifyTargetComponent(b)
+            the_exception = cm.exception
+            self.assertEqual(the_exception.error_code, 3)
+        
+        b.setTargetComponent(dummy)
+        self.assertEqual(
+            b.targetComponent,
+            dummy,
+        )
+
+        self.obj.expansionData._componentDeterminesBlockHeight[b.targetComponent] = True
+        self.assertTrue(
+            self.obj.expansionData._componentDeterminesBlockHeight[b.targetComponent]
+        )
 
 
 class TestInputHeightsConsideredHot(unittest.TestCase):

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -630,9 +630,13 @@ class TestDetermineTargetComponent(unittest.TestCase):
             dummy,
         )
 
-        self.obj.expansionData._componentDeterminesBlockHeight[b.axialExpTargetComponent] = True
+        self.obj.expansionData._componentDeterminesBlockHeight[
+            b.axialExpTargetComponent
+        ] = True
         self.assertTrue(
-            self.obj.expansionData._componentDeterminesBlockHeight[b.axialExpTargetComponent]
+            self.obj.expansionData._componentDeterminesBlockHeight[
+                b.axialExpTargetComponent
+            ]
         )
 
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -609,7 +609,7 @@ class TestSpecifyTargetComponent(unittest.TestCase):
                 fuel
             ),
         )
-    
+
     def test_specifyTargetComponet_BlueprintSpecifed(self):
         b = HexBlock("SodiumBlock", height=10.0)
         sodiumDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
@@ -623,7 +623,7 @@ class TestSpecifyTargetComponent(unittest.TestCase):
             self.obj.expansionData.specifyTargetComponent(b)
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
-        
+
         b.setTargetComponent(dummy)
         self.assertEqual(
             b.targetComponent,

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -494,7 +494,7 @@ class TestExceptions(Base, unittest.TestCase):
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
 
-    def test_specifyTargetComponentRuntimeErrorFirst(self):
+    def test_determineTargetComponentRuntimeErrorFirst(self):
         # build block for testing
         b = HexBlock("test", height=10.0)
         fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.76, "id": 0.00, "mult": 127.0}
@@ -507,12 +507,12 @@ class TestExceptions(Base, unittest.TestCase):
         b.getVolumeFractions()
         # do test
         with self.assertRaises(RuntimeError) as cm:
-            self.obj.expansionData.specifyTargetComponent(b)
+            self.obj.expansionData.determineTargetComponent(b)
 
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
 
-    def test_specifyTargetComponentRuntimeErrorSecond(self):
+    def test_determineTargetComponentRuntimeErrorSecond(self):
         # build block for testing
         b = HexBlock("test", height=10.0)
         fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.76, "id": 0.00, "mult": 127.0}
@@ -525,7 +525,7 @@ class TestExceptions(Base, unittest.TestCase):
         b.getVolumeFractions()
         # do test
         with self.assertRaises(RuntimeError) as cm:
-            self.obj.expansionData.specifyTargetComponent(b)
+            self.obj.expansionData.determineTargetComponent(b)
 
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
@@ -563,8 +563,8 @@ class TestExceptions(Base, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
 
-class TestSpecifyTargetComponent(unittest.TestCase):
-    """verify specifyTargetComponent method is properly updating _componentDeterminesBlockHeight"""
+class TestDetermineTargetComponent(unittest.TestCase):
+    """verify determineTargetComponent method is properly updating _componentDeterminesBlockHeight"""
 
     def setUp(self):
         self.obj = AxialExpansionChanger()
@@ -573,7 +573,7 @@ class TestSpecifyTargetComponent(unittest.TestCase):
         # need an empty dictionary because we want to test for the added component only
         self.obj.expansionData._componentDeterminesBlockHeight = {}
 
-    def test_specifyTargetComponent(self):
+    def test_determineTargetComponent(self):
         # build a test block
         b = HexBlock("fuel", height=10.0)
         fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.76, "id": 0.00, "mult": 127.0}
@@ -583,15 +583,15 @@ class TestSpecifyTargetComponent(unittest.TestCase):
         b.add(fuel)
         b.add(clad)
         # call method, and check that target component is correct
-        self.obj.expansionData.specifyTargetComponent(b)
+        self.obj.expansionData.determineTargetComponent(b)
         self.assertTrue(
             self.obj.expansionData.isTargetComponent(fuel),
-            msg="specifyTargetComponent failed to recognize intended component: {}".format(
+            msg="determineTargetComponent failed to recognize intended component: {}".format(
                 fuel
             ),
         )
 
-    def test_specifyTargetComponentBlockWithMultipleFlags(self):
+    def test_determineTargetComponentBlockWithMultipleFlags(self):
         # build a block that has two flags as well as a component matching each
         # flag
         b = HexBlock("fuel poison", height=10.0)
@@ -602,10 +602,10 @@ class TestSpecifyTargetComponent(unittest.TestCase):
         b.add(fuel)
         b.add(poison)
         # call method, and check that target component is correct
-        self.obj.expansionData.specifyTargetComponent(b)
+        self.obj.expansionData.determineTargetComponent(b)
         self.assertTrue(
             self.obj.expansionData.isTargetComponent(fuel),
-            msg="specifyTargetComponent failed to recognize intended component: {}".format(
+            msg="determineTargetComponent failed to recognize intended component: {}".format(
                 fuel
             ),
         )
@@ -620,7 +620,7 @@ class TestSpecifyTargetComponent(unittest.TestCase):
 
         # check for no target component found
         with self.assertRaises(RuntimeError) as cm:
-            self.obj.expansionData.specifyTargetComponent(b)
+            self.obj.expansionData.determineTargetComponent(b)
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -624,15 +624,15 @@ class TestDetermineTargetComponent(unittest.TestCase):
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
 
-        b.setTargetComponent(dummy)
+        b.setAxialExpTargetComp(dummy)
         self.assertEqual(
-            b.targetComponent,
+            b.axialExpTargetComponent,
             dummy,
         )
 
-        self.obj.expansionData._componentDeterminesBlockHeight[b.targetComponent] = True
+        self.obj.expansionData._componentDeterminesBlockHeight[b.axialExpTargetComponent] = True
         self.assertTrue(
-            self.obj.expansionData._componentDeterminesBlockHeight[b.targetComponent]
+            self.obj.expansionData._componentDeterminesBlockHeight[b.axialExpTargetComponent]
         )
 
 

--- a/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
@@ -43,6 +43,7 @@ blocks:
             op: 16.75
 
     SodiumBlock : &block_dummy
+        flags: dummy
         coolant:
             shape: Hexagon
             material: Sodium
@@ -51,7 +52,7 @@ blocks:
             ip: 0.0
             mult: 1.0
             op: 16.75
-        targetComponent: coolant
+        axial expansion target component: coolant
 
     ## ------------------------------------------------------------------------------------
     ## fuel blocks

--- a/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
@@ -42,7 +42,7 @@ blocks:
             mult: 1.0
             op: 16.75
 
-    dummy : &block_dummy
+    SodiumBlock : &block_dummy
         coolant:
             shape: Hexagon
             material: Sodium
@@ -51,6 +51,7 @@ blocks:
             ip: 0.0
             mult: 1.0
             op: 16.75
+        targetComponent: coolant
 
     ## ------------------------------------------------------------------------------------
     ## fuel blocks

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -21,6 +21,7 @@ What's new in ARMI
 #. Made the min/max temperatures of ``Material`` curves discoverable.
 #. Introduction of axial expansion changer to enable component-level axial expansion of assemblies.
 #. Add setting ``inputHeightsConsideredHot`` to enable thermal expansion of assemblies at BOL.
+#. Add blueprints setting, ``axial expansion target component``, to enable users to manually set a "target component" for axial expansion.
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
<!-- Thanks in advance for you contribution! -->

## Description
In some cases, the standard [methodology to infer a target component](https://github.com/terrapower/armi/blob/d0123831319c746da4150fa6bedcf540d8010a4f/armi/reactor/converters/axialExpansionChanger.py#L671-L715) for the axial expansion changer may not easily enable specifically what is needed. This update adds a new setting to enable users to explicitly specify the target component for axial expansion on a block.

- Class method name change from `specifyTargetComponent` to `determineTargetComponent`
- Modifies `runLog.debug` statement to specify whether the target component was set or inferred.
- Has a check during block construction to determine if the specified axial expansion target component is valid. 
- Unit test added to support new additions.

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.