### PR TITLE
make test_getComponentArea more readable

### DIFF
--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -236,10 +236,11 @@ class TestUnshapedComponent(TestGeneralComponents):
         coldArea = coldComponent.getArea()
 
         self.assertGreater(thermalExpansionFactor, 1)
+        # thermalExpansionFactor accounts density being 3D while area is 2D
         self.assertAlmostEqual(
-            (coldDensity / hotDensity) / (thermalExpansionFactor * hotArea / coldArea),
-            1,
-        )  # account for density being 3D while area is 2D
+            (coldDensity * coldArea),
+            (thermalExpansionFactor * hotDensity * hotArea),
+        )
 
     def test_getBoundingCircleOuterDiameter(self):
         # a case without thermal expansion

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -236,7 +236,7 @@ class TestUnshapedComponent(TestGeneralComponents):
         coldArea = coldComponent.getArea()
 
         self.assertGreater(thermalExpansionFactor, 1)
-        # thermalExpansionFactor accounts density being 3D while area is 2D
+        # thermalExpansionFactor accounts for density being 3D while area is 2D
         self.assertAlmostEqual(
             (coldDensity * coldArea),
             (thermalExpansionFactor * hotDensity * hotArea),


### PR DESCRIPTION
## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

