### PR TITLE
Restore the db `_fullPath` upon close()

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -705,7 +705,8 @@ class Database3:
 
         if self._permission == "w":
             # move out of the FAST_PATH and into the working directory
-            shutil.move(self._fullPath, self._fileName)
+            newPath = shutil.move(self._fullPath, self._fileName)
+            self._fullPath = os.path.abspath(newPath)
 
     def splitDatabase(
         self, keepTimeSteps: Sequence[Tuple[int, int]], label: str

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -15,12 +15,14 @@
 r""" Tests for the Database3 class
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
+import os
 import subprocess
 import unittest
 
 import h5py
 import numpy
 
+from armi import context
 from armi.bookkeeping.db import _getH5File, database3
 from armi.reactor import grids
 from armi.reactor import parameters
@@ -682,6 +684,23 @@ class TestLocationPacking(unittest.TestCase):
         self.assertEqual(unpackedData[1], (4.0, 5.0, 6.0))
         self.assertEqual(unpackedData[2][0], (7, 8, 9))
         self.assertEqual(unpackedData[2][1], (10, 11, 12))
+
+    def test_close(self):
+        intendedFileName = "xyz.h5"
+
+        db = database3.Database3(intendedFileName, "w")
+        self.assertEqual(db._fileName, intendedFileName)
+        self.assertIsNone(db._fullPath)  # this isn't set until the db is opened
+
+        db.open()
+        self.assertEqual(
+            db._fullPath, os.path.join(context.getFastPath(), intendedFileName)
+        )
+
+        db.close()  # this should move the file out of the FAST_PATH
+        self.assertEqual(
+            db._fullPath, os.path.join(os.path.abspath("."), intendedFileName)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

When a db open in write-mode is closed, it is moved out of the `FAST_PATH` back into the working directory. However, it's internal metadata `database._fullPath` was not updated to reflect this new path. 

This PR just updates the `_fullPath` attribute to be consistent.

This helps with keeping track of the DB during a run.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

