### PR TITLE
Removing reference to r.o

### DIFF
--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -123,8 +123,13 @@ class ReportInterface(interfaces.Interface):
 
         dbi = self.o.getInterface("database")
         buGroups = self.cs["buGroups"]
+        history = self.o.getInterface("history")
         reportPlotting.plotReactorPerformance(
-            self.r, dbi, buGroups, extension=self.cs["outputFileExtension"]
+            self.r,
+            dbi,
+            buGroups,
+            extension=self.cs["outputFileExtension"],
+            history=history,
         )
 
         reportingUtils.setNeutronBalancesReport(self.r.core)

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -118,7 +118,7 @@ class ReportInterface(interfaces.Interface):
 
     def interactEOL(self):
         """Adds the data to the report, and generates it"""
-        b = self.o.r.core.getFirstBlock(Flags.FUEL)
+        b = self.r.core.getFirstBlock(Flags.FUEL)
         b.setAreaFractionsReport()
 
         dbi = self.o.getInterface("database")

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -394,7 +394,7 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
         changer.convert(self.r)
 
         converter = uniformMesh.NeutronicsUniformMeshConverter(self.o.cs)
-        newR = converter.initNewReactor(self.r)
+        newR = converter.initNewReactor(self.r, self.o.cs)
 
         # Check the full core conversion is successful
         self.assertTrue(self.r.core.isFullCore)

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -195,7 +195,9 @@ class TestUniformMeshComponents(unittest.TestCase):
 
     def test_blueprintCopy(self):
         """Ensure that necessary blueprint attributes are set"""
-        convReactor = self.converter.initNewReactor(self.converter._sourceReactor)
+        convReactor = self.converter.initNewReactor(
+            self.converter._sourceReactor, self.o.cs
+        )
         converted = convReactor.blueprints
         original = self.converter._sourceReactor.blueprints
         toCompare = [

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -185,8 +185,8 @@ class UniformMeshGeometryConverter(GeometryConverter):
         ----------
         sourceReactor : :py:class:`Reactor <armi.reactor.reactors.Reactor>` object.
             original reactor to be copied
-        cs: TODO
-            TODO
+        cs: CaseSetting object
+            Complete settings object
         """
         # developer note: deepcopy on the blueprint object ensures that all relevant blueprints
         # attributes are set. Simply calling blueprints.loadFromCs() just initializes

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -161,7 +161,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         else:
             runLog.extra(f"Building copy of {r} with a uniform axial mesh.")
-            self.convReactor = self.initNewReactor(r)
+            self.convReactor = self.initNewReactor(r, self._cs)
             self._setParamsToUpdate()
             self._computeAverageAxialMesh()
             self._buildAllUniformAssemblies()
@@ -178,13 +178,15 @@ class UniformMeshGeometryConverter(GeometryConverter):
         )
 
     @staticmethod
-    def initNewReactor(sourceReactor):
+    def initNewReactor(sourceReactor, cs):
         """Build a new, yet empty, reactor with the same settings as sourceReactor
 
         Parameters
         ----------
         sourceReactor : :py:class:`Reactor <armi.reactor.reactors.Reactor>` object.
             original reactor to be copied
+        cs: TODO
+            TODO
         """
         # developer note: deepcopy on the blueprint object ensures that all relevant blueprints
         # attributes are set. Simply calling blueprints.loadFromCs() just initializes
@@ -195,23 +197,13 @@ class UniformMeshGeometryConverter(GeometryConverter):
         newReactor = Reactor(sourceReactor.name, bp)
         coreDesign = bp.systemDesigns["core"]
 
-        # The source reactor may not have an operator available. This can occur
-        # when a different geometry converter is chained together with this. For
-        # instance, using the `HexToRZThetaConverter`, the converted reactor
-        # does not have an operator attached. In this case, we still need some
-        # settings to construct the new core.
-        if sourceReactor.o is None:
-            cs = settings.getMasterCs()
-        else:
-            cs = sourceReactor.o.cs
-
         coreDesign.construct(cs, bp, newReactor, loadAssems=False)
         newReactor.core.lib = sourceReactor.core.lib
         newReactor.core.setPitchUniform(sourceReactor.core.getAssemblyPitch())
 
         # check if the sourceReactor has been modified from the blueprints
         if sourceReactor.core.isFullCore and not newReactor.core.isFullCore:
-            _geometryConverter = newReactor.core.growToFullCore(sourceReactor.o.cs)
+            _geometryConverter = newReactor.core.growToFullCore(cs)
 
         return newReactor
 

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -285,7 +285,7 @@ def xsHistoryVsTime(reactor, history, buGroups, extension=None):
     """
     extension = extension or settings.Settings()["outputFileExtension"]
 
-    if nothistory.xsHistory:
+    if not history.xsHistory:
         return
 
     colors = itertools.cycle(["b", "g", "r", "c", "m", "y", "k"])

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -44,7 +44,7 @@ from armi.physics.neutronics import crossSectionGroupManager
 from armi.reactor.flags import Flags
 
 
-def plotReactorPerformance(reactor, dbi, buGroups, extension=None):
+def plotReactorPerformance(reactor, dbi, buGroups, extension=None, history=None):
     """
     Generates a set of plots useful in reactor analysis given a populated reactor.
 
@@ -62,8 +62,9 @@ def plotReactorPerformance(reactor, dbi, buGroups, extension=None):
     extension : str, optional
         The file extention for saving plots
 
+    history: armi.bookkeeping.historyTracker.HistoryTrackerInterface object
+        The history tracker interface
     """
-    dbi = reactor.o.getInterface("database")
     try:
         data = dbi.getHistory(
             reactor, params=["cycle", "time", "eFeedMT", "eSWU", "eFuelCycleCost"]
@@ -113,8 +114,7 @@ def plotReactorPerformance(reactor, dbi, buGroups, extension=None):
         extension=extension,
     )
     buVsTime(reactor, scalars, extension=extension)
-    distortionVsTime(reactor, scalars, extension=extension)
-    xsHistoryVsTime(reactor, buGroups, extension=extension)
+    xsHistoryVsTime(reactor, history, buGroups, extension=extension)
     movesVsCycle(reactor, scalars, extension=extension)
 
 
@@ -146,7 +146,6 @@ def valueVsTime(reactor, x, y, key, yaxis, title, ymin=None, extension=None):
         it will be ignored.
     extension : str, optional
         The file extention for saving the figure
-
     """
     extension = extension or settings.Settings()["outputFileExtension"]
 
@@ -229,7 +228,6 @@ def buVsTime(reactor, scalars, extension=None):
 
     extension : str, optional
         The file extention for saving the figure
-
     """
     extension = extension or settings.Settings()["outputFileExtension"]
 
@@ -243,6 +241,7 @@ def buVsTime(reactor, scalars, extension=None):
         )
         plt.close(1)
         return
+
     plt.plot(scalars["time"], scalars["maxBuF"], ".-", label="Feed")
     plt.xlabel("Time (yr)")
     plt.ylabel("BU (%FIMA)")
@@ -255,6 +254,7 @@ def buVsTime(reactor, scalars, extension=None):
         plt.legend(loc="lower right")
         plt.ylabel("dpa")
         title += " and DPA"
+
     title += " for " + reactor.name
 
     plt.title(title)
@@ -266,48 +266,28 @@ def buVsTime(reactor, scalars, extension=None):
     report.setData("Burnup Plot", os.path.abspath(figName), report.BURNUP_PLOT)
 
 
-def distortionVsTime(reactor, scalars, extension=None):
-    r"""plots max distortion vs. time if the distortion interface is attached"""
-    dd = reactor.o.getInterface("ductDistortion")
-    if not dd or not "maxSwelling" in dd.__dict__:
-        return  # skip plotting
-
-    extension = extension or settings.Settings()["outputFileExtension"]
-
-    plt.figure()
-    plt.plot(scalars["time"], dd.maxTotal, label="Total")
-    plt.plot(scalars["time"], dd.maxCreep, label="Creep")
-    plt.plot(scalars["time"], dd.maxSwelling, label="Swelling")
-    plt.xlabel("Time (yr)")
-    plt.ylabel("Distortion (mm)")
-    plt.grid(color="0.70")
-    plt.legend(loc="lower right")
-    plt.title("Maximum duct distortion for " + reactor.name)
-    figName = reactor.name + ".duct." + extension
-    plt.savefig(figName)
-    plt.close(1)
-
-    report.setData("Distortion Plot", os.path.abspath(figName), report.DISTORTION_PLOT)
-
-
-def xsHistoryVsTime(reactor, buGroups, extension=None):
+def xsHistoryVsTime(reactor, history, buGroups, extension=None):
     r"""
     Plot cross section history vs. time.
 
     Parameters
     ----------
     reactor : armi.reactor.reactors object
+
+    history : armi.bookkeeping.historyTracker.HistoryTrackerInterface object
+        The history interface.
+
     buGroups : list of float
         The burnup groups in the problem
+
     extension : str, optional
         The file extention for saving the figure
-
     """
     extension = extension or settings.Settings()["outputFileExtension"]
 
-    history = reactor.o.getInterface("history")
-    if not history or not history.xsHistory:
+    if nothistory.xsHistory:
         return
+
     colors = itertools.cycle(["b", "g", "r", "c", "m", "y", "k"])
     plt.figure()
     maxbu = 0.0
@@ -357,7 +337,6 @@ def movesVsCycle(reactor, scalars, extension=None):
     See Also
     --------
     FuelHandler.outage : sets the number of moves in each cycle
-
     """
     extension = extension or settings.Settings()["outputFileExtension"]
 
@@ -367,12 +346,11 @@ def movesVsCycle(reactor, scalars, extension=None):
         if moves is None:
             moves = 0.0
         if cycle not in cycles:  # only one move per cycle
-            cycles.append(
-                cycle
-            )  # use the cycles scalar val in case burnSteps is dynamic
+            # use the cycles scalar val in case burnSteps is dynamic
+            cycles.append(cycle)
             yvals.append(moves)
 
-    plt.figure(figsize=(12, 6))  # make it wide and short.
+    plt.figure(figsize=(12, 6))  # make it wide and short
     plt.bar(cycles, yvals, align="center")
     if len(cycles) > 1:
         plt.xticks(cycles)


### PR DESCRIPTION
## Description

As @jakehader mentioned in #830 , we have a strange "reactor.operator" object in a small number of places. Even though the primary reference is "operator.reactor".

This PR solves about half of those cases.  The second half will be harder to unwind.

I have also opened some PRs in downstream repos to help pre-empt the second half of ticket #830.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.

