### PR TITLE
Fixed bad Sphinx Needs test link

### DIFF
--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -1114,7 +1114,7 @@ class TestHexHoledCircle(TestShapedComponent):
         """Test that ARMI can thermally expands a holed hexagon
 
         .. test:: Test that ARMI can thermally expands a holed hexagon
-           :id: TEST_REACTOR_THERMAL_EXPANSION_9
+           :id: TEST_REACTOR_THERMAL_EXPANSION_10
            :links: REQ_REACTOR_THERMAL_EXPANSION
         """
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -8,9 +8,7 @@ Release Date: TBD
 
 What's new in ARMI
 ------------------
-#. TBD: Composites can now be nested inside other Composites
-#. TBD: The global CaseSettings object has been removed
-#. The method ``Material.density3`` is now called ``density``, and the old ``density`` is now called ``pseudoDensity``. (`PR#1163 <https://github.com/terrapower/armi/pull/1163>`_)
+#. TBD
 #. TBD
 
 Bug fixes

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -8,7 +8,9 @@ Release Date: TBD
 
 What's new in ARMI
 ------------------
-#. TBD
+#. TBD: Composites can now be nested inside other Composites
+#. TBD: The global CaseSettings object has been removed
+#. The method ``Material.density3`` is now called ``density``, and the old ``density`` is now called ``pseudoDensity``. (`PR#1163 <https://github.com/terrapower/armi/pull/1163>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

The docs are currently broken in ARMI.

[The PR #1171](https://github.com/terrapower/armi/pull/1171) tried to duplicate a Sphinx Needs / requirement link in our docs.  (FYI @Ashlita6 )

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
