### PR TITLE
Removing fictitious import

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlerFactory.py
+++ b/armi/physics/fuelCycle/fuelHandlerFactory.py
@@ -31,18 +31,10 @@ def fuelHandlerFactory(operator):
     fuelHandlerModulePath = cs["shuffleLogic"]
 
     if not fuelHandlerClassName:
-        # User did not request a custom fuel handler.
-        # This is code coupling that should be untangled.
-        # Special case for equilibrium-mode shuffling
-        if cs["eqDirect"] and cs["runType"].lower() == RunTypes.STANDARD.lower():
-            from terrapower.physics.neutronics.equilibrium import fuelHandler as efh
-
-            return efh.EqDirectFuelHandler(operator)
-        else:
-            # give the default FuelHandler. This does not have an implemented outage, but
-            # still offers moving capabilities. Useful when you just need to make explicit
-            # moves but do not have a fully-defined fuel management input.
-            return fuelHandlers.FuelHandler(operator)
+        # give the default FuelHandler. This does not have an implemented outage, but
+        # still offers moving capabilities. Useful when you just need to make explicit
+        # moves but do not have a fully-defined fuel management input.
+        return fuelHandlers.FuelHandler(operator)
 
     # User did request a custom fuel handler. We must go find and import it
     # from the input directory.

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -201,7 +201,7 @@ def cleanPath(path, mpiRank=0):
     with full permissions on the cluster. You could accidentally delete everyone's work
     with one misplaced line! This doesn't ask questions.
 
-    Safety nets include a whitelist of paths.
+    Safety nets include an allow-list of paths.
 
     This makes use of shutil.rmtree and os.remove
 


### PR DESCRIPTION
## Description

This import doesn't exist, so I'm removing it.

Also: I removed a usage of the term "whitelist".

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
