### PR TITLE
Moving to Python 3.10 as default

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -8,10 +8,10 @@ jobs:
         runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v2
-            - name: Set up Python 3.9
+            - name: Set up Python 3.10
               uses: actions/setup-python@v2
               with:
-                python-version: 3.9
+                python-version: 3.10
             - name: Install Black
               run: pip install 'black==20.8b1' 'click==8.0.1'
             - name: Run black --check .

--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -11,7 +11,7 @@ jobs:
             - name: Set up Python 3.10
               uses: actions/setup-python@v2
               with:
-                python-version: 3.10
+                python-version: '3.10'
             - name: Install Black
               run: pip install 'black==20.8b1' 'click==8.0.1'
             - name: Run black --check .

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Update package index
         run: sudo apt-get update
       - name: Install mpi libs

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Update package index
         run: sudo apt-get update
       - name: Install mpi libs

--- a/.github/workflows/validatemanifest.yaml
+++ b/.github/workflows/validatemanifest.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox

--- a/.github/workflows/validatemanifest.yaml
+++ b/.github/workflows/validatemanifest.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Upgrade PIP
         run: python -m pip install --upgrade pip
       - name: Install deps

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Upgrade PIP
         run: python -m pip install --upgrade pip
       - name: Install deps


### PR DESCRIPTION
## Description

Moving to 3.10 by default, since the phase out of 3.7 is on the horizon.  This should help us stabilize on a version for as long as possible.

(**NOTE**: All unit tests still run in Python 3.7, 3.8, 3.9, adn 3.10.)

---

## Checklist

- [X] The code is understandable and maintainable to people beyond the author.
- [X] Tests have been added/updated to verify that the new or changed code works.
- [X] There is no commented out code in this PR.
- [X] The commit message follows [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [X] All docstrings are still up-to-date with these changes.
