### PR TITLE
Mixed Upward and Downward Axial Expansion for CRAs

### DIFF
--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -156,6 +156,9 @@ class ComponentBlueprint(yamlize.Object):
     orientation = yamlize.Attribute(type=str, default=None)
     mergeWith = yamlize.Attribute(type=str, default=None)
     area = yamlize.Attribute(type=float, default=None)
+    axiallyExpandsDownwards = yamlize.Attribute(
+        type=bool, default=False, key="axially expands downwards"
+    )
 
     def construct(self, blueprint, matMods):
         """Construct a component or group"""
@@ -176,6 +179,7 @@ class ComponentBlueprint(yamlize.Object):
 
         else:
             constructedObject = components.factory(shape, [], kwargs)
+            constructedObject.axiallyExpandsDownwards = self.axiallyExpandsDownwards
             _setComponentFlags(constructedObject, self.flags, blueprint)
             insertDepletableNuclideKeys(constructedObject, blueprint)
         return constructedObject
@@ -199,6 +203,10 @@ class ComponentBlueprint(yamlize.Object):
             elif attr.name == "flags":
                 # Don't pass these to the component constructor. These are used to
                 # override the flags derived from the type, if present.
+                continue
+            elif attr.name == "axiallyExpandsDownwards":
+                # Don't pass to component constructor. Gets manually assigned after
+                # component is initialized.
                 continue
             else:
                 value = attr.get_value(self)

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -236,6 +236,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         self.setType(name)
         self.p.mergeWith = mergeWith
         self.p.customIsotopicsName = isotopics
+        self.axiallyExpandsDownwards = False
 
     @property
     def temperatureInC(self):

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -83,6 +83,8 @@ class AxialExpansionChanger:
         setFuel : boolean, optional
             Boolean to determine whether or not fuel blocks should have their target components set
             This is useful when target components within a fuel block need to be determined on-the-fly.
+        CRA : boolean, optional
+            boolean to determine whether or not to use the specific control assembly expansion method
 
         Notes
         -----

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -289,9 +289,9 @@ class AxialExpansionChanger:
         # align upward expanding pin components within control rod bundle.
         # new c.height has been updated, but c.zbottom and c.ztop need to be set
         for ib, b in enumerate(self.linked.a.getChildrenWithFlags(Flags.CONTROL)):
-            c = _getComponent(b, Flags.CONTROL)
+            c = b.getComponent(Flags.CONTROL)
             if ib == 0:
-                cladComp = _getComponent(b, Flags.CLAD)
+                cladComp = b.getComponent(Flags.CLAD)
                 c.zbottom = cladComp.zbottom
             else:
                 c.zbottom = self.linked.linkedComponents[c][0].ztop
@@ -484,23 +484,6 @@ class AxialExpansionChanger:
                     growth = 1.0 / (1.0 - growFrac)
                 for key in c.getNuclides():
                     c.setNumberDensity(key, c.getNumberDensity(key) / growth)
-
-
-def _getComponent(b, componentFlag):
-    """return component (with componentFlag) in block, b"""
-    comps = b.getChildrenWithFlags(componentFlag)
-    if len(comps) > 1:
-        raise RuntimeError(
-            f"Block {b} has multiple components with flag {componentFlag}"
-            "_getComponent can only process blocks who have 1 component that"
-            "match componentFlag."
-            "Returned Components = {comps}"
-        )
-    if len(comps) == 0:
-        raise RuntimeError(
-            f"Block {b} has no components matching the flag {componentFlag}!"
-        )
-    return comps[0]
 
 
 def _getSolidComponents(b):

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -190,9 +190,9 @@ class AxialExpansionChanger:
         blkLst = self.linked.a.getBlocks()
         if not blkLst[-1].hasFlags(Flags.DUMMY):
             runLog.warning(
-                "No dummy block present at the top of {0}! "
+                f"No dummy block present at the top of {self.linked.a}! "
                 "Top most block will be artificially chopped "
-                "to preserve assembly height".format(self.linked.a)
+                "to preserve assembly height"
             )
             if self._detailedAxialExpansion:
                 msg = "Cannot run detailedAxialExpansion without a dummy block at the top of the assembly!"
@@ -206,11 +206,11 @@ class AxialExpansionChanger:
         numOfBlocks = self.linked.a.countBlocksWithFlags()
         runLog.debug(
             "Printing component expansion information (growth percentage and 'target component')"
-            "for each block in assembly {0}.".format(self.linked.a)
+            f"for each block in assembly {self.linked.a}."
         )
         # grow components, align, and redistribute blocks
         for ib, b in enumerate(self.linked.a):
-            runLog.debug(msg="  Block {0}".format(b))
+            runLog.debug(msg=f"  Block {b}")
             if thermal:
                 blockHeight = b.p.heightBOL
             else:
@@ -224,11 +224,7 @@ class AxialExpansionChanger:
                 ## grow all the components
                 for c in _getSolidComponents(b):
                     growFrac = self.expansionData.getExpansionFactor(c)
-                    runLog.debug(
-                        msg="      Component {0}, growFrac = {1:.4e}".format(
-                            c, growFrac
-                        )
-                    )
+                    runLog.debug(msg=f"      Component {c}, growFrac = {growFrac:.4e}")
                     if thermal and c in self.expansionData.componentReferenceHeight:
                         blockHeight = self.expansionData.componentReferenceHeight[c]
                     if growFrac >= 0.0:
@@ -301,7 +297,7 @@ class AxialExpansionChanger:
         adjustedLowestControlDuct = False
         for ib, b in enumerate(self.linked.a):
             c = self.expansionData.getTargetComponent(b)
-            runLog.debug("      Component {0} is target component".format(c))
+            runLog.debug(f"      Component {c} is target component")
             if 0 < ib < numOfBlocks - 1:
                 b.p.zbottom = c.zbottom
                 # correct potentially misaligned blocks
@@ -355,11 +351,11 @@ class AxialExpansionChanger:
         numOfBlocks = self.linked.a.countBlocksWithFlags()
         runLog.debug(
             "Printing component expansion information (growth percentage and 'target component')"
-            "for each block in assembly {0}.".format(self.linked.a)
+            f"for each block in assembly {self.linked.a}."
         )
         for ib, b in enumerate(self.linked.a):
 
-            runLog.debug(msg="  Block {0}".format(b))
+            runLog.debug(msg=f"  Block {b}")
             if thermal:
                 blockHeight = b.p.heightBOL
             else:
@@ -372,11 +368,7 @@ class AxialExpansionChanger:
             if not isDummyBlock:
                 for c in _getSolidComponents(b):
                     growFrac = self.expansionData.getExpansionFactor(c)
-                    runLog.debug(
-                        msg="      Component {0}, growFrac = {1:.4e}".format(
-                            c, growFrac
-                        )
-                    )
+                    runLog.debug(msg=f"      Component {c}, growFrac = {growFrac:.4e}")
                     if thermal and c in self.expansionData.componentReferenceHeight:
                         blockHeight = self.expansionData.componentReferenceHeight[c]
                     if growFrac >= 0.0:
@@ -400,15 +392,11 @@ class AxialExpansionChanger:
                     if self.expansionData.isTargetComponent(c):
                         if b.axialExpTargetComponent is None:
                             runLog.debug(
-                                "      Component {0} is target component (inferred)".format(
-                                    c
-                                )
+                                f"      Component {c} is target component (inferred)"
                             )
                         else:
                             runLog.debug(
-                                "      Component {0} is target component (blueprints defined)".format(
-                                    c
-                                )
+                                f"      Component {c} is target component (blueprints defined)"
                             )
                         b.p.ztop = c.ztop
 
@@ -501,15 +489,11 @@ def _getSolidComponents(b):
 def _checkBlockHeight(b):
     if b.p.height < 3.0:
         runLog.debug(
-            "Block {0:s} ({1:s}) has a height less than 3.0 cm. ({2:.12e})".format(
-                b.name, str(b.p.flags), b.p.height
-            )
+            f"Block {b.name:s} ({str(b.p.flags):s}) has a height less than 3.0 cm. ({b.p.height:.12e})"
         )
     if b.p.height < 0.0:
         raise ArithmeticError(
-            "Block {0:s} ({1:s}) has a negative height! ({2:.12e})".format(
-                b.name, str(b.p.flags), b.p.height
-            )
+            f"Block {b.name:s} ({str(b.p.flags):s}) has a negative height! ({b.p.height:.12e})"
         )
 
 
@@ -619,12 +603,10 @@ class AssemblyAxialLinkage:
                     if _determineLinked(c, otherC):
                         if lstLinkedC[ib] is not None:
                             errMsg = (
-                                "Multiple component axial linkages have been found for "
-                                "Component {0}; Block {1}; Assembly {2}."
-                                " This is indicative of an error in the blueprints! Linked components found are"
-                                "{3} and {4}".format(
-                                    c, b, b.parent, lstLinkedC[ib], otherC
-                                )
+                                f"Multiple component axial linkages have been found for "
+                                f"Component {c}; Block {b}; Assembly {b.parent}."
+                                f"This is indicative of an error in the blueprints! Linked components found are"
+                                f"{lstLinkedC[ib]} and {otherC}"
                             )
                             runLog.error(msg=errMsg)
                             raise RuntimeError(errMsg)
@@ -748,11 +730,9 @@ class ExpansionData:
         """
         if len(componentLst) != len(percents):
             runLog.error(
-                "Number of components and percent changes must be the same!\n\
-                    len(componentLst) = {0:d}\n\
-                        len(percents) = {1:d}".format(
-                    len(componentLst), len(percents)
-                )
+                "Number of components and percent changes must be the same!\n"
+                f"    len(componentLst) = {len(componentLst):d}\n"
+                f"        len(percents) = {len(percents):d}"
             )
             raise RuntimeError
         for c, p in zip(componentLst, percents):
@@ -805,10 +785,8 @@ class ExpansionData:
 
             if len(tmpMapping) == 0:
                 raise ValueError(
-                    "Block {0:s} has no temperature points within it! \
-                        Likely need to increase the refinement of the temperature grid.".format(
-                        str(b.name)
-                    )
+                    f"Block {str(b.name):s} has no temperature points within it!\n"
+                    f"Likely need to increase the refinement of the temperature grid."
                 )
 
             blockAveTemp = mean(tmpMapping)
@@ -947,16 +925,12 @@ class ExpansionData:
             componentWFlag = [c for c in b.getChildren() if c.hasFlags(flagOfInterest)]
         if len(componentWFlag) == 0:
             raise RuntimeError(
-                "No target component found!\n   Block {0}\n   Assembly {1}".format(
-                    b, b.parent
-                )
+                f"No target component found!\n   Block {b}\n   Assembly {b.parent}"
             )
         if len(componentWFlag) > 1:
             raise RuntimeError(
                 "Cannot have more than one component within a block that has the target flag!"
-                "Block {0}\nflagOfInterest {1}\nComponents {2}".format(
-                    b, flagOfInterest, componentWFlag
-                )
+                f"Block {b}\nflagOfInterest {flagOfInterest}\nComponents {componentWFlag}"
             )
         self._componentDeterminesBlockHeight[componentWFlag[0]] = True
 
@@ -980,11 +954,9 @@ class ExpansionData:
         """
         c = b.getChildrenWithFlags(Flags.FUEL)
         if len(c) == 0:  # pylint: disable=no-else-raise
-            raise RuntimeError("No fuel component within {0}!".format(b))
+            raise RuntimeError(f"No fuel component within {b}!")
         elif len(c) > 1:
-            raise RuntimeError(
-                "Cannot have more than one fuel component within {0}!".format(b)
-            )
+            raise RuntimeError(f"Cannot have more than one fuel component within {b}!")
         self._componentDeterminesBlockHeight[c[0]] = True
 
     def isTargetComponent(self, c):

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -68,7 +68,7 @@ class AxialExpansionChanger:
         componentLst: list,
         percents: list,
         setFuel: bool = True,
-        CRA: bool = False,
+        isControlAssembly: bool = False,
     ):
         """Perform axial expansion of an assembly given prescribed expansion percentages
 
@@ -83,7 +83,7 @@ class AxialExpansionChanger:
         setFuel : boolean, optional
             Boolean to determine whether or not fuel blocks should have their target components set
             This is useful when target components within a fuel block need to be determined on-the-fly.
-        CRA : boolean, optional
+        isControlAssembly : boolean, optional
             boolean to determine whether or not to use the specific control assembly expansion method
 
         Notes
@@ -92,7 +92,7 @@ class AxialExpansionChanger:
         """
         self.setAssembly(a, setFuel)
         self.expansionData.setExpansionFactors(componentLst, percents)
-        if CRA:
+        if isControlAssembly:
             self.axiallyExpandControlAssembly(thermal=False)
         else:
             self.axiallyExpandAssembly(thermal=False)
@@ -104,7 +104,7 @@ class AxialExpansionChanger:
         tempField: list,
         setFuel: bool = True,
         updateNDensForRadialExp: bool = True,
-        CRA: bool = False,
+        isControlAssembly: bool = False,
     ):
         """Perform thermal expansion for an assembly given an axial temperature grid and field
 
@@ -122,7 +122,7 @@ class AxialExpansionChanger:
         updateNDensForRadialExp: optional, bool
             boolean to determine whether or not the component number densities should be updated
             to account for radial expansion/contraction
-        CRA : boolean, optional
+        isControlAssembly : boolean, optional
             boolean to determine whether or not to use the specific control assembly expansion method
 
         Notes
@@ -137,7 +137,7 @@ class AxialExpansionChanger:
             tempGrid, tempField, updateNDensForRadialExp
         )
         self.expansionData.computeThermalExpansionFactors()
-        if CRA:
+        if isControlAssembly:
             self.axiallyExpandControlAssembly(thermal=True)
         else:
             self.axiallyExpandAssembly(thermal=True)

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -297,7 +297,7 @@ class TestControlAssemblyExpansion(unittest.TestCase):
 
 
 class TestConservation(Base, unittest.TestCase):
-    """verify that conservation is maintained in assembly-level axial expansion"""
+    """verify that conservation of height, target component mass, and total assembly mass is maintained in assembly-level axial expansion"""
 
     def setUp(self):
         Base.setUp(self)
@@ -768,6 +768,7 @@ class TestExceptions(Base, unittest.TestCase):
             self.assertEqual(cm.exception, 3)
 
     def test_getTargetComponent(self):
+        """test that the RuntimeError within axialExpansionChanger.py::ExpansionData::getTargetComponent is catchable"""
         b = HexBlock("test", height=10.0)
         with self.assertRaises(RuntimeError) as cm:
             self.obj.expansionData.getTargetComponent(b)

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -35,7 +35,6 @@ from armi.reactor.converters.axialExpansionChanger import (
     AxialExpansionChanger,
     ExpansionData,
     _determineLinked,
-    _getComponent,
 )
 from armi.reactor.flags import Flags
 from armi import materials
@@ -758,22 +757,6 @@ class TestExceptions(Base, unittest.TestCase):
         shieldComp.setDimension("od", 0.785, cold=True)
         with self.assertRaises(RuntimeError) as cm:
             self.obj.linked._getLinkedComponents(shieldBlock, shieldComp)
-            self.assertEqual(cm.exception, 3)
-
-    def test_getComponent(self):
-        b = HexBlock("test", height=10.0)
-        # Raise len(comps) == 0
-        with self.assertRaises(RuntimeError) as cm:
-            _getComponent(b, Flags.TEST)
-            self.assertEqual(cm.exception, 3)
-        # Raise len(comps) > 1
-        compDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.76, "id": 0.00, "mult": 127.0}
-        comp = Circle("test", "FakeMat", **compDims)
-        comp2 = Circle("test", "FakeMat", **compDims)
-        b.add(comp)
-        b.add(comp2)
-        with self.assertRaises(RuntimeError) as cm:
-            _getComponent(b, Flags.TEST)
             self.assertEqual(cm.exception, 3)
 
     def test_getTargetComponent(self):

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -285,7 +285,7 @@ class TestControlAssemblyExpansion(unittest.TestCase):
                 else:
                     percentList.append(0.0)
         self.axExpChngr.performPrescribedAxialExpansion(
-            self.a, componentList, percentList, CRA=True
+            self.a, componentList, percentList, isControlAssembly=True
         )
         for ib, b in enumerate(self.a):
             self.assertAlmostEqual(
@@ -350,7 +350,11 @@ class TestConservation(Base, unittest.TestCase):
                     assemType = "NonCR Assem -- "
                 else:
                     axialExpChngr.performThermalAxialExpansion(
-                        a, tempGrid, tempField, updateNDensForRadialExp=False, CRA=True
+                        a,
+                        tempGrid,
+                        tempField,
+                        updateNDensForRadialExp=False,
+                        isControlAssembly=True,
                     )
                     assemType = "CR Assem -- "
                 newBlockHeights = [b.getHeight() for b in a]
@@ -404,7 +408,11 @@ class TestConservation(Base, unittest.TestCase):
                     assemType = "NonCR Assem -- "
                 else:
                     axialExpChngr.performThermalAxialExpansion(
-                        a, tempGrid, tempField, updateNDensForRadialExp=False, CRA=True
+                        a,
+                        tempGrid,
+                        tempField,
+                        updateNDensForRadialExp=False,
+                        isControlAssembly=True,
                     )
                     assemType = "CR Assem -- "
                 newBlockHeights = [b.getHeight() for b in a]

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -278,8 +278,10 @@ class Flags(Flag):
     STRUCTURE = auto()
     DEPLETABLE = auto()
 
-    # Allows movement of lower plenum with control rod
+    # Allows movement of control rod bundle
     MOVEABLE = auto()
+    # Allows expansion/contraction of control rod assembly ducts (usually above and below a moveable bundle)
+    EXPANDABLE = auto()
 
     @classmethod
     def fromStringIgnoreErrors(cls, typeSpec):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2341,11 +2341,6 @@ class Core(composites.Composite):
         axialExpChngr = AxialExpansionChanger(self._detailedAxialExpansion)
         for a in assems:
             axialExpChngr.setAssembly(a)
-            # this doesn't get applied to control assems, so CR will be interpreted
-            # as hot. This should be conservative because the control rods will
-            # be modeled as slightly shorter with the correct hot density. Density
-            # is more important than height, so we are forcing density to be correct
-            # since we can't do axial expansion (yet)
             axialExpChngr.applyColdHeightMassIncrease()
             axialExpChngr.expansionData.computeThermalExpansionFactors()
             if a.hasFlags(Flags.CONTROL):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2293,7 +2293,7 @@ class Core(composites.Composite):
                     a.makeAxialSnapList(self.refAssem)
             if not cs["inputHeightsConsideredHot"]:
                 runLog.header(
-                    "=========== Axially expanding all assemblies (except control) from Tinput to Thot ==========="
+                    "=========== Axially expanding all assemblies from Tinput to Thot ==========="
                 )
                 self._applyThermalExpansion(self.getAssemblies(includeAll=True), dbLoad)
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2340,26 +2340,26 @@ class Core(composites.Composite):
         """
         axialExpChngr = AxialExpansionChanger(self._detailedAxialExpansion)
         for a in assems:
-            if not a.hasFlags(Flags.CONTROL):
-                axialExpChngr.setAssembly(a)
-                # this doesn't get applied to control assems, so CR will be interpreted
-                # as hot. This should be conservative because the control rods will
-                # be modeled as slightly shorter with the correct hot density. Density
-                # is more important than height, so we are forcing density to be correct
-                # since we can't do axial expansion (yet)
-                axialExpChngr.applyColdHeightMassIncrease()
-                axialExpChngr.expansionData.computeThermalExpansionFactors()
+            axialExpChngr.setAssembly(a)
+            # this doesn't get applied to control assems, so CR will be interpreted
+            # as hot. This should be conservative because the control rods will
+            # be modeled as slightly shorter with the correct hot density. Density
+            # is more important than height, so we are forcing density to be correct
+            # since we can't do axial expansion (yet)
+            axialExpChngr.applyColdHeightMassIncrease()
+            axialExpChngr.expansionData.computeThermalExpansionFactors()
+            if a.hasFlags(Flags.CONTROL):
+                axialExpChngr.axiallyExpandControlAssembly(thermal=True)
+            else:
                 axialExpChngr.axiallyExpandAssembly(thermal=True)
         # resolve axially disjoint mesh (if needed)
         if not dbLoad:
             axialExpChngr.manageCoreMesh(self.parent)
         elif not self._detailedAxialExpansion:
             for a in assems:
-                if not a.hasFlags(Flags.CONTROL):
-                    a.setBlockMesh(referenceAssembly.getAxialMesh())
+                a.setBlockMesh(referenceAssembly.getAxialMesh())
         # update block BOL heights to reflect hot heights
         for a in assems:
-            if not a.hasFlags(Flags.CONTROL):
-                for b in a:
-                    b.p.heightBOL = b.getHeight()
-                    b.completeInitialLoading()
+            for b in a:
+                b.p.heightBOL = b.getHeight()
+                b.completeInitialLoading()

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -795,13 +795,13 @@ class HexReactorTests(ReactorTests):
 
     def test_getAvgTemp(self):
         t0 = self.r.core.getAvgTemp([Flags.CLAD, Flags.WIRE, Flags.DUCT])
-        self.assertAlmostEqual(t0, 459.267, delta=0.01)
+        self.assertAlmostEqual(t0, 459.456, delta=0.01)
 
         t1 = self.r.core.getAvgTemp([Flags.CLAD, Flags.FUEL])
-        self.assertAlmostEqual(t1, 545.043, delta=0.01)
+        self.assertAlmostEqual(t1, 544.660, delta=0.01)
 
         t2 = self.r.core.getAvgTemp([Flags.CLAD, Flags.WIRE, Flags.DUCT, Flags.FUEL])
-        self.assertAlmostEqual(t2, 521.95269, delta=0.01)
+        self.assertAlmostEqual(t2, 523.137, delta=0.01)
 
     def test_getScalarEvolution(self):
         self.r.core.scalarVals["fake"] = 123

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -798,7 +798,7 @@ class HexReactorTests(ReactorTests):
         self.assertAlmostEqual(t0, 459.456, delta=0.01)
 
         t1 = self.r.core.getAvgTemp([Flags.CLAD, Flags.FUEL])
-        self.assertAlmostEqual(t1, 544.660, delta=0.01)
+        self.assertAlmostEqual(t1, 544.647, delta=0.01)
 
         t2 = self.r.core.getAvgTemp([Flags.CLAD, Flags.WIRE, Flags.DUCT, Flags.FUEL])
         self.assertAlmostEqual(t2, 523.137, delta=0.01)

--- a/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
@@ -25,9 +25,9 @@ blocks:
             material: HT9
             Tinput: 25.0
             Thot: 450.0
-            ip: 15.277
+            ip: 12.0
             mult: 1.0
-            op: 16.577
+            op: 15.5
         coolant: &component_coolant
             shape: DerivedShape
             material: Sodium
@@ -99,7 +99,7 @@ blocks:
             Thot: 450.0
             ip: 16.0
             mult: 1.0
-            op: 16.6
+            op: 16.5
         intercoolant: &component_fuel_intercoolant
             shape: Hexagon
             material: Sodium
@@ -339,24 +339,10 @@ blocks:
     
     ## ------------------------------------------------------------------------------------
     ## control
-    moveable duct: &block_duct
+    expandable duct: &block_control_duct
         coolant: *component_coolant
-        duct: &component_control_duct
-            shape: Hexagon
-            material: HT9
-            Tinput: 25.0
-            Thot: 450.0
-            ip: 15.277
-            mult: 1.0
-            op: 16.28228
-        intercoolant: &component_control_intercoolant
-            shape: Hexagon
-            material: Sodium
-            Tinput: 25.0
-            Thot: 450.0
-            ip: duct.op
-            mult: 1.0
-            op: 16.75
+        duct: *component_fuel_duct
+        intercoolant: *component_fuel_intercoolant
 
     moveable control: &block_control
         control:
@@ -365,25 +351,26 @@ blocks:
             Tinput: 25.0
             Thot: 600.0
             id: 0.0
-            mult: 61.0
-            od: 1.286
+            mult: clad.mult
+            od: 1.0
         gap:
             shape: Circle
             material: Void
             Tinput: 25.0
             Thot: 450.0
             id: control.od
-            mult: control.mult
+            mult: clad.mult
             od: clad.id
-        clad:
+        clad: &component_control_clad
             shape: Circle
             material: HT9
             Tinput: 25.0
             Thot: 450.0
-            id: 1.358
-            mult: control.mult
-            od: 1.686
-        wire:
+            id: 1.2
+            mult: 61.0
+            od: 1.4
+            axially expands downwards: True
+        wire: &component_control_wire
             shape: Helix
             material: HT9
             Tinput: 25.0
@@ -391,19 +378,21 @@ blocks:
             axialPitch: 50.0
             helixDiameter: 1.771
             id: 0.0
-            mult: control.mult
+            mult: clad.mult
             od: 0.085
-        innerDuct:
+            axially expands downwards: True
+        ctrlDuct: &component_control_ctrl_duct
             shape: Hexagon
             material: HT9
             Tinput: 25.0
             Thot: 450.0
-            ip: 14.268
+            ip: 14.0
             mult: 1.0
-            op: 14.582
-        duct: *component_control_duct
+            op: 14.5
+            axially expands downwards: True
+        duct: *component_fuel_duct
         coolant: *component_coolant
-        intercoolant: *component_control_intercoolant
+        intercoolant: *component_fuel_intercoolant
     
     moveable plenum: &block_control_plenum
         gap:
@@ -414,27 +403,12 @@ blocks:
             id: 0.0
             mult: clad.mult
             od: clad.id
-        clad:
-            shape: Circle
-            material: HT9
-            Tinput: 25.0
-            Thot: 450.0
-            id: 1.358
-            mult: 61.0
-            od: 1.686
-        wire:
-            shape: Helix
-            material: HT9
-            Tinput: 25.0
-            Thot: 450.0
-            axialPitch: 30.15
-            helixDiameter: 1.19056
-            id: 0.0
-            mult: clad.mult
-            od: 0.10056
+        clad: *component_control_clad
+        wire: *component_control_wire
+        ctrlDuct: *component_control_ctrl_duct
         coolant: *component_coolant
-        duct: *component_control_duct
-        intercoolant: *component_control_intercoolant
+        duct: *component_fuel_duct
+        intercoolant: *component_fuel_intercoolant
 
     ## ------------------------------------------------------------------------------------
     ## radial shield
@@ -576,13 +550,13 @@ assemblies:
         xs types: *igniter_fuel_xs_types
     secondary control:
         specifier: SC
-        blocks: [*block_grid_plate, *block_duct, *block_duct, *block_control, *block_control, *block_control_plenum, *block_duct, *block_duct, *block_dummy]
+        blocks: [*block_grid_plate, *block_control_duct, *block_control_duct, *block_control, *block_control, *block_control_plenum, *block_control_duct, *block_control_duct, *block_dummy]
         height: [25.0, 49.0, 49.0, 25.0, 25.0, 25.0, 1.0, 1.0, 17.5]
         axial mesh points: *standard_axial_mesh_points
         xs types: *igniter_fuel_xs_types
     primary control:
         specifier: PC
-        blocks: [*block_grid_plate, *block_duct, *block_duct, *block_control, *block_control, *block_control_plenum, *block_duct, *block_duct, *block_dummy]
+        blocks: [*block_grid_plate, *block_control_duct, *block_control_duct, *block_control, *block_control, *block_control_plenum, *block_control_duct, *block_control_duct, *block_dummy]
         height: [25.0, 1.0, 1.0, 25.0, 25.0, 25.0, 49.0, 49.0, 17.5]
         axial mesh points: *standard_axial_mesh_points
         xs types: *igniter_fuel_xs_types

--- a/armi/tests/refSmallReactorBase.yaml
+++ b/armi/tests/refSmallReactorBase.yaml
@@ -77,12 +77,12 @@ blocks:
         control:
             shape: Circle
             material: B4C
-            Tinput: 600.0
-            Thot: 600.0
+            Tinput: 450.0
+            Thot: 450.0
             id: 0.0
             mult: 61.0
             od: 1.286
-        innerDuct:
+        innerDuct: &component_control_duct
             shape: Hexagon
             material: HT9
             Tinput: 450.0
@@ -90,23 +90,18 @@ blocks:
             ip: 14.268
             mult: 1.0
             op: 14.582
-        duct: &component_control_duct
-            shape: Hexagon
-            material: HT9
-            Tinput: 450.0
-            Thot: 450.0
-            ip: 15.277
-            mult: 1.0
-            op: 16.28228
-        clad:
+            axially expands downwards: True
+        duct: *component_fuel_duct
+        clad: &component_control_clad
             shape: Circle
             material: HT9
             Tinput: 450.0
             Thot: 450.0
             id: 1.358
-            mult: control.mult
+            mult: 61.0
             od: 1.686
-        wire:
+            axially expands downwards: True
+        wire: &component_control_wire
             shape: Helix
             material: HT9
             Tinput: 450.0
@@ -114,8 +109,9 @@ blocks:
             axialPitch: 50.0
             helixDiameter: 1.771
             id: 0.0
-            mult: control.mult
+            mult: clad.mult
             od: 0.085
+            axially expands downwards: True
         intercoolant: *component_fuel_intercoolant
         gap:
             shape: Circle
@@ -126,8 +122,23 @@ blocks:
             mult: control.mult
             od: clad.id
         coolant: *component_fuel_coolant
+    moveable plenum: &block_control_plenum
+        gap:
+            shape: Circle
+            material: Void
+            Tinput: 450.0
+            Thot: 450.0
+            id: 0.0
+            mult: clad.mult
+            od: clad.id
+        clad: *component_control_clad
+        wire: *component_control_wire
+        ctrlDuct: *component_control_duct
+        coolant: *component_fuel_coolant
+        duct: *component_fuel_duct
+        intercoolant: *component_fuel_intercoolant
     duct: &block_duct
-        duct: *component_control_duct
+        duct: *component_fuel_duct
         coolant: *component_fuel_coolant
         intercoolant: *component_fuel_intercoolant
     grid plate: &block_grid_plate
@@ -184,7 +195,7 @@ blocks:
             id: shield.od
             mult: shield.mult
             od: clad.id
-        duct: *component_control_duct
+        duct: *component_fuel_duct
         intercoolant: *component_fuel_intercoolant
         coolant: *component_fuel_coolant
         wire:
@@ -197,7 +208,7 @@ blocks:
             id: 0.0
             mult: shield.mult
             od: 0.10056
-    moveable plenum: &block_plenum
+    plenum: &block_plenum
         clad:
             shape: Circle
             material: HT9
@@ -416,7 +427,7 @@ assemblies:
         nozzleType: Outer
     primary control:
         specifier: PC
-        blocks: [*block_grid_plate, *block_duct, *block_control, *block_plenum, *block_duct]
+        blocks: [*block_grid_plate, *block_duct, *block_control, *block_control_plenum, *block_duct]
         height: *standard_heights
         axial mesh points: *standard_axial_mesh_points
         xs types: *igniter_fuel_xs_types

--- a/armi/tests/refSmallReactorBase.yaml
+++ b/armi/tests/refSmallReactorBase.yaml
@@ -77,15 +77,15 @@ blocks:
         control:
             shape: Circle
             material: B4C
-            Tinput: 450.0
-            Thot: 450.0
+            Tinput: 25.0
+            Thot: 600.0
             id: 0.0
             mult: 61.0
             od: 1.286
-        innerDuct: &component_control_duct
+        innerDuct: &component_control_innerDuct
             shape: Hexagon
             material: HT9
-            Tinput: 450.0
+            Tinput: 25.0
             Thot: 450.0
             ip: 14.268
             mult: 1.0
@@ -95,7 +95,7 @@ blocks:
         clad: &component_control_clad
             shape: Circle
             material: HT9
-            Tinput: 450.0
+            Tinput: 25.0
             Thot: 450.0
             id: 1.358
             mult: 61.0
@@ -104,7 +104,7 @@ blocks:
         wire: &component_control_wire
             shape: Helix
             material: HT9
-            Tinput: 450.0
+            Tinput: 25.0
             Thot: 450.0
             axialPitch: 50.0
             helixDiameter: 1.771
@@ -133,7 +133,7 @@ blocks:
             od: clad.id
         clad: *component_control_clad
         wire: *component_control_wire
-        ctrlDuct: *component_control_duct
+        ctrlDuct: *component_control_innerDuct
         coolant: *component_fuel_coolant
         duct: *component_fuel_duct
         intercoolant: *component_fuel_intercoolant

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -10,6 +10,7 @@ What's new in ARMI
 ------------------
 
 #. TBD
+#. Added axial expansion of control rod assemblies. (`PR #931 https://github.com/terrapower/armi/pull/931`)
 #. Cleanup of stale ``coveragerc`` file (`PR#923 <https://github.com/terrapower/armi/pull/923>`_)
 #. Added writer style option to ``SettingsWriter`` and added it as arg to modify CLI (`PR#924 <https://github.com/terrapower/armi/pull/924>`_)
 #. Update the EntryPoint class to provide user feedback on required positional arguments (`PR#922 <https://github.com/terrapower/armi/pull/922>`_)


### PR DESCRIPTION
## Description
This PR introduces mixed upward and downward axial expansion to **pin-type** control rod assemblies (CRAs).

### Assumptions
1. Moveable inner control bundle that is inserted/withdrawn from the top.
2. The moveable control bundle must be surrounded by at least 1 expandable duct block above and below.
3. Control rods (consisting of clad, wire wrap, control pins, and plenum) within the bundle are pinned at **both** the top and bottom.
4. The top of the bundle remains fixed at its prescribed location during expansion or contraction.
5. Within the bundle, the guide tube, clad, and wire wrap expand downwards.
6. Control pins expand upward within downward expanding clad.
7. Driveline axial expansion is not accounted for.
8. Core vessel axial expansion is not accounted for.
9. Like the current axial expansion changer, multiple component axial linkage is not allowed.

### User Considerations:
- A new blueprints attribute, `axially expands downwards` is included for components. This attribute indicates that a given component expands downwards. If a component does not have this attribute, it retains its default behavior (false) of upwards expansion. 
- The expandable duct blocks must be tagged with the `expandable` flag in the blueprints.

### Testing
- Unit tests are included to account for prescribed and thermal expansion of CRAs.

### Other changes
#### `armi/tests/refSmallReactorBase.yaml`
1. `Tinput` of solid components within the CRA (except for grid plate) were made to be 25 C (same as other non-CRA components) to enable thermal expansion.
1. `block_duct`: was using the control duct (i.e., duct for the moveable inner control bundle) as the assembly/outermost duct. This is nonphysical and should rather use the the exterior assembly duct consistent with other assemblies (`component_fuel_duct`).
2. `block_control`: the assembly/outermost duct had inconsistent dimensions with the `block_plenum`. 
3. Within the CRA, `block_plenum` was using the plenum block for the fuel assembly. Since the control and fuel blocks have different dimensions, this was unphysical. So a new plenum block specific for the control assembly was introduced, `block_control_plenum`.


### Note to reviewers:
- This specific/cleaned up feature branch needs to be run through the gamut of downstream projects. 

---
[AxialExpansion_CRA_Algorithm_Simple.pdf](https://github.com/terrapower/armi/files/9748567/AxialExpansion_CRA_Algorithm_Simple.pdf)

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

