### PR TITLE
Don't verify dimensions on irregular hex lattice.

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1900,7 +1900,7 @@ class HexBlock(Block):
         nRings = hexagon.numRingsToHoldNumCells(self.getNumPins())
         if not numPins == 3 * nRings * (nRings - 1) + 1:
             runLog.warning(
-                f"Block design for {b} cannot be verified because of a non-regular hex lattice."
+                f"Block design for {self} cannot be verified because of a non-regular hex lattice."
                 f"Number of pins = {numPins}",
                 single=True,
             )
@@ -1964,7 +1964,6 @@ class HexBlock(Block):
                 # has no ip and is circular on inside so following
                 # code will not work
                 duct = None
-
         clad = self.getComponent(Flags.CLAD)
         if any(c is None for c in (duct, wire, clad)):
             return None

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1883,6 +1883,7 @@ class HexBlock(Block):
             )
             return
         # check wire wrap in contact with clad
+
         if (
             self.getComponent(Flags.CLAD) is not None
             and self.getComponent(Flags.WIRE) is not None
@@ -1894,6 +1895,18 @@ class HexBlock(Block):
                     "".format(self, wwCladGap),
                     single=True,
                 )
+
+        numPins = self.getNumPins()
+        nRings = hexagon.numRingsToHoldNumCells(self.getNumPins())
+        if not numPins == 3 * nRings * (nRings - 1) + 1:
+            # not a regular hex lattice; this code won't work
+            runLog.warning(
+                f"Block design for {b} cannot be verified because of a non-regular hex lattice."
+                f"Number of pins = {numPins}",
+                single=True,
+            )
+            return None
+
         # check clad duct overlap
         pinToDuctGap = self.getPinToDuctGap(cold=True)
         # Allow for some tolerance; user input precision may lead to slight negative
@@ -1904,6 +1917,7 @@ class HexBlock(Block):
                     pinToDuctGap, self
                 )
             )
+        elif pinToDuctGap is not None:
             wire = self.getComponent(Flags.WIRE)
             wireThicknesses = wire.getDimension("od", cold=False)
             if pinToDuctGap < wireThicknesses:
@@ -1951,6 +1965,7 @@ class HexBlock(Block):
                 # has no ip and is circular on inside so following
                 # code will not work
                 duct = None
+
         clad = self.getComponent(Flags.CLAD)
         if any(c is None for c in (duct, wire, clad)):
             return None

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1883,7 +1883,6 @@ class HexBlock(Block):
             )
             return
         # check wire wrap in contact with clad
-
         if (
             self.getComponent(Flags.CLAD) is not None
             and self.getComponent(Flags.WIRE) is not None
@@ -1896,16 +1895,16 @@ class HexBlock(Block):
                     single=True,
                 )
 
+        # check if it is a regular hex lattice; this code won't work otherwise
         numPins = self.getNumPins()
         nRings = hexagon.numRingsToHoldNumCells(self.getNumPins())
         if not numPins == 3 * nRings * (nRings - 1) + 1:
-            # not a regular hex lattice; this code won't work
             runLog.warning(
                 f"Block design for {b} cannot be verified because of a non-regular hex lattice."
                 f"Number of pins = {numPins}",
                 single=True,
             )
-            return None
+            return
 
         # check clad duct overlap
         pinToDuctGap = self.getPinToDuctGap(cold=True)

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1916,14 +1916,6 @@ class HexBlock(Block):
                     pinToDuctGap, self
                 )
             )
-        elif pinToDuctGap is not None:
-            wire = self.getComponent(Flags.WIRE)
-            wireThicknesses = wire.getDimension("od", cold=False)
-            if pinToDuctGap < wireThicknesses:
-                raise ValueError(
-                    "Gap between pins and duct is {0:.4f} cm in {1} which does not allow room for the wire "
-                    "with diameter {2}".format(pinToDuctGap, self, wireThicknesses)
-                )
         elif pinToDuctGap is None:
             # only produce a warning if pin or clad are found, but not all of pin, clad and duct. We
             # may need to tune this logic a bit


### PR DESCRIPTION
## Description

`HexBlock.verifyDims()` verifies that the pins and wires defined for a block fit snugly into the duct. The logic for this check only works for a regular hex lattice. If an irregular hex lattice is defined using a grid in the blueprints, this won't work correctly. Adding code to skip the check in this case.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

