### PR TITLE
XS Library Merge Bug

### DIFF
--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -357,7 +357,7 @@ class TestXSLibrary(unittest.TestCase, TempFileMixin):
 
 class Test_GetISOTXSFilesInWorkingDirectory(unittest.TestCase):
     def test_getISOTXSFilesWithoutLibrarySuffix(self):
-        shouldBeThere = ["ISOAA", "ISOBA", r"file-path\ISOCA"]
+        shouldBeThere = ["ISOAA", "ISOBA", os.path.join("file-path", "ISOCA")]
         shouldNotBeThere = [
             "ISOBA-n2",
             "ISOTXS",
@@ -376,7 +376,7 @@ class Test_GetISOTXSFilesInWorkingDirectory(unittest.TestCase):
             "ISOAAF-n23",
             "ISOBA-n23",
             "ISODA",
-            r"file-path\ISOCA-n23",
+            os.path.join("file-path", "ISOCA-n23"),
         ]
         shouldNotBeThere = [
             "ISOAA",
@@ -390,7 +390,7 @@ class Test_GetISOTXSFilesInWorkingDirectory(unittest.TestCase):
             "ISOAA.BCD",
             "ISOCA-doppler",
             "ISOSA-void",
-            r"file-path\ISOCA-ISO",
+            os.path.join("file-path", "ISOCA-ISO"),
         ]
         filesInDirectory = shouldBeThere + shouldNotBeThere
         toMerge = xsLibraries.getISOTXSLibrariesToMerge("-n23", filesInDirectory)

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -357,7 +357,7 @@ class TestXSLibrary(unittest.TestCase, TempFileMixin):
 
 class Test_GetISOTXSFilesInWorkingDirectory(unittest.TestCase):
     def test_getISOTXSFilesWithoutLibrarySuffix(self):
-        shouldBeThere = ["ISOAA", "ISOBA"]
+        shouldBeThere = ["ISOAA", "ISOBA", r"file-path\ISOCA"]
         shouldNotBeThere = [
             "ISOBA-n2",
             "ISOTXS",
@@ -371,7 +371,7 @@ class Test_GetISOTXSFilesInWorkingDirectory(unittest.TestCase):
         self.assert_contains_only(toMerge, shouldBeThere, shouldNotBeThere)
 
     def test_getISOTXSFilesWithLibrarySuffix(self):
-        shouldBeThere = ["ISOAA-n23", "ISOAAF-n23", "ISOBA-n23", "ISOCA", "ISODA"]
+        shouldBeThere = ["ISOAA-n23", "ISOAAF-n23", "ISOBA-n23", "ISODA", r"file-path\ISOCA-n23"]
         shouldNotBeThere = [
             "ISOAA",
             "ISOAA-n24",
@@ -384,6 +384,7 @@ class Test_GetISOTXSFilesInWorkingDirectory(unittest.TestCase):
             "ISOAA.BCD",
             "ISOCA-doppler",
             "ISOSA-void",
+            r"file-path\ISOCA-ISO"
         ]
         filesInDirectory = shouldBeThere + shouldNotBeThere
         toMerge = xsLibraries.getISOTXSLibrariesToMerge("-n23", filesInDirectory)

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -371,7 +371,13 @@ class Test_GetISOTXSFilesInWorkingDirectory(unittest.TestCase):
         self.assert_contains_only(toMerge, shouldBeThere, shouldNotBeThere)
 
     def test_getISOTXSFilesWithLibrarySuffix(self):
-        shouldBeThere = ["ISOAA-n23", "ISOAAF-n23", "ISOBA-n23", "ISODA", r"file-path\ISOCA-n23"]
+        shouldBeThere = [
+            "ISOAA-n23",
+            "ISOAAF-n23",
+            "ISOBA-n23",
+            "ISODA",
+            r"file-path\ISOCA-n23",
+        ]
         shouldNotBeThere = [
             "ISOAA",
             "ISOAA-n24",
@@ -384,7 +390,7 @@ class Test_GetISOTXSFilesInWorkingDirectory(unittest.TestCase):
             "ISOAA.BCD",
             "ISOCA-doppler",
             "ISOSA-void",
-            r"file-path\ISOCA-ISO"
+            r"file-path\ISOCA-ISO",
         ]
         filesInDirectory = shouldBeThere + shouldNotBeThere
         toMerge = xsLibraries.getISOTXSLibrariesToMerge("-n23", filesInDirectory)

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -111,8 +111,8 @@ def getISOTXSLibrariesToMerge(xsLibrarySuffix, xsLibFileNames):
         XS library suffix is used to determine which ISOTXS files should be merged together. This can be an
         empty string or be something like `-doppler`.
 
-    xsLibPathames : list
-        A list of library file paths like ISOAA, ISOBA, ISOCA, etc.
+    xsLibFileNames : list
+        A list of library file paths like ISOAA, ISOBA, ISOCA, etc. Can be a standalone file name or a full path.
 
     Notes
     -----

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -111,8 +111,8 @@ def getISOTXSLibrariesToMerge(xsLibrarySuffix, xsLibFileNames):
         XS library suffix is used to determine which ISOTXS files should be merged together. This can be an
         empty string or be something like `-doppler`.
 
-    xsLibFileNames : list
-        A list of library names like ISOAA, ISOBA, ISOCA, etc.
+    xsLibPathames : list
+        A list of library file paths like ISOAA, ISOBA, ISOCA, etc.
 
     Notes
     -----
@@ -131,7 +131,7 @@ def getISOTXSLibrariesToMerge(xsLibrarySuffix, xsLibFileNames):
         isosWithSuffix = [
             iso
             for iso in isosToMerge
-            if re.match("ISO[A-Z]{{2}}F?{}$".format(xsLibrarySuffix), iso)
+            if re.match(f".*ISO[A-Z]{{2}}{xsLibrarySuffix}$", iso)
         ]
         isosToMerge = [
             iso
@@ -195,9 +195,8 @@ def mergeXSLibrariesInWorkingDirectory(
     referenceDummyNuclides = None
     for xsLibFilePath in sorted(xsLibFiles):
         try:
-            xsID = re.search("ISO([A-Z0-9]{2})", xsLibFilePath).group(
-                1
-            )  # get XS ID from the cross section library name
+            # get XS ID from the cross section library name
+            xsID = re.search("ISO([A-Z0-9]{2})", xsLibFilePath).group(1)
         except AttributeError:
             # if glob has matched something that is not actually an ISOXX file,
             # the .group() call will fail

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -131,7 +131,7 @@ def getISOTXSLibrariesToMerge(xsLibrarySuffix, xsLibFileNames):
         isosWithSuffix = [
             iso
             for iso in isosToMerge
-            if re.match(f".*ISO[A-Z]{{2}}{xsLibrarySuffix}$", iso)
+            if re.match(f".*ISO[A-Z]{{2}}F?{xsLibrarySuffix}$", iso)
         ]
         isosToMerge = [
             iso

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -137,11 +137,13 @@ def getISOTXSLibrariesToMerge(xsLibrarySuffix, xsLibFileNames):
             iso
             for iso in isosToMerge
             if "-" not in os.path.basename(iso)
-            and not any(iso == iws.split("-")[0] for iws in isosWithSuffix)
+            and not any(
+                iso == os.path.basename(iws).split("-")[0] for iws in isosWithSuffix
+            )
         ]
         isosToMerge += isosWithSuffix
     else:
-        isosToMerge = [iso for iso in isosToMerge if "-" not in iso]
+        isosToMerge = [iso for iso in isosToMerge if "-" not in os.path.basename(iso)]
     return isosToMerge
 
 

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -136,7 +136,7 @@ def getISOTXSLibrariesToMerge(xsLibrarySuffix, xsLibFileNames):
         isosToMerge = [
             iso
             for iso in isosToMerge
-            if "-" not in iso
+            if "-" not in os.path.basename(iso)
             and not any(iso == iws.split("-")[0] for iws in isosWithSuffix)
         ]
         isosToMerge += isosWithSuffix

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -223,6 +223,12 @@ class FissionProductModel(interfaces.Interface):
 
         self._globalLFPs = lfps
 
+    def interactBOC(self, cycle=None):
+        if self._explicitFissionProducts:
+            self.setAllComponentFissionProducts()
+        else:
+            self.setAllBlockLFPs()
+
     def interactDistributeState(self):
         if self._explicitFissionProducts:
             self.setAllComponentFissionProducts()


### PR DESCRIPTION
## Description

Two bugs introduced in #1067:

1. By changing to using an absolute file path for the current working directory, the XS library merge function was not correctly identifying all of the files to be merged. Needed to update regular expression to match the file names correctly with the full path included. Also needed to fix the processing related to suffixes so filepaths with dashes don't get excluded from the merge list. 

2. The FissionProductModel `interactBOC` was removed because the fission products are initialized on interactBOL. This was fine for standard runs but it caused snapShot runs to fail because the fission products were not initialized on the reactor loaded from the database.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

