### PR TITLE
Removing getMasterCs from createAssemblyOfType

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1684,9 +1684,7 @@ class Core(composites.Composite):
         --------
         armi.fuelHandler.doRepeatShuffle : uses this to repeat shuffling
         """
-        a = self.parent.blueprints.constructAssem(
-            cs or settings.getMasterCs(), name=assemType
-        )
+        a = self.parent.blueprints.constructAssem(cs, name=assemType)
 
         # check to see if a default bol assembly is being used or we are adding more information
         if enrichList:


### PR DESCRIPTION
## Description

After several PRs here and in downstream repos, this PR finally removes the call to `getMasterCs()` from `Core.createAssemblyOfType()`.  This is part of the [930 umbrella ticket](https://github.com/terrapower/armi/issues/930) for removing `getMasterCs()` and `setMasterCs()`.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
