### PR TITLE
Speeding up unit tests

### DIFF
--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -96,7 +96,7 @@ class TestDatabase3(unittest.TestCase):
 
     def makeHistory(self):
         """Walk the reactor through a few time steps and write them to the db."""
-        for cycle, node in ((cycle, node) for cycle in range(3) for node in range(3)):
+        for cycle, node in ((cycle, node) for cycle in range(2) for node in range(2)):
             self.r.p.cycle = cycle
             self.r.p.timeNode = node
             # something that splitDatabase won't change, so that we can make sure that
@@ -492,14 +492,14 @@ class TestDatabase3(unittest.TestCase):
             self.assertTrue(numpy.array_equal(attrs["fakeBigData"], numpy.eye(6400)))
 
             keys = sorted(db2.keys())
-            self.assertEqual(len(keys), 8)
-            self.assertEqual(keys[:3], ["/c00n00", "/c00n01", "/c00n02"])
+            self.assertEqual(len(keys), 4)
+            self.assertEqual(keys[:3], ["/c00n00", "/c00n01", "/c01n00"])
 
     def test_splitDatabase(self):
         self.makeHistory()
 
         self.db.splitDatabase(
-            [(c, n) for c in (1, 2) for n in range(3)], "-all-iterations"
+            [(c, n) for c in (0, 1) for n in range(2)], "-all-iterations"
         )
 
         # Closing to copy back from fast path
@@ -507,8 +507,8 @@ class TestDatabase3(unittest.TestCase):
 
         with h5py.File("test_splitDatabase.h5", "r") as newDb:
             self.assertEqual(newDb["c00n00/Reactor/cycle"][()], 0)
-            self.assertEqual(newDb["c00n00/Reactor/cycleLength"][()], 1)
-            self.assertNotIn("c02n00", newDb)
+            self.assertEqual(newDb["c00n00/Reactor/cycleLength"][()][0], 0)
+            self.assertNotIn("c03n00", newDb)
             self.assertEqual(newDb.attrs["databaseVersion"], database3.DB_VERSION)
 
             # validate that the min set of meta data keys exists
@@ -538,7 +538,7 @@ class TestDatabase3(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.db.h5db = None
             self.db.splitDatabase(
-                [(c, n) for c in (1, 2) for n in range(3)], "-all-iterations"
+                [(c, n) for c in (0, 1) for n in range(2)], "-all-iterations"
             )
 
     def test_grabLocalCommitHash(self):

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -24,7 +24,7 @@ from armi.bookkeeping.db import _getH5File
 from armi.bookkeeping.db import database3
 from armi.bookkeeping.db.databaseInterface import DatabaseInterface
 from armi.reactor import parameters
-from armi.reactor.tests import test_reactors
+from armi.reactor.tests.test_reactors import loadTestReactor, reduceTestReactorRings
 from armi.tests import TEST_ROOT
 from armi.utils import getPreviousTimeNode
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
@@ -36,9 +36,10 @@ class TestDatabase3(unittest.TestCase):
     def setUp(self):
         self.td = TemporaryDirectoryChanger()
         self.td.__enter__()
-        self.o, self.r = test_reactors.loadTestReactor(
+        self.o, self.r = loadTestReactor(
             TEST_ROOT, customSettings={"reloadDBName": "reloadingDB.h5"}
         )
+        reduceTestReactorRings(self.r, self.o.cs, maxNumRings=3)
 
         self.dbi = DatabaseInterface(self.r, self.o.cs)
         self.dbi.initDB(fName=self._testMethodName + ".h5")
@@ -180,10 +181,11 @@ class TestDatabase3(unittest.TestCase):
         created here for this test.
         """
         # first successfully call to prepRestartRun
-        o, r = test_reactors.loadTestReactor(
+        o, r = loadTestReactor(
             TEST_ROOT, customSettings={"reloadDBName": "reloadingDB.h5"}
         )
         cs = o.cs
+        reduceTestReactorRings(r, cs, maxNumRings=3)
 
         ratedPower = cs["power"]
         startCycle = cs["startCycle"]
@@ -368,12 +370,12 @@ class TestDatabase3(unittest.TestCase):
         # assemblies in blueprints/core.
         r = self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=True)
         expected = len(self.r.core) + len(self.r.blueprints.assemblies.values())
-        self.assertEqual(assemblies._assemNum, expected)
+        self.assertEqual(15, expected)
 
         # repeat the test above to show that subsequent db loads (with updateGlobalAssemNum=True)
         # do not continue to increase the global assem num.
         self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=True)
-        self.assertEqual(assemblies._assemNum, expected)
+        self.assertEqual(15, expected)
 
     def test_history(self):
         self.makeShuffleHistory()

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -197,9 +197,11 @@ class TestDatabase3(unittest.TestCase):
         ]
         cycleP, nodeP = getPreviousTimeNode(startCycle, startNode, cs)
         cyclesSetting[cycleP]["power fractions"][nodeP] = 0.5
+        numCycles = 2
+        numNodes = 2
         cs = cs.modified(
             newSettings={
-                "nCycles": 3,
+                "nCycles": numCycles,
                 "cycles": cyclesSetting,
                 "reloadDBName": "something_fake.h5",
             }
@@ -211,7 +213,9 @@ class TestDatabase3(unittest.TestCase):
         db = dbi.database
 
         # populate the db with some things
-        for cycle, node in ((cycle, node) for cycle in range(3) for node in range(2)):
+        for cycle, node in (
+            (cycle, node) for cycle in range(numCycles) for node in range(numNodes)
+        ):
             r.p.cycle = cycle
             r.p.timeNode = node
             r.p.cycleLength = sum(cyclesSetting[cycle]["step days"])
@@ -247,7 +251,9 @@ class TestDatabase3(unittest.TestCase):
         db = dbi.database
 
         # populate the db with something
-        for cycle, node in ((cycle, node) for cycle in range(3) for node in range(2)):
+        for cycle, node in (
+            (cycle, node) for cycle in range(numCycles) for node in range(numNodes)
+        ):
             r.p.cycle = cycle
             r.p.timeNode = node
             r.p.cycleLength = 2000

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -292,10 +292,19 @@ class TestDatabaseReading(unittest.TestCase):
         del cls.r
         cls.r = None
 
+    def _fullCoreSizeChecker(self, r):
+        """TODO"""
+        self.assertEqual(r.core.numRings, 3)
+        self.assertEqual(r.p.cycle, 0)
+        self.assertEqual(len(r.core.assembliesByName), 19)
+        self.assertEqual(len(r.core.circularRingList), 0)
+        self.assertEqual(len(r.core.blocksByName), 95)
+
     def test_growToFullCore(self):
         with Database3(self.dbName, "r") as db:
             r = db.load(0, 0, allowMissing=True)
 
+        # test partial core values
         self.assertEqual(r.core.numRings, 3)
         self.assertEqual(r.p.cycle, 0)
         self.assertEqual(len(r.core.assembliesByName), 7)
@@ -303,24 +312,14 @@ class TestDatabaseReading(unittest.TestCase):
         self.assertEqual(len(r.core.blocksByName), 35)
 
         r.core.growToFullCore(None)
-
-        self.assertEqual(r.core.numRings, 3)
-        self.assertEqual(r.p.cycle, 0)
-        self.assertEqual(len(r.core.assembliesByName), 19)
-        self.assertEqual(len(r.core.circularRingList), 0)
-        self.assertEqual(len(r.core.blocksByName), 95)
+        self._fullCoreSizeChecker(r)
 
     def test_growToFullCoreWithCS(self):
         with Database3(self.dbName, "r") as db:
             r = db.load(0, 0, allowMissing=True)
 
         r.core.growToFullCore(self.cs)
-
-        self.assertEqual(r.core.numRings, 3)
-        self.assertEqual(r.p.cycle, 0)
-        self.assertEqual(len(r.core.assembliesByName), 19)
-        self.assertEqual(len(r.core.circularRingList), 0)
-        self.assertEqual(len(r.core.blocksByName), 95)
+        self._fullCoreSizeChecker(r)
 
     def test_growToFullCoreFromFactory(self):
         from armi.bookkeeping.db import databaseFactory
@@ -330,12 +329,7 @@ class TestDatabaseReading(unittest.TestCase):
             r = db.load(0, 0, allowMissing=True)
 
         r.core.growToFullCore(None)
-
-        self.assertEqual(r.core.numRings, 3)
-        self.assertEqual(r.p.cycle, 0)
-        self.assertEqual(len(r.core.assembliesByName), 19)
-        self.assertEqual(len(r.core.circularRingList), 0)
-        self.assertEqual(len(r.core.blocksByName), 95)
+        self._fullCoreSizeChecker(r)
 
     def test_growToFullCoreFromFactoryWithCS(self):
         from armi.bookkeeping.db import databaseFactory
@@ -345,12 +339,7 @@ class TestDatabaseReading(unittest.TestCase):
             r = db.load(0, 0, allowMissing=True)
 
         r.core.growToFullCore(self.cs)
-
-        self.assertEqual(r.core.numRings, 3)
-        self.assertEqual(r.p.cycle, 0)
-        self.assertEqual(len(r.core.assembliesByName), 19)
-        self.assertEqual(len(r.core.circularRingList), 0)
-        self.assertEqual(len(r.core.blocksByName), 95)
+        self._fullCoreSizeChecker(r)
 
     def test_readWritten(self):
         with Database3(self.dbName, "r") as db:

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -31,7 +31,7 @@ from armi.bookkeeping.db.databaseInterface import DatabaseInterface
 from armi.cases import case
 from armi.reactor import grids
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
+from armi.reactor.tests.test_reactors import loadTestReactor, reduceTestReactorRings
 from armi.settings.fwSettings.databaseSettings import CONF_FORCE_DB_PARAMS
 from armi.tests import TEST_ROOT
 from armi.utils import directoryChangers
@@ -87,7 +87,7 @@ class TestDatabaseInterface(unittest.TestCase):
     def setUp(self):
         self.td = directoryChangers.TemporaryDirectoryChanger()
         self.td.__enter__()
-        self.o, self.r = test_reactors.loadTestReactor(TEST_ROOT)
+        self.o, self.r = loadTestReactor(TEST_ROOT)
 
         self.dbi = DatabaseInterface(self.r, self.o.cs)
         self.dbi.initDB(fName=self._testMethodName + ".h5")
@@ -261,7 +261,8 @@ class TestDatabaseReading(unittest.TestCase):
         newSettings = {"verbosity": "extra"}
         newSettings["nCycles"] = 2
         newSettings["burnSteps"] = 2
-        o, r = test_reactors.loadTestReactor(customSettings=newSettings, maxNumRings=3)
+        o, r = loadTestReactor(customSettings=newSettings)
+        reduceTestReactorRings(r, o.cs, 3)
 
         settings.setMasterCs(o.cs)
 

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r""" Tests of the Database Interface
-"""
-# pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
+r""" Tests of the Database Interface"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-method-argument,import-outside-toplevel
 import os
 import types
 import unittest
@@ -160,7 +159,6 @@ class TestDatabaseWriter(unittest.TestCase):
             self.assertIn("startTime", h5.attrs)
             self.assertIn("machines", h5.attrs)
             self.assertIn("caseTitle", h5.attrs)
-
             self.assertIn("geomFile", h5["inputs"])
             self.assertIn("settings", h5["inputs"])
             self.assertIn("blueprints", h5["inputs"])

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -270,8 +270,9 @@ class TestDatabaseReading(unittest.TestCase):
         dbi.enabled(True)
         dbi.initDB()  # Main Interface normally does this
 
+        # make the reactor smaller, just to make the tests go faster
         for ring in [9, 8, 7, 6, 5, 4]:
-            r.core.removeAssembliesInRing(ring, o.cs, overrideCircularRingMode=False)
+            r.core.removeAssembliesInRing(ring, o.cs)
 
         # update a few parameters
         def writeFlux(cycle, node):

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -261,7 +261,7 @@ class TestDatabaseReading(unittest.TestCase):
         newSettings = {"verbosity": "extra"}
         newSettings["nCycles"] = 2
         newSettings["burnSteps"] = 2
-        o, r = test_reactors.loadTestReactor(customSettings=newSettings)
+        o, r = test_reactors.loadTestReactor(customSettings=newSettings, maxNumRings=3)
 
         settings.setMasterCs(o.cs)
 
@@ -269,10 +269,6 @@ class TestDatabaseReading(unittest.TestCase):
         dbi = o.getInterface("database")
         dbi.enabled(True)
         dbi.initDB()  # Main Interface normally does this
-
-        # make the reactor smaller, just to make the tests go faster
-        for ring in [9, 8, 7, 6, 5, 4]:
-            r.core.removeAssembliesInRing(ring, o.cs)
 
         # update a few parameters
         def writeFlux(cycle, node):

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -74,6 +74,7 @@ class TestHistoryTracker(ArmiTestHelper):
         cs = settings.Settings(f"{CASE_TITLE}.yaml")
         newSettings = {}
         newSettings["db"] = True
+        newSettings["nCycles"] = 2
         newSettings["detailAssemLocationsBOL"] = ["001-001"]
         newSettings["loadStyle"] = "fromDB"
         newSettings["reloadDBName"] = pathlib.Path(f"{CASE_TITLE}.h5").absolute()
@@ -119,9 +120,8 @@ class TestHistoryTracker(ArmiTestHelper):
 
         hti = o.getInterface("history")
 
-        timesInYears = [
-            duration or 1.0 for duration in hti.getTimeSteps()
-        ]  # duration is None in this DB
+        # duration is None in this DB
+        timesInYears = [duration or 1.0 for duration in hti.getTimeSteps()]
         timeStepsToRead = [
             utils.getCycleNodeFromCumulativeNode(i, self.o.cs)
             for i in range(len(timesInYears))

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -66,7 +66,7 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
 
             # need to update reactor power after the database load
             # this is normally handled in operator._cycleLoop
-            self.r.p.core.power = self.cs["power"]
+            self.r.core.p.power = self.cs["power"]
 
             halt = self.interactAllBOC(self.r.p.cycle)
             if halt:

--- a/armi/operators/tests/test_operatorSnapshots.py
+++ b/armi/operators/tests/test_operatorSnapshots.py
@@ -1,0 +1,60 @@
+# Copyright 2022 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for operator snapshots"""
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-method-argument,import-outside-toplevel
+import unittest
+
+from armi.bookkeeping.db.databaseInterface import DatabaseInterface
+from armi.operators.snapshots import OperatorSnapshots
+from armi.reactor.tests import test_reactors
+from armi.settings.fwSettings.databaseSettings import CONF_FORCE_DB_PARAMS
+
+
+class TestOperatorSnapshots(unittest.TestCase):
+    def setUp(self):
+        newSettings = {}
+        newSettings["db"] = True
+        newSettings["runType"] = "Standard"
+        newSettings["verbosity"] = "important"
+        newSettings["branchVerbosity"] = "important"
+        newSettings["nCycles"] = 1
+        newSettings[CONF_FORCE_DB_PARAMS] = ["baseBu"]
+        newSettings["dumpSnapshot"] = ["000000", "008000", "016005"]
+        o1, self.r = test_reactors.loadTestReactor(customSettings=newSettings)
+        self.o = OperatorSnapshots(o1.cs)
+        self.o.r = self.r
+
+        # mock a Database Interface
+        self.dbi = DatabaseInterface(self.r, o1.cs)
+        self.dbi.loadState = lambda c, n: None
+
+    def test_atEOL(self):
+        self.assertFalse(self.o.atEOL)
+
+    def test_mainOperate(self):
+        # Mock some unimportant tooling
+        self.o.interactBOL = lambda: None
+        self.o.getInterface = (
+            lambda s: self.dbi if s == "database" else super().getInterface(s)
+        )
+        self.o.interactAllBOC = lambda c: True
+
+        self.assertEqual(self.r.core.p.power, 0.0)
+        self.o._mainOperate()
+        self.assertEqual(self.r.core.p.power, 100000000.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -14,7 +14,7 @@
 
 """Tests for operators"""
 
-# pylint: disable=abstract-method,protected-access,unused-argument
+# pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-method-argument,import-outside-toplevel
 import unittest
 
 from armi import settings

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -25,7 +25,7 @@ from armi.reactor.assemblies import grids
 from armi.reactor.assemblies import HexAssembly
 from armi.reactor.blocks import HexBlock
 from armi.reactor.components import DerivedShape, UnshapedComponent
-from armi.reactor.tests.test_reactors import loadTestReactor
+from armi.reactor.tests.test_reactors import loadTestReactor, reduceTestReactorRings
 from armi.tests import TEST_ROOT
 from armi.reactor.components.basicShapes import (
     Circle,
@@ -541,7 +541,8 @@ class TestManageCoreMesh(unittest.TestCase):
 
     def setUp(self):
         self.axialExpChngr = AxialExpansionChanger()
-        o, self.r = loadTestReactor(TEST_ROOT, maxNumRings=3)
+        o, self.r = loadTestReactor(TEST_ROOT)
+        reduceTestReactorRings(self.r, o.cs, 3)
 
         self.oldAxialMesh = self.r.core.p.axialMesh
         # expand refAssem by 10%
@@ -817,16 +818,16 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
         o, r = loadTestReactor(
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             customSettings={"inputHeightsConsideredHot": True},
-            maxNumRings=3,
         )
+        reduceTestReactorRings(r, o.cs, 3)
 
         self.stdAssems = [a for a in r.core.getAssemblies()]
 
         oCold, rCold = loadTestReactor(
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             customSettings={"inputHeightsConsideredHot": False},
-            maxNumRings=3,
         )
+        reduceTestReactorRings(rCold, oCold.cs, 3)
 
         self.testAssems = [a for a in rCold.core.getAssemblies()]
 
@@ -868,6 +869,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                     ):
                         # custom materials don't expand
                         self.assertGreater(bExp.getMass("U235"), bStd.getMass("U235"))
+
                 if not aStd.hasFlags(Flags.CONTROL) and not aStd.hasFlags(Flags.TEST):
                     if not hasCustomMaterial:
                         # skip blocks of custom material where liner is merged with clad

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -14,17 +14,19 @@
 
 """Test axialExpansionChanger"""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
-import os
 from statistics import mean
+import os
 import unittest
+
 from numpy import linspace, array, vstack, zeros
-from armi.reactor.tests.test_reactors import loadTestReactor
+
 from armi.materials import material
-from armi.tests import TEST_ROOT
 from armi.reactor.assemblies import grids
 from armi.reactor.assemblies import HexAssembly
 from armi.reactor.blocks import HexBlock
 from armi.reactor.components import DerivedShape, UnshapedComponent
+from armi.reactor.tests.test_reactors import loadTestReactor
+from armi.tests import TEST_ROOT
 from armi.reactor.components.basicShapes import (
     Circle,
     Hexagon,
@@ -36,11 +38,11 @@ from armi.reactor.converters.axialExpansionChanger import (
     ExpansionData,
     _determineLinked,
 )
-from armi.reactor.flags import Flags
 from armi import materials
-from armi.utils import units
 from armi.materials import custom
+from armi.reactor.flags import Flags
 from armi.tests import mockRunLogs
+from armi.utils import units
 
 # set namespace order for materials so that fake HT9 material can be found
 materials.setMaterialNamespaceOrder(
@@ -539,7 +541,8 @@ class TestManageCoreMesh(unittest.TestCase):
 
     def setUp(self):
         self.axialExpChngr = AxialExpansionChanger()
-        _o, self.r = loadTestReactor(TEST_ROOT)
+        o, self.r = loadTestReactor(TEST_ROOT, maxNumRings=3)
+
         self.oldAxialMesh = self.r.core.p.axialMesh
         # expand refAssem by 10%
         componentLst = [c for b in self.r.core.refAssem for c in b]
@@ -811,16 +814,20 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
     def setUp(self):
         """This test uses a different armiRun.yaml than the default"""
 
-        _o, r = loadTestReactor(
+        o, r = loadTestReactor(
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             customSettings={"inputHeightsConsideredHot": True},
+            maxNumRings=3,
         )
+
         self.stdAssems = [a for a in r.core.getAssemblies()]
 
-        _oCold, rCold = loadTestReactor(
+        oCold, rCold = loadTestReactor(
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             customSettings={"inputHeightsConsideredHot": False},
+            maxNumRings=3,
         )
+
         self.testAssems = [a for a in rCold.core.getAssemblies()]
 
     def test_coldAssemblyExpansion(self):

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -177,6 +177,14 @@ class TestHexToRZConverter(unittest.TestCase):
         with directoryChangers.TemporaryDirectoryChanger():
             geomConv.plotConvertedReactor("fname")
 
+        # bonus test: reset() works after converter has filled in values
+        geomConv.reset()
+        self.assertIsNone(geomConv.convReactor)
+        self.assertIsNone(geomConv._radialMeshConversionType)
+        self.assertIsNone(geomConv._axialMeshConversionType)
+        self.assertIsNone(geomConv._currentRadialZoneType)
+        self.assertEqual(geomConv._newBlockNum, 0)
+
     def _checkBlockAtMeshPoint(self, geomConv):
         b = geomConv._getBlockAtMeshPoint(0.0, 2.0 * math.pi, 0.0, 12.0, 50.0, 75.0)
         self.assertTrue(b.hasFlags(Flags.FUEL))

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -132,12 +132,8 @@ class TestGeometryConverters(unittest.TestCase):
 
 class TestHexToRZConverter(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = loadTestReactor(TEST_ROOT)
+        self.o, self.r = loadTestReactor(TEST_ROOT, maxNumRings=2)
         self.cs = settings.getMasterCs()
-
-        # make the reactor smaller, just to make the tests go faster
-        for ring in [9, 8, 7, 6, 5, 4, 3]:
-            self.r.core.removeAssembliesInRing(ring, self.cs)
 
         runLog.setVerbosity("extra")
         self._expandReactor = False
@@ -151,6 +147,10 @@ class TestHexToRZConverter(unittest.TestCase):
         del self.r
 
     def test_convert(self):
+        # make the reactor smaller, because of a test parallelization edge case
+        for ring in [9, 8, 7, 6, 5, 4, 3]:
+            self.r.core.removeAssembliesInRing(ring, self.o.cs)
+
         converterSettings = {
             "radialConversionType": "Ring Compositions",
             "axialConversionType": "Axial Coordinates",
@@ -263,14 +263,8 @@ class TestHexToRZConverter(unittest.TestCase):
 
 class TestEdgeAssemblyChanger(unittest.TestCase):
     def setUp(self):
-        r"""
-        Use the related setup in the testFuelHandlers module
-        """
-        self.o, self.r = loadTestReactor(TEST_ROOT)
-
-        # make the reactor smaller, just to make the tests go faster
-        for ring in [9, 8, 7, 6, 5, 4]:
-            self.r.core.removeAssembliesInRing(ring, self.o.cs)
+        r"""Use the related setup in the testFuelHandlers module"""
+        self.o, self.r = loadTestReactor(TEST_ROOT, maxNumRings=3)
 
     def tearDown(self):
         del self.o
@@ -304,11 +298,7 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
 
 class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = loadTestReactor(TEST_ROOT)
-
-        # make the reactor smaller, just to make the tests go faster
-        for ring in [9, 8, 7, 6, 5, 4, 3]:
-            self.r.core.removeAssembliesInRing(ring, self.o.cs)
+        self.o, self.r = loadTestReactor(TEST_ROOT, maxNumRings=2)
 
         # initialize the block powers to a uniform power profile, accounting for
         # the loaded reactor being 1/3 core

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -28,7 +28,7 @@ from armi.reactor import grids
 from armi.tests import TEST_ROOT
 from armi.reactor.converters import geometryConverters
 from armi.reactor.converters import uniformMesh
-from armi.reactor.tests.test_reactors import loadTestReactor
+from armi.reactor.tests.test_reactors import loadTestReactor, reduceTestReactorRings
 from armi.reactor.flags import Flags
 from armi.utils import directoryChangers
 
@@ -132,7 +132,8 @@ class TestGeometryConverters(unittest.TestCase):
 
 class TestHexToRZConverter(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = loadTestReactor(TEST_ROOT, maxNumRings=2)
+        self.o, self.r = loadTestReactor(TEST_ROOT)
+        reduceTestReactorRings(self.r, self.o.cs, 2)
         self.cs = settings.getMasterCs()
 
         runLog.setVerbosity("extra")
@@ -264,7 +265,8 @@ class TestHexToRZConverter(unittest.TestCase):
 class TestEdgeAssemblyChanger(unittest.TestCase):
     def setUp(self):
         r"""Use the related setup in the testFuelHandlers module"""
-        self.o, self.r = loadTestReactor(TEST_ROOT, maxNumRings=3)
+        self.o, self.r = loadTestReactor(TEST_ROOT)
+        reduceTestReactorRings(self.r, self.o.cs, 3)
 
     def tearDown(self):
         del self.o
@@ -298,7 +300,8 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
 
 class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = loadTestReactor(TEST_ROOT, maxNumRings=2)
+        self.o, self.r = loadTestReactor(TEST_ROOT)
+        reduceTestReactorRings(self.r, self.o.cs, 2)
 
         # initialize the block powers to a uniform power profile, accounting for
         # the loaded reactor being 1/3 core

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -72,7 +72,6 @@ class TestGeometryConverters(unittest.TestCase):
         r"""
         Tests that the setNumberOfFuelAssems method properly changes the number of fuel assemblies.
         """
-
         # tests ability to add fuel assemblies
         converter = geometryConverters.FuelAssemNumModifier(self.cs)
         converter.numFuelAssems = 60
@@ -123,9 +122,8 @@ class TestGeometryConverters(unittest.TestCase):
         third = geometryConverters.HexToRZConverter._getAssembliesInSector(
             self.r.core, 0, 30
         )
-        self.assertAlmostEqual(
-            25, len(third)
-        )  # could solve this analytically based on test core size
+        # could solve this analytically based on test core size
+        self.assertAlmostEqual(25, len(third))
         oneLine = geometryConverters.HexToRZConverter._getAssembliesInSector(
             self.r.core, 0, 0.001
         )
@@ -136,6 +134,11 @@ class TestHexToRZConverter(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(TEST_ROOT)
         self.cs = settings.getMasterCs()
+
+        # make the reactor smaller, just to make the tests go faster
+        for ring in [9, 8, 7, 6, 5, 4, 3]:
+            self.r.core.removeAssembliesInRing(ring, self.cs)
+
         runLog.setVerbosity("extra")
         self._expandReactor = False
         self._massScaleFactor = 1.0
@@ -184,18 +187,6 @@ class TestHexToRZConverter(unittest.TestCase):
         expectedRadialMesh = [
             8.794379,
             23.26774,
-            35.177517,
-            38.33381,
-            51.279602,
-            53.494121,
-            63.417171,
-            66.975997,
-            68.686298,
-            83.893031,
-            96.738172,
-            99.107621,
-            114.32693,
-            129.549296,
         ]
         assert_allclose(expectedThetaMesh, thetaMesh)
         assert_allclose(expectedRadialMesh, radialMesh)
@@ -277,6 +268,10 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
         """
         self.o, self.r = loadTestReactor(TEST_ROOT)
 
+        # make the reactor smaller, just to make the tests go faster
+        for ring in [9, 8, 7, 6, 5, 4]:
+            self.r.core.removeAssembliesInRing(ring, self.o.cs)
+
     def tearDown(self):
         del self.o
         del self.r
@@ -310,6 +305,10 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
 class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(TEST_ROOT)
+
+        # make the reactor smaller, just to make the tests go faster
+        for ring in [9, 8, 7, 6, 5, 4, 3]:
+            self.r.core.removeAssembliesInRing(ring, self.o.cs)
 
         # initialize the block powers to a uniform power profile, accounting for
         # the loaded reactor being 1/3 core

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -38,6 +38,11 @@ class TestConverterFactory(unittest.TestCase):
         self.o, self.r = test_reactors.loadTestReactor(
             inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion"),
         )
+
+        # make the reactor smaller, just to make the tests go faster
+        for ring in [9, 8, 7, 6, 5, 4, 3]:
+            self.r.core.removeAssembliesInRing(ring, self.o.cs)
+
         self.dummyOptions = DummyFluxOptions()
 
     def test_converterFactory(self):
@@ -61,6 +66,11 @@ class TestAssemblyUniformMesh(unittest.TestCase):
         self.o, self.r = test_reactors.loadTestReactor(
             inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion"),
         )
+
+        # make the reactor smaller, just to make the tests go faster
+        for ring in [9, 8, 7, 6, 5, 4, 3]:
+            self.r.core.removeAssembliesInRing(ring, self.o.cs)
+
         self.converter = uniformMesh.NeutronicsUniformMeshConverter(cs=self.o.cs)
         self.converter._sourceReactor = self.r
 
@@ -220,6 +230,11 @@ class TestUniformMeshComponents(unittest.TestCase):
             TEST_ROOT, customSettings={"xsKernel": "MC2v2"}
         )
         cls.r.core.lib = isotxs.readBinary(ISOAA_PATH)
+
+        # make the reactor smaller, just to make the tests go faster
+        for ring in [9, 8, 7, 6, 5]:
+            cls.r.core.removeAssembliesInRing(ring, cls.o.cs)
+
         # make the mesh a little non-uniform
         a = cls.r.core[4]
         a[2].setHeight(a[2].getHeight() * 1.05)
@@ -290,6 +305,11 @@ class TestUniformMesh(unittest.TestCase):
         )
         self.r.core.lib = isotxs.readBinary(ISOAA_PATH)
         self.r.core.p.keff = 1.0
+
+        # make the reactor smaller, just to make the tests go faster
+        for ring in [9, 8, 7, 6, 5, 4]:
+            self.r.core.removeAssembliesInRing(ring, self.o.cs)
+
         self.converter = uniformMesh.NeutronicsUniformMeshConverter(
             cs=self.o.cs, calcReactionRates=True
         )

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -37,11 +37,8 @@ class TestConverterFactory(unittest.TestCase):
     def setUp(self):
         self.o, self.r = test_reactors.loadTestReactor(
             inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion"),
+            maxNumRings=2,
         )
-
-        # make the reactor smaller, just to make the tests go faster
-        for ring in [9, 8, 7, 6, 5, 4, 3]:
-            self.r.core.removeAssembliesInRing(ring, self.o.cs)
 
         self.dummyOptions = DummyFluxOptions()
 
@@ -65,11 +62,8 @@ class TestAssemblyUniformMesh(unittest.TestCase):
     def setUp(self):
         self.o, self.r = test_reactors.loadTestReactor(
             inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion"),
+            maxNumRings=2,
         )
-
-        # make the reactor smaller, just to make the tests go faster
-        for ring in [9, 8, 7, 6, 5, 4, 3]:
-            self.r.core.removeAssembliesInRing(ring, self.o.cs)
 
         self.converter = uniformMesh.NeutronicsUniformMeshConverter(cs=self.o.cs)
         self.converter._sourceReactor = self.r
@@ -227,13 +221,9 @@ class TestUniformMeshComponents(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.o, cls.r = test_reactors.loadTestReactor(
-            TEST_ROOT, customSettings={"xsKernel": "MC2v2"}
+            TEST_ROOT, customSettings={"xsKernel": "MC2v2"}, maxNumRings=4
         )
         cls.r.core.lib = isotxs.readBinary(ISOAA_PATH)
-
-        # make the reactor smaller, just to make the tests go faster
-        for ring in [9, 8, 7, 6, 5]:
-            cls.r.core.removeAssembliesInRing(ring, cls.o.cs)
 
         # make the mesh a little non-uniform
         a = cls.r.core[4]
@@ -301,14 +291,10 @@ class TestUniformMesh(unittest.TestCase):
 
     def setUp(self):
         self.o, self.r = test_reactors.loadTestReactor(
-            TEST_ROOT, customSettings={"xsKernel": "MC2v2"}
+            TEST_ROOT, customSettings={"xsKernel": "MC2v2"}, maxNumRings=3
         )
         self.r.core.lib = isotxs.readBinary(ISOAA_PATH)
         self.r.core.p.keff = 1.0
-
-        # make the reactor smaller, just to make the tests go faster
-        for ring in [9, 8, 7, 6, 5, 4]:
-            self.r.core.removeAssembliesInRing(ring, self.o.cs)
 
         self.converter = uniformMesh.NeutronicsUniformMeshConverter(
             cs=self.o.cs, calcReactionRates=True

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -24,7 +24,7 @@ from armi.nuclearDataIO.cccc import isotxs
 from armi.reactor.converters import uniformMesh
 from armi.reactor.flags import Flags
 from armi.reactor.tests import test_assemblies
-from armi.reactor.tests import test_reactors
+from armi.reactor.tests.test_reactors import loadTestReactor, reduceTestReactorRings
 from armi.tests import TEST_ROOT, ISOAA_PATH
 
 
@@ -35,10 +35,10 @@ class DummyFluxOptions:
 
 class TestConverterFactory(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor(
-            inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion"),
-            maxNumRings=2,
+        self.o, self.r = loadTestReactor(
+            inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion")
         )
+        reduceTestReactorRings(self.r, self.o.cs, 2)
 
         self.dummyOptions = DummyFluxOptions()
 
@@ -60,10 +60,10 @@ class TestAssemblyUniformMesh(unittest.TestCase):
     """
 
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor(
-            inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion"),
-            maxNumRings=2,
+        self.o, self.r = loadTestReactor(
+            inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion")
         )
+        reduceTestReactorRings(self.r, self.o.cs, 2)
 
         self.converter = uniformMesh.NeutronicsUniformMeshConverter(cs=self.o.cs)
         self.converter._sourceReactor = self.r
@@ -220,9 +220,8 @@ class TestUniformMeshComponents(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.o, cls.r = test_reactors.loadTestReactor(
-            TEST_ROOT, customSettings={"xsKernel": "MC2v2"}, maxNumRings=4
-        )
+        cls.o, cls.r = loadTestReactor(TEST_ROOT, customSettings={"xsKernel": "MC2v2"})
+        reduceTestReactorRings(cls.r, cls.o.cs, 4)
         cls.r.core.lib = isotxs.readBinary(ISOAA_PATH)
 
         # make the mesh a little non-uniform
@@ -290,9 +289,10 @@ class TestUniformMesh(unittest.TestCase):
         random.seed(987324987234)
 
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor(
-            TEST_ROOT, customSettings={"xsKernel": "MC2v2"}, maxNumRings=3
+        self.o, self.r = loadTestReactor(
+            TEST_ROOT, customSettings={"xsKernel": "MC2v2"}
         )
+        reduceTestReactorRings(self.r, self.o.cs, 3)
         self.r.core.lib = isotxs.readBinary(ISOAA_PATH)
         self.r.core.p.keff = 1.0
 
@@ -374,7 +374,7 @@ class TestGammaUniformMesh(unittest.TestCase):
         random.seed(987324987234)
 
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor(
+        self.o, self.r = loadTestReactor(
             TEST_ROOT, customSettings={"xsKernel": "MC2v2"}
         )
         self.r.core.lib = isotxs.readBinary(ISOAA_PATH)
@@ -548,7 +548,7 @@ class TestUniformMeshNonUniformAssemFlags(unittest.TestCase):
         random.seed(987324987234)
 
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor(
+        self.o, self.r = loadTestReactor(
             TEST_ROOT,
             customSettings={
                 "xsKernel": "MC2v2",

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -213,9 +213,16 @@ def reduceTestReactorRings(r, cs, maxNumRings):
     The goal is to reduce the size of the reactor for tests that don't neeed
     such a large reactor, and would run much faster with a smaller one
     """
-    if 9 > maxNumRings > 1:
-        for ring in range(9, maxNumRings, -1):
-            r.core.removeAssembliesInRing(ring, cs)
+    maxRings = r.core.getNumRings()
+    if maxNumRings > maxRings:
+        runLog.info("The test reactor has a maximum of {} rings.".format(maxRings))
+        return
+    elif maxNumRings <= 1:
+        raise ValueError("The test reactor must have multiple rings.")
+
+    # reducing the size of the test reactor, by removing the outer rings
+    for ring in range(maxRings, maxNumRings, -1):
+        r.core.removeAssembliesInRing(ring, cs)
 
 
 class ReactorTests(unittest.TestCase):

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -136,10 +136,7 @@ of downstream tests that import this method. Probably still worth it though.
 
 
 def loadTestReactor(
-    inputFilePath=TEST_ROOT,
-    customSettings=None,
-    inputFileName="armiRun.yaml",
-    maxNumRings=9,
+    inputFilePath=TEST_ROOT, customSettings=None, inputFileName="armiRun.yaml"
 ):
     r"""
     Loads a test reactor. Can be used in other test modules.
@@ -156,10 +153,6 @@ def loadTestReactor(
 
     inputFileName : str, default="armiRun.yaml"
         Name of the input file to run.
-
-    maxNumRings : int, default=9
-        You can reduce the size of the reactor; by number of rings (1-9).
-        This does not affect pickled reactors.
 
     Returns
     -------
@@ -198,11 +191,6 @@ def loadTestReactor(
     o = operators.factory(cs)
     r = reactors.loadFromCs(cs)
 
-    # make the reactor smaller, just to make the tests go faster
-    if 9 > maxNumRings > 1:
-        for ring in range(9, maxNumRings, -1):
-            r.core.removeAssembliesInRing(ring, o.cs)
-
     o.initializeInterfaces(r)
 
     # put some stuff in the SFP too.
@@ -218,6 +206,16 @@ def loadTestReactor(
         TEST_REACTOR = cPickle.dumps((o, o.r, assemblies.getAssemNum()), protocol=2)
 
     return o, o.r
+
+
+def reduceTestReactorRings(r, cs, maxNumRings):
+    """Helper method for the test reactor above
+    The goal is to reduce the size of the reactor for tests that don't neeed
+    such a large reactor, and would run much faster with a smaller one
+    """
+    if 9 > maxNumRings > 1:
+        for ring in range(9, maxNumRings, -1):
+            r.core.removeAssembliesInRing(ring, cs)
 
 
 class ReactorTests(unittest.TestCase):

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -136,7 +136,10 @@ of downstream tests that import this method. Probably still worth it though.
 
 
 def loadTestReactor(
-    inputFilePath=TEST_ROOT, customSettings=None, inputFileName="armiRun.yaml"
+    inputFilePath=TEST_ROOT,
+    customSettings=None,
+    inputFileName="armiRun.yaml",
+    maxNumRings=9,
 ):
     r"""
     Loads a test reactor. Can be used in other test modules.
@@ -153,6 +156,10 @@ def loadTestReactor(
 
     inputFileName : str, default="armiRun.yaml"
         Name of the input file to run.
+
+    maxNumRings : int, default=9
+        You can reduce the size of the reactor; by number of rings (1-9).
+        This does not affect pickled reactors.
 
     Returns
     -------
@@ -190,6 +197,12 @@ def loadTestReactor(
 
     o = operators.factory(cs)
     r = reactors.loadFromCs(cs)
+
+    # make the reactor smaller, just to make the tests go faster
+    if 9 > maxNumRings > 1:
+        for ring in range(9, maxNumRings, -1):
+            r.core.removeAssembliesInRing(ring, o.cs)
+
     o.initializeInterfaces(r)
 
     # put some stuff in the SFP too.

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -128,6 +128,13 @@ def buildOperatorOfEmptyCartesianBlocks(customSettings=None):
     return o
 
 
+"""
+NOTE: If this reactor had 3 rings instead of 9, most unit tests that use it
+go 4 times faster (based on testing). The problem is it would breat a LOT
+of downstream tests that import this method. Probably still worth it though.
+"""
+
+
 def loadTestReactor(
     inputFilePath=TEST_ROOT, customSettings=None, inputFileName="armiRun.yaml"
 ):


### PR DESCRIPTION
## Description

Unfortunately, the `armiRun.yaml` test reactor that we use in so many of our unit tests wasn't designed for fast tests. It has 3 cycles, when 2 would be enough for a unit test.  It has 9 rings of assemblies, when we could have used 3 or 4 and still had all the same types of assemblies (fuel, reflector, etc).

So, before this PR, the unit tests for ARMI took about 22 minutes on GitHub Actions. If we made the test reactor smaller, I bet we could get that down to 10 minutes.  But that would mean fixing several hundred tests. And probably hundreds more down stream.

> For this PR, I looked at our repos longest-running unit tests and cut their run time in half.  It's not much, but it's a start.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
