### PR TITLE
Clean up axial expansion in core.processLoading for DB load

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1227,7 +1227,7 @@ class Database3(database.Database):
             # We only have a good geom for the main core, so can't do process loading on
             # the SFP, etc.
             if comp.hasFlags(Flags.CORE):
-                comp.processLoading(cs)
+                comp.processLoading(cs, dbLoad=True)
         elif isinstance(comp, Assembly):
             comp.calculateZCoords()
 

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -246,7 +246,7 @@ class AxialExpansionChanger:
             self.expansionData.computeThermalExpansionFactors()
             self.axiallyExpandAssembly()
 
-        self._manageCoreMesh(r)
+        self.manageCoreMesh(r)
 
     def axiallyExpandCorePercent(self, r, components, percents):
         """
@@ -268,9 +268,9 @@ class AxialExpansionChanger:
             self.expansionData.setExpansionFactors(components[a], percents[a])
             self.axiallyExpandAssembly()
 
-        self._manageCoreMesh(r)
+        self.manageCoreMesh(r)
 
-    def _manageCoreMesh(self, r):
+    def manageCoreMesh(self, r):
         """
         manage core mesh post assembly-level expansion
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -620,13 +620,13 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             {"inputHeightsConsideredHot": True},
         )
-        self.stdAssems = [a for a in r.core.getAssemblies(includeAll=True)]
+        self.stdAssems = [a for a in r.core.getAssemblies()]
 
         _oCold, rCold = loadTestReactor(
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             {"inputHeightsConsideredHot": False},
         )
-        self.testAssems = [a for a in rCold.core.getAssemblies(includeAll=True)]
+        self.testAssems = [a for a in rCold.core.getAssemblies()]
 
     def test_coldAssemblyHeight(self):
         """block heights are cold and should be expanded

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2236,17 +2236,6 @@ class Core(composites.Composite):
         updateAxialMesh : Perturbs the axial mesh originally set up here.
 
         """
-        if not cs["inputHeightsConsideredHot"]:
-            runLog.header(
-                "=========== Axially expanding all (except control) assemblies from Tinput to Thot ==========="
-            )
-            axialExpChngr = AxialExpansionChanger(cs["detailedAxialExpansion"])
-            for a in self.getAssemblies(includeAll=True):
-                if not a.hasFlags(Flags.CONTROL):
-                    axialExpChngr.setAssembly(a)
-                    axialExpChngr.expansionData.computeThermalExpansionFactors()
-                    axialExpChngr.axiallyExpandAssembly(thermal=True)
-
         runLog.header(
             "=========== Initializing Mesh, Assembly Zones, and Nuclide Categories =========== "
         )
@@ -2299,6 +2288,18 @@ class Core(composites.Composite):
             for a in self.parent.blueprints.assemblies.values():
                 a.makeAxialSnapList(refAssem=finestMeshA)
 
+        if not cs["inputHeightsConsideredHot"]:
+            runLog.header(
+                "=========== Axially expanding all (except control) assemblies from Tinput to Thot ==========="
+            )
+            axialExpChngr = AxialExpansionChanger(cs["detailedAxialExpansion"])
+            for a in self.getAssemblies():
+                if not a.hasFlags(Flags.CONTROL):
+                    axialExpChngr.setAssembly(a)
+                    axialExpChngr.expansionData.computeThermalExpansionFactors()
+                    axialExpChngr.axiallyExpandAssembly(thermal=True)
+            axialExpChngr._manageCoreMesh(self.parent)
+        
         self.numRings = self.getNumRings()  # TODO: why needed?
 
         self.getNuclideCategories()

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2251,25 +2251,17 @@ class Core(composites.Composite):
                 "Please make sure that this is intended and not a input error."
             )
 
-        # TODO: There is an inconsistency with makeAxialSnapList when detailedAxialExpansion: False
-        # In a standard run from the blueprints:
-        #     - All assemblies (blueprints included) have their b.p.topIndex
-        #       set in reference to self.refAssem.getAxialMesh().
-        # In a database load run:
-        #     - All assemblies in the core have their b.p.topIndex as set in the standard run.
-        #     - The blueprints assemblies have the b.p.topIndex set in reference to the assembly with the finest mesh.
-        #       This guarantees functionality of makeAxialSnapList, but, if the assembly with the finest mesh is
-        #       not a fuel assembly, assembly.setBlockMesh may produce unexpected results.
         if dbLoad:
             # reactor.blueprints.assemblies need to be populated
-            # this normally happens during armi/reactor/blueprints/__init__.py::_prepConstruction
+            # this normally happens during armi/reactor/blueprints/__init__.py::constructAssem
             # but for DB load, this is not called so it must be here.
             # pylint: disable=protected-access
             self.parent.blueprints._prepConstruction(cs)
             if not cs["detailedAxialExpansion"]:
                 # Apply mesh snapping for self.parent.blueprints.assemblies
-                # To guarantee mesh snapping will function, makeAxialSnapList should be in reference
-                # to the assembly with the finest mesh as defined in the blueprints.
+                # This is stored as a param for assemblies in-core, so only blueprints assemblies are
+                # considereed here. To guarantee mesh snapping will function, makeAxialSnapList
+                # should be in reference to the assembly with the finest mesh as defined in the blueprints.
                 finestAssemblyMesh = sorted(
                     self.parent.blueprints.assemblies.values(),
                     key=lambda a: len(a),
@@ -2298,7 +2290,7 @@ class Core(composites.Composite):
                         axialExpChngr.setAssembly(a)
                         axialExpChngr.expansionData.computeThermalExpansionFactors()
                         axialExpChngr.axiallyExpandAssembly(thermal=True)
-                axialExpChngr._manageCoreMesh(self.parent)
+                axialExpChngr.manageCoreMesh(self.parent)
 
         self.numRings = self.getNumRings()  # TODO: why needed?
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2286,7 +2286,7 @@ class Core(composites.Composite):
             if not cs["detailedAxialExpansion"]:
                 # prepare core for mesh snapping during axial expansion
                 for a in self.getAssemblies(includeAll=True):
-                    a.makeAxialSnapList()
+                    a.makeAxialSnapList(self.refAssem)
 
             if not cs["inputHeightsConsideredHot"]:
                 runLog.header(

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -37,6 +37,7 @@ Bug fixes
 #. Remove ``copy.deepcopy`` from ``armi/reactor/converters/uniformMesh.py``
 #. Clarify docstring for ``armi/reactor/components/complexShapes.py::Helix``
 #. Bug fix in ``armi/reactor/components/complexShapes.py::Helix::getCircleInnerDiameter``
+#. Fixed issue with axial expansion changer and axial meshing in ``armi/reactor/reactors.py::Core::processLoading``.
 #. TBD
 
 


### PR DESCRIPTION
## Description
This addresses two bugs in `armi/reactor/reactors.py::Core:processLoading`. 

1. When loading from a database the axial expansion changer would be instantiated every time `Core::processLoading` is called. It should only be called when processing blueprints at BOL of an ARMI run. 
      - This was fixed by adding an optional parameter to `Core::processLoading` to recognize if it is being called from a database load or from blueprints processing. 
3. Axial expansion of the assemblies at BOL was occurring too early. Axial expansion was occurring before `makeAxialSnapList` was called on each assembly so there was no way to unify the disjoint axial mesh after the expansion. This meant that `inputHeightsConsideredHot: False` could only be used with `detailedAxialExpansion: True`. 
      - This was fixed by simply moving the call to the axial expansion changer to after `makeAxialSnapList` is called. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

