### PR TITLE
Removing usages of get/setMasterCs in getDpaXs

### DIFF
--- a/armi/cli/reportsEntryPoint.py
+++ b/armi/cli/reportsEntryPoint.py
@@ -158,7 +158,7 @@ def createReportFromSettings(cs):
     This will construct a reactor from the given settings and create BOL reports for
     that reactor/settings.
     """
-    # not sure if this is necessary, but need to investigate more to understand possible
+    # TODO: not sure if this is necessary, but need to investigate more to understand possible
     # side-effects before removing. Probably better to get rid of all uses of
     # getMasterCs(), then we can remove all setMasterCs() calls without worrying.
     settings.setMasterCs(cs)

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -65,7 +65,8 @@ class GlobalFluxInterface(interfaces.Interface):
             self.nodeFmt = "1d"  # produce ig001_1.inp.
         self._bocKeff = None  # for tracking rxSwing
 
-    def getHistoryParams(self):
+    @staticmethod
+    def getHistoryParams():
         """Return parameters that will be added to assembly versus time history printouts."""
         return ["detailedDpa", "detailedDpaPeak", "detailedDpaPeakRate"]
 
@@ -609,11 +610,10 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
         """
         if blockList is None:
             blockList = self.r.core.getBlocks()
+
         hasDPA = False
         for b in blockList:
             xs = self.getDpaXs(b)
-            if not xs:
-                continue
             hasDPA = True
             flux = b.getMgFlux()  # n/cm^2/s
             dpaPerSecond = computeDpaRate(flux, xs)
@@ -622,13 +622,12 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
 
         if not hasDPA:
             return
-        self.r.core.p.peakGridDpaAt60Years = (
-            self.r.core.getMaxBlockParam(
-                "detailedDpaPeakRate", typeSpec=Flags.GRID_PLATE, absolute=False
-            )
-            * 60.0
-            * units.SECONDS_PER_YEAR
+
+        peakRate = self.r.core.getMaxBlockParam(
+            "detailedDpaPeakRate", typeSpec=Flags.GRID_PLATE, absolute=False
         )
+        self.r.core.p.peakGridDpaAt60Years = peakRate * 60.0 * units.SECONDS_PER_YEAR
+
         # also update maxes at this point (since this runs at every timenode, not just those w/ depletion steps)
         self.updateMaxDpaParams()
 

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -592,8 +592,6 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
         else:
             dpaXsSetName = self.cs["dpaXsSet"]
 
-        if not dpaXsSetName:
-            return None
         try:
             return constants.DPA_CROSS_SECTIONS[dpaXsSetName]
         except KeyError:

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -119,6 +119,17 @@ class TestGlobalFluxInterface(unittest.TestCase):
         inf, _outf, _stdname = gfi.getIOFileNames(1, 2, 1)
         self.assertEqual(inf, "armi001_2_001.GlobalFlux.inp")
 
+    def test_getHistoryParams(self):
+        params = globalFluxInterface.GlobalFluxInterface.getHistoryParams()
+        self.assertEqual(len(params), 3)
+        self.assertIn("detailedDpa", params)
+
+    def test_checkEnergyBalance(self):
+        cs = settings.Settings()
+        _o, r = test_reactors.loadTestReactor()
+        gfi = MockGlobalFluxInterface(r, cs)
+        gfi._checkEnergyBalance()
+
 
 class TestGlobalFluxInterfaceWithExecuters(unittest.TestCase):
     """Tests for the default global flux execution."""
@@ -141,6 +152,10 @@ class TestGlobalFluxInterfaceWithExecuters(unittest.TestCase):
 
     def test_calculateKeff(self):
         self.assertEqual(self.gfi.calculateKeff(), 1.05)  # set in mock
+
+    def test_getExecuterCls(self):
+        class0 = globalFluxInterface.GlobalFluxInterfaceUsingExecuters.getExecuterCls()
+        self.assertEqual(class0, globalFluxInterface.GlobalFluxExecuter)
 
 
 class TestGlobalFluxResultMapper(unittest.TestCase):
@@ -207,7 +222,7 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         # test null case
         mapper.cs["gridPlateDpaXsSet"] = "fake"
         with self.assertRaises(KeyError):
-            vals = mapper.getDpaXs(b)
+            mapper.getDpaXs(b)
 
 
 class TestGlobalFluxUtils(unittest.TestCase):

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -40,7 +40,6 @@ from armi.reactor import components
 from armi.utils import units
 from armi.utils.plotting import plotBlockFlux
 from armi.bookkeeping import report
-from armi.physics import constants
 from armi.utils.units import TRACE_NUMBER_DENSITY
 from armi.utils import hexagon
 from armi.utils import densityTools
@@ -1373,24 +1372,6 @@ class Block(composites.Composite):
                 c.updateDims()
             except NotImplementedError:
                 runLog.warning("{0} has no updatedDims method -- skipping".format(c))
-
-    def getDpaXs(self):
-        """Determine which cross sections should be used to compute dpa for this block."""
-        if settings.getMasterCs()["gridPlateDpaXsSet"] and self.hasFlags(
-            Flags.GRID_PLATE
-        ):
-            dpaXsSetName = settings.getMasterCs()["gridPlateDpaXsSet"]
-        else:
-            dpaXsSetName = settings.getMasterCs()["dpaXsSet"]
-
-        if not dpaXsSetName:
-            return None
-        try:
-            return constants.DPA_CROSS_SECTIONS[dpaXsSetName]
-        except KeyError:
-            raise KeyError(
-                "DPA cross section set {} does not exist".format(dpaXsSetName)
-            )
 
     def breakFuelComponentsIntoIndividuals(self):
         """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1311,35 +1311,6 @@ class Block(composites.Composite):
         # return the group the information went to
         return report.ALL[report.BLOCK_AREA_FRACS]
 
-    def getBurnupPeakingFactor(self):
-        """
-        Get the radial peaking factor to be applied to burnup and DPA
-
-        This may be informed by previous runs which used
-        detailed pin reconstruction and rotation. In that case,
-        it should be set on the cs setting ``burnupPeakingFactor``.
-
-        Otherwise, it just takes the current flux peaking, which
-        is typically conservatively high.
-
-        Returns
-        -------
-        burnupPeakingFactor : float
-            The peak/avg factor for burnup and DPA.
-
-        See Also
-        --------
-        armi.physics.neutronics.globalFlux.globalFluxInterface.GlobalFluxInterface.updateFluenceAndDPA : uses this
-        """
-        burnupPeakingFactor = settings.getMasterCs()["burnupPeakingFactor"]
-        if not burnupPeakingFactor and self.p.fluxPeak:
-            burnupPeakingFactor = self.p.fluxPeak / self.p.flux
-        elif not burnupPeakingFactor:
-            # no peak available. Finite difference model?
-            burnupPeakingFactor = 1.0
-
-        return burnupPeakingFactor
-
     def getBlocks(self):
         """
         This method returns all the block(s) included in this block


### PR DESCRIPTION
## Description

As part of #930, this PR removes all 3 usages of `getMasterCs()` and `setMasterCs()` from `Block.getDpaXs()`.  This method is too specific to be on `Block` anyway, but if you move it to the `GlobalFluxInterface` (the only place it is every called), it becomes much simpler.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
