### PR TITLE
Update psuedo density to physical density in materials method

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -622,7 +622,7 @@ class Material:
         """
         Tc = getTc(Tc, Tk)
 
-        rhoCp = self.density(Tc=Tc) * 1000.0 * self.heatCapacity(Tc=Tc)
+        rhoCp = self.density3(Tc=Tc) * 1000.0 * self.heatCapacity(Tc=Tc)
 
         return rhoCp
 

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -606,7 +606,7 @@ class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
 
     def test_densityTimesHeatCapactiy(self):
         Tc = 500.0
-        expectedRhoCp = self.mat.density(Tc=Tc) * 1000.0 * self.mat.heatCapacity(Tc=Tc)
+        expectedRhoCp = self.mat.density3(Tc=Tc) * 1000.0 * self.mat.heatCapacity(Tc=Tc)
         self.assertAlmostEqual(expectedRhoCp, self.mat.densityTimesHeatCapacity(Tc=Tc))
 
     def test_getTempChangeForDensityChange(self):

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -43,6 +43,7 @@ Bug fixes
 #. A bug was fixed in `PR#1022 <https://github.com/terrapower/armi/pull/1022>`_ where the gaseous fission products were not being removed from the core directly, but instead the fission yields within the lumped fission products were being adjusted.
 #. Fixed a bug where non-fuel depletable components were not being initialized with all nuclides with the ``explicitFissionProducts`` model (`PR#1067 https://github.com/terrapower/armi/pull/1067`_)
 #. Bug fix to ensure consistency between cross section group manager and lattice physics interface for tight coupling. (`PR#1118 <https://github.com/terrapower/armi/pull/1118>`_)
+#. Bug fix to update pseudo density to physical density in densityTimesHeatCapacity materials method. (`PR#1129 <https://github.com/terrapower/armi/pull/1129>`_)
 
 ARMI v0.2.5
 ===========


### PR DESCRIPTION
## Description

Addresses one of the checkboxes in Issue #1097. This method needs to be using the physical density. Affected users have been notified and encouraged the change. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

