### PR TITLE
Calculate b.p.puFrac on process loading.

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -178,7 +178,7 @@ class TestCompareDB3(unittest.TestCase):
             dbs[1]._fullPath,
             timestepCompare=[(0, 0), (0, 1)],
         )
-        self.assertEqual(len(diffs.diffs), 462)
+        self.assertEqual(len(diffs.diffs), 465)
         # Cycle length is only diff (x3)
         self.assertEqual(diffs.nDiffs(), 3)
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -379,7 +379,7 @@ class Core(composites.Composite):
         for b in self.getBlocks():
             b.p.kgHM = b.getHMMass() / units.G_PER_KG
             b.p.kgFis = b.getFissileMass() / units.G_PER_KG
-        b.p.puFrac = b.getPun() / b.p.nHMAtBOL if b.p.nHMAtBOL > 0.0 else 0.0
+        b.p.puFrac = b.getPuN() / b.p.nHMAtBOL if b.p.nHMAtBOL > 0.0 else 0.0
 
     def getScalarEvolution(self, key):
         return self.scalarVals[key]

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -375,10 +375,11 @@ class Core(composites.Composite):
         )
 
     def setBlockMassParams(self):
-        """Set the parameters kgHM and kgFis for each block"""
+        """Set the parameters kgHM and kgFis for each block and calculate Pu fraction"""
         for b in self.getBlocks():
             b.p.kgHM = b.getHMMass() / units.G_PER_KG
             b.p.kgFis = b.getFissileMass() / units.G_PER_KG
+        b.p.puFrac = b.getPun() / b.p.nHMAtBOL if b.p.nHMAtBOL > 0.0 else 0.0
 
     def getScalarEvolution(self, key):
         return self.scalarVals[key]

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -35,6 +35,7 @@ What's new in ARMI
 #. Bug fix for Copper density curve. (`PR#1150 https://github.com/terrapower/armi/pull/1150`_)
 #. Bug fix for Component.density. (`PR#1149 https://github.com/terrapower/armi/pull/1149`_)
 #. Calculate block kgHM and kgFis on core loading and after shuffling. (`PR#1136 https://github.com/terrapower/armi/pull/1136`_)
+#. Calculate block PuFrac on core loading and after shuffling. (`PR#1165 https://github.com/terrapower/armi/pull/1165`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

Add a new simple calculation of plutonium fraction (`b.p.puFrac`) when the initial core is created.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

