### PR TITLE
Add the `detailedAxialExpansion` category to the fast flux parameter

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -725,6 +725,7 @@ def _getNeutronicsBlockParams():
             units="1/cm^2/s",
             description="Neutron flux above 100keV",
             location=ParamLocation.AVERAGE,
+            categories=["detailedAxialExpansion"],
         )
 
         pb.defParam(

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -274,7 +274,8 @@ class TestUniformMesh(unittest.TestCase):
         for b in self.converter.convReactor.core.getBlocks():
             b.p.mgFlux = range(33)
             b.p.adjMgFlux = range(33)
-            b.p.flux = 5
+            b.p.fastFlux = 2.0
+            b.p.flux = 5.0
             b.p.power = 5.0
             b.p.pdens = 0.5
 
@@ -292,6 +293,7 @@ class TestUniformMesh(unittest.TestCase):
         self.converter.applyStateToOriginal()
 
         for b in self.r.core.getBlocks():
+            self.assertAlmostEqual(b.p.fastFlux, 2.0)
             self.assertAlmostEqual(b.p.flux, 5.0)
             self.assertAlmostEqual(b.p.pdens, 0.5)
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -12,7 +12,7 @@ What's new in ARMI
 
 Bug fixes
 ---------
-#. TBD
+#. Fixed bug in ``fastFlux`` block parameter mapping in the ``UniformMeshConverter`` by applying it to the ``detailedAxialExpansion`` category.
 
 
 ARMI v0.2.4


### PR DESCRIPTION
## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

The `detailedAxialExpansion` category was not applied to the fast flux block parameter and therefore mapping in the `UniformMeshConverter` was missing this parameter when data was being transferred. We have many parameter assignments in the framework that are not correct and there needs to be more complete audit of the parameter system, but this is just one that was reported.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

