### PR TITLE
Support non-uniform assemblies with `detailedAxialExpansion` disabled

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -713,8 +713,13 @@ class Assembly(composites.Composite):
         belowFuelColumn = True
 
         if self[-1].p.topIndex == 0:
-            # this appears to not have been initialized, so initialize it
-            self.makeAxialSnapList(refMesh=blockMesh)
+            runLog.warning(
+                "Reference uniform mesh not being applied to {}. It was likely "
+                "excluded through the setting `nonUniformAssemFlags`.".format(
+                    self.p.type
+                )
+            )
+            return
 
         for b in self:
             if b.isFuel():

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -366,7 +366,12 @@ def getBlockParameterDefinitions():
         pb.defParam(
             "topIndex",
             units="",
-            description="the axial block index within its parent assembly (0 is bottom block)",
+            description=(
+                "the axial block index within its parent assembly (0 is bottom block). This index with"
+                "regard to the mesh of the reference assembly so it does not increase by 1 for each block."
+                "It is used to keep the mesh of the assemblies uniform with axial expansion."
+                "See setBlockMesh, makeAxialSnapList",
+            ),
             default=0,
             saveToDB=True,
             categories=[parameters.Category.retainOnReplacement],

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2251,6 +2251,7 @@ class Core(composites.Composite):
                 "Please make sure that this is intended and not a input error."
             )
 
+        nonUniformAssems = [Flags.fromString(t) for t in cs["nonUniformAssemFlags"]]
         if dbLoad:
             # reactor.blueprints.assemblies need to be populated
             # this normally happens during armi/reactor/blueprints/__init__.py::constructAssem
@@ -2268,6 +2269,8 @@ class Core(composites.Composite):
                     reverse=True,
                 )[0]
                 for a in self.parent.blueprints.assemblies.values():
+                    if a.hasFlags(nonUniformAssems, exact=True):
+                        continue
                     a.makeAxialSnapList(refAssem=finestAssemblyMesh)
 
         else:
@@ -2278,6 +2281,8 @@ class Core(composites.Composite):
             if not cs["detailedAxialExpansion"]:
                 # prepare core for mesh snapping during axial expansion
                 for a in self.getAssemblies(includeAll=True):
+                    if a.hasFlags(nonUniformAssems, exact=True):
+                        continue
                     a.makeAxialSnapList(self.refAssem)
 
             if not cs["inputHeightsConsideredHot"]:

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -833,6 +833,21 @@ class HexReactorTests(ReactorTests):
             coords = b.getPinCoordinates()
             self.assertGreater(len(coords), -1)
 
+    def test_nonUniformAssems(self):
+        o, r = loadTestReactor(
+            customSettings={"nonUniformAssemFlags": ["primary control"]}
+        )
+        a = o.r.core.getFirstAssembly(Flags.FUEL)
+        self.assertTrue(all(b.p.topIndex != 0 for b in a[1:]))
+        a = o.r.core.getFirstAssembly(Flags.PRIMARY)
+        self.assertTrue(all(b.p.topIndex == 0 for b in a))
+        originalHeights = [b.p.height for b in a]
+        differntMesh = [val + 2 for val in r.core.p.referenceBlockAxialMesh]
+        # wont change because nonUnfiform assem doesn't conform to reference mesh
+        a.setBlockMesh(differntMesh)
+        heights = [b.p.height for b in a]
+        self.assertEqual(originalHeights, heights)
+
 
 class CartesianReactorTests(ReactorTests):
     def setUp(self):

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -106,6 +106,7 @@ CONF_DEFERRED_INTERFACE_NAMES = "deferredInterfaceNames"
 CONF_OUTPUT_CACHE_LOCATION = "outputCacheLocation"
 CONF_MATERIAL_NAMESPACE_ORDER = "materialNamespaceOrder"
 CONF_DETAILED_AXIAL_EXPANSION = "detailedAxialExpansion"
+CONF_NON_UNIFORM_ASSEM_FLAGS = "nonUniformAssemFlags"
 CONF_BLOCK_AUTO_GRID = "autoGenerateBlockGrids"
 CONF_INPUT_HEIGHTS_HOT = "inputHeightsConsideredHot"
 CONF_CYCLES = "cycles"
@@ -162,6 +163,17 @@ def defineSettings() -> List[setting.Setting]:
             description=(
                 "Allow each assembly to expand independently of the others. Results in non-uniform "
                 "axial mesh. Neutronics kernel must be able to handle."
+            ),
+        ),
+        setting.Setting(
+            CONF_NON_UNIFORM_ASSEM_FLAGS,
+            default=[],
+            label="Non Uniform Assem Flags",
+            description=(
+                "Assemblies that match a flag group on this list will not have their "
+                "mesh changed with the reference mesh of the core for uniform mesh cases (non-"
+                "detailed axial expansion). Another plugin may need to make the mesh uniform if "
+                "necessary."
             ),
         ),
         setting.Setting(

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -24,6 +24,7 @@ What's new in ARMI
 #. Add blueprints setting, ``axial expansion target component``, to enable users to manually set a "target component" for axial expansion.
 #. Allow database comparison to continue even if ``unpackSpecialData`` fails. 
 #. Code clarity rewrite of ``armi/cases/case.py::copyInterfaceInputs``.
+#. Added setting nonUniformAssemFlags that allows specific assems to not conform to uniform mesh.
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

