### PR TITLE
Remove `FuelMaterial.__init__()`

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -820,16 +820,9 @@ class FuelMaterial(Material):
     All this really does is enable the special class 1/class 2 isotopics input option.
     """
 
-    def __init__(self):
-        Material.__init__(self)
-        # support for custom isotopics
-        self.class1_wt_frac = None
-        self.class1_custom_isotopics = None
-        self.class2_custom_isotopics = None
-        # tracking depletion status
-        self.puFrac = 0.0
-        self.uFrac = 0.0
-        self.zrFrac = 0.0
+    class1_wt_frac = None
+    class1_custom_isotopics = None
+    class2_custom_isotopics = None
 
     def applyInputParams(
         self,
@@ -904,23 +897,8 @@ class FuelMaterial(Material):
         m.refDens = self.refDens
         m.theoreticalDensityFrac = self.theoreticalDensityFrac
 
-        # Handle the case where a developer creates a FuelMaterial,
-        # but only calls the Material.__init__().
-        m.class1_wt_frac = (
-            self.class1_wt_frac if hasattr(self, "class1_wt_frac") else None
-        )
-        m.class1_custom_isotopics = (
-            self.class1_custom_isotopics
-            if hasattr(self, "class1_custom_isotopics")
-            else None
-        )
-        m.class2_custom_isotopics = (
-            self.class2_custom_isotopics
-            if hasattr(self, "class2_custom_isotopics")
-            else None
-        )
-        m.puFrac = self.puFrac if hasattr(self, "puFrac") else 0.0
-        m.uFrac = self.uFrac if hasattr(self, "uFrac") else 0.0
-        m.zrFrac = self.zrFrac if hasattr(self, "zrFrac") else 0.0
+        m.class1_wt_frac = self.class1_wt_frac
+        m.class1_custom_isotopics = self.class1_custom_isotopics
+        m.class2_custom_isotopics = self.class2_custom_isotopics
 
         return m

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -903,8 +903,8 @@ class FuelMaterial(Material):
         m.class1_wt_frac = self.class1_wt_frac
         m.class1_custom_isotopics = self.class1_custom_isotopics
         m.class2_custom_isotopics = self.class2_custom_isotopics
-        m.puFrac = self.puFrac if hasattr(self, "puFrac") else 0.0
-        m.uFrac = self.uFrac if hasattr(self, "uFrac") else 0.0
-        m.zrFrac = self.zrFrac if hasattr(self, "zrFrac") else 0.0
+        m.puFrac = self.puFrac
+        m.uFrac = self.uFrac
+        m.zrFrac = self.zrFrac
 
         return m

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -823,6 +823,9 @@ class FuelMaterial(Material):
     class1_wt_frac = None
     class1_custom_isotopics = None
     class2_custom_isotopics = None
+    puFrac = 0.0
+    uFrac = 0.0
+    zrFrac = 0.0
 
     def applyInputParams(
         self,
@@ -900,5 +903,8 @@ class FuelMaterial(Material):
         m.class1_wt_frac = self.class1_wt_frac
         m.class1_custom_isotopics = self.class1_custom_isotopics
         m.class2_custom_isotopics = self.class2_custom_isotopics
+        m.puFrac = self.puFrac if hasattr(self, "puFrac") else 0.0
+        m.uFrac = self.uFrac if hasattr(self, "uFrac") else 0.0
+        m.zrFrac = self.zrFrac if hasattr(self, "zrFrac") else 0.0
 
         return m


### PR DESCRIPTION
## Description


`FuelMaterial` has an `__init__()` method which calls directly up to `Material.__init__()`. This makes it difficult to make a new material that has multiple inheritance with, say, `FuelMaterial` and `SimpleSolid`. `FuelMaterial.__init__()` is really not needed anyways, so it was removed in favor of putting the defaults as a class attribute.

This should not impact the user at all.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

