### PR TITLE
Reverting GitHub Actions change - adding in duplicate jobs

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -1,6 +1,6 @@
 name: black
 
-on: [push]
+on: [push, pull_request]
 
 # use workaround due to: https://github.com/psf/black/issues/2079#issuecomment-812359146
 jobs:

--- a/.github/workflows/licensechecker.yaml
+++ b/.github/workflows/licensechecker.yaml
@@ -1,8 +1,8 @@
 name: Check License Lines
-on: [push]
+on: [push, pull_request]
 jobs:
   check-license-lines:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
     - name: Check License Lines

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,6 +1,6 @@
 name: ARMI unit tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/validatemanifest.yaml
+++ b/.github/workflows/validatemanifest.yaml
@@ -1,6 +1,6 @@
 name: Validate Manifest
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -1,6 +1,6 @@
 name: ARMI Windows tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
## Description

So, the problem [this PR](https://github.com/terrapower/armi/pull/1031) tried to solve was that ALL of our tests and CI were run twice during every PR.  Which is just wasteful.

But it turns out after this change, GitHub wasn't DISPLAYING all our CI.  Only the coverage. This was only a problem for PRs from forked repos, but it's still a problem.

So... I don't like being wasteful, but I guess I am going to waste some of github's server time on double CI runs, until they fix this display problem.  #sigh

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
