### PR TITLE
Adding a settings validator for coupling

### DIFF
--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -478,6 +478,16 @@ class Inspector:
         )
 
         self.addQuery(
+            lambda: not self.cs["looseCoupling"]
+            and self.cs["numCoupledIterations"] > 0,
+            "You have {0} coupled iterations selected, but have not activated loose coupling.".format(
+                self.cs["numCoupledIterations"]
+            ),
+            "Set looseCoupling to True?",
+            lambda: self._assignCS("looseCoupling", True),
+        )
+
+        self.addQuery(
             lambda: self.cs["numCoupledIterations"] > 0,
             "You have {0} coupling iterations selected.".format(
                 self.cs["numCoupledIterations"]


### PR DESCRIPTION
## Description
It's easy to set numCoupledIterations > 0 and forget to set looseCoupling: True. If you do this, then the coupling scheme will "run" but o.couplingIsActive() will evaluate to false. This can lead to unexpected results. 
https://github.com/terrapower/armi/blob/359363d06f55b6f33316673ab057a3cb5d2eeb87/armi/operators/operator.py#L1061-L1063
This settings validator aims to remedy this. 

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

