### PR TITLE
Updated run_grids1_hex.py script

### DIFF
--- a/doc/gallery-src/framework/run_grids1_hex.py
+++ b/doc/gallery-src/framework/run_grids1_hex.py
@@ -33,13 +33,15 @@ configure(permissive=True)
 
 hexes = grids.HexGrid.fromPitch(1.0)
 
-fig = plt.figure()
-xyz = []
 polys = []
-ax = fig.add_subplot(1, 1, 1)
+fig, ax = plt.subplots()
+ax.set_aspect('equal')
+ax.set_axis_off()
+
 for hex_i in hexes.generateSortedHexLocationList(127):
     x, y, z = hex_i.getGlobalCoordinates()
-    ax.text(x, y, f"{hex_i.i},{hex_i.j}", ha="center", va="center")
+    ax.text(x, y, f"{hex_i.i},{hex_i.j}", 
+            ha="center", va="center", fontsize=8)
     polys.append(
         mpatches.RegularPolygon(
             (x, y), numVertices=6, radius=1 / math.sqrt(3), orientation=math.pi / 2
@@ -47,7 +49,11 @@ for hex_i in hexes.generateSortedHexLocationList(127):
     )
 patches = PatchCollection(polys, fc="white", ec="k")
 ax.add_collection(patches)
+
+# create a bounding box around patches with a small margin (2%)
+bbox = patches.get_datalim(ax.transData)
+bbox = bbox.expanded(1.02, 1.02)
+ax.set_xlim(bbox.xmin, bbox.xmax)
+ax.set_ylim(bbox.ymin, bbox.ymax)
 ax.set_title("(i, j) indices for a hex grid")
-ax.set_xlim([-7, 7])
-ax.set_ylim([-7, 7])
 plt.show()

--- a/doc/gallery-src/framework/run_grids1_hex.py
+++ b/doc/gallery-src/framework/run_grids1_hex.py
@@ -35,13 +35,12 @@ hexes = grids.HexGrid.fromPitch(1.0)
 
 polys = []
 fig, ax = plt.subplots()
-ax.set_aspect('equal')
+ax.set_aspect("equal")
 ax.set_axis_off()
 
 for hex_i in hexes.generateSortedHexLocationList(127):
     x, y, z = hex_i.getGlobalCoordinates()
-    ax.text(x, y, f"{hex_i.i},{hex_i.j}", 
-            ha="center", va="center", fontsize=8)
+    ax.text(x, y, f"{hex_i.i},{hex_i.j}", ha="center", va="center", fontsize=8)
     polys.append(
         mpatches.RegularPolygon(
             (x, y), numVertices=6, radius=1 / math.sqrt(3), orientation=math.pi / 2


### PR DESCRIPTION
## Description

Updated the `run_grids1_hex.py` script to use equal-axis scaling when drawing the hex grid. 

While reading the documentation on how to make a hex grid I noticed that the illustrated grid was plotted using the default scaling, which results in squashed hexagons. This PR updates the script to use equal-axis scaling so that the hexagons appear as true regular hexagons. It also illustrates some techniques that I regularly use when drawing hex grids, such as generating a bounding box from a `PatchCollection` with padding. 

Because this PR only affects a documentation script, no unit tests are affected. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

