### PR TITLE
Fix typo in `suiteBuilder` API

### DIFF
--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -95,7 +95,7 @@ class SuiteBuilder:
         """
         raise NotImplementedError
 
-    def addModiferSet(self, inputModifierSet: List):
+    def addModifierSet(self, inputModifierSet: List):
         """
         Add a single input modifier set to the suite.
 


### PR DESCRIPTION
## Description

Just a small typo that I came across in the API.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

