### PR TITLE
Fixing duplicate requirement name

### DIFF
--- a/doc/requirements/srsd.rst
+++ b/doc/requirements/srsd.rst
@@ -222,7 +222,7 @@ Based on user settings, the ordering, initialization, and calls to other plugins
    :status: needs implementation, needs test
 
 .. req:: The nucDirectory package shall contain basic nuclide information for a wide range of nuclides.
-   :id: REQ_NUCDIR_DATA
+   :id: REQ_NUCDIR_INFO
    :status: needs implementation, needs test
 
 The nucDirectory package shall contain the following general information for each nuclide:


### PR DESCRIPTION
## Description

Somehow, during the big requirements PR, a change was made that created a duplicate requirement name. This breaks the doc build, so I am fixing it here.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
