### PR TITLE
Allow for onProcessCoreLoading to know if database is being loaded

### DIFF
--- a/armi/physics/neutronics/__init__.py
+++ b/armi/physics/neutronics/__init__.py
@@ -137,7 +137,7 @@ class NeutronicsPlugin(plugins.ArmiPlugin):
 
     @staticmethod
     @plugins.HOOKIMPL
-    def onProcessCoreLoading(core, cs):
+    def onProcessCoreLoading(core, cs, dbLoad):
         applyEffectiveDelayedNeutronFractionToCore(core, cs)
 
     @staticmethod

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -113,7 +113,10 @@ class NeutronicsReactorTests(unittest.TestCase):
                 "decayConstants": [1.0] * 6,
             }
         )
-        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        dbLoad = False
+        getPluginManagerOrFail().hook.onProcessCoreLoading(
+            core=r.core, cs=cs, dbLoad=dbLoad
+        )
         r.core.setOptionsFromCs(cs)
         self.assertEqual(r.core.p.beta, sum(cs["beta"]))
         self.assertListEqual(list(r.core.p.betaComponents), cs["beta"])
@@ -124,7 +127,9 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"beta": 0.00670},
         )
-        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(
+            core=r.core, cs=cs, dbLoad=dbLoad
+        )
         self.assertEqual(r.core.p.beta, cs["beta"])
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -137,7 +142,9 @@ class NeutronicsReactorTests(unittest.TestCase):
                 "beta": [0.0] * 6,
             },
         )
-        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(
+            core=r.core, cs=cs, dbLoad=dbLoad
+        )
         self.assertIsNone(r.core.p.beta)
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -149,7 +156,9 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"beta": [0.0], "decayConstants": [1.0]},
         )
-        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(
+            core=r.core, cs=cs, dbLoad=dbLoad
+        )
         self.assertEqual(r.core.p.beta, sum(cs["beta"]))
         self.assertListEqual(list(r.core.p.betaComponents), cs["beta"])
         self.assertListEqual(list(r.core.p.betaDecayConstants), cs["decayConstants"])
@@ -160,7 +169,9 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"decayConstants": [1.0] * 6},
         )
-        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(
+            core=r.core, cs=cs, dbLoad=dbLoad
+        )
         self.assertIsNone(r.core.p.beta)
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -172,7 +183,9 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"decayConstants": [1.0] * 6, "beta": 0.0},
         )
-        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(
+            core=r.core, cs=cs, dbLoad=dbLoad
+        )
         self.assertEqual(r.core.p.beta, cs["beta"])
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -183,7 +196,9 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = _getModifiedSettings(
             customSettings={"decayConstants": None, "beta": None},
         )
-        getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(
+            core=r.core, cs=cs, dbLoad=dbLoad
+        )
         self.assertEqual(r.core.p.beta, cs["beta"])
         self.assertIsNone(r.core.p.betaComponents)
         self.assertIsNone(r.core.p.betaDecayConstants)
@@ -195,7 +210,9 @@ class NeutronicsReactorTests(unittest.TestCase):
             cs = _getModifiedSettings(
                 customSettings={"decayConstants": [1.0] * 6, "beta": [0.0]},
             )
-            getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+            getPluginManagerOrFail().hook.onProcessCoreLoading(
+                core=r.core, cs=cs, dbLoad=dbLoad
+            )
 
         # Test that an error is raised if the decay constants
         # and group-wise beta are inconsistent sizes
@@ -204,7 +221,9 @@ class NeutronicsReactorTests(unittest.TestCase):
             cs = _getModifiedSettings(
                 customSettings={"decayConstants": [1.0] * 6, "beta": [0.0] * 5},
             )
-            getPluginManagerOrFail().hook.onProcessCoreLoading(core=r.core, cs=cs)
+            getPluginManagerOrFail().hook.onProcessCoreLoading(
+                core=r.core, cs=cs, dbLoad=dbLoad
+            )
 
 
 if __name__ == "__main__":

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -217,7 +217,7 @@ class ArmiPlugin:
 
     @staticmethod
     @HOOKSPEC
-    def onProcessCoreLoading(core, cs) -> None:
+    def onProcessCoreLoading(core, cs, dbLoad) -> None:
         """
         Function to call whenever a Core object is newly built.
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2318,7 +2318,9 @@ class Core(composites.Composite):
 
         self.p.maxAssemNum = self.getMaxParam("assemNum")
 
-        getPluginManagerOrFail().hook.onProcessCoreLoading(core=self, cs=cs, dbLoad=dbLoad)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(
+            core=self, cs=cs, dbLoad=dbLoad
+        )
 
     def _applyThermalExpansion(
         self, assems: list, dbLoad: bool, referenceAssembly=None

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2318,7 +2318,7 @@ class Core(composites.Composite):
 
         self.p.maxAssemNum = self.getMaxParam("assemNum")
 
-        getPluginManagerOrFail().hook.onProcessCoreLoading(core=self, cs=cs)
+        getPluginManagerOrFail().hook.onProcessCoreLoading(core=self, cs=cs, dbLoad=dbLoad)
 
     def _applyThermalExpansion(
         self, assems: list, dbLoad: bool, referenceAssembly=None

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -244,7 +244,7 @@ class TestUserPlugins(unittest.TestCase):
 
         # prove that our plugin affects the core in the desired way
         heights = [float(f.p.height) for f in fuels]
-        plug0.onProcessCoreLoading(core=r.core, cs=o.cs)
+        plug0.onProcessCoreLoading(core=r.core, cs=o.cs, dbLoad=False)
         for i, height in enumerate(heights):
             self.assertEqual(fuels[i].p.height, height + 1.0)
 

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -101,7 +101,7 @@ class UserPluginOnProcessCoreLoading(plugins.UserPlugin):
 
     @staticmethod
     @plugins.HOOKIMPL
-    def onProcessCoreLoading(core, cs):
+    def onProcessCoreLoading(core, cs, dbLoad):
         blocks = core.getBlocks(Flags.FUEL)
         for b in blocks:
             b.p.height += 1.0

--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -398,7 +398,7 @@ This can be done by sublassing :py:class:`armi.plugins.UserPlugin`:
 
         @staticmethod
         @plugins.HOOKIMPL
-        def onProcessCoreLoading(core, cs, dbLoad=False):
+        def onProcessCoreLoading(core, cs, dbLoad):
         for b in core.getBlocks(Flags.FUEL):
             b.p.power += 1.0
 

--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -398,7 +398,7 @@ This can be done by sublassing :py:class:`armi.plugins.UserPlugin`:
 
         @staticmethod
         @plugins.HOOKIMPL
-        def onProcessCoreLoading(core, cs):
+        def onProcessCoreLoading(core, cs, dbLoad=False):
         for b in core.getBlocks(Flags.FUEL):
             b.p.power += 1.0
 


### PR DESCRIPTION
## Description

The docstring for `armi.plugins.ArmiPlugin.onProcessCoreLoading()` suggests that the method is called when either constructing a Core from a blueprints file or from loading a database. Wouldn't it be nice if the method knew if one or the other was occurring, in case that might be useful information for the implementing plugin?

This PR proposes such a nicety.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

