### PR TITLE
Move output cache runLog level from extra to info

### DIFF
--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -169,7 +169,7 @@ def store(exePath, inputPaths, outputFiles, cacheDir):
         cachedLoc = os.path.join(folderLoc, baseName)
         shutil.copy(outputFile, cachedLoc)
 
-    runLog.extra("Added outputs for {} to the cache.".format(exePath))
+    runLog.info("Added outputs for {} to the cache.".format(exePath))
 
 
 def deleteCache(cachedFolder):

--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -69,7 +69,7 @@ def retrieveOutput(exePath, inputPaths, cacheDir, locToRetrieveTo=None):
         successful = _copyOutputs(cachedFolder, locToRetrieveTo)
 
         if successful:
-            runLog.extra("Retrieved cached outputs for {}".format(exePath))
+            runLog.info("Retrieved cached outputs for {}".format(exePath))
             return True
         else:
             # outputs didn't match manifest. Just delete to save checking next time.


### PR DESCRIPTION
## Description

Just a tiny update to get more information automatically printed to a stdout for a case run (rather than requiring a verbosity update).

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

