### PR TITLE
Allow treatment of non-uniform assemblies in the uniform mesh converter

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -438,9 +438,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                     b = self.r.core.getFirstBlock()
                     blockParamNames = []
                     for category in converter.BLOCK_PARAM_MAPPING_CATEGORIES:
-                        blockParamNames.extend(
-                            b.p.paramDefs.inCategory(category).names
-                        )
+                        blockParamNames.extend(b.p.paramDefs.inCategory(category).names)
                     for assem in self.r.core.getAssemblies(
                         self.options.nonUniformMeshFlags
                     ):
@@ -504,9 +502,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                     b = self.r.core.getFirstBlock()
                     blockParamNames = []
                     for category in meshConverter.BLOCK_PARAM_MAPPING_CATEGORIES:
-                        blockParamNames.extend(
-                            b.p.paramDefs.inCategory(category).names
-                        )
+                        blockParamNames.extend(b.p.paramDefs.inCategory(category).names)
                     for assem in self.r.core.getAssemblies(
                         self.options.nonUniformMeshFlags
                     ):
@@ -518,6 +514,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                                     blockParamNames,
                                     mapNumberDensities=False,
                                 )
+                                self.r.core.sfp.remove(storedAssem)
                                 storedAssem.spatialLocator = assem.spatialLocator
                                 self.r.core.removeAssembly(assem, discharge=False)
                                 self.r.core.add(storedAssem)

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -25,6 +25,7 @@ import scipy.integrate
 from armi import runLog
 from armi import interfaces
 from armi.utils import units, codeTiming, getMaxBurnSteps
+from armi.reactor import parameters
 from armi.reactor import geometry
 from armi.reactor import reactors
 from armi.reactor.converters import uniformMesh

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -436,12 +436,12 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                     )
                     b = self.r.core.getFirstBlock()
                     blockParamNames = []
-                    self.blockParamNames.extend(
+                    blockParamNames.extend(
                         b.p.paramDefs.inCategory(
                             parameters.Category.detailedAxialExpansion
                         ).names
                     )
-                    self.blockParamNames.extend(
+                    blockParamNames.extend(
                         b.p.paramDefs.inCategory(
                             parameters.Category.multiGroupQuantities
                         ).names
@@ -504,12 +504,12 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                 if self.options.hasNonUniformAssems:
                     b = self.r.core.getFirstBlock()
                     blockParamNames = []
-                    self.blockParamNames.extend(
+                    blockParamNames.extend(
                         b.p.paramDefs.inCategory(
                             parameters.Category.detailedAxialExpansion
                         ).names
                     )
-                    self.blockParamNames.extend(
+                    blockParamNames.extend(
                         b.p.paramDefs.inCategory(
                             parameters.Category.multiGroupQuantities
                         ).names

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -329,9 +329,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         self.real = neutronics.realCalculationRequested(cs)
         self.detailedAxialExpansion = cs["detailedAxialExpansion"]
         self.hasNonUniformAssems = any(
-            [
-                Flags.fromStringIgnoreErrors(f) for f in cs["nonUniformAssemFlags"]
-            ].nonUniformMeshFlags
+            [Flags.fromStringIgnoreErrors(f) for f in cs["nonUniformAssemFlags"]]
         )
         self.eigenvalueProblem = cs["eigenProb"]
 

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -527,8 +527,8 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                                     blockParamNames,
                                     mapNumberDensities=False,
                                 )
-                                self.r.core.remove(assem)
                                 storedAssem.spatialLocator = assem.spatialLocator
+                                self.r.core.remove(assem)
                                 self.r.core.add(storedAssem)
                                 break
                 else:

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -434,7 +434,6 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                         None,
                         calcReactionRates=self.options.calcReactionRatesOnMeshConversion,
                     )
-                    uniformMesh = converter._computeAverageAxialMesh()
                     b = self.r.core.getFirstBlock()
                     blockParamNames = []
                     self.blockParamNames.extend(
@@ -453,7 +452,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                         storedAssem = copy.deepcopy(assem)
                         self.r.core.sfp.add(storedAssem)
                         converter.makeAssemWithUniformMesh(
-                            assem, uniformMesh, blockParamNames
+                            assem, self.r.core.refAssem.getAxialMesh(), blockParamNames
                         )
 
                     if makePlots:

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -296,6 +296,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         self.isRestart = None
         self.energyDepoCalcMethodStep = None  # for gamma transport/normalization
         self.detailedAxialExpansion = None
+        self.nonUniformAssems = None
         self.boundaries = None
         self.xsKernel = None
 
@@ -327,6 +328,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         self.adjoint = neutronics.adjointCalculationRequested(cs)
         self.real = neutronics.realCalculationRequested(cs)
         self.detailedAxialExpansion = cs["detailedAxialExpansion"]
+        self.nonUniformAssems = len(cs["nonUniformAssemFlags"]) > 0
         self.eigenvalueProblem = cs["eigenProb"]
 
         # dose/dpa specific (should be separate subclass?)
@@ -402,7 +404,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                 + "This is a programming error and requires further investigation."
             )
         neutronicsReactor = self.r
-        if self.options.detailedAxialExpansion:
+        if self.options.detailedAxialExpansion or self.options.nonUniformAssems:
             converter = self.geomConverters.get("axial")
             if not converter:
                 converter = uniformMesh.NeutronicsUniformMeshConverter(

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -431,6 +431,9 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                     not self.options.detailedAxialExpansion
                     and self.options.hasNonUniformAssems
                 ):
+                    # Here we update the axial mesh so that we can use it below
+                    # as the basis for homogenizing each assembly.
+                    self.r.core.updateAxialMesh()
                     converter = uniformMesh.NeutronicsUniformMeshConverter(
                         None,
                         calcReactionRates=self.options.calcReactionRatesOnMeshConversion,
@@ -453,9 +456,8 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                         storedAssem = copy.deepcopy(assem)
                         self.r.core.sfp.add(storedAssem)
                         converter.makeAssemWithUniformMesh(
-                            assem, self.r.core.refAssem.getAxialMesh(), blockParamNames
+                            assem, self.r.core.p.axialMesh, blockParamNames
                         )
-                        self.r.core.updateAxialMesh()
 
                     if makePlots:
                         converter.plotConvertedReactor()

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -456,7 +456,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                         storedAssem = copy.deepcopy(assem)
                         self.r.core.sfp.add(storedAssem)
                         converter.makeAssemWithUniformMesh(
-                            assem, self.r.core.p.axialMesh, blockParamNames
+                            assem, self.r.core.p.axialMesh[1:], blockParamNames
                         )
 
                     if makePlots:

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -519,7 +519,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                     for assem in self.r.core.getAssemblies(
                         self.options.nonUniformMeshFlags
                     ):
-                        for storedAssem in self.r.core.sfr.getChildren():
+                        for storedAssem in self.r.core.sfp.getChildren():
                             if storedAssem.getName() == assem.getName():
                                 meshConverter.setAssemblyStateFromOverlaps(
                                     assem,

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -455,6 +455,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                         converter.makeAssemWithUniformMesh(
                             assem, self.r.core.refAssem.getAxialMesh(), blockParamNames
                         )
+                        self.r.core.updateAxialMesh()
 
                     if makePlots:
                         converter.plotConvertedReactor()
@@ -530,6 +531,8 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                                 self.r.core.remove(assem)
                                 self.r.core.add(storedAssem)
                                 break
+
+                    self.r.core.updateAxialMesh()
                 else:
                     meshConverter.applyStateToOriginal()
                     self.r = (

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -296,7 +296,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         self.isRestart = None
         self.energyDepoCalcMethodStep = None  # for gamma transport/normalization
         self.detailedAxialExpansion = None
-        self.nonUniformAssems = None
+        self.hasNonUniformAssems = None
         self.boundaries = None
         self.xsKernel = None
 
@@ -328,7 +328,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         self.adjoint = neutronics.adjointCalculationRequested(cs)
         self.real = neutronics.realCalculationRequested(cs)
         self.detailedAxialExpansion = cs["detailedAxialExpansion"]
-        self.nonUniformAssems = len(cs["nonUniformAssemFlags"]) > 0
+        self.hasNonUniformAssems = any(cs["nonUniformAssemFlags"])
         self.eigenvalueProblem = cs["eigenProb"]
 
         # dose/dpa specific (should be separate subclass?)
@@ -404,7 +404,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                 + "This is a programming error and requires further investigation."
             )
         neutronicsReactor = self.r
-        if self.options.detailedAxialExpansion or self.options.nonUniformAssems:
+        if self.options.detailedAxialExpansion or self.options.hasNonUniformAssems:
             converter = self.geomConverters.get("axial")
             if not converter:
                 converter = uniformMesh.NeutronicsUniformMeshConverter(

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -437,26 +437,19 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                     )
                     b = self.r.core.getFirstBlock()
                     blockParamNames = []
-                    blockParamNames.extend(
-                        b.p.paramDefs.inCategory(
-                            parameters.Category.detailedAxialExpansion
-                        ).names
-                    )
-                    blockParamNames.extend(
-                        b.p.paramDefs.inCategory(
-                            parameters.Category.multiGroupQuantities
-                        ).names
-                    )
+                    for category in converter.BLOCK_PARAM_MAPPING_CATEGORIES:
+                        self.blockParamNames.extend(
+                            b.p.paramDefs.inCategory(category).names
+                        )
                     for assem in self.r.core.getAssemblies(
                         self.options.nonUniformMeshFlags
                     ):
-                        storedAssem = copy.deepcopy(assem)
-                        self.r.core.sfp.add(storedAssem)
                         homogAssem = converter.makeAssemWithUniformMesh(
                             assem, self.r.core.refAssem.getAxialMesh(), blockParamNames
                         )
                         homogAssem.spatialLocator = assem.spatialLocator
-                        self.r.core.remove(assem)
+                        self.r.core.removeAssembly(assem, discharge=False)
+                        self.r.core.sfp.add(assem)
                         self.r.core.add(homogAssem)
 
                     self.r.core.updateAxialMesh()
@@ -510,16 +503,10 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                 if self.options.hasNonUniformAssems:
                     b = self.r.core.getFirstBlock()
                     blockParamNames = []
-                    blockParamNames.extend(
-                        b.p.paramDefs.inCategory(
-                            parameters.Category.detailedAxialExpansion
-                        ).names
-                    )
-                    blockParamNames.extend(
-                        b.p.paramDefs.inCategory(
-                            parameters.Category.multiGroupQuantities
-                        ).names
-                    )
+                    for category in meshConverter.BLOCK_PARAM_MAPPING_CATEGORIES:
+                        self.blockParamNames.extend(
+                            b.p.paramDefs.inCategory(category).names
+                        )
                     for assem in self.r.core.getAssemblies(
                         self.options.nonUniformMeshFlags
                     ):
@@ -532,7 +519,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                                     mapNumberDensities=False,
                                 )
                                 storedAssem.spatialLocator = assem.spatialLocator
-                                self.r.core.remove(assem)
+                                self.r.core.removeAssembly(assem, discharge=False)
                                 self.r.core.add(storedAssem)
                                 break
 

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -418,6 +418,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                 if self.options.detailedAxialExpansion:
                     converter.convert(self.r)
                     neutronicsReactor = converter.convReactor
+                    self.r = neutronicsReactor
 
                 # Here we are taking a short cut to homogenizing the core by only focusing on the
                 # core assemblies that need to be homogenized. This will have a large speed up
@@ -450,7 +451,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                         self.options.nonUniformMeshFlags
                     ):
                         storedAssem = copy.deepcopy(assem)
-                        core.sfp.add(storedAssem)
+                        self.r.core.sfp.add(storedAssem)
                         converter.makeAssemWithUniformMesh(
                             assem, uniformMesh, blockParamNames
                         )
@@ -463,10 +464,8 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
             converter = self.geomConverters.get(
                 "edgeAssems", geometryConverters.EdgeAssemblyChanger()
             )
-            converter.addEdgeAssemblies(neutronicsReactor.core)
+            converter.addEdgeAssemblies(self.r.core)
             self.geomConverters["edgeAssems"] = converter
-
-        self.r = neutronicsReactor
 
     @codeTiming.timed
     def _undoGeometryTransformations(self):

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -438,7 +438,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                     b = self.r.core.getFirstBlock()
                     blockParamNames = []
                     for category in converter.BLOCK_PARAM_MAPPING_CATEGORIES:
-                        self.blockParamNames.extend(
+                        blockParamNames.extend(
                             b.p.paramDefs.inCategory(category).names
                         )
                     for assem in self.r.core.getAssemblies(
@@ -504,7 +504,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
                     b = self.r.core.getFirstBlock()
                     blockParamNames = []
                     for category in meshConverter.BLOCK_PARAM_MAPPING_CATEGORIES:
-                        self.blockParamNames.extend(
+                        blockParamNames.extend(
                             b.p.paramDefs.inCategory(category).names
                         )
                     for assem in self.r.core.getAssemblies(

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -393,7 +393,7 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
         changer = geometryConverters.ThirdCoreHexToFullCoreChanger(self.o.cs)
         changer.convert(self.r)
 
-        converter = uniformMesh.NeutronicsUniformMeshConverter()
+        converter = uniformMesh.NeutronicsUniformMeshConverter(self.o.cs)
         newR = converter.initNewReactor(self.r)
 
         # Check the full core conversion is successful

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -411,26 +411,13 @@ class TestUniformMeshNonUniformAssemFlags(unittest.TestCase):
         controlAssems = self.r.core.getAssemblies(Flags.PRIMARY | Flags.CONTROL)
         self.converter.convert(self.r)
 
-        print(self.r.core.sfp.getChildren())
         self.assertEqual(
             len(controlAssems),
-            len(
-                [
-                    a
-                    for a in self.r.core.sfp.getChildren()
-                    if self.converter._SFP_TEMP_STORAGE_SUFFIX in a.getName()
-                ]
-            ),
+            len(self.converter._nonUniformAssemStorage),
         )
         self.converter.applyStateToOriginal()
         self.assertEqual(
-            len(
-                [
-                    a
-                    for a in self.r.core.sfp.getChildren()
-                    if self.converter._SFP_TEMP_STORAGE_SUFFIX in a.getName()
-                ]
-            ),
+            len(self.converter._nonUniformAssemStorage),
             0,
         )
 

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -596,16 +596,13 @@ class UniformMeshGeometryConverter(GeometryConverter):
         src = self._sourceReactor
         refAssem = src.core.refAssem
 
-        refNumFinePoints = len(
-            src.core.findAllAxialMeshPoints([refAssem], applySubMesh=True)
-        )
+        refNumPoints = len(src.core.findAllAxialMeshPoints([refAssem], applySubMesh=False)) - 1
         allMeshes = []
         for a in src.core:
             # Get the mesh points of the assembly, neglecting the first coordinate
             # (typically zero).s
-            nFineMesh = len(src.core.findAllAxialMeshPoints([a]))
-            if nFineMesh == refNumFinePoints:
-                aMesh = src.core.findAllAxialMeshPoints([a], applySubMesh=False)[1:]
+            aMesh = src.core.findAllAxialMeshPoints([a], applySubMesh=False)[1:]
+            if len(aMesh) == refNumPoints:
                 allMeshes.append(aMesh)
         self._uniformMesh = average1DWithinTolerance(numpy.array(allMeshes))
 

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -860,6 +860,6 @@ def setNumberDensitiesFromOverlaps(block, overlappingBlockInfo):
             )
     block.setNumberDensities(totalDensities)
     # Set the volume of each component in the block to `None` so that the
-    # volume of each volume is recomputed.
+    # volume of each component is recomputed.
     for c in block:
         c.p.volume = None

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -300,7 +300,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
             block = copy.deepcopy(sourceBlock)
             block.p.xsType = xsType
             block.setHeight(topMeshPoint - bottom)
-            block.p.axMesh = 1
+            block.p.axMesh = sourceBlock.p.axMesh
             newAssem.add(block)
             bottom = topMeshPoint
 

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -300,7 +300,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
             block = copy.deepcopy(sourceBlock)
             block.p.xsType = xsType
             block.setHeight(topMeshPoint - bottom)
-            block.p.axMesh = sourceBlock.p.axMesh
+            block.p.axMesh = 1
             newAssem.add(block)
             bottom = topMeshPoint
 
@@ -596,14 +596,12 @@ class UniformMeshGeometryConverter(GeometryConverter):
         src = self._sourceReactor
         refAssem = src.core.refAssem
 
-        refNumPoints = (
-            len(src.core.findAllAxialMeshPoints([refAssem], applySubMesh=False)) - 1
-        )
+        refNumPoints = len(src.core.findAllAxialMeshPoints([refAssem])) - 1
         allMeshes = []
         for a in src.core:
             # Get the mesh points of the assembly, neglecting the first coordinate
-            # (typically zero).s
-            aMesh = src.core.findAllAxialMeshPoints([a], applySubMesh=False)[1:]
+            # (typically zero).
+            aMesh = src.core.findAllAxialMeshPoints([a])[1:]
             if len(aMesh) == refNumPoints:
                 allMeshes.append(aMesh)
         self._uniformMesh = average1DWithinTolerance(numpy.array(allMeshes))

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -115,7 +115,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
         self._setParamsToUpdate()
         self._computeAverageAxialMesh()
         self._buildAllUniformAssemblies()
-        self._mapStateFromReactorToOther(self._sourceReactor, self.convReactor)
+        self._mapStateFromReactorToOther(
+            self._sourceReactor, self.convReactor, mapNumberDensities=False
+        )
         self.convReactor.core.updateAxialMesh()
 
         self._newAssembliesAdded = self.convReactor.core.getAssemblies()
@@ -178,7 +180,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
         # parameters that did not change.
         self._cachedReactorCoreParamData = {}
         self._clearStateOnReactor(self._sourceReactor, cache=True)
-        self._mapStateFromReactorToOther(self.convReactor, self._sourceReactor)
+        self._mapStateFromReactorToOther(
+            self.convReactor, self._sourceReactor, mapNumberDensities=False
+        )
 
         # We want to map the converted reactor core's library to the source reactor
         # because in some instances this has changed (i.e., when generating cross sections).
@@ -595,7 +599,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
             src.core.findAllAxialMeshPoints([src.core.refAssem], applySubMesh=True)[1:]
         )
 
-
     @staticmethod
     def _createNewAssembly(sourceAssembly):
         a = sourceAssembly.__class__(sourceAssembly.getType())
@@ -632,7 +635,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 self._cachedReactorCoreParamData[rp] = reactor.core.p[rp]
             reactor.core.p[rp] = 0.0
 
-    def _mapStateFromReactorToOther(self, sourceReactor, destReactor):
+    def _mapStateFromReactorToOther(
+        self, sourceReactor, destReactor, mapNumberDensities=True
+    ):
         """
         Map parameters from one reactor to another.
 
@@ -717,9 +722,14 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
                         f"user-input power ({expectedPow})."
                     )
 
-    def _mapStateFromReactorToOther(self, sourceReactor, destReactor):
+    def _mapStateFromReactorToOther(
+        self, sourceReactor, destReactor, mapNumberDensities=True
+    ):
         UniformMeshGeometryConverter._mapStateFromReactorToOther(
-            self, sourceReactor, destReactor
+            self,
+            sourceReactor,
+            destReactor,
+            mapNumberDensities,
         )
 
         # Map reactor core parameters
@@ -743,6 +753,7 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
                 aSource,
                 aDest,
                 self.blockParamNames,
+                mapNumberDensities,
             )
 
             # If requested, the reaction rates will be calculated based on the

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -147,7 +147,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 homogAssem.spatialLocator = assem.spatialLocator
 
                 # Remove this assembly from the core and add it to the
-                # SFP so that it can be replaced with the homogenized assembly.
+                # temporary storage list so that it can be replaced with the homogenized assembly.
                 # Note that we do not call the `removeAssembly` method because
                 # this will delete the core assembly from existence rather than
                 # only stripping its spatialLocator away.
@@ -244,7 +244,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
                             mapNumberDensities=False,
                         )
 
-                        # Remove the stored assembly from the spent fuel pool
+                        # Remove the stored assembly from the temporary storage list
                         # and replace the current assembly with it.
                         storedAssem.spatialLocator = assem.spatialLocator
                         storedAssem.setName(assem.getName())

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -592,7 +592,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
         The reason for this is to account for the fact that multiple assemblies (i.e., fuel assemblies)
         may have a different mesh due to differences in thermal and/or burn-up expansion.
         """
-
         src = self._sourceReactor
         refAssem = src.core.refAssem
 

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -155,12 +155,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
             self.convReactor.core.updateAxialMesh()
 
-            self._checkConversion()
-            completeEndTime = timer()
-            runLog.extra(
-                f"Reactor core conversion time: {completeEndTime-completeStartTime} seconds"
-            )
-
         else:
             self.convReactor = self.initNewReactor(r)
             self._setParamsToUpdate()
@@ -173,7 +167,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
             self._newAssembliesAdded = self.convReactor.core.getAssemblies()
 
-            self._checkConversion()
+        self._checkConversion()
         completeEndTime = timer()
         runLog.extra(
             f"Reactor core conversion time: {completeEndTime-completeStartTime} seconds"

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -450,9 +450,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
                     updatedDestVals[paramName] += sourceBlockVal * integrationFactor
 
-                BlockParamMapper.paramSetter(
-                    destBlock, updatedDestVals.values(), updatedDestVals.keys()
-                )
+            BlockParamMapper.paramSetter(
+                destBlock, updatedDestVals.values(), updatedDestVals.keys()
+            )
 
             UniformMeshGeometryConverter._applyCachedParamValues(
                 destBlock, blockParamNames, cachedParams

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -278,7 +278,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
             self._cachedReactorCoreParamData = {}
             self._clearStateOnReactor(self._sourceReactor, cache=True)
             self._mapStateFromReactorToOther(
-                self.convReactor, self._sourceReactor, mapNumberDensities=False
+                self.convReactor, self._sourceReactor, mapNumberDensities=True
             )
 
             # We want to map the converted reactor core's library to the source reactor

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -127,9 +127,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
         # Here we are taking a short cut to homogenizing the core by only focusing on the
         # core assemblies that need to be homogenized. This will have a large speed up
         # since we don't have to create an entirely new reactor perform the data mapping.
-        # We are using the Spent Fuel Pool (SFP) as a container just to temporarily store
-        # the detailed assembly so that it can be recovered later when the geometry
-        # conversions are undone.
         if self._hasNonUniformAssems:
             runLog.extra(
                 f"Replacing non-uniform assemblies in reactor {r}, "
@@ -248,14 +245,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
                         # and replace the current assembly with it.
                         storedAssem.spatialLocator = assem.spatialLocator
                         storedAssem.setName(assem.getName())
-                        if (
-                            storedAssem.spatialLocator
-                            in self._sourceReactor.core.sfp.childrenByLocator
-                        ):
-                            self._sourceReactor.core.sfp.childrenByLocator.pop(
-                                storedAssem.spatialLocator
-                            )
-
                         self._nonUniformAssemStorage.remove(storedAssem)
                         self._sourceReactor.core.removeAssembly(assem, discharge=False)
                         self._sourceReactor.core.add(storedAssem)
@@ -263,7 +252,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 else:
                     runLog.error(
                         f"No assembly matching name {assem.getName()} "
-                        f"was found in the spent fuel pool. {assem} "
+                        f"was found in the temporary storage list. {assem} "
                         f"will persist as an axially unified assembly. "
                         f"This is likely not intended."
                     )

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -588,20 +588,13 @@ class UniformMeshGeometryConverter(GeometryConverter):
         The reason for this is to account for the fact that multiple assemblies (i.e., fuel assemblies)
         may have a different mesh due to differences in thermal and/or burn-up expansion.
         """
-        src = self._sourceReactor
-        refAssem = src.core.refAssem
         # Get the number of reference mesh points, including the sub-mesh. This subtracts 1
         # to remove the first value (typically zero).
-        refNumPoints = (
-            len(src.core.findAllAxialMeshPoints([refAssem], applySubMesh=True)) - 1
+        src = self._sourceReactor
+        self._uniformMesh = numpy.array(
+            src.core.findAllAxialMeshPoints([src.core.refAssem], applySubMesh=True)[1:]
         )
-        allMeshes = []
-        for a in src.core:
-            # Get the mesh points of the assembly, neglecting the first coordinate (typically zero).s
-            aMesh = src.core.findAllAxialMeshPoints([a], applySubMesh=True)[1:]
-            if len(aMesh) == refNumPoints:
-                allMeshes.append(aMesh)
-        self._uniformMesh = average1DWithinTolerance(numpy.array(allMeshes))
+
 
     @staticmethod
     def _createNewAssembly(sourceAssembly):

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -90,6 +90,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
         - Mapping number densities and block parameters between one assembly to another. See: `<UniformMeshGeometryConverter.setAssemblyStateFromOverlaps>`
     """
 
+    REACTOR_PARAM_MAPPING_CATEGORIES = []
+    BLOCK_PARAM_MAPPING_CATEGORIES = []
+
     def __init__(self, cs=None):
         GeometryConverter.__init__(self, cs)
         self._uniformMesh = None
@@ -667,6 +670,12 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
     back to the source reactor.
     """
 
+    REACTOR_PARAM_MAPPING_CATEGORIES = [parameters.Category.neutronics]
+    BLOCK_PARAM_MAPPING_CATEGORIES = [
+        parameters.Category.detailedAxialExpansion,
+        parameters.Category.multiGroupQuantities,
+    ]
+
     def __init__(self, cs=None, calcReactionRates=True):
         """
         Parameters
@@ -686,19 +695,14 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
         """Activate conversion of various neutronics-only paramters."""
         UniformMeshGeometryConverter._setParamsToUpdate(self)
 
-        self.reactorParamNames.extend(
-            self._sourceReactor.core.p.paramDefs.inCategory(
-                parameters.Category.neutronics
-            ).names
-        )
+        for category in self.REACTOR_PARAM_MAPPING_CATEGORIES:
+            self.reactorParamNames.extend(
+                self._sourceReactor.core.p.paramDefs.inCategory(category).names
+            )
 
         b = self._sourceReactor.core.getFirstBlock()
-        self.blockParamNames.extend(
-            b.p.paramDefs.inCategory(parameters.Category.detailedAxialExpansion).names
-        )
-        self.blockParamNames.extend(
-            b.p.paramDefs.inCategory(parameters.Category.multiGroupQuantities).names
-        )
+        for category in self.BLOCK_PARAM_MAPPING_CATEGORIES:
+            self.blockParamNames.extend(b.p.paramDefs.inCategory(category).names)
 
     def _checkConversion(self):
         """

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -596,7 +596,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
         src = self._sourceReactor
         refAssem = src.core.refAssem
 
-        refNumPoints = len(src.core.findAllAxialMeshPoints([refAssem], applySubMesh=False)) - 1
+        refNumPoints = (
+            len(src.core.findAllAxialMeshPoints([refAssem], applySubMesh=False)) - 1
+        )
         allMeshes = []
         for a in src.core:
             # Get the mesh points of the assembly, neglecting the first coordinate

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -106,17 +106,21 @@ class UniformMeshGeometryConverter(GeometryConverter):
         # This prevents clearing out data on the original reactor that should
         # be preserved since no changes were applied.
         self._cachedReactorCoreParamData = {}
-        self._nonUniformMeshFlags = [
-            Flags.fromStringIgnoreErrors(f) for f in cs["nonUniformAssemFlags"]
-        ]
-        self._hasNonUniformAssems = any(self._nonUniformMeshFlags)
+        
+        self._nonUniformMeshFlags = None
+        self._hasNonUniformAssems = None
+        if cs is not None:
+            self._nonUniformMeshFlags = [
+                Flags.fromStringIgnoreErrors(f) for f in cs["nonUniformAssemFlags"]
+            ]
+            self._hasNonUniformAssems = any(self._nonUniformMeshFlags)
 
     def convert(self, r=None):
         """Create a new reactor core with a uniform mesh."""
         if r is None:
             raise ValueError(f"No reactor provided in {self}")
 
-        runLog.extra(f"Building with a uniform axial mesh reactor from {r}")
+        runLog.extra(f"Building with uniform axial mesh reactor from {r}")
         completeStartTime = timer()
         self._sourceReactor = r
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -884,21 +884,6 @@ class HexReactorTests(ReactorTests):
                         msg="{0}, {1}".format(a, b),
                     )
 
-    def test_nonUniformAssems(self):
-        o, r = loadTestReactor(
-            customSettings={"nonUniformAssemFlags": ["primary control"]}
-        )
-        a = o.r.core.getFirstAssembly(Flags.FUEL)
-        self.assertTrue(all(b.p.topIndex != 0 for b in a[1:]))
-        a = o.r.core.getFirstAssembly(Flags.PRIMARY)
-        self.assertTrue(all(b.p.topIndex == 0 for b in a))
-        originalHeights = [b.p.height for b in a]
-        differntMesh = [val + 2 for val in r.core.p.referenceBlockAxialMesh]
-        # wont change because nonUnfiform assem doesn't conform to reference mesh
-        a.setBlockMesh(differntMesh)
-        heights = [b.p.height for b in a]
-        self.assertEqual(originalHeights, heights)
-
 
 class CartesianReactorTests(ReactorTests):
     def setUp(self):

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -26,7 +26,7 @@ What's new in ARMI
 #. Add blueprints setting, ``axial expansion target component``, to enable users to manually set a "target component" for axial expansion.
 #. Allow database comparison to continue even if ``unpackSpecialData`` fails. 
 #. Code clarity rewrite of ``armi/cases/case.py::copyInterfaceInputs``.
-#. Added setting nonUniformAssemFlags that allows specific assems to not conform to uniform mesh.
+#. Added setting nonUniformAssemFlags that allows specific assems to not conform to uniform mesh. (`PR#879 <https://github.com/terrapower/armi/pull/879>`_ and `PR#827 <https://github.com/terrapower/armi/pull/827>`_).
 #. Added reporting of neutron and gamma energy groups in the XS library `__repr__` for clearer tracking of which cross sections are applied to the core state.
 #. Removed `quiet` kwarg from geometry and block converters as this was generally unused in the code base and was only implemented for developmental debugging.
 #. Refactored the ``UniformMeshGeometryConverter`` to allow for mapping of number densities and parameters to and from a single assembly rather than requiring an entire core.


### PR DESCRIPTION
## Description

The uniform mesh module was updated to treat the conversion of non-uniform assemblies in the core model (using the `nonUniformAssemFlags` setting). In this change, a new branch of code is introduced within the `UniformMeshConverter` that short cuts the entire new reactor creation and entire reactor remeshing/data mapping when the `nonUniformAssemFlags` is provided by the user. This new feature allows for significant acceleration of the reactor unification because only a subset of all the assemblies need to be converted.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

