### PR TITLE
Ensuring the code coverage won't fall below 80%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ tags
 .externalToolBuilders/
 .cache/
 .pytest_cache/
+pytestdebug.log
 dump-temp-*
 .vim-bookmarks
 venv*/

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps=
 whitelist_externals =
     /usr/bin/mpiexec
 commands =
-    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv armi/tests/test_mpiFeatures.py
+    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv --cov-fail-under=80 armi/tests/test_mpiFeatures.py
 
 # Second, run code coverage over the rest of the unit tests, and combine the coverage results together
 [testenv:cov2]


### PR DESCRIPTION
## Description

The code coverage is juuuust over the line to 85%, which is respectable (though my goal is 90%).

But we have a team rule that the coverage can never fall below 80%.  And this PR ensure that the build will fail if that happens.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
