### PR TITLE
Fixing broken doc link for mpi4py

### DIFF
--- a/doc/developer/parallel_coding.rst
+++ b/doc/developer/parallel_coding.rst
@@ -2,7 +2,7 @@
 Parallel Code in ARMI
 #####################
 
-ARMI simulations can be parallelized using the `mpi4py <http://mpi4py.scipy.org/docs/usrman/index.html>`_
+ARMI simulations can be parallelized using the `mpi4py <https://mpi4py.readthedocs.io/en/stable/mpi4py.html>`_
 module. You should go there and read about collective and point-to-point communication if you want to
 understand everything in-depth.
 


### PR DESCRIPTION
## Description

Fixing a broken link to `mpi4py` in the docs.  Thanks @andfranklin!

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
