### PR TITLE
rewrite of copyInterfaceInputs

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -853,7 +853,7 @@ def copyInterfaceInputs(
                             f"with a glob of `{sourceFullPath}`. Will not update "
                             f"`{label}`."
                         )
-                        newFiles.append(f)  # pass?
+                        newFiles.append(f)
                     else:
                         for gFile in globFilePaths:
                             destFilePath = copyInputsHelper(
@@ -871,6 +871,7 @@ def copyInterfaceInputs(
                         f"the following path: `{sourceFullPath}`. Will not update "
                         f"`{label}`."
                     )
+
             # Some settings are a single filename. Others are lists of files. Make
             # sure we are returning what the setting expects
             if len(files) == 1 and not WILDCARD:

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -715,7 +715,7 @@ class Case:
             self.cs.writeToYamlFile(self.title + ".yaml")
 
 
-def copyInputsHelper(
+def _copyInputsHelper(
     fileDescription: str,
     sourcePath: str,
     destPath: str,
@@ -856,12 +856,12 @@ def copyInterfaceInputs(
                         newFiles.append(f)
                     else:
                         for gFile in globFilePaths:
-                            destFilePath = copyInputsHelper(
+                            destFilePath = _copyInputsHelper(
                                 label, gFile, destination, f
                             )
                             newFiles.append(str(destFilePath))
                 else:
-                    destFilePath = copyInputsHelper(
+                    destFilePath = _copyInputsHelper(
                         label, sourceFullPath, destination, f
                     )
                     newFiles.append(str(destFilePath))

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -848,11 +848,6 @@ def copyInterfaceInputs(
                         for g in glob.glob(sourceFullPath)
                     ]
                     if len(globFilePaths) == 0:
-                        runLog.info(
-                            f"No input files for `{label}` setting could be resolved "
-                            f"with a glob of `{sourceFullPath}`. Will not update "
-                            f"`{label}`."
-                        )
                         destFilePath = f
                         newFiles.append(str(destFilePath))
                     else:

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -833,7 +833,7 @@ def copyInterfaceInputs(
                     RELATIVE = True
 
                 path = pathlib.Path(f)
-                if WILDCARD == False and RELATIVE == False:
+                if not WILDCARD and not RELATIVE:
                     try:
                         if path.is_absolute() and path.exists() and path.is_file():
                             # Path is absolute, no settings modification or filecopy needed
@@ -842,7 +842,7 @@ def copyInterfaceInputs(
                         pass
                 # Attempt to construct an absolute file path
                 sourceFullPath = os.path.join(sourceDirPath, f)
-                if WILDCARD == True:
+                if WILDCARD:
                     globFilePaths = [
                         pathlib.Path(os.path.join(sourceDirPath, g))
                         for g in glob.glob(sourceFullPath)

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -829,7 +829,7 @@ def copyInterfaceInputs(
                     # Attempt to find relative path file
                     sourceFullString = os.path.join(sourceDirPath, f)
                     sourceFullPath = pathlib.Path(sourceFullString)
-                    if not os.path.exists(sourceFullPath):
+                    if not sourceFullPath.exists():
                         runLog.extra(
                             f"Input file for `{label}` setting could not be resolved "
                             f"with the following file path: `{sourceFullPath}`. Checking "
@@ -849,9 +849,11 @@ def copyInterfaceInputs(
                     # Finally, copy + update settings according to file path type
                     if not globFilePaths:
                         destFilePath = copyInputsHelper(label, sourceFullPath, destPath)
-                        # Some settings are a single filename. Others are lists of files.
-                        # Either overwrite the empty list at the top of the loop, or
-                        # append to it.
+                        if not pathlib.Path(destFilePath).exists():
+                            destFilePath = f
+                        # Some settings are a single filename. Others are lists of
+                        # files. Either overwrite the empty list at the top of the
+                        # loop, or append to it.
                         if len(files) == 1:
                             newSettings[label] = str(destFilePath)
                         else:
@@ -859,6 +861,8 @@ def copyInterfaceInputs(
                     else:
                         for gFile in globFilePaths:
                             destFilePath = copyInputsHelper(label, gFile, destPath)
+                            if not pathlib.Path(destFilePath).exists():
+                                destFilePath = f
                             newSettings[label].append(str(destFilePath))
 
     return newSettings

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -853,7 +853,8 @@ def copyInterfaceInputs(
                             f"with a glob of `{sourceFullPath}`. Will not update "
                             f"`{label}`."
                         )
-                        newFiles.append(f)
+                        destFilePath = f
+                        newFiles.append(str(destFilePath))
                     else:
                         for gFile in globFilePaths:
                             destFilePath = _copyInputsHelper(

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -20,7 +20,6 @@ import io
 import os
 import platform
 import unittest
-import pathlib
 
 from armi import cases
 from armi import context

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -362,16 +362,6 @@ class TestCopyInterfaceInputs(unittest.TestCase):
                 origFile=shuffleFile,
             )
             self.assertEqual(destFilePath, shuffleFile)
-            # Now try for the exception with a bad file
-            self.assertRaises(
-                Exception,
-                cases.case._copyInputsHelper(
-                    testSetting,
-                    sourcePath="fakeFile.py",
-                    destPath="",
-                    origFile=shuffleFile,
-                ),
-            )
 
     def test_copyInterfaceInputs_singleFile(self):
         testSetting = "shuffleLogic"
@@ -394,10 +384,10 @@ class TestCopyInterfaceInputs(unittest.TestCase):
 
         # ensure we are not in TEST_ROOT
         with directoryChangers.TemporaryDirectoryChanger() as newDir:
-            self.assertRaises(
-                Exception,
-                cases.case.copyInterfaceInputs(cs, destination=newDir.destination),
+            newSettings = cases.case.copyInterfaceInputs(
+                cs, destination=newDir.destination
             )
+            self.assertEqual(newSettings[testSetting], fakeShuffle)
 
     def test_copyInterfaceInputs_multipleFiles(self):
         # register the new Plugin
@@ -439,6 +429,30 @@ class TestCopyInterfaceInputs(unittest.TestCase):
                 cs, destination=newDir.destination
             )
             newFilepath = [os.path.join(newDir.destination, "ISOAA")]
+            self.assertEqual(newSettings[testSetting], newFilepath)
+
+        # Check on a file that doesn't exist (so globFilePaths len is 0)
+        wcFile = "fakeFile*"
+        cs = cs.modified(newSettings={testSetting: wcFile})
+        with directoryChangers.TemporaryDirectoryChanger() as newDir:
+            newSettings = cases.case.copyInterfaceInputs(
+                cs, destination=newDir.destination
+            )
+            self.assertEqual(newSettings[testSetting], [wcFile])
+
+    def test_copyInterfaceInputs_relPath(self):
+        testSetting = "shuffleLogic"
+        cs = settings.Settings(ARMI_RUN_PATH)
+        shuffleFile = cs[testSetting]
+        relFile = "../tests/" + shuffleFile
+        cs = cs.modified(newSettings={testSetting: relFile})
+
+        # ensure we are not in TEST_ROOT
+        with directoryChangers.TemporaryDirectoryChanger() as newDir:
+            newSettings = cases.case.copyInterfaceInputs(
+                cs, destination=newDir.destination
+            )
+            newFilepath = os.path.join(newDir.destination, shuffleFile)
             self.assertEqual(newSettings[testSetting], newFilepath)
 
 

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -20,6 +20,7 @@ import io
 import os
 import platform
 import unittest
+import pathlib
 
 from armi import cases
 from armi import context
@@ -338,7 +339,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
         cs = settings.Settings(ARMI_RUN_PATH)
         shuffleFile = cs[testSetting]
 
-        # test with full filepath too
+        # test it passes
         sourceFullPath = os.path.join(TEST_ROOT, shuffleFile)
         # ensure we are not in TEST_ROOT
         with directoryChangers.TemporaryDirectoryChanger() as newDir:
@@ -354,14 +355,23 @@ class TestCopyInterfaceInputs(unittest.TestCase):
         # test with bad file path, should return original file
         # ensure we are not in TEST_ROOT
         with directoryChangers.TemporaryDirectoryChanger() as newDir:
-            with self.assertRaises(Exception):
-                destFilePath = cases.case._copyInputsHelper(
+            destFilePath = cases.case._copyInputsHelper(
+                testSetting,
+                sourcePath=sourceFullPath,
+                destPath="",
+                origFile=shuffleFile,
+            )
+            self.assertEqual(destFilePath, shuffleFile)
+            # Now try for the exception with a bad file
+            self.assertRaises(
+                Exception,
+                cases.case._copyInputsHelper(
                     testSetting,
-                    sourcePath=sourceFullPath,
+                    sourcePath="fakeFile.py",
                     destPath="",
                     origFile=shuffleFile,
-                )
-                self.assertEqual(destFilePath, shuffleFile)
+                ),
+            )
 
     def test_copyInterfaceInputs_singleFile(self):
         testSetting = "shuffleLogic"

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -342,7 +342,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
         sourceFullPath = os.path.join(TEST_ROOT, shuffleFile)
         # ensure we are not in TEST_ROOT
         with directoryChangers.TemporaryDirectoryChanger() as newDir:
-            destFilePath = cases.case.copyInputsHelper(
+            destFilePath = cases.case._copyInputsHelper(
                 testSetting,
                 sourcePath=sourceFullPath,
                 destPath=newDir.destination,
@@ -355,10 +355,10 @@ class TestCopyInterfaceInputs(unittest.TestCase):
         # ensure we are not in TEST_ROOT
         with directoryChangers.TemporaryDirectoryChanger() as newDir:
             with self.assertRaises(Exception):
-                destFilePath = cases.case.copyInputsHelper(
+                destFilePath = cases.case._copyInputsHelper(
                     testSetting,
                     sourcePath=sourceFullPath,
-                    destPath=pathlib.Path(""),
+                    destPath="",
                     origFile=shuffleFile,
                 )
                 self.assertEqual(destFilePath, shuffleFile)

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -18,7 +18,6 @@ Unit tests for Case and CaseSuite objects
 import copy
 import io
 import os
-import pathlib
 import platform
 import unittest
 
@@ -339,29 +338,30 @@ class TestCopyInterfaceInputs(unittest.TestCase):
         cs = settings.Settings(ARMI_RUN_PATH)
         shuffleFile = cs[testSetting]
 
-        # ensure we are not in TEST_ROOT
-        with directoryChangers.TemporaryDirectoryChanger() as newDir:
-            # null case, give it just the base of shuffleFile
-            destFilePath = cases.case.copyInputsHelper(
-                testSetting,
-                fileFullPath=pathlib.Path(shuffleFile),
-                destPath=pathlib.Path(newDir.destination),
-            )
-            newFilepath = os.path.join(newDir.destination, shuffleFile)
-            self.assertEqual(destFilePath, str(newFilepath))
-
         # test with full filepath too
-        fileFullPath = pathlib.Path(os.path.join(TEST_ROOT, shuffleFile))
-
+        sourceFullPath = os.path.join(TEST_ROOT, shuffleFile)
         # ensure we are not in TEST_ROOT
         with directoryChangers.TemporaryDirectoryChanger() as newDir:
             destFilePath = cases.case.copyInputsHelper(
                 testSetting,
-                fileFullPath=fileFullPath,
-                destPath=pathlib.Path(newDir.destination),
+                sourcePath=sourceFullPath,
+                destPath=newDir.destination,
+                origFile=shuffleFile,
             )
             newFilepath = os.path.join(newDir.destination, shuffleFile)
             self.assertEqual(destFilePath, str(newFilepath))
+
+        # test with bad file path, should return original file
+        # ensure we are not in TEST_ROOT
+        with directoryChangers.TemporaryDirectoryChanger() as newDir:
+            with self.assertRaises(Exception):
+                destFilePath = cases.case.copyInputsHelper(
+                    testSetting,
+                    sourcePath=sourceFullPath,
+                    destPath=pathlib.Path(""),
+                    origFile=shuffleFile,
+                )
+                self.assertEqual(destFilePath, shuffleFile)
 
     def test_copyInterfaceInputs_singleFile(self):
         testSetting = "shuffleLogic"

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -23,6 +23,7 @@ What's new in ARMI
 #. Add setting ``inputHeightsConsideredHot`` to enable thermal expansion of assemblies at BOL.
 #. Add blueprints setting, ``axial expansion target component``, to enable users to manually set a "target component" for axial expansion.
 #. Allow database comparison to continue even if ``unpackSpecialData`` fails. 
+#. Code clarity rewrite of ``armi/cases/case.py::copyInterfaceInputs``.
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

This is just a ~rewrite of an overly complicated function, `copyInterfaceInputs`. This, for the most part, does not change what it does, but hopefully clears up the use cases it is trying to handle. (Caveat: `copyInputsHelper` is a little different but the overall call to `copyInterfaceInputs` should have the same behavior. And a downstream use-case was behaving undesirably)

A unit test that passed on CI failed for someone locally because of the code's fragility, and so instead of fixing that one thing I burned most/half of it and rewrote it. It cannot ever be simpler because it needs to handle so many file path options (and single files and lists), but hopefully this makes it clearer. 

This just offers a modicum of sanity for future me. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

