### PR TITLE
Removing getMasterCs from getMicroSuffix

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -447,7 +447,7 @@ class Block(composites.Composite):
         xsType = self.p.xsType
         if len(xsType) == 1:
             return xsType + bu
-        elif len(xsType) == 2 and ord(bu) < ord("A"):
+        elif len(xsType) == 2 and ord(bu) > ord("A"):
             raise ValueError(
                 f"Use of multiple burnup groups is not allowed with multi-character xs groups!"
             )

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -20,32 +20,32 @@ Assemblies are made of blocks.
 
 Blocks are made of components.
 """
-import math
-import copy
-import collections
 from typing import Optional, Type, Tuple, ClassVar
+import collections
+import copy
+import math
 
 import numpy
 
-from armi.reactor import composites
 from armi import runLog
 from armi import settings
+from armi.bookkeeping import report
 from armi.nucDirectory import nucDir
-from armi.reactor import geometry
-from armi.reactor import parameters
+from armi.physics.neutronics import GAMMA
+from armi.physics.neutronics import NEUTRON
 from armi.reactor import blockParameters
-from armi.reactor import grids
-from armi.reactor.flags import Flags
 from armi.reactor import components
+from armi.reactor import composites
+from armi.reactor import geometry
+from armi.reactor import grids
+from armi.reactor import parameters
+from armi.reactor.flags import Flags
+from armi.reactor.parameters import ParamLocation
+from armi.utils import densityTools
+from armi.utils import hexagon
 from armi.utils import units
 from armi.utils.plotting import plotBlockFlux
-from armi.bookkeeping import report
 from armi.utils.units import TRACE_NUMBER_DENSITY
-from armi.utils import hexagon
-from armi.utils import densityTools
-from armi.physics.neutronics import NEUTRON
-from armi.physics.neutronics import GAMMA
-from armi.reactor.parameters import ParamLocation
 
 PIN_COMPONENTS = [
     Flags.CONTROL,
@@ -437,18 +437,22 @@ class Block(composites.Composite):
         setting has length 1 (i.e. no burnup groups are defined). This is useful for
         high-fidelity XS modeling of V&V models such as the ZPPRs.
         """
-
         bu = self.p.buGroup
         if not bu:
             raise RuntimeError(
                 "Cannot get MicroXS suffix because {0} in {1} does not have a burnup group"
                 "".format(self, self.parent)
             )
+
         xsType = self.p.xsType
-        if len(xsType) == 2 and len(settings.getMasterCs()["buGroups"]) == 1:
-            return xsType
-        else:
+        if len(xsType) == 1:
             return xsType + bu
+        elif len(xsType) == 2 and ord(bu) < ord("A"):
+            raise ValueError(
+                f"Use of multiple burnup groups is not allowed with multi-character xs groups!"
+            )
+        else:
+            return xsType
 
     def getHeight(self):
         """Return the block height."""

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -869,6 +869,20 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(cur, ref, places=places)
         self.block.remove(self.fuelComponent)
 
+    def test_getMicroSuffix(self):
+        self.assertEqual(self.block.getMicroSuffix(), "AA")
+
+        self.block.p.xsType = "Z"
+        self.assertEqual(self.block.getMicroSuffix(), "ZA")
+
+        self.block.p.xsType = "RS"
+        self.assertEqual(self.block.getMicroSuffix(), "RS")
+
+        self.block.p.buGroup = "X"
+        self.block.p.xsType = "AB"
+        with self.assertRaises(ValueError):
+            self.block.getMicroSuffix()
+
     def test_getUraniumMassEnrich(self):
         self.block.adjustUEnrich(0.25)
 


### PR DESCRIPTION
## Description

In reference to [Issue #930](https://github.com/terrapower/armi/issues/930), this is a minor rewrite of `getMicroSuffix()` intended to help us remove one of the last 6 calls to `getMasterCs()` in ARMI.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
