### PR TITLE
Correcting concrete density based on reference

### DIFF
--- a/armi/materials/concrete.py
+++ b/armi/materials/concrete.py
@@ -39,5 +39,5 @@ class Concrete(Material):
         self.setMassFrac("CA", 0.100 / 2.302)
         self.setMassFrac("FE", 0.032 / 2.302)
 
-    def density(self, Tk=None, Tc=None):
-        return 2.302  # g/cc
+    def density3(self, Tk=None, Tc=None):
+        return 2.302  # g/cm3

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -31,6 +31,7 @@ What's new in ARMI
 #. Bug fix to expose new tight coupling functionality to ``OperatorSnapshots``. (`PR#1113 https://github.com/terrapower/armi/pull/1113`_)
 #. But fix for Magnessium density curve. (`PR#1126 https://github.com/terrapower/armi/pull/1126`_)
 #. But fix for Potassium density curve. (`PR#1128 https://github.com/terrapower/armi/pull/1128`_)
+#. But fix for Concrete density curve. (`PR#1131 https://github.com/terrapower/armi/pull/1131`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

After reviewing the reference, @dpham-materials verified my suspicion that the concrete density listed was the usual 3D/physical density and not our 2D/linear-expansion density. 

So I made that update to our concrete material, as part of [this umbrella ticket](https://github.com/terrapower/armi/issues/1097).

I expect the impact of this change to be small, because I do not know anyone who uses this material in a mission-critical reactor.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
