### PR TITLE
Using mockRunLogs in a better way

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -214,7 +214,7 @@ class TestCompareDB3(unittest.TestCase):
             with mockRunLogs.BufferLog() as mock:
                 _diffSpecialData(refData, srcData3, out, dr)
                 self.assertEqual(dr.nDiffs(), 0)
-                self.assertIn("Special formatting parameters for", mock._outputStream)
+                self.assertIn("Special formatting parameters for", mock.getStdout())
 
             # make an H5 datasets that will cause unpackSpecialData to fail
             f4 = h5py.File("test_diffSpecialData4.hdf5", "w")

--- a/armi/bookkeeping/report/tests/test_newReport.py
+++ b/armi/bookkeeping/report/tests/test_newReport.py
@@ -147,15 +147,15 @@ class TestReportContentCreation(unittest.TestCase):
         env = data.Report("Environment", "ARMI Env Info")
 
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             _ = env["badStuff"]
-            self.assertIn("Cannot locate group", mock._outputStream)
+            self.assertIn("Cannot locate group", mock.getStdout())
 
-            mock._outputStream = ""
-            self.assertEqual("", mock._outputStream)
+            mock.emptyStdout()
+            self.assertEqual("", mock.getStdout())
             env.writeHTML()
-            self.assertIn("Writing HTML document", mock._outputStream)
-            self.assertIn("[info] HTML document", mock._outputStream)
+            self.assertIn("Writing HTML document", mock.getStdout())
+            self.assertIn("[info] HTML document", mock.getStdout())
 
 
 if __name__ == "__main__":

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -78,58 +78,58 @@ class TestReport(unittest.TestCase):
 
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.LOG.startLog("test_reactorSpecificReporting")
             runLog.LOG.setVerbosity(logging.INFO)
 
             writeAssemblyMassSummary(r)
-            self.assertIn("BOL Assembly Mass Summary", mock._outputStream)
-            self.assertIn("igniter fuel", mock._outputStream)
-            self.assertIn("primary control", mock._outputStream)
-            self.assertIn("plenum", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("BOL Assembly Mass Summary", mock.getStdout())
+            self.assertIn("igniter fuel", mock.getStdout())
+            self.assertIn("primary control", mock.getStdout())
+            self.assertIn("plenum", mock.getStdout())
+            mock.emptyStdout()
 
             setNeutronBalancesReport(r.core)
-            self.assertIn("No rate information", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("No rate information", mock.getStdout())
+            mock.emptyStdout()
 
             r.core.getFirstBlock().p.rateCap = 1.0
             r.core.getFirstBlock().p.rateProdFis = 1.02
             r.core.getFirstBlock().p.rateFis = 1.01
             r.core.getFirstBlock().p.rateAbs = 1.0
             setNeutronBalancesReport(r.core)
-            self.assertIn("Fission", mock._outputStream)
-            self.assertIn("Capture", mock._outputStream)
-            self.assertIn("Absorption", mock._outputStream)
-            self.assertIn("Leakage", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("Fission", mock.getStdout())
+            self.assertIn("Capture", mock.getStdout())
+            self.assertIn("Absorption", mock.getStdout())
+            self.assertIn("Leakage", mock.getStdout())
+            mock.emptyStdout()
 
             summarizePinDesign(r.core)
-            self.assertIn("Assembly Design Summary", mock._outputStream)
-            self.assertIn("Design & component information", mock._outputStream)
-            self.assertIn("Multiplicity", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("Assembly Design Summary", mock.getStdout())
+            self.assertIn("Design & component information", mock.getStdout())
+            self.assertIn("Multiplicity", mock.getStdout())
+            mock.emptyStdout()
 
             summarizePower(r.core)
-            self.assertIn("Power in radial shield", mock._outputStream)
-            self.assertIn("Power in primary control", mock._outputStream)
-            self.assertIn("Power in feed fuel", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("Power in radial shield", mock.getStdout())
+            self.assertIn("Power in primary control", mock.getStdout())
+            self.assertIn("Power in feed fuel", mock.getStdout())
+            mock.emptyStdout()
 
             writeCycleSummary(r.core)
-            self.assertIn("Core Average", mock._outputStream)
-            self.assertIn("Outlet Temp", mock._outputStream)
-            self.assertIn("End of Cycle", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("Core Average", mock.getStdout())
+            self.assertIn("Outlet Temp", mock.getStdout())
+            self.assertIn("End of Cycle", mock.getStdout())
+            mock.emptyStdout()
 
             # this report won't do much for the test reactor - improve test reactor
             makeBlockDesignReport(r)
-            self.assertEqual(len(mock._outputStream), 0)
-            mock._outputStream = ""
+            self.assertEqual(len(mock.getStdout()), 0)
+            mock.emptyStdout()
 
             # this report won't do much for the test reactor - improve test reactor
             summarizePowerPeaking(r.core)
-            self.assertEqual(len(mock._outputStream), 0)
+            self.assertEqual(len(mock.getStdout()), 0)
 
 
 class TestReportInterface(unittest.TestCase):
@@ -156,10 +156,10 @@ class TestReportInterface(unittest.TestCase):
 
         with mockRunLogs.BufferLog() as mock:
             repInt.interactBOL()
-            self.assertIn("Writing assem layout", mock._outputStream)
-            self.assertIn("BOL Assembly", mock._outputStream)
-            self.assertIn("wetMass", mock._outputStream)
-            self.assertIn("moveable plenum", mock._outputStream)
+            self.assertIn("Writing assem layout", mock.getStdout())
+            self.assertIn("BOL Assembly", mock.getStdout())
+            self.assertIn("wetMass", mock.getStdout())
+            self.assertIn("moveable plenum", mock.getStdout())
 
     def test_interactEveryNode(self):
         o, r = loadTestReactor()
@@ -167,9 +167,9 @@ class TestReportInterface(unittest.TestCase):
 
         with mockRunLogs.BufferLog() as mock:
             repInt.interactEveryNode(0, 0)
-            self.assertIn("Cycle 0", mock._outputStream)
-            self.assertIn("node 0", mock._outputStream)
-            self.assertIn("keff=", mock._outputStream)
+            self.assertIn("Cycle 0", mock.getStdout())
+            self.assertIn("node 0", mock.getStdout())
+            self.assertIn("keff=", mock.getStdout())
 
     def test_interactBOC(self):
         o, r = loadTestReactor()
@@ -185,8 +185,8 @@ class TestReportInterface(unittest.TestCase):
 
         with mockRunLogs.BufferLog() as mock:
             repInt.interactEOC(0)
-            self.assertIn("Cycle 0", mock._outputStream)
-            self.assertIn("TIMER REPORTS", mock._outputStream)
+            self.assertIn("Cycle 0", mock.getStdout())
+            self.assertIn("TIMER REPORTS", mock.getStdout())
 
     def test_interactEOL(self):
         o, r = loadTestReactor()
@@ -194,8 +194,8 @@ class TestReportInterface(unittest.TestCase):
 
         with mockRunLogs.BufferLog() as mock:
             repInt.interactEOL()
-            self.assertIn("Comprehensive Core Report", mock._outputStream)
-            self.assertIn("Assembly Area Fractions", mock._outputStream)
+            self.assertIn("Comprehensive Core Report", mock.getStdout())
+            self.assertIn("Assembly Area Fractions", mock.getStdout())
 
 
 if __name__ == "__main__":

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -36,7 +36,7 @@ class TestMemoryProfiler(unittest.TestCase):
     def test_fullBreakdown(self):
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.LOG.startLog("test_fullBreakdown")
             runLog.LOG.setVerbosity(logging.INFO)
 
@@ -45,13 +45,13 @@ class TestMemoryProfiler(unittest.TestCase):
             self.memPro._printFullMemoryBreakdown(reportSize=False)
 
             # do some basic testing
-            self.assertTrue(mock._outputStream.count("UNIQUE_INSTANCE_COUNT") > 10)
-            self.assertIn("garbage", mock._outputStream)
+            self.assertTrue(mock.getStdout().count("UNIQUE_INSTANCE_COUNT") > 10)
+            self.assertIn("garbage", mock.getStdout())
 
     def test_displayMemoryUsage(self):
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.LOG.startLog("test_displayMemUsage")
             runLog.LOG.setVerbosity(logging.INFO)
 
@@ -60,12 +60,12 @@ class TestMemoryProfiler(unittest.TestCase):
             self.memPro.displayMemoryUsage(1)
 
             # do some basic testing
-            self.assertIn("End Memory Usage Report", mock._outputStream)
+            self.assertIn("End Memory Usage Report", mock.getStdout())
 
     def test_printFullMemoryBreakdown(self):
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.LOG.startLog("test_displayMemUsage")
             runLog.LOG.setVerbosity(logging.INFO)
 
@@ -74,20 +74,20 @@ class TestMemoryProfiler(unittest.TestCase):
             self.memPro._printFullMemoryBreakdown(reportSize=True)
 
             # do some basic testing
-            self.assertIn("UNIQUE_INSTANCE_COUNT", mock._outputStream)
-            self.assertIn(" MB", mock._outputStream)
+            self.assertIn("UNIQUE_INSTANCE_COUNT", mock.getStdout())
+            self.assertIn(" MB", mock.getStdout())
 
     def test_getReferrers(self):
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             testName = "test_getReferrers"
             runLog.LOG.startLog(testName)
             runLog.LOG.setVerbosity(logging.DEBUG)
 
             # grab the referrers
             self.memPro.getReferrers(self.r)
-            memLog = mock._outputStream
+            memLog = mock.getStdout()
 
         # test the results
         self.assertGreater(memLog.count("ref for"), 10)
@@ -99,7 +99,7 @@ class TestMemoryProfiler(unittest.TestCase):
     def test_checkForDuplicateObjectsOnArmiModel(self):
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             testName = "test_checkForDuplicateObjectsOnArmiModel"
             runLog.LOG.startLog(testName)
             runLog.LOG.setVerbosity(logging.IMPORTANT)
@@ -110,13 +110,13 @@ class TestMemoryProfiler(unittest.TestCase):
 
             # validate the outputs are as we expect
             self.assertIn(
-                "There are 2 unique objects stored as `.cs`", mock._outputStream
+                "There are 2 unique objects stored as `.cs`", mock.getStdout()
             )
-            self.assertIn("Expected id", mock._outputStream)
-            self.assertIn("Expected object", mock._outputStream)
-            self.assertIn("These types of objects", mock._outputStream)
-            self.assertIn("MemoryProfiler", mock._outputStream)
-            self.assertIn("MainInterface", mock._outputStream)
+            self.assertIn("Expected id", mock.getStdout())
+            self.assertIn("Expected object", mock.getStdout())
+            self.assertIn("These types of objects", mock.getStdout())
+            self.assertIn("MemoryProfiler", mock.getStdout())
+            self.assertIn("MainInterface", mock.getStdout())
 
     def test_profileMemoryUsageAction(self):
         pmua = memoryProfiler.ProfileMemoryUsageAction("timeDesc")

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -206,15 +206,15 @@ class TestArmiCase(unittest.TestCase):
 
             with mockRunLogs.BufferLog() as mock:
                 # we should start with a clean slate
-                self.assertEqual("", mock._outputStream)
+                self.assertEqual("", mock.getStdout())
                 runLog.LOG.startLog("test_run")
                 runLog.LOG.setVerbosity(logging.INFO)
 
                 case.run()
 
-                self.assertIn("Triggering BOL Event", mock._outputStream)
-                self.assertIn("xsGroups", mock._outputStream)
-                self.assertIn("Completed EveryNode - cycle 0", mock._outputStream)
+                self.assertIn("Triggering BOL Event", mock.getStdout())
+                self.assertIn("xsGroups", mock.getStdout())
+                self.assertIn("Completed EveryNode - cycle 0", mock.getStdout())
 
     def test_clone(self):
         testTitle = "CLONE_TEST"

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -85,12 +85,12 @@ class TestCheckInputEntryPoint(unittest.TestCase):
         ci.parse_args([ARMI_RUN_PATH])
 
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
 
             ci.invoke()
 
-            self.assertIn(ARMI_RUN_PATH, mock._outputStream)
-            self.assertIn("input is self consistent", mock._outputStream)
+            self.assertIn(ARMI_RUN_PATH, mock.getStdout())
+            self.assertIn("input is self consistent", mock.getStdout())
 
 
 class TestCloneArmiRunCommandBatch(unittest.TestCase):
@@ -195,7 +195,7 @@ class TestConvertDB(unittest.TestCase):
             cdb.args.nodes = [1, 2, 3]
             with self.assertRaises(ValueError):
                 cdb.invoke()
-            self.assertIn("Converting the", mock._outputStream)
+            self.assertIn("Converting the", mock.getStdout())
 
     def test_convertDbOutputVersion(self):
         cdb = ConvertDB()
@@ -221,9 +221,9 @@ class TestExpandBlueprints(unittest.TestCase):
 
         # Since the file is fake, invoke() should exit early.
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             ebp.invoke()
-            self.assertIn("does not exist", mock._outputStream)
+            self.assertIn("does not exist", mock.getStdout())
 
 
 class TestExtractInputs(unittest.TestCase):

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -244,7 +244,7 @@ class TestXSLibrary(unittest.TestCase, TempFileMixin):
                 lib = xsLibraries.IsotxsLibrary()
                 with self.assertRaises(OSError):
                     xsLibraries.mergeXSLibrariesInWorkingDirectory(lib, "ISOTXS", "")
-                self.assertIn(dummyFileName, log.getStdoutValue())
+                self.assertIn(dummyFileName, log.getStdout())
         finally:
             os.remove(dummyFileName)
 
@@ -261,7 +261,7 @@ class TestXSLibrary(unittest.TestCase, TempFileMixin):
                 xsLibraries.mergeXSLibrariesInWorkingDirectory(lib)
                 self.assertIn(
                     f"{dummyFileName} in the merging of ISOXX files",
-                    log.getStdoutValue(),
+                    log.getStdout(),
                 )
         finally:
             pass

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -62,30 +62,30 @@ class NuclideTests(unittest.TestCase):
 
     def test_nuclide_newLabelsDontCauseWarnings(self):
         with mockRunLogs.BufferLog() as logCapture:
-            self.assertEqual("", logCapture._outputStream)
+            self.assertEqual("", logCapture.getStdout())
             fe = nuclideBases.byName["FE"]
             feNuc = xsNuclides.XSNuclide(None, "FEAA")
             feNuc.isotxsMetadata["nuclideId"] = fe.name
             feNuc.updateBaseNuclide()
             self.assertEqual(fe, feNuc._base)
-            self.assertEqual("", logCapture._outputStream)
+            self.assertEqual("", logCapture.getStdout())
 
     def test_nuclide_oldLabelsCauseWarnings(self):
         with mockRunLogs.BufferLog() as logCapture:
-            self.assertEqual("", logCapture._outputStream)
+            self.assertEqual("", logCapture.getStdout())
             pu = nuclideBases.byName["PU239"]
             puNuc = xsNuclides.XSNuclide(None, "PLUTAA")
             puNuc.isotxsMetadata["nuclideId"] = pu.name
             puNuc.updateBaseNuclide()
             self.assertEqual(pu, puNuc._base)
-            length = len(logCapture._outputStream)
+            length = len(logCapture.getStdout())
             self.assertGreater(length, 15)
             # now get it with a legitmate same label, length shouldn't change
             puNuc = xsNuclides.XSNuclide(None, "PLUTAB")
             puNuc.isotxsMetadata["nuclideId"] = pu.name
             puNuc.updateBaseNuclide()
             self.assertEqual(pu, puNuc._base)
-            self.assertEqual(length, len(logCapture._outputStream))
+            self.assertEqual(length, len(logCapture.getStdout()))
 
     def test_nuclide_nuclideBaseMethodsShouldNotFail(self):
         for nuc in self.lib.nuclides:

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -817,8 +817,8 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         assembly.reestablishBlockOrder()
         with mockRunLogs.BufferLog() as mock:
             self.obj.performPrescribedAxialExpansion(assembly, [dummy], [0.01])
-            self.assertIn("(blueprints defined)", mock._outputStream)
-            self.assertIn("(inferred)", mock._outputStream)
+            self.assertIn("(blueprints defined)", mock.getStdout())
+            self.assertIn("(inferred)", mock.getStdout())
 
 
 class TestInputHeightsConsideredHot(unittest.TestCase):

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -1010,12 +1010,11 @@ class CartesianReactorTests(ReactorTests):
 
         # run the actual method in question
         self.r.core.getNuclideCategories()
-        messages = log.getStdoutValue()
+        messages = log.getStdout()
 
         self.assertIn("Nuclide categorization", messages)
         self.assertIn("Structure", messages)
 
 
 if __name__ == "__main__":
-    # import sys;sys.argv = ["", "ReactorTests.test_genAssembliesAddedThisCycle"]
     unittest.main()

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -281,15 +281,15 @@ class TestZones(unittest.TestCase):
         with mockRunLogs.BufferLog() as mock:
             runLog.LOG.startLog("test_summary")
             runLog.LOG.setVerbosity(logging.INFO)
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
 
             self.zonez.summary()
 
-            self.assertIn("zoneDefinitions:", mock._outputStream)
-            self.assertIn("- ring-1: ", mock._outputStream)
-            self.assertIn("- ring-2: ", mock._outputStream)
-            self.assertIn("- ring-3: ", mock._outputStream)
-            self.assertIn("003-001, 003-002, 003-003", mock._outputStream)
+            self.assertIn("zoneDefinitions:", mock.getStdout())
+            self.assertIn("- ring-1: ", mock.getStdout())
+            self.assertIn("- ring-2: ", mock.getStdout())
+            self.assertIn("- ring-3: ", mock.getStdout())
+            self.assertIn("003-001, 003-002, 003-003", mock.getStdout())
 
     def test_sortZones(self):
         # create some zones in non-alphabetical order

--- a/armi/tests/mockRunLogs.py
+++ b/armi/tests/mockRunLogs.py
@@ -93,8 +93,11 @@ class BufferLog(runLog._RunLog):
         """Reset the single warned list so we get messages again."""
         self._singleMessageCounts.clear()
 
-    def getStdoutValue(self):
+    def getStdout(self):
         return self._outputStream
+
+    def emptyStdout(self):
+        self._outputStream = ""
 
     def getStderrValue(self):
         return self._errStream.getvalue()

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -51,7 +51,7 @@ class C5G7ReactorTests(unittest.TestCase):
         """
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.LOG.startLog("test_loadC5G7")
             runLog.LOG.setVerbosity(WARNING)
 
@@ -61,7 +61,7 @@ class C5G7ReactorTests(unittest.TestCase):
             b = o.r.core.getFirstBlock(Flags.MOX)
 
             # test warnings are being logged for malformed isotopics info in the settings file
-            streamVal = mock._outputStream
+            streamVal = mock.getStdout()
             self.assertGreater(streamVal.count("[warn]"), 32, msg=streamVal)
             self.assertGreater(streamVal.count("custom isotopics"), 32, msg=streamVal)
             self.assertIn("Uranium Oxide", streamVal, msg=streamVal)

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -144,18 +144,18 @@ class MpiIterTests(unittest.TestCase):
         o, _ = test_reactors.loadTestReactor(TEST_ROOT)
 
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
 
             # Run the diagnosis on the test reactor
             _diagnosePickleError(o)
 
             # Hopefully, the test reactor can be pickled, and we get no errors
-            self.assertIn("Pickle Error Detection", mock._outputStream)
-            self.assertIn("Scanning the Reactor", mock._outputStream)
-            self.assertIn("Scanning all assemblies", mock._outputStream)
-            self.assertIn("Scanning all blocks", mock._outputStream)
-            self.assertIn("Scanning blocks by name", mock._outputStream)
-            self.assertIn("Scanning the ISOTXS library", mock._outputStream)
+            self.assertIn("Pickle Error Detection", mock.getStdout())
+            self.assertIn("Scanning the Reactor", mock.getStdout())
+            self.assertIn("Scanning all assemblies", mock.getStdout())
+            self.assertIn("Scanning all blocks", mock.getStdout())
+            self.assertIn("Scanning blocks by name", mock.getStdout())
+            self.assertIn("Scanning the ISOTXS library", mock.getStdout())
 
 
 def passer():

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -196,39 +196,39 @@ class TestRunLog(unittest.TestCase):
         """Let's test the setVerbosity() method carefully"""
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.LOG.startLog("test_setVerbosity")
             runLog.LOG.setVerbosity(logging.INFO)
 
             # we should start at info level, and that should be working correctly
             self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
             runLog.info("hi")
-            self.assertIn("hi", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("hi", mock.getStdout())
+            mock.emptyStdout()
 
             runLog.debug("invisible")
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
 
             # setVerbosity() to WARNING, and verify it is working
             runLog.LOG.setVerbosity(logging.WARNING)
             runLog.info("still invisible")
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.warning("visible")
-            self.assertIn("visible", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("visible", mock.getStdout())
+            mock.emptyStdout()
 
             # setVerbosity() to DEBUG, and verify it is working
             runLog.LOG.setVerbosity(logging.DEBUG)
             runLog.debug("Visible")
-            self.assertIn("Visible", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("Visible", mock.getStdout())
+            mock.emptyStdout()
 
             # setVerbosity() to ERROR, and verify it is working
             runLog.LOG.setVerbosity(logging.ERROR)
             runLog.warning("Still Invisible")
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.error("Visible!")
-            self.assertIn("Visible!", mock._outputStream)
+            self.assertIn("Visible!", mock.getStdout())
 
             # we shouldn't be able to setVerbosity() to a non-canonical value (logging module defense)
             self.assertEqual(runLog.LOG.getVerbosity(), logging.ERROR)
@@ -239,29 +239,29 @@ class TestRunLog(unittest.TestCase):
         """The user/dev my accidentally call setVerbosity() before startLog(), this should be mostly supportable"""
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.LOG.setVerbosity(logging.DEBUG)
             runLog.LOG.startLog("test_setVerbosityBeforeStartLog")
 
             # we should start at info level, and that should be working correctly
             self.assertEqual(runLog.LOG.getVerbosity(), logging.DEBUG)
             runLog.debug("hi")
-            self.assertIn("hi", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("hi", mock.getStdout())
+            mock.emptyStdout()
 
     def test_callingStartLogMultipleTimes(self):
         """calling startLog() multiple times will lead to multiple output files, but logging should still work"""
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             runLog.LOG.startLog("test_callingStartLogMultipleTimes1")
             runLog.LOG.setVerbosity(logging.INFO)
 
             # we should start at info level, and that should be working correctly
             self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
             runLog.info("hi1")
-            self.assertIn("hi1", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("hi1", mock.getStdout())
+            mock.emptyStdout()
 
             # call startLog() again
             runLog.LOG.startLog("test_callingStartLogMultipleTimes2")
@@ -270,8 +270,8 @@ class TestRunLog(unittest.TestCase):
             # we should start at info level, and that should be working correctly
             self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
             runLog.info("hi2")
-            self.assertIn("hi2", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("hi2", mock.getStdout())
+            mock.emptyStdout()
 
             # call startLog() again
             runLog.LOG.startLog("test_callingStartLogMultipleTimes3")
@@ -280,8 +280,8 @@ class TestRunLog(unittest.TestCase):
             # we should start at info level, and that should be working correctly
             self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
             runLog.info("hi3")
-            self.assertIn("hi3", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("hi3", mock.getStdout())
+            mock.emptyStdout()
 
             # call startLog() again, with a duplicate logger name
             runLog.LOG.startLog("test_callingStartLogMultipleTimes3")
@@ -290,8 +290,8 @@ class TestRunLog(unittest.TestCase):
             # we should start at info level, and that should be working correctly
             self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
             runLog.info("hi333")
-            self.assertIn("hi333", mock._outputStream)
-            mock._outputStream = ""
+            self.assertIn("hi333", mock.getStdout())
+            mock.emptyStdout()
 
     def test_concatenateLogs(self):
         """simple test of the concat logs function"""

--- a/armi/utils/tests/test_custom_exceptions.py
+++ b/armi/utils/tests/test_custom_exceptions.py
@@ -28,10 +28,10 @@ class CustomExceptionTests(unittest.TestCase):
 
     def test_info_decorator(self):
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             for ii in range(1, 3):
                 self.exampleInfoMessage()
-                self.assertEqual("[info] output message\n" * ii, mock._outputStream)
+                self.assertEqual("[info] output message\n" * ii, mock.getStdout())
 
     @important
     def exampleImportantMessage(self):
@@ -39,10 +39,10 @@ class CustomExceptionTests(unittest.TestCase):
 
     def test_important_decorator(self):
         with mockRunLogs.BufferLog() as mock:
-            self.assertEqual("", mock._outputStream)
+            self.assertEqual("", mock.getStdout())
             for ii in range(1, 3):
                 self.exampleImportantMessage()
-                self.assertEqual("[impt] important message?\n" * ii, mock._outputStream)
+                self.assertEqual("[impt] important message?\n" * ii, mock.getStdout())
 
     @warn
     def exampleWarnMessage(self):
@@ -54,7 +54,7 @@ class CustomExceptionTests(unittest.TestCase):
                 self.exampleWarnMessage()
                 self.assertEqual(
                     "[warn] you're not tall enough to ride this elephant\n" * ii,
-                    mock._outputStream,
+                    mock.getStdout(),
                 )
 
     @warn_when_root
@@ -68,10 +68,10 @@ class CustomExceptionTests(unittest.TestCase):
             for ii in range(1, 4):
                 self.exampleWarnWhenRootMessage()
                 msg = "[warn] warning from root\n" * ii
-                self.assertEqual(msg, mock._outputStream)
+                self.assertEqual(msg, mock.getStdout())
                 armi.MPI_RANK = 1
                 self.exampleWarnWhenRootMessage()
-                self.assertEqual(msg, mock._outputStream)
+                self.assertEqual(msg, mock.getStdout())
                 armi.MPI_RANK = 0
 
 


### PR DESCRIPTION
## Description

It turns out, in our unit tests, people have been directly accessing `._outputStream` when there was already a method to access that value: `.getStdoutValue()`. Well, let's just use that method instead.

Also, I changed the name of that method to `.getStdout()` to make it easier to use and added a new method, because we tend to need it a lot: `.emptyStdout()`.

**NOTE**: This change was chosen because it does not break any downstream code.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
