### PR TITLE
Removing potential circular import in reporting

### DIFF
--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -33,7 +33,6 @@ from armi import interfaces
 from armi import runLog
 from armi.bookkeeping import report
 from armi.operators import RunTypes
-from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
 from armi.reactor.components import ComponentType
 from armi.reactor.flags import Flags
 from armi.utils import getFileSHA1Hash
@@ -629,6 +628,7 @@ def makeCoreDesignReport(core, cs):
 
 def _setGeneralCoreDesignData(cs, coreDesignTable):
     # pylint: disable=import-outside-toplevel # avoid cyclic import
+    from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
     from armi.physics.neutronics.settings import CONF_LOADING_FILE
 
     report.setData(

--- a/armi/physics/fuelCycle/__init__.py
+++ b/armi/physics/fuelCycle/__init__.py
@@ -39,7 +39,6 @@ from armi import runLog
 from armi.operators import RunTypes
 from armi.physics.fuelCycle import fuelHandlers
 from armi.physics.fuelCycle import settings
-from armi.physics.neutronics.settings import CONF_NEUTRONICS_KERNEL
 from armi.utils import directoryChangers
 
 ORDER = interfaces.STACK_ORDER.FUEL_MANAGEMENT
@@ -59,6 +58,8 @@ class FuelHandlerPlugin(plugins.ArmiPlugin):
         The interface may import user input modules to customize the actual
         fuel management.
         """
+        from armi.physics.neutronics.settings import CONF_NEUTRONICS_KERNEL
+
         fuelHandlerNeedsToBeActive = cs[settings.CONF_FUEL_HANDLER_NAME] or (
             cs["eqDirect"] and cs["runType"].lower() == RunTypes.STANDARD.lower()
         )


### PR DESCRIPTION
## Description

It looks like usages of Python can lead to a circular import in the old reporting utils file. This PR is a small change meant to solve that circular import.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [X] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.

