### PR TITLE
Parse through applyInputParams in the MRO

### DIFF
--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -135,7 +135,7 @@ class BlockBlueprint(yamlize.KeyedList):
                     # could call to Parent.applyInputParams()
                     if issubclass(materialParentClass, Material):
                         validMatModOptions |= signature(
-                            c.material.applyInputParams
+                            materialParentClass.applyInputParams
                         ).parameters.keys()
                 for key in byComponentMatModKeys:
                     if key not in validMatModOptions:

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -134,9 +134,11 @@ class BlockBlueprint(yamlize.KeyedList):
                     # we must loop over parents as well, since applyInputParams
                     # could call to Parent.applyInputParams()
                     if issubclass(materialParentClass, Material):
-                        validMatModOptions |= signature(
-                            materialParentClass.applyInputParams
-                        ).parameters.keys()
+                        validMatModOptions.update(
+                            signature(
+                                materialParentClass.applyInputParams
+                            ).parameters.keys()
+                        )
                 for key in byComponentMatModKeys:
                     if key not in validMatModOptions:
                         raise ValueError(
@@ -175,9 +177,11 @@ class BlockBlueprint(yamlize.KeyedList):
                     # we must loop over parents as well, since applyInputParams
                     # could call to Parent.applyInputParams()
                     if issubclass(materialParentClass, Material):
-                        validMatModOptions |= signature(
-                            materialParentClass.applyInputParams
-                        ).parameters.keys()
+                        validMatModOptions.update(
+                            signature(
+                                materialParentClass.applyInputParams
+                            ).parameters.keys()
+                        )
 
         if "byBlock" in materialInput:
             for key in materialInput["byBlock"]:

--- a/armi/reactor/blueprints/tests/test_materialModifications.py
+++ b/armi/reactor/blueprints/tests/test_materialModifications.py
@@ -239,6 +239,54 @@ assemblies:
         """
             )
 
+    def test_matModsUpTheMRO(self):
+        """
+        Make sure that valid/invalid material modifications are searched up
+        the MRO for a material class.
+        """
+        a = self.loadUZrAssembly(
+            """
+        material modifications:
+            ZR_wt_frac: [1]
+            class1_wt_frac: [1]
+            class1_custom_isotopics: [dummy]
+            class2_custom_isotopics: [dummy]
+            by component:
+                fuel2:
+                    ZR_wt_frac: [0]
+                    class1_wt_frac: [1]
+                    class1_custom_isotopics: [dummy]
+                    class2_custom_isotopics: [dummy]
+custom isotopics:
+    dummy:
+        input format: mass fractions
+        density: 1
+        U: 1
+"""
+        )
+
+        with self.assertRaises(ValueError):
+            a = self.loadUZrAssembly(
+                """
+        material modifications:
+            ZR_wt_frac: [1]
+            klass1_wt_frac: [1]
+            klass1_custom_isotopics: [dummy]
+            klass2_custom_isotopics: [dummy]
+            by component:
+                fuel2:
+                    ZR_wt_frac: [0]
+                    klass1_wt_frac: [1]
+                    klass1_custom_isotopics: [dummy]
+                    klass2_custom_isotopics: [dummy]
+custom isotopics:
+    dummy:
+        input format: mass fractions
+        density: 1
+        U: 1
+"""
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

This is a fix to the issue pointed out in https://github.com/terrapower/armi/pull/1122#issuecomment-1416242677

This change now makes the error checking a little bit more lenient. For example, it will allow material modifications from a parent class to go through, even if those modifications are not applied in the child. I don't see any way around this. But we will still be protected from straight-up typos like `TD_frac` mistakenly being typed as `Td_frac`, which was really the point of this issue in the first place.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

