### PR TITLE
Cleaning up UserPlugins

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -31,7 +31,6 @@ customizing much of the Framework's behavior.
 from typing import Dict, Optional, Tuple, List
 import collections
 import importlib
-import os
 import sys
 
 from armi import context, plugins, pluginManager, meta, settings
@@ -263,7 +262,7 @@ class App:
         self.__initNewPlugins()
 
         for pluginPath in pluginPaths:
-            if os.sep in pluginPath:
+            if ".py:" in pluginPath:
                 # The path is of the form: /path/to/why.py:MyPlugin
                 self.__registerUserPluginsAbsPath(pluginPath)
             else:
@@ -274,19 +273,11 @@ class App:
         """Helper method to register a single UserPlugin where
         the given path is of the form: /path/to/why.py:MyPlugin
         """
-        # determine if this is a Windows system
-        isWindows = False
-        if os.name == "nt":
-            isWindows = True
+        assert pluginPath.count(".py:") == 1, f"Invalid plugin path: {pluginPath}"
 
-        # handle the minor variations on Windows file pathing
-        if isWindows:
-            assert pluginPath.count(":") == 2, f"Invalid plugin path: {pluginPath}"
-            drive, filePath, className = pluginPath.split(":")
-            filePath = drive + ":" + filePath
-        else:
-            assert pluginPath.count(":") == 1, f"Invalid plugin path: {pluginPath}"
-            filePath, className = pluginPath.split(":")
+        # split the settings string into file path and class name
+        filePath, className = pluginPath.split(".py:")
+        filePath += ".py"
 
         spec = importlib.util.spec_from_file_location(className, filePath)
         mod = importlib.util.module_from_spec(spec)

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -88,7 +88,7 @@ class OperatorTests(unittest.TestCase):
         self.assertTrue(o.interfaceIsActive("main"))
         self.assertFalse(o.interfaceIsActive("Fake-o"))
 
-    def test_loadState(self):
+    def test_loadStateError(self):
         """The loadTestReactor() test tool does not have any history in the DB to load from"""
         o, _r = test_reactors.loadTestReactor()
 

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -53,11 +53,12 @@ class TestPlugin(unittest.TestCase):
         """Make sure that the exposeInterfaces hook is properly implemented"""
         if self.plugin is None:
             return
-        if not hasattr(self.plugin, "exposeInterfaces"):
-            return
 
         cs = settings.getMasterCs()
         results = self.plugin.exposeInterfaces(cs)
+        if results is None or not results:
+            return
+
         # each plugin should return a list
         self.assertIsInstance(results, list)
         for result in results:

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -34,12 +34,11 @@ from armi.tests import TEST_ROOT
 from armi.utils import directoryChangers
 
 
-HOOKSPEC = pluggy.HookspecMarker("armi")
-
-
 class UserPluginFlags(plugins.UserPlugin):
     """Simple UserPlugin that defines a single, new flag."""
 
+    @staticmethod
+    @plugins.HOOKIMPL
     def defineFlags():
         return {"SPECIAL": utils.flags.auto()}
 
@@ -47,6 +46,8 @@ class UserPluginFlags(plugins.UserPlugin):
 class UserPluginFlags2(plugins.UserPlugin):
     """Simple UserPlugin that defines a single, new flag."""
 
+    @staticmethod
+    @plugins.HOOKIMPL
     def defineFlags():
         return {"FLAG2": utils.flags.auto()}
 
@@ -54,6 +55,8 @@ class UserPluginFlags2(plugins.UserPlugin):
 class UserPluginFlags3(plugins.UserPlugin):
     """Simple UserPlugin that defines a single, new flag."""
 
+    @staticmethod
+    @plugins.HOOKIMPL
     def defineFlags():
         return {"FLAG3": utils.flags.auto()}
 
@@ -64,6 +67,8 @@ from armi import plugins
 from armi import utils
 
 class UserPluginFlags4(plugins.UserPlugin):
+    @staticmethod
+    @plugins.HOOKIMPL
     def defineFlags():
         return {"FLAG4": utils.flags.auto()}
 """
@@ -72,6 +77,8 @@ class UserPluginFlags4(plugins.UserPlugin):
 class UserPluginBadDefinesSettings(plugins.UserPlugin):
     """This is invalid/bad because it implements defineSettings()"""
 
+    @staticmethod
+    @plugins.HOOKIMPL
     def defineSettings():
         return [1, 2, 3]
 
@@ -79,6 +86,8 @@ class UserPluginBadDefinesSettings(plugins.UserPlugin):
 class UserPluginBadDefineParameterRenames(plugins.UserPlugin):
     """This is invalid/bad because it implements defineParameterRenames()"""
 
+    @staticmethod
+    @plugins.HOOKIMPL
     def defineParameterRenames():
         return {"oldType": "type"}
 
@@ -91,7 +100,7 @@ class UserPluginOnProcessCoreLoading(plugins.UserPlugin):
     """
 
     @staticmethod
-    @HOOKSPEC
+    @plugins.HOOKIMPL
     def onProcessCoreLoading(core, cs):
         blocks = core.getBlocks(Flags.FUEL)
         for b in blocks:

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -100,20 +100,7 @@ def isAccessible(path):
     path : str
         a directory or file
     """
-    if os.path.exists(path):
-        # This can potentially return a false positive in Python 2 if the path
-        # exists but the user does not have access. As a workaround, we attempt
-        # to list the contents of the containing directory, which will throw an
-        # OSError if the user doesn't have access.
-        try:
-            if not os.path.isdir(path):
-                path = os.path.dirname(path)
-            os.listdir(path)
-            return True
-        except OSError:
-            return False
-    else:
-        return False
+    return os.path.exists(path)
 
 
 def separateModuleAndAttribute(pathAttr):

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -17,6 +17,7 @@ Unit tests for pathTools.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import os
+import time
 import types
 import unittest
 
@@ -119,6 +120,29 @@ class PathToolsTests(unittest.TestCase):
             pathTools.cleanPath(dir3, mpiRank=0)
             context.waitAll()
             self.assertFalse(os.path.exists(dir3))
+
+    def test_isFilePathNewer(self):
+        with TemporaryDirectoryChanger():
+            path1 = "test_isFilePathNewer1.txt"
+            with open(path1, "w") as f1:
+                f1.write("test1")
+
+            time.sleep(1)
+
+            path2 = "test_isFilePathNewer2.txt"
+            with open(path2, "w") as f2:
+                f2.write("test2")
+
+            self.assertFalse(pathTools.isFilePathNewer(path1, path2))
+            self.assertTrue(pathTools.isFilePathNewer(path2, path1))
+
+    def test_isAccessible(self):
+        with TemporaryDirectoryChanger():
+            path1 = "test_isAccessible.txt"
+            with open(path1, "w") as f1:
+                f1.write("test")
+
+            self.assertTrue(pathTools.isAccessible(path1))
 
 
 if __name__ == "__main__":

--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -392,17 +392,15 @@ This can be done by sublassing :py:class:`armi.plugins.UserPlugin`:
 
     class UserPluginExample(plugins.UserPlugin):
         """
-        This plugin flex-tests the onProcessCoreLoading() hook,
-        and arbitrarily adds "1" to the height of every block,
-        after the DB is loaded.
+        This plugin flex-tests the onProcessCoreLoading() hook, and
+        arbitrarily adds "1" to the power ever each fuel block.
         """
 
         @staticmethod
-        @HOOKSPEC
+        @plugins.HOOKIMPL
         def onProcessCoreLoading(core, cs):
-            blocks = core.getBlocks(Flags.FUEL)
-            for b in blocks:
-                b.p.height += 1.0
+        for b in core.getBlocks(Flags.FUEL):
+            b.p.power += 1.0
 
 In most ways, ``UserPluginExample`` above is just a normal
 :py:class:`ArmiPlugin <armi.plugins.ArmiPlugin>`. You can implement any of the normal
@@ -424,7 +422,7 @@ file:
 
 .. code-block::
 
-  userPlugins::
+  userPlugins:
     - armi.tests.test_user_plugins.UserPlugin0
     - //path/to/my/pluginz.py:UserPlugin1
     - C:\\path\to\my\pluginZ.py:UserPlugin2


### PR DESCRIPTION
## Description

This PR is meant to fix some issues with `UserPlugin`s:

* In `armi/apps.py` there was a Windows Pathing bug.
* In `docs/` there were some typos to do with `UserPlugin`s.
* In `armi/tests/` there were some typos in the `UserPlugin` unit tests.

Because this PR removed code, the code coverage went down. So I added some unrelated code coverage to `HistoryTracker` and `pathTools`, just so the build would pass.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

