### PR TITLE
Converting some methods to staticmethod

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1017,7 +1017,8 @@ class Database3:
         exclude.add("layout")
         return (groupName + "/" + key for key in timeGroup.keys() if key not in exclude)
 
-    def getAuxiliaryDataPath(self, ts: Tuple[int, int], name: str) -> str:
+    @staticmethod
+    def getAuxiliaryDataPath(ts: Tuple[int, int], name: str) -> str:
         return getH5GroupName(*ts) + "/" + name
 
     def keys(self):

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -146,7 +146,8 @@ class ArmiCLI:
 
         self.parser = parser
 
-    def showVersion(self):
+    @staticmethod
+    def showVersion():
         """Print the App name and version on the command line"""
         from armi import getApp  # pylint: disable=import-outside-toplevel
 
@@ -192,7 +193,7 @@ class ArmiCLI:
             self.listCommands()
             return 0
         elif args.version:
-            self.showVersion()
+            ArmiCLI.showVersion()
             return 0
         elif args.command == "help":
             self.parser.print_help()

--- a/armi/cli/tests/test_runSuite.py
+++ b/armi/cli/tests/test_runSuite.py
@@ -39,13 +39,11 @@ class TestRunSuiteSuite(unittest.TestCase):
         """Test the ArmiCLI.showVersion method"""
         from armi import cli, meta
 
-        cli = cli.ArmiCLI()
-
         origout = sys.stdout
         try:
             out = io.StringIO()
             sys.stdout = out
-            cli.showVersion()
+            cli.ArmiCLI.showVersion()
         finally:
             sys.stdout = origout
 

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -475,7 +475,7 @@ class DistributeStateAction(MpiAction):
             cs = self._distributeSettings()
 
             self._distributeReactor(cs)
-            self._distributeParamAssignments()
+            DistributeStateAction._distributeParamAssignments()
 
             if self._skipInterfaces:
                 self.o.reattach(self.r, cs)  # may be redundant?
@@ -564,7 +564,8 @@ class DistributeStateAction(MpiAction):
         # attach here so any interface actions use a properly-setup reactor.
         self.o.reattach(self.r, cs)  # sets r and cs
 
-    def _distributeParamAssignments(self):
+    @staticmethod
+    def _distributeParamAssignments():
         data = dict()
         if context.MPI_RANK == 0:
             data = {

--- a/armi/nuclearDataIO/nuclearFileMetadata.py
+++ b/armi/nuclearDataIO/nuclearFileMetadata.py
@@ -127,9 +127,8 @@ class _Metadata:
             mergedData[key] = mergedVal
         return mergedData
 
-    def _getSkippedKeys(
-        self, other, selfContainer, otherContainer, mergedData
-    ):  # pylint: disable=unused-argument
+    # pylint: disable=unused-argument, no-self-use
+    def _getSkippedKeys(self, other, selfContainer, otherContainer, mergedData):
         return set()
 
     def _mergeLibrarySpecificData(

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -1428,7 +1428,8 @@ class FuelHandler:
         )
         return moves
 
-    def trackChain(self, moveList, startingAt, alreadyDone=None):
+    @staticmethod
+    def trackChain(moveList, startingAt, alreadyDone=None):
         r"""
         builds a chain of locations based on starting location
 
@@ -1604,7 +1605,7 @@ class FuelHandler:
 
             elif "SFP" in toLoc or "ExCore" in toLoc:
                 # discharge. Track chain.
-                chain, enrichList, assemType, loadAssemName = self.trackChain(
+                chain, enrichList, assemType, loadAssemName = FuelHandler.trackChain(
                     moveList, startingAt=fromLoc
                 )
                 runLog.extra(
@@ -1629,7 +1630,7 @@ class FuelHandler:
                 continue
             else:
                 # normal move
-                chain, _enrichList, _assemType, _loadAssemName = self.trackChain(
+                chain, _enrichList, _assemType, _loadAssemName = FuelHandler.trackChain(
                     moveList, startingAt=fromLoc
                 )
                 loopChains.append(chain)

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -1628,7 +1628,7 @@ class HexGrid(Grid):
             self.symmetry.domain == geometry.DomainType.THIRD_CORE
             and self.symmetry.boundary == geometry.BoundaryType.PERIODIC
         ):
-            return self._getSymmetricIdenticalsThird(indices)
+            return HexGrid._getSymmetricIdenticalsThird(indices)
         elif self.symmetry.domain == geometry.DomainType.FULL_CORE:
             return []
         else:
@@ -1638,7 +1638,8 @@ class HexGrid(Grid):
                 )
             )
 
-    def _getSymmetricIdenticalsThird(self, indices):
+    @staticmethod
+    def _getSymmetricIdenticalsThird(indices):
         """This works by rotating the indices by 120 degrees twice, counterclockwise."""
         i, j = indices[:2]
         if i == 0 and j == 0:

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for grids."""
-# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
-import unittest
-import math
+"""Tests for grids"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-self-use,attribute-defined-outside-init
 from io import BytesIO
+import math
+import unittest
 
-import numpy
-from six.moves import cPickle
-
-from armi.reactor import grids
-from armi.reactor import geometry
 from numpy.testing import assert_allclose
+from six.moves import cPickle
+import numpy
+
+from armi.reactor import geometry
+from armi.reactor import grids
 
 
 class MockLocator(grids.IndexLocation):
@@ -44,9 +44,7 @@ class MockCoordLocator(grids.CoordinateLocation):
 
 
 class MockArmiObject:
-    """
-    Any sort of object that can serve as a grid's armiObject attribute.
-    """
+    """Any sort of object that can serve as a grid's armiObject attribute."""
 
     def __init__(self, parent=None):
         self.parent = parent

--- a/doc/requirements/srsd.rst
+++ b/doc/requirements/srsd.rst
@@ -222,7 +222,7 @@ Based on user settings, the ordering, initialization, and calls to other plugins
    :status: needs implementation, needs test
 
 .. req:: The nucDirectory package shall contain basic nuclide information for a wide range of nuclides.
-   :id: REQ_NUCDIR_DATA
+   :id: REQ_NUCDIR_INFO
    :status: needs implementation, needs test
 
 The nucDirectory package shall contain the following general information for each nuclide:


### PR DESCRIPTION
## Description

Pylint suggested that these 5 class methods could be `staticmethod`s, so I made the conversion. Nothing fancy, just a little cleanup.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
