### PR TITLE
Use b.core instead of b.r.core.

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -168,16 +168,23 @@ class Block(composites.Composite):
     @property
     def r(self):
         """
-        A block should only have a reactor through a parent assembly.
+        Look through the ancestors of the Block to find a Reactor, and return it.
 
+        Notes
+        -----
+        Typical hierarchy: Reactor <- Core <- Assembly <- Block
+        A block should only have a reactor through a parent assembly.
         It may make sense to try to factor out usage of ``b.r``.
 
-        For now, this is presumptive of the structure of the composite hierarchy; i.e.
-        the parent of a CORE must be the reactor. Fortunately, we probably don't
-        ultimately want to return the reactor in the first place. Rather, we probably want the core
-        anyways, since practically all `b.r` calls are historically `b.r.core`. It may be
-        prefereable to remove this property, replace with `self.core`, which can return the core.
-        Then refactor all of the b.r.cores, to b.core.
+        Returns
+        -------
+        core.parent : armi.reactor.reactors.Reactor
+            ARMI reactor object that is an ancestor of the block.
+
+        Raises
+        ------
+        ValueError
+            If the parent of the block's ``core`` is not an ``armi.reactor.reactors.Reactor``.
         """
 
         from armi.reactor.reactors import Reactor

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1263,7 +1263,7 @@ class Block(composites.Composite):
         -------
         mfp, mfpAbs, diffusionLength : tuple(float, float float)
         """
-        lib = self.r.core.lib
+        lib = self.core.lib
         flux = self.getMgFlux(gamma=gamma)
         flux = [fi / max(flux) for fi in flux]
         mfpNumerator = numpy.zeros(len(flux))
@@ -1513,7 +1513,7 @@ class Block(composites.Composite):
         try:
             return components.component.getReactionRateDict(
                 nucName,
-                self.r.core.lib,
+                self.core.lib,
                 self.p.xsType,
                 self.getIntegratedMgFlux(),
                 nDensity,
@@ -1970,21 +1970,19 @@ class HexBlock(Block):
                 # central location
                 return 3.0
             else:
-                symmetryLine = self.r.core.spatialGrid.overlapsWhichSymmetryLine(
-                    indices
-                )
+                symmetryLine = self.core.spatialGrid.overlapsWhichSymmetryLine(indices)
                 # detect if upper edge assemblies are included. Doing this is the only way to know
                 # definitively whether or not the edge assemblies are half-assems or full.
                 # seeing the first one is the easiest way to detect them.
                 # Check it last in the and statement so we don't waste time doing it.
-                upperEdgeLoc = self.r.core.spatialGrid[-1, 2, 0]
+                upperEdgeLoc = self.core.spatialGrid[-1, 2, 0]
                 if (
                     symmetryLine
                     in [
                         grids.BOUNDARY_0_DEGREES,
                         grids.BOUNDARY_120_DEGREES,
                     ]
-                    and bool(self.r.core.childrenByLocator.get(upperEdgeLoc))
+                    and bool(self.core.childrenByLocator.get(upperEdgeLoc))
                 ):
                     return 2.0
         return 1.0
@@ -2158,9 +2156,9 @@ class CartesianBlock(Block):
         Return a factor between 1 and N where 1/N is how much cut-off by symmetry lines this mesh
         cell is.
         """
-        if self.r is not None:
+        if self.core is not None:
             indices = self.spatialLocator.getCompleteIndices()
-            if self.r.core.symmetry.isThroughCenterAssembly:
+            if self.core.symmetry.isThroughCenterAssembly:
                 if indices[0] == 0 and indices[1] == 0:
                     # central location
                     return 4.0


### PR DESCRIPTION
## Description

Blocks have an `r` property and a core property. Both functions just look up the chain of ancestors of the block to find the `core` and `reactor`. It's unnecessary to go all the way up to the `reactor` just to then grab the `core` off of it.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

