### PR TITLE
Fixing HT9 density - to match reference

### DIFF
--- a/armi/materials/ht9.py
+++ b/armi/materials/ht9.py
@@ -46,6 +46,7 @@ class HT9(materials.Material):
         HT9 mass fractions
 
         From E.2-1 of [MFH]_.
+        https://www.osti.gov/biblio/1506477-metallic-fuels-handbook
         """
         self.setMassFrac("C", 0.002)
         self.setMassFrac("MN", 0.005)
@@ -57,7 +58,7 @@ class HT9(materials.Material):
         self.setMassFrac("V", 0.0030)
         self.setMassFrac("FE", 1.0 - sum(self.p.massFrac.values()))
 
-        self.p.refDens = 8.86
+        self.p.refDens = 7.778
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         """


### PR DESCRIPTION
## Description

For some reason, the density of HT9 did not match the listed reference density: https://www.osti.gov/biblio/1506477-metallic-fuels-handbook (page 194/210)

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.

