### PR TITLE
Fix non uniform assembly treatment

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2251,7 +2251,7 @@ class Core(composites.Composite):
                 "Please make sure that this is intended and not a input error."
             )
 
-        nonUniformAssems = [Flags.fromString(t) for t in cs["nonUniformAssemFlags"]]
+        nonUniformAssems = [Flags.fromStringIgnoreErrors(t) for t in cs["nonUniformAssemFlags"]]
         if dbLoad:
             # reactor.blueprints.assemblies need to be populated
             # this normally happens during armi/reactor/blueprints/__init__.py::constructAssem
@@ -2269,6 +2269,8 @@ class Core(composites.Composite):
                     reverse=True,
                 )[0]
                 for a in self.parent.blueprints.assemblies.values():
+                    if any(a.hasFlags(f) for f in nonUniformAssems):
+                        continue
                     a.makeAxialSnapList(refAssem=finestMeshAssembly)
             if not cs["inputHeightsConsideredHot"]:
                 runLog.header(
@@ -2280,15 +2282,18 @@ class Core(composites.Composite):
                     finestMeshAssembly,
                 )
                 # after initial thermal expansion, delete axialSnapList for non-uniform assemblies
-                for a in self.parent.blueprints.assemblies.values():
-                    if any(a.hasFlags(f) for f in nonUniformAssems):
-                        for b in a:
-                            b.p.topIndex = 0
+                #for a in self.parent.blueprints.assemblies.values():
+                #    if any(a.hasFlags(f) for f in nonUniformAssems):
+                #        runLog.info("No axialSnapList for nonuniform assembly {a}")
+                #        for b in a:
+                #            b.p.topIndex = 0
 
         else:
             if not cs["detailedAxialExpansion"]:
                 # prepare core for mesh snapping during axial expansion
                 for a in self.getAssemblies(includeAll=True):
+                    if any(a.hasFlags(f) for f in nonUniformAssems):
+                        continue
                     a.makeAxialSnapList(self.refAssem)
             if not cs["inputHeightsConsideredHot"]:
                 runLog.header(
@@ -2296,10 +2301,11 @@ class Core(composites.Composite):
                 )
                 self._applyThermalExpansion(self.getAssemblies(includeAll=True), dbLoad)
                 # after initial thermal expansion, delete axialSnapList for non-uniform assemblies
-                for a in self.parent.blueprints.assemblies.values():
-                    if any(a.hasFlags(f) for f in nonUniformAssems):
-                        for b in a:
-                            b.p.topIndex = 0
+                #for a in self.parent.blueprints.assemblies.values():
+                #    if any(a.hasFlags(f) for f in nonUniformAssems):
+                #        runLog.info("No axialSnapList for nonuniform assembly {a}")
+                #        for b in a:
+                #            b.p.topIndex = 0
 
             self.p.referenceBlockAxialMesh = self.findAllAxialMeshPoints(
                 applySubMesh=False

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2251,7 +2251,9 @@ class Core(composites.Composite):
                 "Please make sure that this is intended and not a input error."
             )
 
-        nonUniformAssems = [Flags.fromStringIgnoreErrors(t) for t in cs["nonUniformAssemFlags"]]
+        nonUniformAssems = [
+            Flags.fromStringIgnoreErrors(t) for t in cs["nonUniformAssemFlags"]
+        ]
         if dbLoad:
             # reactor.blueprints.assemblies need to be populated
             # this normally happens during armi/reactor/blueprints/__init__.py::constructAssem

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2251,6 +2251,7 @@ class Core(composites.Composite):
                 "Please make sure that this is intended and not a input error."
             )
 
+        nonUniformAssems = [Flags.fromString(t) for t in cs["nonUniformAssemFlags"]]
         if dbLoad:
             # reactor.blueprints.assemblies need to be populated
             # this normally happens during armi/reactor/blueprints/__init__.py::constructAssem
@@ -2278,6 +2279,11 @@ class Core(composites.Composite):
                     dbLoad,
                     finestMeshAssembly,
                 )
+                # after initial thermal expansion, delete axialSnapList for non-uniform assemblies
+                for a in self.parent.blueprints.assemblies.values():
+                    if any(a.hasFlags(f) for f in nonUniformAssems):
+                        for b in a:
+                            b.p.topIndex = 0
 
         else:
             if not cs["detailedAxialExpansion"]:
@@ -2289,6 +2295,11 @@ class Core(composites.Composite):
                     "=========== Axially expanding all assemblies (except control) from Tinput to Thot ==========="
                 )
                 self._applyThermalExpansion(self.getAssemblies(includeAll=True), dbLoad)
+                # after initial thermal expansion, delete axialSnapList for non-uniform assemblies
+                for a in self.parent.blueprints.assemblies.values():
+                    if any(a.hasFlags(f) for f in nonUniformAssems):
+                        for b in a:
+                            b.p.topIndex = 0
 
             self.p.referenceBlockAxialMesh = self.findAllAxialMeshPoints(
                 applySubMesh=False

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2281,12 +2281,6 @@ class Core(composites.Composite):
                     dbLoad,
                     finestMeshAssembly,
                 )
-                # after initial thermal expansion, delete axialSnapList for non-uniform assemblies
-                #for a in self.parent.blueprints.assemblies.values():
-                #    if any(a.hasFlags(f) for f in nonUniformAssems):
-                #        runLog.info("No axialSnapList for nonuniform assembly {a}")
-                #        for b in a:
-                #            b.p.topIndex = 0
 
         else:
             if not cs["detailedAxialExpansion"]:
@@ -2300,12 +2294,6 @@ class Core(composites.Composite):
                     "=========== Axially expanding all assemblies (except control) from Tinput to Thot ==========="
                 )
                 self._applyThermalExpansion(self.getAssemblies(includeAll=True), dbLoad)
-                # after initial thermal expansion, delete axialSnapList for non-uniform assemblies
-                #for a in self.parent.blueprints.assemblies.values():
-                #    if any(a.hasFlags(f) for f in nonUniformAssems):
-                #        runLog.info("No axialSnapList for nonuniform assembly {a}")
-                #        for b in a:
-                #            b.p.topIndex = 0
 
             self.p.referenceBlockAxialMesh = self.findAllAxialMeshPoints(
                 applySubMesh=False

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -832,6 +832,21 @@ class HexReactorTests(ReactorTests):
             coords = b.getPinCoordinates()
             self.assertGreater(len(coords), -1)
 
+    def test_nonUniformAssems(self):
+        o, r = loadTestReactor(
+            customSettings={"nonUniformAssemFlags": ["primary control"]}
+        )
+        a = o.r.core.getFirstAssembly(Flags.FUEL)
+        self.assertTrue(all(b.p.topIndex != 0 for b in a[1:]))
+        a = o.r.core.getFirstAssembly(Flags.PRIMARY)
+        self.assertTrue(all(b.p.topIndex == 0 for b in a))
+        originalHeights = [b.p.height for b in a]
+        differntMesh = [val + 2 for val in r.core.p.referenceBlockAxialMesh]
+        # wont change because nonUnfiform assem doesn't conform to reference mesh
+        a.setBlockMesh(differntMesh)
+        heights = [b.p.height for b in a]
+        self.assertEqual(originalHeights, heights)
+
     def test_applyThermalExpansion_CoreConstruct(self):
         """test Core::_applyThermalExpansion for core construction
 


### PR DESCRIPTION
## Description

When working on PR #879 , most of PR #827 was reverted because it was not working correctly with #879.

About halfway through development of #879, the implementation of non uniform assembly treatment was significantly overhauled, so that only the individual non-uniform assemblies are processed by the uniform mesh converter (instead of putting the full reactor through the uniform mesh conversion). With this updated implementation, we could have taken out the partial reversion of PR #827, but this wasn't immediately apparent.

It is now clear that we can bring back the parts of PR #827 that were reverted and still have PR #879 function as intended.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

