### PR TITLE
Conserve component density

### DIFF
--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -79,7 +79,7 @@ class Zr(Material):
 
     def __init__(self):
         Material.__init__(self)
-        referenceTemp = 291.62
+        referenceTemp = 298.15
         referenceDensity = self._computeReferenceDensity(Tk=referenceTemp)
         self.p.refTempK = referenceTemp
         self.p.refDens = referenceDensity
@@ -130,7 +130,7 @@ class Zr(Material):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tk)
 
-        if Tk >= self.p.refTempK and Tk < 1137:
+        if Tk >= 291.62 and Tk < 1137:
             return (
                 -0.111 + (2.325e-4 * Tk) + (5.595e-7 * Tk ** 2) - (1.768e-10 * Tk ** 3)
             )

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -79,7 +79,7 @@ class Zr(Material):
 
     def __init__(self):
         Material.__init__(self)
-        referenceTemp = 298.15
+        referenceTemp = 291.62
         referenceDensity = self._computeReferenceDensity(Tk=referenceTemp)
         self.p.refTempK = referenceTemp
         self.p.refDens = referenceDensity
@@ -130,7 +130,7 @@ class Zr(Material):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tk)
 
-        if Tk >= 293 and Tk < 1137:
+        if Tk >= self.p.refTempK and Tk < 1137:
             return (
                 -0.111 + (2.325e-4 * Tk) + (5.595e-7 * Tk ** 2) - (1.768e-10 * Tk ** 3)
             )

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -249,7 +249,8 @@ class Component(composites.Composite, metaclass=ComponentType):
             runLog.warning(
                 f"Thermal expansion for {self.material} at Tinput = {Tinput} is non-zero "
                 f"({expansionFactor}). The modeled density for this material will be off "
-                f"by a factor of {(1 + expansionFactor) ** 2}."
+                f"by a factor of {(1 + expansionFactor) ** 2}.",
+                single=True,
             )
 
     @property

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -232,10 +232,25 @@ class Component(composites.Composite, metaclass=ComponentType):
         self.temperatureInC = Thot
         self.material = None
         self.setProperties(material)
+        self.tInputWarning(Tinput)
         self.applyMaterialMassFracsToNumberDensities()  # not necessary when duplicating...
         self.setType(name)
         self.p.mergeWith = mergeWith
         self.p.customIsotopicsName = isotopics
+
+    def tInputWarning(self, Tinput):
+        """
+        Check whether thermal expansion factor is 0.0% exactly at T=Tinput
+        """
+        expansionFactor = (
+            self.material.linearExpansionPercent(Tc=self.inputTemperatureInC) / 100.0
+        )
+        if not (abs(expansionFactor) < 1.0e-6):
+            runLog.warning(
+                f"Thermal expansion for {self.material} at Tinput = {Tinput} is non-zero "
+                f"({expansionFactor}). The modeled density for this material will be off "
+                f"by a factor of {(1 + expansionFactor) ** 2}."
+            )
 
     @property
     def temperatureInC(self):

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -289,8 +289,8 @@ class AxialExpansionChanger:
     def _conserveComponentDensity(self, b, oldHeight, oldVolume):
         """Update block height dependent component parameters
 
-        1) update component volume (used to compute block volume)
-        2) update number density
+        1) update component volume for all materials (used to compute block volume)
+        2) update number density for solid materials only (no fluid)
 
         Parameters
         ----------
@@ -300,7 +300,7 @@ class AxialExpansionChanger:
             list containing component volumes pre-expansion
         """
 
-        solidMaterials = _getSolidMaterials(b)
+        solidMaterials = _getSolidComponents(b)
         for ic, c in enumerate(b):
             c.p.volume = oldVolume[ic] * b.p.height / oldHeight
             if c in solidMaterials:
@@ -313,7 +313,15 @@ class AxialExpansionChanger:
                     c.setNumberDensity(key, c.getNumberDensity(key) / growth)
 
 
-def _getSolidMaterials(b):
+def _getSolidComponents(b):
+    """
+    Return list of components in the block that have solid material.
+
+    Notes
+    -----
+    Axial expansion only needs to be applied to solid materials. We should not update
+    number densities on fluid materials to account for changes in block height.
+    """
     return [c for c in b if not isinstance(c.material, material.Fluid)]
 
 

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -300,10 +300,10 @@ class AxialExpansionChanger:
             list containing component volumes pre-expansion
         """
 
-        solidMaterials = _getSolidComponents(b)
+        solidComponents = _getSolidComponents(b)
         for ic, c in enumerate(b):
             c.p.volume = oldVolume[ic] * b.p.height / oldHeight
-            if c in solidMaterials:
+            if c in solidComponents:
                 growFrac = self.expansionData.getExpansionFactor(c)
                 if growFrac >= 0.0:
                     growth = 1.0 + growFrac

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -197,7 +197,7 @@ class AxialExpansionChanger:
                 b.p.zbottom = self.linked.linkedBlocks[b][0].p.ztop
             isDummyBlock = ib == (numOfBlocks - 1)
             if not isDummyBlock:
-                for c in _getSolidMaterials(b):
+                for c in _getSolidComponents(b):
                     growFrac = self.expansionData.getExpansionFactor(c)
                     runLog.debug(
                         msg="      Component {0}, growFrac = {1:.4e}".format(

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -831,11 +831,16 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                             if not isinstance(cExp.material, custom.Custom):
                                 matDens = cExp.material.density3(Tc=cExp.temperatureInC)
                                 compDens = cExp.getMassDensity()
+                                msg = (
+                                    f"{cExp} {cExp.material} in {bExp} was not at correct density. \n"
+                                    + f"expansion = {bExp.p.height / bStd.p.height} \n"
+                                    + f"density3 = {matDens}, component density = {compDens} \n"
+                                )
                                 self.assertAlmostEqual(
-                                    cExp.material.density3(Tc=cExp.temperatureInC),
-                                    cExp.getMassDensity(),
+                                    matDens,
+                                    compDens,
                                     places=7,
-                                    msg=f"{cExp} {cExp.material} in {bExp} was not at correct density, expansion = {bExp.p.height / bStd.p.height}",
+                                    msg=msg,
                                 )
 
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -718,10 +718,13 @@ class TestDetermineTargetComponent(unittest.TestCase):
     def test_specifyTargetComponet_BlueprintSpecified(self):
         b = HexBlock("SodiumBlock", height=10.0)
         sodiumDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
+        ductDims = {"Tinput": 25.0, "Thot": 25.0, "op": 16, "ip": 15.0, "mult": 1.0}
         dummy = Hexagon("coolant", "Sodium", **sodiumDims)
+        dummyDuct = Hexagon("duct", "FakeMat", **sodiumDims)
         b.add(dummy)
+        b.add(dummyDuct)
         b.getVolumeFractions()
-        b.setType("SodiumBlock")
+        b.setType("DuctBlock")
 
         # check for no target component found
         with self.assertRaises(RuntimeError) as cm:
@@ -730,10 +733,10 @@ class TestDetermineTargetComponent(unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
         # check that target component is explicitly specified
-        b.setAxialExpTargetComp(dummy)
+        b.setAxialExpTargetComp(dummyDuct)
         self.assertEqual(
             b.axialExpTargetComponent,
-            dummy,
+            dummyDuct,
         )
 
         # check that target component is stored on expansionData object correctly

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -818,7 +818,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                                 self.assertAlmostEqual(
                                     cExp.material.density3(Tc=cExp.temperatureInC),
                                     cExp.getMassDensity(),
-                                    delta=0.001, # g/cc
+                                    delta=0.001,  # g/cc
                                     msg=f"{cExp} {cExp.material} in {bExp} was not at correct density, expansion = {bExp.p.height / bStd.p.height}",
                                 )
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -810,6 +810,17 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                     ):
                         # custom materials don't expand
                         self.assertGreater(bExp.getMass("U235"), bStd.getMass("U235"))
+                if not aStd.hasFlags(Flags.CONTROL) and not aStd.hasFlags(Flags.TEST):
+                    if not hasCustomMaterial:
+                        # skip blocks of custom material where liner is merged with clad
+                        for cExp in bExp:
+                            if not isinstance(cExp.material, custom.Custom):
+                                self.assertAlmostEqual(
+                                    cExp.material.density3(Tc=cExp.temperatureInC),
+                                    cExp.getMassDensity(),
+                                    delta=0.001, # g/cc
+                                    msg=f"{cExp} {cExp.material} in {bExp} was not at correct density, expansion = {bExp.p.height / bStd.p.height}",
+                                )
 
 
 def checkColdBlockHeight(bStd, bExp, assertType, strForAssertion):

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -198,7 +198,7 @@ class TestAxialExpansionHeight(Base, unittest.TestCase):
                 self.assertAlmostEqual(
                     self.trueZtop[ib, idt],
                     self.blockHeights[b.name][idt][1],
-                    places=5,
+                    places=7,
                     msg="Block height is not correct.\
                          Temp Step = {0:d}, Block ID = {1:}.".format(
                         idt, b.name

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -834,7 +834,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                                 self.assertAlmostEqual(
                                     cExp.material.density3(Tc=cExp.temperatureInC),
                                     cExp.getMassDensity(),
-                                    places=4,
+                                    places=7,
                                     msg=f"{cExp} {cExp.material} in {bExp} was not at correct density, expansion = {bExp.p.height / bStd.p.height}",
                                 )
 

--- a/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
@@ -113,7 +113,7 @@ blocks:
         fuel: &component_fuel_fuel
             shape: Circle
             material: UZr
-            Tinput: 25.0
+            Tinput: 19.85
             Thot: 600.0
             id: 0.0
             mult: 169.0

--- a/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
@@ -236,7 +236,7 @@ blocks:
         duct: *component_fuel_duct
         intercoolant: *component_fuel_intercoolant
     
-    lta1 fuel: &block_lta1_fuel
+    lta fuel a: &block_lta1_fuel
         fuel: *component_fuel_fuel
         bond: *component_fuel_bond
         liner2: *component_fuel2_liner2
@@ -247,7 +247,7 @@ blocks:
         duct: *component_fuel_duct
         intercoolant: *component_fuel_intercoolant
     
-    lta2 fuel: &block_lta2_fuel
+    lta fuel b: &block_lta2_fuel
         fuel:
             shape: Circle
             material: UZr
@@ -547,7 +547,7 @@ assemblies:
         height: *highOffset_height
         axial mesh points: *standard_axial_mesh_points
         xs types: *igniter_fuel_xs_types
-    lta fuel:
+    lead test fuel:
         specifier: LA
         blocks: [*block_grid_plate, *block_fuel_axial_shield, *block_lta1_fuel, *block_lta1_fuel, *block_lta1_fuel, *block_plenum,  *block_aclp, *block_plenum, *block_dummy]
         height: *highOffset_height
@@ -556,7 +556,7 @@ assemblies:
             U235_wt_frac: &lta_fuel_u235_wt_frac ['', '', 0.2, 0.2, 0.2, '', '', '', '']
             ZR_wt_frac: &lta_fuel_zr_wt_frac ['', '', 0.07, 0.07, 0.06, '', '', '', '']
         xs types: *igniter_fuel_xs_types
-    lta fuel b:
+    lead test fuel b:
         specifier: LB
         blocks: [*block_grid_plate, *block_fuel_axial_shield, *block_lta2_fuel, *block_lta2_fuel, *block_lta2_fuel, *block_plenum, *block_aclp, *block_plenum, *block_dummy]
         height: *highOffset_height

--- a/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
@@ -251,7 +251,7 @@ blocks:
         fuel:
             shape: Circle
             material: UZr
-            Tinput: 25.0
+            Tinput: 45.187
             Thot: 600.0
             id: 0.0
             isotopics: PuUZr
@@ -311,7 +311,7 @@ blocks:
         outer liner:
             shape: Circle
             material: Zr
-            Tinput: 19.85
+            Tinput: 18.474
             Thot: 430.0
             id: 0.898
             mult: fuel.mult

--- a/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
@@ -23,7 +23,7 @@ blocks:
         grid:
             shape: Hexagon
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             ip: 15.277
             mult: 1.0
@@ -60,7 +60,7 @@ blocks:
         shield:
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 600.0
             id: 0.0
             mult: 169.0
@@ -76,7 +76,7 @@ blocks:
         clad:
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 470.0
             id: 1.0
             mult: shield.mult
@@ -84,7 +84,7 @@ blocks:
         wire:
             shape: Helix
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             axialPitch: 30.15
             helixDiameter: 1.19056
@@ -95,7 +95,7 @@ blocks:
         duct: &component_fuel_duct
             shape: Hexagon
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             ip: 16.0
             mult: 1.0
@@ -113,7 +113,7 @@ blocks:
         fuel: &component_fuel_fuel
             shape: Circle
             material: UZr
-            Tinput: 19.85
+            Tinput: 45.187
             Thot: 600.0
             id: 0.0
             mult: 169.0
@@ -129,7 +129,7 @@ blocks:
         clad: &component_fuel_clad
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 470.0
             id: 1.0
             mult: fuel.mult
@@ -137,7 +137,7 @@ blocks:
         wire: &component_fuel_wire
             shape: Helix
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             axialPitch: 30.15
             helixDiameter: 1.19056
@@ -160,7 +160,7 @@ blocks:
         clad: &component_plenum_clad
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 470.0
             id: 1.0
             mult: 169.0
@@ -168,7 +168,7 @@ blocks:
         wire: &component_plenum_wire
             shape: Helix
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             axialPitch: 30.15
             helixDiameter: 1.19056
@@ -187,7 +187,7 @@ blocks:
         duct:
             shape: Hexagon
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             ip: 16.0
             mult: 1.0
@@ -215,7 +215,7 @@ blocks:
         liner2: &component_fuel2_liner2
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 600.0
             id: 0.98
             mergeWith: clad
@@ -224,7 +224,7 @@ blocks:
         liner1: &component_fuel2_liner1
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 600.0
             id: 0.99
             mergeWith: clad
@@ -278,7 +278,7 @@ blocks:
         fuel:
             shape: Circle
             material: UZr
-            Tinput: 25.0
+            Tinput: 45.187
             Thot: 600.0
             id: 0.600
             mult: 169.0
@@ -295,7 +295,7 @@ blocks:
         inner liner:
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 430.0
             id: 0.878
             mult: fuel.mult
@@ -311,7 +311,7 @@ blocks:
         outer liner:
             shape: Circle
             material: Zr
-            Tinput: 25.0
+            Tinput: 19.85
             Thot: 430.0
             id: 0.898
             mult: fuel.mult
@@ -327,7 +327,7 @@ blocks:
         clad:
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 430.0
             id: 0.900
             mult: fuel.mult
@@ -344,7 +344,7 @@ blocks:
         duct: &component_control_duct
             shape: Hexagon
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             ip: 15.277
             mult: 1.0
@@ -378,7 +378,7 @@ blocks:
         clad:
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             id: 1.358
             mult: control.mult
@@ -386,7 +386,7 @@ blocks:
         wire:
             shape: Helix
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             axialPitch: 50.0
             helixDiameter: 1.771
@@ -396,7 +396,7 @@ blocks:
         innerDuct:
             shape: Hexagon
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             ip: 14.268
             mult: 1.0
@@ -417,7 +417,7 @@ blocks:
         clad:
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             id: 1.358
             mult: 61.0
@@ -425,7 +425,7 @@ blocks:
         wire:
             shape: Helix
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             axialPitch: 30.15
             helixDiameter: 1.19056
@@ -442,7 +442,7 @@ blocks:
         shield:
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 600.0
             id: 0.0
             mult: 169.0
@@ -458,7 +458,7 @@ blocks:
         clad:
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             id: 0.90562
             mult: shield.mult
@@ -466,7 +466,7 @@ blocks:
         wire:
             shape: Helix
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             axialPitch: 30.15
             helixDiameter: 16.85056
@@ -489,7 +489,7 @@ blocks:
         clad: &component_radial_shield_clad
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             id: 0.90562
             mult: 169.0
@@ -497,7 +497,7 @@ blocks:
         wire: &component_radial_shield_plenum_wire
             shape: Helix
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             axialPitch: 30.15
             helixDiameter: 1.19056
@@ -516,7 +516,7 @@ blocks:
         duct:
             shape: Hexagon
             material: HT9
-            Tinput: 25.0
+            Tinput: 27.548
             Thot: 450.0
             ip: 16.0
             mult: 1.0

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -47,6 +47,7 @@ Bug fixes
 #. Bug fix in ``armi/reactor/components/component.py::getReac``
 #. Store thermally expanded block heights at BOL (via ``b.p.heightBOL``) when thermally expanding assemblies in ``armi/reactor/reactors.py::Core::processLoading``.
 #. Fixed bug where components were different if initialized through blueprints vs init (bug active for ~ 2 months).
+#. Fixed bug where component mass was being conserved in axial expansion instead of correct density (`PR#846 <https://github.com/terrapower/armi/pull/846>`_)
 #. TBD
 
 


### PR DESCRIPTION
## Description

The `axialExpansionChanger` was implemented to conserve the initial mass of each component in a block with axial expansion determined by the target component, using the funciton `_conserveComponentMass`. Since different components are made of different materials that thermally expand at different rates, this necessarily means that the densities have to be adjusted artificially for the mass to be conserved over the block for each individual component.

After testing and discussing the methodology, it has been decided that it is preferred to conserve the realistic density of the material rather than conserving mass within a block. Effectively, we are allowing mass to move between blocks.

The `Tinput` values in the test reactor for `detailedAxialExpansion` were updated because the unit test to ensure density conservation requires that the `Tinput` is equal to the material reference temperature for calculating thermal expansion factors.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

