### PR TITLE
Calculate block masses at BOC

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -174,7 +174,6 @@ class TestCompareDB3(unittest.TestCase):
 
         # end-to-end validation that comparing a photocopy database works
         diffs = compareDatabases(dbs[0]._fullPath, dbs[1]._fullPath)
-        print(diffs.diffs)
         self.assertEqual(len(diffs.diffs), 462)
         # Cycle length is only diff (x3)
         self.assertEqual(diffs.nDiffs(), 3)

--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -174,7 +174,8 @@ class TestCompareDB3(unittest.TestCase):
 
         # end-to-end validation that comparing a photocopy database works
         diffs = compareDatabases(dbs[0]._fullPath, dbs[1]._fullPath)
-        self.assertEqual(len(diffs.diffs), 456)
+        print(diffs.diffs)
+        self.assertEqual(len(diffs.diffs), 462)
         # Cycle length is only diff (x3)
         self.assertEqual(diffs.nDiffs(), 3)
 

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -177,7 +177,7 @@ class TestReportInterface(unittest.TestCase):
 
         self.assertEqual(repInt.fuelCycleSummary["bocFissile"], 0.0)
         repInt.interactBOC(1)
-        self.assertEqual(repInt.fuelCycleSummary["bocFissile"], 0.0)
+        self.assertEqual(repInt.fuelCycleSummary["bocFissile"], 726304.0175506991)
 
     def test_interactEOC(self):
         o, r = loadTestReactor()

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -177,7 +177,7 @@ class TestReportInterface(unittest.TestCase):
 
         self.assertEqual(repInt.fuelCycleSummary["bocFissile"], 0.0)
         repInt.interactBOC(1)
-        self.assertEqual(repInt.fuelCycleSummary["bocFissile"], 726304.0175506991)
+        self.assertEqual(repInt.fuelCycleSummary["bocFissile"], 726.3040175506991)
 
     def test_interactEOC(self):
         o, r = loadTestReactor()

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -177,7 +177,7 @@ class TestReportInterface(unittest.TestCase):
 
         self.assertEqual(repInt.fuelCycleSummary["bocFissile"], 0.0)
         repInt.interactBOC(1)
-        self.assertEqual(repInt.fuelCycleSummary["bocFissile"], 726.3040175506991)
+        self.assertAlmostEqual(repInt.fuelCycleSummary["bocFissile"], 726.30401755)
 
     def test_interactEOC(self):
         o, r = loadTestReactor()

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -162,6 +162,8 @@ class FuelHandler:
 
         self.o.r.core.p.numMoves = numMoved
 
+        self.o.r.core.setBlockMassParams()
+
         runLog.important(
             "Fuel handler performed {0} assembly shuffles.".format(numMoved)
         )

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -334,6 +334,10 @@ class TestFuelHandler(FuelHandlerTestHelper):
             fh.manageFuel(cycle)
             for a in self.r.core.sfp.getChildren():
                 self.assertEqual(a.getLocation(), "SFP")
+            for b in self.r.core.getBlocks(Flags.FUEL):
+                self.assertGreater(b.p.kgHM, 0.0, "b.p.kgHM not populated!")
+                self.assertGreater(b.p.kgFis, 0.0, "b.p.kgFis not populated!")
+
         fh.interactEOL()
 
     def test_repeatShuffles(self):

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -935,14 +935,14 @@ def getBlockParameterDefinitions():
             "kgFis",
             units="kg",
             description="Mass of fissile material in block",
-            location=ParamLocation.AVERAGE,
+            location=ParamLocation.VOLUME_INTEGRATED,
         )
 
         pb.defParam(
             "kgHM",
             units="kg",
             description="Mass of heavy metal in block",
-            location=ParamLocation.AVERAGE,
+            location=ParamLocation.VOLUME_INTEGRATED,
         )
 
         pb.defParam(

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -378,7 +378,7 @@ class Core(composites.Composite):
         """Set the parameters kgHM and kgFis for each block"""
         for b in self.getBlocks():
             b.p.kgHM = b.getHMMass()
-            b.p.kgFis = b.geFissileMass()
+            b.p.kgFis = b.getFissileMass()
 
     def getScalarEvolution(self, key):
         return self.scalarVals[key]

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -374,6 +374,12 @@ class Core(composites.Composite):
             )
         )
 
+    def setBlockMassParams(self):
+        """Set the parameters kgHM and kgFis for each block"""
+        for b in self.getBlocks():
+            b.p.kgHM = b.getHMMass()
+            b.p.kgFis = b.geFissileMass()
+
     def getScalarEvolution(self, key):
         return self.scalarVals[key]
 
@@ -2279,6 +2285,8 @@ class Core(composites.Composite):
             stationaryBlockFlags.append(Flags.fromString(stationaryBlockFlagString))
 
         self.stationaryBlockFlagsList = stationaryBlockFlags
+
+        self.setBlockMassParams()
 
         self.p.maxAssemNum = self.getMaxParam("assemNum")
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -377,8 +377,8 @@ class Core(composites.Composite):
     def setBlockMassParams(self):
         """Set the parameters kgHM and kgFis for each block"""
         for b in self.getBlocks():
-            b.p.kgHM = b.getHMMass()
-            b.p.kgFis = b.getFissileMass()
+            b.p.kgHM = b.getHMMass() / units.G_PER_KG
+            b.p.kgFis = b.getFissileMass() / units.G_PER_KG
 
     def getScalarEvolution(self, key):
         return self.scalarVals[key]

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -29,9 +29,10 @@ What's new in ARMI
 #. Refine logic for Block.getNumPins() to only count components that are actually pins. (`PR#1098 <https://github.com/terrapower/armi/pull/1098>`_)
 #. Improve handling of peak/max parameters by the UniformMeshConverter parameter mapper. (`PR#1108 <https://github.com/terrapower/armi/pull/1108>`_)
 #. Bug fix to expose new tight coupling functionality to ``OperatorSnapshots``. (`PR#1113 https://github.com/terrapower/armi/pull/1113`_)
-#. But fix for Magnessium density curve. (`PR#1126 https://github.com/terrapower/armi/pull/1126`_)
-#. But fix for Potassium density curve. (`PR#1128 https://github.com/terrapower/armi/pull/1128`_)
-#. But fix for Concrete density curve. (`PR#1131 https://github.com/terrapower/armi/pull/1131`_)
+#. Bug fix for Magnessium density curve. (`PR#1126 https://github.com/terrapower/armi/pull/1126`_)
+#. Bug fix for Potassium density curve. (`PR#1128 https://github.com/terrapower/armi/pull/1128`_)
+#. Bug fix for Concrete density curve. (`PR#1131 https://github.com/terrapower/armi/pull/1131`_)
+#. Calculate block kgHM and kgFis on core loading and after shuffling. (`PR#1136 https://github.com/terrapower/armi/pull/1136`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

Block heavy metal and fissile masses are calculated in the depletion interface, which is the only interface where they would typically be affected. However, depletion is typically inactive at node 0 of a cycle. This PR adds a simple calculation for `b.p.kgHM` and `b.p.kgFis` on core loading and after shuffling.

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

