### PR TITLE
Use TempraryDirectoryChanger for Executer.run()

### DIFF
--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -99,7 +99,7 @@ class ExecutionOptions:
 
         This is optional (you can set runDir to whatever you want). If you
         use this, you will get a relatively consistent naming convention
-        for your fast-past folders.
+        for your fast-path folders.
         """
         # This creates a hash of the case title plus the label
         # to shorten the running directory and to avoid path length
@@ -196,12 +196,13 @@ class DefaultExecuter(Executer):
         # or not list it in inputs (for optimization)
         self.writeInput()
         with directoryChangers.TemporaryDirectoryChanger(
-            self.options.runDir,
+            root=self.options.runDir,
             filesToMove=inputs,
             filesToRetrieve=outputs,
             outputPath=outputDir,
         ) as dc:
             self.options.workingDir = dc.initial
+            self.options.runDir = dc.destination
             self._execute()
             output = self._readOutput()
             if self.options.applyResultsToReactor:

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -195,7 +195,7 @@ class DefaultExecuter(Executer):
         # must either write input to CWD for analysis and then copy to runDir
         # or not list it in inputs (for optimization)
         self.writeInput()
-        with directoryChangers.ForcedCreationDirectoryChanger(
+        with directoryChangers.TemporaryDirectoryChanger(
             self.options.runDir,
             filesToMove=inputs,
             filesToRetrieve=outputs,

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -10,6 +10,7 @@ What's new in ARMI
 ------------------
 #. The method ``Material.density3`` is now called ``density``, and the old ``density`` is now called ``pseudoDensity``. (`PR#1163 <https://github.com/terrapower/armi/pull/1163>`_)
 #. Added documentation for the thermal expansion approach used in ARMI. (`PR#1204 <https://github.com/terrapower/armi/pull/1204>`_)
+#. Use TemporaryDirectoryChanger for executer.run() so dirs are cleaned up during run. (`PR#1209 <https://github.com/terrapower/armi/pull/1209>`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description
---

ForcedCreationDirectoryChanger doesn't clean up after itself. For big runs, this can end up creating a huge amount of data in temporary folders. ARMI will clean up after the run completes, but it's possible that it could fill up the entire hard drive on some systems and cause the run to crash. TemporaryDirectoryChanger cleans up on `__exit__()`, which will prevent too much temporary directory memory using during a run.

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

