### PR TITLE
Using fuelCycle settings constants

### DIFF
--- a/armi/bookkeeping/report/newReportUtils.py
+++ b/armi/bookkeeping/report/newReportUtils.py
@@ -15,10 +15,12 @@ import collections
 import os
 import numpy
 
-from armi.reactor.components import component
 from armi import runLog
-from armi.reactor.flags import Flags
 from armi.bookkeeping.report import newReports
+from armi.materials import custom
+from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
+from armi.reactor.components import component
+from armi.reactor.flags import Flags
 from armi.utils import (
     units,
     plotting,
@@ -27,7 +29,6 @@ from armi.utils import (
     getCycleLengths,
     getStepLengths,
 )
-from armi.materials import custom
 
 
 def insertBlueprintContent(r, cs, report, blueprint):
@@ -193,7 +194,7 @@ def _setGeneralCoreDesignData(cs, coreDesignTable):
     coreDesignTable.addRow(["Geometry File", "{}".format(cs["geomFile"])])
     coreDesignTable.addRow(["Loading File", "{}".format(cs["loadingFile"])])
     coreDesignTable.addRow(
-        ["Fuel Shuffling Logic File", "{}".format(cs["shuffleLogic"])]
+        ["Fuel Shuffling Logic File", "{}".format(cs[CONF_SHUFFLE_LOGIC])]
     )
     coreDesignTable.addRow(["Reactor State Loading", "{}".format(cs["loadStyle"])])
     if cs["loadStyle"] == "fromDB":

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -16,6 +16,7 @@ r"""
 A collection of miscellaneous functions used by ReportInterface to generate
 various reports
 """
+from copy import copy
 import collections
 import os
 import pathlib
@@ -24,7 +25,6 @@ import sys
 import tabulate
 import textwrap
 import time
-from copy import copy
 
 import numpy
 
@@ -33,6 +33,7 @@ from armi import interfaces
 from armi import runLog
 from armi.bookkeeping import report
 from armi.operators import RunTypes
+from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
 from armi.reactor.components import ComponentType
 from armi.reactor.flags import Flags
 from armi.utils import getFileSHA1Hash
@@ -631,7 +632,7 @@ def _setGeneralCoreDesignData(cs, coreDesignTable):
     )
     report.setData(
         "Fuel Shuffling Logic File",
-        "{}".format(cs["shuffleLogic"]),
+        "{}".format(cs[CONF_SHUFFLE_LOGIC]),
         coreDesignTable,
         report.DESIGN,
     )

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -28,12 +28,13 @@ from armi import interfaces
 from armi import plugins
 from armi import runLog
 from armi import settings
+from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
 from armi.reactor import blueprints
 from armi.reactor import systemLayoutInput
 from armi.settings import setMasterCs
 from armi.tests import ARMI_RUN_PATH
-from armi.tests import TEST_ROOT
 from armi.tests import mockRunLogs
+from armi.tests import TEST_ROOT
 from armi.utils import directoryChangers
 
 
@@ -411,7 +412,7 @@ class TestExtraInputWriting(unittest.TestCase):
         with directoryChangers.TemporaryDirectoryChanger():
             case = baseCase.clone()
             case.writeInputs()
-            self.assertTrue(os.path.exists(cs["shuffleLogic"]))
+            self.assertTrue(os.path.exists(cs[CONF_SHUFFLE_LOGIC]))
             # Availability factor is in the original settings file but since it is a
             # default value, gets removed for the write-out
             txt = open("armiRun.yaml", "r").read()
@@ -485,7 +486,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
 
     def test_copyInputsHelper(self):
         """Test the helper function for copyInterfaceInputs."""
-        testSetting = "shuffleLogic"
+        testSetting = CONF_SHUFFLE_LOGIC
         cs = settings.Settings(ARMI_RUN_PATH)
         shuffleFile = cs[testSetting]
 
@@ -514,7 +515,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
             self.assertEqual(destFilePath, shuffleFile)
 
     def test_copyInterfaceInputs_singleFile(self):
-        testSetting = "shuffleLogic"
+        testSetting = CONF_SHUFFLE_LOGIC
         cs = settings.Settings(ARMI_RUN_PATH)
         shuffleFile = cs[testSetting]
 
@@ -527,7 +528,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
             self.assertEqual(newSettings[testSetting], str(newFilepath))
 
     def test_copyInterfaceInputs_nonFilePath(self):
-        testSetting = "shuffleLogic"
+        testSetting = CONF_SHUFFLE_LOGIC
         cs = settings.Settings(ARMI_RUN_PATH)
         fakeShuffle = "fakeFile.py"
         cs = cs.modified(newSettings={testSetting: fakeShuffle})
@@ -567,7 +568,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
             self.assertEqual(newSettings[testSetting], newFilepaths)
 
     def test_copyInterfaceInputs_wildcardFile(self):
-        testSetting = "shuffleLogic"
+        testSetting = CONF_SHUFFLE_LOGIC
         cs = settings.Settings(ARMI_RUN_PATH)
         # Use something that isn't the shuffle logic file in the case settings
         wcFile = "ISO*"
@@ -591,7 +592,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
             self.assertEqual(newSettings[testSetting], [wcFile])
 
     def test_copyInterfaceInputs_relPath(self):
-        testSetting = "shuffleLogic"
+        testSetting = CONF_SHUFFLE_LOGIC
         cs = settings.Settings(ARMI_RUN_PATH)
         shuffleFile = cs[testSetting]
         relFile = "../tests/" + shuffleFile
@@ -606,7 +607,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
             self.assertEqual(newSettings[testSetting], newFilepath)
 
     def test_copyInterfaceInputs_absPath(self):
-        testSetting = "shuffleLogic"
+        testSetting = CONF_SHUFFLE_LOGIC
         cs = settings.Settings(ARMI_RUN_PATH)
         shuffleFile = cs[testSetting]
         absFile = os.path.dirname(os.path.abspath(ARMI_RUN_PATH))

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -39,6 +39,7 @@ from armi.bookkeeping import memoryProfiler
 from armi.bookkeeping.report import reportingUtils
 from armi.operators import settingsValidation
 from armi.operators.runTypes import RunTypes
+from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
 from armi.utils import codeTiming
 from armi.utils import (
     pathTools,
@@ -1037,7 +1038,7 @@ class Operator:  # pylint: disable=too-many-public-methods
             newFolder,
         )
         pathTools.copyOrWarn(
-            "Shuffle logic for snapshot", self.cs["shuffleLogic"], newFolder
+            "Shuffle logic for snapshot", self.cs[CONF_SHUFFLE_LOGIC], newFolder
         )
         pathTools.copyOrWarn(
             "Geometry file for snapshot", self.cs["geomFile"], newFolder

--- a/armi/physics/fuelCycle/__init__.py
+++ b/armi/physics/fuelCycle/__init__.py
@@ -58,7 +58,7 @@ class FuelHandlerPlugin(plugins.ArmiPlugin):
         The interface may import user input modules to customize the actual
         fuel management.
         """
-        fuelHandlerNeedsToBeActive = cs["fuelHandlerName"] or (
+        fuelHandlerNeedsToBeActive = cs[settings.CONF_FUEL_HANDLER_NAME] or (
             cs["eqDirect"] and cs["runType"].lower() == RunTypes.STANDARD.lower()
         )
         if not fuelHandlerNeedsToBeActive or "MCNP" in cs["neutronicsKernel"]:

--- a/armi/physics/fuelCycle/assemblyRotationAlgorithms.py
+++ b/armi/physics/fuelCycle/assemblyRotationAlgorithms.py
@@ -25,6 +25,7 @@ from armi import runLog
 from armi.physics.fuelCycle.hexAssemblyFuelMgmtUtils import (
     getOptimalAssemblyOrientation,
 )
+from armi.physics.fuelCycle.settings import CONF_ASSEM_ROTATION_STATIONARY
 
 
 def buReducingAssemblyRotation(fh):
@@ -58,7 +59,7 @@ def buReducingAssemblyRotation(fh):
             )
 
     # rotate NON-MOVING assemblies (stationary)
-    if fh.cs["assemblyRotationStationary"]:
+    if fh.cs[CONF_ASSEM_ROTATION_STATIONARY]:
         for a in hist.getDetailAssemblies():
             if a not in fh.moved:
                 rot = getOptimalAssemblyOrientation(a, a)
@@ -98,7 +99,7 @@ def simpleAssemblyRotation(fh):
     numRotated = 0
     hist = fh.o.getInterface("history")
     for a in hist.getDetailAssemblies():
-        if a in fh.moved or fh.cs["assemblyRotationStationary"]:
+        if a in fh.moved or fh.cs[CONF_ASSEM_ROTATION_STATIONARY]:
             a.rotatePins(1)
             numRotated += 1
             i, j = a.spatialLocator.getRingPos()  # hex indices (i,j) = (ring,pos)

--- a/armi/physics/fuelCycle/fuelHandlerFactory.py
+++ b/armi/physics/fuelCycle/fuelHandlerFactory.py
@@ -14,6 +14,8 @@
 
 """factory for the FuelHandler"""
 from armi.physics.fuelCycle import fuelHandlers
+from armi.physics.fuelCycle.settings import CONF_FUEL_HANDLER_NAME
+from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
 from armi.utils import directoryChangers, pathTools
 
 
@@ -26,8 +28,8 @@ def fuelHandlerFactory(operator):
     called again to instantiate a new FuelHandler.
     """
     cs = operator.cs
-    fuelHandlerClassName = cs["fuelHandlerName"]
-    fuelHandlerModulePath = cs["shuffleLogic"]
+    fuelHandlerClassName = cs[CONF_FUEL_HANDLER_NAME]
+    fuelHandlerModulePath = cs[CONF_SHUFFLE_LOGIC]
 
     if not fuelHandlerClassName:
         # give the default FuelHandler. This does not have an implemented outage, but

--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -14,10 +14,13 @@
 
 """A place for the FuelHandler's Interface"""
 
-from armi import runLog
 from armi import interfaces
-from armi.utils import plotting
+from armi import runLog
 from armi.physics.fuelCycle import fuelHandlerFactory
+from armi.physics.fuelCycle.settings import CONF_PLOT_SHUFFLE_ARROWS
+from armi.physics.fuelCycle.settings import CONF_RUN_LATTICE_BEFORE_SHUFFLING
+from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
+from armi.utils import plotting
 
 
 class FuelHandlerInterface(interfaces.Interface):
@@ -48,7 +51,7 @@ class FuelHandlerInterface(interfaces.Interface):
             cs.getSetting(settingName): [
                 cs[settingName],
             ]
-            for settingName in ["shuffleLogic", "explicitRepeatShuffles"]
+            for settingName in [CONF_SHUFFLE_LOGIC, "explicitRepeatShuffles"]
             if cs[settingName]
         }
         return files
@@ -62,10 +65,12 @@ class FuelHandlerInterface(interfaces.Interface):
         # if lattice physics is requested, compute it here instead of after fuel management.
         # This enables XS to exist for branch searching, etc.
         mc2 = self.o.getInterface(function="latticePhysics")
-        if mc2 and self.cs["runLatticePhysicsBeforeShuffling"]:
+        if mc2 and self.cs[CONF_RUN_LATTICE_BEFORE_SHUFFLING]:
             runLog.extra(
-                'Running {0} lattice physics before fuel management due to the "runLatticePhysicsBeforeShuffling"'
-                " setting being activated.".format(mc2)
+                'Running {0} lattice physics before fuel management due to the "{1}"'
+                " setting being activated.".format(
+                    mc2, CONF_RUN_LATTICE_BEFORE_SHUFFLING
+                )
             )
             mc2.interactBOC(cycle=cycle)
 
@@ -104,7 +109,7 @@ class FuelHandlerInterface(interfaces.Interface):
         self.r.core.locateAllAssemblies()
         shuffleFactors, _ = fh.getFactorList(cycle)
         fh.outage(shuffleFactors)  # move the assemblies around
-        if self.cs["plotShuffleArrows"]:
+        if self.cs[CONF_PLOT_SHUFFLE_ARROWS]:
             arrows = fh.makeShuffleArrows()
             plotting.plotFaceMap(
                 self.r.core,

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -34,6 +34,7 @@ from armi import runLog
 from armi.physics.fuelCycle import assemblyRotationAlgorithms as rotAlgos
 from armi.physics.fuelCycle.fuelHandlerFactory import fuelHandlerFactory
 from armi.physics.fuelCycle.fuelHandlerInterface import FuelHandlerInterface
+from armi.physics.fuelCycle.settings import CONF_ASSEMBLY_ROTATION_ALG
 from armi.reactor.flags import Flags
 from armi.utils.customExceptions import InputError
 
@@ -117,17 +118,21 @@ class FuelHandler:
             self.chooseSwaps(factor)
 
         # do rotations if pin-level details are available (requires fluxRecon plugin)
-        if self.cs["fluxRecon"] and self.cs["assemblyRotationAlgorithm"]:
+        if self.cs["fluxRecon"] and self.cs[CONF_ASSEMBLY_ROTATION_ALG]:
             # Rotate assemblies ONLY IF at least some assemblies have pin detail
             # The user can choose the algorithm method name directly in the settings
-            if hasattr(rotAlgos, self.cs["assemblyRotationAlgorithm"]):
-                rotationMethod = getattr(rotAlgos, self.cs["assemblyRotationAlgorithm"])
+            if hasattr(rotAlgos, self.cs[CONF_ASSEMBLY_ROTATION_ALG]):
+                rotationMethod = getattr(rotAlgos, self.cs[CONF_ASSEMBLY_ROTATION_ALG])
                 rotationMethod()
             else:
                 raise RuntimeError(
                     "FuelHandler {0} does not have a rotation algorithm called {1}.\n"
-                    'Change your "assemblyRotationAlgorithm" setting'
-                    "".format(rotAlgos, self.cs["assemblyRotationAlgorithm"])
+                    "Change your {2} setting"
+                    "".format(
+                        rotAlgos,
+                        self.cs[CONF_ASSEMBLY_ROTATION_ALG],
+                        CONF_ASSEMBLY_ROTATION_ALG,
+                    )
                 )
 
         # inform the reactor of how many moves occurred so it can put the number in the database.

--- a/armi/physics/fuelCycle/settings.py
+++ b/armi/physics/fuelCycle/settings.py
@@ -130,8 +130,8 @@ def getFuelCycleSettingValidators(inspector):
 
     queries.append(
         settingsValidation.Query(
-            lambda: bool(inspector.cs["shuffleLogic"])
-            ^ bool(inspector.cs["fuelHandlerName"]),
+            lambda: bool(inspector.cs[CONF_SHUFFLE_LOGIC])
+            ^ bool(inspector.cs[CONF_FUEL_HANDLER_NAME]),
             "A value was provided for `fuelHandlerName` or `shuffleLogic`, but not "
             "the other. Either both `fuelHandlerName` and `shuffleLogic` should be "
             "defined, or neither of them.",
@@ -177,7 +177,7 @@ def getFuelCycleSettingValidators(inspector):
     ]
 
     def _locateRegexOccurences():
-        with open(inspector._csRelativePath(inspector.cs["shuffleLogic"])) as src:
+        with open(inspector._csRelativePath(inspector.cs[CONF_SHUFFLE_LOGIC])) as src:
             src = src.read()
             matches = []
             for pattern, _sub in regex_solutions:
@@ -185,7 +185,7 @@ def getFuelCycleSettingValidators(inspector):
             return matches
 
     def _applyRegexSolutions():
-        srcFile = inspector._csRelativePath(inspector.cs["shuffleLogic"])
+        srcFile = inspector._csRelativePath(inspector.cs[CONF_SHUFFLE_LOGIC])
         destFile = os.path.splitext(srcFile)[0] + "migrated.py"
         with open(srcFile) as src, open(destFile, "w") as dest:
             srcContent = src.read()  # get the buffer content
@@ -198,28 +198,28 @@ def getFuelCycleSettingValidators(inspector):
                 dest.write("from armi import runLog\n")
             dest.write(regexContent)
 
-        inspector.cs = inspector.cs.modified(newSettings={"shuffleLogic": destFile})
+        inspector.cs = inspector.cs.modified(newSettings={CONF_SHUFFLE_LOGIC: destFile})
 
     queries.append(
         settingsValidation.Query(
-            lambda: " " in inspector.cs["shuffleLogic"],
+            lambda: " " in inspector.cs[CONF_SHUFFLE_LOGIC],
             "Spaces are not allowed in shuffleLogic file location. You have specified {0}. "
-            "Shuffling will not occur.".format(inspector.cs["shuffleLogic"]),
+            "Shuffling will not occur.".format(inspector.cs[CONF_SHUFFLE_LOGIC]),
             "",
             inspector.NO_ACTION,
         )
     )
 
     def _clearShufflingInput():
-        inspector._assignCS("shuffleLogic", "")
-        inspector._assignCS("fuelHandlerName", "")
+        inspector._assignCS(CONF_SHUFFLE_LOGIC, "")
+        inspector._assignCS(CONF_FUEL_HANDLER_NAME, "")
 
     queries.append(
         settingsValidation.Query(
-            lambda: inspector.cs["shuffleLogic"]
-            and not inspector._csRelativePathExists(inspector.cs["shuffleLogic"]),
+            lambda: inspector.cs[CONF_SHUFFLE_LOGIC]
+            and not inspector._csRelativePathExists(inspector.cs[CONF_SHUFFLE_LOGIC]),
             "The specified shuffle logic file '{0}' cannot be found. "
-            "Shuffling will not occur.".format(inspector.cs["shuffleLogic"]),
+            "Shuffling will not occur.".format(inspector.cs[CONF_SHUFFLE_LOGIC]),
             "Clear specified file value?",
             _clearShufflingInput,
         )
@@ -227,13 +227,13 @@ def getFuelCycleSettingValidators(inspector):
 
     queries.append(
         settingsValidation.Query(
-            lambda: inspector.cs["shuffleLogic"]
-            and inspector._csRelativePathExists(inspector.cs["shuffleLogic"])
+            lambda: inspector.cs[CONF_SHUFFLE_LOGIC]
+            and inspector._csRelativePathExists(inspector.cs[CONF_SHUFFLE_LOGIC])
             and _locateRegexOccurences(),
             "The shuffle logic file {} uses deprecated code."
             " It will not work unless you permit some automated changes to occur."
             " The logic file will be backed up to the current directory under a timestamped name"
-            "".format(inspector.cs["shuffleLogic"]),
+            "".format(inspector.cs[CONF_SHUFFLE_LOGIC]),
             "Proceed?",
             _applyRegexSolutions,
         )

--- a/armi/physics/fuelCycle/tests/test_assemblyRotationAlgorithms.py
+++ b/armi/physics/fuelCycle/tests/test_assemblyRotationAlgorithms.py
@@ -22,8 +22,9 @@ These algorithms are defined in assemblyRotationAlgorithms.py, but they are used
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
-from armi.physics.fuelCycle import fuelHandlers
 from armi.physics.fuelCycle import assemblyRotationAlgorithms as rotAlgos
+from armi.physics.fuelCycle import fuelHandlers
+from armi.physics.fuelCycle.settings import CONF_ASSEM_ROTATION_STATIONARY
 from armi.physics.fuelCycle.tests.test_fuelHandlers import addSomeDetailAssemblies
 from armi.physics.fuelCycle.tests.test_fuelHandlers import FuelHandlerTestHelper
 from armi.reactor.flags import Flags
@@ -33,7 +34,7 @@ class TestFuelHandlerMgmtTools(FuelHandlerTestHelper):
     def test_buReducingAssemblyRotation(self):
         fh = fuelHandlers.FuelHandler(self.o)
         hist = self.o.getInterface("history")
-        newSettings = {"assemblyRotationStationary": True}
+        newSettings = {CONF_ASSEM_ROTATION_STATIONARY: True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
 
@@ -52,7 +53,7 @@ class TestFuelHandlerMgmtTools(FuelHandlerTestHelper):
 
     def test_simpleAssemblyRotation(self):
         fh = fuelHandlers.FuelHandler(self.o)
-        newSettings = {"assemblyRotationStationary": True}
+        newSettings = {CONF_ASSEM_ROTATION_STATIONARY: True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         hist = self.o.getInterface("history")
         assems = hist.o.r.core.getAssemblies(Flags.FUEL)[:5]

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -25,6 +25,7 @@ import unittest
 import numpy as np
 
 from armi.physics.fuelCycle import fuelHandlers, settings
+from armi.physics.fuelCycle.settings import CONF_ASSEM_ROTATION_STATIONARY
 from armi.reactor import assemblies, blocks, components, grids
 from armi.reactor.flags import Flags
 from armi.reactor.tests import test_reactors
@@ -432,7 +433,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
     def test_linPowByPin(self):
         _fh = fuelHandlers.FuelHandler(self.o)
         _hist = self.o.getInterface("history")
-        newSettings = {"assemblyRotationStationary": True}
+        newSettings = {CONF_ASSEM_ROTATION_STATIONARY: True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
         b = assem.getBlocks(Flags.FUEL)[0]
@@ -446,7 +447,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
     def test_linPowByPinNeutron(self):
         _fh = fuelHandlers.FuelHandler(self.o)
         _hist = self.o.getInterface("history")
-        newSettings = {"assemblyRotationStationary": True}
+        newSettings = {CONF_ASSEM_ROTATION_STATIONARY: True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
         b = assem.getBlocks(Flags.FUEL)[0]
@@ -460,7 +461,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
     def test_linPowByPinGamma(self):
         _fh = fuelHandlers.FuelHandler(self.o)
         _hist = self.o.getInterface("history")
-        newSettings = {"assemblyRotationStationary": True}
+        newSettings = {CONF_ASSEM_ROTATION_STATIONARY: True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
         b = assem.getBlocks(Flags.FUEL)[0]
@@ -472,9 +473,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         self.assertEqual(type(b.p.linPowByPinGamma), np.ndarray)
 
     def test_transferStationaryBlocks(self):
-        """
-        Test the _transferStationaryBlocks method .
-        """
+        """Test the _transferStationaryBlocks method."""
         # grab stationary block flags
         sBFList = self.r.core.stationaryBlockFlagsList
 

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -26,6 +26,7 @@ import numpy as np
 
 from armi.physics.fuelCycle import fuelHandlers, settings
 from armi.physics.fuelCycle.settings import CONF_ASSEM_ROTATION_STATIONARY
+from armi.physics.fuelCycle.settings import CONF_PLOT_SHUFFLE_ARROWS
 from armi.reactor import assemblies, blocks, components, grids
 from armi.reactor.flags import Flags
 from armi.reactor.tests import test_reactors
@@ -368,7 +369,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         # reset assembly counter to get the same assem nums.
         self.setUp()
 
-        newSettings = {"plotShuffleArrows": True}
+        newSettings = {CONF_PLOT_SHUFFLE_ARROWS: True}
         # now repeat shuffles
         newSettings["explicitRepeatShuffles"] = "armiRun-SHUFFLES.txt"
         self.o.cs = self.o.cs.modified(newSettings=newSettings)

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -41,6 +41,7 @@ from armi import getPluginManagerOrFail, materials, nuclearDataIO, settings
 from armi import runLog
 from armi.nuclearDataIO import xsLibraries
 from armi.physics.fuelCycle.settings import CONF_CIRCULAR_RING_MODE
+from armi.physics.fuelCycle.settings import CONF_JUMP_RING_NUM
 from armi.reactor import assemblies
 from armi.reactor import assemblyLists
 from armi.reactor import composites
@@ -213,7 +214,7 @@ class Core(composites.Composite):
 
     def setOptionsFromCs(self, cs):
         # these are really "user modifiable modeling constants"
-        self.p.jumpRing = cs["jumpRingNum"]
+        self.p.jumpRing = cs[CONF_JUMP_RING_NUM]
         self._freshFeedType = cs["freshFeedType"]
         self._trackAssems = cs["trackAssems"]
         self._circularRingMode = cs[CONF_CIRCULAR_RING_MODE]

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -40,6 +40,7 @@ import tabulate
 from armi import getPluginManagerOrFail, materials, nuclearDataIO, settings
 from armi import runLog
 from armi.nuclearDataIO import xsLibraries
+from armi.physics.fuelCycle.settings import CONF_CIRCULAR_RING_MODE
 from armi.reactor import assemblies
 from armi.reactor import assemblyLists
 from armi.reactor import composites
@@ -215,7 +216,7 @@ class Core(composites.Composite):
         self.p.jumpRing = cs["jumpRingNum"]
         self._freshFeedType = cs["freshFeedType"]
         self._trackAssems = cs["trackAssems"]
-        self._circularRingMode = cs["circularRingMode"]
+        self._circularRingMode = cs[CONF_CIRCULAR_RING_MODE]
         self._circularRingPitch = cs["circularRingPitch"]
         self._automaticVariableMesh = cs["automaticVariableMesh"]
         self._minMeshSizeRatio = cs["minMeshSizeRatio"]

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -114,10 +114,10 @@ CONF_USER_PLUGINS = "userPlugins"
 # TODO: Unused by ARMI, slated for removal
 CONF_CONDITIONAL_MODULE_NAME = "conditionalModuleName"  # mcfr
 CONF_GROW_TO_FULL_CORE_AFTER_LOAD = "growToFullCoreAfterLoad"  # mcnp & gui
-CONF_MEM_PER_NODE = "memPerNode"  # unused?
-CONF_NUM_CONTROL_BLOCKS = "numControlBlocks"  # dif3d
-CONF_REMOVE_PER_CYCLE = "removePerCycle"  # fuel handler, equilibrium, mcnp
-CONF_USE_INPUT_TEMPERATURES_ON_DBLOAD = "useInputTemperaturesOnDBLoad"  # th
+CONF_MEM_PER_NODE = "memPerNode"  # unused
+CONF_NUM_CONTROL_BLOCKS = "numControlBlocks"  # unused
+CONF_REMOVE_PER_CYCLE = "removePerCycle"  # crucible, equilibrium, gui
+CONF_USE_INPUT_TEMPERATURES_ON_DBLOAD = "useInputTemperaturesOnDBLoad"  # unused
 
 
 def defineSettings() -> List[setting.Setting]:

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -111,7 +111,7 @@ CONF_INPUT_HEIGHTS_HOT = "inputHeightsConsideredHot"
 CONF_CYCLES = "cycles"
 CONF_USER_PLUGINS = "userPlugins"
 
-# Unused by ARMI, slated for removal
+# TODO: Unused by ARMI, slated for removal
 CONF_CONDITIONAL_MODULE_NAME = "conditionalModuleName"  # mcfr
 CONF_GROW_TO_FULL_CORE_AFTER_LOAD = "growToFullCoreAfterLoad"  # mcnp & gui
 CONF_MEM_PER_NODE = "memPerNode"  # unused?

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -31,6 +31,7 @@ from armi import settings
 from armi.operators import settingsValidation
 from armi.physics.fuelCycle import FuelHandlerPlugin
 from armi.physics.fuelCycle.settings import CONF_CIRCULAR_RING_ORDER
+from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
 from armi.reactor.flags import Flags
 from armi.settings import caseSettings
 from armi.settings import setting
@@ -214,7 +215,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         cs = cs.modified(
             caseTitle="test_pluginValidatorsAreDiscovered",
             newSettings={
-                "shuffleLogic": "nothere",
+                CONF_SHUFFLE_LOGIC: "nothere",
                 "cycleLengths": [3, 4, 5, 6, 9],
                 "powerFractions": [0.2, 0.2, 0.2, 0.2, 0.2],
             },

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -30,6 +30,7 @@ from armi import plugins
 from armi import settings
 from armi.operators import settingsValidation
 from armi.physics.fuelCycle import FuelHandlerPlugin
+from armi.physics.fuelCycle.settings import CONF_CIRCULAR_RING_ORDER
 from armi.reactor.flags import Flags
 from armi.settings import caseSettings
 from armi.settings import setting
@@ -206,7 +207,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
     def test_csWorks(self):
         """Ensure plugin settings become available and have defaults"""
         a = settings.Settings()
-        self.assertEqual(a["circularRingOrder"], "angle")
+        self.assertEqual(a[CONF_CIRCULAR_RING_ORDER], "angle")
 
     def test_pluginValidatorsAreDiscovered(self):
         cs = caseSettings.Settings()


### PR DESCRIPTION
## Description

As part of [the constants umbrella ticket](https://github.com/terrapower/armi/issues/1103), this PR uses the fuelCycle settings constants that are in ARMI.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
