### PR TITLE
TOX has changed their naming conventions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
     pytest --ignore=armi/utils/tests/test_gridGui.py -n 4 armi
 
 [testenv:doc]
-whitelist_externals =
+allowlist_externals =
     /usr/bin/git
     /usr/bin/make
 deps=
@@ -37,7 +37,7 @@ deps=
     mpi4py
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-testing.txt
-whitelist_externals =
+allowlist_externals =
     /usr/bin/mpiexec
 commands =
     mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv --cov-fail-under=80 armi/tests/test_mpiFeatures.py
@@ -49,7 +49,7 @@ deps=
     mpi4py
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-testing.txt
-whitelist_externals =
+allowlist_externals =
     /usr/bin/mpiexec
 commands =
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
@@ -61,7 +61,7 @@ commands =
 deps=
     pip >= 20.2
     mpi4py
-whitelist_externals =
+allowlist_externals =
     /usr/bin/mpiexec
 commands =
     pip install -r requirements.txt


### PR DESCRIPTION
## Description

TOX has made a change to their naming conventions. They changed the name `whitelist_externals` to `allowlist_externals`.

It's a fine change. I don't mind it.  But it surprised me and bit our CI for a few hours.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
