### PR TITLE
reduce number of run log messages

### DIFF
--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -74,8 +74,9 @@ class BlockConverter:
         """
         runLog.extra(
             "Homogenizing the {} component into the {} component in block {}".format(
-                soluteName, solventName, self._sourceBlock
-            )
+                soluteName, solventName, self._sourceBlock.getType()
+            ),
+            single=True,
         )
         # break up dimension links since we will be messing with this block's components
         newBlock = copy.deepcopy(self._sourceBlock)
@@ -154,7 +155,8 @@ class BlockConverter:
         runLog.extra(
             "Solute is linked to component(s) {} and these links will be reestablished.".format(
                 soluteLinks
-            )
+            ),
+            single=True,
         )
         for linkedC in soluteLinks:
             if linkedC in solvent.getLinkedComponents():
@@ -167,14 +169,16 @@ class BlockConverter:
                     )
                 runLog.extra(
                     "Removing void component {} in converted block {}."
-                    "".format(linkedC, self._sourceBlock)
+                    "".format(linkedC, self._sourceBlock.getType()),
+                    single=True,
                 )
                 self._sourceBlock.remove(linkedC)
             else:
                 dims = linkedC.getDimensionNamesLinkedTo(solute)
                 runLog.extra(
                     "Linking component {} in converted block {} to solvent {}."
-                    "".format(linkedC, self._sourceBlock, solvent)
+                    "".format(linkedC, self._sourceBlock.getType(), solvent),
+                    single=True,
                 )
                 for dimToChange, dimOfOther in dims:
                     linkedC.setLink(dimToChange, solvent, dimOfOther)


### PR DESCRIPTION
## Description
This module prints 50,000+ lines of info in the stdout for one of our internal plugins. i think the intent it to tell the user the types of block conversions being performed, not to tell the user for every single block it does.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [N/A] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

