### PR TITLE
Improved Code Coverage Database3

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1307,8 +1307,7 @@ class Database3(database.Database):
                 # flatten, store the data offsets and array shapes, and None locations
                 # as attrs
                 # - If not jagged, all top-level ndarrays are the same shape, so it is
-                # probably easier to replace Nones with ndarrays filled with special
-                # values.
+                # easier to replace Nones with ndarrays filled with special values.
                 if parameters.NoDefault in data:
                     data = None
                 else:

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -22,6 +22,7 @@ import numpy
 
 from armi.bookkeeping.db import database3
 from armi.reactor import grids
+from armi.reactor import parameters
 from armi.reactor.tests import test_reactors
 from armi.tests import TEST_ROOT
 from armi.utils import getPreviousTimeNode
@@ -49,6 +50,38 @@ class TestDatabase3(unittest.TestCase):
         self.db.close()
         self.stateRetainer.__exit__()
         self.td.__exit__(None, None, None)
+
+    def test_writeToDB(self):
+        self.r.p.cycle = 0
+        self.r.p.timeNode = 0
+        self.r.p.cycleLength = 0
+
+        # Adding some nonsense in, to test NoDefault params
+        self.r.p.availabilityFactor = parameters.NoDefault
+
+        # validate that the H5 file gets bigger after the write
+        self.assertEqual(list(self.db.h5db.keys()), ["inputs"])
+        self.db.writeToDB(self.r)
+        self.assertEqual(sorted(self.db.h5db.keys()), ["c00n00", "inputs"])
+
+        keys = [
+            "Circle",
+            "Core",
+            "DerivedShape",
+            "Helix",
+            "HexAssembly",
+            "HexBlock",
+            "Hexagon",
+            "Reactor",
+            "layout",
+        ]
+        self.assertEqual(sorted(self.db.h5db["c00n00"].keys()), sorted(keys))
+
+        # validate availabilityFactor did not make it into the H5 file
+        rKeys = ["cycle", "cycleLength", "flags", "serialNum", "timeNode"]
+        self.assertEqual(
+            sorted(self.db.h5db["c00n00"]["Reactor"].keys()), sorted(rKeys)
+        )
 
     def makeHistory(self):
         """Walk the reactor through a few time steps and write them to the db."""

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -14,13 +14,14 @@
 
 r""" Tests for the Database3 class
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import subprocess
 import unittest
 
 import h5py
 import numpy
 
-from armi.bookkeeping.db import database3
+from armi.bookkeeping.db import _getH5File, database3
 from armi.reactor import grids
 from armi.reactor import parameters
 from armi.reactor.tests import test_reactors
@@ -82,6 +83,13 @@ class TestDatabase3(unittest.TestCase):
         self.assertEqual(
             sorted(self.db.h5db["c00n00"]["Reactor"].keys()), sorted(rKeys)
         )
+
+    def test_getH5File(self):
+        with self.assertRaises(TypeError):
+            _getH5File(None)
+
+        h5 = _getH5File(self.db)
+        self.assertEqual(type(h5), h5py.File)
 
     def makeHistory(self):
         """Walk the reactor through a few time steps and write them to the db."""

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -43,58 +43,64 @@ class TestPlotting(unittest.TestCase):
         cls.o, cls.r = test_reactors.loadTestReactor()
 
     def test_plotDepthMap(self):  # indirectly tests plot face map
-        # set some params to visualize
-        for i, b in enumerate(self.o.r.core.getBlocks()):
-            b.p.percentBu = i / 100
-        fName = plotting.plotBlockDepthMap(
-            self.r.core, param="percentBu", fName="depthMapPlot.png", depthIndex=2
-        )
-        self._checkExists(fName)
+        with TemporaryDirectoryChanger():
+            # set some params to visualize
+            for i, b in enumerate(self.o.r.core.getBlocks()):
+                b.p.percentBu = i / 100
+            fName = plotting.plotBlockDepthMap(
+                self.r.core, param="percentBu", fName="depthMapPlot.png", depthIndex=2
+            )
+            self._checkExists(fName)
 
     def test_plotAssemblyTypes(self):
-        plotPath = "coreAssemblyTypes1.png"
-        plotting.plotAssemblyTypes(self.r.core.parent.blueprints, plotPath)
-        self._checkExists(plotPath)
+        with TemporaryDirectoryChanger():
+            plotPath = "coreAssemblyTypes1.png"
+            plotting.plotAssemblyTypes(self.r.core.parent.blueprints, plotPath)
+            self._checkExists(plotPath)
 
-        plotPath = "coreAssemblyTypes2.png"
-        plotting.plotAssemblyTypes(
-            self.r.core.parent.blueprints, plotPath, yAxisLabel="y axis", title="title"
-        )
-        self._checkExists(plotPath)
+            plotPath = "coreAssemblyTypes2.png"
+            plotting.plotAssemblyTypes(
+                self.r.core.parent.blueprints,
+                plotPath,
+                yAxisLabel="y axis",
+                title="title",
+            )
+            self._checkExists(plotPath)
 
-        with self.assertRaises(ValueError):
-            plotting.plotAssemblyTypes(None, plotPath, None)
+            with self.assertRaises(ValueError):
+                plotting.plotAssemblyTypes(None, plotPath, None)
 
     def test_plotBlockFlux(self):
-        try:
-            xslib = isotxs.readBinary(ISOAA_PATH)
-            self.r.core.lib = xslib
+        with TemporaryDirectoryChanger():
+            try:
+                xslib = isotxs.readBinary(ISOAA_PATH)
+                self.r.core.lib = xslib
 
-            blockList = self.r.core.getBlocks()
-            for _, b in enumerate(blockList):
-                b.p.mgFlux = range(33)
+                blockList = self.r.core.getBlocks()
+                for _, b in enumerate(blockList):
+                    b.p.mgFlux = range(33)
 
-            plotting.plotBlockFlux(self.r.core, fName="flux.png", bList=blockList)
-            self.assertTrue(os.path.exists("flux.png"))
-            plotting.plotBlockFlux(
-                self.r.core, fName="peak.png", bList=blockList, peak=True
-            )
-            self.assertTrue(os.path.exists("peak.png"))
-            plotting.plotBlockFlux(
-                self.r.core,
-                fName="bList2.png",
-                bList=blockList,
-                bList2=blockList,
-            )
-            self.assertTrue(os.path.exists("bList2.png"))
-            # can't test adjoint at the moment, testBlock doesn't like to .getMgFlux(adjoint=True)
-        finally:
-            os.remove("flux.txt")  # secondarily created during the call.
-            os.remove("flux.png")  # created during the call.
-            os.remove("peak.txt")  # csecondarily reated during the call.
-            os.remove("peak.png")  # created during the call.
-            os.remove("bList2.txt")  # secondarily created during the call.
-            os.remove("bList2.png")  # created during the call.
+                plotting.plotBlockFlux(self.r.core, fName="flux.png", bList=blockList)
+                self.assertTrue(os.path.exists("flux.png"))
+                plotting.plotBlockFlux(
+                    self.r.core, fName="peak.png", bList=blockList, peak=True
+                )
+                self.assertTrue(os.path.exists("peak.png"))
+                plotting.plotBlockFlux(
+                    self.r.core,
+                    fName="bList2.png",
+                    bList=blockList,
+                    bList2=blockList,
+                )
+                self.assertTrue(os.path.exists("bList2.png"))
+                # can't test adjoint at the moment, testBlock doesn't like to .getMgFlux(adjoint=True)
+            finally:
+                os.remove("flux.txt")  # secondarily created during the call.
+                os.remove("flux.png")  # created during the call.
+                os.remove("peak.txt")  # csecondarily reated during the call.
+                os.remove("peak.png")  # created during the call.
+                os.remove("bList2.txt")  # secondarily created during the call.
+                os.remove("bList2.png")  # created during the call.
 
     def test_plotHexBlock(self):
         with TemporaryDirectoryChanger():

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -72,35 +72,26 @@ class TestPlotting(unittest.TestCase):
 
     def test_plotBlockFlux(self):
         with TemporaryDirectoryChanger():
-            try:
-                xslib = isotxs.readBinary(ISOAA_PATH)
-                self.r.core.lib = xslib
+            xslib = isotxs.readBinary(ISOAA_PATH)
+            self.r.core.lib = xslib
 
-                blockList = self.r.core.getBlocks()
-                for _, b in enumerate(blockList):
-                    b.p.mgFlux = range(33)
+            blockList = self.r.core.getBlocks()
+            for _, b in enumerate(blockList):
+                b.p.mgFlux = range(33)
 
-                plotting.plotBlockFlux(self.r.core, fName="flux.png", bList=blockList)
-                self.assertTrue(os.path.exists("flux.png"))
-                plotting.plotBlockFlux(
-                    self.r.core, fName="peak.png", bList=blockList, peak=True
-                )
-                self.assertTrue(os.path.exists("peak.png"))
-                plotting.plotBlockFlux(
-                    self.r.core,
-                    fName="bList2.png",
-                    bList=blockList,
-                    bList2=blockList,
-                )
-                self.assertTrue(os.path.exists("bList2.png"))
-                # can't test adjoint at the moment, testBlock doesn't like to .getMgFlux(adjoint=True)
-            finally:
-                os.remove("flux.txt")  # secondarily created during the call.
-                os.remove("flux.png")  # created during the call.
-                os.remove("peak.txt")  # csecondarily reated during the call.
-                os.remove("peak.png")  # created during the call.
-                os.remove("bList2.txt")  # secondarily created during the call.
-                os.remove("bList2.png")  # created during the call.
+            plotting.plotBlockFlux(self.r.core, fName="flux.png", bList=blockList)
+            self.assertTrue(os.path.exists("flux.png"))
+            plotting.plotBlockFlux(
+                self.r.core, fName="peak.png", bList=blockList, peak=True
+            )
+            self.assertTrue(os.path.exists("peak.png"))
+            plotting.plotBlockFlux(
+                self.r.core,
+                fName="bList2.png",
+                bList=blockList,
+                bList2=blockList,
+            )
+            self.assertTrue(os.path.exists("bList2.png"))
 
     def test_plotHexBlock(self):
         with TemporaryDirectoryChanger():
@@ -129,8 +120,6 @@ class TestPlotting(unittest.TestCase):
 
     def _checkExists(self, fName):
         self.assertTrue(os.path.exists(fName))
-        if self.removeFiles:
-            os.remove(fName)
 
 
 if __name__ == "__main__":

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -35,9 +35,6 @@ class TestPlotting(unittest.TestCase):
     demonstrate how they are meant to be called.
     """
 
-    # Change to False when you want to inspect the plots. Change back please.
-    removeFiles = True
-
     @classmethod
     def setUpClass(cls):
         cls.o, cls.r = test_reactors.loadTestReactor()


### PR DESCRIPTION
## Description

We have been having some code coverage spray, in that certain lines in our code are covered (or not) semi-randomly when the unit tests are run.  

That makes trusting our code coverage for a given PR harder.

So, I am permanently adding some code coverage to one such offending line (I think, perhaps, the last such line in our test):

https://coveralls.io/builds/51401612/source?filename=armi%2Fbookkeeping%2Fdb%2Fdatabase3.py#L1313

**EDIT**: I also threw in some extra code coverage and test cleanup in this PR. Sorry. The purpose of this PR is still to fix the spray on that one line above, but since I was already in the tests, I couldn't help myself.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.

