### PR TITLE
Fixing copper density curve

### DIFF
--- a/armi/materials/copper.py
+++ b/armi/materials/copper.py
@@ -29,8 +29,8 @@ class Cu(Material):
         self.setMassFrac("CU63", 0.6915)
         self.setMassFrac("CU65", 0.3085)
 
-    def density(self, Tk=None, Tc=None):
-        return 8.913
+    def density3(self, Tk=None, Tc=None):
+        return 8.913  # g/cm3
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         """

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -913,6 +913,7 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
+"""
 class Copper_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Cu
 
@@ -932,6 +933,7 @@ class Copper_TestCase(_Material_Test, unittest.TestCase):
         for i, temp in enumerate(temps):
             cur = self.mat.linearExpansionPercent(Tk=temp)
             self.assertAlmostEqual(cur, expansions[i], 4)
+"""
 
 
 class Sulfur_TestCase(_Material_Test, unittest.TestCase):

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -910,25 +910,28 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
 class Copper_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Cu
 
-    # def test_setDefaultMassFracs(self):
-    #    cur = self.mat.massFrac
-    #    ref = {"CU63": 0.6915, "CU65": 0.3085}
-    #    self.assertEqual(cur, ref)
+    def test_setDefaultMassFracs(self):
+        cur = self.mat.massFrac
+        ref = {"CU63": 0.6915, "CU65": 0.3085}
+        self.assertEqual(cur, ref)
 
     def test_densityNeverChanges(self):
         for tk in [200.0, 400.0, 800.0, 1111.1]:
             cur = self.mat.density3(tk)
             self.assertAlmostEqual(cur, 8.913, 4)
 
-
-"""
     def test_linearExpansionPercent(self):
         temps = [100.0, 200.0, 600.0]
         expansions = [-0.2955, -0.1500, 0.5326]
         for i, temp in enumerate(temps):
             cur = self.mat.linearExpansionPercent(Tk=temp)
             self.assertAlmostEqual(cur, expansions[i], 4)
-"""
+
+    def test_getChildren(self):
+        self.assertEqual(len(self.mat.getChildren()), 0)
+
+    def test_getChildrenWithFlags(self):
+        self.assertEqual(len(self.mat.getChildrenWithFlags("anything")), 0)
 
 
 class Sulfur_TestCase(_Material_Test, unittest.TestCase):

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -913,6 +913,27 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
+class Copper_TestCase(_Material_Test, unittest.TestCase):
+    MAT_CLASS = materials.Cu
+
+    def test_setDefaultMassFracs(self):
+        cur = self.mat.massFrac
+        ref = {"CU63": 0.6915, "CU65": 0.3085}
+        self.assertEqual(cur, ref)
+
+    def test_density3(self):
+        for tk in [200.0, 400.0, 800.0, 1111.1]:
+            cur = self.mat.density3(tk)
+            self.assertAlmostEqual(cur, 8.913, 4)
+
+    def test_linearExpansionPercent(self):
+        temps = [100.0, 200.0, 600.0]
+        expansions = [-0.2955, -0.1500, 0.5326]
+        for i, temp in enumerate(temps):
+            cur = self.mat.linearExpansionPercent(Tk=temp)
+            self.assertAlmostEqual(cur, expansions[i], 4)
+
+
 class Sulfur_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Sulfur
 

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -15,8 +15,8 @@
 r"""Tests materials.py"""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,invalid-name
 
-import pickle
 import math
+import pickle
 import unittest
 
 from numpy import testing
@@ -913,7 +913,6 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
 
 
-"""
 class Copper_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Cu
 
@@ -922,11 +921,13 @@ class Copper_TestCase(_Material_Test, unittest.TestCase):
     #    ref = {"CU63": 0.6915, "CU65": 0.3085}
     #    self.assertEqual(cur, ref)
 
-    def test_density3(self):
+    def test_densityNeverChanges(self):
         for tk in [200.0, 400.0, 800.0, 1111.1]:
             cur = self.mat.density3(tk)
             self.assertAlmostEqual(cur, 8.913, 4)
 
+
+"""
     def test_linearExpansionPercent(self):
         temps = [100.0, 200.0, 600.0]
         expansions = [-0.2955, -0.1500, 0.5326]

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -49,12 +49,6 @@ class _Material_Test:
         """Test that all materials produce a zero density from density3"""
         self.assertNotEqual(self.mat.density3(500), 0)
 
-    def test_getChildren(self):
-        self.assertEqual(len(self.mat.getChildren()), 0)
-
-    def test_getChildrenWithFlags(self):
-        self.assertEqual(len(self.mat.getChildrenWithFlags("anything")), 0)
-
     def test_TD(self):
         self.assertEqual(self.mat.getTD(), self.mat.theoreticalDensityFrac)
 

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -916,10 +916,10 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
 class Copper_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Cu
 
-    def test_setDefaultMassFracs(self):
-        cur = self.mat.massFrac
-        ref = {"CU63": 0.6915, "CU65": 0.3085}
-        self.assertEqual(cur, ref)
+    # def test_setDefaultMassFracs(self):
+    #    cur = self.mat.massFrac
+    #    ref = {"CU63": 0.6915, "CU65": 0.3085}
+    #    self.assertEqual(cur, ref)
 
     def test_density3(self):
         for tk in [200.0, 400.0, 800.0, 1111.1]:

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -32,6 +32,7 @@ What's new in ARMI
 #. Bug fix for Magnessium density curve. (`PR#1126 https://github.com/terrapower/armi/pull/1126`_)
 #. Bug fix for Potassium density curve. (`PR#1128 https://github.com/terrapower/armi/pull/1128`_)
 #. Bug fix for Concrete density curve. (`PR#1131 https://github.com/terrapower/armi/pull/1131`_)
+#. Bug fix for Copper density curve. (`PR#1150 https://github.com/terrapower/armi/pull/1150`_)
 #. Calculate block kgHM and kgFis on core loading and after shuffling. (`PR#1136 https://github.com/terrapower/armi/pull/1136`_)
 
 Bug fixes


### PR DESCRIPTION
## Description

The copper density provided in the reference is, of course, for 3D density. So this is a Minor bug fix for a material that I think is broadly unused in the ARMI ecosystem. I expect this to make no difference to our major downstream projects.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
