### PR TITLE
Fixing temperature range of Potassium

### DIFF
--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -26,7 +26,7 @@ class Potassium(material.Fluid):
     """
 
     name = "Potassium"
-    propertyValidTemperature = {"density": ((63.38, 1250), "C")}
+    propertyValidTemperature = {"density": ((63.2, 1250), "C")}
 
     def density(self, Tk=None, Tc=None):
         r"""

--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -41,5 +41,5 @@ class Potassium(material.Fluid):
         """
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc=Tc)
-        self.checkPropertyTempRange("density", Tk)
+        self.checkPropertyTempRange("density", Tc)
         return 0.8415 - 2.172e-4 * Tc - 2.70e-8 * Tc ** 2 + 4.77e-12 * Tc ** 3

--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -26,7 +26,7 @@ class Potassium(material.Fluid):
     """
 
     name = "Potassium"
-    propertyValidTemperature = {"density": ((63.38, 759), "K")}
+    propertyValidTemperature = {"density": ((63.38, 1250), "C")}
 
     def density(self, Tk=None, Tc=None):
         r"""

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -305,18 +305,28 @@ class Potassium_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Potassium
 
     def test_density(self):
-        cur = self.mat.density(Tk=333)
-        ref = 0.828
+        cur = self.mat.density(Tc=100)
+        ref = 0.8195
         delta = ref * 0.001
         self.assertAlmostEqual(cur, ref, delta=delta)
 
-        cur = self.mat.density(Tk=500)
-        ref = 0.7909
+        cur = self.mat.density(Tc=333)
+        ref = 0.7664
         delta = ref * 0.001
         self.assertAlmostEqual(cur, ref, delta=delta)
 
-        cur = self.mat.density(Tk=750)
-        ref = 0.732
+        cur = self.mat.density(Tc=500)
+        ref = 0.7267
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.density(Tc=750)
+        ref = 0.6654
+        delta = ref * 0.001
+        self.assertAlmostEqual(cur, ref, delta=delta)
+
+        cur = self.mat.density(Tc=1200)
+        ref = 0.5502
         delta = ref * 0.001
         self.assertAlmostEqual(cur, ref, delta=delta)
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -29,6 +29,8 @@ What's new in ARMI
 #. Refine logic for Block.getNumPins() to only count components that are actually pins. (`PR#1098 <https://github.com/terrapower/armi/pull/1098>`_)
 #. Improve handling of peak/max parameters by the UniformMeshConverter parameter mapper. (`PR#1108 <https://github.com/terrapower/armi/pull/1108>`_)
 #. Bug fix to expose new tight coupling functionality to ``OperatorSnapshots``. (`PR#1113 https://github.com/terrapower/armi/pull/1113`_)
+#. But fix for Magnessium density curve. (`PR#1126 https://github.com/terrapower/armi/pull/1126`_)
+#. But fix for Potassium density curve. (`PR#1128 https://github.com/terrapower/armi/pull/1128`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

@dpham-materials pointed out [here](https://github.com/terrapower/armi/issues/1097#issuecomment-1398849029) that the Potassium material had the `(min, max)` temperature ranges:

* `(63.38, 759) "K"`

But that reference is valid for:

* `(63.2, 1250), "C")`

Which is:

* `(336.35, 1523), "K")`

So I made that update, as part of [this umbrella ticket](https://github.com/terrapower/armi/issues/1097).

I expect the impact of this change to be small, because reactor cores are rarely at temperatures below 336K (which they would have to be for this change to break backwards compatibility).

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
