### PR TITLE
Moving some axial expansion debug statements to single

### DIFF
--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -257,7 +257,6 @@ class AxialExpansionChanger:
             f"for each block in assembly {self.linked.a}."
         )
         for ib, b in enumerate(self.linked.a):
-
             runLog.debug(msg=f"  Block {b}")
             blockHeight = b.getHeight()
             # set bottom of block equal to top of block below it
@@ -385,12 +384,20 @@ def _getSolidComponents(b):
 
 
 def _checkBlockHeight(b):
+    """
+    Do some basic block height validation
+
+    Notes
+    -----
+    3cm is a presumptive lower threshhold for DIF3D
+    """
     if b.getHeight() < 3.0:
         runLog.debug(
             "Block {0:s} ({1:s}) has a height less than 3.0 cm. ({2:.12e})".format(
                 b.name, str(b.p.flags), b.getHeight()
             )
         )
+
     if b.getHeight() < 0.0:
         raise ArithmeticError(
             "Block {0:s} ({1:s}) has a negative height! ({2:.12e})".format(
@@ -471,7 +478,8 @@ class AssemblyAxialLinkage:
                     str(self.a.getName()),
                     str(self.a.getLocation()),
                     str(b.p.flags),
-                )
+                ),
+                single=True,
             )
         if upperLinkedBlock is None:
             runLog.debug(
@@ -480,7 +488,8 @@ class AssemblyAxialLinkage:
                     str(self.a.getName()),
                     str(self.a.getLocation()),
                     str(b.p.flags),
-                )
+                ),
+                single=True,
             )
 
     def _getLinkedComponents(self, b, c):
@@ -526,7 +535,8 @@ class AssemblyAxialLinkage:
                     str(self.a.getLocation()),
                     str(b.p.flags),
                     str(c.p.flags),
-                )
+                ),
+                single=True,
             )
         if lstLinkedC[1] is None:
             runLog.debug(
@@ -536,7 +546,8 @@ class AssemblyAxialLinkage:
                     str(self.a.getLocation()),
                     str(b.p.flags),
                     str(c.p.flags),
-                )
+                ),
+                single=True,
             )
 
 


### PR DESCRIPTION
## Description

I am just moving some of the debug statements in the axial expansion changer to `single=True`, to reduce debug log volume.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
