### PR TITLE
Fix Issues with Peak Params

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -677,6 +677,7 @@ def _getNeutronicsBlockParams():
             units="DPA/s",
             description="Peak DPA rate based on detailedDpaPeak",
             location=ParamLocation.MAX,
+            categories=["detailedAxialExpansion", "neutronics"],
         )
 
         pb.defParam(

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -677,7 +677,10 @@ def _getNeutronicsBlockParams():
             units="dpa",
             location=ParamLocation.AVERAGE,
             description="Displacement per atom accumulated during this cycle. This accumulates over a cycle and resets to zero at BOC.",
-            categories=["cumulative over cycle", "detailedAxialExpansion"],
+            categories=[
+                parameters.Category.cumulativeOverCycle,
+                parameters.Category.detailedAxialExpansion,
+            ],
         )
 
         pb.defParam(
@@ -685,7 +688,7 @@ def _getNeutronicsBlockParams():
             units="DPA/s",
             description="Peak DPA rate based on detailedDpaPeak",
             location=ParamLocation.MAX,
-            categories=["detailedAxialExpansion", "neutronics"],
+            categories=[parameters.Category.cumulative, parameters.Category.neutronics],
         )
 
         pb.defParam(
@@ -693,7 +696,10 @@ def _getNeutronicsBlockParams():
             units="dpa",
             description="DPA approximation based on a fluence conversion factor set in the dpaPerFluence setting",
             location=ParamLocation.MAX,
-            categories=["cumulative", "detailedAxialExpansion"],
+            categories=[
+                parameters.Category.cumulative,
+                parameters.Category.detailedAxialExpansion,
+            ],
         )
 
         pb.defParam(

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -613,7 +613,7 @@ def _getNeutronicsBlockParams():
 
     with pDefs.createBuilder(
         default=0.0,
-        location=ParamLocation.VOLUME_INTEGRATED,
+        location=ParamLocation.AVERAGE,
         categories=[parameters.Category.detailedAxialExpansion],
     ) as pb:
         pb.defParam(
@@ -626,6 +626,11 @@ def _getNeutronicsBlockParams():
             description="Production rate of neutrons from fission reactions (nu * fission source / k-eff)",
         )
 
+    with pDefs.createBuilder(
+        default=0.0,
+        location=ParamLocation.VOLUME_INTEGRATED,
+        categories=[parameters.Category.detailedAxialExpansion],
+    ) as pb:
         pb.defParam(
             "powerGenerated",
             units=" W",

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -466,6 +466,7 @@ def _getNeutronicsBlockParams():
             "fastFluencePeak",
             units="#/cm^2",
             description="Fast spectrum fluence with a peaking factor",
+            location=ParamLocation.MAX,
         )
 
         pb.defParam(
@@ -489,6 +490,7 @@ def _getNeutronicsBlockParams():
             "fluxAdjPeak",
             units="",
             description="Adjoint flux",
+            location=ParamLocation.MAX,
         )
 
         pb.defParam(
@@ -532,6 +534,8 @@ def _getNeutronicsBlockParams():
             "fluxPeak",
             units="n/cm^2/s",
             description="Peak neutron flux calculated within the mesh",
+            categories=parameters.Category.fluxQuantities,
+            location=ParamLocation.MAX,
         )
 
         pb.defParam(
@@ -567,13 +571,19 @@ def _getNeutronicsBlockParams():
             categories=[parameters.Category.gamma],
         )
 
-        pb.defParam("ppdens", units="W/cm^3", description="Peak power density")
+        pb.defParam(
+            "ppdens",
+            units="W/cm^3",
+            description="Peak power density",
+            location=ParamLocation.MAX,
+        )
 
         pb.defParam(
             "ppdensGamma",
             units="W/cm^3",
             description="Peak gamma density",
             categories=[parameters.Category.gamma],
+            location=ParamLocation.MAX,
         )
 
     # rx rate params that are derived during mesh conversion.
@@ -660,14 +670,14 @@ def _getNeutronicsBlockParams():
             "detailedDpaPeakRate",
             units="DPA/s",
             description="Peak DPA rate based on detailedDpaPeak",
-            location=ParamLocation.AVERAGE,
+            location=ParamLocation.MAX,
         )
 
         pb.defParam(
             "dpaPeakFromFluence",
             units="dpa",
             description="DPA approximation based on a fluence conversion factor set in the dpaPerFluence setting",
-            location=ParamLocation.AVERAGE,
+            location=ParamLocation.MAX,
         )
 
         pb.defParam(

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -360,7 +360,10 @@ def _getNeutronicsBlockParams():
         saveToDB=True,
         default=None,
         location=ParamLocation.CORNERS,
-        categories=[parameters.Category.detailedAxialExpansion, "depletion"],
+        categories=[
+            parameters.Category.detailedAxialExpansion,
+            parameters.Category.depletion,
+        ],
     ) as pb:
         pb.defParam(
             "cornerFastFlux",
@@ -459,7 +462,10 @@ def _getNeutronicsBlockParams():
             "fastFluence",
             units="#/cm^2",
             description="Fast spectrum fluence",
-            categories=["cumulative"],
+            categories=[
+                parameters.Category.cumulative,
+                parameters.Category.detailedAxialExpansion,
+            ],
         )
 
         pb.defParam(
@@ -467,7 +473,10 @@ def _getNeutronicsBlockParams():
             units="#/cm^2",
             description="Fast spectrum fluence with a peaking factor",
             location=ParamLocation.MAX,
-            categories=["cumulative"],
+            categories=[
+                parameters.Category.cumulative,
+                parameters.Category.detailedAxialExpansion,
+            ],
         )
 
         pb.defParam(
@@ -535,7 +544,6 @@ def _getNeutronicsBlockParams():
             "fluxPeak",
             units="n/cm^2/s",
             description="Peak neutron flux calculated within the mesh",
-            categories=parameters.Category.fluxQuantities,
             location=ParamLocation.MAX,
         )
 
@@ -685,7 +693,7 @@ def _getNeutronicsBlockParams():
             units="dpa",
             description="DPA approximation based on a fluence conversion factor set in the dpaPerFluence setting",
             location=ParamLocation.MAX,
-            categories=["cumulative"],
+            categories=["cumulative", "detailedAxialExpansion"],
         )
 
         pb.defParam(

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -467,6 +467,7 @@ def _getNeutronicsBlockParams():
             units="#/cm^2",
             description="Fast spectrum fluence with a peaking factor",
             location=ParamLocation.MAX,
+            categories=["cumulative"],
         )
 
         pb.defParam(
@@ -683,6 +684,7 @@ def _getNeutronicsBlockParams():
             units="dpa",
             description="DPA approximation based on a fluence conversion factor set in the dpaPerFluence setting",
             location=ParamLocation.MAX,
+            categories=["cumulative"],
         )
 
         pb.defParam(

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -275,6 +275,7 @@ def getBlockParameterDefinitions():
             units="dpa",
             description="displacements per atom with peaking factor",
             categories=["cumulative", "detailedAxialExpansion", "depletion"],
+            location=ParamLocation.MAX,
         )
 
         pb.defParam(

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -331,13 +331,14 @@ class TestUniformMesh(unittest.TestCase):
         applyNonUniformHeightDistribution(self.r)  # note: this perturbs the ref. mass
 
         self.converter.convert(self.r)
-        for b in self.converter.convReactor.core.getBlocks():
+        for ib, b in enumerate(self.converter.convReactor.core.getBlocks()):
             b.p.mgFlux = range(33)
             b.p.adjMgFlux = range(33)
             b.p.fastFlux = 2.0
             b.p.flux = 5.0
             b.p.power = 5.0
             b.p.pdens = 0.5
+            b.p.fluxPeak = 10.0 + (-1) ** ib
 
         # check integral and density params
         assemblyPowers = [
@@ -356,6 +357,11 @@ class TestUniformMesh(unittest.TestCase):
             self.assertAlmostEqual(b.p.fastFlux, 2.0)
             self.assertAlmostEqual(b.p.flux, 5.0)
             self.assertAlmostEqual(b.p.pdens, 0.5)
+
+            # fluxPeak is mapped differently as a ParamLocation.MAX value
+            # make sure that it's one of the two exact possible values
+            print(b.p.fluxPeak)
+            self.assertIn(b.p.fluxPeak, [9.0, 11.0])
 
         for expectedPower, a in zip(assemblyPowers, self.r.core):
             self.assertAlmostEqual(a.calcTotalParam("power"), expectedPower)
@@ -446,7 +452,6 @@ class TestGammaUniformMesh(unittest.TestCase):
             # equal to original value because these were never mapped
             self.assertEqual(b.p.fastFlux, 2.0)
             self.assertEqual(b.p.flux, 5.0)
-            self.assertEqual(b.p.fastFlux, 2.0)
 
             # not equal because blocks are different size
             self.assertNotEqual(b.p.powerGamma, 0.5)

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -888,7 +888,12 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
         b = self._sourceReactor.core.getFirstBlock()
         excludedCategories = [parameters.Category.gamma]
         if direction == "out":
-            excludedCategories.append(parameters.Category.cumulative)
+            excludeList = (
+                b.p.paramDefs.inCategory(parameters.Category.cumulative).names
+                + b.p.paramDefs.inCategory(
+                    parameters.Category.cumulativeOverCycle
+                ).names
+            )
         excludedParamNames = []
         for category in excludedCategories:
             excludedParamNames.extend(b.p.paramDefs.inCategory(category).names)
@@ -973,7 +978,12 @@ class GammaUniformMeshConverter(UniformMeshGeometryConverter):
             )
         b = self._sourceReactor.core.getFirstBlock()
         if direction == "out":
-            excludeList = b.p.paramDefs.inCategory(parameters.Category.cumulative).names
+            excludeList = (
+                b.p.paramDefs.inCategory(parameters.Category.cumulative).names
+                + b.p.paramDefs.inCategory(
+                    parameters.Category.cumulativeOverCycle
+                ).names
+            )
         else:
             excludeList = b.p.paramDefs.inCategory(parameters.Category.gamma).names
         for category in self.blockParamMappingCategories[direction]:

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -888,12 +888,8 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
         b = self._sourceReactor.core.getFirstBlock()
         excludedCategories = [parameters.Category.gamma]
         if direction == "out":
-            excludeList = (
-                b.p.paramDefs.inCategory(parameters.Category.cumulative).names
-                + b.p.paramDefs.inCategory(
-                    parameters.Category.cumulativeOverCycle
-                ).names
-            )
+            excludedCategories.append(parameters.Category.cumulative)
+            excludedCategories.append(parameters.Category.cumulativeOverCycle)
         excludedParamNames = []
         for category in excludedCategories:
             excludedParamNames.extend(b.p.paramDefs.inCategory(category).names)

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -73,6 +73,7 @@ class Category:
     """
 
     cumulative = "cumulative"
+    cumulativeOverCycle = "cumulative over cycle"
     assignInBlueprints = "assign in blueprints"
     retainOnReplacement = "retain on replacement"
     pinQuantities = "pinQuantities"

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -72,6 +72,7 @@ class Category:
     * `detailedAxialExpansion` parameters are marked as such so that they are mapped from the uniform mesh back to the non-uniform mesh
     """
 
+    depletion = "depletion"
     cumulative = "cumulative"
     cumulativeOverCycle = "cumulative over cycle"
     assignInBlueprints = "assign in blueprints"

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -384,7 +384,7 @@ def defineSettings() -> List[setting.Setting]:
         ),
         setting.Setting(
             CONF_BURNUP_PEAKING_FACTOR,
-            default=0.0,
+            default=1.0,
             label="Burn-up Peaking Factor",
             description="None",
             schema=vol.All(vol.Coerce(float), vol.Range(min=0)),

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -384,7 +384,7 @@ def defineSettings() -> List[setting.Setting]:
         ),
         setting.Setting(
             CONF_BURNUP_PEAKING_FACTOR,
-            default=1.0,
+            default=0.0,
             label="Burn-up Peaking Factor",
             description="None",
             schema=vol.All(vol.Coerce(float), vol.Range(min=0)),

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -25,6 +25,7 @@ What's new in ARMI
 #. General improvements to efficiency in many places to speed up uniform mesh conversion. (`PR#1042 <https://github.com/terrapower/armi/pull/1042>`_)
 #. Allow MCNP material card number to be defined after the card is written. (`PR#1086 <https://github.com/terrapower/armi/pull/1086>`_)
 #. Refine logic for Block.getNumPins() to only count components that are actually pins. (`PR#1098 <https://github.com/terrapower/armi/pull/1098>`_)
+#. Improve handling of peak/max parameters by the UniformMeshConverter parameter mapper. (`PR#1108 <https://github.com/terrapower/armi/pull/1108>`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

When mapping parameters between the non-uniform and uniform mesh, the mapper could handle volume-integrated or average values. There needs to also be a way to map "peak" or max parameters (`ParamLocation.MAX`) between the uniform and non-uniform mesh. Before they were just mapped the same as average values, which doesn't quite make sense. The "peak" values aren't associated with a location, so we still end up fudging a little bit when mapping between meshes.

Also, `cumulative` category was added to some params that are cumulative, and the `"cumulative over cycle"` category was formalized in `parameterDefinitions.Category`.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

