### PR TITLE
Matching the Magnesium density curve to match the reference

### DIFF
--- a/armi/materials/magnesium.py
+++ b/armi/materials/magnesium.py
@@ -26,10 +26,15 @@ class Magnesium(material.Fluid):
         self.setMassFrac("MG", 1.0)
 
     def density(self, Tk=None, Tc=None):
-        r"""returns mass density of magnesium in g/cc
+        r"""Returns mass density of magnesium in g/cm3.
+
         The Liquid Temperature Range, Density and Constants of Magnesium. P.J. McGonigal. Temple University 1961.
+
+        Notes
+        -----
+        For Fluids, ARMI defines this 2D pseudodensity is the same as the usual 3D physical density.
         """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 
-        return 1.59 - 0.00026 * (Tk - 924.0)
+        return 1.834 - 2.647e-4 * Tk

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -159,13 +159,13 @@ class Magnesium_TestCase(_Material_Test, unittest.TestCase):
 
     def test_density(self):
         cur = self.mat.density(923)
-        ref = 1.59
-        delta = ref * 0.05
+        ref = 1.5897
+        delta = ref * 0.0001
         self.assertAlmostEqual(cur, ref, delta=delta)
 
         cur = self.mat.density(1390)
-        ref = 1.466
-        delta = ref * 0.05
+        ref = 1.4661
+        delta = ref * 0.0001
         self.assertAlmostEqual(cur, ref, delta=delta)
 
     def test_propertyValidTemperature(self):


### PR DESCRIPTION
## Description

Based on [a discussion here](https://github.com/terrapower/armi/issues/1097#issuecomment-1398587207) with @dpham-materials, it appears our Magnesium density curve very slightly mis-matched the provided reference.

It is a very slight difference, but since there is no other reference provided, I am just going to fix it.

@opotowsky It will be up to us to determine if any downstream projects/integration tests actually USE this material. If not, it's easy. If so, we will have to determine how this change affects our project results.

> This PR is part of [this umbrella ticket](https://github.com/terrapower/armi/issues/1097).

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
