### PR TITLE
Fix armi/materials/b4c.py::density3 to utilize TD frac

### DIFF
--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -159,7 +159,11 @@ class B4C(material.Material):
 
     def density(self, Tk: float = None, Tc: float = None) -> float:
         """
-        mass density
+        Return density that preserves mass when thermally expanded in 2D.
+
+        Notes
+        -----
+        - applies theoretical density of B4C to parent method 
         """
         density = material.Material.density(self, Tk, Tc)
         theoreticalDensityFrac = self.p.theoreticalDensityFrac
@@ -171,6 +175,25 @@ class B4C(material.Material):
                 single=True,
             )
         return density * theoreticalDensityFrac  # g/cc
+
+    def density3(self, Tk: float = None, Tc: float = None) -> float:
+        """
+        Return density that preserves mass when thermally expanded in 3D.
+
+        Notes
+        -----
+        - applies theoretical density of B4C to parent method 
+        """
+        density3 = material.Material.density3(self, Tk, Tc)
+        theoreticalDensityFrac = self.p.theoreticalDensityFrac
+        if theoreticalDensityFrac is None:
+            theoreticalDensityFrac = 1.0
+            runLog.warning(
+                "Assumption: 100% theoretical density",
+                label="Assumption: B4C is at 100% theoretical density",
+                single=True,
+            )
+        return density3 * theoreticalDensityFrac  # g/cc
 
     def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
         """Boron carbide expansion. Very preliminary"""

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -494,28 +494,33 @@ class TestCircle(TestShapedComponent):
 
 
 class TestComponentExpansion(unittest.TestCase):
-    # when comparing to 3D density, the comparison is not quite correct.
-    # We need a bigger delta, this will be investigated/fixed in another PR
+    tCold = 20
     tWarm = 50
     tHot = 500
     coldOuterDiameter = 1.0
 
-    def test_ComponentMassIndependentOfInputTemp(self):
-        coldT = 20
-        circle1 = Circle("circle", "HT9", coldT, self.tHot, self.coldOuterDiameter)
-        coldT += 200
+    def test_ComponentExpansion(self):
+        """tests (material, isotope) pairs over several conservation tests"""
+        materials = [("HT9", "FE"), ("UZr", "U235"), ("B4C", "B10")]
+        for mat, isotope in materials:
+            self.componentMassIndependentOfInputTemp(mat)
+            self.expansionConservationHotHeightDefined(mat, isotope)
+            self.expansionConservationColdHeightDefined(mat)
+
+    def componentMassIndependentOfInputTemp(self, mat: str):
+        circle1 = Circle("circle", mat, self.tCold, self.tHot, self.coldOuterDiameter)
         # pick the input dimension to get the same hot component
         hotterDim = self.coldOuterDiameter * (
-            1 + circle1.material.linearExpansionFactor(coldT, 20)
+            1 + circle1.material.linearExpansionFactor(self.tCold + 200, self.tCold)
         )
-        circle2 = Circle("circle", "HT9", coldT, self.tHot, hotterDim)
+        circle2 = Circle("circle", mat, self.tCold + 200, self.tHot, hotterDim)
         self.assertAlmostEqual(circle1.getDimension("od"), circle2.getDimension("od"))
         self.assertAlmostEqual(circle1.getArea(), circle2.getArea())
         self.assertAlmostEqual(circle1.getMassDensity(), circle2.getMassDensity())
 
-    def test_ExpansionConservationHotHeightDefined(self):
+    def expansionConservationHotHeightDefined(self, mat: str, isotope: str):
         """
-        Demonstrate tutorial for how to expand and relation ships conserved at during expansion.
+        Demonstrate tutorial for how to expand and relationships conserved at during expansion.
 
         Notes
         -----
@@ -524,13 +529,13 @@ class TestComponentExpansion(unittest.TestCase):
         """
         hotHeight = 1.0
 
-        circle1 = Circle("circle", "HT9", 20, self.tWarm, self.coldOuterDiameter)
-        circle2 = Circle("circle", "HT9", 20, self.tHot, self.coldOuterDiameter)
+        circle1 = Circle("circle", mat, self.tCold, self.tWarm, self.coldOuterDiameter)
+        circle2 = Circle("circle", mat, self.tCold, self.tHot, self.coldOuterDiameter)
 
         # mass density is proportional to Fe number density and derived from
         # all the number densities and atomic masses
         self.assertAlmostEqual(
-            circle1.p.numberDensities["FE"] / circle2.p.numberDensities["FE"],
+            circle1.p.numberDensities[isotope] / circle2.p.numberDensities[isotope],
             circle1.getMassDensity() / circle2.getMassDensity(),
         )
 
@@ -615,7 +620,7 @@ class TestComponentExpansion(unittest.TestCase):
             mass1, circle1.getMassDensity() * circle1.getArea() * hotHeight
         )
 
-    def test_ExpansionConservationColdHeightDefined(self):
+    def expansionConservationColdHeightDefined(self, mat: str):
         """
         Demonstrate that material is conserved at during expansion
 
@@ -625,10 +630,12 @@ class TestComponentExpansion(unittest.TestCase):
           inputHeightsConsideredHot = False
         """
         coldHeight = 1.0
-        circle1 = Circle("circle", "HT9", 20, self.tWarm, self.coldOuterDiameter)
-        circle2 = Circle("circle", "HT9", 20, self.tHot, self.coldOuterDiameter)
+        circle1 = Circle("circle", mat, self.tCold, self.tWarm, self.coldOuterDiameter)
+        circle2 = Circle("circle", mat, self.tCold, self.tHot, self.coldOuterDiameter)
         # same as 1 but we will make like 2
-        circle1AdjustTo2 = Circle("circle", "HT9", 20, self.tWarm, 1.0)
+        circle1AdjustTo2 = Circle(
+            "circle", mat, self.tCold, self.tWarm, self.coldOuterDiameter
+        )
 
         # make it hot like 2
         circle1AdjustTo2.adjustDensityForHeightExpansion(self.tHot)


### PR DESCRIPTION
## Description
B4C was having issues with density conservation and component expansion. Turns out, density3 was not including the theoretical density defined in `armi/materials/b4c.py`. This PR resolves:
1. resolves this
2. updates `test_components.py::TestComponentExpansion` to loop over multiple materials. The additional cost is minimal and covers common important reactor materials.
    - also includes minimal clean up for clarity improvements.

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

