### PR TITLE
Cycle node bug fix

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -352,7 +352,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         self.geomType = reactor.core.geomType
         self.symmetry = reactor.core.symmetry
 
-        cycleNodeStamp = "{reactor.p.cycle:03d}{reactor.p.timeNode:03d}"
+        cycleNodeStamp = f"{reactor.p.cycle:03d}{reactor.p.timeNode:03d}"
         if self.savePhysicsFilesList is not None:
             self.savePhysicsFiles = cycleNodeStamp in self.savePhysicsFilesList
         else:

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -31,8 +31,8 @@ from armi.tests import ISOAA_PATH
 # pylint: disable=abstract-method
 class MockReactorParams:
     def __init__(self):
-        self.cycle = 0
-        self.timeNode = 0
+        self.cycle = 1
+        self.timeNode = 2
 
 
 class MockCoreParams:
@@ -103,6 +103,21 @@ class TestGlobalFluxOptions(unittest.TestCase):
         opts = globalFluxInterface.GlobalFluxOptions("neutronics-run")
         opts.fromReactor(reactor)
         self.assertEqual(opts.geomType, geometry.GeomType.CARTESIAN)
+        self.assertFalse(opts.savePhysicsFiles)
+
+    def test_savePhysicsFiles(self):
+        reactor = MockReactor()
+        opts = globalFluxInterface.GlobalFluxOptions("neutronics-run")
+
+        # savePhysicsFilesList matches MockReactor parameters
+        opts.savePhysicsFilesList = ["001002"]
+        opts.fromReactor(reactor)
+        self.assertTrue(opts.savePhysicsFiles)
+
+        # savePhysicsFilesList does not match MockReactor parameters
+        opts.savePhysicsFilesList = ["001000"]
+        opts.fromReactor(reactor)
+        self.assertFalse(opts.savePhysicsFiles)
 
 
 class TestGlobalFluxInterface(unittest.TestCase):

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -29,7 +29,13 @@ from armi.tests import ISOAA_PATH
 
 
 # pylint: disable=abstract-method
-class MockParams:
+class MockReactorParams:
+    def __init__(self):
+        self.cycle = 0
+        self.timeNode = 0
+
+
+class MockCoreParams:
     pass
 
 
@@ -38,13 +44,14 @@ class MockCore:
         # just pick a random geomType
         self.geomType = geometry.GeomType.CARTESIAN
         self.symmetry = "full"
-        self.p = MockParams()
+        self.p = MockCoreParams()
 
 
 class MockReactor:
     def __init__(self):
         self.core = MockCore()
         self.o = None
+        self.p = MockReactorParams()
 
 
 class MockGlobalFluxInterface(globalFluxInterface.GlobalFluxInterface):


### PR DESCRIPTION
## Description

Typo in #952, plus it needed some extra unit testing. The typo (missing the `f` to format a string) circumvented what would have otherwise been a failing test. Needed to add the `cycle` and `timeNode` parameters to the `MockReactor` for testing purposes.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

