### PR TITLE
Replace yaml.load with yaml.YAML.load to get rid of deprecation warnings

### DIFF
--- a/armi/cases/inputModifiers/tests/test_inputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_inputModifiers.py
@@ -200,7 +200,7 @@ class TestsuiteBuilderIntegrations(unittest.TestCase):
                 f"case-suite-testBPBM/000{case_nbr}/armi-000{case_nbr}-blueprints.yaml",
                 "r",
             )
-            bp_dict = yaml.load(yamlfile)
+            bp_dict = yaml.YAML(typ="unsafe", pure=True).load(yamlfile)
             yamlfile.close()
 
             self.assertEqual(bp_dict["blocks"]["fuel 1"]["clad"]["od"], 3.14)

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -308,7 +308,7 @@ def __readMc2Nuclides():
     that have already been added from RIPL.
     """
     with open(os.path.join(context.RES, "mc2Nuclides.yaml"), "r") as mc2Nucs:
-        mc2Nuclides = yaml.load(mc2Nucs, yaml.RoundTripLoader)
+        mc2Nuclides = yaml.YAML(typ="unsafe", pure=True).load(mc2Nucs)
 
     # now add the mc2 specific nuclideBases, and correct the mc2Ids when a > 0 and state = 0
     for name, data in mc2Nuclides.items():
@@ -400,7 +400,7 @@ def imposeBurnChain(burnChainStream):
         runLog.warning("Burn chain already imposed. Skipping reimposition.")
         return
     _burnChainImposed = True
-    burnData = yaml.load(burnChainStream, yaml.RoundTripLoader)
+    burnData = yaml.YAML(typ="unsafe", pure=True).load(burnChainStream)
 
     for nucName, burnInfo in burnData.items():
         nuclide = byName[nucName]

--- a/armi/physics/neutronics/tests/test_crossSectionSettings.py
+++ b/armi/physics/neutronics/tests/test_crossSectionSettings.py
@@ -159,7 +159,7 @@ class Test_XSSettings(unittest.TestCase):
     def test_yamlIO(self):
         """Ensure we can read/write this custom setting object to yaml"""
         yaml = YAML()
-        inp = yaml.load(io.StringIO(XS_EXAMPLE))
+        inp = yaml.YAML(typ="unsafe", pure=True).load(io.StringIO(XS_EXAMPLE))
         xs = XSSettingDef("TestSetting")
         xs.setValue(inp)
         self.assertEqual(xs.value["BA"].geometry, "1D slab")
@@ -167,7 +167,7 @@ class Test_XSSettings(unittest.TestCase):
         output = xs.dump()
         yaml.dump(output, outBuf)
         outBuf.seek(0)
-        inp2 = yaml.load(outBuf)
+        inp2 = yaml.YAML(typ="unsafe", pure=True).load(outBuf)
         self.assertEqual(inp.keys(), inp2.keys())
 
     def test_caseSettings(self):

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -59,7 +59,7 @@ class Test_NeutronicsPlugin(TestPlugin):
         """Check specialized settings can build objects as values and write."""
         cs = caseSettings.Settings()
         yaml = YAML()
-        inp = yaml.load(io.StringIO(XS_EXAMPLE))
+        inp = yaml.YAML(typ="unsafe", pure=True).load(io.StringIO(XS_EXAMPLE))
         cs[CONF_CROSS_SECTION] = inp
         self.assertEqual(cs[CONF_CROSS_SECTION]["AA"].geometry, "0D")
         fname = "test_setting_obj_io_.yaml"
@@ -71,7 +71,7 @@ class Test_NeutronicsPlugin(TestPlugin):
         """Check specialized settings can go back and forth."""
         cs = caseSettings.Settings()
         yaml = YAML()
-        inp = yaml.load(io.StringIO(XS_EXAMPLE))
+        inp = yaml.YAML(typ="unsafe", pure=True).load(io.StringIO(XS_EXAMPLE))
         cs[CONF_CROSS_SECTION] = inp
         cs[CONF_CROSS_SECTION] = cs[CONF_CROSS_SECTION]
         fname = "test_setting_obj_io_round.yaml"

--- a/armi/reactor/systemLayoutInput.py
+++ b/armi/reactor/systemLayoutInput.py
@@ -275,7 +275,7 @@ class SystemLayoutInput:
         consistent inputs.
         """
         yaml = YAML()
-        tree = yaml.load(stream)
+        tree = yaml.YAML(typ="unsafe", pure=True).load(stream)
         tree = INPUT_SCHEMA(tree)
         self.assemTypeByIndices.clear()
         for _systemName, system in tree[INP_SYSTEMS].items():

--- a/armi/scripts/migration/crossSectionBlueprintsToSettings.py
+++ b/armi/scripts/migration/crossSectionBlueprintsToSettings.py
@@ -133,7 +133,7 @@ def _migrateInputData(origXsInputLines):
         "mesh points per cm": CONF_MESH_PER_CM,
     }
     yaml = YAML()
-    oldXsData = yaml.load(io.StringIO("\n".join(origXsInputLines)))
+    oldXsData = yaml.YAML(typ="unsafe", pure=True).load(io.StringIO("\n".join(origXsInputLines)))
     newXsData = {}
     for xsID, xsIdData in oldXsData["cross sections"].items():
         newIdData = {}

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -403,7 +403,7 @@ class Settings:
         # from the settings file to know which settings are user-defined
         with open(fPath, "r") as stream:
             yaml = YAML()
-            tree = yaml.load(stream)
+            tree = yaml.YAML(typ="unsafe", pure=True).load(stream)
             userSettings = tree[settingsIO.Roots.CUSTOM]
         userSettingsNames = list(userSettings.keys())
         return userSettingsNames

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -208,7 +208,7 @@ class SettingsReader:
         from armi.physics.thermalHydraulics import const  # avoid circular import
 
         yaml = YAML()
-        tree = yaml.load(stream)
+        tree = yaml.YAML(typ="unsafe", pure=True).load(stream)
         if "settings" not in tree:
             raise InvalidSettingsFileError(
                 self.inputPath,

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -153,12 +153,12 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
 
         yaml = YAML()
 
-        inp = yaml.load(good_input)
+        inp = yaml.YAML(typ="unsafe", pure=True).load(good_input)
         for inputSetting, inputVal in inp.items():
             settin = [s for s in newSettings if s.name == inputSetting][0]
             settin.schema(inputVal)
 
-        inp = yaml.load(bad_input)
+        inp = yaml.YAML(typ="unsafe", pure=True).load(bad_input)
         for inputSetting, inputVal in inp.items():
             with self.assertRaises(vol.error.MultipleInvalid):
                 settin = [s for s in newSettings if s.name == inputSetting][0]


### PR DESCRIPTION
## Description

This is a common warning:

```python
armi\nucDirectory\nuclideBases.py:311: PendingDeprecationWarning:
  load will be removed, use

    yaml=YAML(typ='unsafe', pure=True)
    yaml.load(...)

  instead
    mc2Nuclides = yaml.load(mc2Nucs, yaml.RoundTripLoader)
'''

But it doesn't have to be that way. And the best part is that the warning told me how to fix it. Opening the PR to see how the unit tests do on different systems. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [ ] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [ ] The documentation is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `setup.py`.

