### PR TITLE
Uniform mesh update for reaction rate calculations of non-uniform assemblies

### DIFF
--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -24,6 +24,10 @@ from armi.scripts.migration.crossSectionBlueprintsToSettings import (
 )
 from armi.settings import setting
 from armi.utils import directoryChangers
+from armi.settings.fwSettings.globalSettings import (
+    CONF_DETAILED_AXIAL_EXPANSION,
+    CONF_NON_UNIFORM_ASSEM_FLAGS,
+)
 
 
 CONF_BC_COEFFICIENT = "bcCoefficient"
@@ -506,6 +510,19 @@ def getNeutronicsSettingValidators(inspector):
                 inspector.cs.path
             ),
             lambda: migrateCrossSectionsFromBlueprints(inspector.cs),
+        )
+    )
+
+    queries.append(
+        settingsValidation.Query(
+            lambda: inspector.cs[CONF_DETAILED_AXIAL_EXPANSION]
+            and inspector.cs[CONF_NON_UNIFORM_ASSEM_FLAGS],
+            f"The use of {CONF_DETAILED_AXIAL_EXPANSION} and {CONF_NON_UNIFORM_ASSEM_FLAGS} is not supported.",
+            "Automatically set non-uniform assembly treatment to its default?",
+            lambda: inspector._assignCS(
+                CONF_NON_UNIFORM_ASSEM_FLAGS,
+                inspector.cs.getSetting(CONF_NON_UNIFORM_ASSEM_FLAGS).default,
+            ),
         )
     )
 

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -249,7 +249,7 @@ class NeutronicsReactorTests(unittest.TestCase):
         cs = settings.Settings()
         inspector = settingsValidation.Inspector(cs)
         sv = getNeutronicsSettingValidators(inspector)
-        self.assertEqual(len(sv), 7)
+        self.assertEqual(len(sv), 8)
 
         # Test the Query: boundaries are now "Extrapolated", not "Normal"
         cs = cs.modified(newSettings={"boundaries": "Normal"})

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -410,19 +410,36 @@ class TestUniformMeshNonUniformAssemFlags(unittest.TestCase):
     def test_reactorConversion(self):
         """Tests the reactor conversion to and from the original reactor."""
         self.assertTrue(self.converter._hasNonUniformAssems)
+        self.assertTrue(self.r.core.lib)
+        self.assertEqual(self.r.core.p.keff, 1.0)
 
         controlAssems = self.r.core.getAssemblies(Flags.PRIMARY | Flags.CONTROL)
+        # Add a bunch of multi-group flux to the control assemblies
+        # in the core to demonstrate that data can be mapped back
+        # to the original control rod assemblies if they are changed.
+        # Additionally, this will check that block-level reaction rates
+        # are being calculated (i.e., `rateAbs`).
+        for a in controlAssems:
+            for b in a:
+                b.p.mgFlux = [1.0] * 33
+                self.assertFalse(b.p.rateAbs)
+
         self.converter.convert(self.r)
 
         self.assertEqual(
             len(controlAssems),
             len(self.converter._nonUniformAssemStorage),
         )
+
         self.converter.applyStateToOriginal()
         self.assertEqual(
             len(self.converter._nonUniformAssemStorage),
             0,
         )
+        for a in controlAssems:
+            for b in a:
+                self.assertTrue(all(b.getMgFlux()))
+                self.assertTrue(b.p.rateAbs)
 
 
 if __name__ == "__main__":

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -551,7 +551,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 else:
                     runLog.warning(
                         f"Reaction rates requested for {destinationAssembly}, but no core object exists. This calculation "
-                        "will be skipped."
+                        "will be skipped.",
+                        single=True,
+                        label="Block reaction rate calculation skipped due to insufficient multi-group flux data.",
                     )
 
     @staticmethod

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from framework.armi.physics.neutronics.globalFlux.globalFluxInterface import (
-    calcReactionRates,
-)
-
 """
 Converts reactor with arbitrary axial meshing (e.g. multiple assemblies with different
 axial meshes) to one with a global uniform axial mesh.
@@ -75,9 +71,6 @@ from armi.reactor.flags import Flags
 from armi.reactor.converters.geometryConverters import GeometryConverter
 from armi.reactor import parameters
 from armi.reactor.reactors import Reactor
-
-# unfortunate physics coupling, but still in the framework
-from armi.physics.neutronics.globalFlux import globalFluxInterface
 
 
 class UniformMeshGeometryConverter(GeometryConverter):
@@ -766,8 +759,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
         If a block in the assembly does not contain any multi-group flux
         than the reaction rate calculation for this block will be skipped.
         """
+        from armi.physics.neutronics.globalFlux import globalFluxInterface
+
         for b in assem:
-            print(b)
             # Checks if the block has a multi-group flux defined and if it
             # does not then this will skip the reaction rate calculation. This
             # is captured by the TypeError, due to a `NoneType` divide by float
@@ -776,8 +770,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 b.getMgFlux()
             except TypeError:
                 continue
-
-            print(b.getMgFlux())
             globalFluxInterface.calcReactionRates(b, keff, lib)
 
 


### PR DESCRIPTION
## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

Update the uniform mesh converter to handle the reaction rate calculations and to remove the overly restrictive power conversion check. This allows the following block-level parameters for non uniform assemblies: `["rateCap", "rateFis", "rateProdN2n", "rateProdFis", "rateAbs"]`

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

