### PR TITLE
highlight specific inconsistency in Comp creation

### DIFF
--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -336,19 +336,14 @@ class TestGriddedBlock(unittest.TestCase):
             clad.material.density3(Tc=clad.temperatureInC),
             delta=biggerDelta,
         )
-        # This should be equal, but block construction calls applyHotHeightDensityReduction
-        # while programmatic construction allows components to exist in a state where
-        # their density is not consistent with material density.
-        self.assertNotAlmostEqual(
-            clad.getMassDensity(),
-            programaticClad.getMassDensity(),
-            delta=biggerDelta,
-        )
-        # its off by a factor of thermal expansion
-        self.assertNotAlmostEqual(
+        # This illustrates an inconsistency with how Components are created
+        # programmatically and from blueprints. The latter computes number densities
+        # at hot radial dims cold heights; the former assumes hot radial dims and hot
+        # axial dims (since cs["inputHeightsConsideredHot'] = True by default).
+        self.assertAlmostEqual(
             clad.getMassDensity(),
             programaticClad.getMassDensity()
-            * programaticClad.getThermalExpansionFactor(),
+            / programaticClad.getThermalExpansionFactor(),
             delta=biggerDelta,
         )
 


### PR DESCRIPTION
## Description

I gave a slight revision to the second and third test to illustrate my point from this comment https://github.com/terrapower/armi/issues/819#issuecomment-1206646380. 

Feel free to consider these changes and either ignore or accept as you see fit. Just trying to best communicate my comment. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->
(doc check boxes removed for relevancy)
