### PR TITLE
Fix errant docstring

### DIFF
--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1277,9 +1277,6 @@ class ArmiObject(metaclass=CompositeModelType):
         expandFissionProducts : bool (optional)
             expand the fission product number densities
 
-        nuclideNames : iterable (optional)
-            nuclide names to get number densities
-
         Returns
         -------
         numberDensities : dict


### PR DESCRIPTION
## Description

The docstring lists a method parameter that doesn't exist. Just remove it.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

