### PR TITLE
Moving hyper-specific TH parameters out of ARMI

### DIFF
--- a/armi/physics/thermalHydraulics/parameters.py
+++ b/armi/physics/thermalHydraulics/parameters.py
@@ -46,19 +46,6 @@ def _getBlockParams():
     with pDefs.createBuilder(
         default=0.0, location=ParamLocation.AVERAGE, categories=["thermal hydraulics"]
     ) as pb:
-        pb.defParam(
-            "THaveInletVel",
-            units="m/s",
-            saveToDB=True,
-            description="Average fluid velocity taken at the inlet of the block.",
-        )
-
-        pb.defParam(
-            "THaveOutletVel",
-            units="m/s",
-            saveToDB=True,
-            description="Average fluid velocity taken at the outlet of the block.",
-        )
 
         pb.defParam(
             "THhotChannelCladMidwallT",
@@ -72,34 +59,6 @@ def _getBlockParams():
             units="W/m^2/K",
             saveToDB=True,
             description="Film heat transfer coefficient for hot channel in the assembly.",
-        )
-
-        pb.defParam(
-            "THinletDynamicPressure",
-            units="Pa",
-            saveToDB=False,
-            description="Dynamic pressure drop component taken at the inlet of the block.",
-        )
-
-        pb.defParam(
-            "THmixingLength",
-            units=units.UNITLESS,
-            saveToDB=False,
-            description="Approximation of length for subchannel mixing in subchan model.",
-        )
-
-        pb.defParam(
-            "THpeakingStdDev",
-            units=units.UNITLESS,
-            saveToDB=False,
-            description="Standard deviation of pin peaking for modeling pin-level power in subchan.",
-        )
-
-        pb.defParam(
-            "THradialPeakingFactor",
-            units=units.UNITLESS,
-            saveToDB=False,
-            description="Approximation of radial peaking for modeling pin-level power in subchan.",
         )
 
     with pDefs.createBuilder(
@@ -131,13 +90,6 @@ def _getBlockParams():
             "THhotChannelFuelCenterlineT",
             units=units.DEGC,
             description="Nominal hot channel fuel centerline temperature",
-            categories=["thInterface"],
-        )
-
-        pb.defParam(
-            "THdeltaPBundle",
-            units="Pa",
-            description="Pressure difference in a bundle, including contributions from friction, acceleration, and gravity",
             categories=["thInterface"],
         )
 
@@ -184,27 +136,6 @@ def _getBlockParams():
         )
 
         pb.defParam(
-            "TH0SigmaFuelCenterlineT",
-            units=units.DEGC,
-            description="0-sigma fuel centerline temperature",
-            categories=["thInterface"],
-        )
-
-        pb.defParam(
-            "TH2SigmaFuelCenterlineT",
-            units=units.DEGC,
-            description="2-sigma fuel centerline temperature",
-            categories=["thInterface"],
-        )
-
-        pb.defParam(
-            "TH3SigmaFuelCenterlineT",
-            units=units.DEGC,
-            description="3-sigma fuel centerline temperature",
-            categories=["thInterface"],
-        )
-
-        pb.defParam(
             "THdilationPressure",
             units="Pa",
             description="Dilation pressure",
@@ -216,27 +147,6 @@ def _getBlockParams():
     with pDefs.createBuilder(
         default=0.0, categories=["thInterface"], saveToDB=True
     ) as pb:
-
-        pb.defParam(
-            "TH0SigmaOutletT",
-            units=units.DEGC,
-            description="0-sigma clad outer diameter temperature of the hot pin",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "TH2SigmaOutletT",
-            units=units.DEGC,
-            description="2-sigma clad outer diameter temperature of the hot pin",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "TH3SigmaOutletT",
-            units=units.DEGC,
-            description="3-sigma clad outer diameter temperature of the hot pin",
-            location=ParamLocation.AVERAGE,
-        )
 
         pb.defParam(
             "THTfuelCL",
@@ -263,13 +173,6 @@ def _getBlockParams():
             "THaverageCladIDT",
             units=units.DEGC,
             description="Block average of the inner clad temperature",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "THaveCoolantVel",
-            units="m/s",
-            description="Average of the inlet and outlet coolant velocities",
             location=ParamLocation.AVERAGE,
         )
 
@@ -324,27 +227,6 @@ def _getBlockParams():
         )
 
         pb.defParam(
-            "THdeltaPFormLoss",
-            units="Pa",
-            description="Pressure differences due to user input loss coefficeints",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "THdeltaPGrav",
-            units="Pa",
-            description="hydrostatic pressure difference in a block",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "THdeltaPNoGrav",
-            units="Pa",
-            description="Sum of the loss pressure drops due to friction, acceleration, and inlet + outlet",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "THdeltaPTotal",
             units="Pa",
             description="Total pressure difference in a block",
@@ -380,20 +262,6 @@ def _getBlockParams():
         )
 
         pb.defParam(
-            "THmaxCoolantVel",
-            units="m/s",
-            description="The maximum outlet coolant velocity",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "THorificeSetting",
-            units="Pa/(kg/s)**2",
-            description="A list of orifice settings corresponding to the assembly list",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "THorificeZone",
             units=units.UNITLESS,
             description="A list of orificing zones corresponding to the assembly list",
@@ -419,37 +287,10 @@ def _getBlockParams():
         )
 
         pb.defParam(
-            "THcoldChanTemp",
-            units=units.DEGC,
-            description="Best estimate cold channel temperature",
-            location=ParamLocation.TOP,
-        )
-
-        pb.defParam(
-            "THcoldChannel",
-            units=units.UNITLESS,
-            description="Cold channel (lowest coolant dT) identifier",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "THcoldPin",
-            units=units.UNITLESS,
-            description="Cold pin (lowest PCT) pin identifier",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "THhotChannel",
             units=units.UNITLESS,
             description="Hot channel (highest coolant dT) identifier",
             location=ParamLocation.AVERAGE,
         )
 
-        pb.defParam(
-            "THhotPin",
-            units=units.UNITLESS,
-            description="Hot pin (highest PCT) pin identifier",
-            location=ParamLocation.AVERAGE,
-        )
     return pDefs

--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -286,13 +286,6 @@ def getAssemblyParameterDefinitions():
         )
 
         pb.defParam(
-            "THorificeSetting",
-            units="Pa/$(kg/s)^2$",
-            description="The ratio of pressure drop over mass flow rate squared, through an orifice",
-            default=None,
-        )
-
-        pb.defParam(
             "THorificeZone",
             units=None,
             description="orifice zone for assembly; should be location specific",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -347,12 +347,6 @@ def getBlockParameterDefinitions():
             categories=[parameters.Category.retainOnReplacement],
         )
 
-        pb.defParam(
-            "pinPeakingStdDev",
-            units="None",
-            description="Standard deviation of the pin peaking factors for the block",
-        )
-
     with pDefs.createBuilder() as pb:
 
         pb.defParam(


### PR DESCRIPTION
## Description

After working with @andfranklin , I have determined that we should move the following 23 parameters out of ARMI and into a downstream Thermal Hydraulics Plugin.  The major motivation here is to help centralize the TH teams work. As these parameters are a bit too specific to be generally useful to the community. And more importantly, the TH team is putting a lot of effort into tweaking and re-aligning these parameters, which really makes it sound like these parameters should belong in their code.

- pinPeakingStdDev
- TH0SigmaFuelCenterlineT
- TH0SigmaOutletT
- TH2SigmaFuelCenterlineT
- TH2SigmaOutletT
- TH3SigmaFuelCenterlineT
- TH3SigmaOutletT
- THaveCoolantVel
- THaveInletVel
- THaveOutletVel
- THcoldChannel
- THcoldChanTemp
- THcoldPin
- THdeltaPBundle
- THdeltaPFormLoss
- THdeltaPGrav
- THdeltaPNoGrav
- THhotPin
- THinletDynamicPressure
- THmaxCoolantVel
- THmixingLength
- THorificeSetting
- THpeakingStdDev
- THradialPeakingFactor 

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
