### PR TITLE
Removing strange ban against super() statements

### DIFF
--- a/doc/developer/standards_and_practices.rst
+++ b/doc/developer/standards_and_practices.rst
@@ -302,9 +302,5 @@ General do's and don'ts
 do not use ``print``
     ARMI code should not use the ``print`` function; use one of the methods within ``armi.runLog``.
 
-do not use ``super``
-    In preference to the ``super`` function, explicitly call the parent object's method. For example, in an
-    ``__init__``, use ``ParentClass.__init__(self, plus, additional, arguments)``.
-
-do not leave ``TODO`` statements in production code
-    If your ``TODO`` statement is important, perhaps it should be a GitHub Issue.
+Do not add new ``TODO`` statements in your commits and PRs.
+    If your new ``TODO`` statement is important, it should be a GitHub Issue. Yes, we have existing ``TODO`` statements in the code, those are relic and should be handled.


### PR DESCRIPTION
## Description

ARMI has always had `super()` statements.  This is a rule that pre-dates me on the ARMI project, and I have never enforced it.  First off, there are hundreds of `super()` statements I don't feel like removing. But, more importantly, I do not see any benefit to this rule.  It serves no purpose.  And I cannot find any other open source Python projects with this strange rule.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
