### PR TITLE
Adding a note on Fluid density in ARMI

### DIFF
--- a/armi/materials/air.py
+++ b/armi/materials/air.py
@@ -75,6 +75,10 @@ class Air(material.Fluid):
         Tc : float, optional
             temperature in degrees Celsius
 
+        Notes
+        -----
+        In ARMI, we define density() and density3() as the same for Fluids.
+
         Returns
         -------
         density : float

--- a/armi/materials/cs.py
+++ b/armi/materials/cs.py
@@ -28,8 +28,13 @@ class Cs(Fluid):
         self.setMassFrac("CS133", 1.0)
 
     def density(self, Tk=None, Tc=None):
-        """
+        """The 2D/3D density of liquid Cesium.
+
         https://en.wikipedia.org/wiki/Caesium
+
+        Notes
+        -----
+        In ARMI, we define density() and density3() as the same for Fluids.
         """
         Tk = getTk(Tc, Tk)
         if Tk < self.meltingPoint():

--- a/armi/materials/lithium.py
+++ b/armi/materials/lithium.py
@@ -53,12 +53,15 @@ class Lithium(material.Fluid):
             self.adjustMassEnrichment(LI6_wt_frac)
 
     def density(self, Tk=None, Tc=None):
-        r"""
-        Wikipedia
+        r"""Density (g/cc) from Wikipedia.
 
         Will be liquid above 180C.
+
+        Notes
+        -----
+        In ARMI, we define density() and density3() as the same for Fluids.
         """
-        return 0.512  # g/cc
+        return 0.512
 
     def setDefaultMassFracs(self):
         self.setMassFrac("LI6", nb.byName["LI6"].abundance)

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -714,7 +714,7 @@ class Fluid(Material):
 
         Notes
         -----
-        for fluids, there is no such thing as 2 d expansion so density() is already 3D.
+        For fluids, there is no such thing as 2D expansion so density() is already 3D.
         """
         return self.density(Tk=Tk, Tc=Tc)
 

--- a/armi/materials/sulfur.py
+++ b/armi/materials/sulfur.py
@@ -59,7 +59,14 @@ class Sulfur(material.Fluid):
         self.setMassFrac("S36", 0.002)
 
     def density(self, Tk=None, Tc=None):
-        r"""P. Espeau, R. Ceolin "density of molten sulfur in the 334-508K range" """
+        r"""Density of Liquid Sulfur.
+
+        Ref: P. Espeau, R. Ceolin "density of molten sulfur in the 334-508K range"
+
+        Notes
+        -----
+        In ARMI, we define density() and density3() as the same for Fluids.
+        """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 

--- a/armi/materials/water.py
+++ b/armi/materials/water.py
@@ -313,6 +313,13 @@ class Water(Fluid):
         return phi + 1.0 / rho * dp_dT
 
     def density(self, Tk=None, Tc=None):
+        """
+        Density for arbitrary forms of water.
+
+        Notes
+        -----
+        In ARMI, we define density() and density3() as the same for Fluids.
+        """
         raise NotImplementedError(
             "Please use a concrete instance: SaturatedWater or SaturatedSteam."
         )
@@ -350,6 +357,7 @@ class SaturatedWater(Water):
 
         Note
         ----
+        In ARMI, we define density() and density3() as the same for Fluids.
         IAPWS-IF97
         http://www.iapws.org/relguide/supsat.pdf
         IAPWS-IF97 is now the international standard for calculations in the steam power industry
@@ -407,8 +415,9 @@ class SaturatedSteam(Water):
         density: float
             density in g/cc
 
-        Note
-        ----
+        Notes
+        -----
+        In ARMI, we define density() and density3() as the same for Fluids.
         IAPWS-IF97
         http://www.iapws.org/relguide/supsat.pdf
         IAPWS-IF97 is now the international standard for calculations in the steam power industry


### PR DESCRIPTION
## Description

It came as quite a surprise to me that 2D density (`density()`) and 3D density (`density3()`) in ARMI are the same for `Fluid` materials.  I am adding a comment to the relevant docstrings so this doesn't bite anyone else.

> This PR is part of [this umbrella ticket](https://github.com/terrapower/armi/issues/1097).

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
