### PR TITLE
Updating case compare to match new signature

### DIFF
--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -253,11 +253,7 @@ class CaseSuite:
                 suiteHasMissingFiles = False
             else:
                 caseIssues = refCase.compare(
-                    cmpCase,
-                    exclusion=exclusion,
-                    weights=weights,
-                    tolerance=tolerance,
-                    timestepMatchup=timestepMatchup,
+                    cmpCase, exclusion=exclusion, tolerance=tolerance
                 )
             nIssues += caseIssues
             tableResults[caseTitle] = (userFile, refFile, caseIssues)


### PR DESCRIPTION
## Description

@Nebbychadnezzar  points out that in suite.py, there is a call to `Case.compare()` using the old method signature, even though that was clean up [recently](https://github.com/terrapower/armi/commit/3f834e0c10ffeef677c57ca663a2ce816a4b54f5#diff-6536c3908288492aa22255261bfa4e3bb4c4ffa1e4d027a1d7b4a7be635071ddL632).  This PR fixes this problem.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
