### PR TITLE
Implement timestep compare argument for database comparison

### DIFF
--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -164,7 +164,7 @@ def compareDatabases(
     srcFileName: str,
     exclusions: Optional[Sequence[str]] = None,
     tolerance: float = 0.0,
-    timestepMatchup: Sequence[Tuple[int, int]] = None,
+    timestepCompare: Optional[Sequence[Tuple[int, int]]] = None,
 ) -> Optional[DiffResults]:
     """High-level method to compare two ARMI H5 files, given file paths."""
     compiledExclusions = None
@@ -186,7 +186,7 @@ def compareDatabases(
             )
 
         with ref, src:
-            if not timestepMatchup:
+            if not timestepCompare:
                 _, nDiff = _compareH5Groups(out, ref, src, "timesteps")
 
                 if nDiff > 0:
@@ -198,8 +198,8 @@ def compareDatabases(
                     return None
 
             for refGroup, srcGroup in zip(
-                ref.genTimeStepGroups(timeSteps=timestepMatchup),
-                src.genTimeStepGroups(timeSteps=timestepMatchup),
+                ref.genTimeStepGroups(timeSteps=timestepCompare),
+                src.genTimeStepGroups(timeSteps=timestepCompare),
             ):
                 runLog.info(
                     f"Comparing ref time step {refGroup.name.split('/')[1]} to src time "

--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -173,7 +173,11 @@ class TestCompareDB3(unittest.TestCase):
             dbs.append(db)
 
         # end-to-end validation that comparing a photocopy database works
-        diffs = compareDatabases(dbs[0]._fullPath, dbs[1]._fullPath)
+        diffs = compareDatabases(
+            dbs[0]._fullPath,
+            dbs[1]._fullPath,
+            timestepCompare=[(0, 0), (0, 1)],
+        )
         self.assertEqual(len(diffs.diffs), 456)
         # Cycle length is only diff (x3)
         self.assertEqual(diffs.nDiffs(), 3)

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -742,7 +742,7 @@ class Case:
         that,
         exclusion: Optional[Sequence[str]] = None,
         tolerance=0.01,
-        timestepMatchup=None,
+        timestepCompare=None,
     ) -> int:
         """
         Compare the output databases from two run cases. Return number of differences.
@@ -759,7 +759,7 @@ class Case:
             that.dbName,
             tolerance=tolerance,
             exclusions=exclusion,
-            timestepMatchup=timestepMatchup,
+            timestepCompare=timestepCompare,
         )
 
         code = 1 if diffResults is None else diffResults.nDiffs()

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -742,6 +742,7 @@ class Case:
         that,
         exclusion: Optional[Sequence[str]] = None,
         tolerance=0.01,
+        timestepMatchup=None,
     ) -> int:
         """
         Compare the output databases from two run cases. Return number of differences.
@@ -754,7 +755,11 @@ class Case:
             "SRC: {}".format(self.dbName, that.dbName)
         )
         diffResults = compareDatabases(
-            self.dbName, that.dbName, tolerance=tolerance, exclusions=exclusion
+            self.dbName,
+            that.dbName,
+            tolerance=tolerance,
+            exclusions=exclusion,
+            timestepMatchup=timestepMatchup,
         )
 
         code = 1 if diffResults is None else diffResults.nDiffs()

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -219,7 +219,7 @@ class CaseSuite:
         exclusion: Optional[Sequence[str]] = None,
         weights=None,
         tolerance=0.01,
-        timestepMatchup=None,
+        timestepCompare=None,
     ) -> int:
         """
         Compare one case suite with another.
@@ -261,7 +261,7 @@ class CaseSuite:
                     cmpCase,
                     exclusion=exclusion,
                     tolerance=tolerance,
-                    timestepMatchup=timestepMatchup,
+                    timestepCompare=timestepCompare,
                 )
             nIssues += caseIssues
             tableResults[caseTitle] = (userFile, refFile, caseIssues)

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -258,7 +258,10 @@ class CaseSuite:
                 suiteHasMissingFiles = False
             else:
                 caseIssues = refCase.compare(
-                    cmpCase, exclusion=exclusion, tolerance=tolerance
+                    cmpCase,
+                    exclusion=exclusion,
+                    tolerance=tolerance,
+                    timestepMatchup=timestepMatchup,
                 )
             nIssues += caseIssues
             tableResults[caseTitle] = (userFile, refFile, caseIssues)

--- a/armi/cli/compareCases.py
+++ b/armi/cli/compareCases.py
@@ -68,14 +68,14 @@ class CompareCases(EntryPoint):
             help=("Patterns for parameters to ignore in comparisons"),
         )
         parser.add_argument(
-            "--timestepMatchup",
+            "--timestepCompare",
             default=None,
             action="store",
             nargs="+",
             help=(
-                "How to line up timesteps for comparisons. Note that any timestep not listed"
-                "will not be compared. Format the key and value separated by a period. "
-                "E.g. 0.0 1.2 2.1 3.3 will swap comparisons on the 1st and 2nd timenodes"
+                "List of timesteps to compare. Note that any timestep not listed will "
+                "not be compared. Format the cycle and node separated by a period. E.g. "
+                "0.0 0.1 1.2 3.3 will compare c0n0, c0n1, c1n2, c3n3 and skip all others"
             ),
         )
 
@@ -99,9 +99,9 @@ class CompareCases(EntryPoint):
     def parse(self, args):
         EntryPoint.parse(self, args)
 
-        if self.args.timestepMatchup:
-            self.args.timestepMatchup = list(
-                tuple(map(int, step.split("."))) for step in self.args.timestepMatchup
+        if self.args.timestepCompare:
+            self.args.timestepCompare = list(
+                tuple(map(int, step.split("."))) for step in self.args.timestepCompare
             )
 
         if self.args.weights:
@@ -115,7 +115,7 @@ class CompareCases(EntryPoint):
             self.args.cmpDB,
             tolerance=self.args.tolerance,
             exclusions=self.args.exclude,
-            timestepMatchup=self.args.timestepMatchup,
+            timestepCompare=self.args.timestepCompare,
         )
         return diffs.nDiffs()
 
@@ -202,7 +202,7 @@ class CompareSuites(CompareCases):
             weights=self.args.weights,
             tolerance=self.args.tolerance,
             exclusion=self.args.exclude,
-            timestepMatchup=self.args.timestepMatchup,
+            timestepCompare=self.args.timestepCompare,
         )
 
         if nIssues > 0:

--- a/armi/cli/compareCases.py
+++ b/armi/cli/compareCases.py
@@ -100,8 +100,8 @@ class CompareCases(EntryPoint):
         EntryPoint.parse(self, args)
 
         if self.args.timestepMatchup:
-            self.args.timestepMatchup = dict(
-                map(int, kv.split(".")) for kv in self.args.timestepMatchup
+            self.args.timestepMatchup = list(
+                tuple(map(int, step.split("."))) for step in self.args.timestepMatchup
             )
 
         if self.args.weights:
@@ -115,6 +115,7 @@ class CompareCases(EntryPoint):
             self.args.cmpDB,
             tolerance=self.args.tolerance,
             exclusions=self.args.exclude,
+            timestepMatchup=self.args.timestepMatchup,
         )
         return diffs.nDiffs()
 

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -165,7 +165,7 @@ class TestCompareCases(unittest.TestCase):
         cc.parse_args(["/path/to/fake1.h5", "/path/to/fake2.h5"])
 
         self.assertEqual(cc.name, "compare")
-        self.assertIsNone(cc.args.timestepMatchup)
+        self.assertIsNone(cc.args.timestepCompare)
         self.assertIsNone(cc.args.weights)
 
 


### PR DESCRIPTION
## Description

There was some phantom `timestepMatchup` argument floating around that got my hopes up when I needed to compare two databases, one of which had additional time steps. 

I didn't fully implement the original intention of this argument since no one was using it in the first place and I'm not sure it's a useful feature. What I needed was a list of time steps to include in a comparison of two DBs. So I implemented that instead. Selfish? Maybe. Sorry? Not yet.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

