### PR TITLE
UserPlugins can't define Parameters

### DIFF
--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -640,6 +640,9 @@ class UserPlugin(ArmiPlugin):
         """
         if issubclass(self.__class__, UserPlugin):
             assert (
+                len(self.__class__.defineParameters()) == 0
+            ), "UserPlugins cannot define parameters, consider using an ArmiPlugin."
+            assert (
                 len(self.__class__.defineParameterRenames()) == 0
             ), "UserPlugins cannot define parameter renames, consider using an ArmiPlugin."
             assert (
@@ -653,6 +656,23 @@ class UserPlugin(ArmiPlugin):
 
     @staticmethod
     @HOOKSPEC
+    def defineParameters():
+        """
+        Prevents defining additional parameters.
+
+        .. warning:: This is not overridable.
+
+        Notes
+        -----
+        It is a designed limitation of user plugins that they not define parameters.
+        Parameters are defined when the App() is read in, which is LONG before the settings
+        file has been read. So the parameters are defined before we discover the user plugin.
+        If this is a feature you need, just use an ArmiPlugin.
+        """
+        return {}
+
+    @staticmethod
+    @HOOKSPEC
     def defineParameterRenames():
         """
         Prevents parameter renames.
@@ -662,7 +682,9 @@ class UserPlugin(ArmiPlugin):
         Notes
         -----
         It is a designed limitation of user plugins that they not generate parameter renames,
-        so that they are able to be added to the plugin stack during run time.
+        Parameters are defined when the App() is read in, which is LONG before the settings
+        file has been read. So the parameters are defined before we discover the user plugin.
+        If this is a feature you need, just use a normal Plugin.
         """
         return {}
 

--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -410,6 +410,7 @@ In most ways, ``UserPluginExample`` above is just a normal
 :py:class:`UserPlugin <armi.plugins.UserPlugin>` class is more limited than a
 regular plugin though, you cannot implement:
 
+* :py:meth:`armi.plugins.ArmiPlugin.defineParameters`
 * :py:meth:`armi.plugins.ArmiPlugin.defineParameterRenames`
 * :py:meth:`armi.plugins.ArmiPlugin.defineSettings`
 * :py:meth:`armi.plugins.ArmiPlugin.defineSettingsValidators`


### PR DESCRIPTION
## Description

Based on the discussion [in ticket #939](https://github.com/terrapower/armi/issues/939), I did some research and found the obvious truth that `UserPlugin`s can't (at least yet) define parameters.

Essentially, when we `armi.Configure(MyApp())`, we get the full set of `Parameter`s from the ARMI `App()`.  THEN, optionally, must later, we can read in a Settings file, that might include a `UserPlugin`.  And at that point, it's just too late to define a `Parameter`.  This is, I'm sure, fixable. But it would demand a high-level re-design of how and when we read plugins and parameters in ARMI.

This has always been a limit of my `UserPlugin` design. But no one had ever tested it before.

Due to Level-of-Effort, I think it makes more sense to leave this as a limitation of `UserPlugin`s, and anyone who needs this much power should just use a regular `ArmiPlugin`.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
