### PR TITLE
Remove unused calcs from `calcReactionRates()`

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -1140,7 +1140,6 @@ def calcReactionRates(obj, keff, lib):
         nucrate = {}
         for simple in RX_PARAM_NAMES:
             nucrate[simple] = 0.0
-        tot = 0.0
 
         nucMc = lib.getNuclide(nucName, obj.getMicroSuffix())
         micros = nucMc.micros
@@ -1149,7 +1148,6 @@ def calcReactionRates(obj, keff, lib):
             # dE = flux_e*dE
             dphi = numberDensity * groupFlux
 
-            tot += micros.total[g, 0] * dphi
             # absorption is fission + capture (no n2n here)
             for name in RX_ABS_MICRO_LABELS:
                 nucrate["rateAbs"] += dphi * micros[name][g]


### PR DESCRIPTION
## Description

We are currently calculating the total reaction rate within `calcReactionRates()` but not doing anything with it. This is wasteful, so I removed it.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

