### PR TITLE
Return mapping from createRepresentativeBlocksUsingExistingBlocks

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -864,7 +864,8 @@ class CrossSectionGroupManager(interfaces.Interface):
         modifiedReprBlocks : dict
             Mapping between XS IDs and the new representative blocks
         origXSIDsFromNew : dict
-            Mapping of original XS IDs to new
+            Mapping of original XS IDs to new XS IDs. New XS IDs are created to 
+            represent a modified state (e.g., a Doppler temperature perturbation).
 
         Raises
         ------

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -864,7 +864,7 @@ class CrossSectionGroupManager(interfaces.Interface):
         modifiedReprBlocks : dict
             Mapping between XS IDs and the new representative blocks
         origXSIDsFromNew : dict
-            Mapping of original XS IDs to new XS IDs. New XS IDs are created to 
+            Mapping of original XS IDs to new XS IDs. New XS IDs are created to
             represent a modified state (e.g., a Doppler temperature perturbation).
 
         Raises

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -861,6 +861,8 @@ class CrossSectionGroupManager(interfaces.Interface):
             Mapping between XS IDs and the new block collections
         modifiedReprBlocks : dict
             Mapping between XS IDs and the new representative blocks
+        origXSIDsFromNew : dict
+            Mapping of original XS IDs to new
 
         Raises
         ------
@@ -890,7 +892,7 @@ class CrossSectionGroupManager(interfaces.Interface):
                 oldBlockCollection.allNuclidesInProblem
             )
             newBlockCollectionsByXsGroup[newXSID] = newBlockCollection
-        return newBlockCollectionsByXsGroup, modifiedReprBlocks
+        return newBlockCollectionsByXsGroup, modifiedReprBlocks, origXSIDsFromNew
 
     def _getModifiedReprBlocks(self, blockList, originalRepresentativeBlocks):
         """
@@ -1152,7 +1154,11 @@ class CrossSectionGroupManager(interfaces.Interface):
         for xsID, collection in blockCollectionsByXsGroup.items():
             collection.calcAvgNuclideTemperatures()
             self.avgNucTemperatures[xsID] = collection.avgNucTemperatures
-            runLog.extra("XS ID: {}, Collection: {}".format(xsID, collection))
+            runLog.extra(
+                "XS ID: {}, Collection: {}, temperature: {}".format(
+                    xsID, collection, self.avgNucTemperatures[xsID]
+                )
+            )
 
 
 BLOCK_COLLECTIONS = {

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -850,8 +850,10 @@ class CrossSectionGroupManager(interfaces.Interface):
         ----------
         blockList : list
             A list of blocks defined within the core
-        originalRepresentativeBlocks : list
-            A list of unperturbed representative blocks that the new representative blocks are formed from
+        originalRepresentativeBlocks : dict
+            A dict of unperturbed representative blocks that the new representative blocks are formed from
+            keys: XS group ID (e.g., "AA")
+            values: representative block for the XS group
 
         Returns
         -------

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -1154,11 +1154,7 @@ class CrossSectionGroupManager(interfaces.Interface):
         for xsID, collection in blockCollectionsByXsGroup.items():
             collection.calcAvgNuclideTemperatures()
             self.avgNucTemperatures[xsID] = collection.avgNucTemperatures
-            runLog.extra(
-                "XS ID: {}, Collection: {}, temperature: {}".format(
-                    xsID, collection, self.avgNucTemperatures[xsID]
-                )
-            )
+            runLog.extra("XS ID: {}, Collection: {}".format(xsID, collection))
 
 
 BLOCK_COLLECTIONS = {

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -343,6 +343,7 @@ class Test_CrossSectionGroupManager(unittest.TestCase):
         (
             _bCollect,
             newRepresentativeBlocks,
+            _origXSIDsFromNew,
         ) = self.csm.createRepresentativeBlocksUsingExistingBlocks(
             blockList, unperturbedReprBlocks
         )

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -343,7 +343,7 @@ class Test_CrossSectionGroupManager(unittest.TestCase):
         (
             _bCollect,
             newRepresentativeBlocks,
-            _origXSIDsFromNew,
+            origXSIDsFromNew,
         ) = self.csm.createRepresentativeBlocksUsingExistingBlocks(
             blockList, unperturbedReprBlocks
         )
@@ -354,6 +354,7 @@ class Test_CrossSectionGroupManager(unittest.TestCase):
         self.assertEqual(
             newReprBlock.getNumberDensities(), oldReprBlock.getNumberDensities()
         )
+        self.assertEqual(origXSIDsFromNew["BA"], "AA")
 
     def test_interactCoupled(self):
         # ensure that representativeBlocks remains empty if timeNode == 1

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -10,6 +10,7 @@ What's new in ARMI
 ------------------
 #. The method ``Material.density3`` is now called ``density``, and the old ``density`` is now called ``pseudoDensity``. (`PR#1163 <https://github.com/terrapower/armi/pull/1163>`_)
 #. Added documentation for the thermal expansion approach used in ARMI. (`PR#1204 <https://github.com/terrapower/armi/pull/1204>`_)
+#. createRepresentativeBlocksFromExistingBlocks() now returns the mapping of original to new XS IDs. (`PR#1217 <https://github.com/terrapower/armi/pull/1217>`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

When creating new representative blocks from existing blocks, return a mapping of the original XS IDs to the new XS IDs.
This mapping was already created in the method, but it wasn't being returned.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

