### PR TITLE
Map pin quantities

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -165,6 +165,7 @@ def _getNeutronicsBlockParams():
                 units are the standard n/cm^2/s.  The "ARMI pin ordering" is used, which is counter-clockwise from 3
                 o'clock.  See TP1-1.9.31-RPT-0010 for more details.
             """,
+            categories=[parameters.Category.pinQuantities],
             saveToDB=True,
             default=None,
         )
@@ -173,6 +174,7 @@ def _getNeutronicsBlockParams():
             "pinMgFluxesAdj",
             units="",
             description="should be a blank 3-D array, but re-defined later (ng x nPins x nAxialSegments)",
+            categories=[parameters.Category.pinQuantities],
             saveToDB=False,
             default=None,
         )
@@ -181,6 +183,7 @@ def _getNeutronicsBlockParams():
             "pinMgFluxesGamma",
             units="g/s/cm$^2$",
             description="should be a blank 3-D array, but re-defined later (ng x nPins x nAxialSegments)",
+            categories=[parameters.Category.pinQuantities],
             saveToDB=False,
             default=None,
         )
@@ -372,6 +375,7 @@ def _getNeutronicsBlockParams():
                 "heating results applies."
             ),
             location=ParamLocation.CHILDREN,
+            categories=[parameters.Category.pinQuantities],
             default=None,
         )
 
@@ -387,6 +391,7 @@ def _getNeutronicsBlockParams():
             units="W/cm",
             description="Pin linear neutron heat rate. This is the neutron heating component of `linPowByPin`",
             location=ParamLocation.CHILDREN,
+            categories=[parameters.Category.pinQuantities],
             default=None,
         )
 
@@ -402,6 +407,7 @@ def _getNeutronicsBlockParams():
             units="W/cm",
             description="Pin linear gamma heat rate. This is the gamma heating component of `linPowByPin`",
             location=ParamLocation.CHILDREN,
+            categories=[parameters.Category.pinQuantities],
             default=None,
         )
 

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -131,11 +131,12 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 f"the core's reference assembly mesh: {r.core.refAssem.getAxialMesh()}"
             )
             self.convReactor = self._sourceReactor
+            self.convReactor.core.updateAxialMesh()
             self._setParamsToUpdate()
             for assem in self.convReactor.core.getAssemblies(self._nonUniformMeshFlags):
                 homogAssem = self.makeAssemWithUniformMesh(
                     assem,
-                    self.convReactor.core.refAssem.getAxialMesh(),
+                    self.convReactor.core.p.axialMesh[1:],
                     self.blockParamNames,
                 )
                 homogAssem.spatialLocator = assem.spatialLocator

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -131,12 +131,11 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 f"the core's reference assembly mesh: {r.core.refAssem.getAxialMesh()}"
             )
             self.convReactor = self._sourceReactor
-            self.convReactor.core.updateAxialMesh()
             self._setParamsToUpdate()
             for assem in self.convReactor.core.getAssemblies(self._nonUniformMeshFlags):
                 homogAssem = self.makeAssemWithUniformMesh(
                     assem,
-                    self.convReactor.core.p.axialMesh[1:],
+                    self.convReactor.core.refAssem.getAxialMesh(),
                     self.blockParamNames,
                 )
                 homogAssem.spatialLocator = assem.spatialLocator

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -793,6 +793,7 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
     BLOCK_PARAM_MAPPING_CATEGORIES = [
         parameters.Category.detailedAxialExpansion,
         parameters.Category.multiGroupQuantities,
+        parameters.Category.pinQuantities,
     ]
 
     def __init__(self, cs=None, calcReactionRates=True):

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -61,20 +61,16 @@ class Category:
     """A "namespace" for storing parameter categories."""
 
     assignInBlueprints = "assign in blueprints"
-
     retainOnReplacement = "retain on replacement"
-
     volumeIntegrated = "volumeIntegrated"
-
+    pinQuantities = "pinQuantities"
     fluxQuantities = "fluxQuantities"
-
     multiGroupQuantities = "multi-group quantities"
+    neutronics = "neutronics"
 
     # This is used to tell the UniformMesh converter to map these parameters back and
-    # forth between the source and destination meshs.
+    # forth between the source and destination meshes.
     detailedAxialExpansion = "detailedAxialExpansion"
-
-    neutronics = "neutronics"
 
 
 class ParamLocation(enum.Flag):

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -8,7 +8,8 @@ Release Date: TBD
 
 What's new in ARMI
 ------------------
-#. Split 3 classes in ``da5abase3.py`` into 3 files (`PR#955 <https://github.com/terrapower/armi/pull/955>`_)
+#. Split 3 classes in ``database3.py`` into 3 files (`PR#955 <https://github.com/terrapower/armi/pull/955>`_)
+#. Add pinQuantities parameter category for blockParams that have spatial distribution within a block.
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

Create a new parameter category `pinQuantities` for parameters that are defined on a pin-by-pin basis within a block (or other spatial basis at a finer scale than the assembly). Add this parameter category to the list of values to be mapped between assemblies by the UniformMeshConverter.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

