### PR TITLE
Removing relative imports from axial expansion YAMLs

### DIFF
--- a/armi/tests/detailedAxialExpansion/armiRun.yaml
+++ b/armi/tests/detailedAxialExpansion/armiRun.yaml
@@ -40,7 +40,6 @@ settings:
   numCoupledIterations: 0
   outputFileExtension: png
   power: 100000000.0
-  shuffleLogic: ../refSmallReactorShuffleLogic.py
   summarizeAssemDesign: false
   targetK: 1.002
   verbosity: extra

--- a/armi/tests/detailedAxialExpansion/refSmallReactor.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallReactor.yaml
@@ -14,4 +14,14 @@ systems:
             z: 6000.0
 grids:
     !include refSmallCoreGrid.yaml
-    !include ../refSmallSfpGrid.yaml
+    sfp:
+        symmetry: full
+        geom: cartesian
+        lattice pitch:
+            x: 50.0
+            y: 50.0
+        grid contents:
+            [0,0]: MC
+            [1,0]: MC
+            [0,1]: MC
+            [1,1]: MC


### PR DESCRIPTION
## Description

These relative imports in the axial expansion YAML files were causing some really obscur errors that are kind of mystifying and strange. They are random, and hard to track down. Impossible to reproduce.

So, whatever, let's just remove the relative imports and move on with our lives.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
