### PR TITLE
Improving HistoryTracker code coverage

### DIFF
--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -137,7 +137,6 @@ class HistoryTrackerInterface(interfaces.Interface):
     def interactEOL(self):
         """Generate the history reports."""
         self._writeDetailAssemblyHistories()
-        self.printFullCoreLocations()
 
     def addDetailAssembliesBOL(self):
         """
@@ -329,38 +328,6 @@ class HistoryTrackerInterface(interfaces.Interface):
             out.write("{0} {1}\n".format(a.getName(), a.getType()))
             for b in blocks:
                 out.write('"{}" {} {}\n'.format(b.getType(), b.p.xsType, b.p.buGroup))
-
-    def printFullCoreLocations(self):
-        """
-        Print a report showing the locations of each assembly as functions of time.
-
-        This is useful for third-party follow-on analysis of fuel management.
-        """
-        aNameList = []  # NWT: Have to read this from the DB.
-
-        ofile = open(self.cs.caseTitle + ".locationHistory.txt", "w")  # MORE data files
-        ofile.write(
-            " ".join(
-                ["Assem"]
-                + ["{:5d}".format(c) for c in range(self.cs["nCycles"])]
-                + ["\n"]
-            )
-        )
-
-        for aName in aNameList:
-            # print the assembly number and then all the locations it was ever in.
-            line = [aName[1:] + " "]
-            for cycle in range(self.cs["nCycles"]):
-                row, loc = self.fullCoreLocations.get((aName, cycle), (None, None))
-                if row:
-                    val1 = "{0:02d}{1:03d}".format(row, loc)
-                else:
-                    # none returned
-                    val1 = "     "
-                line.append(val1)
-            line.append("\n")
-            ofile.write(" ".join(line))
-        ofile.close()
 
     def preloadBlockHistoryVals(self, names, keys, timesteps):
         """

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -388,10 +388,6 @@ class HistoryTrackerInterface(interfaces.Interface):
         """
         block = self.r.core.getBlockByName(name)
 
-        if paramName == "loc":
-            # special behavior for location param.
-            return self._blockLocationAtTimenode(block, ts)
-
         if self._isCurrentTimeStep(ts) and not self._databaseHasDataForTimeStep(ts):
             # current timenode may not have been written to the DB. Use the current
             # value in the param system.  works for fuel performance, for some params,
@@ -467,25 +463,3 @@ class HistoryTrackerInterface(interfaces.Interface):
                 "A tracked assembly does not contain fuel and has caused this error, see the details in stdout."
             )
         return b
-
-    def _blockLocationAtTimenode(self, block, timeNode):
-        """
-        Find block location label at a specific timenode.
-
-        Warning
-        -------
-        This fuction no longer functions, as it relies on implmentation details of
-        Database version 2, which is no longer used. Retaining for historical purposes,
-        but this should be removed soon.
-        """
-        dbi = self.getInterface("database")
-        ids = dbi.database.readBlockParam("id", timeNode)
-        locs = dbi.database.lookupGeometry()
-        if ids is None:
-            return None
-        ids = ids.tolist()
-        try:
-            blockIndex = ids.index(block.p.id)
-            return locs[blockIndex]
-        except ValueError:
-            return None

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -194,6 +194,18 @@ class TestHistoryTracker(ArmiTestHelper):
         history.addAllFuelAssems()
         self.assertEqual(len(history.detailAssemblyNames), 51)
 
+    def test_getBlockInAssembly(self):
+        history = self.o.getInterface("history")
+        aFuel = self.o.r.core.getFirstAssembly(Flags.FUEL)
+
+        b = history._getBlockInAssembly(aFuel)
+        self.assertGreater(b.p.height, 1.0)
+        self.assertEqual(b.getType(), "fuel")
+
+        with self.assertRaises(RuntimeError):
+            aShield = self.o.r.core.getFirstAssembly(Flags.SHIELD)
+            history._getBlockInAssembly(aShield)
+
 
 class TestHistoryTrackerNoModel(unittest.TestCase):
     """History tracker tests that do not require a Reactor Model."""

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -183,8 +183,6 @@ class TestHistoryTracker(ArmiTestHelper):
         shutil.move(fileName, os.path.join(THIS_DIR, fileName))
 
         self.compareFilesLineByLine(expectedFileName, actualFilePath)
-        # clean file created at interactEOL
-        os.remove("armiRun.locationHistory.txt")
 
         # test that detailAssemblyNames() is working
         self.assertEqual(len(history.detailAssemblyNames), 1)

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -19,27 +19,27 @@ These tests actually run a jupyter notebook that's in the documentation to build
 a valid HDF5 file to load from as a test fixtures. Thus they take a little longer
 than usual.
 """
-import unittest
 import os
 import pathlib
 import shutil
+import unittest
 
-from armi.context import ROOT
 from armi import init as armi_init
+from armi import settings
 from armi import utils
 from armi.bookkeeping import historyTracker
-from armi.reactor import blocks
-from armi.reactor.flags import Flags
-from armi import settings
-from armi.utils import directoryChangers
-from armi.reactor import grids
-from armi.cases import case
-from armi.tests import ArmiTestHelper
 from armi.bookkeeping.tests._constants import TUTORIAL_FILES
+from armi.cases import case
+from armi.context import ROOT
+from armi.reactor import blocks
+from armi.reactor import grids
+from armi.reactor.flags import Flags
+from armi.tests import ArmiTestHelper
+from armi.utils import directoryChangers
 
+CASE_TITLE = "anl-afci-177"
 THIS_DIR = os.path.dirname(__file__)  # b/c tests don't run in this folder
 TUTORIAL_DIR = os.path.join(ROOT, "tests", "tutorials")
-CASE_TITLE = "anl-afci-177"
 
 
 def runTutorialNotebook():
@@ -161,6 +161,11 @@ class TestHistoryTracker(ArmiTestHelper):
                 mgFluence += timeInSec * mgFlux
 
         self.assertTrue(len(mgFluence) > 1, "mgFluence should have more than 1 group")
+
+        # test that unloadBlockHistoryVals() is working
+        self.assertIsNotNone(hti._preloadedBlockHistory)
+        hti.unloadBlockHistoryVals()
+        self.assertIsNone(hti._preloadedBlockHistory)
 
     def test_historyReport(self):
         """

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -151,9 +151,8 @@ class TestHistoryTracker(ArmiTestHelper):
         mgFluence = None
         for ts, years in enumerate(timesInYears):
             cycle, node = utils.getCycleNodeFromCumulativeNode(ts, self.o.cs)
-            mgFlux = (
-                hti.getBlockHistoryVal(bName, "mgFlux", (cycle, node)) / bVolume
-            )  #  b.p.mgFlux is vol integrated
+            #  b.p.mgFlux is vol integrated
+            mgFlux = hti.getBlockHistoryVal(bName, "mgFlux", (cycle, node)) / bVolume
             timeInSec = years * 365 * 24 * 3600
             if mgFluence is None:
                 mgFluence = timeInSec * mgFlux

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -256,7 +256,6 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
         ValueError
             If neither name nor specifier are passed
 
-
         Notes
         -----
         There is some possibility for "compiling" the logic with closures to make
@@ -344,7 +343,6 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
         :py:meth:`Component construction <armi.reactor.blueprints.componentBlueprint.
         ComponentBlueprint._constructMaterial>`.
         """
-
         from armi import utils
 
         actives = set()

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -254,7 +254,6 @@ class BoundaryType(enum.Enum):
     @property
     def label(self):
         """Human-presentable label"""
-
         if self == self.NO_SYMMETRY:
             return "No Symmetry"
         elif self == self.REFLECTIVE:

--- a/pylintrc
+++ b/pylintrc
@@ -23,6 +23,7 @@
 # invalid-name: frequently, scientifically-meaningful names do not apply to these rules
 # line-too-long: we rely on black to handle this
 # logging-format-interpolation: this rule seems arbitrary and useless
+# unnecessary-pass: We actually like these, particularly for abstract classes.
 disable =
     bad-whitespace,
     trailing-whitespace,
@@ -47,7 +48,8 @@ disable =
     duplicate-code,
     invalid-name,
     line-too-long,
-    logging-format-interpolation
+    logging-format-interpolation,
+    unnecessary-pass
 
 [BASIC]
 dummy-variables-rgx=_[a-zA-Z_]*


### PR DESCRIPTION
## Description

The code coverage for the `HistoryTrackerInterface` was really low, so I added some unit tests.  

While working on that, I also found that:

* The method `printFullCoreLocations()` has never worked, and just created an empty file.
* The method `_blockLocationAtTimenode()` hasn't worked in years, and that was actually stated in its docstring.
* The class `AssemblyHistory(HistoryFile)` hasn't worked in years either.

So this PR _does_ improve code coverage, but the most substantial changes are definitely removing the broken code.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
