### PR TITLE
Use r.core.axialMesh() for uniform mesh.

### DIFF
--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -68,7 +68,6 @@ class TestAssemblyUniformMesh(unittest.TestCase):
                 )
             prevB = newB
 
-
         newAssemNumberDens = newAssem.getNumberDensities()
         for nuc, val in sourceAssem.getNumberDensities().items():
             self.assertAlmostEqual(val, newAssemNumberDens[nuc])
@@ -95,9 +94,10 @@ class TestAssemblyUniformMesh(unittest.TestCase):
 
         self.assertNotEqual(len(newAssem), len(sourceAssem))
         newHeights = [b.getHeight() for b in newAssem]
-        sourceHeights = [ b.getHeight() / b.p.axMesh for b in sourceAssem for i in range(b.p.axMesh)]
+        sourceHeights = [
+            b.getHeight() / b.p.axMesh for b in sourceAssem for i in range(b.p.axMesh)
+        ]
         self.assertListEqual(newHeights, sourceHeights)
-
 
     def test_makeAssemUniformMeshParamMappingSameMesh(self):
         """Tests creating a uniform mesh assembly while mapping both number densities and specified parameters."""

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -68,6 +68,7 @@ class TestAssemblyUniformMesh(unittest.TestCase):
                 )
             prevB = newB
 
+
         newAssemNumberDens = newAssem.getNumberDensities()
         for nuc, val in sourceAssem.getNumberDensities().items():
             self.assertAlmostEqual(val, newAssemNumberDens[nuc])
@@ -78,6 +79,25 @@ class TestAssemblyUniformMesh(unittest.TestCase):
             self.assertAlmostEqual(
                 newAssem.getNumberOfAtoms(nuc) / sourceAssem.getNumberOfAtoms(nuc), 1.0
             )
+
+    def test_makeAssemWithUniformMeshSubmesh(self):
+        """If sourceAssem has submesh, check that newAssem splits into separate blocks"""
+
+        # assign axMesh to blocks randomly
+        sourceAssem = self.r.core.refAssem
+        for i, b in enumerate(sourceAssem):
+            b.p.axMesh = i % 2 + 1
+
+        self.r.core.updateAxialMesh()
+        newAssem = self.converter.makeAssemWithUniformMesh(
+            sourceAssem, self.r.core.p.axialMesh[1:]
+        )
+
+        self.assertNotEqual(len(newAssem), len(sourceAssem))
+        newHeights = [b.getHeight() for b in newAssem]
+        sourceHeights = [ b.getHeight() / b.p.axMesh for b in sourceAssem for i in range(b.p.axMesh)]
+        self.assertListEqual(newHeights, sourceHeights)
+
 
     def test_makeAssemUniformMeshParamMappingSameMesh(self):
         """Tests creating a uniform mesh assembly while mapping both number densities and specified parameters."""

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -131,11 +131,12 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 f"the core's reference assembly mesh: {r.core.refAssem.getAxialMesh()}"
             )
             self.convReactor = self._sourceReactor
+            self.convReactor.core.updateAxialMesh()
             self._setParamsToUpdate()
             for assem in self.convReactor.core.getAssemblies(self._nonUniformMeshFlags):
                 homogAssem = self.makeAssemWithUniformMesh(
                     assem,
-                    self.convReactor.core.refAssem.getAxialMesh(),
+                    self.convReactor.core.p.axialMesh[1:],
                     self.blockParamNames,
                 )
                 homogAssem.spatialLocator = assem.spatialLocator

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -10,7 +10,7 @@ What's new in ARMI
 ------------------
 #. Split 3 classes in ``database3.py`` into 3 files (`PR#955 <https://github.com/terrapower/armi/pull/955>`_)
 #. Add pinQuantities parameter category for blockParams that have spatial distribution within a block.
-#. Use r.core.p.axialMesh instead of r.core.refAssem.getAxialMesh() for uniform mesh converter. (`PR#959 <https://github.com/terrapower/armi/pull/959>`_)
+#. Use r.core.p.axialMesh instead of r.core.refAssem.getAxialMesh() for the uniform mesh converter. (`PR#959 <https://github.com/terrapower/armi/pull/959>`_)
 #. TBD
 
 Bug fixes

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -9,6 +9,7 @@ Release Date: TBD
 What's new in ARMI
 ------------------
 #. Split 3 classes in ``da5abase3.py`` into 3 files (`PR#955 <https://github.com/terrapower/armi/pull/955>`_)
+#. Use r.core.p.axialMesh instead of r.core.refAssem.getAxialMesh() for uniform mesh converter. (`PR#959 <https://github.com/terrapower/armi/pull/959>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

When making a uniform mesh assembly in the `UniformMeshConverter`, the freshly minted assembly does not have any submesh (i.e., `b.p.axMesh = 1`).

https://github.com/terrapower/armi/blob/bc3cf475b2158bc3be626287b18f2e21d5da52a7/armi/reactor/converters/uniformMesh.py#L380

Creating a uniform mesh assembly with the refAssem's block mesh (`r.core.refAssem.getAxialMesh()`) poses problems if some blocks in the `refAssem` have a submesh (i.e., `b.p.axMesh > 1`), because the uniform mesh assembly will not have a submesh. `r.core.p.axialMesh()` contains the computational neutronics mesh, which has all of the mesh subdivisions; this is the mesh that should be used for `makeAssemWithUniformMesh()`.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

