### PR TITLE
Move imports to method to avoid circular import issue

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -40,8 +40,6 @@ import tabulate
 from armi import getPluginManagerOrFail, materials, nuclearDataIO, settings
 from armi import runLog
 from armi.nuclearDataIO import xsLibraries
-from armi.physics.fuelCycle.settings import CONF_CIRCULAR_RING_MODE
-from armi.physics.fuelCycle.settings import CONF_JUMP_RING_NUM
 from armi.reactor import assemblies
 from armi.reactor import assemblyLists
 from armi.reactor import composites
@@ -213,6 +211,9 @@ class Core(composites.Composite):
         self._detailedAxialExpansion = False
 
     def setOptionsFromCs(self, cs):
+        from armi.physics.fuelCycle.settings import CONF_CIRCULAR_RING_MODE
+        from armi.physics.fuelCycle.settings import CONF_JUMP_RING_NUM
+
         # these are really "user modifiable modeling constants"
         self.p.jumpRing = cs[CONF_JUMP_RING_NUM]
         self._freshFeedType = cs["freshFeedType"]

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -13,7 +13,8 @@ What's new in ARMI
 
 Bug fixes
 ---------
-#. Fixed interface/event ``runLog.header`` for tight coupling. (`PR#1178 https://github.com/terrapower/armi/pull/1178`_) 
+#. Fixed interface/event ``runLog.header`` for tight coupling. (`PR#1178 https://github.com/terrapower/armi/pull/1178`_)
+#. Fixed circular import bug in ``reactors.py`` caused by importing settings constants. (`PR#1185 <https://github.com/terrapower/armi/pull/1185>`_)
 #. Fixed TBD
 
 


### PR DESCRIPTION
## Description

This import caused a circular import that was hidden for a lot of us, partially because so many unit tests call `armi.configure()` (or app of choice) or because case runs already have an application configured. Thanks to @alexhjames for finding this and being patient while we figured it out!

This resolves the issue found in #1184, but I don't think it resolves the issue itself, since it is broader than this little fix. 

I do not believe this is unit testable; willing to be proven wrong. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

