### PR TITLE
Cleaning up createFreshFeed

### DIFF
--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -208,7 +208,7 @@ class FuelAssemNumModifier(GeometryChanger):
                 # Add new fuel assembly to the core
                 if assem.hasFlags(self.overwriteList):
                     fuelAssem = self._sourceReactor.core.createAssemblyOfType(
-                        assemType=self.fuelType
+                        assemType=self.fuelType, cs=self._cs
                     )
                     # Remove existing assembly in the core location before adding new assembly
                     if assem.hasFlags(self.overwriteList):
@@ -308,8 +308,8 @@ class FuelAssemNumModifier(GeometryChanger):
             if dist <= newRingDist:  # check distance
                 if assem is None:  # no assembly in that position, add assembly
                     newAssem = r.core.createAssemblyOfType(
-                        assemType=assemType
-                    )  # create a fuel assembly
+                        assemType=assemType, cs=self._cs
+                    )
                     r.core.add(newAssem, locator)  # put new assembly in reactor!
                 else:  # all other types of assemblies (fuel, control, etc) leave as is
                     pass

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -27,18 +27,18 @@ plant-wide state variables such as keff, cycle, and node.
    The Reactor contains a Core, which contains a heirachical collection of Assemblies, which in turn
    each contain a collection of Blocks.
 """
+from typing import Optional
 import collections
 import copy
 import itertools
 import os
 import time
-from typing import Optional
 
 import numpy
 import tabulate
 
-from armi import runLog
 from armi import getPluginManagerOrFail, materials, nuclearDataIO, settings
+from armi import runLog
 from armi.nuclearDataIO import xsLibraries
 from armi.reactor import assemblies
 from armi.reactor import assemblyLists
@@ -49,13 +49,13 @@ from armi.reactor import parameters
 from armi.reactor import reactorParameters
 from armi.reactor import systemLayoutInput
 from armi.reactor import zones
+from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 from armi.reactor.flags import Flags
 from armi.settings.fwSettings.globalSettings import CONF_MATERIAL_NAMESPACE_ORDER
 from armi.utils import createFormattedStrWithDelimiter, units
 from armi.utils import directoryChangers
 from armi.utils.iterables import Sequence
 from armi.utils.mathematics import average1DWithinTolerance
-from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 
 
 class Reactor(composites.Composite):
@@ -164,10 +164,6 @@ class Core(composites.Composite):
 
     assemblies : list
         List of assembly objects that are currently in the core
-
-    cs : CaseSettings object
-        Global settings for the case
-
     """
 
     pDefs = reactorParameters.defineCoreParameters()
@@ -1646,20 +1642,20 @@ class Core(composites.Composite):
             self.moveList[cycle].remove(data)
         self.moveList[cycle].append(data)
 
-    def createFreshFeed(self):
+    def createFreshFeed(self, cs=None):
         """
         Creates a new feed assembly.
+
+        Parameters
+        ----------
+        cs : CaseSettings object
+            Global settings for the case
 
         See Also
         --------
         createAssemblyOfType: creates an assembly
-
-        Notes
-        -----
-        createFreshFeed and createAssemblyOfType and this
-        all need to be merged together somehow.
         """
-        return self.createAssemblyOfType(assemType=self._freshFeedType)
+        return self.createAssemblyOfType(assemType=self._freshFeedType, cs=cs)
 
     def createAssemblyOfType(self, assemType=None, enrichList=None, cs=None):
         """
@@ -1671,6 +1667,8 @@ class Core(composites.Composite):
             The assembly type to create
         enrichList : list
             weight percent enrichments of each block
+        cs : CaseSettings object
+            Global settings for the case
 
         Returns
         -------

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -751,7 +751,7 @@ class HexReactorTests(ReactorTests):
         """Test creation of new assemblies."""
         # basic creation
         aOld = self.r.core.getFirstAssembly(Flags.FUEL)
-        aNew = self.r.core.createAssemblyOfType(aOld.getType())
+        aNew = self.r.core.createAssemblyOfType(aOld.getType(), cs=self.o.cs)
         self.assertAlmostEqual(aOld.getMass(), aNew.getMass())
 
         # test axial mesh alignment
@@ -762,7 +762,7 @@ class HexReactorTests(ReactorTests):
             )  # use i+1 to skip 0.0
 
         # creation with modified enrichment
-        aNew2 = self.r.core.createAssemblyOfType(aOld.getType(), 0.195)
+        aNew2 = self.r.core.createAssemblyOfType(aOld.getType(), 0.195, self.o.cs)
         fuelBlock = aNew2.getFirstBlock(Flags.FUEL)
         self.assertAlmostEqual(fuelBlock.getUraniumMassEnrich(), 0.195)
 
@@ -771,11 +771,17 @@ class HexReactorTests(ReactorTests):
         bol = self.r.blueprints.assemblies[aOld.getType()]
         changer = AxialExpansionChanger()
         changer.performPrescribedAxialExpansion(bol, [fuelComp], [0.05])
-        aNew3 = self.r.core.createAssemblyOfType(aOld.getType(), 0.195)
+        aNew3 = self.r.core.createAssemblyOfType(aOld.getType(), 0.195, self.o.cs)
         self.assertAlmostEqual(
             aNew3.getFirstBlock(Flags.FUEL).getUraniumMassEnrich(), 0.195
         )
         self.assertAlmostEqual(aNew3.getMass(), bol.getMass())
+
+    def test_createFreshFeed(self):
+        # basic creation
+        aOld = self.r.core.getFirstAssembly(Flags.FEED)
+        aNew = self.r.core.createFreshFeed(cs=self.o.cs)
+        self.assertAlmostEqual(aOld.getMass(), aNew.getMass())
 
     def test_createAssemblyOfTypeExpandedCore(self):
         """Test creation of new assemblies in an expanded core."""
@@ -793,7 +799,7 @@ class HexReactorTests(ReactorTests):
         aType = self.r.core.getFirstAssembly(Flags.FUEL).getType()
 
         # demonstrate we can still create assemblies
-        self.assertTrue(self.r.core.createAssemblyOfType(aType))
+        self.assertTrue(self.r.core.createAssemblyOfType(aType, cs=self.o.cs))
 
     def test_getAvgTemp(self):
         t0 = self.r.core.getAvgTemp([Flags.CLAD, Flags.WIRE, Flags.DUCT])


### PR DESCRIPTION
## Description

This is an intermediary PR to improve `Core.createFreshFeed()`, because I want to make it easier to make [this fix](https://github.com/terrapower/armi/issues/930) to `Core.createAssemblyOfType()` and such in downstream repos.

This is a very small change, on its own. But I want to be able to clean out a bunch of downstream repos usages of `Core.createFreshFeed()`, in a backwards-compatibility-safe way.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
