### PR TITLE
Allow for a reactor to be loaded without setting its cs to the master

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1085,6 +1085,7 @@ class Database3:
         statePointName=None,
         allowMissing=False,
         updateGlobalAssemNum=True,
+        updateMasterCs=True,
     ):
         """Load a new reactor from (cycle, node).
 
@@ -1100,18 +1101,23 @@ class Database3:
             cycle number
         node : int
             time node
-        cs : armi.settings.Settings (optional)
+        cs : armi.settings.Settings, optional
             if not provided one is read from the database
-        bp : armi.reactor.Blueprints (optional)
+        bp : armi.reactor.Blueprints, optional
             if not provided one is read from the database
-        statePointName : str
+        statePointName : str, optional
             Optional arbitrary statepoint name (e.g., "special" for "c00n00-special/")
-        allowMissing : bool
+        allowMissing : bool, optional
             Whether to emit a warning, rather than crash if reading a database
             with undefined parameters. Default False.
-        updateGlobalAssemNum : bool
+        updateGlobalAssemNum : bool, optional
             Whether to update the global assembly number to the value stored in
             r.core.p.maxAssemNum. Default True.
+        updateMasterCs : bool, optional
+            Whether to apply the cs (whether provided as an argument or read from
+            the database) as the primary for the case. Default True. Can be useful
+            if you don't intend to use the loaded reactor as the basis for further
+            computations in the current operator.
 
         Returns
         -------
@@ -1121,8 +1127,9 @@ class Database3:
         runLog.info("Loading reactor state for time node ({}, {})".format(cycle, node))
 
         cs = cs or self.loadCS()
-        # apply to avoid defaults in getMasterCs calls
-        settings.setMasterCs(cs)
+        if updateMasterCs:
+            # apply to avoid defaults in getMasterCs calls
+            settings.setMasterCs(cs)
         bp = bp or self.loadBlueprints()
 
         h5group = self.h5db[getH5GroupName(cycle, node, statePointName)]

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -13,6 +13,7 @@ What's new in ARMI
 #. Cleanup of stale ``coveragerc`` file (`PR#923 <https://github.com/terrapower/armi/pull/923>`_)
 #. Added `medium` writer style option to ``SettingsWriter``. Added it as arg to modify CLI (`PR#924 <https://github.com/terrapower/armi/pull/924>`_), and to clone CLI (`PR#932 <https://github.com/terrapower/armi/pull/932>`_).
 #. Update the EntryPoint class to provide user feedback on required positional arguments (`PR#922 <https://github.com/terrapower/armi/pull/922>`_)
+#. Allow for the loading of a reactor from a db without necessarily setting the associated cs as the master
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

When loading a reactor from a DB, it has been the default behavior to apply the associated CS to be the "master" CS for the run. This is not always desirable. Just because you load a reactor doesn't mean you want to apply it to the entire run. This small PR simply allows for that possibility.

This is _related_, but not actively working against, #930 .

---

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

