### PR TITLE
Add try/except around unpackSpecialData

### DIFF
--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -47,6 +47,7 @@ from typing import Sequence, Optional, Pattern, Tuple
 import collections
 import os
 import re
+import traceback
 
 from tabulate import tabulate
 import h5py
@@ -359,9 +360,15 @@ def _diffSpecialData(
 
     if not attrsMatch:
         return
-
-    src = database3.unpackSpecialData(srcData[()], srcData.attrs, paramName)
-    ref = database3.unpackSpecialData(refData[()], refData.attrs, paramName)
+    try:
+        src = database3.unpackSpecialData(srcData[()], srcData.attrs, paramName)
+        ref = database3.unpackSpecialData(refData[()], refData.attrs, paramName)
+    except Exception:
+        runLog.error(
+            f"Unable to unpack special data for paramName {paramName}. "
+            f"{traceback.format_exc()}",
+        )
+        return
 
     diff = []
     for dSrc, dRef in zip(src.tolist(), ref.tolist()):

--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -360,6 +360,7 @@ def _diffSpecialData(
 
     if not attrsMatch:
         return
+
     try:
         src = database3.unpackSpecialData(srcData[()], srcData.attrs, paramName)
         ref = database3.unpackSpecialData(refData[()], refData.attrs, paramName)

--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -204,6 +204,22 @@ class TestCompareDB3(unittest.TestCase):
                 self.assertEqual(dr.nDiffs(), 0)
                 self.assertIn("Special formatting parameters for", mock._outputStream)
 
+            # make an H5 datasets that will cause unpackSpecialData to fail
+            f4 = h5py.File("test_diffSpecialData4.hdf5", "w")
+            refData4 = f4.create_dataset("numberDensities", data=a1)
+            refData4.attrs["shapes"] = "2"
+            refData4.attrs["numDens"] = a1
+            f5 = h5py.File("test_diffSpecialData5.hdf5", "w")
+            srcData5 = f5.create_dataset("numberDensities", data=a2)
+            srcData5.attrs["shapes"] = "2"
+            srcData5.attrs["numDens"] = a2
+
+            # there should a logged error, but no diff
+            with mockRunLogs.BufferLog() as mock:
+                _diffSpecialData(refData4, srcData5, out, dr)
+                self.assertEqual(dr.nDiffs(), 0)
+                self.assertIn("Special formatting parameters for", mock._outputStream)
+
     def test_diffSimpleData(self):
         dr = DiffResults(0.01)
 

--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -206,19 +206,18 @@ class TestCompareDB3(unittest.TestCase):
 
             # make an H5 datasets that will cause unpackSpecialData to fail
             f4 = h5py.File("test_diffSpecialData4.hdf5", "w")
-            refData4 = f4.create_dataset("numberDensities", data=a1)
+            refData4 = f4.create_dataset("numberDensities", data=a2)
             refData4.attrs["shapes"] = "2"
-            refData4.attrs["numDens"] = a1
+            refData4.attrs["numDens"] = a2
             f5 = h5py.File("test_diffSpecialData5.hdf5", "w")
             srcData5 = f5.create_dataset("numberDensities", data=a2)
             srcData5.attrs["shapes"] = "2"
             srcData5.attrs["numDens"] = a2
 
-            # there should a logged error, but no diff
-            with mockRunLogs.BufferLog() as mock:
+            # there should an exception
+            with self.assertRaises(Exception) as e:
                 _diffSpecialData(refData4, srcData5, out, dr)
-                self.assertEqual(dr.nDiffs(), 0)
-                self.assertIn("Special formatting parameters for", mock._outputStream)
+                self.assertIn("Unable to unpack special data for paramName", e)
 
     def test_diffSimpleData(self):
         dr = DiffResults(0.01)

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -21,6 +21,7 @@ What's new in ARMI
 #. Made the min/max temperatures of ``Material`` curves discoverable.
 #. Introduction of axial expansion changer to enable component-level axial expansion of assemblies.
 #. Add setting ``inputHeightsConsideredHot`` to enable thermal expansion of assemblies at BOL.
+#. Allow database comparison to continue even if ``unpackSpecialData`` fails. 
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

`compareDatabases` should be able to continue to run even if `unpackSpecialData` fails. 

Some parameters are not able to be compared, which in a recent scenario led to a failure inside `unpackSpecialData`. This PR adds the try/except so that there is just an error and not a failure, and it also adds a the traceback to the log printout so parameters that cause this step to fail can be more easily addressed / manually compared. 

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
