### PR TITLE
Removing unused Parameters

### DIFF
--- a/armi/physics/fuelPerformance/parameters.py
+++ b/armi/physics/fuelPerformance/parameters.py
@@ -94,10 +94,4 @@ def _getFuelPerformanceBlockParams():
             default=0.0,
         )
 
-        pb.defParam(
-            "fuelRadialDisplacement",
-            units="cm",
-            description="Radial fuel displacement from irradiation",
-        )
-
     return pDefs

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -408,6 +408,12 @@ def _getNeutronicsBlockParams():
     ) as pb:
         # Neutronics reaction rate params that are not re-derived in mesh conversion
         pb.defParam(
+            "rateBalance",
+            units="1/cm^3/s",
+            description="Numerical balance between particle production and destruction (should be small)",
+        )
+
+        pb.defParam(
             "rateExtSrc",
             units="1/cm^3/s",
             description="Rate of production of neutrons from an external source.",

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -408,12 +408,6 @@ def _getNeutronicsBlockParams():
     ) as pb:
         # Neutronics reaction rate params that are not re-derived in mesh conversion
         pb.defParam(
-            "rateBalance",
-            units="1/cm^3/s",
-            description="Numerical balance between particle production and destruction (should be small)",
-        )
-
-        pb.defParam(
             "rateExtSrc",
             units="1/cm^3/s",
             description="Rate of production of neutrons from an external source.",
@@ -634,20 +628,6 @@ def _getNeutronicsBlockParams():
         pb.defParam("powerNeutron", units="W", description="Total neutron power")
 
     with pDefs.createBuilder(default=0.0) as pb:
-        pb.defParam(
-            "detailedDpaNewCycle",
-            units="dpa",
-            description="The total DPA accumulated in all burn steps of one cycle",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "detailedDpaPeakNewCycle",
-            units="dpa",
-            description="The total peak DPA accumulated in all burn steps of one cycle",
-            location=ParamLocation.AVERAGE,
-        )
-
         pb.defParam(
             "detailedDpaThisCycle",
             units="dpa",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -303,10 +303,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "dpaRx", units="dpa/s", description="?", location=ParamLocation.AVERAGE
-        )
-
-        pb.defParam(
             "heliumInB4C",
             units="He/s/cm$^3$",
             description="?",
@@ -336,8 +332,6 @@ def getBlockParameterDefinitions():
         pb.defParam("baseBu", units="?", description="?", saveToDB=False)
 
         pb.defParam("basePBu", units="?", description="?", saveToDB=False)
-
-        pb.defParam("hydDiam", units="?", description="?", saveToDB=False)
 
         pb.defParam(
             "nHMAtBOL",
@@ -439,14 +433,6 @@ def getBlockParameterDefinitions():
             saveToDB=True,
         )
 
-        pb.defParam(
-            "regName",
-            units="?",
-            description="Set by Assembly in writeNIP30 once the region has been placed",
-            default=False,
-            saveToDB=False,
-        )
-
     with pDefs.createBuilder(
         default=0.0,
         location=ParamLocation.AVERAGE,
@@ -468,12 +454,6 @@ def getBlockParameterDefinitions():
         pb.defParam(
             "fuelWorth",
             units="dk/kk'-kg",
-            description="Reactivity worth of fuel material per unit mass",
-        )
-
-        pb.defParam(
-            "fuelWorthDollarsPerKg",
-            units="$/kg",
             description="Reactivity worth of fuel material per unit mass",
         )
 
@@ -508,33 +488,9 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "coolantWorthDollarsPerKg",
-            units="$/kg",
-            description="Reactivity worth of coolant material per unit mass",
-        )
-
-        pb.defParam(
             "cladWorth",
             units="dk/kk'-kg",
             description="Reactivity worth of clad material per unit mass",
-        )
-
-        pb.defParam(
-            "cladWorthDollarsPerKg",
-            units="$/kg",
-            description="Reactivity worth of clad material per unit mass",
-        )
-
-        pb.defParam(
-            "structureWorth",
-            units="dk/kk'-kg",
-            description="Reactivity worth of structure material per unit mass",
-        )
-
-        pb.defParam(
-            "structureWorthDollarsPerKg",
-            units="$/kg",
-            description="Reactivity worth of structure material (non-clad and non-wire wrap material) per unit mass",
         )
 
         pb.defParam(
@@ -644,10 +600,6 @@ def getBlockParameterDefinitions():
             "rxVoidedDopplerCentsPerPow",
             units="cents/K",
             description="Voided Doppler power reactivity coefficient",
-        )
-
-        pb.defParam(
-            "assemPeakStd", units="pcm/%/cm^3", description="Spectral reactivity"
         )
 
     with pDefs.createBuilder(

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -217,12 +217,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "directPertKeff",
-            units=None,
-            description="K-eff is computed for the perturbed case with a direct calculation",
-        )
-
-        pb.defParam(
             "doublingTime",
             units="EFPY",
             description="The time it takes to produce enough spent fuel to fuel a daughter reactor",
@@ -232,12 +226,6 @@ def defineCoreParameters():
 
         pb.defParam(
             "heavyMetalMass", units="g", description="Heavy Metal mass of the reactor"
-        )
-
-        pb.defParam(
-            "innerMatrixIndex",
-            units=None,
-            description="The item index of the inner matrix in an optimization case",
         )
 
         pb.defParam(
@@ -505,16 +493,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "cladDensity", units="cents/K", description="Clad temperature coefficient"
-        )
-
-        pb.defParam(
-            "structureDensity",
-            units="cents/K",
-            description="Structure temperature coefficient",
-        )
-
-        pb.defParam(
             "Voideddoppler", units="cents/K", description="Voided Doppler coefficient"
         )
 
@@ -769,8 +747,6 @@ def defineCoreParameters():
             description="Percent of axial growth of fuel blocks",
             default=0.0,
         )
-
-        pb.defParam("corePow", units="?", description="?")
 
         pb.defParam("coupledIteration", units="?", description="?", default=0)
 


### PR DESCRIPTION
## Description

I have done extensive testing on all the downstream repos I have access to.

And removing these 16 parameters changed nothing.  I believe they are all unused and defunct.

This PR removes the parameters:

* assemPeakStd
* cladDensity
* cladWorthDollarsPerKg
* coolantWorthDollarsPerKg
* corePow
* coupledIteration
* detailedDpaNewCycle
* detailedDpaPeakNewCycle
* directPertKeff
* dpaRx
* fuelRadialDisplacement
* fuelWorthDollarsPerKg
* hydDiam
* innerMatrixIndex
* regName
* structureDensity
* structureWorth
* structureWorthDollarsPerKg

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
