### PR TITLE
Expose tight coupling to `OperatorSnapshots`

### DIFF
--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -378,7 +378,10 @@ class Operator:  # pylint: disable=too-many-public-methods
         """Run the portion of the main loop that happens each subcycle."""
         self.r.p.timeNode = timeNode
         self.interactAllEveryNode(cycle, timeNode)
-        # perform tight coupling if requested
+        self._performTightCoupling(cycle, timeNode)
+
+    def _performTightCoupling(self, cycle: int, timeNode: int):
+        """if requested, perform tight coupling"""
         if self.couplingIsActive():
             self._convergenceSummary = collections.defaultdict(list)
             for coupledIteration in range(self.cs["tightCouplingMaxNumIters"]):

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -380,8 +380,13 @@ class Operator:  # pylint: disable=too-many-public-methods
         self.interactAllEveryNode(cycle, timeNode)
         self._performTightCoupling(cycle, timeNode)
 
-    def _performTightCoupling(self, cycle: int, timeNode: int):
-        """if requested, perform tight coupling"""
+    def _performTightCoupling(self, cycle: int, timeNode: int, writeDB: bool = True):
+        """if requested, perform tight coupling and write out database
+
+        Notes
+        -----
+        writeDB is False for OperatorSnapshots as the DB gets written at EOL.
+        """
         if self.couplingIsActive():
             self._convergenceSummary = collections.defaultdict(list)
             for coupledIteration in range(self.cs["tightCouplingMaxNumIters"]):
@@ -389,9 +394,10 @@ class Operator:  # pylint: disable=too-many-public-methods
                 converged = self.interactAllCoupled(coupledIteration)
                 if converged:
                     break
-            # database has not yet been written, so we need to write it.
-            dbi = self.getInterface("database")
-            dbi.writeDBEveryNode(cycle, timeNode)
+            if writeDB:
+                # database has not yet been written, so we need to write it.
+                dbi = self.getInterface("database")
+                dbi.writeDBEveryNode(cycle, timeNode)
 
     def _interactAll(self, interactionName, activeInterfaces, *args):
         """

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -76,7 +76,7 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
             self.interactAllEveryNode(
                 ssCycle, ssNode, excludedInterfaceNames=("database",)
             )
-            self._performTightCoupling(ssCycle, ssNode)
+            self._performTightCoupling(ssCycle, ssNode, writeDB=False)
 
             # database is excluded at last snapshot since it writes at EOL
             exclude = ("database",) if (ssCycle, ssNode) == lastTimeStep else ()

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -76,6 +76,7 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
             self.interactAllEveryNode(
                 ssCycle, ssNode, excludedInterfaceNames=("database",)
             )
+            self._performTightCoupling(ssCycle, ssNode)
 
             # database is excluded at last snapshot since it writes at EOL
             exclude = ("database",) if (ssCycle, ssNode) == lastTimeStep else ()

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -27,6 +27,8 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 from armi.physics.neutronics.globalFlux.globalFluxInterface import (
     GlobalFluxInterfaceUsingExecuters,
 )
+from armi.utils import directoryChangers
+from armi.bookkeeping.db.databaseInterface import DatabaseInterface
 
 
 class InterfaceA(Interface):
@@ -106,6 +108,30 @@ class OperatorTests(unittest.TestCase):
         self.assertFalse(self.o.couplingIsActive())
         self.o.cs["tightCoupling"] = True
         self.assertTrue(self.o.couplingIsActive())
+
+    def test_dbWrittenForCoupling(self):
+        with directoryChangers.TemporaryDirectoryChanger():
+            self.o.cs["tightCoupling"] = True
+            self.o.removeAllInterfaces()
+            dbi = DatabaseInterface(self.r, self.o.cs)
+            dbi.initDB(fName=self._testMethodName + ".h5")
+            self.o.addInterface(dbi)
+            self.o._performTightCoupling(0, 0, writeDB=True)
+            h5Contents = list(dbi.database.getH5Group(dbi.r).items())
+            self.assertTrue(h5Contents)
+            dbi.database.close()
+
+    def test_dbNotWrittenForCoupling(self):
+        with directoryChangers.TemporaryDirectoryChanger():
+            self.o.cs["tightCoupling"] = True
+            self.o.removeAllInterfaces()
+            dbi = DatabaseInterface(self.r, self.o.cs)
+            dbi.initDB(fName=self._testMethodName + ".h5")
+            self.o.addInterface(dbi)
+            self.o._performTightCoupling(0, 0, writeDB=False)
+            h5Contents = list(dbi.database.getH5Group(dbi.r).items())
+            self.assertFalse(h5Contents)
+            dbi.database.close()
 
     def test_computeTightCouplingConvergence(self):
         """ensure that tight coupling convergence can be computed and checked

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -109,29 +109,24 @@ class OperatorTests(unittest.TestCase):
         self.o.cs["tightCoupling"] = True
         self.assertTrue(self.o.couplingIsActive())
 
-    def test_dbWrittenForCoupling(self):
+    def test_dbWriteForCoupling(self):
         with directoryChangers.TemporaryDirectoryChanger():
             self.o.cs["tightCoupling"] = True
-            self.o.removeAllInterfaces()
-            dbi = DatabaseInterface(self.r, self.o.cs)
-            dbi.initDB(fName=self._testMethodName + ".h5")
-            self.o.addInterface(dbi)
-            self.o._performTightCoupling(0, 0, writeDB=True)
-            h5Contents = list(dbi.database.getH5Group(dbi.r).items())
-            self.assertTrue(h5Contents)
-            dbi.database.close()
+            self.dbWriteForCoupling(writeDB=True)
+            self.dbWriteForCoupling(writeDB=False)
 
-    def test_dbNotWrittenForCoupling(self):
-        with directoryChangers.TemporaryDirectoryChanger():
-            self.o.cs["tightCoupling"] = True
-            self.o.removeAllInterfaces()
-            dbi = DatabaseInterface(self.r, self.o.cs)
-            dbi.initDB(fName=self._testMethodName + ".h5")
-            self.o.addInterface(dbi)
-            self.o._performTightCoupling(0, 0, writeDB=False)
-            h5Contents = list(dbi.database.getH5Group(dbi.r).items())
+    def dbWriteForCoupling(self, writeDB: bool):
+        self.o.removeAllInterfaces()
+        dbi = DatabaseInterface(self.r, self.o.cs)
+        dbi.initDB(fName=self._testMethodName + ".h5")
+        self.o.addInterface(dbi)
+        self.o._performTightCoupling(0, 0, writeDB=writeDB)
+        h5Contents = list(dbi.database.getH5Group(dbi.r).items())
+        if writeDB:
+            self.assertTrue(h5Contents)
+        else:
             self.assertFalse(h5Contents)
-            dbi.database.close()
+        dbi.database.close()
 
     def test_computeTightCouplingConvergence(self):
         """ensure that tight coupling convergence can be computed and checked

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -27,6 +27,7 @@ What's new in ARMI
 #. Allow MCNP material card number to be defined after the card is written. (`PR#1086 <https://github.com/terrapower/armi/pull/1086>`_)
 #. Refine logic for Block.getNumPins() to only count components that are actually pins. (`PR#1098 <https://github.com/terrapower/armi/pull/1098>`_)
 #. Improve handling of peak/max parameters by the UniformMeshConverter parameter mapper. (`PR#1108 <https://github.com/terrapower/armi/pull/1108>`_)
+#. Bug fix to expose new tight coupling functionality to ``OperatorSnapshots``. (`PR#1113 https://github.com/terrapower/armi/pull/1113`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description
PR #1033 introduced the capability to measure the convergence of tight coupling and removed the `looseCoupling` setting. However, its exposure to the snapshot operator was missed. This PR serves to resolve that. 

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

