### PR TITLE
Fixing docstring for setDimension

### DIFF
--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -34,7 +34,6 @@ from armi.utils.units import C_TO_K
 from armi.materials import void
 from armi.nucDirectory import nuclideBases
 from armi import materials
-from armi.reactor.flags import Flags
 
 COMPONENT_LINK_REGEX = re.compile(r"^\s*(.+?)\s*\.\s*(.+?)\s*$")
 
@@ -792,8 +791,7 @@ class Component(composites.Composite, metaclass=ComponentType):
             If True, the val will be applied to the dimension of linked
             component which indirectly changes this component's dimensions.
         cold : book, optional
-            If True sets the component to the dimension that would cause
-            the hot dimension to be the specified value.
+            If True sets the component cold dimension to the specified value.
         """
         if not key:
             return


### PR DESCRIPTION
## Description

This was a documentation upgrade suggested by @jasonbmeng in Issue #1011 

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
