### PR TITLE
Freezing the maximum NumPy version to 1.23.5

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -36,6 +36,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           pip install click==8.1.3
+          pip install coverage==6.5.0
           pip install coveragepy-lcov==0.1.2
           coveragepy-lcov --data_file_path coverage_results.cov --output_file_path lcov.txt
       - name: Publish to coveralls.io

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -35,7 +35,8 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
-          pip install coveragepy-lcov
+          pip install click==7.1.2
+          pip install coveragepy-lcov==0.1.2
           coveragepy-lcov --data_file_path coverage_results.cov --output_file_path lcov.txt
       - name: Publish to coveralls.io
         uses: coverallsapp/github-action@v1.1.2

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -35,7 +35,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
-          pip install click==7.1.2
+          pip install click==8.1.3
           pip install coveragepy-lcov==0.1.2
           coveragepy-lcov --data_file_path coverage_results.cov --output_file_path lcov.txt
       - name: Publish to coveralls.io

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -23,6 +23,7 @@ Bug fixes
 #. Removed Barriers in temp directory changers and output cache to avoid deadlocks in MPI cases
 #. Fixed bug with database writing and tight coupling. (`PR#1005 https://github.com/terrapower/armi/pull/1005`)
 #. Fixed a bug where snapshot load would not respect the new cs["power"] setting.
+#. Froze the NumPy version to be <= 1.23.5 (`PR#1035 https://github.com/terrapower/armi/pull/1035`) to continue to support numpy jagged arrays within the Database interface.
 
 ARMI v0.2.5
 ===========

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,5 +1,5 @@
 --prefer-binary
-numpy>=1.21
+numpy>=1.21,<=1.23.5
 
 # docutils 0.17 introduced a bug that prevents bullets from rendering
 # see https://github.com/terrapower/armi/issues/274

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 --prefer-binary
 # see https://github.com/advisories/GHSA-6p56-wp2h-9hxr
 # This is included in requirements.txt because of a security alert numpy released
-numpy>=1.21
+numpy>=1.21,<=1.23.5
 
 -e .[memprof]

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "future",
         "h5py>=3.0",
         "matplotlib",
-        "numpy<=1.23.5",
+        "numpy>=1.21,<=1.23.5",
         "ordered-set",
         "pillow",
         "pluggy",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "future",
         "h5py>=3.0",
         "matplotlib",
-        "numpy",
+        "numpy<=1.23.5",
         "ordered-set",
         "pillow",
         "pluggy",

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps=
 allowlist_externals =
     /usr/bin/mpiexec
 commands =
-    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
+    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi/tests/test_runLog.py
     coverage combine --rcfile=.coveragerc --keep -a
 
 # NOTE: This only runs the MPI unit tests.

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps=
 allowlist_externals =
     /usr/bin/mpiexec
 commands =
-    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi/tests/test_runLog.py
+    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=armi/utils/tests/test_gridGui.py --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a
 
 # NOTE: This only runs the MPI unit tests.


### PR DESCRIPTION

## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

After running into several testing issues in #998 it was observed that the NumPy version on `https://pypi.org/simple` was updated to version `1.24.0`. This release occurred on 12/18/2022 - https://github.com/numpy/numpy/releases/tag/v1.24.0 and was not caught by the last pull request 3 days ago. This freeze on NumPy `1.23.5` allows us to continue to use the jagged numpy arrays within the database interface.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

