### PR TITLE
Defer setting material number in MCNP material card

### DIFF
--- a/armi/utils/densityTools.py
+++ b/armi/utils/densityTools.py
@@ -192,7 +192,10 @@ def formatMaterialCard(
         for nuc in densities
     ):
         return []  # no valid nuclides to write
-    mCard = ["m{matNum}\n".format(matNum=matNum)]
+    if matNum > 0:
+        mCard = ["m{matNum}\n".format(matNum=matNum)]
+    else:
+        mCard = ["m{}\n"]
     for nuc, dens in sorted(densities.items()):
         # skip LFPs and Dummies.
         if isinstance(nuc, (nuclideBases.LumpNuclideBase)):

--- a/armi/utils/densityTools.py
+++ b/armi/utils/densityTools.py
@@ -192,7 +192,7 @@ def formatMaterialCard(
         for nuc in densities
     ):
         return []  # no valid nuclides to write
-    if matNum > 0:
+    if matNum >= 0:
         mCard = ["m{matNum}\n".format(matNum=matNum)]
     else:
         mCard = ["m{}\n"]

--- a/armi/utils/tests/test_densityTools.py
+++ b/armi/utils/tests/test_densityTools.py
@@ -159,6 +159,7 @@ class Test_densityTools(unittest.TestCase):
         numDens = {o16: 0.7, pu239: 1e-8, u235: 0.2, lfp35: 1e-3, dump1: 1e-4}
         matCard = densityTools.formatMaterialCard(
             numDens,
+            matNum=-1,
             minDens=1e-6,
             mcnp6Compatible=True,
             mcnpLibrary="81",
@@ -174,7 +175,6 @@ class Test_densityTools(unittest.TestCase):
         numDens = {lfp35: 0.5, dump1: 0.5}
         matCard = densityTools.formatMaterialCard(
             numDens,
-            matNum=1,
             mcnp6Compatible=False,
             mcnpLibrary=None,
         )

--- a/armi/utils/tests/test_densityTools.py
+++ b/armi/utils/tests/test_densityTools.py
@@ -136,6 +136,50 @@ class Test_densityTools(unittest.TestCase):
         self.assertAlmostEqual(norm["U234"], 2.1502965265880334e-05)
         self.assertAlmostEqual(norm["U235"], 0.5951128604216736)
 
+    def test_formatMaterialCard(self):
+        u235 = nuclideBases.byName["U235"]
+        pu239 = nuclideBases.byName["PU239"]
+        o16 = nuclideBases.byName["O16"]
+        numDens = {o16: 0.7, pu239: 0.1, u235: 0.2}
+        matCard = densityTools.formatMaterialCard(
+            numDens,
+            matNum=1,
+            sigFigs=4,
+        )
+        refMatCard = """m1
+       8016 7.0000e-01
+      92235 2.0000e-01
+      94239 1.0000e-01
+"""
+        self.assertEqual(refMatCard, "".join(matCard))
+
+        lfp35 = nuclideBases.byName["LFP35"]
+        dump1 = nuclideBases.byName["DUMP1"]
+        o16 = nuclideBases.byName["O16"]
+        numDens = {o16: 0.7, pu239: 1e-8, u235: 0.2, lfp35: 1e-3, dump1: 1e-4}
+        matCard = densityTools.formatMaterialCard(
+            numDens,
+            minDens=1e-6,
+            mcnp6Compatible=True,
+            mcnpLibrary="81",
+        )
+        refMatCard = """m{}
+       8016 7.00000000e-01
+      92235 2.00000000e-01
+      94239 1.00000000e-06
+      nlib=81c
+"""
+        self.assertEqual(refMatCard, "".join(matCard))
+
+        numDens = {lfp35: 0.5, dump1: 0.5}
+        matCard = densityTools.formatMaterialCard(
+            numDens,
+            matNum=1,
+            mcnp6Compatible=False,
+            mcnpLibrary=None,
+        )
+        refMatCard = []
+        self.assertEqual(refMatCard, matCard)
 
 if __name__ == "__main__":
     unittest.main()

--- a/armi/utils/tests/test_densityTools.py
+++ b/armi/utils/tests/test_densityTools.py
@@ -181,5 +181,6 @@ class Test_densityTools(unittest.TestCase):
         refMatCard = []
         self.assertEqual(refMatCard, matCard)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -22,6 +22,7 @@ What's new in ARMI
 #. Cleanup of unnecessary and confusing functionality in axialExpansionChanger.py. (`PR#1032 <https://github.com/terrapower/armi/pull/1032>`_)
 #. Axially expand from cold to hot before deepcopy of assemblies into reactor improving speed and preserving same functionality. (`PR#1047 <https://github.com/terrapower/armi/pull/1047>`_)
 #. Add a how-to on restart calculations in the docs
+#. Allow MCNP material card number to be defined after the card is written. (`PR#1086 <https://github.com/terrapower/armi/pull/1086>`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

This is a minor change that should not impact functionality of any existing code. This slight modification allows downstream code to generate MCNP inputs more effectively by avoiding duplication of identical materials many times over.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

