### PR TITLE
Call `completeInitialLoading` after applying thermal expansion to the reactor core.

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2355,3 +2355,4 @@ class Core(composites.Composite):
             if not a.hasFlags(Flags.CONTROL):
                 for b in a:
                     b.p.heightBOL = b.getHeight()
+                    b.completeInitialLoading()

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -27,18 +27,8 @@ plant-wide state variables such as keff, cycle, and node.
    The Reactor contains a Core, which contains a heirachical collection of Assemblies, which in turn
    each contain a collection of Blocks.
 """
-from typing import Optional
-import collections
-import copy
-import itertools
-import os
-import tabulate
-import time
-
-import numpy
-
-from armi import runLog
 from armi import getPluginManagerOrFail, materials, nuclearDataIO, settings
+from armi import runLog
 from armi.nuclearDataIO import xsLibraries
 from armi.reactor import assemblies
 from armi.reactor import assemblyLists
@@ -49,13 +39,22 @@ from armi.reactor import parameters
 from armi.reactor import reactorParameters
 from armi.reactor import systemLayoutInput
 from armi.reactor import zones
+from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 from armi.reactor.flags import Flags
 from armi.settings.fwSettings.globalSettings import CONF_MATERIAL_NAMESPACE_ORDER
 from armi.utils import createFormattedStrWithDelimiter, units
 from armi.utils import directoryChangers
 from armi.utils.iterables import Sequence
 from armi.utils.mathematics import average1DWithinTolerance
-from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
+import collections
+import copy
+import itertools
+import os
+import time
+from typing import Optional
+
+import numpy
+import tabulate
 
 
 class Reactor(composites.Composite):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -27,8 +27,18 @@ plant-wide state variables such as keff, cycle, and node.
    The Reactor contains a Core, which contains a heirachical collection of Assemblies, which in turn
    each contain a collection of Blocks.
 """
-from armi import getPluginManagerOrFail, materials, nuclearDataIO, settings
+import collections
+import copy
+import itertools
+import os
+import time
+from typing import Optional
+
+import numpy
+import tabulate
+
 from armi import runLog
+from armi import getPluginManagerOrFail, materials, nuclearDataIO, settings
 from armi.nuclearDataIO import xsLibraries
 from armi.reactor import assemblies
 from armi.reactor import assemblyLists
@@ -39,22 +49,13 @@ from armi.reactor import parameters
 from armi.reactor import reactorParameters
 from armi.reactor import systemLayoutInput
 from armi.reactor import zones
-from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 from armi.reactor.flags import Flags
 from armi.settings.fwSettings.globalSettings import CONF_MATERIAL_NAMESPACE_ORDER
 from armi.utils import createFormattedStrWithDelimiter, units
 from armi.utils import directoryChangers
 from armi.utils.iterables import Sequence
 from armi.utils.mathematics import average1DWithinTolerance
-import collections
-import copy
-import itertools
-import os
-import time
-from typing import Optional
-
-import numpy
-import tabulate
+from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 
 
 class Reactor(composites.Composite):

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -58,6 +58,7 @@ Bug fixes
 #. Fixed bug where components were different if initialized through blueprints vs init (bug active for ~ 2 months).
 #. Fixed bug where component mass was being conserved in axial expansion instead of correct density (`PR#846 <https://github.com/terrapower/armi/pull/846>`_)
 #. Fixed bug in ``armi/reactor/blocks.py::HexBlock::rotatePins`` that failed to modify pinLocation parameter (`#855 <https://github.com/terrapower/armi/pull/855>`_).
+#. Fixed bug in ``armi/reactor.py::Core::_applyThermalExpansion`` that failed to call the ``block.completeInitiaLoading`` (`#885 <https://github.com/terrapower/armi/pull/885>`_).
 #. TBD
 
 ARMI v0.2.3


### PR DESCRIPTION
Add fix in applyThermalExpansion to the reactor to call the block's completeInitialLoading method. This method is required to be called as it sets initial BOL values on each block, like heavy metal mass/moles on itself and its components. Additionally, this sets the smear density and initial enrichment

## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

