### PR TITLE
Modeling fission products in the HexToRZReactor Conversion

### DIFF
--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -800,6 +800,9 @@ class HexToRZThetaConverter(GeometryConverter):
             newBlock.p.zbottom = lowerAxialZ
             newBlock.p.ztop = upperAxialZ
 
+            fpi = self._o.getInterface("fissionProducts")
+            newBlock.setLumpedFissionProducts(fpi.getGlobalLumpedFissionProducts())
+
             # Assign the new block cross section type and burn up group
             newBlock.setType(newBlockType)
             newXsType, newBuGroup = self._createBlendedXSID(newBlock)

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -1164,7 +1164,7 @@ class FakeMat(materials.ht9.HT9):
         materials.ht9.HT9.__init__(self)
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
-        """ A fake linear expansion percent"""
+        """A fake linear expansion percent"""
         Tc = units.getTc(Tc, Tk)
         return 0.02 * Tc
 
@@ -1184,6 +1184,6 @@ class FakeMatException(materials.ht9.HT9):
         materials.ht9.HT9.__init__(self)
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
-        """ A fake linear expansion percent"""
+        """A fake linear expansion percent"""
         Tc = units.getTc(Tc, Tk)
         return 0.08 * Tc


### PR DESCRIPTION
Supports the modeling of fission products when the reactor is converted from Hex to RZT.

## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

