### PR TITLE
Removing unused (and redundant) Parameter Category

### DIFF
--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -62,7 +62,6 @@ class Category:
 
     assignInBlueprints = "assign in blueprints"
     retainOnReplacement = "retain on replacement"
-    volumeIntegrated = "volumeIntegrated"
     pinQuantities = "pinQuantities"
     fluxQuantities = "fluxQuantities"
     multiGroupQuantities = "multi-group quantities"


### PR DESCRIPTION
## Description

The `Parameter` `Category` `volumeIntegrated` is unused in ARMI and is not involved in any code that actual integrates volumes. More importantly, there is a `ParamLocation.VOLUME_INTEGRATED` attribute just a few lines lower that _is_ actually used to deal with volume calculations.

So, this PR removes a single line of essentially dead code, with the goal of helping people understand "volume integrated Parameters" more easily.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
