### PR TITLE
Simplify calcs in `Material.density3()`

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -412,8 +412,7 @@ class Material(composites.Leaf):
             )
             return None
         f = (1.0 + dLL / 100.0) ** 3
-        dRhoOverRho = (1.0 - f) / f
-        return refD * (dRhoOverRho + 1)
+        return refD / f
 
     def density3KgM3(self, Tk: float = None, Tc: float = None) -> float:
         """Return density that preserves mass when thermally expanded in 3D in units of kg/m^3.


### PR DESCRIPTION
## Description

There were a couple lines of code in the calculation sequence of `Material.density3()` that were completely unneeded. Simplifying the math a little bit allows for the number of evaluations to be reduced. This also puts the calculation in line with the same sequence that is done in `Material.density()`, which hopefully can reduce confusion.

Just a tiny optimization.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

