### PR TITLE
Fix user plugins case suite

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -283,6 +283,16 @@ class App:
 
         or on Windows:
         ``C:\\path\\to\\pluginMod.py:pluginCls``
+
+        Parameters
+        -----------
+        pluginPath : str
+            String path to a userPlugin.
+
+        Returns
+        --------
+        bool
+            Whether or not the plugin name is already registered with the manager.
         """
 
         if ":" in pluginPath:

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -269,7 +269,7 @@ class App:
                 # The path is of the form: armi.thing.what.MyPlugin
                 self.__registerUserPluginsInternalImport(pluginPath)
 
-    def _isPluginRegistered(self, pluginPath:str):
+    def _isPluginRegistered(self, pluginPath: str):
         """
         Check if the plugin at the provided path is already registered.
 
@@ -284,11 +284,12 @@ class App:
         or on Windows:
         ``C:\\path\\to\\pluginMod.py:pluginCls``
         """
+
         if ":" in pluginPath:
             pluginName = pluginPath.strip().split(":")[-1]
         else:
             pluginName = pluginPath.strip().split(".")[-1]
-        
+
         return self._pm.has_plugin(pluginName)
 
     def __registerUserPluginsAbsPath(self, pluginPath):

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -260,12 +260,36 @@ class App:
         restrict their flexibility and power as compared to the usual ArmiPlugins.
         """
         for pluginPath in pluginPaths:
+            if self._isPluginRegistered(pluginPath):
+                continue
             if ".py:" in pluginPath:
                 # The path is of the form: /path/to/why.py:MyPlugin
                 self.__registerUserPluginsAbsPath(pluginPath)
             else:
                 # The path is of the form: armi.thing.what.MyPlugin
                 self.__registerUserPluginsInternalImport(pluginPath)
+
+    def _isPluginRegistered(self, pluginPath:str):
+        """
+        Check if the plugin at the provided path is already registered.
+
+        The expected path formats are:
+        ------------------------------
+        importable namespace:
+        ``armi.stuff.plugindir.pluginMod.pluginCls``
+
+        or on Linux/Unix:
+        ``/path/to/pluginMod.py:pluginCls``
+
+        or on Windows:
+        ``C:\\path\\to\\pluginMod.py:pluginCls``
+        """
+        if ":" in pluginPath:
+            pluginName = pluginPath.strip().split(":")[-1]
+        else:
+            pluginName = pluginPath.strip().split(".")[-1]
+        
+        return self._pm.has_plugin(pluginName)
 
     def __registerUserPluginsAbsPath(self, pluginPath):
         """Helper method to register a single UserPlugin where

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -281,3 +281,29 @@ class TestUserPlugins(unittest.TestCase):
         o.cs["nCycles"] = 2
         o.operate()
         self.assertGreater(r.core.p.power, power0)
+
+    def test_registerRepeatedUserPlugins(self):
+        app = getApp()
+
+        # Test plugin registration with two userPlugins with the same name
+        with directoryChangers.TemporaryDirectoryChanger():
+            # write a simple UserPlugin to a simple Python file
+            with open("plugin4.py", "w") as f:
+                f.write(upFlags4)
+
+            # register that plugin using an absolute path
+            cwd = os.getcwd()
+            plugins = [os.path.join(cwd, "plugin4.py") + ":UserPluginFlags4"] * 2
+            app.registerUserPlugins(plugins)
+
+        # Repeat test for other type of path
+        cs = caseSettings.Settings().modified(
+            caseTitle="test_registerUserPluginsFromSettings",
+            newSettings={
+                "userPlugins": [
+                    "armi.tests.test_user_plugins.UserPluginFlags3",
+                    "armi.tests.test_user_plugins.UserPluginFlags3",
+                ],
+            },
+        )
+        cs.registerUserPlugins()

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -295,6 +295,8 @@ class TestUserPlugins(unittest.TestCase):
             cwd = os.getcwd()
             plugins = [os.path.join(cwd, "plugin4.py") + ":UserPluginFlags4"] * 2
             app.registerUserPlugins(plugins)
+        pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
+        self.assertEqual(pluginNames.count("UserPluginFlags4"), 1)
 
         # Repeat test for other type of path
         cs = caseSettings.Settings().modified(
@@ -307,3 +309,5 @@ class TestUserPlugins(unittest.TestCase):
             },
         )
         cs.registerUserPlugins()
+        pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
+        self.assertEqual(pluginNames.count("UserPluginFlags3"), 1)


### PR DESCRIPTION
## Description

When submitting a `case-suite` that uses `userPlugin`s, registration of the `userPlugin` with the plugin manager is attempted multiple times. The plugin manager does not allow this, and the `case-suite` fails.

To fix this, the registration of `userPlugin`s now checks if the user plugin name has already been registered with the plugin manager.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

