### PR TITLE
Fix Sphinx errors in docs for `code-blocks`

### DIFF
--- a/doc/user/inputs/settings.rst
+++ b/doc/user/inputs/settings.rst
@@ -157,14 +157,16 @@ in power, length, and uptime.
 The history is restricted, however, to each cycle having a constant power, to
 each cycle having the same number of burnup nodes, and to those burnup nodes being
 evenly spaced within each cycle.
-An example simple cycle history might look like::
+An example simple cycle history might look like
 
-    power: 1000000
-    nCycles: 3
-    burnSteps: 2
-    cycleLengths: [100, R2]
-    powerFractions: [1.0, 0.5, 1.0]
-    availabilityFactors: [0.9, 0.3, 0.93]
+.. code-block:: yaml
+
+       power: 1000000
+       nCycles: 3
+       burnSteps: 2
+       cycleLengths: [100, R2]
+       powerFractions: [1.0, 0.5, 1.0]
+       availabilityFactors: [0.9, 0.3, 0.93]
 
 Note the use of the special shorthand list notation, where repeated values in a list can be specified using an "R" followed by the number of times the value is to be repeated.
 
@@ -187,24 +189,26 @@ For each cycle, an entry to the ``cycles`` list is made with the following optio
     * ``cumulative days``, ``step days``, or ``burn steps`` + ``cycle length``
     * ``availability factor``
 
-An example detailed cycle history employing all of these fields could look like::
+An example detailed cycle history employing all of these fields could look like
 
-    power: 1000000
-    nCycles: 4
-    cycles: 
-      - name: A
-        step days: [1, 1, 98]
-        power fractions: [0.1, 0.2, 1]
-        availability factor: 0.1
-      - name: B
-        cumulative days: [2, 72, 78, 86]
-        power fractions: [0.2, 1.0, 0.95, 0.93]
-      - name: C
-        step days: [5, R5]
-        power fractions: [1, R5]
-      - cycle length: 100
-        burn steps: 2
-        availability factor: 0.9
+.. code-block:: yaml
+
+       power: 1000000
+       nCycles: 4
+       cycles:
+         - name: A
+           step days: [1, 1, 98]
+           power fractions: [0.1, 0.2, 1]
+           availability factor: 0.1
+         - name: B
+           cumulative days: [2, 72, 78, 86]
+           power fractions: [0.2, 1.0, 0.95, 0.93]
+         - name: C
+           step days: [5, R5]
+           power fractions: [1, R5]
+         - cycle length: 100
+           burn steps: 2
+           availability factor: 0.9
 
 Note that repeated values in a list may be again be entered using the shorthand notation for ``step days``, ``power fractions``, and ``availability factors`` (though not ``cumulative days`` because entries must be monotonically increasing).
 
@@ -254,9 +258,10 @@ To run a snapshot, the following settings must be added to your case settings:
 An example of a snapshot run input:
 
 .. code-block:: yaml
-    runType: Snapshots
-    reloadDBName: my-old-results.h5
-    dumpSnapshot: ['000000', '001002'] # would produce 2 snapshots, at BOL and at node 2 of cycle 1
+       
+       runType: Snapshots
+       reloadDBName: my-old-results.h5
+       dumpSnapshot: ['000000', '001002'] # would produce 2 snapshots, at BOL and at node 2 of cycle 1
 
 To run a restart, the following settings must be added to your case settings:
 
@@ -274,92 +279,100 @@ A few examples of restart cases:
     
     - Restarting a calculation at a specific cycle/node and continuing for the remainder of the originally-specified cycle history:
         .. code-block:: yaml
-            # old settings
-            nCycles: 2
-            burnSteps: 2
-            cycleLengths: [100, 100]
-            runType: Standard
-            loadStyle: fromInput
-            loadingFile: my-blueprints.yaml
+               
+               # old settings
+               nCycles: 2
+               burnSteps: 2
+               cycleLengths: [100, 100]
+               runType: Standard
+               loadStyle: fromInput
+               loadingFile: my-blueprints.yaml
 
         .. code-block:: yaml
-            # restart settings
-            nCycles: 2
-            burnSteps: 2
-            cycleLengths: [100, 100]
-            runType: Standard
-            loadStyle: fromDB
-            startCycle: 1
-            startNode: 0
-            reloadDBName: my-original-results.h5
+            
+               # restart settings
+               nCycles: 2
+               burnSteps: 2
+               cycleLengths: [100, 100]
+               runType: Standard
+               loadStyle: fromDB
+               startCycle: 1
+               startNode: 0
+               reloadDBName: my-original-results.h5
 
     - Add an additional cycle to the end of a case:
         .. code-block:: yaml
-            # old settings
-            nCycles: 1
-            burnSteps: 2
-            cycleLengths: [100]
-            runType: Standard
-            loadStyle: fromInput
-            loadingFile: my-blueprints.yaml
+            
+               # old settings
+               nCycles: 1
+               burnSteps: 2
+               cycleLengths: [100]
+               runType: Standard
+               loadStyle: fromInput
+               loadingFile: my-blueprints.yaml
 
         .. code-block:: yaml
-            # restart settings
-            nCycles: 2
-            burnSteps: 2
-            cycleLengths: [100, 100]
-            runType: Standard
-            loadStyle: fromDB
-            startCycle: 0
-            startNode: -1
-            reloadDBName: my-original-results.h5
+            
+               # restart settings
+               nCycles: 2
+               burnSteps: 2
+               cycleLengths: [100, 100]
+               runType: Standard
+               loadStyle: fromDB
+               startCycle: 0
+               startNode: -1
+               reloadDBName: my-original-results.h5
 
     - Restart but cut the reactor history short:
         .. code-block:: yaml
-            # old settings
-            nCycles: 3
-            burnSteps: 2
-            cycleLengths: [100, 100, 100]
-            runType: Standard
-            loadStyle: fromInput
-            loadingFile: my-blueprints.yaml
+            
+               # old settings
+               nCycles: 3
+               burnSteps: 2
+               cycleLengths: [100, 100, 100]
+               runType: Standard
+               loadStyle: fromInput
+               loadingFile: my-blueprints.yaml
 
         .. code-block:: yaml
-            # restart settings
-            nCycles: 2
-            burnSteps: 2
-            cycleLengths: [100, 100]
-            runType: Standard
-            loadStyle: fromDB
-            startCycle: 1
-            startNode: 0
-            reloadDBName: my-original-results.h5
+            
+               # restart settings
+               nCycles: 2
+               burnSteps: 2
+               cycleLengths: [100, 100]
+               runType: Standard
+               loadStyle: fromDB
+               startCycle: 1
+               startNode: 0
+               reloadDBName: my-original-results.h5
 
     - Restart with a different number of steps in the third cycle using the detailed ``cycles`` setting:
         .. code-block:: yaml
-            # old settings
-            nCycles: 3
-            burnSteps: 2
-            cycleLengths: [100, 100, 100]
-            runType: Standard
-            loadStyle: fromInput
-            loadingFile: my-blueprints.yaml
+            
+               # old settings
+               nCycles: 3
+               burnSteps: 2
+               cycleLengths: [100, 100, 100]
+               runType: Standard
+               loadStyle: fromInput
+               loadingFile: my-blueprints.yaml
 
         .. code-block:: yaml
-            # restart settings
-            nCycles: 3
-            cycles:
-              - cycle length: 100
-                burn steps: 2
-              - cycle length: 100
-                burn steps: 2
-              - cycle length: 100
-                burn steps: 4
-            runType: Standard
-            loadStyle: fromDB
-            startCycle: 2
-            startNode: 0
-            reloadDBName: my-original-results.h5
+            
+               # restart settings
+               nCycles: 3
+               cycles:
+                 - cycle length: 100
+                   burn steps: 2
+                 - cycle length: 100
+                   burn steps: 2
+                 - cycle length: 100
+                   burn steps: 4
+               runType: Standard
+               loadStyle: fromDB
+               startCycle: 2
+               startNode: 0
+               reloadDBName: my-original-results.h5
 
 .. note:: The ``skipCycles`` setting is related to skipping the lattice physics calculation specifically, it is not required to do a restart run.
 


### PR DESCRIPTION
## Description
While creating docs for PR #1033, I came across some existing errors for `code-block`s in the docs. This PR resolves those and closes #1000. 

It turns out the `code-block` directive is pretty sensitive to spacing. 

> Be careful as the indent is not a fixed number of whitespace, e.g. three, but any number whitespace. This can be surprising when a fixed indent is used throughout the document and can make a difference for directives which are sensitive to whitespace.... In the first code block, the indent for the content was fixated by the option line to three spaces, consequently the content starts with four spaces. In the latter the indent was fixed by the content itself to seven spaces, thus it does not start with a space.

Changing the existing `code-block`s to having 7 spaces and an empty line between the directive and content resolved the errors. 

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
~- [ ] Tests have been added/updated to verify that the new/changed code works.~
    - Docs were compiled locally and confirmed to have the error resolved. 

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

