### PR TITLE
Reset caching on block components within uniform mesh converter

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -955,8 +955,6 @@ class Assembly(composites.Composite):
                 top = min(b.p.ztop, zUpper)
                 bottom = max(b.p.zbottom, zLower)
                 heightHere = top - bottom
-                if not heightHere:
-                    continue
 
                 # Filter out blocks that have an extremely small height fraction
                 if heightHere / b.getHeight() > EPS:

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -946,6 +946,7 @@ class Assembly(composites.Composite):
         EPS = 1e-10
         blocksHere = []
         allMeshPoints = set()
+
         for b in self:
             if b.p.ztop >= zLower and b.p.zbottom <= zUpper:
                 allMeshPoints.add(b.p.zbottom)
@@ -954,6 +955,8 @@ class Assembly(composites.Composite):
                 top = min(b.p.ztop, zUpper)
                 bottom = max(b.p.zbottom, zLower)
                 heightHere = top - bottom
+                if not heightHere:
+                    continue
 
                 # Filter out blocks that have an extremely small height fraction
                 if heightHere / b.getHeight() > EPS:

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -859,3 +859,7 @@ def setNumberDensitiesFromOverlaps(block, overlappingBlockInfo):
                 + numberDensity * overlappingHeightInCm / blockHeightInCm
             )
     block.setNumberDensities(totalDensities)
+    # Set the volume of each component in the block to `None` so that the
+    # volume of each volume is recomputed.
+    for c in block:
+        c.p.volume = None


### PR DESCRIPTION
Small update for resetting component volumes during setting number densities to ensure that the component volumes are recalculated.

## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

