### PR TITLE
Fixing UserPlugins - Save the Interface Stack

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -113,29 +113,6 @@ def isStableReleaseVersion(version=None):
     return "-" not in version
 
 
-def _registerUserPlugin(plugManager, userPluginName):
-    """Register one individual user plugin by name."""
-    try:
-        pluginMod = importlib.import_module(userPluginName)
-    except ImportError:
-        runLog.error(
-            f"The plugin `{userPluginName}` could not be imported. Verify it is installed "
-            "in your current environment or adjust the active user plugins."
-        )
-        raise
-
-    # Each plugin must have a constant called PLUGIN pointing to the plugin class.
-    # This allows discoverability without being overly restrictive in class names
-    try:
-        plugManager.register(pluginMod.PLUGIN)
-    except AttributeError:
-        runLog.error(
-            f"The plugin `{userPluginName}` does not have a PLUGIN constant defined. "
-            "This constant is required in user plugins. Please adjust plugin."
-        )
-        raise
-
-
 def init(choice=None, fName=None, cs=None):
     """
     Scan a directory for armi inputs and load one to interact with.

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -259,8 +259,6 @@ class App:
         because they are defined during run time, not import time. As such, we
         restrict their flexibility and power as compared to the usual ArmiPlugins.
         """
-        self.__initNewPlugins()
-
         for pluginPath in pluginPaths:
             if ".py:" in pluginPath:
                 # The path is of the form: /path/to/why.py:MyPlugin

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for the App class."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,import-outside-toplevel
 import copy
 import unittest
 
@@ -21,6 +22,7 @@ from armi import configure
 from armi import context
 from armi import getApp
 from armi import getDefaultPluginManager
+from armi import isStableReleaseVersion
 from armi import meta
 from armi import plugins
 from armi.__main__ import main
@@ -179,6 +181,11 @@ class TestApps(unittest.TestCase):
         self.assertIn("version", splash)
         self.assertIn(meta.__version__, splash)
         self.assertIn("DifferentApp", splash)
+
+    def test_isStableReleaseVersion(self):
+        self.assertTrue(isStableReleaseVersion(None))
+        self.assertTrue(isStableReleaseVersion("0.1.2"))
+        self.assertFalse(isStableReleaseVersion("1.2.3-asda132a"))
 
 
 class TestArmi(unittest.TestCase):

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -187,6 +187,19 @@ class TestApps(unittest.TestCase):
         self.assertTrue(isStableReleaseVersion("0.1.2"))
         self.assertFalse(isStableReleaseVersion("1.2.3-asda132a"))
 
+    def test_disableFutureConfigures(self):
+        import armi
+
+        # save off, in in case of poorly parallelized tests
+        old = armi._ignoreConfigures
+
+        # test it works (should be False to start)
+        armi.disableFutureConfigures()
+        self.assertTrue(armi._ignoreConfigures)
+
+        # reset, in case of poorly parallelized tests
+        armi._ignoreConfigures = old
+
 
 class TestArmi(unittest.TestCase):
     """Tests for functions in the ARMI __init__ module."""

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -209,11 +209,13 @@ class TestUserPlugins(unittest.TestCase):
         )
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
+        numPluginsBefore = len(pluginNames)
         self.assertNotIn("UserPluginFlags3", pluginNames)
 
         cs.registerUserPlugins()
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
+        self.assertEqual(len(pluginNames), numPluginsBefore + 1)
         self.assertIn("UserPluginFlags3", pluginNames)
 
     def test_userPluginOnProcessCoreLoading(self):
@@ -254,6 +256,7 @@ class TestUserPlugins(unittest.TestCase):
         app = getApp()
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
+        numPluginsBefore = len(pluginNames)
         self.assertNotIn("UserPluginWithInterface", pluginNames)
 
         # register custom UserPlugin, that has an
@@ -262,6 +265,7 @@ class TestUserPlugins(unittest.TestCase):
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
         self.assertIn("UserPluginWithInterface", pluginNames)
+        self.assertEqual(len(pluginNames), numPluginsBefore + 1)
 
         # load a reactor and grab the fuel assemblieapps
         o, r = test_reactors.loadTestReactor(TEST_ROOT)

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -209,16 +209,14 @@ class TestUserPlugins(unittest.TestCase):
         )
 
         pNames = [p[0] for p in app.pluginManager.list_name_plugin()]
-        numPluginsBefore = len(pNames)
         self.assertNotIn("UserPluginFlags3", pNames)
 
         cs.registerUserPlugins()
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
-        self.assertEqual(
-            len(pluginNames), numPluginsBefore + 1, f"{pNames} vs {pluginNames}"
-        )
         self.assertIn("UserPluginFlags3", pluginNames)
+        for pluginName in pNames:
+            self.assertIn(pluginName, pluginNames)
 
     def test_userPluginOnProcessCoreLoading(self):
         """
@@ -257,9 +255,8 @@ class TestUserPlugins(unittest.TestCase):
         # register the plugin
         app = getApp()
 
-        pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
-        numPluginsBefore = len(pluginNames)
-        self.assertNotIn("UserPluginWithInterface", pluginNames)
+        pNames = [p[0] for p in app.pluginManager.list_name_plugin()]
+        self.assertNotIn("UserPluginWithInterface", pNames)
 
         # register custom UserPlugin, that has an
         plugins = ["armi.tests.test_user_plugins.UserPluginWithInterface"]
@@ -267,7 +264,8 @@ class TestUserPlugins(unittest.TestCase):
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
         self.assertIn("UserPluginWithInterface", pluginNames)
-        self.assertEqual(len(pluginNames), numPluginsBefore + 1)
+        for pluginName in pNames:
+            self.assertIn(pluginName, pluginNames)
 
         # load a reactor and grab the fuel assemblieapps
         o, r = test_reactors.loadTestReactor(TEST_ROOT)

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -208,14 +208,16 @@ class TestUserPlugins(unittest.TestCase):
             },
         )
 
-        pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
-        numPluginsBefore = len(pluginNames)
-        self.assertNotIn("UserPluginFlags3", pluginNames)
+        pNames = [p[0] for p in app.pluginManager.list_name_plugin()]
+        numPluginsBefore = len(pNames)
+        self.assertNotIn("UserPluginFlags3", pNames)
 
         cs.registerUserPlugins()
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
-        self.assertEqual(len(pluginNames), numPluginsBefore + 1)
+        self.assertEqual(
+            len(pluginNames), numPluginsBefore + 1, f"{pNames} vs {pluginNames}"
+        )
         self.assertIn("UserPluginFlags3", pluginNames)
 
     def test_userPluginOnProcessCoreLoading(self):

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -215,8 +215,6 @@ class TestUserPlugins(unittest.TestCase):
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
         self.assertIn("UserPluginFlags3", pluginNames)
-        for pluginName in pNames:
-            self.assertIn(pluginName, pluginNames)
 
     def test_userPluginOnProcessCoreLoading(self):
         """
@@ -264,8 +262,6 @@ class TestUserPlugins(unittest.TestCase):
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
         self.assertIn("UserPluginWithInterface", pluginNames)
-        for pluginName in pNames:
-            self.assertIn(pluginName, pluginNames)
 
         # load a reactor and grab the fuel assemblieapps
         o, r = test_reactors.loadTestReactor(TEST_ROOT)


### PR DESCRIPTION
## Description

In more complicated ARMI apps than our unit tests showed, there was a bug where registering a `UserPlugin` also wiped clean the `Interface` stack, by wiping out the `Plugin` stack.

This was fixed by removing one line of code in `armi/apps.py`.

Also, while doing that, I found an entirely unused `UserPlugin` function (from back during my `UserPlugin` development) in `armi/__init__.py`. So I removed that.

(While testing `armi/apps.py` I found some wholes in our code coverage, that I have filled in.)

---

## Checklist

- [X] This PR has only one purpose or idea (fixing `UserPlugins`).
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
