### PR TITLE
Add rootDir arg to modify CLI

### DIFF
--- a/armi/cli/modify.py
+++ b/armi/cli/modify.py
@@ -56,6 +56,12 @@ class ModifyCaseSettingsCommand(EntryPoint):
             "suppress the inspection step.",
         )
         self.parser.add_argument(
+            "--rootDir",
+            type=str,
+            default=".",
+            help="A root directory in which to search for settings files, e.g., armi/tests.",
+        )
+        self.parser.add_argument(
             "patterns",
             type=str,
             nargs="*",
@@ -70,7 +76,9 @@ class ModifyCaseSettingsCommand(EntryPoint):
                 self.createOptionFromSetting(settingName, suppressHelp=True)
 
     def invoke(self):
-        csInstances = settings.recursivelyLoadSettingsFiles(".", self.args.patterns)
+        csInstances = settings.recursivelyLoadSettingsFiles(
+            self.args.rootDir, self.args.patterns
+        )
         messages = (
             ("found", "listing")
             if self.args.list_setting_files

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -164,10 +164,11 @@ class TestModifyCaseSettingsCommand(unittest.TestCase):
     def test_modifyCaseSettingsCommandBasics(self):
         mcs = ModifyCaseSettingsCommand()
         mcs.addOptions()
-        mcs.parse_args(["/path/to/fake.yaml"])
+        mcs.parse_args(["--rootDir", "/path/to/", "fake.yaml"])
 
         self.assertEqual(mcs.name, "modify")
-        self.assertEqual(mcs.args.patterns, ["/path/to/fake.yaml"])
+        self.assertEqual(mcs.args.rootDir, "/path/to/")
+        self.assertEqual(mcs.args.patterns, ["fake.yaml"])
 
 
 class TestReportsEntryPoint(unittest.TestCase):


### PR DESCRIPTION
## Description

I was frustrated having to change directories to get this to find the files I wanted. So I just added a little flexibility so users can specify their preferred directory to search in if needed.

This is a tiny enough add that I excluded it from the release notes -- lemme know if you prefer me to add it, though!

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

