### PR TITLE
Adding Code Coverage to Utils

### DIFF
--- a/armi/bookkeeping/report/tests/test_newReport.py
+++ b/armi/bookkeeping/report/tests/test_newReport.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Test new reports"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import collections
 import os
 import unittest

--- a/armi/bookkeeping/tests/test_snapshot.py
+++ b/armi/bookkeeping/tests/test_snapshot.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test Snapshots"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.bookkeeping import snapshotInterface

--- a/armi/bookkeeping/visualization/tests/test_vis.py
+++ b/armi/bookkeeping/visualization/tests/test_vis.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test report visutalizaion"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 import numpy

--- a/armi/cases/inputModifiers/tests/test_inputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_inputModifiers.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for input modifiers"""
-import unittest
-import os
-import io
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 from ruamel import yaml
+import io
+import os
+import unittest
 
 from armi.utils import directoryChangers
 from armi import cases

--- a/armi/cases/inputModifiers/tests/test_pinTypeInputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_pinTypeInputModifiers.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for input modifiers"""
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
-
-from armi.cases.inputModifiers import pinTypeInputModifiers
-from armi.cases.inputModifiers.tests.test_inputModifiers import BLUEPRINT_INPUT
+import unittest
 
 from armi import settings
+from armi.cases.inputModifiers import pinTypeInputModifiers
+from armi.cases.inputModifiers.tests.test_inputModifiers import BLUEPRINT_INPUT
 from armi.reactor import blueprints
 
 

--- a/armi/cases/tests/test_suiteBuilder.py
+++ b/armi/cases/tests/test_suiteBuilder.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Unit tests for the SuiteBuilder
-"""
+"""Unit tests for the SuiteBuilder"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import unittest
 

--- a/armi/cli/tests/test_runSuite.py
+++ b/armi/cli/tests/test_runSuite.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Test for runsuite cli entry point
-"""
+"""Test for runsuite cli entry point"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import io
 import sys
 import unittest

--- a/armi/materials/tests/test__init__.py
+++ b/armi/materials/tests/test__init__.py
@@ -15,6 +15,7 @@
 """
 This module tests the __init__.py file since it has rather unique behavior.
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi import materials

--- a/armi/materials/tests/test_b4c.py
+++ b/armi/materials/tests/test_b4c.py
@@ -14,7 +14,7 @@
 """
 Tests for boron carbide
 """
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.materials.b4c import B4C, DEFAULT_THEORETICAL_DENSITY_FRAC

--- a/armi/materials/tests/test_be9.py
+++ b/armi/materials/tests/test_be9.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit test for Beryllium"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.materials.be9 import Be9

--- a/armi/materials/tests/test_graphite.py
+++ b/armi/materials/tests/test_graphite.py
@@ -14,6 +14,7 @@
 """
 Tests for graphite material
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
 import unittest
 

--- a/armi/materials/tests/test_lithium.py
+++ b/armi/materials/tests/test_lithium.py
@@ -14,7 +14,7 @@
 """
 Tests for lithium.
 """
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.materials.tests.test_materials import _Material_Test

--- a/armi/materials/tests/test_sic.py
+++ b/armi/materials/tests/test_sic.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test for SiC"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.materials.siC import SiC

--- a/armi/materials/tests/test_sulfur.py
+++ b/armi/materials/tests/test_sulfur.py
@@ -14,7 +14,7 @@
 """
 Tests for sulfur.
 """
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.materials.tests.test_materials import _Material_Test

--- a/armi/materials/tests/test_thoriumOxide.py
+++ b/armi/materials/tests/test_thoriumOxide.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Tests for ThO2.
+Tests for ThO2
 """
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.materials.tests.test_materials import _Material_Test

--- a/armi/materials/tests/test_uZr.py
+++ b/armi/materials/tests/test_uZr.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for simplified UZr material."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.materials.uZr import UZr

--- a/armi/materials/tests/test_water.py
+++ b/armi/materials/tests/test_water.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""unit tests for water materials"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 from armi.materials.water import SaturatedWater, SaturatedSteam
-
-"""
-unit tests for water materials
-"""
 
 
 class Test_Water(unittest.TestCase):

--- a/armi/nucDirectory/tests/test_elements.py
+++ b/armi/nucDirectory/tests/test_elements.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for elements."""
+"""Tests for elements"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.nucDirectory import nuclideBases  # required to init natural isotopics

--- a/armi/nucDirectory/tests/test_nucDirectory.py
+++ b/armi/nucDirectory/tests/test_nucDirectory.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests nuclide directory."""
-
+"""Tests nuclide directory"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.nucDirectory import nucDir, elements, nuclideBases

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tests for nuclideBases.
-"""
-import unittest
+"""Tests for nuclideBases"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import random
 import re
+import unittest
 
-from armi.nucDirectory import nuclideBases
 from armi.nucDirectory import elements
-
+from armi.nucDirectory import nuclideBases
 from armi.nucDirectory.tests import NUCDIRECTORY_TESTS_DEFAULT_DIR_PATH
 
 

--- a/armi/nucDirectory/tests/test_transmutations.py
+++ b/armi/nucDirectory/tests/test_transmutations.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
-Unit tests for transmutations
-"""
-import unittest
-import string
+r"""Unit tests for transmutations"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import random
+import string
+import unittest
 
 from armi.nucDirectory import transmutations
 

--- a/armi/nuclearDataIO/cccc/tests/test_cccc.py
+++ b/armi/nuclearDataIO/cccc/tests/test_cccc.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-import unittest
+"""test CCCC"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import io
+import unittest
 
 import six
 

--- a/armi/nuclearDataIO/cccc/tests/test_compxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_compxs.py
@@ -15,9 +15,9 @@
 """
 Test the COMPXS reader/writer with a simple problem.
 """
-
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
+import unittest
 
 import numpy
 from scipy.sparse import csc_matrix

--- a/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
@@ -15,10 +15,11 @@
 """
 Tests for DELAYXS
 """
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import copy
-import os
 import filecmp
+import os
+import unittest
 
 import numpy
 

--- a/armi/nuclearDataIO/cccc/tests/test_gamiso.py
+++ b/armi/nuclearDataIO/cccc/tests/test_gamiso.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Test GAMISO reading and writing"""
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 from copy import deepcopy
 import os
 import unittest

--- a/armi/nuclearDataIO/cccc/tests/test_geodst.py
+++ b/armi/nuclearDataIO/cccc/tests/test_geodst.py
@@ -14,8 +14,9 @@
 """
 Test GEODST reading and writing.
 """
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
+import unittest
 
 from numpy.testing import assert_equal
 

--- a/armi/nuclearDataIO/cccc/tests/test_isotxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_isotxs.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
-Tests the workings of the library wrappers.
-
-"""
+r"""Tests the workings of the library wrappers."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi import nuclearDataIO

--- a/armi/nuclearDataIO/cccc/tests/test_labels.py
+++ b/armi/nuclearDataIO/cccc/tests/test_labels.py
@@ -15,8 +15,9 @@
 """
 Test the reading and writing of the DIF3D/VARIANT LABELS interface file
 """
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
+import unittest
 
 from armi.nuclearDataIO.cccc import labels
 

--- a/armi/nuclearDataIO/cccc/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_nhflux.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Test reading/writing of NHFLUX dataset."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import re
 import shutil

--- a/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
+++ b/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
@@ -14,12 +14,11 @@
 
 r"""
 Tests the workings of the library wrappers.
-
 """
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
+import os
 import filecmp
 import unittest
-import os
 
 from armi import nuclearDataIO
 from armi.nuclearDataIO.cccc import pmatrx

--- a/armi/nuclearDataIO/cccc/tests/test_pwdint.py
+++ b/armi/nuclearDataIO/cccc/tests/test_pwdint.py
@@ -14,8 +14,9 @@
 """
 Test PWDINT reading and writing.
 """
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
+import unittest
 
 from armi.nuclearDataIO.cccc import pwdint
 

--- a/armi/nuclearDataIO/cccc/tests/test_rtflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_rtflux.py
@@ -14,8 +14,9 @@
 """
 Test rtflux reading and writing.
 """
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
+import unittest
 
 from armi.nuclearDataIO.cccc import rtflux
 

--- a/armi/nuclearDataIO/cccc/tests/test_rzflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_rzflux.py
@@ -14,8 +14,9 @@
 """
 Test rzflux reading and writing.
 """
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
+import unittest
 
 from armi.nuclearDataIO.cccc import rzflux
 

--- a/armi/nuclearDataIO/tests/test_ripl.py
+++ b/armi/nuclearDataIO/tests/test_ripl.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for RIPL."""
-
-import unittest
-import os
+"""Tests for RIPL"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
+import os
+import unittest
 
 import six
 

--- a/armi/nuclearDataIO/tests/test_xsCollections.py
+++ b/armi/nuclearDataIO/tests/test_xsCollections.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Module that tests methods within xsCollections
-"""
+"""Module that tests methods within xsCollections"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
-from armi.nuclearDataIO import xsCollections
-from armi.tests import ISOAA_PATH
-from armi.physics.neutronics.tests import test_cross_section_manager
 from armi.nuclearDataIO import isotxs
+from armi.nuclearDataIO import xsCollections
+from armi.physics.neutronics.tests import test_cross_section_manager
+from armi.tests import ISOAA_PATH
 
 
 class TestXsCollections(unittest.TestCase):

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -179,7 +179,7 @@ class TempFileMixin:
     """really a test case"""
 
     @property
-    def test_fileName(self):
+    def testFileName(self):
         return os.path.join(
             THIS_DIR,
             "{}-{}.nucdata".format(self.__class__.__name__, self._testMethodName),

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -179,7 +179,7 @@ class TempFileMixin:
     """really a test case"""
 
     @property
-    def testFileName(self):
+    def test_fileName(self):
         return os.path.join(
             THIS_DIR,
             "{}-{}.nucdata".format(self.__class__.__name__, self._testMethodName),

--- a/armi/physics/fuelPerformance/tests/test_executers.py
+++ b/armi/physics/fuelPerformance/tests/test_executers.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Tests for generic fuel performance executers
-"""
+"""Tests for generic fuel performance executers"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.physics.fuelPerformance.executers import (

--- a/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
+++ b/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
@@ -11,13 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Tests for generic fuel performance plugin.
-"""
+"""Tests for generic fuel performance plugin"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
-from armi.tests.test_plugins import TestPlugin
 from armi.physics.fuelPerformance.plugin import FuelPerformancePlugin
+from armi.tests.test_plugins import TestPlugin
 
 
 class TestFuelPerformancePlugin(TestPlugin):

--- a/armi/physics/fuelPerformance/tests/test_fuelPerformanceUtils.py
+++ b/armi/physics/fuelPerformance/tests/test_fuelPerformanceUtils.py
@@ -14,7 +14,7 @@
 """
 Tests for fuel performance utilities.
 """
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.physics.fuelPerformance import utils

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Test the Lattice Interface"""
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.physics.neutronics.latticePhysics.latticePhysicsInterface import (

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Test the Lattice Physics Writer"""
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.physics.neutronics.const import CONF_CROSS_SECTION

--- a/armi/physics/neutronics/tests/test_crossSectionTable.py
+++ b/armi/physics/neutronics/tests/test_crossSectionTable.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for cross section table for depletion"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.nuclearDataIO.cccc import isotxs

--- a/armi/physics/neutronics/tests/test_energyGroups.py
+++ b/armi/physics/neutronics/tests/test_energyGroups.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 """Energy group tests."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
-
-from .. import energyGroups
+from armi.physics.neutronics import energyGroups
 
 
 class TestEnergyGroups(unittest.TestCase):

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+"""unit tests for the neutronics plugin"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import io
 import os
+import unittest
 
 from ruamel.yaml import YAML
 

--- a/armi/physics/tests/test_executers.py
+++ b/armi/physics/tests/test_executers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """This module provides tests for the generic Executers."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import unittest
 

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -13,22 +13,23 @@
 # limitations under the License.
 
 """Tests the blueprints (loading input) file"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import pathlib
 import unittest
 
 import yamlize
 
+from armi import settings
+from armi.nucDirectory.elements import bySymbol
 from armi.reactor import blueprints
 from armi.reactor import parameters
+from armi.reactor.blueprints.componentBlueprint import ComponentBlueprint
+from armi.reactor.blueprints.isotopicOptions import NuclideFlags, CustomIsotopics
 from armi.reactor.flags import Flags
-from armi.nucDirectory.elements import bySymbol
-from armi import settings
 from armi.tests import TEST_ROOT
 from armi.utils import directoryChangers
 from armi.utils import textProcessors
-from armi.reactor.blueprints.isotopicOptions import NuclideFlags, CustomIsotopics
-from armi.reactor.blueprints.componentBlueprint import ComponentBlueprint
 
 
 class TestBlueprints(unittest.TestCase):

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -15,7 +15,7 @@
 """
 Module for testing componentBlueprint
 """
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import inspect
 import unittest
 

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""unit test custom isotopics"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 import yamlize

--- a/armi/reactor/blueprints/tests/test_reactorBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_reactorBlueprints.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for reactor blueprints."""
-import unittest
+"""Tests for reactor blueprints"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
+import unittest
 
 from armi.reactor import blueprints
 from armi import settings

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test block conversions."""
-import unittest
+"""Test block conversions"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
+import unittest
 
 import numpy
 

--- a/armi/reactor/converters/tests/test_meshConverters.py
+++ b/armi/reactor/converters/tests/test_meshConverters.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+"""unit tests of RZ Mesh Converter"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
+import unittest
 
 from armi.reactor.tests.test_reactors import loadTestReactor
 from armi.reactor.converters import meshConverters, geometryConverters

--- a/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
+++ b/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
@@ -14,8 +14,9 @@
 """
 Unit tests for pin type block converters
 """
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import copy
+import unittest
 
 from armi.reactor.flags import Flags
 

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -14,17 +14,18 @@
 """
 Tests for the uniform mesh geometry converter
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
+import collections
 import os
 import random
 import unittest
-import collections
 
-from armi.reactor.tests import test_reactors
-from armi.reactor.tests import test_assemblies
-from armi.tests import TEST_ROOT, ISOAA_PATH
 from armi.nuclearDataIO.cccc import isotxs
 from armi.reactor.converters import uniformMesh
 from armi.reactor.flags import Flags
+from armi.reactor.tests import test_assemblies
+from armi.reactor.tests import test_reactors
+from armi.tests import TEST_ROOT, ISOAA_PATH
 
 
 class TestAssemblyUniformMesh(unittest.TestCase):

--- a/armi/reactor/tests/test_flags.py
+++ b/armi/reactor/tests/test_flags.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for flags."""
-import unittest
+"""Tests for flags"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import pickle
+import unittest
 
 from armi.reactor import flags
 

--- a/armi/reactor/tests/test_rz_reactors.py
+++ b/armi/reactor/tests/test_rz_reactors.py
@@ -15,9 +15,10 @@
 """
 Test loading Theta-RZ reactor models.
 """
-import unittest
-import os
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
+import os
+import unittest
 
 from armi import settings
 from armi.tests import TEST_ROOT

--- a/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
+++ b/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test Locationlabel migration"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import io
 import unittest
 

--- a/armi/settings/fwSettings/tests/test_fwSettings.py
+++ b/armi/settings/fwSettings/tests/test_fwSettings.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for the framework settings"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 import voluptuous as vol

--- a/armi/tests/mockRunLogs.py
+++ b/armi/tests/mockRunLogs.py
@@ -11,19 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 This module contains subclasses of the armi.runLog._RunLog class that can be used to determine whether or not
 one of the specific methods were called. These should only be used in testing.
 """
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import six
 import sys
 
 from armi import runLog
 
 
-class BufferLog(runLog._RunLog):  # pylint: disable=protected-access
+class BufferLog(runLog._RunLog):
     r"""Log which captures the output in attributes instead of emitting them
 
     Used mostly in testing to ensure certain things get output, or to prevent any output

--- a/armi/tests/test_armiTestHelper.py
+++ b/armi/tests/test_armiTestHelper.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests to demonstrate the test helper is functional."""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import unittest
 

--- a/armi/tests/test_cartesian.py
+++ b/armi/tests/test_cartesian.py
@@ -15,6 +15,7 @@
 """
 Tests for Cartesian reactors
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.reactor import geometry

--- a/armi/tests/test_docs.py
+++ b/armi/tests/test_docs.py
@@ -14,9 +14,9 @@
 """Test that the code examples in the docs are valid"""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
+import doctest
 import os
 import unittest
-import doctest
 
 from armi import DOC
 

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 """Tests the Interface"""
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 import os
 
 from armi import interfaces
-from armi.utils import textProcessors
 from armi import settings
 from armi.tests import TEST_ROOT
+from armi.utils import textProcessors
 
 
 class DummyInterface(interfaces.Interface):

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Tests for MPI actions"""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import unittest

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -23,7 +23,7 @@ mpiexec -n 2 python -m pytest armi/tests/test_mpiFeatures.py
 or
 mpiexec.exe -n 2 python -m pytest armi/tests/test_mpiFeatures.py
 """
-# pylint: disable=abstract-method,no-self-use,unused-argument
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 from distutils.spawn import find_executable
 import os
 import unittest

--- a/armi/tests/test_notebooks.py
+++ b/armi/tests/test_notebooks.py
@@ -19,8 +19,9 @@ assumes each cell is a test. To prevent inadvertent breaking
 of the ipynbs, we imply run them here and show during unit
 testing that a failure was introduced.
 """
-import unittest
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
+import unittest
 
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Provides functionality for testing implementations of plugins"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 from typing import Optional
 

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests of the runLog tooling"""
-# pylint: disable=protected-access,missing-function-docstring,missing-class-docstring
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 from io import StringIO
 from shutil import rmtree
 import logging

--- a/armi/tests/test_tests.py
+++ b/armi/tests/test_tests.py
@@ -15,7 +15,7 @@
 """
 Unit tests for the test helpers.
 """
-
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi import tests

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -572,42 +572,6 @@ def slantSplit(val, ratio, nodes, order="low first"):
     return X
 
 
-def runFunctionFromAllModules(funcName, *args, **kwargs):
-    r"""
-    Runs funcName on all modules of ARMI, if it exists.
-
-    Parameters
-    ----------
-    funcName : str
-        The function to run if it is found in a module.
-
-    \*args, \*\*kwargs : arguments to pass to func if it is found
-
-    Notes
-    -----
-    This imports all modules in ARMI, and if you have a script that isn't inside a
-    ``if __name__=='__main__'``, you will be in trouble.
-
-    This could also be useful for finding input consistency checkers for the GUI.
-
-    See Also
-    --------
-    armi.settings.addAllDefaultSettings : gets all the settings from all modules
-
-    """
-    for _modImporter, name, _ispkg in pkgutil.walk_packages(
-        path=armi_path, prefix=armi_name + "."
-    ):
-        try:
-            mod = importlib.import_module(name)
-            if funcName in dir(mod):  # there is a module.funcName. so call it.
-                func = getattr(mod, funcName)
-                func(*args, **kwargs)
-        except:
-            # just print traceback but don't throw an error.
-            traceback.print_exc()
-
-
 def prependToList(originalList, listToPrepend):
     """
     Add a new list to the beginnning of an original list.

--- a/armi/utils/dynamicImporter.py
+++ b/armi/utils/dynamicImporter.py
@@ -14,22 +14,6 @@
 """
 Dynamic importing help
 """
-import glob
-import os
-from importlib import import_module
-
-
-def importEntirePackage(module):
-    """Load every module in a package
-
-    Notes
-    -----
-    This method may only work for a flat directory
-    """
-    modules = glob.glob(os.path.dirname(module.__file__) + "/*.py")
-    names = [os.path.basename(f)[:-3] for f in modules]
-    for name in names:
-        import_module(module.__package__ + "." + name)
 
 
 def getEntireFamilyTree(cls):

--- a/armi/utils/tests/test_asciimaps.py
+++ b/armi/utils/tests/test_asciimaps.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
+"""Test ASCII maps"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import io
+import unittest
 
 from armi.utils import asciimaps
 

--- a/armi/utils/tests/test_dochelpers.py
+++ b/armi/utils/tests/test_dochelpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for documentation helpers"""
-# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import unittest
 
 from armi.reactor import reactors

--- a/armi/utils/tests/test_gridGui.py
+++ b/armi/utils/tests/test_gridGui.py
@@ -41,7 +41,7 @@ loginctl list-sessions --no-legend | \
 ```
 If it outputs "x11", it should work (and if it outputs "wayland", it probably won't, for now).
 """
-# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import asyncio
 import os
 import time

--- a/armi/utils/tests/test_iterables.py
+++ b/armi/utils/tests/test_iterables.py
@@ -15,6 +15,7 @@
 """
 unittests for iterables.py
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import time
 import unittest
 

--- a/armi/utils/tests/test_parsing.py
+++ b/armi/utils/tests/test_parsing.py
@@ -15,6 +15,7 @@
 """
 Unit tests for parsing.
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi.utils import parsing

--- a/armi/utils/tests/test_textProcessors.py
+++ b/armi/utils/tests/test_textProcessors.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Tests for functions in textProcessors.py
 """
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import pathlib
 import unittest

--- a/armi/utils/tests/test_units.py
+++ b/armi/utils/tests/test_units.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test armi.utils.units.py"""
+import math
 import unittest
 
 from armi.utils import units
@@ -19,7 +20,6 @@ from armi.utils import units
 
 class TestUnits(unittest.TestCase):
     def test_getTc(self):
-
         self.assertAlmostEqual(units.getTc(Tc=200), 200.0)
         self.assertAlmostEqual(units.getTc(Tk=300), 26.85)
 
@@ -35,7 +35,6 @@ class TestUnits(unittest.TestCase):
             units.getTc(Tc=0, Tk=200)
 
     def test_getTk(self):
-
         self.assertAlmostEqual(units.getTk(Tc=200), 473.15)
         self.assertAlmostEqual(units.getTk(Tk=300), 300.00)
 
@@ -51,7 +50,6 @@ class TestUnits(unittest.TestCase):
             units.getTk(Tc=0, Tk=200)
 
     def test_getTf(self):
-
         # 0 C = 32 F
         self.assertAlmostEqual(units.getTf(Tc=0), 32.0)
         self.assertAlmostEqual(units.getTf(Tk=273.15), 32.0)
@@ -73,3 +71,70 @@ class TestUnits(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Tc=0 and Tk=200"):
             units.getTf(Tc=0, Tk=200)
+
+    def test_convertPascalToPascal(self):
+        """This is a pass-through function"""
+        for val in [0.0, -99.141, 123, 3.14159, -2.51212e-12]:
+            self.assertEqual(val, units.convertPascalToPascal(val))
+
+    def test_getTmev(self):
+        val = units.getTmev(Tc=45.0)
+        self.assertAlmostEqual(val, 2.74160430306e-08)
+
+        val = units.getTmev(Tc=145.0)
+        self.assertAlmostEqual(val, 3.60333754306e-08)
+
+        val = units.getTmev(Tk=445.0)
+        self.assertAlmostEqual(val, 3.8347129180000004e-08)
+
+    def test_getTemperature(self):
+        val = units.getTemperature(Tc=42, tempUnits="Tc")
+        self.assertEqual(val, 42)
+
+        val = units.getTemperature(Tk=42, tempUnits="Tk")
+        self.assertEqual(val, 42)
+
+        val = units.getTemperature(Tc=42, tempUnits="Tk")
+        self.assertAlmostEqual(val, 315.15)
+
+        val = units.getTemperature(Tk=42, tempUnits="Tc")
+        self.assertAlmostEqual(val, -231.15)
+
+        with self.assertRaises(ValueError):
+            units.getTemperature(Tc=42)
+
+    def test_convertXtoPascal(self):
+        val = units.convertMmhgToPascal(11.1)
+        self.assertAlmostEqual(val, 1479.8782894736883)
+
+        val = units.convertBarToPascal(2.2)
+        self.assertAlmostEqual(val, 220000)
+
+        val = units.convertAtmToPascal(3.1)
+        self.assertAlmostEqual(val, 314107.5)
+
+    def test_sanitizeAngle(self):
+        val = units.sanitizeAngle(0)
+        self.assertEqual(val, 0)
+
+        val = units.sanitizeAngle(1.01)
+        self.assertEqual(val, 1.01)
+
+        val = units.sanitizeAngle(-6)
+        self.assertAlmostEqual(val, 0.28318530717958623)
+
+        val = units.sanitizeAngle(9)
+        self.assertAlmostEqual(val, 2.7168146928204138)
+
+    def test_getXYLineParameters(self):
+        a, b, c, d = units.getXYLineParameters(0)
+        self.assertEqual(a, 0.0)
+        self.assertEqual(b, 1.0)
+        self.assertEqual(c, 0.0)
+        self.assertEqual(d, 0.0)
+
+        a, b, c, d = units.getXYLineParameters(1, 0.1, 0.2)
+        self.assertEqual(a, 1)
+        self.assertEqual(b, 0)
+        self.assertEqual(c, 0)
+        self.assertEqual(d, 0.1)

--- a/armi/utils/tests/test_units.py
+++ b/armi/utils/tests/test_units.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test armi.utils.units.py"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
 import unittest
 

--- a/armi/utils/units.py
+++ b/armi/utils/units.py
@@ -297,7 +297,6 @@ def sanitizeAngle(theta):
     theta : float
         an angle between 0 and 2*pi
     """
-
     if theta < 0:
         theta = theta + (1 + -1 * int(theta / (math.pi * 2.0))) * math.pi * 2.0
 
@@ -344,7 +343,6 @@ def getXYLineParameters(theta, x=0, y=0):
     -----
     the line is in the form of A*x + B*y + C*z - D = 0 -- this corresponds to a MCNP arbitrary line equation
     """
-
     theta = sanitizeAngle(theta)
 
     if (


### PR DESCRIPTION
## Description

Just adding a little code coverage.

In the process, my pylint tripped up on a bunch of unit tests, so I fixed that too.

---

## Checklist

- [X] This PR has only one purpose or idea.  (Well, one idea plus cleanup.)
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
