### PR TITLE
Remove unused HCFcoretype setting

### DIFF
--- a/armi/operators/tests/test_inspectors.py
+++ b/armi/operators/tests/test_inspectors.py
@@ -87,13 +87,7 @@ class TestInspector(unittest.TestCase):
 
     def test_assignCS(self):
         keys = sorted(self.inspector.cs.keys())
-        self.assertIn("HCFcoretype", keys)
-
-        self.assertEqual(self.inspector.cs["HCFcoretype"], "TWRC")
-        self.inspector._assignCS(
-            "HCFcoretype", "FAKE"
-        )  # pylint: disable=protected-access
-        self.assertEqual(self.inspector.cs["HCFcoretype"], "FAKE")
+        self.assertIn("nCycles", keys)
 
     def test_createQueryRevertBadPathToDefault(self):
         query = createQueryRevertBadPathToDefault(self.inspector, "numProcessors")

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -100,7 +100,6 @@ CONF_ZONE_DEFINITIONS = "zoneDefinitions"
 CONF_ACCEPTABLE_BLOCK_AREA_ERROR = "acceptableBlockAreaError"
 CONF_FLUX_RECON = "fluxRecon"  # strange coupling in fuel handlers
 CONF_INDEPENDENT_VARIABLES = "independentVariables"
-CONF_HCF_CORETYPE = "HCFcoretype"
 CONF_T_IN = "Tin"
 CONF_T_OUT = "Tout"
 CONF_DEFERRED_INTERFACES_CYCLE = "deferredInterfacesCycle"
@@ -741,14 +740,6 @@ def defineSettings() -> List[setting.Setting]:
             label="Independent Variables",
             description="List of (independentVarName, value) tuples to inform "
             "optimization post-processing",
-        ),
-        setting.Setting(
-            CONF_HCF_CORETYPE,
-            default="TWRC",
-            label="Hot Channel Factor Set",
-            description="Switch to apply different sets of hot channel factors based "
-            "on design being analyzed",
-            options=["TWRC", "TWRP", "TWRC-HEX"],
         ),
         setting.Setting(
             CONF_T_IN,

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -8,7 +8,7 @@ Release Date: TBD
 
 What's new in ARMI
 ------------------
-#. TBD
+#. Remove unused `HCFcoretype` setting. (`PR#1179 <https://github.com/terrapower/armi/pull/1179>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

The `HCFcoretype` setting is not used anywhere in the framework or in downstream TerraPower projects.

Since the only options are `TWR*`, I assume nobody outside of TerraPower is using this setting either.

TerraPower TH solvers use an assembly parameter to track hot channel factors: https://github.com/terrapower/armi/blob/05765608596bc907a88a6033cf5d4640f610ab7d/armi/reactor/assemblyParameters.py#L358-L366

I assume anybody else wanting to apply hot channel factors would want to use the same assembly parameter, and not this case setting.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

