### PR TITLE
Adding code coverage to snapshots and massFracs

### DIFF
--- a/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
@@ -18,7 +18,6 @@ Tests for DELAYXS
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import copy
 import filecmp
-import os
 import unittest
 
 import numpy

--- a/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
+++ b/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
@@ -17,7 +17,6 @@ Tests the workings of the library wrappers.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import filecmp
-import os
 import unittest
 
 from armi import nuclearDataIO

--- a/armi/operators/tests/test_operatorSnapshots.py
+++ b/armi/operators/tests/test_operatorSnapshots.py
@@ -16,11 +16,13 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-method-argument,import-outside-toplevel
 import unittest
 
+from armi import settings
 from armi.bookkeeping.db.databaseInterface import DatabaseInterface
+from armi.operators import getOperatorClassFromSettings
+from armi.operators.runTypes import RunTypes
 from armi.operators.snapshots import OperatorSnapshots
 from armi.reactor.tests import test_reactors
 from armi.settings.fwSettings.databaseSettings import CONF_FORCE_DB_PARAMS
-from armi.operators.runTypes import RunTypes
 
 
 class TestOperatorSnapshots(unittest.TestCase):
@@ -60,6 +62,14 @@ class TestOperatorSnapshots(unittest.TestCase):
         self.assertEqual(self.r.core.p.power, 0.0)
         self.o._mainOperate()
         self.assertEqual(self.r.core.p.power, 100000000.0)
+
+
+class TestOperatorSnapshotsSettings(unittest.TestCase):
+    def test_getOperatorClassFromSettings(self):
+        cs = settings.Settings()
+        cs = cs.modified(newSettings={"runType": RunTypes.SNAPSHOTS})
+        clazz = getOperatorClassFromSettings(cs)
+        self.assertEqual(clazz, OperatorSnapshots)
 
 
 if __name__ == "__main__":

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -15,11 +15,11 @@
 """unit tests for the neutronics plugin"""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import io
-import os
 import unittest
 
 from ruamel.yaml import YAML
 
+from armi import getPluginManagerOrFail, settings, tests
 from armi.operators import settingsValidation
 from armi.physics import neutronics
 from armi.physics.neutronics.const import CONF_CROSS_SECTION
@@ -33,7 +33,6 @@ from armi.settings import caseSettings
 from armi.tests import TEST_ROOT
 from armi.tests.test_plugins import TestPlugin
 from armi.utils import directoryChangers
-from armi import getPluginManagerOrFail, settings, tests
 
 XS_EXAMPLE = """AA:
     geometry: 0D

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -21,15 +21,14 @@ import unittest
 from numpy.testing import assert_allclose
 
 from armi import runLog
-from armi import settings
 from armi.reactor import blocks
 from armi.reactor import geometry
 from armi.reactor import grids
-from armi.tests import TEST_ROOT
 from armi.reactor.converters import geometryConverters
 from armi.reactor.converters import uniformMesh
-from armi.reactor.tests.test_reactors import loadTestReactor, reduceTestReactorRings
 from armi.reactor.flags import Flags
+from armi.reactor.tests.test_reactors import loadTestReactor, reduceTestReactorRings
+from armi.tests import TEST_ROOT
 from armi.utils import directoryChangers
 
 

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -1382,6 +1382,13 @@ class TestMaterialAdjustments(unittest.TestCase):
         self.fuel.setMassFrac("U235", target35)
         self.assertAlmostEqual(self.fuel.getMassFrac("U235"), target35)
 
+    def test_adjustMassFrac_invalid(self):
+        with self.assertRaises(ValueError):
+            self.fuel.adjustMassFrac(nuclideToAdjust="ZR", val=-0.23)
+
+        with self.assertRaises(ValueError):
+            self.fuel.adjustMassFrac(nuclideToAdjust="ZR", val=1.12)
+
     def test_adjustMassFrac_U235(self):
         zrMass = self.fuel.getMass("ZR")
         uMass = self.fuel.getMass("U")

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -1389,6 +1389,10 @@ class TestMaterialAdjustments(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.fuel.adjustMassFrac(nuclideToAdjust="ZR", val=1.12)
 
+        alwaysFalse = lambda a: False
+        self.fuel.parent = None
+        self.assertIsNone(self.fuel.getAncestorAndDistance(alwaysFalse))
+
     def test_adjustMassFrac_U235(self):
         zrMass = self.fuel.getMass("ZR")
         uMass = self.fuel.getMass("U")

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -260,6 +260,11 @@ class TestCompositePattern(unittest.TestCase):
         self.assertEqual(len(rRates), 6)
         self.assertEqual(sum([r for r in rRates.values()]), 0)
 
+    def test_syncParameters(self):
+        data = [{"serialNum": 123}, {"flags": "FAKE"}]
+        numSynced = self.container._syncParameters(data, {})
+        self.assertEqual(numSynced, 2)
+
 
 class TestCompositeTree(unittest.TestCase):
 

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -42,6 +42,17 @@ class MpiIterTests(unittest.TestCase):
         context.MPI_SIZE = self._mpiSize
         context.MPI_RANK = 0
 
+    def test_parallel(self):
+        self.action.serial = False
+        self.assertTrue(self.action.parallel)
+
+        self.action.serial = True
+        self.assertFalse(self.action.parallel)
+
+    def test_serialGather(self):
+        self.action.serial = True
+        self.assertEqual(len(self.action.gather()), 1)
+
     def test_mpiIter(self):
         allObjs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
         distObjs = [[0, 1, 2], [3, 4, 5], [6, 7], [8, 9], [10, 11]]

--- a/armi/utils/tests/test_units.py
+++ b/armi/utils/tests/test_units.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Test armi.utils.units.py"""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
-import math
 import unittest
 
 from armi.utils import units


### PR DESCRIPTION
## Description

While I was bug hunting last week, I built some unit tests to make sure things were working.  The branches I worked on didn't come to much, but I figure we can use the code coverage anyway.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
