### PR TITLE
add ability to compute hydraulic diameter for unpinned HexBlock objects

### DIFF
--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -715,8 +715,10 @@ class Block_TestCase(unittest.TestCase):
         cur = self.block.getWettedPerimeter()
         ref = math.pi * (
             self.block.getDim(Flags.CLAD, "od") + self.block.getDim(Flags.WIRE, "od")
-        ) + 6 * self.block.getDim(Flags.DUCT, "ip") / math.sqrt(3) / self.block.getDim(
-            Flags.CLAD, "mult"
+        ) * self.block.getDim(Flags.CLAD, "mult") + 6 * self.block.getDim(
+            Flags.DUCT, "ip"
+        ) / math.sqrt(
+            3
         )
         self.assertAlmostEqual(cur, ref)
 
@@ -727,9 +729,15 @@ class Block_TestCase(unittest.TestCase):
         ref = area / nPins
         self.assertAlmostEqual(cur, ref)
 
+    def test_getFlowArea(self):
+        area = self.block.getComponent(Flags.COOLANT).getArea()
+        cur = self.block.getFlowArea()
+        ref = area
+        self.assertAlmostEqual(cur, ref)
+
     def test_getHydraulicDiameter(self):
         cur = self.block.getHydraulicDiameter()
-        ref = 4.0 * self.block.getFlowAreaPerPin() / self.block.getWettedPerimeter()
+        ref = 4.0 * self.block.getFlowArea() / self.block.getWettedPerimeter()
         self.assertAlmostEqual(cur, ref)
 
     def test_adjustUEnrich(self):


### PR DESCRIPTION
## Description

1. Update the `HexBlock.getWettedPerimeter` function to return the total wetted perimeter of the block, instead of the wetted perimeter per pin. Add logic to account for unpinned blocks and control assembly `innerDuct`s.

2. Add a `HexBlock.getFlowArea` function to return the total flow area (previously, only `HexBlock.getFlowAreaPerPin` existed).

3. Use the above two items to update `HexBlock.getHydraulicDiameter` such that it is able to handle the computation of hydraulic diameters for unpinned `HexBlock` objects.

Note: a `grep` on the `HexBlock.getWettedPerimeter` function within the other downstream applications shows that this function is only called by the `HexBlock.getHydraulicDiameter` function, so updating it to return a total value instead of a per-pin value should not impact any plugins. If a per-pin value is truly desired, then a `HexBlock.getWettedPerimeterPerPin` function may be created.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

