### PR TITLE
Update `removeAssembly()` docstring formatting

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -405,7 +405,7 @@ class Core(composites.Composite):
         -----
         Please expect this method will delete your assembly (instead of moving it to a
         Spent Fuel Pool) unless you set the ``trackAssems`` to True in your settings file.
-        
+
         Originally, this held onto all assemblies in the spend fuel pool. However, having
         this sitting in memory becomes constraining for large simulations. It is more
         memory-efficient to only save the assemblies that are required for detailed

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -401,16 +401,16 @@ class Core(composites.Composite):
         discharge : bool, optional
             Discharge the assembly, including adding it to the SFP. Default: True
 
+        Notes
+        -----
+        Please expect this method will delete your assembly (instead of moving it to a
+        Spent Fuel Pool) unless you set the ``trackAssems`` to True in your settings file.
+        
         Originally, this held onto all assemblies in the spend fuel pool. However, having
         this sitting in memory becomes constraining for large simulations. It is more
         memory-efficient to only save the assemblies that are required for detailed
         history tracking. In fact, there's no need to save the assembly object at all,
         just have the history interface save the relevant parameters.
-
-        Notes
-        -----
-        Please expect this method will delete your assembly (instead of moving it to a
-        Spent Fuel Pool) unless you set the ``trackAssems`` to True in your settings file.
 
         See Also
         --------


### PR DESCRIPTION
## Description

As is, the doxygen formatting is all messed up:
![image](https://user-images.githubusercontent.com/21959600/184218728-9fcd71e2-4cc6-4c77-964c-c25bef5eea6c.png)

This PR just fixes the formatting.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

