### PR TITLE
Add writer style option to SettingsWriter pt1

### DIFF
--- a/armi/cli/modify.py
+++ b/armi/cli/modify.py
@@ -65,7 +65,8 @@ class ModifyCaseSettingsCommand(EntryPoint):
             "--style",
             type=str,
             default="short",
-            help="Writing style for settings writer. Can be short, medium, or full",
+            help="Writing style for settings writer.",
+            choices=["short", "medium", "full"],
         )
         self.parser.add_argument(
             "patterns",

--- a/armi/cli/modify.py
+++ b/armi/cli/modify.py
@@ -62,10 +62,10 @@ class ModifyCaseSettingsCommand(EntryPoint):
             help="A root directory in which to search for settings files, e.g., armi/tests.",
         )
         self.parser.add_argument(
-            "--style",
+            "--settingsWriteStyle",
             type=str,
             default="short",
-            help="Writing style for settings writer.",
+            help="Writing style for which settings get written back to the settings files.",
             choices=["short", "medium", "full"],
         )
         self.parser.add_argument(
@@ -113,7 +113,7 @@ class ModifyCaseSettingsCommand(EntryPoint):
                 inspector.run()
 
             if not self.args.list_setting_files:
-                cs.writeToYamlFile(cs.path, style=self.args.style)
+                cs.writeToYamlFile(cs.path, style=self.args.settingsWriteStyle)
 
         runLog.important(
             "Finished {} {} settings files.".format(messages[1], len(csInstances))

--- a/armi/cli/modify.py
+++ b/armi/cli/modify.py
@@ -62,6 +62,12 @@ class ModifyCaseSettingsCommand(EntryPoint):
             help="A root directory in which to search for settings files, e.g., armi/tests.",
         )
         self.parser.add_argument(
+            "--style",
+            type=str,
+            default="short",
+            help="Writing style for settings writer. Can be short, medium, or full",
+        )
+        self.parser.add_argument(
             "patterns",
             type=str,
             nargs="*",
@@ -106,7 +112,7 @@ class ModifyCaseSettingsCommand(EntryPoint):
                 inspector.run()
 
             if not self.args.list_setting_files:
-                cs.writeToYamlFile(cs.path)
+                cs.writeToYamlFile(cs.path, style=self.args.style)
 
         runLog.important(
             "Finished {} {} settings files.".format(messages[1], len(csInstances))

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -63,23 +63,21 @@ class TestCloneArmiRunCommandBatch(unittest.TestCase):
     def test_cloneArmiRunCommandBatchBasics(self):
         ca = CloneArmiRunCommandBatch()
         ca.addOptions()
-        ca.parse_args(["--additional-files", "test", "--settingsWriteStyle", "full"])
+        ca.parse_args(["--additional-files", "test"])
 
         self.assertEqual(ca.name, "clone-batch")
         self.assertEqual(ca.settingsArgument, "required")
         self.assertEqual(ca.args.additional_files, ["test"])
-        self.assertEqual(ca.args.settingsWriteStyle, "full")
 
 
 class TestCloneSuiteCommand(unittest.TestCase):
     def test_cloneSuiteCommandBasics(self):
         cs = CloneSuiteCommand()
         cs.addOptions()
-        cs.parse_args(["-d", "test", "--settingsWriteStyle", "medium"])
+        cs.parse_args(["-d", "test"])
 
         self.assertEqual(cs.name, "clone-suite")
         self.assertEqual(cs.args.directory, "test")
-        self.assertEqual(cs.args.settingsWriteStyle, "medium")
 
 
 class TestCompareCases(unittest.TestCase):

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -63,19 +63,23 @@ class TestCloneArmiRunCommandBatch(unittest.TestCase):
     def test_cloneArmiRunCommandBatchBasics(self):
         ca = CloneArmiRunCommandBatch()
         ca.addOptions()
-        ca.parse_args(["--additional-files", "test"])
+        ca.parse_args(["--additional-files", "test", "--settingsWriteStyle", "full"])
 
         self.assertEqual(ca.name, "clone-batch")
         self.assertEqual(ca.settingsArgument, "required")
+        self.assertEqual(ca.args.additional_files, ["test"])
+        self.assertEqual(ca.args.settingsWriteStyle, "full")
 
 
 class TestCloneSuiteCommand(unittest.TestCase):
     def test_cloneSuiteCommandBasics(self):
         cs = CloneSuiteCommand()
         cs.addOptions()
-        cs.parse_args(["-d", "test"])
+        cs.parse_args(["-d", "test", "--settingsWriteStyle", "medium"])
 
         self.assertEqual(cs.name, "clone-suite")
+        self.assertEqual(cs.args.directory, "test")
+        self.assertEqual(cs.args.settingsWriteStyle, "medium")
 
 
 class TestCompareCases(unittest.TestCase):
@@ -180,10 +184,13 @@ class TestModifyCaseSettingsCommand(unittest.TestCase):
     def test_modifyCaseSettingsCommandBasics(self):
         mcs = ModifyCaseSettingsCommand()
         mcs.addOptions()
-        mcs.parse_args(["--rootDir", "/path/to/", "fake.yaml"])
+        mcs.parse_args(
+            ["--rootDir", "/path/to/", "--settingsWriteStyle", "medium", "fake.yaml"]
+        )
 
         self.assertEqual(mcs.name, "modify")
         self.assertEqual(mcs.args.rootDir, "/path/to/")
+        self.assertEqual(mcs.args.settingsWriteStyle, "medium")
         self.assertEqual(mcs.args.patterns, ["fake.yaml"])
 
     def test_modifyCaseSettingsCommandInvoke(self):

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -29,6 +29,7 @@ import io
 import logging
 import os
 from copy import copy, deepcopy
+from ruamel.yaml import YAML
 
 from armi import context
 from armi import runLog
@@ -391,7 +392,6 @@ class Settings:
         userSettingsNames : list
             The settings names read in from a yaml settings file
         """
-        from ruamel.yaml import YAML
 
         # We do not want to load these as settings, but just grab the dictionary straight
         # from the settings file to know which settings are user-defined

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -363,9 +363,9 @@ class Settings:
         ----------
         fName : str
             the file to write to
-        style : str
-            the method of output to be used when creating the file for
-            the current state of settings
+        style : str (optional)
+            the method of output to be used when creating the file for the current
+            state of settings
         """
         self.path = pathTools.armiAbsPath(fName)
         if style == "medium":
@@ -409,14 +409,11 @@ class Settings:
         Parameters
         ----------
         stream : file object
-            Write-only file stream
-
-        style : str
+            Writable file stream
+        style : str (optional)
             Writing style for settings file. Can be short, medium, or full.
-
         settingsSetByUser : list
             List of settings names in user-defined settings file
-
 
         Returns
         -------

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -369,14 +369,14 @@ class Settings:
         """
         self.path = pathTools.armiAbsPath(fName)
         if style == "medium":
-            originalSettings = self.getOriginalCaseSettings(self.path)
+            settingsSetByUser = self.getSettingsSetByUser(self.path)
         else:
-            originalSettings = None
+            settingsSetByUser = None
         with open(self.path, "w") as stream:
-            writer = self.writeToYamlStream(stream, style, originalSettings)
+            writer = self.writeToYamlStream(stream, style, settingsSetByUser)
         return writer
 
-    def getOriginalCaseSettings(self, fPath):
+    def getSettingsSetByUser(self, fPath):
         """
         Grabs the list of settings in the user-defined input file so that the settings
         can be tracked outside of a Settings Object
@@ -388,8 +388,8 @@ class Settings:
 
         Returns
         -------
-        list(originalSettings.keys()) : list
-            The keys of the settings read in from a yaml settings file
+        userSettingsNames : list
+            The settings names read in from a yaml settings file
         """
         from ruamel.yaml import YAML
 
@@ -398,10 +398,11 @@ class Settings:
         with open(fPath, "r") as stream:
             yaml = YAML()
             tree = yaml.load(stream)
-            originalSettings = tree[settingsIO.Roots.CUSTOM]
-        return list(originalSettings.keys())
+            userSettings = tree[settingsIO.Roots.CUSTOM]
+        userSettingsNames = list(userSettings.keys())
+        return userSettingsNames
 
-    def writeToYamlStream(self, stream, style="short", originalSettingsNames=None):
+    def writeToYamlStream(self, stream, style="short", settingsSetByUser=None):
         """
         Write settings in yaml format to an arbitrary stream.
 
@@ -413,8 +414,8 @@ class Settings:
         style : str
             Writing style for settings file. Can be short, medium, or full.
 
-        originalSettingsNames : list
-            List of settings names in original settings file
+        settingsSetByUser : list
+            List of settings names in user-defined settings file
 
 
         Returns
@@ -422,7 +423,7 @@ class Settings:
         writer : SettingsWriter object
         """
         writer = settingsIO.SettingsWriter(
-            self, style=style, originalSettingsNames=originalSettingsNames
+            self, style=style, settingsSetByUser=settingsSetByUser
         )
         writer.writeYaml(stream)
         return writer

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -371,7 +371,7 @@ class Settings:
         if style == "medium":
             settingsSetByUser = self.getSettingsSetByUser(self.path)
         else:
-            settingsSetByUser = None
+            settingsSetByUser = []
         with open(self.path, "w") as stream:
             writer = self.writeToYamlStream(stream, style, settingsSetByUser)
         return writer
@@ -402,7 +402,7 @@ class Settings:
         userSettingsNames = list(userSettings.keys())
         return userSettingsNames
 
-    def writeToYamlStream(self, stream, style="short", settingsSetByUser=None):
+    def writeToYamlStream(self, stream, style="short", settingsSetByUser=[]):
         """
         Write settings in yaml format to an arbitrary stream.
 

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -32,6 +32,7 @@ from armi import context
 from armi.settings.setting import Setting
 from armi.utils.customExceptions import (
     InvalidSettingsFileError,
+    InvalidSettingsStopProcess,
     SettingException,
 )
 
@@ -244,7 +245,7 @@ class SettingsReader:
 
     def _applySettings(self, name, val):
         """Add a setting, if it is valid. Capture invalid settings."""
-        nameToSet, _wasRenamed = self._renamer.renameSetting(name)
+        _nameToSet, _wasRenamed = self._renamer.renameSetting(name)
 
         if name not in self.cs:
             self.invalidSettings.add(name)
@@ -321,7 +322,7 @@ class SettingsWriter:
         This is general so it can be dumped to whatever file format.
         """
         settingData = collections.OrderedDict()
-        for _settingName, settingObject in iter(
+        for settingName, settingObject in iter(
             sorted(self.cs.items(), key=lambda name: name[0].lower())
         ):
             if self.style == WRITE_SHORT and not settingObject.offDefault:
@@ -330,7 +331,7 @@ class SettingsWriter:
             if (
                 self.style == WRITE_MEDIUM
                 and not settingObject.offDefault
-                and _settingName not in self.settingsSetByUser
+                and settingName not in self.settingsSetByUser
             ):
                 continue
 

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -273,13 +273,14 @@ class SettingsWriter:
         medium = "medium"
         full = "full"
 
-    def __init__(self, settings_instance, style="short", originalSettingsNames=None):
+    def __init__(self, settings_instance, style="short", settingsSetByUser=None):
         self.cs = settings_instance
         self.style = style
         if style not in {self.Styles.short, self.Styles.medium, self.Styles.full}:
             raise ValueError("Invalid supplied setting writing style {}".format(style))
-        # The writer should know about the old settings it is overwriting, sometimes
-        self.originalSettingsNames = originalSettingsNames
+        # The writer should know about the old settings it is overwriting,
+        # but only sometimes (when the style is medium)
+        self.settingsSetByUser = settingsSetByUser
 
     @staticmethod
     def _getVersion():
@@ -331,7 +332,7 @@ class SettingsWriter:
             if (
                 self.style == self.Styles.medium
                 and not settingObject.offDefault
-                and _settingName not in self.originalSettingsNames
+                and _settingName not in self.settingsSetByUser
             ):
                 continue
 

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -35,6 +35,11 @@ from armi.utils.customExceptions import (
     SettingException,
 )
 
+# Constants defining valid output styles
+WRITE_SHORT = "short"
+WRITE_MEDIUM = "medium"
+WRITE_FULL = "full"
+
 
 class Roots:
     """XML tree root node common strings"""
@@ -266,17 +271,10 @@ class SettingsWriter:
 
     """
 
-    class Styles:
-        """Enumeration of valid output styles"""
-
-        short = "short"
-        medium = "medium"
-        full = "full"
-
     def __init__(self, settings_instance, style="short", settingsSetByUser=[]):
         self.cs = settings_instance
         self.style = style
-        if style not in {self.Styles.short, self.Styles.medium, self.Styles.full}:
+        if style not in {WRITE_SHORT, WRITE_MEDIUM, WRITE_FULL}:
             raise ValueError("Invalid supplied setting writing style {}".format(style))
         # The writer should know about the old settings it is overwriting,
         # but only sometimes (when the style is medium)
@@ -326,11 +324,11 @@ class SettingsWriter:
         for _settingName, settingObject in iter(
             sorted(self.cs.items(), key=lambda name: name[0].lower())
         ):
-            if self.style == self.Styles.short and not settingObject.offDefault:
+            if self.style == WRITE_SHORT and not settingObject.offDefault:
                 continue
 
             if (
-                self.style == self.Styles.medium
+                self.style == WRITE_MEDIUM
                 and not settingObject.offDefault
                 and _settingName not in self.settingsSetByUser
             ):

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -273,7 +273,7 @@ class SettingsWriter:
         medium = "medium"
         full = "full"
 
-    def __init__(self, settings_instance, style="short", settingsSetByUser=None):
+    def __init__(self, settings_instance, style="short", settingsSetByUser=[]):
         self.cs = settings_instance
         self.style = style
         if style not in {self.Styles.short, self.Styles.medium, self.Styles.full}:

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -33,7 +33,7 @@ from armi.physics.fuelCycle import FuelHandlerPlugin
 from armi.reactor.flags import Flags
 from armi.settings import caseSettings
 from armi.settings import setting
-from armi.tests import TEST_ROOT
+from armi.tests import TEST_ROOT, ARMI_RUN_PATH
 from armi.utils import directoryChangers
 from armi.utils.customExceptions import NonexistentSetting
 
@@ -265,6 +265,15 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         newDefault = setting.Default(5, "testsetting")
         a.changeDefault(newDefault)
         self.assertEqual(a.value, 5)
+
+    def test_getSettingsSetByUser(self):
+        cs = caseSettings.Settings()
+        settingsList = cs.getSettingsSetByUser(ARMI_RUN_PATH)
+        # This test is dependent on the current setup of armiRun.yaml, which includes
+        # some default settings values
+        for setting in ["availabilityFactor", "economics"]:
+            self.assertIn(setting, settingsList)
+        self.assertNotIn("numProcessors", settingsList)
 
     def test_setModuleVerbosities(self):
         # init settings and use them to set module-level logging levels

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -127,11 +127,31 @@ class SettingsWriterTests(unittest.TestCase):
         context.Mode.setMode(self.init_mode)
         self.td.__exit__(None, None, None)
 
-    def test_writeShorthand(self):
+    def test_writeShort(self):
         """Setting output as a sparse file"""
         self.cs.writeToYamlFile(self.filepathYaml, style="short")
         self.cs.loadFromInputFile(self.filepathYaml)
-        self.assertEqual(self.cs["nCycles"], 55)
+        txt = open(self.filepathYaml, "r").read()
+        self.assertIn("nCycles: 55", txt)
+        self.assertNotIn("numProcessors", txt)
+
+    def test_writeMedium(self):
+        """Setting output as a sparse file that only includes defaults if they are
+        user-specified"""
+        with open(self.filepathYaml, "w") as stream:
+            # Specify a setting that is also a default
+            self.cs.writeToYamlStream(stream, "medium", ["numProcessors"])
+        txt = open(self.filepathYaml, "r").read()
+        self.assertIn("nCycles: 55", txt)
+        self.assertIn("numProcessors: 1", txt)
+
+    def test_writeFull(self):
+        """Setting output as a full, all defaults included file"""
+        self.cs.writeToYamlFile(self.filepathYaml, style="full")
+        txt = open(self.filepathYaml, "r").read()
+        self.assertIn("nCycles: 55", txt)
+        # check a default setting
+        self.assertIn("numProcessors: 1", txt)
 
     def test_writeYaml(self):
         self.cs.writeToYamlFile(self.filepathYaml)

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -9,6 +9,36 @@ Release Date: TBD
 
 What's new in ARMI
 ------------------
+
+#. TBD
+#. Added writer style option to ``SettingsWriter`` and added it as arg to modify CLI (`PR#924 <https://github.com/terrapower/armi/pull/924>`_)
+
+Bug fixes
+---------
+#. TBD
+
+
+ARMI v0.2.4
+===========
+Release Date: 2022-10-03
+
+What's new in ARMI
+------------------
+#. Added new ``UserPlugin`` functionality.
+#. Introduced ``axial expansion changer``.
+#. Greatly improved the ``UniformMeshGeometryConverter``.
+#. Made the min/max temperatures of ``Material`` curves discoverable.
+#. Removed the ``PyYaml`` dependency.
+#. Changed the default Git branch name to ``main``.
+#. Moved math utilities into their own module.
+#. Moved ``newReports`` into their final location in ``armi/bookkeeping/report/``.
+#. Removed ``_swapFluxParam`` method (`PR#665 <https://github.com/terrapower/armi/pull/665#discussion_r893348409>`_)
+#. Removed the last usage of ``settingsRules``; now only use ``settingsValidation``.
+#. Removed separate blueprints in snapshot runs, they must come from the database (`PR#872 https://github.com/terrapower/armi/pull/872`)
+#. Added reporting of neutron and gamma energy groups in the XS library ``__repr__``.
+#. Updated NHFLUX reader to store VARIANT data that was being discarded.
+#. Store thermally expanded block heights at BOL in ``armi/reactor/reactors.py::Core::processLoading``.
+>>>>>>> e091882 (Release notes)
 #. Added neutronics settings: ``inners`` and ``outers`` for downstream support.
 #. Removed unused Thermal Hydraulics settings.
 #. Minor code re-org, moving math utilities into their own module.


### PR DESCRIPTION
NOTE: the updates to the original PR on this topic requested by @keckler will be in a follow-up PR, namely making this argument available to `clone` / `writeInputs`.

## Description

As described in Issue #897, we would like a third option that preserves the original settings file even if a setting defined in it is a default value. Currently, `short` removes all settings that have the default value, and `full` prints out every possible setting to the file.

To accomplish that, I added a `medium` style option to `SettingsWriter` (which involved editing the handling of the strings of "acceptable" styles to constant strings as well as a helper function in the `caseSettings` module called `getSettingSetByUser` so the full list of user defined settings can be tracked.).

I made the `settingsWriteStyle` flag available to the `modify` EntryPoint, so one can alter the writing style from the command line.

The testing was a little difficult. `writeToYamlFile` method and `SettingsWriter` class aren't explicitly tested. I have the 3 writing style options tested, the new method (`getSettingsSetByUser`) in `caseSettings.py` is tested, and a sad attempt at adding this to the `modify` CLI testing. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

