### PR TITLE
Constrain jinja2 version

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1309,9 +1309,8 @@ class Database3(database.Database):
                 # - If not jagged, all top-level ndarrays are the same shape, so it is
                 # probably easier to replace Nones with ndarrays filled with special
                 # values.
-                if parameters.NoDefault in data:
-                    data = None
-                else:
+                data = None
+                if parameters.NoDefault not in data:
                     data, specialAttrs = packSpecialData(data, paramDef.name)
                     attrs.update(specialAttrs)
 

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1309,8 +1309,9 @@ class Database3(database.Database):
                 # - If not jagged, all top-level ndarrays are the same shape, so it is
                 # probably easier to replace Nones with ndarrays filled with special
                 # values.
-                data = None
-                if parameters.NoDefault not in data:
+                if parameters.NoDefault in data:
+                    data = None
+                else:
                     data, specialAttrs = packSpecialData(data, paramDef.name)
                     attrs.update(specialAttrs)
 

--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -35,3 +35,6 @@ docutils<0.18
 
 # used to generate UML diagrams
 pylint==2.7.4
+
+# needed to side step bug: https://github.com/numpy/numpydoc/issues/380
+Jinja2==3.0.1


### PR DESCRIPTION
## Description

In the process of trying to support Python 3.10 I ran into [this jinja2 bug](https://github.com/numpy/numpydoc/issues/380) a couple of times.

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
