### PR TITLE
Added reactor operator back into geometry converted reactor for model…

### DIFF
--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -103,10 +103,8 @@ class LatticePhysicsWriter(interfaces.InputWriter):
         self.driverXsID = self.xsSettings.driverID
         self.numExternalRings = self.xsSettings.numExternalRings
         self.criticalBucklingSearchActive = self.xsSettings.criticalBuckling
-        blockNeedsFPs = (
-            representativeBlock.hasFlags(Flags.FUEL)
-            and representativeBlock.getLumpedFissionProductCollection()
-        )
+        blockNeedsFPs = representativeBlock.getLumpedFissionProductCollection() != None
+
         self.modelFissionProducts = (
             blockNeedsFPs and self.cs["fpModel"] != "noFissionProducts"
         )

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -197,7 +197,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
         coreDesign.construct(cs, bp, newReactor, loadAssems=False)
         newReactor.core.lib = sourceReactor.core.lib
         newReactor.core.setPitchUniform(sourceReactor.core.getAssemblyPitch())
-        newReactor.o = sourceReactor.o  # This is needed later for geometry transformation
+        newReactor.o = (
+            sourceReactor.o
+        )  # This is needed later for geometry transformation
 
         # check if the sourceReactor has been modified from the blueprints
         if sourceReactor.core.isFullCore and not newReactor.core.isFullCore:

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -197,6 +197,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         coreDesign.construct(cs, bp, newReactor, loadAssems=False)
         newReactor.core.lib = sourceReactor.core.lib
         newReactor.core.setPitchUniform(sourceReactor.core.getAssemblyPitch())
+        newReactor.o = sourceReactor.o  # This is needed later for geometry transformation
 
         # check if the sourceReactor has been modified from the blueprints
         if sourceReactor.core.isFullCore and not newReactor.core.isFullCore:


### PR DESCRIPTION
…ing FPs, changed check for needing to model fission products within the lattice physics writer based on if FPs are present, which generalizes to allow blanket fuel to be depleted.

## Description

Users were running into issues with modeling MC2 1D CR with global flux solvers for self-shielding calculations. The error is caused by blocks not containing fission products due to the operator missing in the converted reactor.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [ x ] This PR has only one purpose or idea.
- [ x ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ x ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ x ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ x ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [ x ] The documentation is still up-to-date in the `doc` folder.
- [ x ] The dependencies are still up-to-date in `setup.py`.

