### PR TITLE
Update corner and edge DPA in DoseResultsMapper

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -840,9 +840,13 @@ class DoseResultsMapper(GlobalFluxResultMapper):
             # this is specific to hex geometry, but they are general neutronics block parameters
             # if it is a non-hex block, this should be a no-op
             if not None in (b.p.pointsCornerDpa, b.p.pointsCornerDpaRate):
-                b.p.pointsCornerDpa = b.p.pointsCornerDpa + b.p.pointsCornerDpaRate * stepTimeInSeconds
+                b.p.pointsCornerDpa = (
+                    b.p.pointsCornerDpa + b.p.pointsCornerDpaRate * stepTimeInSeconds
+                )
             if not None in (b.p.pointsDpa, b.p.pointsEdgeDpaRate):
-                b.p.pointsEdgeDpa = b.p.pointsEdgeDpa + b.p.pointsEdgeDpaRate * stepTimeInSeconds
+                b.p.pointsEdgeDpa = (
+                    b.p.pointsEdgeDpa + b.p.pointsEdgeDpaRate * stepTimeInSeconds
+                )
 
             if self.options.dpaPerFluence:
                 # do the less rigorous fluence -> DPA conversion if the user gave a factor.

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -836,6 +836,14 @@ class DoseResultsMapper(GlobalFluxResultMapper):
             b.p.detailedDpaPeak = b.p.detailedDpaPeak + newDPAPeak
             b.p.detailedDpaThisCycle = b.p.detailedDpaThisCycle + newDpaThisStep
 
+            # increment point dpas
+            # this is specific to hex geometry, but they are general neutronics block parameters
+            # if it is a non-hex block, this should be a no-op
+            if b.p.pointsCornerDpaRate is not None:
+                b.p.pointsCornerDpa = b.p.pointsCornerDpa + b.p.pointsCornerDpaRate * stepTimeInSeconds
+            if b.p.pointsEdgeDpaRate is not None:
+                b.p.pointsEdgeDpa = b.p.pointsEdgeDpa + b.p.pointsEdgeDpaRate * stepTimeInSeconds
+
             if self.options.dpaPerFluence:
                 # do the less rigorous fluence -> DPA conversion if the user gave a factor.
                 b.p.dpaPeakFromFluence = (

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -839,11 +839,11 @@ class DoseResultsMapper(GlobalFluxResultMapper):
             # increment point dpas
             # this is specific to hex geometry, but they are general neutronics block parameters
             # if it is a non-hex block, this should be a no-op
-            if not None in (b.p.pointsCornerDpa, b.p.pointsCornerDpaRate):
+            if b.p.pointsCornerDpa is not None and b.p.pointsCornerDpaRate is not None:
                 b.p.pointsCornerDpa = (
                     b.p.pointsCornerDpa + b.p.pointsCornerDpaRate * stepTimeInSeconds
                 )
-            if not None in (b.p.pointsEdgeDpa, b.p.pointsEdgeDpaRate):
+            if b.p.pointsEdgeDpa is not None and b.p.pointsEdgeDpaRate is not None:
                 b.p.pointsEdgeDpa = (
                     b.p.pointsEdgeDpa + b.p.pointsEdgeDpaRate * stepTimeInSeconds
                 )

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -843,7 +843,7 @@ class DoseResultsMapper(GlobalFluxResultMapper):
                 b.p.pointsCornerDpa = (
                     b.p.pointsCornerDpa + b.p.pointsCornerDpaRate * stepTimeInSeconds
                 )
-            if not None in (b.p.pointsDpa, b.p.pointsEdgeDpaRate):
+            if not None in (b.p.pointsEdgeDpa, b.p.pointsEdgeDpaRate):
                 b.p.pointsEdgeDpa = (
                     b.p.pointsEdgeDpa + b.p.pointsEdgeDpaRate * stepTimeInSeconds
                 )

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -839,11 +839,15 @@ class DoseResultsMapper(GlobalFluxResultMapper):
             # increment point dpas
             # this is specific to hex geometry, but they are general neutronics block parameters
             # if it is a non-hex block, this should be a no-op
-            if b.p.pointsCornerDpa is not None and b.p.pointsCornerDpaRate is not None:
+            if b.p.pointsCornerDpaRate is not None:
+                if b.p.pointsCornerDpa is None:
+                    b.p.pointsCornerDpa = numpy.zeros((6,))
                 b.p.pointsCornerDpa = (
                     b.p.pointsCornerDpa + b.p.pointsCornerDpaRate * stepTimeInSeconds
                 )
-            if b.p.pointsEdgeDpa is not None and b.p.pointsEdgeDpaRate is not None:
+            if b.p.pointsEdgeDpaRate is not None:
+                if b.p.pointsEdgeDpa is None:
+                    b.p.pointsEdgeDpa = numpy.zeros((6,))
                 b.p.pointsEdgeDpa = (
                     b.p.pointsEdgeDpa + b.p.pointsEdgeDpaRate * stepTimeInSeconds
                 )

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -839,9 +839,9 @@ class DoseResultsMapper(GlobalFluxResultMapper):
             # increment point dpas
             # this is specific to hex geometry, but they are general neutronics block parameters
             # if it is a non-hex block, this should be a no-op
-            if b.p.pointsCornerDpaRate is not None:
+            if not None in (b.p.pointsCornerDpa, b.p.pointsCornerDpaRate):
                 b.p.pointsCornerDpa = b.p.pointsCornerDpa + b.p.pointsCornerDpaRate * stepTimeInSeconds
-            if b.p.pointsEdgeDpaRate is not None:
+            if not None in (b.p.pointsDpa, b.p.pointsEdgeDpaRate):
                 b.p.pointsEdgeDpa = b.p.pointsEdgeDpa + b.p.pointsEdgeDpaRate * stepTimeInSeconds
 
             if self.options.dpaPerFluence:

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -276,6 +276,10 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         block = r.core.getFirstBlock()
         self.assertGreater(block.p.detailedDpaRate, 0)
         self.assertEqual(block.p.detailedDpa, 0)
+        block.p.pointsEdgeDpa = numpy.array([0 for i in range(6)])
+        block.p.pointsCornerDpa = numpy.array([0 for i in range(6)])
+        block.p.pointsEdgeDpaRate = numpy.array([1.0e-5 for i in range(6)])
+        block.p.pointsCornerDpaRate = numpy.array([1.0e-5 for i in range(6)])
 
         # Test DoseResultsMapper. Pass in full list of blocks to apply() in order
         # to exercise blockList option (does not change behavior, since this is what
@@ -285,6 +289,8 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         dosemapper = globalFluxInterface.DoseResultsMapper(1000, opts)
         dosemapper.apply(r, blockList=r.core.getBlocks())
         self.assertGreater(block.p.detailedDpa, 0)
+        self.assertGreater(numpy.min(block.p.pointsCornerDpa), 0)
+        self.assertGreater(numpy.min(block.p.pointsEdgeDpa), 0)
 
         mapper.clearFlux()
         self.assertEqual(len(block.p.mgFlux), 0)

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -34,6 +34,7 @@ What's new in ARMI
 #. Bug fix for Concrete density curve. (`PR#1131 https://github.com/terrapower/armi/pull/1131`_)
 #. Bug fix for Component.density. (`PR#1149 https://github.com/terrapower/armi/pull/1149`_)
 #. Calculate block kgHM and kgFis on core loading and after shuffling. (`PR#1136 https://github.com/terrapower/armi/pull/1136`_)
+#. Update point DPAs along with block aveage DPA values. (`PR#1156 https://github.com/terrapower/armi/pull/1156`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

Corner and edge DPA should be incremented in the dose results mapper. These were previously incremented in an internal physics plugin on the TerraPower side. Now a plugin just needs to set the DPA rate, and the incrementing is handled by the `DoseResultsMapper`, which is how other DPA parameters are handled.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

