### PR TITLE
Fixing ruamel.yaml deprecation warning

### DIFF
--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -96,7 +96,7 @@ Retrieve U-235 by the AAAZZZS ID:
 
 import os
 
-from ruamel import yaml
+from ruamel.yaml import YAML
 import numpy
 
 from armi import context
@@ -1082,7 +1082,8 @@ def imposeBurnChain(burnChainStream):
         runLog.warning("Burn chain already imposed. Skipping reimposition.")
         return
     burnChainImposed = True
-    burnData = yaml.load(burnChainStream, yaml.RoundTripLoader)
+    yaml = YAML(typ="rt")
+    burnData = yaml.load(burnChainStream)
 
     for nucName, burnInfo in burnData.items():
         nuclide = byName[nucName]
@@ -1193,7 +1194,9 @@ def __addLumpedFissionProductNuclideBases():
 def __readMCCNuclideData():
     """Read in the label data for the MC2-2 and MC2-3 cross section codes to the nuclide bases."""
     with open(os.path.join(context.RES, "mcc-nuclides.yaml"), "r") as f:
-        nuclides = yaml.load(f, yaml.RoundTripLoader)
+        yaml = YAML(typ="rt")
+        nuclides = yaml.load(f)
+
     for n in nuclides:
         nb = byName[n]
         mcc2id = nuclides[n]["ENDF/B-V.2"]

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -14,16 +14,17 @@
 
 """Tests for nuclideBases"""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
+import math
 import os
 import random
-import math
 import unittest
-from ruamel import yaml
+
+from ruamel.yaml import YAML
 
 from armi.context import RES
-from armi.utils.units import SECONDS_PER_HOUR, AVOGADROS_NUMBER, CURIE_PER_BECQUEREL
 from armi.nucDirectory import nuclideBases, elements
 from armi.nucDirectory.tests import NUCDIRECTORY_TESTS_DEFAULT_DIR_PATH
+from armi.utils.units import SECONDS_PER_HOUR, AVOGADROS_NUMBER, CURIE_PER_BECQUEREL
 
 
 class TestNuclide(unittest.TestCase):
@@ -375,7 +376,8 @@ class TestNuclide(unittest.TestCase):
     def test_loadMcc2Data(self):
         """Tests consistency with the `mcc-nuclides.yaml` input and the nuclides in the data model."""
         with open(os.path.join(RES, "mcc-nuclides.yaml")) as f:
-            data = yaml.load(f, Loader=yaml.RoundTripLoader)
+            yaml = YAML(typ="rt")
+            data = yaml.load(f)
             expectedNuclides = set(
                 [nuc for nuc in data.keys() if data[nuc]["ENDF/B-V.2"] is not None]
             )
@@ -390,7 +392,8 @@ class TestNuclide(unittest.TestCase):
     def test_loadMcc3Data(self):
         """Tests consistency with the `mcc-nuclides.yaml` input and the nuclides in the data model."""
         with open(os.path.join(RES, "mcc-nuclides.yaml")) as f:
-            data = yaml.load(f, Loader=yaml.RoundTripLoader)
+            yaml = YAML(typ="rt")
+            data = yaml.load(f)
             expectedNuclides = set(
                 [nuc for nuc in data.keys() if data[nuc]["ENDF/B-VII.0"] is not None]
             )

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -405,6 +405,7 @@ class Settings:
             yaml = YAML()
             tree = yaml.load(stream)
             userSettings = tree[settingsIO.Roots.CUSTOM]
+
         userSettingsNames = list(userSettings.keys())
         return userSettingsNames
 

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -207,7 +207,7 @@ class SettingsReader:
         """Read settings from a YAML stream."""
         from armi.physics.thermalHydraulics import const  # avoid circular import
 
-        yaml = YAML()
+        yaml = YAML(typ="rt")
         tree = yaml.load(stream)
         if "settings" not in tree:
             raise InvalidSettingsFileError(

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -153,7 +153,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
 """
         )
 
-        yaml = YAML()
+        yaml = YAML(typ="rt")
 
         inp = yaml.load(good_input)
         for inputSetting, inputVal in inp.items():


### PR DESCRIPTION
## Description

Some recent code changes to Python have started to raise a `ruamel.yaml` `DepreceationWarning` that we have fixed in the past:

```
 armi/armi/nucDirectory/tests/test_nuclideBases.py:378: PendingDeprecationWarning: load will be removed, use
  
    yaml=YAML(typ='unsafe', pure=True)
    yaml.load(...)
  
instead
    data = yaml.load(f, Loader=yaml.RoundTripLoader)
```

This PR fixes these problems.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
