### PR TITLE
Moving tests to use TempDir tooling

### DIFF
--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -622,6 +622,13 @@ class TestDatabase3(unittest.TestCase):
 class TestLocationPacking(unittest.TestCase):
     r"""Tests for database location"""
 
+    def setUp(self):
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
+
+    def tearDown(self):
+        self.td.__exit__(None, None, None)
+
     def test_locationPacking(self):
         # pylint: disable=protected-access
         loc1 = grids.IndexLocation(1, 2, 3, None)

--- a/armi/bookkeeping/report/tests/test_newReport.py
+++ b/armi/bookkeeping/report/tests/test_newReport.py
@@ -27,35 +27,39 @@ from armi.physics.neutronics.reports import neutronicsPlotting
 from armi.reactor.tests import test_reactors
 from armi.tests import TEST_ROOT
 from armi.tests import mockRunLogs
-from armi.utils import directoryChangers
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestReportContentCreation(unittest.TestCase):
     def setUp(self):
         self.o, self.r = test_reactors.loadTestReactor(TEST_ROOT)
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
+
+    def tearDown(self):
+        self.td.__exit__(None, None, None)
 
     def test_timeSeries(self):
         """Test execution of TimeSeries object."""
-        with directoryChangers.TemporaryDirectoryChanger():
-            times = [0.1, 0.3, 0.5, 0.7, 0.9, 1.1, 1.3]
-            data1 = [7, 4, 3, 2, 1, 5, 7]
-            data2 = [1, 2, 3, 4, 5, 5, 7]
-            # Labels are predetermined at creation...
-            series = newReports.TimeSeries(
-                "Example Plot",
-                "ReactorName",
-                ["data1", "data2"],
-                "height (cm)",
-                "plotexample.png",
-                "This is the Caption",
-            )
+        times = [0.1, 0.3, 0.5, 0.7, 0.9, 1.1, 1.3]
+        data1 = [7, 4, 3, 2, 1, 5, 7]
+        data2 = [1, 2, 3, 4, 5, 5, 7]
+        # Labels are predetermined at creation...
+        series = newReports.TimeSeries(
+            "Example Plot",
+            "ReactorName",
+            ["data1", "data2"],
+            "height (cm)",
+            "plotexample.png",
+            "This is the Caption",
+        )
 
-            for val in range(len(times)):
-                series.add("data1", times[val], data1[val])
-                series.add("data2", times[val], data2[val])
+        for val in range(len(times)):
+            series.add("data1", times[val], data1[val])
+            series.add("data2", times[val], data2[val])
 
-            series.plot()
-            self.assertTrue(os.path.exists("ReactorName.plotexample.png"))
+        series.plot()
+        self.assertTrue(os.path.exists("ReactorName.plotexample.png"))
 
     def test_tableCreation(self):
         header = ["item", "value"]
@@ -68,44 +72,38 @@ class TestReportContentCreation(unittest.TestCase):
         self.assertTrue(isinstance(result, htmltree.HtmlElement))
 
     def test_reportContents(self):
-        with directoryChangers.TemporaryDirectoryChanger():
-            reportTest = newReports.ReportContent("Test")
+        reportTest = newReports.ReportContent("Test")
 
-            getPluginManagerOrFail().hook.getReportContents(
-                r=self.r,
-                cs=self.o.cs,
-                report=reportTest,
-                stage=newReports.ReportStage.Begin,
-                blueprint=self.r.blueprints,
-            )
+        getPluginManagerOrFail().hook.getReportContents(
+            r=self.r,
+            cs=self.o.cs,
+            report=reportTest,
+            stage=newReports.ReportStage.Begin,
+            blueprint=self.r.blueprints,
+        )
 
-            self.assertTrue(isinstance(reportTest.sections, collections.OrderedDict))
-            self.assertIn("Comprehensive Report", reportTest.sections)
-            self.assertIn("Design", reportTest.sections)
-            self.assertIn("Neutronics", reportTest.sections)
-            self.assertTrue(
-                isinstance(reportTest.tableOfContents(), htmltree.HtmlElement)
-            )
+        self.assertTrue(isinstance(reportTest.sections, collections.OrderedDict))
+        self.assertIn("Comprehensive Report", reportTest.sections)
+        self.assertIn("Design", reportTest.sections)
+        self.assertIn("Neutronics", reportTest.sections)
+        self.assertTrue(isinstance(reportTest.tableOfContents(), htmltree.HtmlElement))
 
     def test_reportContentsEnd(self):
-        with directoryChangers.TemporaryDirectoryChanger():
-            reportTest = newReports.ReportContent("Test")
+        reportTest = newReports.ReportContent("Test")
 
-            getPluginManagerOrFail().hook.getReportContents(
-                r=self.r,
-                cs=self.o.cs,
-                report=reportTest,
-                stage=newReports.ReportStage.End,
-                blueprint=self.r.blueprints,
-            )
+        getPluginManagerOrFail().hook.getReportContents(
+            r=self.r,
+            cs=self.o.cs,
+            report=reportTest,
+            stage=newReports.ReportStage.End,
+            blueprint=self.r.blueprints,
+        )
 
-            self.assertTrue(isinstance(reportTest.sections, collections.OrderedDict))
-            self.assertNotIn("Comprehensive Report", reportTest.sections)
-            self.assertIn("Design", reportTest.sections)
-            self.assertIn("Neutronics", reportTest.sections)
-            self.assertTrue(
-                isinstance(reportTest.tableOfContents(), htmltree.HtmlElement)
-            )
+        self.assertTrue(isinstance(reportTest.sections, collections.OrderedDict))
+        self.assertNotIn("Comprehensive Report", reportTest.sections)
+        self.assertIn("Design", reportTest.sections)
+        self.assertIn("Neutronics", reportTest.sections)
+        self.assertTrue(isinstance(reportTest.tableOfContents(), htmltree.HtmlElement))
 
     def test_neutronicsPlotFunctions(self):
         reportTest = newReports.ReportContent("Test")
@@ -117,22 +115,21 @@ class TestReportContentCreation(unittest.TestCase):
         )
 
     def test_writeReports(self):
-        with directoryChangers.TemporaryDirectoryChanger():
-            reportTest = newReports.ReportContent("Test")
-            table = newReports.Table("Example")
-            table.addRow(["example", 1])
-            table.addRow(["example", 2])
+        reportTest = newReports.ReportContent("Test")
+        table = newReports.Table("Example")
+        table.addRow(["example", 1])
+        table.addRow(["example", 2])
 
-            reportTest["TableTest"]["Table Example"] = table
+        reportTest["TableTest"]["Table Example"] = table
 
-            reportTest.writeReports()
-            # Want to check that two <tr> exists...
-            times = 0
-            with open("index.html") as f:
-                for line in f:
-                    if "<tr>" in line:
-                        times = times + 1
-            self.assertEqual(times, 2)
+        reportTest.writeReports()
+        # Want to check that two <tr> exists...
+        times = 0
+        with open("index.html") as f:
+            for line in f:
+                if "<tr>" in line:
+                    times = times + 1
+        self.assertEqual(times, 2)
 
     def test_reportBasics(self):
         env = data.Report("Environment", "ARMI Env Info")

--- a/armi/nuclearDataIO/cccc/tests/test_compxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_compxs.py
@@ -25,7 +25,7 @@ from scipy.sparse import csc_matrix
 from armi import nuclearDataIO
 from armi.nuclearDataIO.cccc import compxs
 from armi.nuclearDataIO.xsLibraries import CompxsLibrary
-from armi.tests import COMPXS_PATH, TEST_ROOT
+from armi.tests import COMPXS_PATH
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
@@ -34,11 +34,11 @@ class TestCompxs(unittest.TestCase):
 
     @property
     def binaryWritePath(self):
-        return os.path.join(TEST_ROOT, self._testMethodName + "compxs-b")
+        return os.path.join(self._testMethodName + "compxs-b")
 
     @property
     def asciiWritePath(self):
-        return os.path.join(TEST_ROOT, self._testMethodName + "compxs-a.txt")
+        return os.path.join(self._testMethodName + "compxs-a.txt")
 
     @classmethod
     def setUpClass(cls):

--- a/armi/nuclearDataIO/cccc/tests/test_compxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_compxs.py
@@ -22,10 +22,11 @@ import unittest
 import numpy
 from scipy.sparse import csc_matrix
 
-from armi.tests import COMPXS_PATH, TEST_ROOT
 from armi import nuclearDataIO
 from armi.nuclearDataIO.cccc import compxs
 from armi.nuclearDataIO.xsLibraries import CompxsLibrary
+from armi.tests import COMPXS_PATH, TEST_ROOT
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestCompxs(unittest.TestCase):
@@ -296,17 +297,19 @@ class TestCompxs(unittest.TestCase):
 
     def test_binaryRW(self):
         """Test to make sure the binary read/writer reads/writes the exact same library."""
-        compxs.writeBinary(self.lib, self.binaryWritePath)
-        self.assertTrue(
-            compxs.compare(self.lib, compxs.readBinary(self.binaryWritePath))
-        )
-        os.remove(self.binaryWritePath)
+        with TemporaryDirectoryChanger():
+            compxs.writeBinary(self.lib, self.binaryWritePath)
+            self.assertTrue(
+                compxs.compare(self.lib, compxs.readBinary(self.binaryWritePath))
+            )
 
     def test_asciiRW(self):
         """Test to make sure the ascii reader/writer reads/writes the exact same library."""
-        compxs.writeAscii(self.lib, self.asciiWritePath)
-        self.assertTrue(compxs.compare(self.lib, compxs.readAscii(self.asciiWritePath)))
-        os.remove(self.asciiWritePath)
+        with TemporaryDirectoryChanger():
+            compxs.writeAscii(self.lib, self.asciiWritePath)
+            self.assertTrue(
+                compxs.compare(self.lib, compxs.readAscii(self.asciiWritePath))
+            )
 
     def test_mergeCompxsLibraries(self):
         """Test to verify the compxs merging returns a library with new regions."""

--- a/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
@@ -23,10 +23,11 @@ import unittest
 
 import numpy
 
-from armi.tests import mockRunLogs
-from armi.nuclearDataIO.cccc import dlayxs
 from armi.nucDirectory import nuclideBases
+from armi.nuclearDataIO.cccc import dlayxs
 from armi.nuclearDataIO.tests import test_xsLibraries
+from armi.tests import mockRunLogs
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class DlayxsTests(unittest.TestCase):
@@ -1078,11 +1079,11 @@ class DlayxsTests(unittest.TestCase):
             self.assertTrue(dlayxs.compare(self.dlayxs3, copy.deepcopy(self.dlayxs3)))
 
     def test_writeBinary_mcc3(self):
-        dlayxs.writeBinary(self.dlayxs3, "test_writeBinary_mcc3.temp")
-        self.assertTrue(
-            filecmp.cmp(test_xsLibraries.DLAYXS_MCC3, "test_writeBinary_mcc3.temp")
-        )
-        os.remove("test_writeBinary_mcc3.temp")
+        with TemporaryDirectoryChanger():
+            dlayxs.writeBinary(self.dlayxs3, "test_writeBinary_mcc3.temp")
+            self.assertTrue(
+                filecmp.cmp(test_xsLibraries.DLAYXS_MCC3, "test_writeBinary_mcc3.temp")
+            )
 
     def test_nuclides(self):
         nucs3 = set(

--- a/armi/nuclearDataIO/cccc/tests/test_geodst.py
+++ b/armi/nuclearDataIO/cccc/tests/test_geodst.py
@@ -21,6 +21,7 @@ import unittest
 from numpy.testing import assert_equal
 
 from armi.nuclearDataIO.cccc import geodst
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 THIS_DIR = os.path.dirname(__file__)
 SIMPLE_GEODST = os.path.join(THIS_DIR, "fixtures", "simple_hexz.geodst")
@@ -46,10 +47,10 @@ class TestGeodst(unittest.TestCase):
 
     def test_writeGeodst(self):
         """Ensure that we can write a modified GEODST."""
-        geo = geodst.readBinary(SIMPLE_GEODST)
-        geo.zmesh[-1] *= 2
-        geodst.writeBinary(geo, "GEODST2")
-        geo2 = geodst.readBinary("GEODST2")
-        self.assertAlmostEqual(geo2.zmesh[-1], 448.0 * 2, places=5)
-        assert_equal(geo.kintervals, geo2.kintervals)
-        os.remove("GEODST2")
+        with TemporaryDirectoryChanger():
+            geo = geodst.readBinary(SIMPLE_GEODST)
+            geo.zmesh[-1] *= 2
+            geodst.writeBinary(geo, "GEODST2")
+            geo2 = geodst.readBinary("GEODST2")
+            self.assertAlmostEqual(geo2.zmesh[-1], 448.0 * 2, places=5)
+            assert_equal(geo.kintervals, geo2.kintervals)

--- a/armi/nuclearDataIO/cccc/tests/test_labels.py
+++ b/armi/nuclearDataIO/cccc/tests/test_labels.py
@@ -20,6 +20,7 @@ import os
 import unittest
 
 from armi.nuclearDataIO.cccc import labels
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 THIS_DIR = os.path.dirname(__file__)
 
@@ -49,15 +50,15 @@ class TestLabels(unittest.TestCase):
         self.assertEqual(len(labelsData.regionLabels), expectedNumRegions)
 
     def test_writeLabelsAscii(self):
-        labelsData = labels.readBinary(LABELS_FILE_BIN)
-        labels.writeAscii(labelsData, self._testMethodName + "labels.ascii")
-        with open(self._testMethodName + "labels.ascii", "r") as f:
-            actualData = f.read().splitlines()
-        with open(LABELS_FILE_ASCII) as f:
-            expectedData = f.read().splitlines()
-        for expected, actual in zip(expectedData, actualData):
-            self.assertEqual(expected, actual)
-        os.remove(self._testMethodName + "labels.ascii")
+        with TemporaryDirectoryChanger():
+            labelsData = labels.readBinary(LABELS_FILE_BIN)
+            labels.writeAscii(labelsData, self._testMethodName + "labels.ascii")
+            with open(self._testMethodName + "labels.ascii", "r") as f:
+                actualData = f.read().splitlines()
+            with open(LABELS_FILE_ASCII) as f:
+                expectedData = f.read().splitlines()
+            for expected, actual in zip(expectedData, actualData):
+                self.assertEqual(expected, actual)
 
 
 if __name__ == "__main__":

--- a/armi/nuclearDataIO/cccc/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_nhflux.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from armi import settings
 from armi.nuclearDataIO.cccc import nhflux
-
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 THIS_DIR = os.path.dirname(__file__)
 
@@ -181,13 +181,13 @@ class TestNhflux(unittest.TestCase):
 
     def test_write(self):
         """Verify binary equivalence of written binary file."""
-        nhflux.NhfluxStream.writeBinary(self.nhf, "NHFLUX2")
-        with open(SIMPLE_HEXZ_NHFLUX, "rb") as f1, open("NHFLUX2", "rb") as f2:
-            expectedData = f1.read()
-            actualData = f2.read()
-        for expected, actual in zip(expectedData, actualData):
-            self.assertEqual(expected, actual)
-        os.remove("NHFLUX2")
+        with TemporaryDirectoryChanger():
+            nhflux.NhfluxStream.writeBinary(self.nhf, "NHFLUX2")
+            with open(SIMPLE_HEXZ_NHFLUX, "rb") as f1, open("NHFLUX2", "rb") as f2:
+                expectedData = f1.read()
+                actualData = f2.read()
+            for expected, actual in zip(expectedData, actualData):
+                self.assertEqual(expected, actual)
 
 
 class TestNhfluxVariant(unittest.TestCase):
@@ -212,7 +212,6 @@ class TestNhfluxVariant(unittest.TestCase):
         self.assertEqual(self.nhf.metadata["nMoms"], 0)
 
     def test_fluxMoments(self):
-        """"""
         # node 1 (ring=1, position=1), axial=3, group=2
         i = 0
         self.assertEqual(self.nhf.geodstCoordMap[i], 13)
@@ -240,16 +239,16 @@ class TestNhfluxVariant(unittest.TestCase):
         )
 
     def test_write(self):
-        """
-        Verify binary equivalence of written binary file.
-        """
-        nhflux.NhfluxStreamVariant.writeBinary(self.nhf, "NHFLUX2")
-        with open(SIMPLE_HEXZ_NHFLUX_VARIANT, "rb") as f1, open("NHFLUX2", "rb") as f2:
-            expectedData = f1.read()
-            actualData = f2.read()
-        for expected, actual in zip(expectedData, actualData):
-            self.assertEqual(expected, actual)
-        os.remove("NHFLUX2")
+        """Verify binary equivalence of written binary file"""
+        with TemporaryDirectoryChanger():
+            nhflux.NhfluxStreamVariant.writeBinary(self.nhf, "NHFLUX2")
+            with open(SIMPLE_HEXZ_NHFLUX_VARIANT, "rb") as f1, open(
+                "NHFLUX2", "rb"
+            ) as f2:
+                expectedData = f1.read()
+                actualData = f2.read()
+            for expected, actual in zip(expectedData, actualData):
+                self.assertEqual(expected, actual)
 
 
 if __name__ == "__main__":

--- a/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
+++ b/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
@@ -230,13 +230,16 @@ class TestProductionMatrix_FromWrittenAscii(TestPmatrx):
         cls.origLib = pmatrx.readBinary(test_xsLibraries.PMATRX_AA)
 
     def setUp(self):
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
+
         self.fname = self._testMethodName + "temp-aa.pmatrx.ascii"
         lib = pmatrx.readBinary(test_xsLibraries.PMATRX_AA)
         pmatrx.writeAscii(lib, self.fname)
         self.lib = pmatrx.readAscii(self.fname)
 
-        self.td = TemporaryDirectoryChanger()
-        self.td.__enter__()
+    def tearDown(self):
+        self.td.__exit__(None, None, None)
 
 
 if __name__ == "__main__":

--- a/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
+++ b/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
@@ -16,14 +16,15 @@ r"""
 Tests the workings of the library wrappers.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
-import os
 import filecmp
+import os
 import unittest
 
 from armi import nuclearDataIO
 from armi.nuclearDataIO.cccc import pmatrx
 from armi.nuclearDataIO.tests import test_xsLibraries
 from armi.utils import properties
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestPmatrxNuclides(unittest.TestCase):
@@ -87,6 +88,13 @@ class TestPmatrx(unittest.TestCase):
         # load a library that is in the ARMI tree. This should
         # be a small library with LFPs, Actinides, structure, and coolant
         cls.lib = pmatrx.readBinary(test_xsLibraries.PMATRX_AA)
+
+    def setUp(self):
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
+
+    def tearDown(self):
+        self.td.__exit__(None, None, None)
 
     def test_pmatrxGammaEnergies(self):
         energies = [
@@ -197,31 +205,24 @@ class TestProductionMatrix_FromWritten(TestPmatrx):
     Note that this runs all the tests from TestPmatrx.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.origLib = pmatrx.readBinary(test_xsLibraries.PMATRX_AA)
-
-    def setUp(self):
-        self.fname = self._testMethodName + "temp-aa.pmatrx"
-        pmatrx.writeBinary(self.origLib, self.fname)
-        self.lib = pmatrx.readBinary(self.fname)
-
-    def tearDown(self):
-        try:
-            os.remove(self.fname)
-        except:
-            pass
-
     def test_writtenIsIdenticalToOriginal(self):
         """Make sure our writer produces something identical to the original."""
-        self.assertTrue(filecmp.cmp(test_xsLibraries.PMATRX_AA, self.fname))
+        origLib = pmatrx.readBinary(test_xsLibraries.PMATRX_AA)
+
+        fname = self._testMethodName + "temp-aa.pmatrx"
+        pmatrx.writeBinary(origLib, fname)
+        lib = pmatrx.readBinary(fname)
+
+        self.assertTrue(filecmp.cmp(test_xsLibraries.PMATRX_AA, fname))
 
 
 class TestProductionMatrix_FromWrittenAscii(TestPmatrx):
     """
     Tests that show you can read and write pmatrx files from ascii libraries.
 
-    Note that this runs all the tests from TestPmatrx.
+    NOTES
+    -----
+    This runs all the tests from TestPmatrx.
     """
 
     @classmethod
@@ -234,11 +235,8 @@ class TestProductionMatrix_FromWrittenAscii(TestPmatrx):
         pmatrx.writeAscii(lib, self.fname)
         self.lib = pmatrx.readAscii(self.fname)
 
-    def tearDown(self):
-        try:
-            os.remove(self.fname)
-        except:
-            pass
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
 
 
 if __name__ == "__main__":

--- a/armi/nuclearDataIO/cccc/tests/test_pwdint.py
+++ b/armi/nuclearDataIO/cccc/tests/test_pwdint.py
@@ -19,6 +19,7 @@ import os
 import unittest
 
 from armi.nuclearDataIO.cccc import pwdint
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 THIS_DIR = os.path.dirname(__file__)
 SIMPLE_PWDINT = os.path.join(THIS_DIR, "fixtures", "simple_cartesian.pwdint")
@@ -38,9 +39,9 @@ class TestGeodst(unittest.TestCase):
         self.assertGreater(pwr.powerDensity.min(), 0.0)
 
     def test_writeGeodst(self):
-        """Ensure that we can write a modified PWDINT."""
-        pwr = pwdint.readBinary(SIMPLE_PWDINT)
-        pwdint.writeBinary(pwr, "PWDINT2")
-        pwr2 = pwdint.readBinary("PWDINT2")
-        self.assertTrue((pwr2.powerDensity == pwr.powerDensity).all())
-        os.remove("PWDINT2")
+        """Ensure that we can write a modified PWDINT"""
+        with TemporaryDirectoryChanger():
+            pwr = pwdint.readBinary(SIMPLE_PWDINT)
+            pwdint.writeBinary(pwr, "PWDINT2")
+            pwr2 = pwdint.readBinary("PWDINT2")
+            self.assertTrue((pwr2.powerDensity == pwr.powerDensity).all())

--- a/armi/nuclearDataIO/cccc/tests/test_rtflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_rtflux.py
@@ -19,6 +19,7 @@ import os
 import unittest
 
 from armi.nuclearDataIO.cccc import rtflux
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 THIS_DIR = os.path.dirname(__file__)
 # This rtflux was made by DIF3D 11 in a Cartesian test case.
@@ -45,24 +46,24 @@ class Testrtflux(unittest.TestCase):
 
     def test_writertflux(self):
         """Ensure that we can write a modified rtflux file."""
-        flux = rtflux.RtfluxStream.readBinary(SIMPLE_RTFLUX)
-        # perturb off-diag item to check row/col ordering
-        flux.groupFluxes[2, 1, 3, 5] *= 1.1
-        flux.groupFluxes[1, 2, 4, 6] *= 1.2
-        rtflux.RtfluxStream.writeBinary(flux, "rtflux2")
-        flux2 = rtflux.RtfluxStream.readBinary("rtflux2")
-        self.assertAlmostEqual(
-            flux2.groupFluxes[2, 1, 3, 5], flux.groupFluxes[2, 1, 3, 5]
-        )
-        os.remove("rtflux2")
+        with TemporaryDirectoryChanger():
+            flux = rtflux.RtfluxStream.readBinary(SIMPLE_RTFLUX)
+            # perturb off-diag item to check row/col ordering
+            flux.groupFluxes[2, 1, 3, 5] *= 1.1
+            flux.groupFluxes[1, 2, 4, 6] *= 1.2
+            rtflux.RtfluxStream.writeBinary(flux, "rtflux2")
+            flux2 = rtflux.RtfluxStream.readBinary("rtflux2")
+            self.assertAlmostEqual(
+                flux2.groupFluxes[2, 1, 3, 5], flux.groupFluxes[2, 1, 3, 5]
+            )
 
     def test_rwAscii(self):
         """Ensure that we can read/write in ascii format."""
-        flux = rtflux.RtfluxStream.readBinary(SIMPLE_RTFLUX)
-        rtflux.RtfluxStream.writeAscii(flux, "rtflux.ascii")
-        flux2 = rtflux.RtfluxStream.readAscii("rtflux.ascii")
-        self.assertTrue((flux2.groupFluxes == flux.groupFluxes).all())
-        os.remove("rtflux.ascii")
+        with TemporaryDirectoryChanger():
+            flux = rtflux.RtfluxStream.readBinary(SIMPLE_RTFLUX)
+            rtflux.RtfluxStream.writeAscii(flux, "rtflux.ascii")
+            flux2 = rtflux.RtfluxStream.readAscii("rtflux.ascii")
+            self.assertTrue((flux2.groupFluxes == flux.groupFluxes).all())
 
     def test_adjoint(self):
         """Ensure adjoint reads energy groups differently."""

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -178,18 +178,19 @@ def createTestXSLibraryFiles(cachePath):
 class TempFileMixin:
     """really a test case"""
 
+    def setUp(self):
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
+
+    def tearDown(self):
+        self.td.__exit__(None, None, None)
+
     @property
     def testFileName(self):
         return os.path.join(
             THIS_DIR,
             "{}-{}.nucdata".format(self.__class__.__name__, self._testMethodName),
         )
-
-    def tearDown(self):
-        try:
-            os.remove(self.testFileName)
-        except OSError:
-            pass
 
 
 class TestXSLibrary(unittest.TestCase, TempFileMixin):
@@ -263,7 +264,7 @@ class TestXSLibrary(unittest.TestCase, TempFileMixin):
                     log.getStdoutValue(),
                 )
         finally:
-            os.remove(dummyFileName)
+            pass
 
     def _xsLibraryAttributeHelper(
         self,

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -400,18 +400,6 @@ class TestFuelHandler(ArmiTestHelper):
         for a in self.r.core.sfp.getChildren():
             self.assertEqual(a.getLocation(), "SFP")
 
-        if os.path.exists("armiRun2-SHUFFLES.txt"):
-            # sometimes pytest runs two of these at once.
-            os.remove("armiRun2-SHUFFLES.txt")
-
-        restartFileName = "armiRun2.restart.dat"
-        if os.path.exists(restartFileName):
-            os.remove(restartFileName)
-        for i in range(3):
-            fname = f"armiRun2.shuffles_{i}.png"
-            if os.path.exists(fname):
-                os.remove(fname)
-
     def test_readMoves(self):
         """
         Depends on the shuffleLogic created by repeatShuffles

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -48,6 +48,13 @@ BA:
 class Test_NeutronicsPlugin(TestPlugin):
     plugin = neutronics.NeutronicsPlugin
 
+    def setUp(self):
+        self.td = directoryChangers.TemporaryDirectoryChanger()
+        self.td.__enter__()
+
+    def tearDown(self):
+        self.td.__exit__(None, None, None)
+
     def test_customSettingObjectIO(self):
         """Check specialized settings can build objects as values and write."""
         cs = caseSettings.Settings()
@@ -59,7 +66,6 @@ class Test_NeutronicsPlugin(TestPlugin):
         cs.writeToYamlFile(fname)
         outText = open(fname, "r").read()
         self.assertIn("geometry: 0D", outText)
-        os.remove(fname)
 
     def test_customSettingRoundTrip(self):
         """Check specialized settings can go back and forth."""
@@ -73,7 +79,6 @@ class Test_NeutronicsPlugin(TestPlugin):
         outText = open(fname, "r").read()
         self.assertIn("geometry: 0D", outText)
         self.assertIn("geometry: 1D", outText)
-        os.remove(fname)
 
     def test_neutronicsSettingsLoaded(self):
         """Check that various special neutronics-specifics settings are loaded"""

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -25,6 +25,7 @@ from armi.reactor import systemLayoutInput
 from armi.reactor.blueprints import Blueprints
 from armi.reactor.blueprints.gridBlueprint import Grids, saveToStream
 from armi.reactor.blueprints.tests.test_blockBlueprints import FULL_BP, FULL_BP_GRID
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 LATTICE_BLUEPRINT = """
@@ -337,7 +338,12 @@ class TestGridBlueprintsSection(unittest.TestCase):
     """Tests for lattice blueprint section."""
 
     def setUp(self):
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
         self.grids = Grids.load(LATTICE_BLUEPRINT.format(self._testMethodName))
+
+    def tearDown(self):
+        self.td.__exit__(None, None, None)
 
     def test_simpleRead(self):
         gridDesign = self.grids["control"]
@@ -405,10 +411,6 @@ class TestGridBlueprintsSection(unittest.TestCase):
             self.assertNotIn("readFromLatticeMap", outText)
 
         self.assertTrue(os.path.exists(filePath))
-        try:
-            os.remove(filePath)
-        except:
-            pass
 
     def test_simpleReadNoLatticeMap(self):
         # Cartesian full, even/odd hybrid
@@ -440,10 +442,6 @@ class TestGridBlueprintsSection(unittest.TestCase):
             self.assertNotIn("readFromLatticeMap", outText)
 
         self.assertTrue(os.path.exists(filePath))
-        try:
-            os.remove(filePath)
-        except:
-            pass
 
 
 class TestRZTGridBlueprint(unittest.TestCase):

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -226,9 +226,9 @@ class TestBlockConverter(unittest.TestCase):
 
             for c in list(reversed(convertedBlock))[:externalRings]:
                 self.assertTrue(c.isFuel(), "c was {}".format(c.name))
-                convertedBlock.remove(
-                    c
-                )  # remove external driver rings in preperation to check composition
+                # remove external driver rings in preperation to check composition
+                convertedBlock.remove(c)
+
             self._checkAreaAndComposition(block, convertedBlock)
 
     def _checkAreaAndComposition(self, block, convertedBlock):

--- a/armi/reactor/tests/test_geometry.py
+++ b/armi/reactor/tests/test_geometry.py
@@ -14,14 +14,15 @@
 
 """Tests the geometry (loading input) file"""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
+import io
 import os
 import unittest
-import io
 
 from armi.reactor import geometry
 from armi.reactor.systemLayoutInput import SystemLayoutInput
 from armi.reactor.tests import test_reactors
 from armi.tests import TEST_ROOT
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 GEOM_INPUT = """<?xml version="1.0" ?>
 <reactor geom="hex" symmetry="third core periodic">
@@ -232,13 +233,13 @@ class TestSymmetryType(unittest.TestCase):
 
 class TestSystemLayoutInput(unittest.TestCase):
     def test_readHexGeomXML(self):
-        geom = SystemLayoutInput()
-        geom.readGeomFromFile(os.path.join(TEST_ROOT, "geom.xml"))
-        self.assertEqual(str(geom.geomType), geometry.HEX)
-        self.assertEqual(geom.assemTypeByIndices[(1, 1)], "IC")
-        out = os.path.join(TEST_ROOT, "geom-output.xml")
-        geom.writeGeom(out)
-        os.remove(out)
+        with TemporaryDirectoryChanger():
+            geom = SystemLayoutInput()
+            geom.readGeomFromFile(os.path.join(TEST_ROOT, "geom.xml"))
+            self.assertEqual(str(geom.geomType), geometry.HEX)
+            self.assertEqual(geom.assemTypeByIndices[(1, 1)], "IC")
+            out = os.path.join(TEST_ROOT, "geom-output.xml")
+            geom.writeGeom(out)
 
     def test_readReactor(self):
         reactor = test_reactors.buildOperatorOfEmptyHexBlocks().r
@@ -265,16 +266,16 @@ class TestSystemLayoutInput(unittest.TestCase):
 
     def test_yamlIO(self):
         """Ensure we can read and write to YAML formatted streams."""
-        geom = SystemLayoutInput()
-        geom.readGeomFromStream(io.StringIO(GEOM_INPUT))
-        fName = "testYamlIO.yaml"
-        with open(fName, "w") as f:
-            geom._writeYaml(f)  # pylint: disable=protected-access
-        with open(fName) as f:
-            geom2 = SystemLayoutInput()
-            geom2._readYaml(f)  # pylint: disable=protected-access
-        self.assertEqual(geom2.assemTypeByIndices[2, 2], "A2")
-        os.remove(fName)
+        with TemporaryDirectoryChanger():
+            geom = SystemLayoutInput()
+            geom.readGeomFromStream(io.StringIO(GEOM_INPUT))
+            fName = "testYamlIO.yaml"
+            with open(fName, "w") as f:
+                geom._writeYaml(f)  # pylint: disable=protected-access
+            with open(fName) as f:
+                geom2 = SystemLayoutInput()
+                geom2._readYaml(f)  # pylint: disable=protected-access
+            self.assertEqual(geom2.assemTypeByIndices[2, 2], "A2")
 
     def test_asciimap(self):  # pylint: disable=no-self-use
         """Ensure this can write ascii maps"""
@@ -307,16 +308,16 @@ class TestSystemLayoutInputTRZ(unittest.TestCase):
         self.assertEqual(geom.assemTypeByIndices[(0.0, 2.0, 0.0, 360.0, 1, 1)], "IC")
 
     def test_TRZyamlIO(self):
-        geom = SystemLayoutInput()
-        geom.readGeomFromFile(os.path.join(TEST_ROOT, "trz_geom.xml"))
-        fName = "testTRZYamlIO.yaml"
-        with open(fName, "w") as f:
-            geom._writeYaml(f)  # pylint: disable=protected-access
-        with open(fName) as f:
-            geom2 = SystemLayoutInput()
-            geom2._readYaml(f)  # pylint: disable=protected-access
-        self.assertEqual(geom2.assemTypeByIndices[2.0, 3.0, 0.0, 180.0, 1, 1], "MC")
-        os.remove(fName)
+        with TemporaryDirectoryChanger():
+            geom = SystemLayoutInput()
+            geom.readGeomFromFile(os.path.join(TEST_ROOT, "trz_geom.xml"))
+            fName = "testTRZYamlIO.yaml"
+            with open(fName, "w") as f:
+                geom._writeYaml(f)  # pylint: disable=protected-access
+            with open(fName) as f:
+                geom2 = SystemLayoutInput()
+                geom2._readYaml(f)  # pylint: disable=protected-access
+            self.assertEqual(geom2.assemTypeByIndices[2.0, 3.0, 0.0, 180.0, 1, 1], "MC")
 
 
 if __name__ == "__main__":

--- a/armi/reactor/tests/test_geometry.py
+++ b/armi/reactor/tests/test_geometry.py
@@ -238,7 +238,7 @@ class TestSystemLayoutInput(unittest.TestCase):
             geom.readGeomFromFile(os.path.join(TEST_ROOT, "geom.xml"))
             self.assertEqual(str(geom.geomType), geometry.HEX)
             self.assertEqual(geom.assemTypeByIndices[(1, 1)], "IC")
-            out = os.path.join(TEST_ROOT, "geom-output.xml")
+            out = os.path.join("geom-output.xml")
             geom.writeGeom(out)
 
     def test_readReactor(self):

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -598,7 +598,6 @@ class HexReactorTests(ReactorTests):
             b.p.mgFlux = range(5)
             b.p.adjMgFlux = range(5)
         self.r.core.saveAllFlux()
-        os.remove("allFlux.txt")
 
     def test_getFluxVector(self):
         class MockLib:

--- a/armi/utils/tests/test_codeTiming.py
+++ b/armi/utils/tests/test_codeTiming.py
@@ -127,6 +127,13 @@ class CodeTimingTest(unittest.TestCase):
         self.assertLess(timer.time, larger_time_end - larger_time_start)
         self.assertEqual(timer.pauses, 3)
 
+        # test report
+        table = codeTiming.MasterTimer.report(inclusion_cutoff=0.01, total_time=True)
+        self.assertIn("TIMER REPORTS", table)
+        self.assertIn(name, table)
+        self.assertIn("CUMULATIVE", table)
+        self.assertIn("ACTIVE", table)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/utils/tests/test_codeTiming.py
+++ b/armi/utils/tests/test_codeTiming.py
@@ -12,23 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Unit tests for code timing.
-"""
-import unittest
+"""Unit tests for code timing"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import time
+import unittest
 
 from armi.utils import codeTiming
 
 
 class CodeTimingTest(unittest.TestCase):
     def setUp(self):
-        codeTiming._Timer._frozen = False  # pylint: disable=protected-access
-        codeTiming.MasterTimer._instance = None  # pylint: disable=protected-access
+        codeTiming._Timer._frozen = False
+        codeTiming.MasterTimer._instance = None
 
     def tearDown(self):
-        codeTiming._Timer._frozen = False  # pylint: disable=protected-access
-        codeTiming.MasterTimer._instance = None  # pylint: disable=protected-access
+        codeTiming._Timer._frozen = False
+        codeTiming.MasterTimer._instance = None
 
     def test_method_definitions(self):
         @codeTiming.timed
@@ -92,9 +91,10 @@ class CodeTimingTest(unittest.TestCase):
     def test_messy_starts_and_stops(self):
         master = codeTiming.getMasterTimer()
 
+        name = "sometimerthatihaventmadeyet"
         larger_time_start = master.time()
         time.sleep(0.01)
-        timer = master.getTimer("sometimerthatihaventmadeyet")
+        timer = master.getTimer(name)
         time.sleep(0.01)
         lesser_time_start = master.time()
 
@@ -102,6 +102,7 @@ class CodeTimingTest(unittest.TestCase):
         timer.start()  # 2nd time pair
         timer.start()  # 3rd time pair
         timer.stop()
+        self.assertIn(name, str(timer))
         self.assertTrue(timer.isActive)
 
         timer.stop()
@@ -116,6 +117,7 @@ class CodeTimingTest(unittest.TestCase):
         lesser_time_end = master.time()
         time.sleep(0.01)
         timer.stop()
+        self.assertIn(name, str(timer))
         self.assertEqual(len(timer.times), 4)
         time.sleep(0.01)
         larger_time_end = master.time()
@@ -123,6 +125,7 @@ class CodeTimingTest(unittest.TestCase):
         # even with all the starts and stops the total time needs to be between these two values.
         self.assertGreater(timer.time, lesser_time_end - lesser_time_start)
         self.assertLess(timer.time, larger_time_end - larger_time_start)
+        self.assertEqual(timer.pauses, 3)
 
 
 if __name__ == "__main__":

--- a/armi/utils/tests/test_reportPlotting.py
+++ b/armi/utils/tests/test_reportPlotting.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from armi.reactor.tests import test_reactors
 from armi.tests import TEST_ROOT
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 from armi.utils.reportPlotting import (
     buVsTime,
     createPlotMetaData,
@@ -36,6 +37,11 @@ from armi.utils.reportPlotting import (
 class TestRadar(unittest.TestCase):
     def setUp(self):
         self.o, self.r = test_reactors.loadTestReactor(TEST_ROOT)
+        self.td = TemporaryDirectoryChanger()
+        self.td.__enter__()
+
+    def tearDown(self):
+        self.td.__exit__(None, None, None)
 
     def test_radar(self):
         """Test execution of radar plot. Note this has no asserts and is therefore a smoke test."""
@@ -45,7 +51,6 @@ class TestRadar(unittest.TestCase):
         r2.core.p.voidWorth = 1.0
         r2.core.p.doppler = 1.0
         plotCoreOverviewRadar([self.r, r2], ["Label1", "Label2"])
-        os.remove("reactor_comparison.png")
 
     def test_createPlotMetaData(self):
         title = "test_createPlotMetaData"
@@ -74,7 +79,6 @@ class TestRadar(unittest.TestCase):
 
         plotAxialProfile(vals, np.ones((5, 2)), fName, meta, nPlot=2)
         self.assertTrue(os.path.exists(fName + ".png"))
-        os.remove(fName + ".png")
 
     def test_keffVsTime(self):
         t = list(range(12))
@@ -84,13 +88,11 @@ class TestRadar(unittest.TestCase):
         keffVsTime(self.r.name, t, t, keffUnc=[], extension=ext)
         self.assertTrue(os.path.exists("R-armiRun.keff.png"))
         self.assertGreater(os.path.getsize("R-armiRun.keff.png"), 0)
-        os.remove("R-armiRun.keff.png")
 
         # plot with a keff function
         keffVsTime(self.r.name, t, t, t, extension=ext)
         self.assertTrue(os.path.exists("R-armiRun.keff.png"))
         self.assertGreater(os.path.getsize("R-armiRun.keff.png"), 0)
-        os.remove("R-armiRun.keff.png")
 
     def test_valueVsTime(self):
         t = list(range(12))
@@ -98,7 +100,6 @@ class TestRadar(unittest.TestCase):
         valueVsTime(self.r.name, t, t, "val", "yaxis", "title", extension=ext)
         self.assertTrue(os.path.exists("R-armiRun.val.png"))
         self.assertGreater(os.path.getsize("R-armiRun.val.png"), 0)
-        os.remove("R-armiRun.val.png")
 
     def test_buVsTime(self):
         name = "buvstime"
@@ -112,7 +113,6 @@ class TestRadar(unittest.TestCase):
         buVsTime(name, scalars, "png")
         self.assertTrue(os.path.exists(figName))
         self.assertGreater(os.path.getsize(figName), 0)
-        os.remove(figName)
 
     def test_movesVsCycle(self):
         name = "movesVsCycle"
@@ -128,7 +128,6 @@ class TestRadar(unittest.TestCase):
         movesVsCycle(name, scalars, "png")
         self.assertTrue(os.path.exists(figName))
         self.assertGreater(os.path.getsize(figName), 0)
-        os.remove(figName)
 
     def test_xsHistoryVsTime(self):
         name = "xsHistoryVsTime"
@@ -145,7 +144,6 @@ class TestRadar(unittest.TestCase):
         xsHistoryVsTime(name, history, [], "png")
         self.assertTrue(os.path.exists(figName))
         self.assertGreater(os.path.getsize(figName), 0)
-        os.remove(figName)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

**NOTE**: This is just a cleanup PR to do with #815 .

I have noticed that a bunch of our unit tests are flaky, particularly in parallel mode. They leave files scattered around the workspace, and don't properly clean up after themselves.

By and large, these problems are because people use `os.remove(test_file)`, instead of using our `TemporaryDirectory` tooling. So, this PR just moves some tests to use the better, more stable, tooling.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
