### PR TITLE
Add coveralls token to GH action config.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,7 @@ omit =
     venv/
 source = armi
 # change default .coverage file to something that doesn't have a dot
-# because our Windows file server can't handle dots. :s
+# because the Windows file server can't handle dots.
 data_file = coverage_results.cov
 
 [coverage:run]

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,18 +27,12 @@ jobs:
         run: tox -e cov1 || true
       - name: Run Coverage Part 2
         run: tox -e cov2
-      - name: Covert Coverage Results
+      - name: Convert Coverage Results
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           pip install coveragepy-lcov
           coveragepy-lcov --data_file_path coverage_results.cov --output_file_path lcov.txt
-#      - name: Run Coverage Part 3
-#        env:
-#          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-#        run: |
-#          pip install coveralls
-#          coveralls --service=github
       - name: Publish to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -26,15 +26,19 @@ jobs:
       - name: Run Coverage Part 1
         run: tox -e cov1 || true
       - name: Run Coverage Part 2
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: tox -e cov2
-      - name: Run Coverage Part 3
+      - name: Covert Coverage Results
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
-          pip install coveralls
-          coveralls --service=github
+          pip install coveragepy-lcov
+          coveragepy-lcov --data_file_path coverage_results.cov --output_file_path lcov.info
+#      - name: Run Coverage Part 3
+#        env:
+#          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+#        run: |
+#          pip install coveralls
+#          coveralls --service=github
       - name: Publish to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -26,10 +26,17 @@ jobs:
       - name: Run Coverage Part 1
         run: tox -e cov1 || true
       - name: Run Coverage Part 2
-        run: tox -e cov2
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: tox -e cov2
+      - name: Run Coverage Part 3
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          pip install coveralls
+          coveralls --service=github
       - name: Publish to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -43,4 +43,5 @@ jobs:
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          path-to-lcov: lcov.info
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,6 +9,7 @@ jobs:
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,6 +27,8 @@ jobs:
         run: tox -e cov1 || true
       - name: Run Coverage Part 2
         run: tox -e cov2
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       - name: Publish to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -26,5 +26,8 @@ jobs:
       - name: Run Coverage Part 1
         run: tox -e cov1 || true
       - name: Run Coverage Part 2
-        run: tox -e cov2,report
-
+        run: tox -e cov2
+      - name: Publish to coveralls.io
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -32,7 +32,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           pip install coveragepy-lcov
-          coveragepy-lcov --data_file_path coverage_results.cov --output_file_path lcov.info
+          coveragepy-lcov --data_file_path coverage_results.cov --output_file_path lcov.txt
 #      - name: Run Coverage Part 3
 #        env:
 #          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
@@ -43,5 +43,5 @@ jobs:
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          path-to-lcov: lcov.info
+          path-to-lcov: lcov.txt
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -42,6 +42,6 @@ jobs:
       - name: Publish to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:
-          github-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.txt
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,6 +1,5 @@
 --prefer-binary
 numpy>=1.21
-coveralls
 
 # docutils 0.17 introduced a bug that prevents bullets from rendering
 # see https://github.com/terrapower/armi/issues/274

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,5 +1,6 @@
 --prefer-binary
 numpy>=1.21
+coveralls
 
 # docutils 0.17 introduced a bug that prevents bullets from rendering
 # see https://github.com/terrapower/armi/issues/274

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,6 @@ commands =
     coveralls --service=github
 depends =
     cov
-passenv = TOXENV CI GITHUB_*
 
 [testenv:manifest]
 basepython = {env:PYTHON3_PATH:python3}

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ allowlist_externals =
 commands =
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a
+    coveralls
 
 # NOTE: This only runs the MPI unit tests.
 # NOTE: This will only work in POSIX/BASH Linux.
@@ -72,6 +73,17 @@ commands =
 ignore_errors = true
 commands =
      - pylint armi --rcfile={toxinidir}/pylintrc
+
+[testenv:report]
+skip_install = true
+deps=
+    pip>=20.2
+    mpi4py
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-testing.txt
+commands =
+    coverage report
+    coverage html
 
 [testenv:manifest]
 basepython = {env:PYTHON3_PATH:python3}

--- a/tox.ini
+++ b/tox.ini
@@ -52,9 +52,9 @@ deps=
 allowlist_externals =
     /usr/bin/mpiexec
 commands =
-    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
+    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi/tests/test_runLog.py
     coverage combine --rcfile=.coveragerc --keep -a
-    coveralls --service=github
+#    coveralls --service=github
 
 # NOTE: This only runs the MPI unit tests.
 # NOTE: This will only work in POSIX/BASH Linux.

--- a/tox.ini
+++ b/tox.ini
@@ -73,17 +73,6 @@ ignore_errors = true
 commands =
      - pylint armi --rcfile={toxinidir}/pylintrc
 
-[testenv:report]
-skip_install = true
-deps=
-    coveralls
-commands =
-    coverage report
-    coverage html
-    coveralls --service=github
-depends =
-    cov
-
 [testenv:manifest]
 basepython = {env:PYTHON3_PATH:python3}
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -52,9 +52,8 @@ deps=
 allowlist_externals =
     /usr/bin/mpiexec
 commands =
-    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi/tests/test_runLog.py
+    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a
-#    coveralls --service=github
 
 # NOTE: This only runs the MPI unit tests.
 # NOTE: This will only work in POSIX/BASH Linux.

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ allowlist_externals =
 commands =
     coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a
-    coveralls
+    coveralls --service=github
 
 # NOTE: This only runs the MPI unit tests.
 # NOTE: This will only work in POSIX/BASH Linux.


### PR DESCRIPTION
This secret is obtained from the coveralls page and loaded using the github secrets feature.

We realized we needed this when coveralls started giving an error message that said we needed
to include this env variable.

The error message we saw was: 

```
  Wrote HTML report to htmlcov/index.html
  report: commands[2]> coveralls --service=github
  Not on TravisCI. You have to provide either repo_token in .coveralls.yml or set the COVERALLS_REPO_TOKEN env var.
  Traceback (most recent call last):
    File "/home/runner/work/armi/armi/.tox/report/lib/python3.10/site-packages/coveralls/cli.py", line 64, in main
      coverallz = Coveralls(token_required,
    File "/home/runner/work/armi/armi/.tox/report/lib/python3.10/site-packages/coveralls/api.py", line 49, in __init__
      self.ensure_token()
    File "/home/runner/work/armi/armi/.tox/report/lib/python3.10/site-packages/coveralls/api.py", line 61, in ensure_token
      raise CoverallsException(
  coveralls.exception.CoverallsException: Not on TravisCI. You have to provide either repo_token in .coveralls.yml or set the COVERALLS_REPO_TOKEN env var.
  report: exit 1 (0.16 seconds) /home/runner/work/armi/armi> coveralls --service=github pid=4199
    cov2: OK (978.37=setup[45.03]+cmd[933.23,0.11] seconds)
    report: FAIL code 1 (13.47=setup[3.72]+cmd[2.25,7.34,0.16] seconds)
    evaluation failed :( (991.99 seconds)
  Error: Process completed with exit code 255.
```

Fixes #1017 
