### PR TITLE
Copy dummy micro XS.

### DIFF
--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -171,6 +171,7 @@ def addDummyNuclidesToLibrary(lib, dummyNuclides):
             continue
 
         newDummy = xsNuclides.XSNuclide(lib, dummyKey)
+        newDummy.micros = dummyNuclide.micros
         # Copy isotxs metadata from the isotxs metadata of the given dummy nuclide
         for kk, vv in dummyNuclide.isotxsMetadata.items():
             if kk in ["jj", "jband"]:


### PR DESCRIPTION
## Description

Potential bug introduced by #1081 where the XS of dummy nuclides created in ISOTXS are not initialized. Most of them are approximately zero, as they should be, but sometimes a NaN value would show up in the ISOTXS file. This can cause an error when that microscopic XS is used in a reaction rate or macroscopic XS calculation.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

