### PR TITLE
Uniform mesh refactor to simplify block-level parameter mapping

### DIFF
--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -92,8 +92,7 @@ class TestAssemblyUniformMesh(unittest.TestCase):
         newAssem = self.converter.makeAssemWithUniformMesh(
             sourceAssem,
             sourceAssem.getAxialMesh(),
-            blockScalarParamNames=["flux", "power"],
-            blockArrayParamNames=["mgFlux"],
+            blockParamNames=["flux", "power", "mgFlux"],
         )
         for b, origB in zip(newAssem, sourceAssem):
             self.assertEqual(b.p.flux, 1.0)
@@ -116,8 +115,7 @@ class TestAssemblyUniformMesh(unittest.TestCase):
         uniformMesh.UniformMeshGeometryConverter.setAssemblyStateFromOverlaps(
             sourceAssembly=newAssem,
             destinationAssembly=sourceAssem,
-            blockScalarParamNames=["flux", "power"],
-            blockArrayParamNames=["mgFlux"],
+            blockParamNames=["flux", "power", "mgFlux"],
         )
         for b, updatedB in zip(newAssem, sourceAssem):
             self.assertEqual(b.p.flux, 2.0)
@@ -148,8 +146,7 @@ class TestAssemblyUniformMesh(unittest.TestCase):
         cachedBlockParams = (
             uniformMesh.UniformMeshGeometryConverter.clearStateOnAssemblies(
                 [sourceAssem],
-                blockScalarParamNames=["flux", "power"],
-                blockArrayParamNames=["mgFlux"],
+                blockParamNames=["flux", "power", "mgFlux"],
                 cache=True,
             )
         )
@@ -360,8 +357,7 @@ class TestParamConversion(unittest.TestCase):
         uniformMesh.UniformMeshGeometryConverter.setAssemblyStateFromOverlaps(
             self.sourceAssem,
             self.destinationAssem,
-            blockScalarParamNames=paramList,
-            blockArrayParamNames=["mgNeutronVelocity"],
+            blockParamNames=paramList + ["mgNeutronVelocity"],
         )
 
         for paramName in paramList:

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -32,6 +32,7 @@ What's new in ARMI
 #. Refactored the ``UniformMeshGeometryConverter`` to allow for mapping of number densities and parameters to and from a single assembly rather than requiring an entire core.
 #. Updated NHFLUX reader to store VARIANT data that was being discarded. Reading/writing VARIANT NHFLUX files now show binary equivalance.
 #. The ``newReports`` were moved into their final location in ``armi/bookkeeping/report/``.
+#. Refactored the ``UniformMeshGeometryConverter`` again to auto-detect if block-level parameters are scalar or array values and implemented a feature to optionally disable number density mapping.
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
Small refactor of the `UniformMeshConverter` to allow users to provide just the block-level parameter names as a single list rather than requiring the users/developers to differentiate in the code which parameters are scalar or array values. This will now auto-detect the type based on the parameter definition and then apply the correct setters/getters.

Add an optional argument the `makeAssemWithUniformMesh` and `setAssemblyStateFromOverlaps` staticmethods to disable the mapping of number densities on the creation of a new uniform assembly or when mapping block-level parameter data between two assemblies. This allows for more application-dependent flexibility for handling edge cases. An example of where this is useful is in the situation of moving meshes in vertical control rod movements.

## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

