### PR TITLE
bug fix for xsGroup manager w/ coupling

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -610,8 +610,26 @@ class CrossSectionGroupManager(interfaces.Interface):
         self.clearRepresentativeBlocks()
 
     def interactCoupled(self, iteration):
-        """Update XS groups on each physics coupling iteration to get latest temperatures."""
-        self.interactBOC(cycle=None)
+        """Update XS groups on each physics coupling iteration to get latest temperatures.
+
+        Notes
+        -----
+        This coupling iteration is limited to when the time node is equal to zero. This is
+        assumed to be reasonable for most applications as 1) microscopic cross section changes with burn-up
+        are deemed to be less significant compared to convergence on the temperature state, and 2) temperature
+        distributions are not expected to dramatically change for time steps > 0.
+
+        .. warning::
+
+            The latter assumptions are design and application-specific and a subclass should be
+            considered when violated.
+
+        See Also
+        --------
+        :py:meth:`Assembly <armi.physics.neutronics.latticePhysics.latticePhysics.LatticePhysicsInterface.interactCoupled>`
+        """
+        if self.r.p.timeNode == 0:
+            self.interactBOC(cycle=None)
 
     def clearRepresentativeBlocks(self):
         """Clear the representative blocks."""

--- a/armi/physics/neutronics/tests/test_cross_section_manager.py
+++ b/armi/physics/neutronics/tests/test_cross_section_manager.py
@@ -348,6 +348,16 @@ class Test_CrossSectionGroupManager(unittest.TestCase):
             newReprBlock.getNumberDensities(), oldReprBlock.getNumberDensities()
         )
 
+    def test_interactCoupled(self):
+        # ensure that representativeBlocks remains empty if timeNode == 1
+        self.blockList[0].r.p.timeNode = 1
+        self.csm.interactCoupled(iteration=0)
+        self.assertFalse(self.csm.representativeBlocks)
+        # ensure that representativeBlocks get populated if timeNode == 0
+        self.blockList[0].r.p.timeNode = 0
+        self.csm.interactCoupled(iteration=0)
+        self.assertTrue(self.csm.representativeBlocks)
+
 
 class TestXSNumberConverters(unittest.TestCase):
     def test_conversion(self):

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -40,6 +40,7 @@ Bug fixes
 #. Fixed a bug where the material namespace order for test_axialExpansionChanger.py was persisting beyond the tests. (`PR#1046 https://github.com/terrapower/armi/pull/1046`_)
 #. A bug was fixed in `PR#1022 <https://github.com/terrapower/armi/pull/1022>`_ where the gaseous fission products were not being removed from the core directly, but instead the fission yields within the lumped fission products were being adjusted.
 #. Fixed a bug where non-fuel depletable components were not being initialized with all nuclides with the ``explicitFissionProducts`` model (`PR#1067 https://github.com/terrapower/armi/pull/1067`_)
+#. Bug fix to ensure consistency between cross section group manager and lattice physics interface for tight coupling. (`PR#1118 <https://github.com/terrapower/armi/pull/1118>`_)
 
 ARMI v0.2.5
 ===========


### PR DESCRIPTION
## Description
Bug fix to create consistency with `latticePhysicsInterface::interactCoupled` for tight coupling. 

This [change to the lattice physics interface](https://github.com/terrapower/armi/pull/1067/commits/6728c85bf444247ea616fdc1343e3c979e8fbde1) was snuck into PR #1067 and limited the lattice physics interface to execute only on time node 0 of each cycle. This resulted in an inconsistency between the cross section group manager and the lattice physics interface. This PR serves to resolve this inconsistency.

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

