### PR TITLE
Fix `Block.getReactionRates()`

### DIFF
--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1217,7 +1217,8 @@ def getReactionRateDict(nucName, lib, xsType, mgFlux, nDens):
     Parameters
     ----------
     nucName - str
-        nuclide name -- e.g. 'U235'
+        nuclide name -- e.g. 'U235', 'PU239', etc. Not to be confused with the nuclide
+        _label_, see the nucDirectory module for a description of the difference.
     lib - isotxs
         cross section library
     xsType - str
@@ -1237,7 +1238,8 @@ def getReactionRateDict(nucName, lib, xsType, mgFlux, nDens):
     assume there is no n3n cross section in ISOTXS
 
     """
-    key = "{}{}A".format(nucName, xsType)
+    nucLabel = nuclideBases.byName[nucName].label
+    key = "{}{}A".format(nucLabel, xsType)
     libNuc = lib[key]
     rxnRates = {"n3n": 0}
     for rxName, mgXSs in [

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1555,6 +1555,29 @@ class Block_TestCase(unittest.TestCase):
         hasPitch = self.block.hasPinPitch()
         self.assertTrue(hasPitch)
 
+    def test_getReactionRates(self):
+        block = blocks.HexBlock("HexBlock")
+        block.setType("defaultType")
+        comp = components.basicShapes.Hexagon("hexagon", "MOX", 1, 1, 1)
+        block.add(comp)
+        block.setHeight(1)
+        block.p.xsType = "A"
+
+        r = tests.getEmptyHexReactor()
+        assembly = makeTestAssembly(1, 1, r=r)
+        assembly.add(block)
+        r.core.add(assembly)
+        r.core.lib = isotxs.readBinary(ISOAA_PATH)
+        block.p.mgFlux = 1
+
+        self.assertEqual(
+            block.getReactionRates("PU239")["nG"],
+            block.getNumberDensity("PU239") * sum(r.core.lib["PU39AA"].micros.nGamma),
+        )
+
+        with self.assertRaises(KeyError):
+            block.getReactionRates("PU39")
+
 
 class Test_NegativeVolume(unittest.TestCase):
     def test_negativeVolume(self):

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -20,6 +20,7 @@ import copy
 import math
 import unittest
 
+from armi import nuclearDataIO
 from armi.reactor import components
 from armi.reactor.components import (
     Component,
@@ -45,6 +46,8 @@ from armi.reactor.components import (
     ComponentType,
 )
 from armi.reactor.components import materials
+from armi.reactor.components.component import getReactionRateDict
+from armi.tests import ISOAA_PATH
 from armi.utils import units
 
 
@@ -1248,6 +1251,15 @@ class TestMaterialAdjustments(unittest.TestCase):
     def test_getEnrichment(self):
         self.fuel.adjustMassEnrichment(0.3)
         self.assertAlmostEqual(self.fuel.getEnrichment(), 0.3)
+
+
+class TestGetReactionRateDict(unittest.TestCase):
+    def test_getReactionRateDict(self):
+        lib = nuclearDataIO.isotxs.readBinary(ISOAA_PATH)
+        rxRatesDict = getReactionRateDict(
+            nucName="PU239", lib=lib, xsType="A", mgFlux=1, nDens=1
+        )
+        self.assertEqual(rxRatesDict["nG"], sum(lib["PU39AA"].micros.nGamma))
 
 
 if __name__ == "__main__":

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -38,6 +38,7 @@ Bug fixes
 #. Clarify docstring for ``armi/reactor/components/complexShapes.py::Helix``
 #. Bug fix in ``armi/reactor/components/complexShapes.py::Helix::getCircleInnerDiameter``
 #. Bug fix in ``armi/cases/case.py::copyInterfaceInputs``
+#. Bug fix in ``armi/reactor/components/component.py::getReac``
 #. TBD
 
 


### PR DESCRIPTION
## Description

This PR fixes the `Block.getReactionRates()` method by switching to the correct key when looking up isotope cross-sections from the ISOTXS file. It also adds tests to prove that it is now working.

This is in response to #808 .

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

