### PR TITLE
Allow case coverage to use user-supplied coverage config file

### DIFF
--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -125,11 +125,15 @@ class TestArmiCase(unittest.TestCase):
         case = cases.Case(settings.Settings())
         covRcDir = os.path.abspath(context.PROJECT_ROOT)
         # Don't actually copy the file, just check the file paths match
-        covRcFile = case._getCoverageRcFile(makeCopy=False)
+        covRcFile = case._getCoverageRcFile(userCovFile="", makeCopy=False)
         if platform.system() == "Windows":
             self.assertEqual(covRcFile, os.path.join(covRcDir, "coveragerc"))
         else:
             self.assertEqual(covRcFile, os.path.join(covRcDir, ".coveragerc"))
+
+        userFile = "UserCovRc"
+        covRcFile = case._getCoverageRcFile(userCovFile=userFile, makeCopy=False)
+        self.assertEqual(covRcFile, os.path.abspath(userFile))
 
     def test_startCoverage(self):
         with directoryChangers.TemporaryDirectoryChanger():
@@ -153,7 +157,7 @@ class TestArmiCase(unittest.TestCase):
             outFile = "coverage_results.cov"
             prof = case._startCoverage()
             self.assertFalse(os.path.exists(outFile))
-            case._endCoverage(prof)
+            case._endCoverage(userCovFile="", cov=prof)
             self.assertFalse(os.path.exists(outFile))
 
     @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -230,7 +230,7 @@ def defineSettings() -> List[setting.Setting]:
         ),
         setting.Setting(
             CONF_COVERAGE_CONFIG_FILE,
-            default="",  # should default be empty string, or the armi .coveragerc file?
+            default="",
             label="File to Define Coverage Configuration",
             description="User-defined coverage configuration file",
         ),

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -40,6 +40,7 @@ CONF_AUTOMATIC_VARIABLE_MESH = "automaticVariableMesh"
 CONF_TRACE = "trace"
 CONF_PROFILE = "profile"
 CONF_COVERAGE = "coverage"
+CONF_COVERAGE_CONFIG_FILE = "coverageConfigFile"
 CONF_MIN_MESH_SIZE_RATIO = "minMeshSizeRatio"
 CONF_CYCLE_LENGTH = "cycleLength"
 CONF_CYCLE_LENGTHS = "cycleLengths"
@@ -226,6 +227,12 @@ def defineSettings() -> List[setting.Setting]:
             description="Turn on coverage report generation which tracks all the lines "
             "of code that execute during a run",
             isEnvironment=True,
+        ),
+        setting.Setting(
+            CONF_COVERAGE_CONFIG_FILE,
+            default="",  # should default be empty string, or the armi .coveragerc file?
+            label="File to Define Coverage Configuration",
+            description="User-defined coverage configuration file",
         ),
         setting.Setting(
             CONF_MIN_MESH_SIZE_RATIO,


### PR DESCRIPTION
## Description

Someone might want to get code coverage on cases running with ARMI + plugins, in which case they would need to supply their own coverage configuration file. 

Does this look like an OK idea?

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

