### PR TITLE
Removing unused getMassFrac parameters

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -479,8 +479,6 @@ class Material(composites.Leaf):
     def getMassFrac(
         self,
         nucName=None,
-        elementSymbol=None,
-        nucList=None,
         normalized=True,
         expandFissionProducts=False,
     ):
@@ -491,12 +489,6 @@ class Material(composites.Leaf):
         ----------
         nucName : str, optional
             Nuclide name to return ('ZR','PU239',etc.)
-
-        elementSymbol :str, optional
-             Return mass fractions of all isotopes of this element (example: 'Pu', 'U')
-
-        nucList : optional, list
-            List of nuclides to sum up and return the total
 
         normalized : bool, optional
             Return the mass fraction such that the sum of all nuclides is sum to 1.0. Default True


### PR DESCRIPTION
## Description

Removing two unused parameters from `Material.getMassFrac()`.

I have looked at downstream projects, and these two parameters are defunct. Though, two more (`normalized` and `expandFissionProducts`) are now only used by one downstream repo each, so I will recommend to those projects to help us clean up this method signature more.

But there is low-hanging fruit, let's grab it.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
