### PR TITLE
Improve logic for getNumPins

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -32,6 +32,7 @@ from armi.bookkeeping import report
 from armi import nuclideBases
 from armi.physics.neutronics import GAMMA
 from armi.physics.neutronics import NEUTRON
+from armi.reactor.components import basicShapes
 from armi.reactor import blockParameters
 from armi.reactor import components
 from armi.reactor.components.basicShapes import Hexagon, Circle
@@ -1016,7 +1017,15 @@ class Block(composites.Composite):
 
     def getNumPins(self):
         """Return the number of pins in this block."""
-        nPins = [self.getNumComponents(compType) for compType in PIN_COMPONENTS]
+        nPins = [
+            sum[
+                int(c.getDimension("mult"))
+                for c in self.iterComponents(compType)
+                if isinstance(c, basicShapes.Circle)
+                else 0
+            ]
+            for compType in PIN_COMPONENTS
+        ] 
         return 0 if not nPins else max(nPins)
 
     def mergeWithBlock(self, otherBlock, fraction):

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1018,14 +1018,16 @@ class Block(composites.Composite):
     def getNumPins(self):
         """Return the number of pins in this block."""
         nPins = [
-            sum[
-                int(c.getDimension("mult"))
-                for c in self.iterComponents(compType)
-                if isinstance(c, basicShapes.Circle)
-                else 0
-            ]
+            sum(
+                [
+                    int(c.getDimension("mult"))
+                    if isinstance(c, basicShapes.Circle)
+                    else 0
+                    for c in self.iterComponents(compType)
+                ]
+            )
             for compType in PIN_COMPONENTS
-        ] 
+        ]
         return 0 if not nPins else max(nPins)
 
     def mergeWithBlock(self, otherBlock, fraction):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -23,7 +23,7 @@ import numpy
 from numpy.testing import assert_allclose
 
 from armi import materials, runLog, settings, tests
-from armi.reactor.components import basicShapes
+from armi.reactor.components import basicShapes, complexShapes
 from armi.nucDirectory import nucDir, nuclideBases
 from armi.nuclearDataIO.cccc import isotxs
 from armi.physics.neutronics import NEUTRON, GAMMA
@@ -1242,10 +1242,22 @@ class Block_TestCase(unittest.TestCase):
         emptyBlock = blocks.HexBlock("empty")
         self.assertEqual(emptyBlock.getNumPins(), 0)
 
-        comp = basicShapes.Hexagon("hexagon", "HT9", 1, 1, 1)
-        comp.setType("component", flags=Flags.SHIELD)
-        emptyBlock.add(comp)
+        holedRectangle = complexShapes.HoledRectangle(
+            "holedRectangle", "HT9", 1, 1, 0.5, 1.0, 1.0
+        )
+        holedRectangle.setType("component", flags=Flags.CONTROL)
+        emptyBlock.add(holedRectangle)
         self.assertEqual(emptyBlock.getNumPins(), 0)
+
+        hexagon = basicShapes.Hexagon("hexagon", "HT9", 1, 1, 1)
+        hexagon.setType("component", flags=Flags.SHIELD)
+        emptyBlock.add(hexagon)
+        self.assertEqual(emptyBlock.getNumPins(), 0)
+
+        pins = basicShapes.Circle("circle", "HT9", 1, 1, 1, 0, 8)
+        pins.setType("component", flags=Flags.PLENUM)
+        emptyBlock.add(pins)
+        self.assertEqual(emptyBlock.getNumPins(), 8)
 
     def test_setLinPowByPin(self):
         numPins = self.block.getNumPins()

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1242,6 +1242,11 @@ class Block_TestCase(unittest.TestCase):
         emptyBlock = blocks.HexBlock("empty")
         self.assertEqual(emptyBlock.getNumPins(), 0)
 
+        comp = basicShapes.Hexagon("hexagon", "HT9", 1, 1, 1)
+        comp.setType("component", flags=Flags.SHIELD)
+        emptyBlock.add(comp)
+        self.assertEqual(emptyBlock.getNumPins(), 0)
+
     def test_setLinPowByPin(self):
         numPins = self.block.getNumPins()
         neutronPower = [10.0 * i for i in range(numPins)]

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -24,6 +24,7 @@ What's new in ARMI
 #. Add a how-to on restart calculations in the docs
 #. General improvements to efficiency in many places to speed up uniform mesh conversion. (`PR#1042 <https://github.com/terrapower/armi/pull/1042>`_)
 #. Allow MCNP material card number to be defined after the card is written. (`PR#1086 <https://github.com/terrapower/armi/pull/1086>`_)
+#. Refine logic for Block.getNumPins() to only count components that are actually pins. (`PR#1098 <https://github.com/terrapower/armi/pull/1098>`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

#1096 

The logic for `Block.getNumPins()` will identify lots of different components as pins, whether or not they are indeed pins. If a component has `Flags.SHIELD`, for example, it will be considered a pin (no matter what the shape or intent of the actual component is).

It is a relatively safe bet to assume all pins are circular, so a filter on component shape is applied to weed out any non-pin components.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

