### PR TITLE
Adding axial expansion support for CRAs

### DIFF
--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -338,7 +338,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
                 )
             if not cs["inputHeightsConsideredHot"]:
                 runLog.header(
-                    "=========== Axially expanding all assemblies (except control) from Tinput to Thot ==========="
+                    "=========== Axially expanding all assemblies from Tinput to Thot ==========="
                 )
                 # expand axial heights from cold to hot so dims and masses are consistent
                 # with specified component hot temperatures.

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -74,26 +74,18 @@ def expandColdDimsToHot(assems, isDetailedAxialExpansion, referenceAssembly=None
         referenceAssembly = getDefaultReferenceAssem(assems)
     axialExpChanger = AxialExpansionChanger(isDetailedAxialExpansion)
     for a in assems:
-        if not a.hasFlags(Flags.CONTROL):
-            axialExpChanger.setAssembly(a)
-            # this doesn't get applied to control assems, so CR will be interpreted
-            # as hot. This should be conservative because the control rods will
-            # be modeled as slightly shorter with the correct hot density. Density
-            # is more important than height, so we are forcing density to be correct
-            # since we can't do axial expansion (yet)
-            axialExpChanger.applyColdHeightMassIncrease()
-            axialExpChanger.expansionData.computeThermalExpansionFactors()
-            axialExpChanger.axiallyExpandAssembly()
+        axialExpChanger.setAssembly(a)
+        axialExpChanger.applyColdHeightMassIncrease()
+        axialExpChanger.expansionData.computeThermalExpansionFactors()
+        axialExpChanger.axiallyExpandAssembly()
     if not isDetailedAxialExpansion:
         for a in assems:
-            if not a.hasFlags(Flags.CONTROL):
-                a.setBlockMesh(referenceAssembly.getAxialMesh())
+            a.setBlockMesh(referenceAssembly.getAxialMesh())
     # update block BOL heights to reflect hot heights
     for a in assems:
-        if not a.hasFlags(Flags.CONTROL):
-            for b in a:
-                b.p.heightBOL = b.getHeight()
-                b.completeInitialLoading()
+        for b in a:
+            b.p.heightBOL = b.getHeight()
+            b.completeInitialLoading()
 
 
 class AxialExpansionChanger:

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -831,7 +831,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             customSettings={"inputHeightsConsideredHot": True},
         )
-        reduceTestReactorRings(r, o.cs, 3)
+        reduceTestReactorRings(r, o.cs, 5)
 
         self.stdAssems = [a for a in r.core.getAssemblies()]
 
@@ -839,7 +839,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             customSettings={"inputHeightsConsideredHot": False},
         )
-        reduceTestReactorRings(rCold, oCold.cs, 3)
+        reduceTestReactorRings(rCold, oCold.cs, 5)
 
         self.testAssems = [a for a in rCold.core.getAssemblies()]
 
@@ -853,9 +853,6 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
             2. in armi.tests.detailedAxialExpansion.refSmallReactorBase.yaml,
                Thot > Tinput resulting in a non-zero DeltaT. Each block in the
                expanded case should therefore be a different height than that of the standard case.
-               - The one exception is for control assemblies. These designs can be unique from regular
-                 pin type assemblies by allowing downward expansion. Because of this, they are skipped
-                 for axial expansion.
         """
         for aStd, aExp in zip(self.stdAssems, self.testAssems):
             self.assertAlmostEqual(
@@ -869,38 +866,48 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                 hasCustomMaterial = any(
                     isinstance(c.material, custom.Custom) for c in bStd
                 )
-                if (aStd.hasFlags(Flags.CONTROL)) or (hasCustomMaterial):
+                if hasCustomMaterial:
                     checkColdBlockHeight(bStd, bExp, self.assertAlmostEqual, "the same")
                 else:
                     checkColdBlockHeight(bStd, bExp, self.assertNotEqual, "different")
                 if bStd.hasFlags(Flags.FUEL):
-                    # fuel mass should grow because heights are considered cold heights
-                    # and a cold 1 cm column has more mass than a hot 1 cm column
-                    if not isinstance(
-                        bStd.getComponent(Flags.FUEL).material, custom.Custom
-                    ):
-                        # custom materials don't expand
-                        self.assertGreater(bExp.getMass("U235"), bStd.getMass("U235"))
+                    self.checkColdHeightBlockMass(bStd, bExp, Flags.FUEL, "U235")
+                elif bStd.hasFlags(Flags.CONTROL):
+                    self.checkColdHeightBlockMass(bStd, bExp, Flags.CONTROL, "B10")
 
-                if not aStd.hasFlags(Flags.CONTROL) and not aStd.hasFlags(Flags.TEST):
-                    if not hasCustomMaterial:
-                        # skip blocks of custom material where liner is merged with clad
-                        for cExp in bExp:
-                            if not isinstance(cExp.material, custom.Custom):
-                                matDens = cExp.material.density(Tc=cExp.temperatureInC)
-                                compDens = cExp.getMassDensity()
-                                msg = (
-                                    f"{cExp} {cExp.material} in {bExp} was not at correct density. \n"
-                                    + f"expansion = {bExp.p.height / bStd.p.height} \n"
-                                    + f"density = {matDens}, component density = {compDens} \n"
-                                )
-                                self.assertAlmostEqual(
-                                    matDens,
-                                    compDens,
-                                    places=7,
-                                    msg=msg,
-                                )
+                if not aStd.hasFlags(Flags.TEST) and not hasCustomMaterial:
+                    # skip blocks of custom material where liner is merged with clad
+                    for cExp in bExp:
+                        if not isinstance(cExp.material, custom.Custom):
+                            matDens = cExp.material.density(Tc=cExp.temperatureInC)
+                            compDens = cExp.getMassDensity()
+                            msg = (
+                                f"{cExp} {cExp.material} in {bExp} was not at correct density. \n"
+                                + f"expansion = {bExp.p.height / bStd.p.height} \n"
+                                + f"density = {matDens}, component density = {compDens} \n"
+                            )
+                            self.assertAlmostEqual(
+                                matDens,
+                                compDens,
+                                places=7,
+                                msg=msg,
+                            )
 
+    def checkColdHeightBlockMass(self, bStd: HexBlock, bExp: HexBlock, flagType: Flags, nuclide: str):
+        """checks that nuclide masses for blocks with input cold heights and "inputHeightsConsideredHot": True are underpredicted
+
+        Notes
+        -----
+        If blueprints have cold blocks heights with "inputHeightsConsideredHot": True in the inputs, then
+        the nuclide densities are thermally expanded but the block height is not. This ultimately results in
+        nuclide masses being underpredicted relative to the case where both nuclide densities and block heights
+        are thermally expanded.
+        """
+        # custom materials don't expand
+        if not isinstance(
+            bStd.getComponent(flagType).material, custom.Custom
+        ):
+            self.assertGreater(bExp.getMass(nuclide), bStd.getMass(nuclide))
 
 def checkColdBlockHeight(bStd, bExp, assertType, strForAssertion):
     assertType(

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -893,7 +893,9 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                                 msg=msg,
                             )
 
-    def checkColdHeightBlockMass(self, bStd: HexBlock, bExp: HexBlock, flagType: Flags, nuclide: str):
+    def checkColdHeightBlockMass(
+        self, bStd: HexBlock, bExp: HexBlock, flagType: Flags, nuclide: str
+    ):
         """checks that nuclide masses for blocks with input cold heights and "inputHeightsConsideredHot": True are underpredicted
 
         Notes
@@ -904,10 +906,9 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
         are thermally expanded.
         """
         # custom materials don't expand
-        if not isinstance(
-            bStd.getComponent(flagType).material, custom.Custom
-        ):
+        if not isinstance(bStd.getComponent(flagType).material, custom.Custom):
             self.assertGreater(bExp.getMass(nuclide), bStd.getMass(nuclide))
+
 
 def checkColdBlockHeight(bStd, bExp, assertType, strForAssertion):
     assertType(

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -13,6 +13,7 @@ What's new in ARMI
 #. Use TemporaryDirectoryChanger for executer.run() so dirs are cleaned up during run. (`PR#1219 <https://github.com/terrapower/armi/pull/1219>`_)
 #. New option ``copyOutput`` for globalFluxInterface to not copy output back to working directory. (`PR#1218 <https://github.com/terrapower/armi/pull/1218>`_, `PR#1227 <https://github.com/terrapower/armi/pull/1227>`_)
 #. `Executer` class has a ``dcType`` attribute to define the type of ``DirectoryChanger`` it will use. (`PR#1228 <https://github.com/terrapower/armi/pull/1228>`_)
+#. Enabling one-way (upwards) axial expansion of control assemblies. (`PR#1226 <https://github.com/terrapower/armi/pull/1226>`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description
This PR adds support for axial expansion of pin-type control rod assemblies (CRAs). The primary assumption with this approach is that all components axially expand upwards. This is a valid assumption as long as the z-elevation of the control bundle tip is relative to itself; i.e., simply placing the bundle at a prescribed z-elevation. This is in contrast to the case where the z-elevation of the control bundle is relative to the control rod driveline. In this case, the downward expansion of components within the control bundle becomes important and this approach is invalidated. 

This PR will remain in draft state until 1) unit tests are added to support CRA expansion, and 2) the effects on downstream applications have been quantified. 

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

