### PR TITLE
Density3 temp k

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -717,7 +717,7 @@ class SimpleSolid(Material):
 
     def __init__(self):
         Material.__init__(self)
-        self.p.refDens = self.density3(Tc=self.refTempK)
+        self.p.refDens = self.density3(Tk=self.refTempK)
 
     def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
         """
@@ -742,7 +742,7 @@ class SimpleSolid(Material):
         the density3 function returns 'free expansion' density as a function
         temperature
         """
-        density1 = self.density3(Tc=self.refTempK)
+        density1 = self.density3(Tk=self.refTempK)
         density2 = self.density3(Tk=Tk, Tc=Tc)
 
         if density1 == density2:
@@ -754,7 +754,7 @@ class SimpleSolid(Material):
         return 0.0
 
 
-class FuelMaterial(SimpleSolid):
+class FuelMaterial(Material):
     """
     Material that is considered a nuclear fuel.
 

--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -79,9 +79,6 @@ class ThoriumOxide(FuelMaterial):
         self.setMassFrac("TH232", 0.8788)
         self.setMassFrac("O16", 0.1212)
 
-    def density3(self, Tk: float = None, Tc: float = None) -> float:
-        return Material.density3(self, Tk=Tk, Tc=Tc)
-
     def linearExpansion(self, Tk=None, Tc=None):
         r"""m/m/K from IAEA TE 1450"""
         Tk = getTk(Tc, Tk)

--- a/armi/materials/uZr.py
+++ b/armi/materials/uZr.py
@@ -73,9 +73,6 @@ class UZr(material.FuelMaterial):
         self._calculateReferenceDensity()
         material.FuelMaterial.applyInputParams(self, *args, **kwargs)
 
-    def density3(self, Tk: float = None, Tc: float = None) -> float:
-        return material.Material.density3(self, Tk=Tk, Tc=Tc)
-
     def _calculateReferenceDensity(self):
         """
         Calculates the reference mass density in g/cc of a U-Pu-Zr alloy at 293K with Vergard's law

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -38,7 +38,7 @@ HeatCapacityConstants = collections.namedtuple(
 )
 
 
-class UraniumOxide(material.FuelMaterial):
+class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
     name = "Uranium Oxide"
 
     enrichedNuclide = "U235"
@@ -102,7 +102,10 @@ class UraniumOxide(material.FuelMaterial):
         1.847,
         1.718,
     ]
-
+    
+    def __init__(self):
+        material.SimpleSolid.__init__(self)
+    
     def adjustTD(self, val: float) -> None:
         self.theoreticalDensityFrac = val
 

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -102,10 +102,10 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
         1.847,
         1.718,
     ]
-    
+
     def __init__(self):
         material.SimpleSolid.__init__(self)
-    
+
     def adjustTD(self, val: float) -> None:
         self.theoreticalDensityFrac = val
 


### PR DESCRIPTION
## Description

An ARMI user was observing differences in density results due to the https://github.com/terrapower/armi/pull/868 caused in materials that are subclasses of Fuel Material. Fuel Material initially inherited from SimpleSolid, but in reality Fuel Materials are not really "Simple Solid Materials".

I refactored the lineage of Fuel Materials, back to the original lineage. This simplified the Fuel Materials because I didn't need to overload density functions back to the base Material class. 

I also noticed a cancellation of errors, that should be resolved where linearExpansionPercent was using Tc with a reference temperature in K -- this should be resolved.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.

