### PR TITLE
Removing unused ARMI Parameters

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -234,25 +234,7 @@ def _getNeutronicsBlockParams():
         )
 
         pb.defParam(
-            "axialMgFluxProfileAdj",
-            units="",
-            description="",
-            location=ParamLocation.AVERAGE,
-            saveToDB=False,
-            default=None,
-        )
-
-        pb.defParam(
             "axialMgFluxProfileNeutron",
-            units="",
-            description="",
-            location=ParamLocation.AVERAGE,
-            saveToDB=False,
-            default=None,
-        )
-
-        pb.defParam(
-            "axialMgFluxProfileNeutronAdj",
             units="",
             description="",
             location=ParamLocation.AVERAGE,
@@ -757,30 +739,12 @@ def _getNeutronicsBlockParams():
             saveToDB=True,
             default=None,
         )
-        pb.defParam(
-            "pointsEdgeFastFluxFr",
-            units=None,
-            description="Fraction of flux above 100keV at edges of the block",
-            location=ParamLocation.EDGES,
-            categories=["detailedAxialExpansion", "depletion"],
-            saveToDB=True,
-            default=None,
-        )
 
         pb.defParam(
             "pointsCornerDpa",
             units="dpa",
             description="displacements per atom at corners of the block",
             location=ParamLocation.CORNERS,
-            categories=["cumulative", "detailedAxialExpansion", "depletion"],
-            saveToDB=True,
-            default=None,
-        )
-        pb.defParam(
-            "pointsEdgeDpa",
-            units="dpa",
-            description="displacements per atom at edges of the block",
-            location=ParamLocation.EDGES,
             categories=["cumulative", "detailedAxialExpansion", "depletion"],
             saveToDB=True,
             default=None,
@@ -792,15 +756,6 @@ def _getNeutronicsBlockParams():
             description="Current time derivative of the displacement per atoms at corners of the block",
             location=ParamLocation.CORNERS,
             categories=["detailedAxialExpansion", "depletion"],
-            saveToDB=True,
-            default=None,
-        )
-        pb.defParam(
-            "pointsEdgeDpaRate",
-            units="dpa/s",
-            description="Current time derivative of the displacement per atoms at edges of the block",
-            categories=["detailedAxialExpansion", "depletion"],
-            location=ParamLocation.EDGES,
             saveToDB=True,
             default=None,
         )

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -529,18 +529,6 @@ def _getNeutronicsBlockParams():
         )
 
         pb.defParam(
-            "fluxDeltaFromRef",
-            units="None",
-            description="Relative difference between the current flux and the directly-computed perturbed flux.",
-        )
-
-        pb.defParam(
-            "fluxDirect",
-            units="n/cm^2/s",
-            description="Flux is computed with a direct method",
-        )
-
-        pb.defParam(
             "fluxGamma",
             units="g/cm^2/s",
             description="Gamma scalar flux",
@@ -555,22 +543,6 @@ def _getNeutronicsBlockParams():
             units="n/cm^2/s",
             description="Peak neutron flux calculated within the mesh",
         )
-
-        pb.defParam(
-            "fluxPertDeltaFromDirect",
-            units="None",
-            description="Relative difference between the perturbed flux and the directly-computed perturbed flux",
-        )
-
-        pb.defParam(
-            "fluxPertDeltaFromDirectfluxRefWeighted", units="None", description=""
-        )
-
-        pb.defParam(
-            "fluxPerturbed", units="1/cm^2/s", description="Flux is computed by MEPT"
-        )
-
-        pb.defParam("fluxRef", units="1/cm^2/s", description="Reference flux")
 
         pb.defParam(
             "kInf",

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -534,10 +534,6 @@ def _getNeutronicsBlockParams():
 
         pb.defParam("arealPd", units="MW/m^2", description="Power divided by XY area")
 
-        pb.defParam(
-            "arealPdGamma", units="MW/m^2", description="Areal gamma power density"
-        )
-
         pb.defParam("fertileBonus", units=None, description="The fertile bonus")
 
         pb.defParam(

--- a/armi/physics/thermalHydraulics/parameters.py
+++ b/armi/physics/thermalHydraulics/parameters.py
@@ -43,15 +43,6 @@ def _getBlockParams():
             categories=[parameters.Category.assignInBlueprints],
         )
 
-        pb.defParam(
-            "inletLossCoeff",
-            units="",
-            description="Pressure loss coefficients from form losses to be applied at the block "
-            "inlet",
-            default=None,
-            categories=[parameters.Category.assignInBlueprints],
-        )
-
     with pDefs.createBuilder(
         default=0.0, location=ParamLocation.AVERAGE, categories=["thermal hydraulics"]
     ) as pb:
@@ -425,13 +416,6 @@ def _getBlockParams():
             units=units.DEGC,
             description="Best estimate duct temperature for assembly edges",
             location=ParamLocation.TOP | ParamLocation.EDGES,
-        )
-
-        pb.defParam(
-            "THbundleAveTemp",
-            units=units.DEGC,
-            description="Bundle averaged temperature",
-            location=ParamLocation.TOP,
         )
 
         pb.defParam(

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -1170,13 +1170,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "powerShapePercent",
-            units="%",
-            description="Percent change in power shape when core temperature rises.",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "puFrac",
             units="None",
             description="Current Pu number density relative to HM at BOL",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -92,38 +92,11 @@ def defineReactorParameters():
         )
 
         pb.defParam(
-            "eFissile",
-            units="MT",
-            description="Fissile mass required in reactor economics",
-        )
-
-        pb.defParam(
-            "eFuelCycleCost",
-            units="$/MT",
-            description="Cost of fuel cycle in an equilibrium-mode in reactor economics",
-        )
-
-        pb.defParam(
-            "eFuelCycleCostRate",
-            units="$/year",
-            description="Rate of fuel cycle cost in an equilibrium mode in reactor economics",
-        )
-
-        pb.defParam(
-            "eProduct",
-            units="MT",
-            description="Total mass of manufactured fuel in reactor economics",
-        )
-
-        pb.defParam(
             "eSWU",
             units="kgSWU",
             description="Separative work units in reactor economics",
         )
 
-        pb.defParam(
-            "eTailsMT", units="MT", description="Depleted Uranium in reactor economics"
-        )
     return pDefs
 
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -423,14 +423,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "maxTH2SigmaCladIDT",
-            units=units.DEGC,
-            description="Max 2-sigma temperature of the inner-diameter of the cladding",
-            default=0.0,
-            categories=["block-max"],
-        )
-
-        pb.defParam(
             "maxTranPCT",
             units=units.DEGC,
             description="Max Peak Clading Temperature of transients",
@@ -483,42 +475,6 @@ def defineCoreParameters():
     ) as pb:
 
         pb.defParam(
-            "assemblyPumpHead",
-            units="Pa",
-            description="Pressure drop for the max power assembly in zone",
-        )
-
-        pb.defParam(
-            "CoreAvgTOut",
-            units=units.DEGC,
-            description="Core average outlet temperature",
-        )
-
-        pb.defParam(
-            "outletTempIdeal",
-            units=units.DEGC,
-            description="Average outlet tempeture loop through all assemblies after doing TH",
-        )
-
-        pb.defParam(
-            "SCMaxDilationPressure",
-            units="Pa",
-            description="The maximum dilation pressure in the core",
-        )
-
-        pb.defParam(
-            "SCorificeEfficiency",
-            units=None,
-            description="Ratio of total flow rate for the optimized orificing scheme to total flow rate for an ideal orificing scheme",
-        )
-
-        pb.defParam(
-            "SCovercoolingRatio",
-            units=None,
-            description="Ratio of the max flow rate to the average flow rate",
-        )
-
-        pb.defParam(
             "THmaxDeltaPPump",
             units="Pa",
             description="The maximum pumping pressure rise required to pump the given mass flow rate through the rod bundle",
@@ -532,20 +488,6 @@ def defineCoreParameters():
             "THoutletTempIdeal",
             units=units.DEGC,
             description="Average outlet temperature loop through all assemblies after doing TH",
-        )
-
-        pb.defParam("vesselTemp", units=units.DEGC, description="vessel temperature")
-
-        pb.defParam(
-            "LMDT",
-            units=units.DEGC,
-            description="Log mean temperature difference in heat exchanger",
-        )
-
-        pb.defParam(
-            "peakTemperature",
-            units=units.DEGC,
-            description="peak temperature anywhere in the reactor",
         )
 
     with pDefs.createBuilder(


### PR DESCRIPTION
## Description

Due to recent discussion, I have been taking an inventory of all the `Parameter`s in ARMI, and scouring our downstream repositories to see which are used and which are not.  The `Parameter`s removed in this PR appear to have all been abandoned and totally unused for at least four years, in all downstream projects I have access to.

I have tested this PR against a few dozen of the biggest and most complex downstream repositories, and it passes muster.

Specifically, I have removed defunct `Parameter`s from:

* Economics
* Flux Reconstruction
* Thermal Hydraulics

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
