### PR TITLE
Removing calls to getMasterCs

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -718,7 +718,6 @@ class Database3:
 
         cs = cs or self.loadCS()
         if updateMasterCs:
-            # apply to avoid defaults in getMasterCs calls
             settings.setMasterCs(cs)
         bp = bp or self.loadBlueprints()
 

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -34,7 +34,7 @@ from armi.tests import mockRunLogs
 
 class TestReport(unittest.TestCase):
     def setUp(self):
-        self.test_group = data.Table(settings.getMasterCs(), "banana")
+        self.test_group = data.Table(settings.Settings(), "banana")
 
     def test_setData(self):
         report.setData("banana_1", ["sundae", "plain"])

--- a/armi/cli/reportsEntryPoint.py
+++ b/armi/cli/reportsEntryPoint.py
@@ -158,11 +158,6 @@ def createReportFromSettings(cs):
     This will construct a reactor from the given settings and create BOL reports for
     that reactor/settings.
     """
-    # TODO: not sure if this is necessary, but need to investigate more to understand possible
-    # side-effects before removing. Probably better to get rid of all uses of
-    # getMasterCs(), then we can remove all setMasterCs() calls without worrying.
-    settings.setMasterCs(cs)
-
     blueprint = blueprints.loadFromCs(cs)
     r = reactors.factory(cs, blueprint)
     report = reports.ReportContent("Overview")

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -1678,7 +1678,7 @@ assemblies:
     def loadAssembly(self, materialModifications):
         yamlString = self.baseInput + "\n" + materialModifications
         design = blueprints.Blueprints.load(yamlString)
-        design._prepConstruction(settings.getMasterCs())
+        design._prepConstruction(settings.Settings())
         return design.assemblies["fuel a"]
 
     def test_class1Class2_class1_wt_frac(self):

--- a/armi/operators/tests/test_inspectors.py
+++ b/armi/operators/tests/test_inspectors.py
@@ -62,7 +62,7 @@ class TestInspector(unittest.TestCase):
         query = self.inspector.queries[0]
         self.assertFalse(query)
 
-        newCS = settings.getMasterCs().duplicate()
+        newCS = settings.Settings().duplicate()
         newSettings = {"runType": "banane"}
         newCS = newCS.modified(newSettings=newSettings)
 

--- a/armi/physics/neutronics/tests/test_cross_section_manager.py
+++ b/armi/physics/neutronics/tests/test_cross_section_manager.py
@@ -19,14 +19,13 @@ Test the cross section manager
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
-import unittest
-import copy
 from io import BytesIO
+import copy
+import unittest
 
 from six.moves import cPickle
 
 from armi import settings
-from armi.utils import units
 from armi.physics.neutronics import crossSectionGroupManager
 from armi.physics.neutronics.crossSectionGroupManager import (
     BlockCollection,
@@ -37,11 +36,12 @@ from armi.physics.neutronics.crossSectionGroupManager import (
     AverageBlockCollection,
 )
 from armi.physics.neutronics.crossSectionGroupManager import CrossSectionGroupManager
+from armi.physics.neutronics.fissionProductModel.tests import test_lumpedFissionProduct
 from armi.reactor.blocks import HexBlock
 from armi.reactor.flags import Flags
 from armi.reactor.tests import test_reactors
 from armi.tests import TEST_ROOT
-from armi.physics.neutronics.fissionProductModel.tests import test_lumpedFissionProduct
+from armi.utils import units
 
 
 class TestBlockCollection(unittest.TestCase):
@@ -377,7 +377,7 @@ class MockBlueprints:
 class MockBlock(HexBlock):
     def __init__(self, name=None, cs=None):
         self.density = {}
-        HexBlock.__init__(self, name or "MockBlock", cs or settings.getMasterCs())
+        HexBlock.__init__(self, name or "MockBlock", cs or settings.Settings())
         self.r = MockReactor()
 
     @property

--- a/armi/reactor/blueprints/tests/test_assemblyBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_assemblyBlueprints.py
@@ -180,7 +180,7 @@ assemblies:
     def loadCustomAssembly(self, assemblyInput):
         yamlString = assemblyInput
         design = blueprints.Blueprints.load(yamlString)
-        design._prepConstruction(settings.getMasterCs())
+        design._prepConstruction(settings.Settings())
         return design.assemblies["fuel a"]
 
     def test_checkParamConsistency(self):

--- a/armi/reactor/blueprints/tests/test_materialModifications.py
+++ b/armi/reactor/blueprints/tests/test_materialModifications.py
@@ -60,7 +60,7 @@ assemblies:
     def loadUZrAssembly(self, materialModifications):
         yamlString = self.uZrInput + "\n" + materialModifications
         design = blueprints.Blueprints.load(yamlString)
-        design._prepConstruction(settings.getMasterCs())
+        design._prepConstruction(settings.Settings())
         return design.assemblies["fuel a"]
 
     def test_noMaterialModifications(self):

--- a/armi/reactor/converters/parameterSweeps/tests/test_paramSweepConverters.py
+++ b/armi/reactor/converters/parameterSweeps/tests/test_paramSweepConverters.py
@@ -40,7 +40,7 @@ THIS_DIR = os.path.dirname(__file__)
 class TestParamSweepConverters(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(TEST_ROOT)
-        self.cs = settings.getMasterCs()
+        self.cs = self.o.cs
 
     def test_paramSweepConverter(self):
         """basic test of the param sweep converter"""

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -39,7 +39,7 @@ THIS_DIR = os.path.dirname(__file__)
 class TestGeometryConverters(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(TEST_ROOT)
-        self.cs = settings.getMasterCs()
+        self.cs = self.o.cs
 
     def test_addRing(self):
         r"""
@@ -134,7 +134,7 @@ class TestHexToRZConverter(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(TEST_ROOT)
         reduceTestReactorRings(self.r, self.o.cs, 2)
-        self.cs = settings.getMasterCs()
+        self.cs = self.o.cs
 
         runLog.setVerbosity("extra")
         self._expandReactor = False

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -199,7 +199,7 @@ class Assembly_TestCase(unittest.TestCase):
         self.name = "A0015"
         self.assemNum = 15
         self.height = 10
-        self.cs = settings.getMasterCs()
+        self.cs = settings.Settings()
         # Print nothing to the screen that would normally go to the log.
         runLog.setVerbosity("error")
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -442,7 +442,7 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(ref, cur, places=places)
 
     def test_getXsType(self):
-        self.cs = settings.getMasterCs()
+        self.cs = settings.Settings()
         newSettings = {"loadingFile": os.path.join(TEST_ROOT, "refSmallReactor.yaml")}
         self.cs = self.cs.modified(newSettings=newSettings)
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -54,7 +54,8 @@ def buildOperatorOfEmptyHexBlocks(customSettings=None):
         Dictionary of off-default settings to update
     """
     settings.setMasterCs(None)  # clear
-    cs = settings.getMasterCs()  # fetch new
+    cs = settings.Settings()  # fetch new
+    settings.setMasterCs(cs)  # reset
 
     if customSettings is None:
         customSettings = {}
@@ -93,7 +94,8 @@ def buildOperatorOfEmptyCartesianBlocks(customSettings=None):
         Dictionary of off-default settings to update
     """
     settings.setMasterCs(None)  # clear
-    cs = settings.getMasterCs()  # fetch new
+    cs = settings.Settings()  # fetch new
+    settings.setMasterCs(cs)  # reset
 
     if customSettings is None:
         customSettings = {}

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -205,7 +205,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
 
     def test_csWorks(self):
         """Ensure plugin settings become available and have defaults"""
-        a = settings.getMasterCs()
+        a = settings.Settings()
         self.assertEqual(a["circularRingOrder"], "angle")
 
     def test_pluginValidatorsAreDiscovered(self):

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -55,7 +55,7 @@ class TestPlugin(unittest.TestCase):
         if self.plugin is None:
             return
 
-        cs = settings.getMasterCs()
+        cs = settings.Settings()
         results = self.plugin.exposeInterfaces(cs)
         if results is None or not results:
             return


### PR DESCRIPTION
## Description

It turns out that the unit test usages of `getMasterCs()` in ARMI were unnecessary anyway. So they were easy to remove.

A reminder of the goal: #930 .  If we remove all calls to `getMasterCs()` in ARMI, we can remove all calls to `setMasterCs()`, and have this strange, invisible, global settings object gone forever.

(**NOTE**: The test method `createSIMPLE_HEXZ_NHFLUX` has been entirely unused in ARMI for at least 4 years now. And besides that, it is a problematic function. So I just removed it.)

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
