### PR TITLE
Removing duplicate GitHub Actions runs

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -1,6 +1,6 @@
 name: black
 
-on: [push, pull_request]
+on: [push]
 
 # use workaround due to: https://github.com/psf/black/issues/2079#issuecomment-812359146
 jobs:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,6 +1,10 @@
 name: Coverage
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/licensechecker.yaml
+++ b/.github/workflows/licensechecker.yaml
@@ -1,5 +1,5 @@
 name: Check License Lines
-on: [push, pull_request]
+on: [push]
 jobs:
   check-license-lines:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,6 +1,6 @@
 name: ARMI unit tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/validatemanifest.yaml
+++ b/.github/workflows/validatemanifest.yaml
@@ -1,6 +1,6 @@
 name: Validate Manifest
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -1,6 +1,6 @@
 name: ARMI Windows tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:


### PR DESCRIPTION
## Description

I believe right now we are running most of our GitHub Actions worksflows twice during a PR.  Waste not, want not.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
