### PR TITLE
Removing unused Virdent parameters

### DIFF
--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -466,13 +466,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "distortWorth",
-            units="pcm/cm^3",
-            description="Distortion reactivity distribution",
-            default=None,
-        )
-
-        pb.defParam(
             "fuelWorth",
             units="dk/kk'-kg",
             description="Reactivity worth of fuel material per unit mass",
@@ -654,34 +647,8 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "virdentGr",
-            units="pcm/%/cm^3",
-            description="Radial surface leakage reactivity",
-        )
-
-        pb.defParam(
-            "virdentGz",
-            units="pcm/%/cm^3",
-            description="Axial surface leakage reactivity",
-        )
-
-        pb.defParam(
-            "virdentLr",
-            units="pcm/%/cm^3",
-            description="Radial volume leakage reactivity",
-        )
-
-        pb.defParam(
-            "virdentLz",
-            units="pcm/%/cm^3",
-            description="Axial volume leakage reactivity",
-        )
-
-        pb.defParam(
             "assemPeakStd", units="pcm/%/cm^3", description="Spectral reactivity"
         )
-
-        pb.defParam("virdentS", units="pcm/%/cm^3", description="Spectral reactivity")
 
     with pDefs.createBuilder(
         default=0.0,
@@ -870,13 +837,6 @@ def getBlockParameterDefinitions():
     with pDefs.createBuilder(default=0.0) as pb:
 
         pb.defParam(
-            "VirDenTerr",
-            units="%",
-            description="VirDenT error",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "assemNum",
             units="None",
             description="Index that refers, nominally, to the assemNum parameter of "
@@ -1003,8 +963,6 @@ def getBlockParameterDefinitions():
             description="Change in fuel temperature due to 1% rise in power.",
             location=ParamLocation.AVERAGE,
         )
-
-        pb.defParam("displacementMAG", units="?", description="?")
 
         pb.defParam(
             "heightBOL",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -213,13 +213,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "breedingRatio2",
-            units="N/A",
-            description="Ratio of fissile Burned and discharged to fissile discharged",
-            saveToDB=False,
-        )
-
-        pb.defParam(
             "critSearchSlope", units=None, description="Critical keff search slope"
         )
 
@@ -227,13 +220,6 @@ def defineCoreParameters():
             "directPertKeff",
             units=None,
             description="K-eff is computed for the perturbed case with a direct calculation",
-        )
-
-        pb.defParam(
-            "distortionReactivity",
-            units="pcm",
-            description="The reactivity effect of the current distortions",
-            default=None,
         )
 
         pb.defParam(


### PR DESCRIPTION
## Description

These parameters are being moved out of ARMI and into the one place that was using them.

This is meant to make it easier for people to understand the parameters that come with ARMI.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
