### PR TITLE
Set default value to None for listy neutronics parameters

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -730,6 +730,7 @@ def _getNeutronicsBlockParams():
             description="Neutron flux above 100keV at hexagon block corners",
             location=ParamLocation.CORNERS,
             saveToDB=True,
+            default=None,
         )
 
         # This quantity should eventually be part of category 'detailedAxialExpansion'
@@ -740,13 +741,15 @@ def _getNeutronicsBlockParams():
             description="Fraction of flux above 100keV at corners of the block",
             location=ParamLocation.CORNERS,
             saveToDB=True,
+            default=None,
         )
         pb.defParam(
             "pointsEdgeFastFluxFr",
             units=None,
-            description="Fraction of flux above 100keV at edsges of the block",
+            description="Fraction of flux above 100keV at edges of the block",
             location=ParamLocation.EDGES,
             saveToDB=True,
+            default=None,
         )
 
         # This quantity should eventually be part of category 'detailedAxialExpansion'
@@ -758,7 +761,7 @@ def _getNeutronicsBlockParams():
             location=ParamLocation.CORNERS,
             categories=["cumulative"],
             saveToDB=True,
-            default=0.0,
+            default=None,
         )
         pb.defParam(
             "pointsEdgeDpa",
@@ -767,7 +770,7 @@ def _getNeutronicsBlockParams():
             location=ParamLocation.EDGES,
             categories=["cumulative"],
             saveToDB=True,
-            default=0.0,
+            default=None,
         )
 
         # This quantity should eventually be part of category 'detailedAxialExpansion'
@@ -778,6 +781,7 @@ def _getNeutronicsBlockParams():
             description="Current time derivative of the displacement per atoms at corners of the block",
             location=ParamLocation.CORNERS,
             saveToDB=True,
+            default=None,
         )
         pb.defParam(
             "pointsEdgeDpaRate",
@@ -785,6 +789,7 @@ def _getNeutronicsBlockParams():
             description="Current time derivative of the displacement per atoms at edges of the block",
             location=ParamLocation.EDGES,
             saveToDB=True,
+            default=None,
         )
 
         pb.defParam(
@@ -807,6 +812,14 @@ def _getNeutronicsCoreParams():
             description="All available lambda-eigenvalues of reactor.",
             default=None,  # will be a list though, can't set default to mutable type.
             location=ParamLocation.AVERAGE,
+        )
+
+        pb.defParam(
+            "axialMesh",
+            units="cm",
+            description="Global axial mesh from bottom to top used in structured-mesh neutronics simulations.",
+            default=None,
+            location=ParamLocation.TOP,
         )
 
         pb.defParam(

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -815,14 +815,6 @@ def _getNeutronicsCoreParams():
         )
 
         pb.defParam(
-            "axialMesh",
-            units="cm",
-            description="Global axial mesh from bottom to top used in structured-mesh neutronics simulations.",
-            default=None,
-            location=ParamLocation.TOP,
-        )
-
-        pb.defParam(
             "kInf",
             units=None,
             description="k-infinity",


### PR DESCRIPTION
## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

In PR #849, changes were made to create new neutronics parameters by replacing existing parameters. However, I did not realize that for parameters that use lists (which these do), any non-assignment needs to have a default value of None instead of 0.0; one cannot write to a database if the default value is 0.0.

This commit fixes this issue and explicitly assigns default None values to those parameters.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

