### PR TITLE
Constraining wxPython version

### DIFF
--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -133,12 +133,9 @@ GUI input
 To use the :py:mod:`graphical core-map editor <armi.utils.gridEditor>` you will need to also install
 `wxPython <https://wxpython.org/pages/downloads/index.html>`_. This is not installed
 by default during armi installation because it can cause installation complexities on some platforms.
-In many cases, a ``pip install`` should suffice::
+In any case, all GUI dependencies can be installed by::
 
-    (armi-venv) $ pip install wxpython
-
-.. warning:: On some platforms, ``pip`` may try to compile wxpython from
-    source which can take a long time and require additional dependencies.
+    (armi-venv) $ pip install armi[grids]
 
 GUI output
 ^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     ],
     extras_require={
         "mpi": ["mpi4py"],
-        "grids": ["wxpython"],
+        "grids": ["wxpython<=4.1.1"],
         "memprof": ["psutil"],
         "dev": [
             "mako",


### PR DESCRIPTION
## Description

Versions of wxPython newer than 4.1.1 cause some conflict with our other dependencies. I am enforcing a version limit for now, as I expect we will be refactoring the GUI to use Jupyter notebooks in the near future and this dependency will be totally removed.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
