### PR TITLE
Update block point parameters so that corner and edge data are separate

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -735,20 +735,36 @@ def _getNeutronicsBlockParams():
         # This quantity should eventually be part of category 'detailedAxialExpansion'
         # to be "remapped" (converter currently do not support arrays)
         pb.defParam(
-            "pointsFastFluxFr",
+            "pointsCornerFastFluxFr",
             units=None,
-            description="Fraction of flux above 100keV at points within the block",
-            location=ParamLocation.CHILDREN,
+            description="Fraction of flux above 100keV at corners of the block",
+            location=ParamLocation.CORNERS,
+            saveToDB=True,
+        )
+        pb.defParam(
+            "pointsEdgeFastFluxFr",
+            units=None,
+            description="Fraction of flux above 100keV at edsges of the block",
+            location=ParamLocation.EDGES,
             saveToDB=True,
         )
 
         # This quantity should eventually be part of category 'detailedAxialExpansion'
         # to be "remapped" (converter currently do not support arrays)
         pb.defParam(
-            "pointsDpa",
+            "pointsCornerDpa",
             units="dpa",
-            description="displacements per atom at points within the block",
-            location=ParamLocation.CHILDREN,
+            description="displacements per atom at corners of the block",
+            location=ParamLocation.CORNERS,
+            categories=["cumulative"],
+            saveToDB=True,
+            default=0.0,
+        )
+        pb.defParam(
+            "pointsEdgeDpa",
+            units="dpa",
+            description="displacements per atom at edges of the block",
+            location=ParamLocation.EDGES,
             categories=["cumulative"],
             saveToDB=True,
             default=0.0,
@@ -757,10 +773,17 @@ def _getNeutronicsBlockParams():
         # This quantity should eventually be part of category 'detailedAxialExpansion'
         # to be "remapped" (converter currently do not support arrays)
         pb.defParam(
-            "pointsDpaRate",
+            "pointsCornerDpaRate",
             units="dpa/s",
-            description="Current time derivative of the displacement per atoms at points within the block",
-            location=ParamLocation.CHILDREN,
+            description="Current time derivative of the displacement per atoms at corners of the block",
+            location=ParamLocation.CORNERS,
+            saveToDB=True,
+        )
+        pb.defParam(
+            "pointsEdgeDpaRate",
+            units="dpa/s",
+            description="Current time derivative of the displacement per atoms at edges of the block",
+            location=ParamLocation.EDGES,
             saveToDB=True,
         )
 


### PR DESCRIPTION
## Description

The point parameters `pointsFastFluxFr`, `pointsDpa`, and `pointsDpaRate` represent point evaluations of data along the boundary of a block. It currently does not distinguish between corner and edge point evaluations (for hexagonal geometry); the data for both is combined together under these parameters (e.g., `pointsDpa` contains both corner and edge data).

This is not good for when these parameters need to get rotated by `Block.rotate()`; because these parameter lists are length 12 and do not use the `ParamLocation.CORNERS` or `ParamLocation.EDGES` labels, they do not get rotated.

There are at least a couple ways to address this. Both solutions proposed below assume that using EDGES and CORNERS "filtering" inside `Block.rotate()` will be maintained, so the above parameters at a minimum will get updated labels so that the method does not reject them on that basis alone.

1. Split each parameter into two, one for corner and one for edges (e.g., `pointsCornerDpa` and `pointsEdgeDpa`). This gives you two lists of length 6, which is good for `Block.rotate()`. This approach would be consistent with similarly-formatted naming scheme used by an internal plugin (which also splits apart corners and edges). However, it deletes the three old parameters and replaces them with six new ones, which increases the number of parameters 
2. Update `Block.rotate()` to be more flexible with list length so that it can process length 12. This keeps the number of parameters the same, but may allow unexpected parameters to be accidentally rotated by the method (since it seems rather keen on processing exactly 6 elements).

I'm not sure what the right thing to do here is, since in talking with @jakehader, it seems like we will be overhauling rotation at some point soon anyway. So, I decided to go down path 1. That effort is captured by this PR.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

