### PR TITLE
Removing prefer-binary PIP requirement

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,3 @@
---prefer-binary
 numpy>=1.21,<=1.23.5
 
 # docutils 0.17 introduced a bug that prevents bullets from rendering

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# See the discussion in docs\developer\tooling
---prefer-binary
 # see https://github.com/advisories/GHSA-6p56-wp2h-9hxr
 # This is included in requirements.txt because of a security alert numpy released
 numpy>=1.21,<=1.23.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py38,lint,cov
-# need pip at least with --prefer-binary
 requires =
 	pip >= 20.2
 


### PR DESCRIPTION
## Description

These [--prefer-binary](https://pip.pypa.io/en/stable/cli/pip_download/#cmdoption-prefer-binary) lines in our PIP requirement files appear to be defunct.  

The reason it is important to remove them, is very soon the PIP ecosystem will no longer support ANYTHING in requirements files except a "library ><= version lines". This is the error we will soon see:

```
test: install_package_deps> python -I -m pip install configparser coverage<=6.5.0 future h5py>=3.0 htmltree
matplotlib numpy<=1.23.5,>=1.21 ordered-set pillow pluggy pyDOE pyevtk scipy tabulate voluptuous xlrd
yamlize -cD:\a\armi\armi\.tox\test\constraints.txt

**DEPRECATION**: Constraints are only allowed to take the form of a package name and a version specifier.
Other forms were originally permitted as an accident of the implementation, but were undocumented.
The new implementation of the resolver no longer supports these forms. A possible replacement is
replacing the constraint with a requirement.
Discussion can be found at https://github.com/pypa/pip/issues/8210
```

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
