### PR TITLE
Clarify definitions of `crInsertedElevation` and `crWithdrawnElevation`

### DIFF
--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -212,8 +212,9 @@ def getAssemblyParameterDefinitions():
             "crInsertedElevation",
             units="cm",
             description=(
-                "The elevation of the bottom of the bottom-most moveable block in a control rod assembly when fully inserted. Note that this should "
-                "be considered a lower elevation than the ``crWithdrawnElevation`` by definition and modeling semantics."
+                "The elevation of the furthest-most insertion point of a control rod assembly. For a control rod assembly "
+                "inserted from the top, this will be the lower tip of the bottom-most moveable section in the assembly when "
+                "fully inserted."
             ),
             categories=[parameters.Category.assignInBlueprints],
             saveToDB=True,
@@ -230,8 +231,9 @@ def getAssemblyParameterDefinitions():
             "crWithdrawnElevation",
             units="cm",
             description=(
-                "The elevation of the bottom of the bottom-most moveable section of a control rod assembly when fully withdrawn. Note that this should "
-                "be considered a higher elevation than the ``crInsertedElevation`` by definition and modeling semantics."
+                "The elevation of the tip of a control rod assembly when it is fully withdrawn. For a control rod assembly "
+                "inserted from the top, this will be the lower tip of the bottom-most moveable section in the assembly when "
+                "fully withdrawn."
             ),
             categories=[parameters.Category.assignInBlueprints],
             saveToDB=True,

--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -212,7 +212,7 @@ def getAssemblyParameterDefinitions():
             "crInsertedElevation",
             units="cm",
             description=(
-                "The final elevation of the bottom of the control material when fully inserted. Note that this should "
+                "The elevation of the bottom of the bottom-most moveable block in a control rod assembly when fully inserted. Note that this should "
                 "be considered a lower elevation than the ``crWithdrawnElevation`` by definition and modeling semantics."
             ),
             categories=[parameters.Category.assignInBlueprints],
@@ -230,7 +230,7 @@ def getAssemblyParameterDefinitions():
             "crWithdrawnElevation",
             units="cm",
             description=(
-                "The initial starting elevation of the moveable section of a control rod assembly when fully withdrawn.  Note that this should "
+                "The elevation of the bottom of the bottom-most moveable section of a control rod assembly when fully withdrawn. Note that this should "
                 "be considered a higher elevation than the ``crInsertedElevation`` by definition and modeling semantics."
             ),
             categories=[parameters.Category.assignInBlueprints],


### PR DESCRIPTION
## Description

The definition of the `crInsertedElevation` parameter mistakenly referred to the length of the section with control material, when in reality it should have referred to the length of the moveable section.

This PR fixes this, and generally clarifies the definitions for these two important parameters.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

