### PR TITLE
Adding two new badges to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,5 @@
 
-
-
-|Build Status| |Code Coverage|
+|Build Status| |Code Coverage| |Commit Activity|
 
 The Advanced Reactor Modeling Interface (ARMI\ :sup:`®`) is an open-source tool that
 streamlines your nuclear reactor design/analysis needs by providing a
@@ -437,3 +435,5 @@ only use third-party Python libraries that have MIT or BSD licenses.
 .. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=main&kill_cache=2
     :target: https://coveralls.io/github/terrapower/armi?branch=main
 
+.. |Commit Activity| image:: https://img.shields.io/github/commit-activity/m/terrapower/armi
+    :target: https://github.com/terrapower/armi/pulse

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 
-|Build Status| |Code Coverage| |Commit Activity|
+|Build Status| |Code Coverage| |Commit Activity| |Good First Issues|
 
 The Advanced Reactor Modeling Interface (ARMI\ :sup:`®`) is an open-source tool that
 streamlines your nuclear reactor design/analysis needs by providing a
@@ -437,3 +437,6 @@ only use third-party Python libraries that have MIT or BSD licenses.
 
 .. |Commit Activity| image:: https://img.shields.io/github/commit-activity/m/terrapower/armi
     :target: https://github.com/terrapower/armi/pulse
+
+.. |Good First Issues| image:: https://img.shields.io/github/issues/terrapower/armi/good%20first%20issue
+    :target: https://github.com/terrapower/armi/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22


### PR DESCRIPTION
## Description

For a bit of fun, informational color, I am adding two badges to the main `README.rst`:

* One will display how many commits/month our `main` branch gets.
* The other will display how many "Good First Issue" Issues we have open.

The top of our `README.rst` will now look like:

![image](https://user-images.githubusercontent.com/1831479/219096490-6d569b62-e446-4d6a-9787-bf1294b5e09a.png)

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
