### PR TITLE
Fix issue where case was mistakenly making absolute paths relative.

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -889,7 +889,8 @@ def copyInterfaceInputs(
                     try:
                         if path.is_absolute() and path.exists() and path.is_file():
                             # Path is absolute, no settings modification or filecopy needed
-                            pass
+                            newFiles.append(path)
+                            continue
                     except OSError:
                         pass
                 # Attempt to construct an absolute file path

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -543,6 +543,20 @@ class TestCopyInterfaceInputs(unittest.TestCase):
             newFilepath = os.path.join(newDir.destination, shuffleFile)
             self.assertEqual(newSettings[testSetting], newFilepath)
 
+    def test_copyInterfaceInputs_absPath(self):
+        testSetting = "shuffleLogic"
+        cs = settings.Settings(ARMI_RUN_PATH)
+        shuffleFile = cs[testSetting]
+        absFile = os.path.dirname(os.path.abspath(ARMI_RUN_PATH))
+        absFile = str(os.path.join(absFile, os.path.basename(shuffleFile)))
+        cs = cs.modified(newSettings={testSetting: absFile})
+
+        with directoryChangers.TemporaryDirectoryChanger() as newDir:
+            newSettings = cases.case.copyInterfaceInputs(
+                cs, destination=newDir.destination
+            )
+            self.assertEqual(str(newSettings[testSetting]), absFile)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description
Closes #913

Though should have a test.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

