### PR TITLE
Add the ability to specify a negative index when loading from a db

### DIFF
--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -326,6 +326,15 @@ class TestDatabase3(unittest.TestCase):
 
         _r = self.db.load(0, 0, allowMissing=True)
 
+        # show that we can use negative indices to load
+        r = self.db.load(0, -2, allowMissing=True)
+        self.assertEqual(r.p.timeNode, 1)
+
+        with self.assertRaises(ValueError):
+            # makeShuffleHistory only populates 2 nodes, but the case settings
+            # defines 3, so we must check -4 before getting an error
+            self.db.load(0, -4, allowMissing=True)
+
         del self.db.h5db["c00n00/Reactor/missingParam"]
         _r = self.db.load(0, 0, allowMissing=False)
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -13,6 +13,7 @@ What's new in ARMI
 #. Add pinQuantities parameter category for blockParams that have spatial distribution within a block.
 #. Use r.core.p.axialMesh instead of r.core.refAssem.getAxialMesh() for the uniform mesh converter. (`PR#959 <https://github.com/terrapower/armi/pull/959>`_)
 #. Split algorithms specific to hex assemblies out of ``FuelHandler``. (`PR#962 <https://github.com/terrapower/armi/pull/962>`_)
+#. Add ability to load from a db using negative node index
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

Add the ability to specify a negative index when loading from a DB. This allows one to load the EOC node without knowing how many nodes are in that cycle.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

