### PR TITLE
Calculate fission rate density.

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -1172,9 +1172,8 @@ def calcReactionRates(obj, keff, lib):
 
     if rate["rateFis"] > 0.0:
         vFuel = obj.getComponentAreaFrac(Flags.FUEL)
-        vol = obj.getVolume()
-        obj.p.fisDens = rate["rateFis"] / (vol * vFuel)
-        obj.p.fisDensHom = rate["rateFis"] / vol
+        obj.p.fisDens = rate["rateFis"] / vFuel
+        obj.p.fisDensHom = rate["rateFis"]
     else:
         obj.p.fisDens = 0.0
         obj.p.fisDensHom = 0.0

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -1170,10 +1170,6 @@ def calcReactionRates(obj, keff, lib):
     for paramName, val in rate.items():
         obj.p[paramName] = val  # put in #/cm^3/s
 
-    if rate["rateFis"] > 0.0:
-        vFuel = obj.getComponentAreaFrac(Flags.FUEL)
-        obj.p.fisDens = rate["rateFis"] / vFuel
-        obj.p.fisDensHom = rate["rateFis"]
-    else:
-        obj.p.fisDens = 0.0
-        obj.p.fisDensHom = 0.0
+    vFuel = obj.getComponentAreaFrac(Flags.FUEL) if rate["rateFis"] > 0.0 else 1.0
+    obj.p.fisDens = rate["rateFis"] / vFuel
+    obj.p.fisDensHom = rate["rateFis"]

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -1169,3 +1169,10 @@ def calcReactionRates(obj, keff, lib):
 
     for paramName, val in rate.items():
         obj.p[paramName] = val  # put in #/cm^3/s
+
+    # if necessary, de-homogenize b.p.fisDensHom to b.p.fisDens
+    if rate["rateFis"] > 0.0:
+        vFuel = obj.getComponentAreaFrac(Flags.FUEL)
+        vol = obj.getVolume()
+        obj.p.fisDens = rate["rateFis"] / (vol * vFuel)
+        obj.p.fisDensHom = rate["rateFis"] / vol

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -1170,9 +1170,11 @@ def calcReactionRates(obj, keff, lib):
     for paramName, val in rate.items():
         obj.p[paramName] = val  # put in #/cm^3/s
 
-    # if necessary, de-homogenize b.p.fisDensHom to b.p.fisDens
     if rate["rateFis"] > 0.0:
         vFuel = obj.getComponentAreaFrac(Flags.FUEL)
         vol = obj.getVolume()
         obj.p.fisDens = rate["rateFis"] / (vol * vFuel)
         obj.p.fisDensHom = rate["rateFis"] / vol
+    else:
+        obj.p.fisDens = 0.0
+        obj.p.fisDensHom = 0.0

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -310,7 +310,8 @@ class TestGlobalFluxUtils(unittest.TestCase):
         self.assertAlmostEqual(b.p.rateAbs, 0.0)
         globalFluxInterface.calcReactionRates(b, 1.01, b.r.core.lib)
         self.assertGreater(b.p.rateAbs, 0.0)
-
+        self.assertGreater(b.p.fisDens, 0.0)
+        self.assertGreater(b.p.fisDensHom, 0.0)
 
 def applyDummyFlux(r, ng=33):
     """Set arbitrary flux distribution on reactor."""

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -310,8 +310,9 @@ class TestGlobalFluxUtils(unittest.TestCase):
         self.assertAlmostEqual(b.p.rateAbs, 0.0)
         globalFluxInterface.calcReactionRates(b, 1.01, b.r.core.lib)
         self.assertGreater(b.p.rateAbs, 0.0)
-        self.assertGreater(b.p.fisDens, 0.0)
-        self.assertGreater(b.p.fisDensHom, 0.0)
+        vfrac = b.getComponentAreaFrac(Flags.FUEL)
+        self.assertEqual(b.p.fisDens, b.p.rateFis / vfrac)
+        self.assertEqual(b.p.fisDensHom, b.p.rateFis)
 
 
 def applyDummyFlux(r, ng=33):

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -313,6 +313,7 @@ class TestGlobalFluxUtils(unittest.TestCase):
         self.assertGreater(b.p.fisDens, 0.0)
         self.assertGreater(b.p.fisDensHom, 0.0)
 
+
 def applyDummyFlux(r, ng=33):
     """Set arbitrary flux distribution on reactor."""
     for b in r.core.getBlocks():


### PR DESCRIPTION
## Description

Calculate `b.p.fisDens` (fissions/cc/sec) in `calcReactionRates`

`fisDens` needs to be calculated here, after de-converison of uniform reactor back to non-uniform assemblies.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

