### PR TITLE
Define copyOutput on ExecutionOptions

### DIFF
--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -59,6 +59,8 @@ class ExecutionOptions:
     savePhysicsFiles : bool
         Dump the physics kernel I/O files from the execution to a dedicated directory that
         will not be overwritten so they will be available after the run.
+    copyOutput : bool
+        Copy the output from running the executable back to the working directory.
     applyResultsToReactor : bool
         Update the in-memory reactor model with results upon completion. Set to False
         when information from a run is needed for auxiliary purposes rather than progressing
@@ -78,6 +80,7 @@ class ExecutionOptions:
         self.applyResultsToReactor = True
         self.paramsToScaleSubset = None
         self.savePhysicsFiles = False
+        self.copyOutput = True
 
     def __repr__(self):
         return f"<{self.__class__.__name__}: {self.label}>"

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -339,7 +339,6 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         # can happen in eig if Fredholm Alternative satisfied
         self.includeFixedSource = False
         self.eigenvalueProblem = True
-        self.copyOutput = True
         self.kernelName: str
         self.isRestart = None
         self.energyDepoCalcMethodStep = None  # for gamma transport/normalization

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -31,7 +31,6 @@ from armi.reactor.tests import test_blocks
 from armi.reactor.tests import test_reactors
 from armi.tests import ISOAA_PATH
 
-
 # pylint: disable=abstract-method
 class MockReactorParams:
     def __init__(self):
@@ -222,31 +221,6 @@ class TestGlobalFluxInterfaceWithExecuters(unittest.TestCase):
 
     def _setTightCouplingFalse(self):
         self.cs["tightCoupling"] = False
-
-    def test_collectInputsAndOutputs(self):
-        """
-        Verify that the executer can select to not copy back output.
-        """
-        executer = self.gfi.getExecuter()
-        cs = settings.Settings()
-        executer.options.fromUserSettings(cs)
-        executer.options.inputFile = "test.inp"
-        executer.options.outputFile = "test.out"
-        executer.options.copyOutput = False
-        inputs, outputs = executer._collectInputsAndOutputs()
-        self.assertEqual(
-            "test.inp", inputs[0], "Input file was not successfully identified."
-        )
-        self.assertTrue(outputs == [], "Outputs were returned erroneously!")
-
-        executer.options.copyOutput = True
-        inputs, outputs = executer._collectInputsAndOutputs()
-        self.assertEqual(
-            "test.inp", inputs[0], "Input file was not successfully identified."
-        )
-        self.assertEqual(
-            "test.out", outputs[0], "Output file was not successfully identified."
-        )
 
 
 class TestGlobalFluxInterfaceWithExecutersNonUniform(unittest.TestCase):

--- a/armi/physics/tests/test_executers.py
+++ b/armi/physics/tests/test_executers.py
@@ -17,7 +17,34 @@
 import os
 import unittest
 
+from armi.reactor import geometry
+from armi import settings
 from armi.physics import executers
+
+# pylint: disable=abstract-method
+class MockReactorParams:
+    def __init__(self):
+        self.cycle = 1
+        self.timeNode = 2
+
+
+class MockCoreParams:
+    pass
+
+
+class MockCore:
+    def __init__(self):
+        # just pick a random geomType
+        self.geomType = geometry.GeomType.CARTESIAN
+        self.symmetry = "full"
+        self.p = MockCoreParams()
+
+
+class MockReactor:
+    def __init__(self):
+        self.core = MockCore()
+        self.o = None
+        self.p = MockReactorParams()
 
 
 class TestExecutionOptions(unittest.TestCase):
@@ -37,6 +64,35 @@ class TestExecutionOptions(unittest.TestCase):
         e = executers.ExecutionOptions(label="label2")
         e.setRunDirFromCaseTitle(caseTitle="test")
         self.assertEqual(os.path.basename(e.runDir), "9c1c83cb-0")
+
+
+class TestExecuters(unittest.TestCase):
+    def setUp(self):
+        e = executers.ExecutionOptions(label=None)
+        self.executer = executers.DefaultExecuter(e, MockReactor())
+
+    def test_collectInputsAndOutputs(self):
+        """
+        Verify that the executer can select to not copy back output.
+        """
+        cs = settings.Settings()
+        self.executer.options.inputFile = "test.inp"
+        self.executer.options.outputFile = "test.out"
+        self.executer.options.copyOutput = False
+        inputs, outputs = self.executer._collectInputsAndOutputs()
+        self.assertEqual(
+            "test.inp", inputs[0], "Input file was not successfully identified."
+        )
+        self.assertTrue(outputs == [], "Outputs were returned erroneously!")
+
+        self.executer.options.copyOutput = True
+        inputs, outputs = self.executer._collectInputsAndOutputs()
+        self.assertEqual(
+            "test.inp", inputs[0], "Input file was not successfully identified."
+        )
+        self.assertEqual(
+            "test.out", outputs[0], "Output file was not successfully identified."
+        )
 
 
 if __name__ == "__main__":

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -11,7 +11,7 @@ What's new in ARMI
 #. The method ``Material.density3`` is now called ``density``, and the old ``density`` is now called ``pseudoDensity``. (`PR#1163 <https://github.com/terrapower/armi/pull/1163>`_)
 #. Added documentation for the thermal expansion approach used in ARMI. (`PR#1204 <https://github.com/terrapower/armi/pull/1204>`_)
 #. Use TemporaryDirectoryChanger for executer.run() so dirs are cleaned up during run. (`PR#1219 <https://github.com/terrapower/armi/pull/1219>`_)
-#. New option ``copyOutput`` for globalFluxInterface to not copy output back to working directory. (`PR#1218 <https://github.com/terrapower/armi/pull/1218>`_)
+#. New option ``copyOutput`` for globalFluxInterface to not copy output back to working directory. (`PR#1218 <https://github.com/terrapower/armi/pull/1218>`_, `PR#1227 <https://github.com/terrapower/armi/pull/1227>`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description

The attribute was initially defined one level below, on GlobalFluxOptions, in #1218 

With `_collectInputsAndOutputs` defined on the base class `ExecutionOptions`, `copyOutput` also needed to be moved up.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

