### PR TITLE
Removing references to broken import path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -434,6 +434,6 @@ only use third-party Python libraries that have MIT or BSD licenses.
 .. |Build Status| image:: https://github.com/terrapower/armi/actions/workflows/unittests.yaml/badge.svg?branch=main
     :target: https://github.com/terrapower/armi/actions/workflows/unittests.yaml
 
-.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=main&kill_cache=7
+.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=main&kill_cache=2
     :target: https://coveralls.io/github/terrapower/armi?branch=main
 

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -164,23 +164,6 @@ class ReportInterface(interfaces.Interface):
     # --------------------------------------------
     def writeRunSummary(self):
         """Make a summary of the run"""
-        opt = self.o.getInterface("optimize")
-        if opt is None:
-            # The opitimization interface has some good reports that we want, even if we
-            # were not running with the optimization interface active. Try to make one.
-            # This is a proprietary plugin, and may not be present, so protect with a
-            # try/except. When the report system gets more attention and becomes more
-            # extensible in the future this will no longer be necessary
-            try:
-                from terrapower.physics.optimize import optimizationInterface
-            except ModuleNotFoundError:
-                return
-
-            opt = optimizationInterface.OptimizationInterface(self.r, self.cs)
-            self.o.addInterface(opt, enabled=False)
-            opt.interactInit()
-            opt.updateDependentVariables()
-            opt.writeOptimizationResults("{0}.optResults.dat".format(self.cs.caseTitle))
-
-        self.r.core.sfp.report()  # spent fuel pool report
+        # spent fuel pool report
+        self.r.core.sfp.report()
         self.r.core.sfp.count()

--- a/armi/materials/__init__.py
+++ b/armi/materials/__init__.py
@@ -159,20 +159,20 @@ def resolveMaterialClassByName(name: str, namespaceOrder: List[str] = None):
 
     Examples
     --------
-    >>> resolveMaterialClassByName("UO2", ["terrapower.twr.materials", "armi.materials"])
-    <class 'terrapower.twr.materials.UO2'>
+    >>> resolveMaterialClassByName("UO2", ["something.else.materials", "armi.materials"])
+    <class 'something.else.materials.UO2'>
 
     See Also
     --------
     armi.reactor.reactors.factory
         Applies user settings to default namespace order.
-
     """
     if ":" in name:
         # assume direct package path like `armi.materials.uZr:UZr`
         modPath, clsName = name.split(":")
         mod = importlib.import_module(modPath)
         return getattr(mod, clsName)
+
     namespaceOrder = namespaceOrder or _MATERIAL_NAMESPACE_ORDER
     for namespace in namespaceOrder:
         mod = importlib.import_module(namespace)

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -563,12 +563,7 @@ class IsotxsLibrary(_XSLibrary):
         Returns
         -------
         scatterWeights : dict
-            (xsID, fromGroup) : weight column (sparse Gx1).
-
-        See Also
-        --------
-        terrapower.physics.neutronics.uq.sensitivities.MeshMatrix.derivativeM
-
+            (xsID, fromGroup) : weight column (sparse Gx1)
         """
         runLog.info(
             "Building {0} weights on cross section library".format(scatterMatrixKey)
@@ -590,7 +585,6 @@ class IsotxsLibrary(_XSLibrary):
             a reactor, or None
 
         .. warning:: Sometimes worker nodes do not have a reactor, fission products will not be purged.
-
         """
         runLog.info("Purging detailed fission products from {}".format(self))
         modeledNucs = r.blueprints.allNuclidesInProblem

--- a/armi/physics/fuelCycle/fuelHandlerFactory.py
+++ b/armi/physics/fuelCycle/fuelHandlerFactory.py
@@ -82,4 +82,5 @@ def fuelHandlerFactory(operator):
                     fuelHandlerModulePath, fuelHandlerClassName, cs.inputDirectory
                 )
             )
+
     return fuelHandler

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -28,8 +28,7 @@ which block is to be deemed **representative** of an entire set of blocks in a p
 Then the representative block is sent to a lattice physics kernel for actual physics
 calculations.
 
-Generally, the cross section manager is a attribute of the lattice physics code interface (e.g.
-the :py:mod:`~terrapower.physics.neutronics.mc2.mc2Interface`.
+Generally, the cross section manager is a attribute of the lattice physics code interface
 
 Examples
 --------
@@ -191,11 +190,7 @@ class BlockCollection(list):
         .. math::
              T = \frac{\sum{n_i v_i T_i}}{\sum{n_i v_i}}
 
-        where :math:`n_i` is a number density, :math:`v_i` is a volume, and :math:`T_i` is a temperature.
-
-        See Also
-        --------
-        terrapower.physics.neutronics.mc2.mc2Writers.Mc2Writer._getAllNuclideDensities : uses these values
+        where :math:`n_i` is a number density, :math:`v_i` is a volume, and :math:`T_i` is a temperature
         """
         self.avgNucTemperatures = {}
         nvt, nv = self._getNucTempHelper()

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -161,7 +161,6 @@ class FissionProductModel(interfaces.Interface):
 
         See Also
         --------
-        terrapower.physics.neutronics.depletion.depletion.DepletionInterface.buildFissionProducts
         armi.reactor.blocks.Block.getLumpedFissionProductCollection : same thing, but block-level compatible. Use this
         """
 

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -282,10 +282,6 @@ class LatticePhysicsInterface(interfaces.Interface):
             A list of what this specific writer instance returns for each representative block.
             It is the responsibility of the subclassed interface to implement.
             In many cases, it is the executing agent.
-
-        See Also
-        --------
-        terrapower.physics.neutronics.mc2.mc2Writers.Mc2V2Writer.write
         """
         returnedFromWriters = []
         baseList = set(baseList or [])

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1324,7 +1324,6 @@ class Block(composites.Composite):
         See Also
         --------
         armi.physics.neutronics.globalFlux.globalFluxInterface.GlobalFluxInterface.updateFluenceAndDPA : uses this
-        terrapower.physics.neutronics.depletion.depletion.DepletionInterface._updateBlockParametersAfterDepletion : also uses this
         """
         burnupPeakingFactor = settings.getMasterCs()["burnupPeakingFactor"]
         if not burnupPeakingFactor and self.p.fluxPeak:

--- a/armi/utils/units.py
+++ b/armi/utils/units.py
@@ -309,10 +309,6 @@ def getXYLineParameters(theta, x=0, y=0):
     D : float
         line coefficient
 
-    See Also
-    --------
-    terrapower.physics.neutronics.mcnp.mcnpInterface.getSenseWrtTheta
-
     Notes
     -----
     the line is in the form of A*x + B*y + C*z - D = 0 -- this corresponds to a MCNP arbitrary line equation


### PR DESCRIPTION
## Description

There are some faulty, fictitious import paths in ARMI, particularly ARMI documentation. And this PR removes those.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
