### PR TITLE
Speedup composites.getMassFrac()

### DIFF
--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -898,7 +898,8 @@ class ArmiObject(metaclass=CompositeModelType):
 
         """
         nuclideNames = self._getNuclidesFromSpecifier(nucName)
-        return sum(self.getMassFracs().get(nucName, 0.0) for nucName in nuclideNames)
+        massFracs = self.getMassFracs()
+        return sum(massFracs.get(nucName, 0.0) for nucName in nuclideNames)
 
     def getMicroSuffix(self):
         raise NotImplementedError(


### PR DESCRIPTION
## Description

`composite.getMassFrac()` is inefficiently implemented to call `self.getMassFracs()` once for each nuclide in the composite.

This dictionary can instead be produced one time by calling `self.getMassFracs()` and saving the output, and then retrieving values from that dictionary.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

