### PR TITLE
Opening up the disable snapshot interfaces list

### DIFF
--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -26,11 +26,17 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
     This operator can be run as a restart, adding new physics to a previous run.
     """
 
-    def createInterfaces(self):
-        operatorMPI.OperatorMPI.createInterfaces(self)
+    def __init__(self, cs):
+        super().__init__(cs)
+
         # disable fuel management and optimization
         # disable depletion because we don't want to change number densities for tn's >0 (or any)
-        for toDisable in ["fuelHandler", "optimize", "depletion"]:
+        self.disabledInterfaces = ["depletion", "fuelHandler", "optimize"]
+
+    def createInterfaces(self):
+        operatorMPI.OperatorMPI.createInterfaces(self)
+
+        for toDisable in self.disabledInterfaces:
             i = self.getInterface(name=toDisable, function=toDisable)
             if i:
                 i.enabled(False)

--- a/armi/operators/tests/test_operatorSnapshots.py
+++ b/armi/operators/tests/test_operatorSnapshots.py
@@ -61,6 +61,34 @@ class TestOperatorSnapshots(unittest.TestCase):
         self.o._mainOperate()
         self.assertEqual(self.r.core.p.power, 100000000.0)
 
+    def test_createInterfaces(self):
+        self.assertEqual(len(self.o.interfaces), 0)
+        self.o.createInterfaces()
+
+        # If someone adds an interface, we don't want this test to break, so let's do >6
+        self.assertGreater(len(self.o.interfaces), 6)
+
+    def test_createInterfacesDisabled(self):
+        self.assertEqual(len(self.o.interfaces), 0)
+        allInterfaces = [
+            "main",
+            "fissionProducts",
+            "xsGroups",
+            "fuelHandler",
+            "history",
+            "database",
+            "memoryProfiler",
+            "snapshot",
+        ]
+        for i in allInterfaces:
+            self.o.disabledInterfaces.append(i)
+        self.o.createInterfaces()
+
+        # If someone adds an interface, we don't want this test to break, so let's do >6
+        self.assertGreater(len(self.o.interfaces), 6)
+        for i in self.o.interfaces:
+            self.assertFalse(i.enabled())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/doc/developer/standards_and_practices.rst
+++ b/doc/developer/standards_and_practices.rst
@@ -299,8 +299,12 @@ zero pylint warnings or errors.
 General do's and don'ts
 =======================
 
-Do not use ``print``.
+do not use ``print``
     ARMI code should not use the ``print`` function; use one of the methods within ``armi.runLog``.
 
-Do not add new ``TODO`` statements in your commits and PRs.
-    If your new ``TODO`` statement is important, it should be a GitHub Issue. Yes, we have existing ``TODO`` statements in the code, those are relic and should be handled.
+do not use ``super``
+    In preference to the ``super`` function, explicitly call the parent object's method. For example, in an
+    ``__init__``, use ``ParentClass.__init__(self, plus, additional, arguments)``.
+
+do not leave ``TODO`` statements in production code
+    If your ``TODO`` statement is important, perhaps it should be a GitHub Issue.

--- a/doc/developer/standards_and_practices.rst
+++ b/doc/developer/standards_and_practices.rst
@@ -299,12 +299,8 @@ zero pylint warnings or errors.
 General do's and don'ts
 =======================
 
-do not use ``print``
+Do not use ``print``.
     ARMI code should not use the ``print`` function; use one of the methods within ``armi.runLog``.
 
-do not use ``super``
-    In preference to the ``super`` function, explicitly call the parent object's method. For example, in an
-    ``__init__``, use ``ParentClass.__init__(self, plus, additional, arguments)``.
-
-do not leave ``TODO`` statements in production code
-    If your ``TODO`` statement is important, perhaps it should be a GitHub Issue.
+Do not add new ``TODO`` statements in your commits and PRs.
+    If your new ``TODO`` statement is important, it should be a GitHub Issue. Yes, we have existing ``TODO`` statements in the code, those are relic and should be handled.


### PR DESCRIPTION
## Description

There was a hard-coded list in `snapshots.py` that recently became really important. People might need to change this list.  By preference, I believe this is not so common a need that it should be done as a `Setting`; it would be better as a class attribute. Even without this request, this list is better as a class attribute, because we don't like hard-coding data.

**NOTE**: Based on a discussion yesterday with @keckler, I am finally removing our rule against using the `super()` method. I have not found this rule to be productive or helpful.  It's high past time.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
