### PR TITLE
Add armi.reactor.compositeList.CompositeList : base class for Assemblies

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -100,7 +100,7 @@ class Assembly(compositeList.CompositeList):
         if assemNum is None:
             assemNum = incrementAssemNum()
         name = self.makeNameFromAssemNum(assemNum)
-        super().__init__(name)
+        compositeList.CompositeList.__init__(self, name)
         self.p.assemNum = assemNum
         self.setType(typ)
         self._current = 0  # for iterating

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -37,6 +37,7 @@ from armi.reactor import blockParameters
 from armi.reactor import components
 from armi.reactor.components.basicShapes import Hexagon, Circle
 from armi.reactor import composites
+from armi.reactor import compositeList
 from armi.reactor import geometry
 from armi.reactor import grids
 from armi.reactor import parameters
@@ -61,7 +62,7 @@ PIN_COMPONENTS = [
 _PitchDefiningComponent = Optional[Tuple[Type[components.Component], ...]]
 
 
-class Block(composites.Composite):
+class Block(compositeList.CompositeWithHeight):
     """
     A homogenized axial slab of material.
 

--- a/armi/reactor/compositeList.py
+++ b/armi/reactor/compositeList.py
@@ -1,0 +1,246 @@
+"""Collection of composites with a 1-D grid"""
+
+from abc import ABC, ABCMeta, abstractmethod
+from typing import Optional, Iterator, Tuple
+
+from numpy import empty, ndarray
+
+from armi import runLog
+from armi.reactor import flags
+from armi.reactor.grids import Grid, axialUnitGrid
+from armi.reactor.composites import Composite, CompositeModelType
+
+
+class AbstractCompositeMetaclass(ABCMeta, CompositeModelType):
+    """Metaclass that allows for abstract composites"""
+
+
+class AbstractComposite(ABC, Composite, metaclass=AbstractCompositeMetaclass):
+    """Composite that can have abstract methods
+
+    Useful for enforcing interfaces across generic subclasses
+    """
+
+
+class CompositeWithHeight(AbstractComposite):
+    """Interface for a composite with a height.
+
+    Like a block but more general
+
+    """
+
+    @abstractmethod
+    def getHeight(self) -> float:
+        """Return the height of this object"""
+
+
+class CompositeList(CompositeWithHeight):
+    """Axial collection of composites
+
+    Many things in an ARMI :class:`~armi.reactor.reactors.Reactor`
+    can be seen as things stacked on things. An
+    :class:`~armi.reactor.assemblies.Assemblies` is a 1-D stack of
+    :class:`~armi.reactor.blocks.Block` instances, each with an axial
+    location and height. Fuel pins are another concept that would benefit
+    from a 1-D stack of :class:`~armi.reactor.composites.Composite` like things.
+
+    This class seeks to separate out storing and maintaing the axial mesh
+    of things (iteration, item access, mesh updating, etc.) from
+    assembly-specific tasks (moving assemblies within the reactor,
+    looking for coolant channels, etc.)
+
+    """
+
+    spatialGrid: Optional[Grid]
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.spatialGrid = None
+
+    def __iter__(self) -> Iterator[CompositeWithHeight]:
+        """Iterate over all children"""
+        return super().__iter__()
+
+    def __getitem__(self, index: int) -> CompositeWithHeight:
+        """Return the child at a specific index"""
+        return super().__getitem__(index)
+
+    def add(self, obj: CompositeWithHeight):
+        """Add an item to the end of the list
+
+        .. note::
+
+            Object **must** at least have a ``getHeight`` method
+            to understand how the spatial grid needs to be updated
+
+        Parameters
+        ----------
+        obj : Composite
+            Object to be added to the end.
+
+        """
+        super().add(obj)
+        nItems = len(self)
+        # Assume spatial grid has been added already
+        obj.spatialLocator = self.spatialGrid[0, 0, nItems - 1]
+        zbounds = self.spatialGrid.getBounds()[2]
+        # Spatial grid has space for this component
+        if len(zbounds) < nItems:
+            zbounds[nItems] = zbounds[nItems - 1] + obj.getHeight()
+        else:
+            self.reestablishOrder()
+            self.calculateZCoords()
+
+    def insert(self, index: int, obj: CompositeWithHeight):
+        """Insert an object at a given position
+
+        Parameters
+        ----------
+        index : int
+            Position to insert the object
+        obj : CompositeWithHeight
+            Child to be inserted
+
+        """
+        super().insert(index, obj)
+        obj.spatialLocator = self.spatialGrid[0, 0, index]
+
+    def reestablishOrder(self):
+        """After children have been mixed up axially, place them in ascending order
+
+        See Also
+        --------
+        * :meth:`calculateZCoords` : Updates the zbottom / ztop parameters on each block
+
+        """
+        self.spatialGrid = axialUnitGrid(len(self), self)
+        for zi, child in enumerate(self):
+            child.spatialLocator = self.spatialGrid[0, 0, zi]
+            self._renameChild(child, zi)
+
+    @abstractmethod
+    def _renameChild(self, child: Composite, index: int):
+        """Rename a child at a given index in the list"""
+
+    def calculateZCoords(self):
+        """Set the top, bottom, and center z-coordinates"""
+        bottom = 0.0
+        # Bounds include N + 1 entries to capture the bottom and top of each cell.
+        mesh = empty(len(self) + 1)
+        mesh[0] = bottom
+
+        for zi, child in enumerate(self):
+            height = child.getHeight()
+            child.p.zbottom = bottom
+            child.p.z = bottom + 0.5 * height
+
+            # Update the upper index and mesh height
+            bottom += height
+            child.p.ztop = bottom
+            mesh[zi + 1] = bottom
+
+            child.spatialLocator = self.spatialGrid[0, 0, zi]
+
+        self._updateZGrid(mesh)
+
+    def _updateZGrid(self, mesh: ndarray):
+        previousX, previousY, _previousZ = self.spatialGrid.getBounds()
+        self.spatialGrid._bounds = (previousX, previousY, mesh)
+
+    def getHeight(self, typeSpec: Optional[flags.TypeSpec] = None) -> float:
+        """Return the height of some or all items in this list
+
+        Parameters
+        ----------
+        typeSpec : optional Flag or sequence of flags
+            Only calculate the height of children that match these flags
+
+        Returns
+        -------
+        float
+            Cumulative height of some or all children
+
+        """
+        h = 0.0
+        for child in filter(lambda c: c.hasFlags(typeSpec), self):
+            h += child.getHeight()
+        return h
+
+    def getVolume(self):
+        """Compute the total volume in cm^3"""
+        return self.getArea() * self.getHeight()
+
+    def getArea(self, cold=False):
+        """Return the area of the first child
+
+        .. note::
+
+            This assumes that all children have the same area
+
+        Parameters
+        ----------
+        cold : optional bool
+            Evaluate at cold temperatures if ``cold==True``
+
+        Returns
+        -------
+        float
+            Area in cm^2
+
+        """
+        try:
+            return self[0].getArea(cold=cold)
+        except IndexError:
+            runLog.warning(f"{self} has no blocks and therefore no area. Assuming 1.0")
+            return 1.0
+
+    def getChildrenAndZ(
+        self,
+        typeSpec: Optional[flags.TypeSpec] = None,
+        returnBottomZ=False,
+        returnTopZ=False,
+    ) -> Iterator[Tuple[CompositeWithHeight, float]]:
+        """
+        Get children and their z-coordinates from bottom to top.
+
+        By default, z-coordinates returned will reflect the center of
+        the mesh.
+
+        This method is useful when you need to know the z-coord of a
+        child in the list.
+
+        Parameters
+        ----------
+        typeSpec : Flags or list of Flags, optional
+            Composite type specification to restrict to
+        returnBottomZ : bool, optional
+            If true, will return bottom coordinates instead of centers.
+        returnTopZ : bool, optional
+            If true, return the top coordinates instead of centers.
+
+        Returns
+        -------
+        iterator of (Composite, float)
+            Children and the appropriate z-coordinate
+        """
+
+        if returnBottomZ and returnTopZ:
+            raise ValueError(
+                "Both returnTopZ and returnBottomZ cannot be set to ``True``"
+            )
+        children = []
+        zCoords = []
+        bottom = 0.0
+        for child in self:
+            height = child.getHeight()
+            if child.hasFlags(typeSpec):
+                children.append(child)
+                if returnBottomZ:
+                    value = bottom
+                elif returnTopZ:
+                    value = bottom + height
+                else:
+                    value = bottom + 0.5 * height
+                zCoords.append(value)
+            bottom += height
+        return zip(children, zCoords)

--- a/armi/reactor/compositeList.py
+++ b/armi/reactor/compositeList.py
@@ -1,3 +1,17 @@
+# Copyright 2023 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Collection of composites with a 1-D grid"""
 
 from abc import ABC, ABCMeta, abstractmethod

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -893,6 +893,21 @@ class Assembly_TestCase(unittest.TestCase):
 
         self.assertRaises(TypeError, self.assembly.getBlocksAndZ, 1.0)
 
+    def test_getBlockAtElevation(self):
+        """Ensure that blocks are returned in the correct range of elevations"""
+        zBounds = self.assembly.spatialGrid.getBounds()[2]
+        getter = self.assembly.getBlockAtElevation
+        # Bottom block returned for values
+        self.assertIs(getter(zBounds[0]), self.assembly[0])
+        self.assertIs(getter(zBounds[1]), self.assembly[0])
+        # Second block returned for values in range (z[1], z[2]]
+        # (exclusive left, inclusive right)
+        mid = 0.5 * (zBounds[1] + zBounds[2])
+        self.assertIs(getter(mid), self.assembly[1])
+
+        # Nothing is returned if z > max
+        self.assertIsNone(getter(zBounds[-1] * 1.1))
+
     def test_getBlocksBetweenElevations(self):
         # assembly should have 3 blocks of 10 cm in it
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -8,8 +8,7 @@ Release Date: TBD
 
 What's new in ARMI
 ------------------
-#. TBD
-#. TBD
+#. Provide :class:`armi.reactor.compositeLists.CompositeList` base class for things that contain composites on a 1-D grid, like assemblies (`PR#1088 <https://github.com/terrapower/armi/pull/1088>`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

The intention of the abstract parent class is to shift most of the composite-tree traversal routines onto a generic parent class. It's abstract only because the Assembly does some re-naming of children during `Assembly.add` which subclasses might want to override. Might not be enough to justify all the metaclasses and just make that an empty method.

Later, another subclass of `CompositeList` could be used to model stacks of fuel pellets in a ``Block``. But that would require many blueprint side modifications that are to be discussed.

Some assembly methods like `getBlockAndZ` pass directly off to the parent method to maintain the same API. Wondering if there is room to make some of these iterator-based methods a generator? But that would also be an API change and should be done after some discussions.

Added a test for getBlocksAtElevation.

Closes #1030 

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

