### PR TITLE
Bug fix for precision issue with axial submesh

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1802,6 +1802,11 @@ class Core(composites.Composite):
         from fuel performance, an imbalanced axial mesh may result.
 
         There is a challenge with TRZ blocks because we need the mesh centroid in terms of RZT, not XYZ
+
+        When determining the submesh, it is important to not use too small of a rounding precision. It was
+        found that when using a precision of units.FLOAT_DIMENSION_DECIMALS, that the division in `step`
+        can produce mesh points that are the same up to the 9th or 10th digit, resulting in a repeated
+        mesh point. This repetition results in problems in downstream methods, such as the uniform mesh converter.
         """
         runLog.debug("Finding all mesh points.")
         if assems is None:

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1825,10 +1825,10 @@ class Core(composites.Composite):
                     axisVal = float(base[axis])  # convert from numpy.float64
                     step = float(top[axis] - axisVal) / subdivisions
                     for _subdivision in range(subdivisions):
-                        collection.add(round(axisVal, units.FLOAT_DIMENSION_DECIMALS))
+                        collection.add(round(axisVal, 8))
                         axisVal += step
                     # add top too (only needed for last point)
-                    collection.add(round(axisVal, units.FLOAT_DIMENSION_DECIMALS))
+                    collection.add(round(axisVal, 8))
 
         iMesh, jMesh, kMesh = map(sorted, (iMesh, jMesh, kMesh))
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -388,6 +388,13 @@ class HexReactorTests(ReactorTests):
         blockMesh = self.r.core.getFirstAssembly(Flags.FUEL).spatialGrid._bounds[2]
         assert_allclose(blockMesh, mesh)
 
+    def test_findAllAxialMeshPoints_wSubmesh(self):
+        referenceMesh = [0.0, 25.0, 50.0, 75.0, 100.0, 118.75, 137.5, 156.25, 175.0]
+        mesh = self.r.core.findAllAxialMeshPoints(
+            assems=[self.r.core.getFirstAssembly(Flags.FUEL)], applySubMesh=True
+        )
+        self.assertListEqual(referenceMesh, mesh)
+
     def test_findAllAziMeshPoints(self):
         aziPoints = self.r.core.findAllAziMeshPoints()
         expectedPoints = [

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -18,6 +18,7 @@ Bug fixes
 ---------
 #. Force GAMISO/PMATRX file path extensions to be lower case for linux support (`PR#1216 <https://github.com/terrapower/armi/pull/1216>`_)
 #. Fixed an invalid assumption on the lattice physics and cross section manager interfaces when using tight coupling for snapshot runs. (`PR#1206 <https://github.com/terrapower/armi/pull/1206>`_)
+#. Fixed a bug where the precision used to determine the axial submesh was too small. (`PR#1225 <https://github.com/terrapower/armi/pull/1225>`_)
 #. Fixed TBD
 
 


### PR DESCRIPTION
## Description
A bug was identified in downstream analysis when using the uniform mesh converter. Specifically, the uniform mesh, computed here,
https://github.com/terrapower/armi/blob/14e879896a1fe1b22b9b73c89dd028eef697bad0/armi/reactor/converters/uniformMesh.py#L701
was found to have a repeated mesh point. This led to the uniform mesh converter trying to create a uniform mesh for a block with essentially a zero height - which results in a fatal error. 

This PR aims to resolve this bug by coarsening the tolerance set forth here,
https://github.com/terrapower/armi/blob/14e879896a1fe1b22b9b73c89dd028eef697bad0/armi/reactor/reactors.py#L1828-L1831

It was found that a rounding tolerance of `units.FLOAT_DIMENSION_DECIMALS` (10) was too restrictive based on the precision of the division done here,
https://github.com/terrapower/armi/blob/14e879896a1fe1b22b9b73c89dd028eef697bad0/armi/reactor/reactors.py#L1826

Given a a block height, when you have a "nice" number of subdivisions, a precision of 10 digits works. But when the number of subdivisions is not "nice", 10 digits of precision it too restrictive and the same axial mesh point is tacked on to the set, `collection`, resulting in a block height on the order of 1e-10 cm and the uniform mesh converter failing. 

I think there is reason to believe that a coarser tolerance could be used (e.g., 4 or 5, possibly even 0 digits for some cases), but to limit the potential impact of other downstream applications, 8 digits of precision was chosen as an adequate balance.

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

