### PR TITLE
Removing unused Life Metal methods from Material

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -473,27 +473,6 @@ class Material:
         """
         return 0.0
 
-    def getLifeMetalCorrelation(self, days: float, Tk: float) -> float:
-        r"""
-        life-metal correlation calculates the wastage of the material due to fission products.
-        """
-        return 0.0
-
-    def getReverseLifeMetalCorrelation(
-        self, thicknessFCCIWastageMicrons: float, Tk: float
-    ) -> float:
-        r"""
-        Life metal correlation reverse lookup.  Knowing wastage and Temperature
-        determine the effective time at that temperature.
-        """
-        return 0.0
-
-    def getLifeMetalConservativeFcciCoeff(self, Tk: float) -> float:
-        """
-        Return the coefficient to be used in the LIFE-METAL correlation
-        """
-        return 0.0
-
     def yieldStrength(self, Tk: float = None, Tc: float = None) -> float:
         r"""returns yield strength at given T in MPa"""
         pass


### PR DESCRIPTION
## Description

This "Life Metal" methods in our base `Material` class are entirely unused in the ARMI ecosystem.  If someone wants to use them, probably they should apply them to their own `Material` subclass.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
