### PR TITLE
Add neutronics category to linPow parameter

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -263,7 +263,10 @@ def _getNeutronicsBlockParams():
             ),
             location=ParamLocation.AVERAGE,
             default=0.0,
-            categories=[parameters.Category.detailedAxialExpansion],
+            categories=[
+                parameters.Category.detailedAxialExpansion,
+                parameters.Category.neutronics,
+            ],
         )
 
         def linPowByPin(self, value):

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -424,12 +424,14 @@ class TestGammaUniformMesh(unittest.TestCase):
             b.p.fastFlux = 2.0
             b.p.flux = 5.0
             b.p.power = 5.0
+            b.p.linPow = 2.0
 
-        # set original parameters on pre-mapped core with non-uniform assemblies
+        # set new parameters on core with uniform assemblies (emulate a physics kernel)
         self.converter.convert(self.r)
         for b in self.converter.convReactor.core.getBlocks():
             b.p.powerGamma = 0.5
             b.p.powerNeutron = 0.5
+            b.p.linPow = 10.0
             b.p.power = b.p.powerGamma + b.p.powerNeutron
 
         # check integral and density params
@@ -457,6 +459,9 @@ class TestGammaUniformMesh(unittest.TestCase):
             self.assertNotEqual(b.p.powerGamma, 0.5)
             self.assertNotEqual(b.p.powerNeutron, 0.5)
             self.assertNotEqual(b.p.power, 1.0)
+
+            # has updated value
+            self.assertAlmostEqual(b.p.linPow, 10.0)
 
         # equal because these are mapped
         for expectedPower, expectedGammaPower, a in zip(


### PR DESCRIPTION
## Description

Add `parameterDefinitions.Category.neutronics` to `b.p.linPow`. This will allow `linPow` to be mapped out of gamma solves in addition to neutronics solves. The `linPow` can be modified during a gamma solve to match with the updated `power`, which includes neutron & gamma heating.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

