### PR TITLE
Cleanup umc

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -492,7 +492,10 @@ def _getNeutronicsBlockParams():
         )
 
         pb.defParam(
-            "pdens", units="W/cm$^3$", description="Average volumetric power density"
+            "pdens",
+            units="W/cm$^3$",
+            description="Average volumetric power density",
+            categories=[parameters.Category.neutronics],
         )
 
         pb.defParam(
@@ -620,7 +623,12 @@ def _getNeutronicsBlockParams():
             categories=[parameters.Category.gamma],
         )
 
-        pb.defParam("power", units="W", description="Total power")
+        pb.defParam(
+            "power",
+            units="W",
+            description="Total power",
+            categories=[parameters.Category.neutronics],
+        )
 
         pb.defParam("powerDecay", units="W", description="Total decay power")
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1585,6 +1585,7 @@ class HexBlock(Block):
         hexComponent.setNumberDensities(self.getNumberDensities())
         b.add(hexComponent)
 
+        b.p.nPins = self.p.nPins
         if pinSpatialLocators:
             # create a null component with cladding flags and spatialLocator from source block's
             # clad components in case pin locations need to be known for physics solver

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -424,6 +424,7 @@ class TestGammaUniformMesh(unittest.TestCase):
         for b in self.converter.convReactor.core.getBlocks():
             b.p.powerGamma = 0.5
             b.p.powerNeutron = 0.5
+            b.p.power = b.p.powerGamma + b.p.powerNeutron
 
         # check integral and density params
         assemblyPowers = [
@@ -446,11 +447,11 @@ class TestGammaUniformMesh(unittest.TestCase):
             self.assertEqual(b.p.fastFlux, 2.0)
             self.assertEqual(b.p.flux, 5.0)
             self.assertEqual(b.p.fastFlux, 2.0)
-            self.assertEqual(b.p.power, 5.0)
 
             # not equal because blocks are different size
             self.assertNotEqual(b.p.powerGamma, 0.5)
             self.assertNotEqual(b.p.powerNeutron, 0.5)
+            self.assertNotEqual(b.p.power, 1.0)
 
         # equal because these are mapped
         for expectedPower, expectedGammaPower, a in zip(

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -934,6 +934,7 @@ class GammaUniformMeshConverter(UniformMeshGeometryConverter):
         ],
         "out": [
             parameters.Category.gamma,
+            parameters.Category.neutronics,
         ],
     }
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -467,6 +467,7 @@ class Block_TestCase(unittest.TestCase):
             if arg:
                 # check that homogenized block has correct pin coordinates
                 self.assertEqual(self.block.getNumPins(), homogBlock.getNumPins())
+                self.assertEqual(self.block.p.nPins, homogBlock.p.nPins)
                 pinCoords = self.block.getPinCoordinates()
                 homogPinCoords = homogBlock.getPinCoordinates()
                 for refXYZ, homogXYZ in zip(list(pinCoords), list(homogPinCoords)):


### PR DESCRIPTION
## Description

Some subtle bugs in #1042 were missed until more detailed testing was performed.

1. There are two ways of getting the number of pins in a block: `block.getNumPins()` and `b.p.nPins`. `b.p.nPins` is set in the blueprints:

https://github.com/terrapower/armi/blob/b5235f0872dafc1428c6209e20ec1365b1c35c92/armi/reactor/blueprints/blockBlueprint.py#L180

It also needs to be set in `_createHomogenizedCopy`

2. `power` and `pdens` are initially set by the neutronics solver in a downstream workflow, but when gamma transport is performed these parameters are modified. Thus, they need to be mapped "out" from the `GammaUniformMeshConverter`. This is likely to be true of any implementation of a coupled neutronics/gamma transport solution.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

