### PR TITLE
Remove MPI barriers in TemporaryDirectoryChanger and Output cache.

### DIFF
--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -30,6 +30,7 @@ from armi.utils import pathTools
 from armi import operators
 from armi.utils.customExceptions import InputError
 from armi.bookkeeping.db.database3 import Database3
+from armi import context
 
 
 ORDER = interfaces.STACK_ORDER.PREPROCESSING
@@ -150,11 +151,17 @@ class MainInterface(interfaces.Interface):
         runLog.warningReport()
 
     def cleanARMIFiles(self):
-        r"""delete ARMI run files like MC**2 and REBUS inputs/outputs. Useful
-        if running a clean job that doesn't require restarts."""
+        """
+        Delete temporary ARMI run files like simulation inputs/outputs.
+
+        Useful if running a clean job that doesn't require restarts.
+        """
+        if context.MPI_RANK != 0:
+            # avoid inadvertently calling from worker nodes which could cause filesystem lockups.
+            raise ValueError("Only the master node is allowed to clean files here.")
         runLog.important("Cleaning ARMI files due to smallRun option")
         for fileName in os.listdir(os.getcwd()):
-            # clean MC**2 and REBUS inputs and outputs
+            # clean simulation inputs and outputs
             for candidate in [".BCD", ".inp", ".out", "ISOTXS-"]:
                 if candidate in fileName:
                     if ".htos.out" in fileName:
@@ -174,7 +181,6 @@ class MainInterface(interfaces.Interface):
             node = int(snapText[3:])
             newFolder = "snapShot{0}_{1}".format(cycle, node)
             utils.pathTools.cleanPath(newFolder)
-            context.waitAll()
 
         # delete database if it's SQLlite
         # no need to delete because the database won't have copied it back if using fastpath.
@@ -182,12 +188,10 @@ class MainInterface(interfaces.Interface):
         # clean temp directories.
         if os.path.exists("shuffleBranches"):
             utils.pathTools.cleanPath("shuffleBranches")
-            context.waitAll()
             # Potentially, wait for all the processes to catch up.
 
         if os.path.exists("failedRuns"):
             utils.pathTools.cleanPath("failedRuns")
-            context.waitAll()
 
     # pylint: disable=no-self-use
     def cleanLastCycleFiles(self):

--- a/armi/context.py
+++ b/armi/context.py
@@ -285,14 +285,6 @@ def cleanAllArmiTempDirs(olderThanDays: int) -> None:
             pass
 
 
-def waitAll() -> None:
-    """
-    If there are parallel processes running, wait for all to catch up to the checkpoint.
-    """
-    if MPI_SIZE > 1 and MPI_DISTRIBUTABLE:
-        MPI_COMM.barrier()
-
-
 def disconnectAllHdfDBs() -> None:
     """
     Forcibly disconnect all instances of HdfDB objects

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -49,6 +49,8 @@ if find_executable("mpiexec.exe") is not None:
 elif find_executable("mpiexec") is not None:
     MPI_EXE = "mpiexec"
 
+MPI_COMM = context.MPI_COMM
+
 
 class FailingInterface1(Interface):
     """utility classes to make sure the logging system fails properly"""
@@ -262,7 +264,7 @@ class MpiPathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(filePath0))
             with self.assertRaises(Exception):
                 pathTools.cleanPath(filePath0, mpiRank=context.MPI_RANK)
-            context.waitAll()
+            MPI_COMM.barrier()
 
             # TEST 1: Delete a single file
             filePath1 = "test1_cleanPathNoMpi_mongoose"
@@ -270,7 +272,7 @@ class MpiPathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(filePath1))
             pathTools.cleanPath(filePath1, mpiRank=context.MPI_RANK)
-            context.waitAll()
+            MPI_COMM.barrier()
             self.assertFalse(os.path.exists(filePath1))
 
             # TEST 2: Delete an empty directory
@@ -279,7 +281,7 @@ class MpiPathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(dir2))
             pathTools.cleanPath(dir2, mpiRank=context.MPI_RANK)
-            context.waitAll()
+            MPI_COMM.barrier()
             self.assertFalse(os.path.exists(dir2))
 
             # TEST 3: Delete a directory with two files inside
@@ -296,7 +298,7 @@ class MpiPathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(dir3, "file1.txt")))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file2.txt")))
             pathTools.cleanPath(dir3, mpiRank=context.MPI_RANK)
-            context.waitAll()
+            MPI_COMM.barrier()
             self.assertFalse(os.path.exists(dir3))
 
 

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -313,7 +313,6 @@ class TemporaryDirectoryChanger(DirectoryChanger):
                     "That is, if you create a directory with a name starting with a period, the "
                     "TempDirChanger will not be able to clean it (for instance, a '.git' dir)."
                 )
-        context.waitAll()
 
 
 class ForcedCreationDirectoryChanger(DirectoryChanger):

--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -182,7 +182,6 @@ def deleteCache(cachedFolder):
         raise RuntimeError("Cache location must contain safeword: `Output_Cache`.")
 
     cleanPath(cachedFolder)
-    context.waitAll()
 
 
 def cacheCall(

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -26,6 +26,7 @@ from armi.utils import pathTools
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 THIS_DIR = os.path.dirname(__file__)
+MPI_COMM = context.MPI_COMM
 
 
 class PathToolsTests(unittest.TestCase):
@@ -75,7 +76,9 @@ class PathToolsTests(unittest.TestCase):
 
     @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")
     def test_cleanPathNoMpi(self):
-        """Simple tests of cleanPath(), in the no-MPI scenario"""
+        """
+        Simple tests of cleanPath(), in the no-MPI scenario
+        """
         with TemporaryDirectoryChanger():
             # TEST 0: File is not safe to delete, due to name pathing
             filePath0 = "test0_cleanPathNoMpi"
@@ -84,7 +87,6 @@ class PathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(filePath0))
             with self.assertRaises(Exception):
                 pathTools.cleanPath(filePath0, mpiRank=0)
-                context.waitAll()
 
             # TEST 1: Delete a single file
             filePath1 = "test1_cleanPathNoMpi_mongoose"
@@ -92,7 +94,6 @@ class PathToolsTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(filePath1))
             pathTools.cleanPath(filePath1, mpiRank=0)
-            context.waitAll()
             self.assertFalse(os.path.exists(filePath1))
 
             # TEST 2: Delete an empty directory
@@ -100,8 +101,6 @@ class PathToolsTests(unittest.TestCase):
             os.mkdir(dir2)
 
             self.assertTrue(os.path.exists(dir2))
-            pathTools.cleanPath(dir2, mpiRank=0)
-            context.waitAll()
             self.assertFalse(os.path.exists(dir2))
 
             # TEST 3: Delete a directory with two files inside
@@ -118,7 +117,6 @@ class PathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(dir3, "file1.txt")))
             self.assertTrue(os.path.exists(os.path.join(dir3, "file2.txt")))
             pathTools.cleanPath(dir3, mpiRank=0)
-            context.waitAll()
             self.assertFalse(os.path.exists(dir3))
 
     def test_isFilePathNewer(self):

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -100,6 +100,7 @@ class PathToolsTests(unittest.TestCase):
             os.mkdir(dir2)
 
             self.assertTrue(os.path.exists(dir2))
+            pathTools.cleanPath(dir2, mpiRank=0)
             self.assertFalse(os.path.exists(dir2))
 
             # TEST 3: Delete a directory with two files inside

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -26,7 +26,6 @@ from armi.utils import pathTools
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 THIS_DIR = os.path.dirname(__file__)
-MPI_COMM = context.MPI_COMM
 
 
 class PathToolsTests(unittest.TestCase):

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -17,7 +17,7 @@ What's new in ARMI
 
 Bug fixes
 ---------
-#. TBD
+#. Removed Barriers in temp directory changers and output cache to avoid deadlocks in MPI cases
 
 
 ARMI v0.2.5


### PR DESCRIPTION
## Description

These utilities aren't always used in a way that has all MPI nodes synced up. For example if worker x has 3 tasks and worker y has 5, that could lead to a deadlock if they use these utilities. Rather than requiring all clients of these utlities know the MPI global state, we just remove the barriers, and will deal with file lock issues in more forgiving ways.

Closes #982

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

