### PR TITLE
Add new mesh converter for axially nodalization with block flags and XS IDs

### DIFF
--- a/armi/reactor/converters/tests/test_meshConverters.py
+++ b/armi/reactor/converters/tests/test_meshConverters.py
@@ -67,6 +67,22 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
         self.assertListEqual(meshConvert.thetaMesh, expectedThetaMesh)
 
+    def test_meshByRingCompositionAxialFlagsSmallCore(self):
+        expectedRadialMesh = [2, 3, 4, 4, 5, 5, 6, 6, 6, 7, 8, 8, 9, 10]
+        expectedAxialMesh = [25.0, 50.0, 75.0, 100.0, 175.0]
+        expectedThetaMesh = [2 * math.pi]
+
+        meshConvert = (
+            meshConverters.RZThetaReactorMeshConverterByRingCompositionAxialFlags(
+                self._converterSettings
+            )
+        )
+        meshConvert.generateMesh(self.r)
+
+        self.assertListEqual(meshConvert.radialMesh, expectedRadialMesh)
+        self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
+        self.assertListEqual(meshConvert.thetaMesh, expectedThetaMesh)
+
     def _growReactor(self):
         modifier = geometryConverters.FuelAssemNumModifier(self.o.cs)
         modifier.numFuelAssems = 1
@@ -105,6 +121,23 @@ class TestRZReactorMeshConverter(unittest.TestCase):
 
         meshConvert = (
             meshConverters.RZThetaReactorMeshConverterByRingCompositionAxialCoordinates(
+                self._converterSettingsLargerCore
+            )
+        )
+        meshConvert.generateMesh(self.r)
+
+        self.assertListEqual(meshConvert.radialMesh, expectedRadialMesh)
+        self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
+        self.assertListEqual(meshConvert.thetaMesh, expectedThetaMesh)
+
+    def test_meshByRingCompositionAxialFlagsLargeCore(self):
+        self._growReactor()
+        expectedRadialMesh = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 13]
+        expectedAxialMesh = [25.0, 100.0, 175.0]
+        expectedThetaMesh = [2 * math.pi]
+
+        meshConvert = (
+            meshConverters.RZThetaReactorMeshConverterByRingCompositionAxialFlags(
                 self._converterSettingsLargerCore
             )
         )


### PR DESCRIPTION
Add new mesh converter for HexToRZTheta reactor conversions that examines the state of the core and determines the axially nodalization based on the flags and XS IDs. This is useful for dynamically creating an RZ reactor core model that minimizes the number of material regions while preserving the XS ID assignments by users and with burnup.

<!-- Thanks in advance for you contribution! -->

## Description

<!-- Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] The code is understandable and maintainable to people beyond the author.
- [x] Tests have been added/updated to verify that the new or changed code works.
- [x] There is no commented out code in this PR.
- [x] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] All docstrings are still up-to-date with these changes.

If user exposed functionality was added/changed:

- [x] Documentation added/updated in the `doc` folder.
- [x] New or updated dependencies have been added to `setup.py`.
