### PR TITLE
Save HCF assembly parameter to DB

### DIFF
--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -359,7 +359,7 @@ def getAssemblyParameterDefinitions():
             description="Definition of set of HCFs to be applied to assembly.",
             location="?",
             default="Default",
-            saveToDB=False,
+            saveToDB=True,
             categories=[parameters.Category.assignInBlueprints],
         )
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -49,6 +49,7 @@ Bug fixes
 #. Bug fix to ensure consistency between cross section group manager and lattice physics interface for tight coupling. (`PR#1118 <https://github.com/terrapower/armi/pull/1118>`_)
 #. Bug fix to update pseudo density to physical density in densityTimesHeatCapacity materials method. (`PR#1129 <https://github.com/terrapower/armi/pull/1129>`_)
 #. Fixed a bug in which the TD_frac material modification on UraniumOxide and MOX materials was not being applied correctly in density calculations
+#. Fixed hotChannelFactors assembly parameter from not being written to DB so that snapshot runs know about the parameter. (`PR#1157 <https://github.com/terrapower/armi/pull/1157>`_)
 
 ARMI v0.2.5
 ===========

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -49,7 +49,7 @@ Bug fixes
 #. Bug fix to ensure consistency between cross section group manager and lattice physics interface for tight coupling. (`PR#1118 <https://github.com/terrapower/armi/pull/1118>`_)
 #. Bug fix to update pseudo density to physical density in densityTimesHeatCapacity materials method. (`PR#1129 <https://github.com/terrapower/armi/pull/1129>`_)
 #. Fixed a bug in which the TD_frac material modification on UraniumOxide and MOX materials was not being applied correctly in density calculations
-#. Fixed hotChannelFactors assembly parameter from not being written to DB so that snapshot runs know about the parameter. (`PR#1157 <https://github.com/terrapower/armi/pull/1157>`_)
+#. Added hotChannelFactors assembly parameter to the DB so that snapshot runs know about the parameter. (`PR#1157 <https://github.com/terrapower/armi/pull/1157>`_)
 
 ARMI v0.2.5
 ===========


### PR DESCRIPTION
## Description

This is a really tiny update, but important. The `hotChannelFactors` parameter was given `saveToDb=False`, but this prevents snapshot runs from knowing about this parameter for a given assembly. This fixes that undesirable behavior.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

