### PR TITLE
Hashing log messages for quicker deduplication

### DIFF
--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -450,8 +450,9 @@ class DeduplicationFilter(logging.Filter):
         # If the message is set to "do not duplicate" we may filter it out
         if single:
             if record.levelno in (logging.WARNING, logging.CRITICAL):
-                # grab the custom label, if it exists, for warning logging later
+                # if this is from the custom logger, it will have a "label"
                 label = getattr(record, "label", msg)
+                # the "label" default is None, which needs to be replaced
                 label = msg if label is None else label
 
                 if label not in self.singleWarningMessageCounts:

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -383,23 +383,23 @@ def raw(msg):
     """
     Print raw text without any special functionality.
     """
-    LOG.log("header", msg, single=False, label=msg)
+    LOG.log("header", msg, single=False)
 
 
 def extra(msg, single=False, label=None):
-    LOG.log("extra", msg, single=single, label=label)
+    LOG.log("extra", msg, single=single)
 
 
 def debug(msg, single=False, label=None):
-    LOG.log("debug", msg, single=single, label=label)
+    LOG.log("debug", msg, single=single)
 
 
 def info(msg, single=False, label=None):
-    LOG.log("info", msg, single=single, label=label)
+    LOG.log("info", msg, single=single)
 
 
 def important(msg, single=False, label=None):
-    LOG.log("important", msg, single=single, label=label)
+    LOG.log("important", msg, single=single)
 
 
 def warning(msg, single=False, label=None):
@@ -446,18 +446,22 @@ class DeduplicationFilter(logging.Filter):
         # determine if this is a "do not duplicate" message
         msg = str(record.msg)
         single = getattr(record, "single", False)
-        label = getattr(record, "label", msg)
-        label = msg if label is None else label
 
         # If the message is set to "do not duplicate" we may filter it out
         if single:
             if record.levelno in (logging.WARNING, logging.CRITICAL):
+                # grab the custom label, if it exists, for warning logging later
+                label = getattr(record, "label", msg)
+                label = msg if label is None else label
+
                 if label not in self.singleWarningMessageCounts:
                     self.singleWarningMessageCounts[label] = 1
                 else:
                     self.singleWarningMessageCounts[label] += 1
                     return False
             else:
+                # in sub-warning cases, hash the msg, for a faster label lookup
+                label = hash(msg)
                 if label not in self.singleMessageCounts:
                     self.singleMessageCounts[label] = 1
                 else:


### PR DESCRIPTION
## Description

In references to [Issue #1135](https://github.com/terrapower/armi/issues/1135), I am just hashing the string message of a log statement, when we are trying to de-duplicate it. This requires less memory and is faster than storing and comparing the full strings.  

I decided it was time to do this because people are using this feature more and more often lately.

I could only speed-up the situation so much because we are currently saving all `Warning`/`Error` level messages and printing a collection of them at the end. So we need to save he entire log message. From my perspective, this is a nice-to-have feature that we will lose if people starting using this "don't duplicate this log message" feature a lot more in the future.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
