### PR TITLE
Update way that settings report defaults are printed

### DIFF
--- a/doc/user/inputs/settings_report.rst
+++ b/doc/user/inputs/settings_report.rst
@@ -22,7 +22,7 @@ through the :py:class:`armi.settings.caseSettings.Settings` object, which is typ
     for setting in sorted(cs.values(), key=lambda s: s.name):
         content += '   * - {}\n'.format(' '.join(wrapper.wrap(setting.name)))
         content += '     - {}\n'.format(' '.join(wrapper.wrap(setting.description or '')))
-        content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper2.wrap(str(getattr(setting,'default','') or '').split("/")[-1])]))
+        content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper2.wrap((z if (z:=str(getattr(setting,'default',None)) is not None else '').split("/")[-1])])) # need to be able to print falsey booleans, so this looks a bit complicated
         content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper.wrap(str(getattr(setting,'options','') or ''))]))
 
     content += '\n'


### PR DESCRIPTION
## Description

The settings report in the docs is supposed to print out the default values. For many boolean settings that default to `False`, nothing is printed in the default column.
An example:
![image](https://user-images.githubusercontent.com/21959600/223589629-788b5d6d-40db-4c5d-ad9e-6247628667c4.png)

The default value for `trackAssems` is `False`:
https://github.com/terrapower/armi/blob/9de4be8b706a3b4ef96d78b57632fb3130bf3114/armi/settings/fwSettings/globalSettings.py#L695-L703

Turns out there is a small piece of the logic that generates the table that will turn values of `False` into empty strings.

This fixes that.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

