### PR TITLE
Removing two usages of getMasterCs

### DIFF
--- a/armi/bookkeeping/report/data.py
+++ b/armi/bookkeeping/report/data.py
@@ -85,7 +85,7 @@ class Report:
         runLog.debug("Writing HTML document {}.".format(filename))
 
         with html.HTMLFile(filename, "w") as f:
-            html.writeStandardReportTemplate(f, self)
+            html.writeStandardReportTemplate(f, self, self.title)
 
         runLog.info("HTML document {} written".format(filename))
 

--- a/armi/bookkeeping/report/html.py
+++ b/armi/bookkeeping/report/html.py
@@ -199,15 +199,14 @@ def encode64(file_path):
 # ---------------------------
 
 
-def writeStandardReportTemplate(f, report):
+def writeStandardReportTemplate(f, report, caseTitle=""):
     f.write(r"<!DOCTYPE html>" + "\n")
-    cs = settings.getMasterCs()
     with Html(f):
-
         with Head(f):
             f.write(r'<meta charset="UTF-8">' + "\n")
-            with Title(f):
-                f.write(cs.caseTitle)
+            if caseTitle:
+                with Title(f):
+                    f.write(caseTitle)
 
         with Body(f):
 
@@ -244,8 +243,9 @@ def writeStandardReportTemplate(f, report):
                                 "style": "color: #d9230f;",
                             },
                         ):
-                            with B(f):
-                                f.write(cs.caseTitle)
+                            if caseTitle:
+                                with B(f):
+                                    f.write(caseTitle)
 
                         with Span(
                             f, attrs={"class": "navbar-text navbar-version pull-left"}
@@ -264,8 +264,6 @@ def writeStandardReportTemplate(f, report):
                 with Div(f, attrs={"class": "page-header"}):
                     with H1(f):
                         f.write(report.title)
-                    with P(f):
-                        f.write(cs["comment"])
 
                 report.writeGroupsHTML(f)
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -436,7 +436,7 @@ class Core(composites.Composite):
         else:
             self._removeListFromAuxiliaries(a1)
 
-    def removeAssembliesInRing(self, ringNum, overrideCircularRingMode=False):
+    def removeAssembliesInRing(self, ringNum, cs, overrideCircularRingMode=False):
         """
         Removes all of the assemblies in a given ring
 
@@ -444,7 +444,8 @@ class Core(composites.Composite):
         ----------
         ringNum : int
             The ring to remove
-
+        cs: CaseSettings
+            A relevant settings object
         overrideCircularRingMode : bool, optional
             False ~ default: use circular/square/hex rings, just as the reactor defines them
             True ~ If you know you don't want to use the circular ring mode, and instead want square or hex.
@@ -458,7 +459,7 @@ class Core(composites.Composite):
         ):
             self.removeAssembly(a)
 
-        self.processLoading(settings.getMasterCs())
+        self.processLoading(cs)
 
     def _removeListFromAuxiliaries(self, assembly):
         """

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -19,25 +19,25 @@ import copy
 import os
 import unittest
 
-from six.moves import cPickle
 from numpy.testing import assert_allclose, assert_equal
+from six.moves import cPickle
 
 from armi import operators
 from armi import runLog
 from armi import settings
 from armi import tests
 from armi.materials import uZr
-from armi.reactor.flags import Flags
 from armi.reactor import assemblies
 from armi.reactor import blocks
-from armi.reactor import grids
 from armi.reactor import geometry
+from armi.reactor import grids
 from armi.reactor import reactors
 from armi.reactor.components import Hexagon, Rectangle
 from armi.reactor.converters import geometryConverters
+from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
+from armi.reactor.flags import Flags
 from armi.tests import ARMI_RUN_PATH, mockRunLogs, TEST_ROOT
 from armi.utils import directoryChangers
-from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 
 TEST_REACTOR = None  # pickled string of test reactor (for fast caching)
 
@@ -719,14 +719,14 @@ class HexReactorTests(ReactorTests):
             for i, loc in enumerate(aLoc)
             if loc in self.r.core.childrenByLocator
         }
-        self.r.core.removeAssembliesInRing(3)
+        self.r.core.removeAssembliesInRing(3, self.o.cs)
         for i, a in assems.items():
             self.assertNotEqual(aLoc[i], a.spatialLocator)
             self.assertEqual(a.spatialLocator.grid, self.r.core.sfp.spatialGrid)
 
     def test_removeAssembliesInRingByCount(self):
         self.assertEqual(self.r.core.getNumRings(), 9)
-        self.r.core.removeAssembliesInRing(9)
+        self.r.core.removeAssembliesInRing(9, self.o.cs)
         self.assertEqual(self.r.core.getNumRings(), 8)
 
     def test_removeAssembliesInRingHex(self):
@@ -736,7 +736,9 @@ class HexReactorTests(ReactorTests):
         """
         self.assertEqual(self.r.core.getNumRings(), 9)
         for ringNum in range(6, 10):
-            self.r.core.removeAssembliesInRing(ringNum, overrideCircularRingMode=True)
+            self.r.core.removeAssembliesInRing(
+                ringNum, self.o.cs, overrideCircularRingMode=True
+            )
         self.assertEqual(self.r.core.getNumRings(), 5)
 
     def test_getNozzleTypes(self):


### PR DESCRIPTION
## Description

As part of the on-going work on #930, this PR removes to usages of `getMasterCs()` in reports and reactor.py.

I have reviewed this PRs change on downstream repos, and there is only one place I can find this will make a difference, and it is a unit test. So I will open the fixing PR into that repo.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
