### PR TITLE
Cleaning out duplicate context import in bootstrap

### DIFF
--- a/armi/_bootstrap.py
+++ b/armi/_bootstrap.py
@@ -34,9 +34,6 @@ if (
     )
 
 
-from armi import context
-
-
 def _addCustomTabulateTables():
     """Create a custom ARMI tables within tabulate."""
     tabulate._table_formats["armi"] = tabulate.TableFormat(


### PR DESCRIPTION
## Description

I ran some case suites and integration tests in downstream repos and was able to determine that we can safely remove this line.

**NOTE**: Several of the items on our ARMI Road Map would be easier if ARMI ran less code at import time. At some point, we will need to reduce the work done in `context.py` and `_boostrap.py` so that people can use ARMI in a more piecemeal fashion.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
