### PR TITLE
Fix file copy of rzmflx files for snapshot runs

### DIFF
--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -1087,8 +1087,15 @@ class Operator:  # pylint: disable=too-many-public-methods
                         newFolder, "{0}_{1:03d}_{2:d}{3}".format(base, cycle, node, ext)
                     ),
                 )
-            if "rzmflx" in fileName:
-                pathTools.copyOrWarn("rzmflx for snapshot", fileName, newFolder)
+
+        # rzmflx files may be in the run directory, or they may be elsewhere and listed
+        # as absolute file paths. This means we need to parse the crossSectionControl
+        # setting without knowing the relevant xsIDs.
+        if self.cs[CONF_CROSS_SECTION]:
+            for xsID in self.cs[CONF_CROSS_SECTION].keys():
+                fluxFile = self.cs[CONF_CROSS_SECTION][xsID].fluxFileLocation
+                if fluxFile:
+                    pathTools.copyOrWarn("rzmflx for snapshot", fluxFile, newFolder)
 
         isoFName = "ISOTXS-c{0}".format(cycle)
         pathTools.copyOrWarn(

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -41,6 +41,7 @@ from armi.bookkeeping.report import reportingUtils
 from armi.operators import settingsValidation
 from armi.operators.runTypes import RunTypes
 from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
+from armi.physics.neutronics.const import CONF_CROSS_SECTION
 from armi.utils import codeTiming
 from armi.utils import (
     pathTools,

--- a/armi/operators/tests/rzmflxYA
+++ b/armi/operators/tests/rzmflxYA
@@ -1,0 +1,1 @@
+Not a real flux spectrum file; just a placeholder to unit test the file copying function.

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -190,7 +190,7 @@ class OperatorTests(unittest.TestCase):
             fluxFile = "rzmflxYA"
             # update the case settings object so that the snapshot request will copy a file
             self.o.cs[CONF_CROSS_SECTION]["YA"].fluxFileLocation = os.path.join(
-                THIS_DIR, "../../physics/neutronics/tests", fluxFile
+                THIS_DIR, fluxFile
             )
             self.o.snapshotRequest(0, 1)
             # A snapshot dir should have been created

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -15,20 +15,24 @@
 """Tests for operators"""
 
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-method-argument,import-outside-toplevel
-import unittest
 import collections
+import os
+import unittest
 
 from armi import settings
+from armi.bookkeeping.db.databaseInterface import DatabaseInterface
 from armi.interfaces import Interface
 from armi.operators.operator import Operator
-from armi.reactor.tests import test_reactors
-from armi.settings.caseSettings import Settings
-from armi.utils.directoryChangers import TemporaryDirectoryChanger
+from armi.physics.neutronics.const import CONF_CROSS_SECTION
 from armi.physics.neutronics.globalFlux.globalFluxInterface import (
     GlobalFluxInterfaceUsingExecuters,
 )
+from armi.reactor.tests import test_reactors
+from armi.settings.caseSettings import Settings
 from armi.utils import directoryChangers
-from armi.bookkeeping.db.databaseInterface import DatabaseInterface
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class InterfaceA(Interface):
@@ -183,7 +187,13 @@ class OperatorTests(unittest.TestCase):
 
     def test_snapshotRequest(self):
         with TemporaryDirectoryChanger():
+            fluxFile = "rzmflxYA"
+            self.o.cs[CONF_CROSS_SECTION]["YA"].fluxFileLocation = os.path.join(
+                THIS_DIR, "../../physics/neutronics/tests", fluxFile
+            )
             self.o.snapshotRequest(0, 1)
+            self.assertTrue(os.path.exists("snapShot0_1"))
+            self.assertTrue(os.path.exists(os.path.join("snapShot0_1", fluxFile)))
 
 
 class CyclesSettingsTests(unittest.TestCase):

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -188,11 +188,14 @@ class OperatorTests(unittest.TestCase):
     def test_snapshotRequest(self):
         with TemporaryDirectoryChanger():
             fluxFile = "rzmflxYA"
+            # update the case settings object so that the snapshot request will copy a file
             self.o.cs[CONF_CROSS_SECTION]["YA"].fluxFileLocation = os.path.join(
                 THIS_DIR, "../../physics/neutronics/tests", fluxFile
             )
             self.o.snapshotRequest(0, 1)
+            # A snapshot dir should have been created
             self.assertTrue(os.path.exists("snapShot0_1"))
+            # and our empty flux file should have been copied to it
             self.assertTrue(os.path.exists(os.path.join("snapShot0_1", fluxFile)))
 
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -13,7 +13,7 @@ What's new in ARMI
 
 Bug fixes
 ---------
-#. Fixed TBD
+#. Fixed a bug to allow snapshotRequest to copy rzmflx files with both absolute and relative paths (`PR#1182 <https://github.com/terrapower/armi/pull/1182>`_)
 #. Fixed TBD
 
 


### PR DESCRIPTION
## Description

The previous implementation of the file copy for rzmflx file presumed the files were already in the case run directory. But when absolute file paths are given for the `fluxLocation` setting in `crossSectionControl`, the files are very possibly not in the run directory already. 

This PR changes the snapshot file copy step to parse the whole of the `crossSectionControl` setting to copy any file to the snapshot directory, whether relative or absolute file path.

This is not an elegant way to handle this, but the issue is known (#1166) and will be addressed in the future.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

