### PR TITLE
Speed up runLog

### DIFF
--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -522,12 +522,6 @@ class RunLogger(logging.Logger):
         # Determine the log level: users can optionally pass in custom strings ("debug")
         msgLevel = msgType if isinstance(msgType, int) else LOG.logLevels[msgType][0]
 
-        # os.path.exists is slow, only call this if writing is needed
-        if self.isEnabledFor(msgLevel):
-            # If the log dir hasn't been created yet, create it.
-            if not os.path.exists(LOG_DIR):
-                createLogDir(LOG_DIR)
-
         # Do the actual logging
         logging.Logger.log(
             self, msgLevel, str(msg), extra={"single": single, "label": label}
@@ -663,6 +657,8 @@ def createLogDir(logDir: str = None) -> None:
         time.sleep(secondsWait)
 
 
+if not os.path.exists(LOG_DIR):
+    createLogDir(LOG_DIR)
 # ---------------------------------------
 
 

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -519,12 +519,14 @@ class RunLogger(logging.Logger):
         In this situation, we do the mangling needed to get the log level to the correct number.
         And we do some custom string manipulation so we can handle de-duplicating warnings.
         """
-        # If the log dir hasn't been created yet, create it.
-        if not os.path.exists(LOG_DIR):
-            createLogDir(LOG_DIR)
-
         # Determine the log level: users can optionally pass in custom strings ("debug")
         msgLevel = msgType if isinstance(msgType, int) else LOG.logLevels[msgType][0]
+
+        # os.path.exists is slow, only call this if writing is needed
+        if self.isEnabledFor(msgLevel):
+            # If the log dir hasn't been created yet, create it.
+            if not os.path.exists(LOG_DIR):
+                createLogDir(LOG_DIR)
 
         # Do the actual logging
         logging.Logger.log(


### PR DESCRIPTION
## Description

(trying to avoid tagging stilley for reviews if possible)

A profile of a long case run showed that **4.5 hours** was being spent inside `runLog`, and digging further in, specifically evaluating `os.path.exists`. 

~This proposed change cut that time down to 2.3 hours (just not running `os.path.exists` if the log level isn't applicable)~ Chris' suggestion that `os.path.exists` can be module level has the time spent in `runLog` down to **9 minutes**.

~However, I'd like to consider other options on how this speedup can happen. Would moving it to `__init__` be possible? Or is running it only one time problematic? There are some places where this gets evaluated thousands of times in a loop.~

Update: This was evaluated using a pretty hefty run that included tight coupling. The time spent in `runLog` without tight coupling enabled was never all that bad / didn't see much improvement. But yay for the tight coupling cases!

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

