### PR TITLE
Fix Pu frac calculation

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -814,6 +814,11 @@ class Block(composites.Composite):
         for child in self.iterComponents():
             child.p.massHmBOL = child.getHMMass() * sf  # scale to full block
             massHmBOL += child.p.massHmBOL
+            self.p.puFrac = (
+                self.getPuMoles() / self.p.molesHmBOL
+                if self.p.molesHmBOL > 0.0
+                else 0.0
+            )
         self.p.massHmBOL = massHmBOL
         return hmDens
 

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1718,6 +1718,15 @@ class ArmiObject(metaclass=CompositeModelType):
         nucNames = [nuc.name for nuc in elements.byZ[94].nuclides]
         return sum(self.getNuclideNumberDensities(nucNames))
 
+    def getPuMoles(self):
+        """Returns total number of moles of Pu isotopes"""
+        return (
+            self.getPuN()
+            / units.MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
+            * self.getVolume()
+            * self.getSymmetryFactor()
+        )
+
     def calcTotalParam(
         self,
         param,

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -379,7 +379,9 @@ class Core(composites.Composite):
         for b in self.getBlocks():
             b.p.kgHM = b.getHMMass() / units.G_PER_KG
             b.p.kgFis = b.getFissileMass() / units.G_PER_KG
-            b.p.puFrac = b.getPuN() / b.p.nHMAtBOL if b.p.nHMAtBOL > 0.0 else 0.0
+            b.p.puFrac = (
+                b.getPuMoles() / b.p.molesHmBOL if b.p.molesHmBOL > 0.0 else 0.0
+            )
 
     def getScalarEvolution(self, key):
         return self.scalarVals[key]

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1009,6 +1009,38 @@ class Block_TestCase(unittest.TestCase):
         places = 6
         self.assertAlmostEqual(cur, ref, places=places)
 
+    def test_getPuMoles(self):
+        fuel = self.block.getComponent(Flags.FUEL)
+        vFrac = fuel.getVolumeFraction()
+        refDict = {
+            "AM241": 2.695633500634074e-05,
+            "U238": 0.015278429635341755,
+            "O16": 0.04829586365251901,
+            "U235": 0.004619446966056436,
+            "PU239": 0.0032640382635406515,
+            "PU238": 4.266845903720035e-06,
+            "PU240": 0.000813669265183342,
+            "PU241": 0.00011209296581262849,
+            "PU242": 2.3078961257395204e-05,
+        }
+        fuel.setNumberDensities({nuc: v / vFrac for nuc, v in refDict.items()})
+
+        cur = self.block.getPuMoles()
+
+        ndens = 0.0
+        for nucName in refDict.keys():
+            if nucName in ["PU238", "PU239", "PU240", "PU241", "PU242"]:
+                ndens += self.block.getNumberDensity(nucName)
+        ref = (
+            ndens
+            / units.MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
+            * self.block.getVolume()
+            * self.block.getSymmetryFactor()
+        )
+
+        places = 6
+        self.assertAlmostEqual(cur, ref, places=places)
+
     def test_getPuMass(self):
         fuel = self.block.getComponent(Flags.FUEL)
         refDict = {


### PR DESCRIPTION
## Description

The previous puFrac calculation had a numerator that was adjusted for density changes (from block expansion) but a constant denominator that did not account for expansion.

The new formula calculates number of Pu atoms directly and does not account for density in either the numerator or denominator.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

