### PR TITLE
Adding a helper method to validate versions in settings files

### DIFF
--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -746,9 +746,9 @@ def validateVersion(versionThis: str, versionRequired: str) -> bool:
     bool
         Does this version match the version in the Settings file/object?
     """
-    fullV = "[0-9]\.[0-9]\.[0-9]"
-    medV = "[0-9]\.[0-9]"
-    minV = "[0-9]"
+    fullV = "\d+\.\d+\.\d+"
+    medV = "\d+\.\d+"
+    minV = "\d+"
 
     if versionRequired == "uncontrolled":
         # This default flag means we don't want to check the version.

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -737,7 +737,7 @@ def validateVersion(versionThis: str, versionRequired: str) -> bool:
     versionThis: str
         The version of this ARMI, App, or Plugin.
         This MUST be in the form: 1.2.3
-    versionRequired: str:
+    versionRequired: str
         The version to compare against, say in a Settings file.
         This must be in one of the forms: 1.2.3, 1.2, or 1
 
@@ -750,7 +750,10 @@ def validateVersion(versionThis: str, versionRequired: str) -> bool:
     medV = "[0-9]\.[0-9]"
     minV = "[0-9]"
 
-    if re.search(fullV, versionThis) is None:
+    if versionRequired == "uncontrolled":
+        # This default flag means we don't want to check the version.
+        return True
+    elif re.search(fullV, versionThis) is None:
         raise ValueError(
             "The input version ({0}) does not match the required format: {1}".format(
                 versionThis, fullV

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -762,9 +762,9 @@ def validateVersion(versionThis: str, versionRequired: str) -> bool:
     elif re.search(fullV, versionRequired) is not None:
         return versionThis == versionRequired
     elif re.search(medV, versionRequired) is not None:
-        return versionThis[:-2] == versionRequired
+        return ".".join(versionThis.split(".")[:2]) == versionRequired
     elif re.search(minV, versionRequired) is not None:
-        return versionThis[0] == versionRequired
+        return versionThis.split(".")[0] == versionRequired
     else:
         raise ValueError(
             "The required version is not a valid format: {}".format(versionRequired)

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -21,6 +21,7 @@ dialogues in the GUI. They say things like: "Your ___ setting has the value ___,
 is impossible. Would you like to switch to ___?"
 
 """
+import re
 import os
 
 from armi import context
@@ -726,3 +727,42 @@ def createQueryRevertBadPathToDefault(inspector, settingName, initialLambda=None
         inspector.cs.getSetting(settingName).revertToDefault,
     )
     return query
+
+
+def validateVersion(versionThis: str, versionRequired: str) -> bool:
+    """Helper function to allow users to verify that their version matches the settings file.
+
+    Parameters
+    ----------
+    versionThis: str
+        The version of this ARMI, App, or Plugin.
+        This MUST be in the form: 1.2.3
+    versionRequired: str:
+        The version to compare against, say in a Settings file.
+        This must be in one of the forms: 1.2.3, 1.2, or 1
+
+    Returns
+    -------
+    bool
+        Does this version match the version in the Settings file/object?
+    """
+    fullV = "[0-9]\.[0-9]\.[0-9]"
+    medV = "[0-9]\.[0-9]"
+    minV = "[0-9]"
+
+    if re.search(fullV, versionThis) is None:
+        raise ValueError(
+            "The input version ({0}) does not match the required format: {1}".format(
+                versionThis, fullV
+            )
+        )
+    elif re.search(fullV, versionRequired) is not None:
+        return versionThis == versionRequired
+    elif re.search(medV, versionRequired) is not None:
+        return versionThis[:-2] == versionRequired
+    elif re.search(minV, versionRequired) is not None:
+        return versionThis[0] == versionRequired
+    else:
+        raise ValueError(
+            "The required version is not a valid format: {}".format(versionRequired)
+        )

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -458,7 +458,10 @@ class TestSettingsValidationUtils(unittest.TestCase):
     def test_validateVersion(self):
         # controlled version, and true
         self.assertTrue(validateVersion("1.22.3", "1.22.3"))
+        self.assertTrue(validateVersion("1.3.102", "1.3.102"))
         self.assertTrue(validateVersion("1.2.3", "1.2"))
+        self.assertTrue(validateVersion("1.2.37", "1.2"))
+        self.assertTrue(validateVersion("13.7.3", "13.7"))
         self.assertTrue(validateVersion("1.22.310", "1"))
 
         # uncontrolled version is always true

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -456,16 +456,22 @@ class TestFlagListSetting(unittest.TestCase):
 
 class TestSettingsValidationUtils(unittest.TestCase):
     def test_validateVersion(self):
-        self.assertTrue(validateVersion("1.2.3", "1.2.3"))
+        # controlled version, and true
+        self.assertTrue(validateVersion("1.22.3", "1.22.3"))
         self.assertTrue(validateVersion("1.2.3", "1.2"))
-        self.assertTrue(validateVersion("1.2.3", "1"))
-        self.assertTrue(validateVersion("4.2.0", "uncontrolled"))
-        self.assertFalse(validateVersion("1.2.3", "1.2.4"))
-        self.assertFalse(validateVersion("1.2.3", "3.2.1"))
-        self.assertFalse(validateVersion("1.2.3", "2.2"))
+        self.assertTrue(validateVersion("1.22.310", "1"))
 
+        # uncontrolled version is always true
+        self.assertTrue(validateVersion("4.2.0", "uncontrolled"))
+
+        # controlled versions and false
+        self.assertFalse(validateVersion("11.2.3", "11.2.4"))
+        self.assertFalse(validateVersion("1.2.3", "3.2.1"))
+        self.assertFalse(validateVersion("11.2.3", "2.2"))
+
+        # examples of various errors
         with self.assertRaises(ValueError):
-            validateVersion("1.2.a", "1.2.3")
+            validateVersion("1.2.a", "1.20.3")
 
         with self.assertRaises(ValueError):
             validateVersion("nope", "7")

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -28,7 +28,7 @@ from armi import getApp
 from armi import getPluginManagerOrFail
 from armi import plugins
 from armi import settings
-from armi.operators import settingsValidation
+from armi.operators.settingsValidation import Inspector, validateVersion
 from armi.physics.fuelCycle import FuelHandlerPlugin
 from armi.reactor.flags import Flags
 from armi.settings import caseSettings
@@ -219,7 +219,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
             },
         )
 
-        inspector = settingsValidation.Inspector(cs)
+        inspector = Inspector(cs)
         self.assertTrue(
             any(
                 [
@@ -452,6 +452,25 @@ class TestFlagListSetting(unittest.TestCase):
         fs = setting.FlagListSetting(name="testFlagSetting", default=[])
         with self.assertRaises(TypeError):
             fs.value = "DUCT"
+
+
+class TestSettingsValidationUtils(unittest.TestCase):
+    def test_validateVersion(self):
+        self.assertTrue(validateVersion("1.2.3", "1.2.3"))
+        self.assertTrue(validateVersion("1.2.3", "1.2"))
+        self.assertTrue(validateVersion("1.2.3", "1"))
+        self.assertFalse(validateVersion("1.2.3", "1.2.4"))
+        self.assertFalse(validateVersion("1.2.3", "3.2.1"))
+        self.assertFalse(validateVersion("1.2.3", "2.2"))
+
+        with self.assertRaises(ValueError):
+            validateVersion("1.2.a", "1.2.3")
+
+        with self.assertRaises(ValueError):
+            validateVersion("nope", "7")
+
+        with self.assertRaises(ValueError):
+            validateVersion("1.2.3", "zzz")
 
 
 if __name__ == "__main__":

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -459,6 +459,7 @@ class TestSettingsValidationUtils(unittest.TestCase):
         self.assertTrue(validateVersion("1.2.3", "1.2.3"))
         self.assertTrue(validateVersion("1.2.3", "1.2"))
         self.assertTrue(validateVersion("1.2.3", "1"))
+        self.assertTrue(validateVersion("4.2.0", "uncontrolled"))
         self.assertFalse(validateVersion("1.2.3", "1.2.4"))
         self.assertFalse(validateVersion("1.2.3", "3.2.1"))
         self.assertFalse(validateVersion("1.2.3", "2.2"))

--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -164,6 +164,27 @@ add a little more to the plugin.
     :language: python
 
 
+Defining custom settings
+========================
+An important facet of the above plugin is that it takes custom Settings, and has some
+validation built in for those ``Setting`` values. That is, the plugin registers new
+settings that can go in the settings file, and help the user define how the simulation
+runs.
+
+The following example boiler plate code defines three settings. We define two simple
+number settings (inlet and outlet temperatures), and we use :py:class:`Query 
+<armi.operators.settingsValidation .Query>` to define validation on those settings. Here,
+the validation isn't very exciting, we just make sure the temperatures are above zero.
+That's not particularly physically meaningful, but serves as a simple example. The next
+setting is a little more complicated, we define a setting ``myAppVersion`` that defines
+a specific version of our app that this setting file is valid for. And if you try to run
+a different version you get a nasty warning printed to the screen.
+
+.. literalinclude:: armi-example-app/myapp/settings.py
+    :caption: ``myapp/settings.py``
+    :language: python
+
+
 Creating the physics kernels
 ============================
 So far we have basically been weaving an administrative thread to tell ARMI about the code


### PR DESCRIPTION
## Description

There was [a request](https://github.com/terrapower/armi/issues/1095) to validate the versions of the app or plugin from a custom setting.

This is a little tool the user can use as part of a setting validation, to validate their versions for controlled runs.  Please see [this armi-example-app PR](https://github.com/terrapower/armi-example-app/pull/3) for how to do that.  

After both of these PRs are merged, I could also add examples of custom settings to the ARMI docs, under tutorials.

### Docs

I have also added a basic introduction to how to add new `Settings` to you `Plugin` in the docs.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
