### PR TITLE
Add Thermal Expansion/Contraction Methodology to Docs

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -212,7 +212,7 @@ class Material:
 
         See Also
         --------
-        :py:meth: `armi.materials.material.Material.linearExpansionPercent`
+        linearExpansionPercent
         """
         dLLhot = self.linearExpansionPercent(Tc=Tc)
         dLLcold = self.linearExpansionPercent(Tc=T0)

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -190,19 +190,13 @@ class Material:
 
     def linearExpansionFactor(self, Tc: float, T0: float) -> float:
         """
-        Return a dL/L factor relative to T0 instead of to the material-dependent reference
-        temperature. This factor dL/Lc is a ratio and will be used in dimensions through the
-        formula::
+        Return a dL/L factor relative to T0 instead of the material-dependent reference
+        temperature.
 
-            dim = dim0*(1+dLL).
-
-        If there is no dLL, it should return 0.0
-
-        calculate thermal expansion based on dL/L0, which is dependent on the mat-dep ref temp.::
-
-             L(T) = L0(1+dL/L0)
-             (Lh-Lc)/L0 = dL/L0(Th) - dL/L0(Tc)
-             (Lh-Lc)/Lc = (Lh-Lc)/L0 * L0/Lc = (dL/L0(Th)-dL/L0(Tc)/L0 / (dL/L0(Tc)+1.0)
+        Notes
+        -----
+        For a detailed description of the linear expansion methodology, see
+        :ref:`thermalExpansion` in the documentation.
 
         Parameters
         ----------
@@ -213,13 +207,12 @@ class Material:
 
         Returns
         -------
-        dL/L_fromCold : float
-            The average thermal expansion between T_current and T0
+        dLL: float
+            The average thermal expansion between Tc and T0
 
         See Also
         --------
-        linearExpansionPercent
-        components.Component.getThermalExpansionFactor
+        :py:meth: `armi.materials.material.Material.linearExpansionPercent`
         """
         dLLhot = self.linearExpansionPercent(Tc=Tc)
         dLLcold = self.linearExpansionPercent(Tc=T0)

--- a/doc/user/index.rst
+++ b/doc/user/index.rst
@@ -21,4 +21,5 @@ analyzing ARMI output files, etc.
    assembly_parameters_report
    block_parameters_report
    physics_coupling
+   radial_and_axial_expansion
    accessingEntryPoints

--- a/doc/user/inputs/blueprints.rst
+++ b/doc/user/inputs/blueprints.rst
@@ -186,6 +186,8 @@ the difference between the area of the block and the sum of the areas
 comprised by the other components in the block. This is useful for complex shapes like coolant surrounding
 a lattice of pins.
 
+.. _componentLinks:
+
 Component Links
 ---------------
 Dimensions of a component may depend on the dimensions of a previously-defined component in the same

--- a/doc/user/radial_and_axial_expansion.rst
+++ b/doc/user/radial_and_axial_expansion.rst
@@ -2,26 +2,85 @@
 Radial and Axial Expansion and Contraction
 *******************************************
 
-ARMI natively supports both one-dimensional radial and axial expansion. These expansion types function independently of one another and each have their own set of underlying assumptions and use-cases. In the following sections we describe their design, limitations, and intended functionality.
+ARMI natively supports both one-dimensional radial and axial expansion. These expansion types function independently of one another and each have their own set of underlying assumptions and use-cases. The remainder of this section is described as follows: in Section :ref:`thermalExpansion` the methodology used for thermal expansion within ARMI is described; in Sections :ref:`radialExpansion` and :ref:`axialExpansion`, we describe the design, limitations, and intended functionality of radial and axial expansion, respecitely.
+
+.. _thermalExpansion:
 
 Thermal Expansion
 -----------------
 ARMI treats thermal expansion as a linear phenomena using the standard linear expansion relationship,
 
 .. math::
-    :linearExp:
-    \frac{\Delta L}{L_0} = \alpha \Delta T,
+    \frac{\Delta L}{L_0} = \alpha(T) \Delta T,
+    :label: linearExp
 
-where, :math:`\Delta L` and :math:`\Delta T` are the change in length and temperature from the reference state, respectively, and :math:`\alpha` is the thermal expansion coefficient. 
+where, :math:`\Delta L` and :math:`\Delta T` are the change in length and temperature from the reference state, respectively, and :math:`\alpha` is the thermal expansion coefficient relative to :math:`T_0`. Expanding Equation :eq:`linearExp` we obtain,
 
 .. math::
-    :label: diffEq
-    \frac{dL}{dT} = \alpha T
+    \frac{L_1 - L_0}{L_0} = \alpha(T_1)\left(T_1 - T_0\right).
+    :label: linearExp2
 
-Equation :eq:`diffEq` does stuff.
+Rearranging Equation :eq:`linearExp2`, we can obtain an expression for the new length, :math:`L_1`,
+
+.. math::
+    L_1 = L_0\left[1 + \alpha(T_1)\left(T_1 - T_0\right) \right].
+    :label: newLength
+
+Given Equation :eq:`linearExp2`, we can create expressions for the change in length between our "hot" temperature (Equation :eq:`hotExp`)
+
+.. math::
+    \begin{align}
+        \frac{L_h - L_0}{L_0} &= \alpha(T_h)\left(T_h - T_0\right),\\
+        \frac{L_h}{L_0} &= 1 + \alpha(T_h)\left(T_h - T_0\right).
+    \end{align}
+    :label: hotExp
+
+and "non-reference" temperature, :math:`T_c` (Equation :eq:`nonRefExp`),
+
+.. math::
+    \begin{align}
+        \frac{L_c - L_0}{L_0} &= \alpha(T_c)\left(T_c - T_0\right),\\
+        \frac{L_c}{L_0} &= 1 + \alpha(T_c)\left(T_c - T_0\right).
+    \end{align}
+    :label: nonRefExp
+
+These are used within ARMI to enable thermal expansion and contraction with a temperature not equal to the reference temperature, :math:`T_0`. By taking the difference between Equation :eq:`hotExp` and :eq:`nonRefExp`, we can obtain an expression relating the change in length, :math:`L_h - L_c`, to the reference length, :math:`L_0`,
+
+.. math::
+    \begin{align}
+        \frac{L_h - L_0}{L_0} - \frac{L_c - L_0}{L_0} &= \frac{L_h}{L_0} - 1 - \frac{L_c}{L_0} + 1, \\
+        &= \frac{L_h - L_c}{L_0}.
+    \end{align}
+    :label: diffHotNonRef
+
+Using Equations :eq:`diffHotNonRef` and :eq:`nonRefExp`, we can obtain an expression for the change in length, :math:`L_h - L_c`, relative to the non-reference temperature,
+
+.. math::
+    \frac{L_h - L_c}{L_c} &= \frac{L_h - L_c}{L_0} \frac{L_0}{L_c}\\
+    &= \left( \frac{L_h}{L_0} - \frac{L_c}{L_0} \right) \left( 1 + \alpha(T_c)\left(T_c - T_0\right) \right)^{-1}.
+    :label: expNewRelative
+
+Using Equations :eq:`hotExp` and :eq:`nonRefExp`, we can simplify Equation :eq:`expNewRelative`,
+
+.. math::
+    \frac{L_h - L_c}{L_c} = \frac{\alpha(T_h) \left(T_h - T_0\right) - \alpha(T_c)\left(T_c - T_0\right)}{1 + \alpha(T_c)\left(T_c - T_0\right)}.
+    :label: linearExpansionFactor
+
+Equation :eq:`linearExpansionFactor` is the expression used by ARMI in :py:meth:`linearExpansionFactor <armi.materials.material.Material.linearExpansionFactor>`.
+
+.. note::
+    :py:meth:`linearExpansionPercent <armi.materials.material.Material.linearExpansionPercent>` returns :math:`\frac{L - L_0}{L_0}` in %. The expression used in :py:meth:`linearExpansionFactor <armi.materials.material.Material.linearExpansionFactor>` can be found as follows,
+    
+    .. math::
+        \frac{L_h - L_c}{L_c} &= \frac{\frac{\alpha(T_h) \left(T_h - T_0\right)}{100} - \frac{\alpha(T_c)\left(T_c - T_0\right)}{100}}{\frac{1 + \alpha(T_c)\left(T_c - T_0\right)}{100}}, \\
+        &= \frac{\alpha(T_h) \left(T_h - T_0\right) - \alpha(T_c)\left(T_c - T_0\right)}{100 + \alpha(T_c)\left(T_c - T_0\right)}.
+
+.. _radialExpansion:
 
 Radial Expansion
 ----------------
+
+.. _axialExpansion:
 
 Axial Expansion
 ---------------

--- a/doc/user/radial_and_axial_expansion.rst
+++ b/doc/user/radial_and_axial_expansion.rst
@@ -1,0 +1,27 @@
+*******************************************
+Radial and Axial Expansion and Contraction
+*******************************************
+
+ARMI natively supports both one-dimensional radial and axial expansion. These expansion types function independently of one another and each have their own set of underlying assumptions and use-cases. In the following sections we describe their design, limitations, and intended functionality.
+
+Thermal Expansion
+-----------------
+ARMI treats thermal expansion as a linear phenomena using the standard linear expansion relationship,
+
+.. math::
+    :linearExp:
+    \frac{\Delta L}{L_0} = \alpha \Delta T,
+
+where, :math:`\Delta L` and :math:`\Delta T` are the change in length and temperature from the reference state, respectively, and :math:`\alpha` is the thermal expansion coefficient. 
+
+.. math::
+    :label: diffEq
+    \frac{dL}{dT} = \alpha T
+
+Equation :eq:`diffEq` does stuff.
+
+Radial Expansion
+----------------
+
+Axial Expansion
+---------------


### PR DESCRIPTION
## Description
This is the first of a series of PRs that will add documentation for radial and axial expansion methodologies in ARMI.

This PR adds the methodology used in ARMI to perform linear expansion by creating a new page/section within `doc/user` and cleans up the docstring for `Material.linearExpansionFactor`. 

Cross linking #935 as it is related. 

Reviewers, please pull the feature branch and compile the ARMI docs to confirm that they build correctly. There are no new dependencies, but it will be good to confirm. 


<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [ ] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [ ] The documentation is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `setup.py`.

