### PR TITLE
Block Param Data Rotations

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1200,17 +1200,17 @@ class Assembly(composites.Composite):
         """Return the symmetry factor of this assembly."""
         return self[0].getSymmetryFactor()
 
-    def rotate(self, deg):
+    def rotate(self, rad):
         """Rotates the spatial variables on an assembly the specified angle.
 
         Each block on the assembly is rotated in turn.
 
         Parameters
         ----------
-        deg - float
-            number specifying the angle of counter clockwise rotation"""
+        rad - float
+            number (in radians) specifying the angle of counter clockwise rotation"""
         for b in self.getBlocks():
-            b.rotate(deg)
+            b.rotate(rad)
 
 
 class HexAssembly(Assembly):

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1478,13 +1478,13 @@ class Block(composites.Composite):
         """
         return composites.ArmiObject.getLumpedFissionProductCollection(self)
 
-    def rotate(self, deg):
-        """Function for rotating a block's spatially varying variables by a specified angle.
+    def rotate(self, rad):
+        """Function for rotating a block's spatially varying variables by a specified angle (radians).
 
         Parameters
         ----------
-        deg - float
-            number specifying the angle of counter clockwise rotation
+        rad - float
+            number (in radians) specifying the angle of counter clockwise rotation
         """
         raise NotImplementedError
 
@@ -1753,9 +1753,32 @@ class HexBlock(Block):
                         f"on {param}"
                     )
                     runLog.warning(msg)
-            else:
+            elif isinstance(self.p[param], numpy.ndarray):
+                if len(self.p[param]) == 6:
+                    self.p[param] = numpy.concatenate(
+                        (self.p[param][-rotNum:], self.p[param][:-rotNum])
+                    )
+                elif len(self.p[param]) == 0:
+                    # Hasn't been defined yet, no warning needed.
+                    pass
+                else:
+                    msg = (
+                        "No rotation method defined for spatial parameters that aren't "
+                        "defined once per hex edge/corner. No rotation performed "
+                        f"on {param}"
+                    )
+                    runLog.warning(msg)
+            elif isinstance(self.p[param], (int, float)):
                 # this is a scalar and there shouldn't be any rotation.
                 pass
+            elif self.p[param] is None:
+                # param is not set yet. no rotations as well.
+                pass
+            else:
+                raise TypeError(
+                    f"b.rotate() method received unexpected data type for {param} on block {self}\n"
+                    + f"expected list, np.ndarray, int, or float. received {self.p[param]}"
+                )
         # This specifically uses the .get() functionality to avoid an error if this
         # parameter does not exist.
         dispx = self.p.get("displacementX")

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -38,7 +38,7 @@ from armi.reactor.assemblies import (
     numpy,
     runLog,
 )
-from armi.tests import TEST_ROOT
+from armi.tests import TEST_ROOT, mockRunLogs
 from armi.utils import directoryChangers
 from armi.utils import textProcessors
 from armi.reactor.tests import test_reactors
@@ -1046,6 +1046,32 @@ class Assembly_TestCase(unittest.TestCase):
         b.p.THcornTemp = "bad data"
         with self.assertRaises(TypeError):
             a.rotate(math.radians(120))
+
+        # check that list of len != 6 ends up in runlog warning
+        # list len=5
+        b.p.THcornTemp = [400, 450, 500, 550, 600]
+        with mockRunLogs.BufferLog() as mock:
+            self.assertEqual("", mock.getStdout())
+            a.rotate(math.radians(120))
+            self.assertIn("No rotation method defined", mock.getStdout())
+        # np.ndarray len=5
+        b.p.THcornTemp = np.array([400, 450, 500, 550, 600])
+        with mockRunLogs.BufferLog() as mock:
+            self.assertEqual("", mock.getStdout())
+            a.rotate(math.radians(120))
+            self.assertIn("No rotation method defined", mock.getStdout())
+        # list len=7
+        b.p.THcornTemp = [400, 450, 500, 550, 600, 650, 700]
+        with mockRunLogs.BufferLog() as mock:
+            self.assertEqual("", mock.getStdout())
+            a.rotate(math.radians(120))
+            self.assertIn("No rotation method defined", mock.getStdout())
+        # np.ndarray len=7
+        b.p.THcornTemp = np.array([400, 450, 500, 550, 600, 650, 700])
+        with mockRunLogs.BufferLog() as mock:
+            self.assertEqual("", mock.getStdout())
+            a.rotate(math.radians(120))
+            self.assertIn("No rotation method defined", mock.getStdout())
 
 
 class AssemblyInReactor_TestCase(unittest.TestCase):

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -17,7 +17,7 @@
 import pathlib
 import random
 import unittest
-
+import numpy as np
 from numpy.testing import assert_allclose
 
 from armi import settings
@@ -1022,9 +1022,30 @@ class Assembly_TestCase(unittest.TestCase):
         rotY = -0.5
         a.add(b)
         a.rotate(math.radians(120))
+        # test list rotation
         self.assertEqual(a.getBlocks()[0].p.THcornTemp, rotTemp)
         self.assertAlmostEqual(a.getBlocks()[0].p.displacementX, rotX)
         self.assertAlmostEqual(a.getBlocks()[0].p.displacementY, rotY)
+
+        b.p.THcornTemp = np.array([400, 450, 500, 550, 600, 650])
+        rotTemp = np.array([600, 650, 400, 450, 500, 550])
+        a.rotate(math.radians(120))
+        # test np.ndarray rotation
+        for i in range(len(b.p.THcornTemp)):
+            self.assertEqual(a.getBlocks()[0].p.THcornTemp[i], rotTemp[i])
+
+        # test that floats and ints are left alone
+        b.p.THcornTemp = 3
+        a.rotate(math.radians(120))
+        self.assertEqual(a.getBlocks()[0].p.THcornTemp, 3)
+        b.p.THcornTemp = 4.0
+        a.rotate(math.radians(120))
+        self.assertEqual(a.getBlocks()[0].p.THcornTemp, 4.0)
+
+        # check that TypeError is raised for unexpected data type
+        b.p.THcornTemp = "bad data"
+        with self.assertRaises(TypeError):
+            a.rotate(math.radians(120))
 
 
 class AssemblyInReactor_TestCase(unittest.TestCase):


### PR DESCRIPTION
## Description
Supporting mechanical team's use of `r.core.growToFullCore()`.

- Added block param rotation handling for non-list data types (ndarrays)
- Throws `TypeError` if attempting to rotate an unexpected data type
- Added unit testing for new data type handling

---

## Checklist
- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

