### PR TITLE
Specifying both Tk and Tc is an error

### DIFF
--- a/armi/materials/hastelloyN.py
+++ b/armi/materials/hastelloyN.py
@@ -87,7 +87,7 @@ class HastelloyN(Material):
         Hastelloy N thermal conductivity (W/m-K)
         """
         Tc = getTc(Tc, Tk)
-        Tk = getTk(Tc, Tk)
+        Tk = getTk(Tc=Tc)
         self.checkPropertyTempRange("thermal conductivity", Tk)
         return 1.92857e-05 * Tc ** 2 + 3.12857e-03 * Tc + 1.17743e01  # W/m-K
 
@@ -109,7 +109,7 @@ class HastelloyN(Material):
         Hastelloy N specific heat capacity (J/kg-C)
         """
         Tc = getTc(Tc, Tk)
-        Tk = getTk(Tc, Tk)
+        Tk = getTk(Tc=Tc)
         self.checkPropertyTempRange("heat capacity", Tk)
         return (
             +3.19981e02
@@ -157,6 +157,6 @@ class HastelloyN(Material):
         mean coefficient of thermal expansion in m/m/C
         """
         Tc = getTc(Tc, Tk)
-        Tk = getTk(Tc, Tk)
+        Tk = getTk(Tc=Tc)
         self.checkPropertyTempRange("thermal expansion", Tk)
         return 2.60282e-12 * Tc ** 2 + 7.69859e-10 * Tc + 1.21036e-05

--- a/armi/materials/mgO.py
+++ b/armi/materials/mgO.py
@@ -53,6 +53,6 @@ class MgO(Material):
         This is based on a 3rd order polynomial fit of the data in Table I.
         """
         Tc = getTc(Tc, Tk)
-        Tk = getTk(Tc, Tk)
+        Tk = getTk(Tc=Tc)
         self.checkPropertyTempRange("linear expansion percent", Tk)
         return 1.0489e-5 * Tc + 6.0458e-9 * Tc ** 2 - 2.6875e-12 * Tc ** 3

--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -35,6 +35,6 @@ class Potassium(material.Fluid):
         Page 18.
         """
         Tc = getTc(Tc, Tk)
-        Tk = getTk(Tc, Tk)
+        Tk = getTk(Tc=Tc)
         self.checkPropertyTempRange("density", Tk)
         return 0.8415 - 2.172e-4 * Tc - 2.70e-8 * Tc ** 2 + 4.77e-12 * Tc ** 3

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -129,7 +129,7 @@ class Sodium(material.Fluid):
             thermal conductivity of Sodium (W/m-K)
 
         """
-        Tc = getTc(Tc, Tk)
+        Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tk)
         thermalConductivity = (
             124.67 - 0.11381 * Tk + 5.5226e-5 * Tk ** 2 - 1.1842e-8 * Tk ** 3

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -65,7 +65,6 @@ class Sodium(material.Fluid):
         density : float
             mass density in g/cc
         """
-        Tk = getTk(Tc, Tk)
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("density", Tc)
 

--- a/armi/utils/tests/test_units.py
+++ b/armi/utils/tests/test_units.py
@@ -1,0 +1,75 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test armi.utils.units.py"""
+import unittest
+
+from armi.utils import units
+
+
+class TestUnits(unittest.TestCase):
+    def test_getTc(self):
+
+        self.assertAlmostEqual(units.getTc(Tc=200), 200.0)
+        self.assertAlmostEqual(units.getTc(Tk=300), 26.85)
+
+        ## error if no argument provided
+        with self.assertRaisesRegex(ValueError, "Tc=None and Tk=None"):
+            units.getTc()
+
+        ## error if two arguments provided even if those arguments are "falsy"
+        with self.assertRaisesRegex(ValueError, "Tc=0 and Tk=0"):
+            units.getTc(Tc=0, Tk=0)
+
+        with self.assertRaisesRegex(ValueError, "Tc=0 and Tk=200"):
+            units.getTc(Tc=0, Tk=200)
+
+    def test_getTk(self):
+
+        self.assertAlmostEqual(units.getTk(Tc=200), 473.15)
+        self.assertAlmostEqual(units.getTk(Tk=300), 300.00)
+
+        ## error if no argument provided
+        with self.assertRaisesRegex(ValueError, "Tc=None and Tk=None"):
+            units.getTk()
+
+        ## error if two arguments provided even if those arguments are "falsy"
+        with self.assertRaisesRegex(ValueError, "Tc=0 and Tk=0"):
+            units.getTk(Tc=0, Tk=0)
+
+        with self.assertRaisesRegex(ValueError, "Tc=0 and Tk=200"):
+            units.getTk(Tc=0, Tk=200)
+
+    def test_getTf(self):
+
+        # 0 C = 32 F
+        self.assertAlmostEqual(units.getTf(Tc=0), 32.0)
+        self.assertAlmostEqual(units.getTf(Tk=273.15), 32.0)
+
+        # 100 C = 212 F
+        self.assertAlmostEqual(units.getTf(Tc=100), 212.0)
+        self.assertAlmostEqual(units.getTf(Tk=373.15), 212.0)
+
+        # -40 C = -40 F
+        self.assertAlmostEqual(units.getTf(Tc=-40), -40)
+
+        ## error if no argument provided
+        with self.assertRaisesRegex(ValueError, "Tc=None and Tk=None"):
+            units.getTf()
+
+        ## error if two arguments provided even if those arguments are "falsy"
+        with self.assertRaisesRegex(ValueError, "Tc=0 and Tk=0"):
+            units.getTf(Tc=0, Tk=0)
+
+        with self.assertRaisesRegex(ValueError, "Tc=0 and Tk=200"):
+            units.getTf(Tc=0, Tk=200)

--- a/armi/utils/units.py
+++ b/armi/utils/units.py
@@ -118,15 +118,12 @@ def getTk(Tc=None, Tk=None):
     TypeError
         The temperature was not provided as an int or float.
     """
-    if Tk is not None:
-        return float(Tk)
-    if Tc is not None:
-        return Tc + C_TO_K
-    raise TypeError(
-        "Cannot produce T in K from Tc={0} and Tk={1}. Please supply a temperature.".format(
-            Tc, Tk
+    if not ((Tc is not None) ^ (Tk is not None)):
+        raise ValueError(
+            f"Cannot produce T in K from Tc={Tc} and Tk={Tk}. "
+            "Please supply a single temperature."
         )
-    )
+    return float(Tk) if Tk is not None else Tc + C_TO_K
 
 
 def getTc(Tc=None, Tk=None):
@@ -143,15 +140,12 @@ def getTc(Tc=None, Tk=None):
     TypeError
         The temperature was not provided as an int or float.
     """
-    if Tc is not None:
-        return float(Tc)
-    if Tk is not None:
-        return Tk - C_TO_K
-    raise TypeError(
-        "Cannot produce T in C from Tc={0} and Tk={1}. Supply a temperature. ".format(
-            Tc, Tk
+    if not ((Tc is not None) ^ (Tk is not None)):
+        raise ValueError(
+            f"Cannot produce T in C from Tc={Tc} and Tk={Tk}. "
+            "Please supply a single temperature."
         )
-    )
+    return float(Tc) if Tc is not None else Tk - C_TO_K
 
 
 def getTf(Tc=None, Tk=None):
@@ -168,15 +162,7 @@ def getTf(Tc=None, Tk=None):
     TypeError
         The temperature was not provided as an int or float.
     """
-    if Tc is not None:
-        return 9.0 * Tc / 5.0 + 32.0
-    if Tk is not None:
-        return 9.0 * (Tk - C_TO_K) / 5.0 + 32.0
-    raise TypeError(
-        "Cannot produce T in F from Tc={0} and Tk={1}. Supply a temperature. ".format(
-            Tc, Tk
-        )
-    )
+    return 1.8 * getTc(Tc, Tk) + 32.0
 
 
 def getTemperature(Tc=None, Tk=None, tempUnits=None):


### PR DESCRIPTION
## Description

This PR makes it an error to specify both `Tk` and `Tc` parameters to material properties routines. This is intended to prevent unexpected behavior such as `sodium.density(200, 300)` being a valid call (the second argument is silently ignored). Unit tests have also been added to test the `getTk`, `getTc`, and `getTf` functions in the `utils.units` module. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [ ] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

