### PR TITLE
Bug fix for global material namespace order

### DIFF
--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -45,7 +45,7 @@ from armi.tests import mockRunLogs
 from armi.utils import units
 
 
-class Base(unittest.TestCase):
+class AxialExpansionTestBase(unittest.TestCase):
     """common methods and variables for unit tests"""
 
     Steel_Component_Lst = [
@@ -177,11 +177,11 @@ class Temperature:
                 self.tempField[i, :] = tmp[i]
 
 
-class TestAxialExpansionHeight(Base, unittest.TestCase):
+class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
     """verify that test assembly is expanded correctly"""
 
     def setUp(self):
-        Base.setUp(self)
+        AxialExpansionTestBase.setUp(self)
         self.a = buildTestAssemblyWithFakeMaterial(name="FakeMat")
 
         self.temp = Temperature(
@@ -201,7 +201,7 @@ class TestAxialExpansionHeight(Base, unittest.TestCase):
             self.axialMeshLocs[idt, :] = self.a.getAxialMesh()
 
     def tearDown(self):
-        Base.tearDown(self)
+        AxialExpansionTestBase.tearDown(self)
 
     def test_AssemblyAxialExpansionHeight(self):
         """test the axial expansion gives correct heights for component-based expansion"""
@@ -274,15 +274,15 @@ class TestAxialExpansionHeight(Base, unittest.TestCase):
         return mean(tmpMapping)
 
 
-class TestConservation(Base, unittest.TestCase):
+class TestConservation(AxialExpansionTestBase, unittest.TestCase):
     """verify that conservation is maintained in assembly-level axial expansion"""
 
     def setUp(self):
-        Base.setUp(self)
+        AxialExpansionTestBase.setUp(self)
         self.a = buildTestAssemblyWithFakeMaterial(name="FakeMat")
 
     def tearDown(self):
-        Base.tearDown(self)
+        AxialExpansionTestBase.tearDown(self)
 
     def expandAssemForMassConservationTest(self):
         """initialize class variables for mass conservation checks"""
@@ -573,16 +573,16 @@ class TestManageCoreMesh(unittest.TestCase):
             self.assertLess(old, new)
 
 
-class TestExceptions(Base, unittest.TestCase):
+class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
     """Verify exceptions are caught"""
 
     def setUp(self):
-        Base.setUp(self)
+        AxialExpansionTestBase.setUp(self)
         self.a = buildTestAssemblyWithFakeMaterial(name="FakeMatException")
         self.obj.setAssembly(self.a)
 
     def tearDown(self):
-        Base.tearDown(self)
+        AxialExpansionTestBase.tearDown(self)
 
     def test_isTopDummyBlockPresent(self):
         # build test assembly without dummy
@@ -717,11 +717,11 @@ class TestExceptions(Base, unittest.TestCase):
             self.assertEqual(cm.exception, 3)
 
 
-class TestDetermineTargetComponent(unittest.TestCase):
+class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
     """verify determineTargetComponent method is properly updating _componentDeterminesBlockHeight"""
 
     def setUp(self):
-        Base.setUp(self)
+        AxialExpansionTestBase.setUp(self)
         self.obj = AxialExpansionChanger()
         self.a = buildTestAssemblyWithFakeMaterial(name="FakeMatException")
         self.obj.setAssembly(self.a)
@@ -729,7 +729,7 @@ class TestDetermineTargetComponent(unittest.TestCase):
         self.obj.expansionData._componentDeterminesBlockHeight = {}
 
     def tearDown(self):
-        Base.tearDown(self)
+        AxialExpansionTestBase.tearDown(self)
 
     def test_determineTargetComponent(self):
         # build a test block
@@ -917,16 +917,16 @@ def checkColdBlockHeight(bStd, bExp, assertType, strForAssertion):
     )
 
 
-class TestLinkage(Base, unittest.TestCase):
+class TestLinkage(AxialExpansionTestBase, unittest.TestCase):
     """test axial linkage between components"""
 
     def setUp(self):
         """contains common dimensions for all component class types"""
-        Base.setUp(self)
+        AxialExpansionTestBase.setUp(self)
         self.common = ("test", "FakeMat", 25.0, 25.0)  # name, material, Tinput, Thot
 
     def tearDown(self):
-        Base.tearDown(self)
+        AxialExpansionTestBase.tearDown(self)
 
     def runTest(
         self,

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -26,6 +26,7 @@ Bug fixes
 #. Fixed bug with database writing and tight coupling. (`PR#1005 https://github.com/terrapower/armi/pull/1005`)
 #. Fixed a bug where snapshot load would not respect the new cs["power"] setting.
 #. Froze the NumPy version to be <= 1.23.5 (`PR#1035 https://github.com/terrapower/armi/pull/1035`) to continue to support numpy jagged arrays within the Database interface.
+#. Fixed a bug where the material namespace order for test_axialExpansionChanger.py was persisting beyond the tests. (`PR#1046 https://github.com/terrapower/armi/pull/1046`)
 
 ARMI v0.2.5
 ===========


### PR DESCRIPTION
## Description
This PR fixes a bug in which the global material namespace order was being set in test_axialExpansionChanger. This namespace change is for testing only local to this file. So while tests are run, we change it, but then via `tearDown` we reset the namespace order. This prevents downstream issues where the namespace is incorrectly set to this testing order. 

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

