### PR TITLE
Cleanup of determineTargetComponent

### DIFF
--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -850,11 +850,6 @@ class ExpansionData:
         else:
             componentWFlag = [c for c in b.getChildren() if c.hasFlags(flagOfInterest)]
         if len(componentWFlag) == 0:
-            # didn't match flags so check type before failing
-            componentWFlag = [
-                c for c in b if (c.p.type in b.p.type or b.p.type in c.p.type)
-            ]
-        if len(componentWFlag) == 0:
             # if only 1 solid, be smart enought to snag it
             solidMaterials = list(
                 c for c in b if not isinstance(c.material, material.Fluid)

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -851,7 +851,9 @@ class ExpansionData:
             componentWFlag = [c for c in b.getChildren() if c.hasFlags(flagOfInterest)]
         if len(componentWFlag) == 0:
             # didn't match flags so check type before failing
-            componentWFlag = [c for c in b if c.p.type == b.p.type]
+            componentWFlag = [
+                c for c in b if (c.p.type in b.p.type or b.p.type in c.p.type)
+            ]
         if len(componentWFlag) == 0:
             # if only 1 solid, be smart enought to snag it
             solidMaterials = list(

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -854,10 +854,9 @@ class ExpansionData:
             componentWFlag = [c for c in b if c.p.type == b.p.type]
         if len(componentWFlag) == 0:
             # if only 1 solid, be smart enought to snag it
-            solidMaterials = []
-            for c in b:
-                if not isinstance(c.material, material.Fluid):
-                    solidMaterials.append(c)
+            solidMaterials = list(
+                c for c in b if not isinstance(c.material, material.Fluid)
+            )
             if len(solidMaterials) == 1:
                 componentWFlag = solidMaterials
         if len(componentWFlag) == 0:

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -850,13 +850,22 @@ class ExpansionData:
         else:
             componentWFlag = [c for c in b.getChildren() if c.hasFlags(flagOfInterest)]
         if len(componentWFlag) == 0:
-            raise RuntimeError("No target component found!\n   Block {0}".format(b))
+            # didn't match flags so check type before failing
+            componentWFlag = [c for c in b if c.p.type == b.p.type]
+        if len(componentWFlag) == 0:
+            # if only 1 solid, be smart enought to snag it
+            solidMaterials = []
+            for c in b:
+                if not isinstance(c.material, material.Fluid):
+                    solidMaterials.append(c)
+            if len(solidMaterials) == 1:
+                componentWFlag = solidMaterials
+        if len(componentWFlag) == 0:
+            raise RuntimeError(f"No target component found!\n   Block {b}")
         if len(componentWFlag) > 1:
             raise RuntimeError(
-                "Cannot have more than one component within a block that has the target flag!"
-                "Block {0}\nflagOfInterest {1}\nComponents {2}".format(
-                    b, flagOfInterest, componentWFlag
-                )
+                f"Cannot have more than one component within a block that has the target flag!"
+                f"Block {b}\nflagOfInterest {flagOfInterest}\nComponents {componentWFlag}"
             )
         self._componentDeterminesBlockHeight[componentWFlag[0]] = True
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -759,29 +759,6 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
             msg=f"determineTargetComponent failed to recognize intended component: {duct}",
         )
 
-    def test_specifyTargetComponent_viaType(self):
-        """set target component via type and not flags
-
-        Notes
-        -----
-        For the case in which a block contains a component that does not have Flags defined.
-        So instead of matching on flags, we match on type.
-        """
-        b = HexBlock("detector", height=10.0)
-        detectorDims = {"Tinput": 25.0, "Thot": 25.0, "widthOuter": 1.1, "mult": 1.0}
-        ductDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
-        detector = Rectangle("detector neutron", "FakeMat", **detectorDims)
-        duct = Hexagon("duct", "FakeMat", **ductDims)
-        b.add(duct)
-        b.add(detector)
-        b.add(self.coolant)
-        b.setType("detector")
-        self.expData.determineTargetComponent(b)
-        self.assertTrue(
-            self.expData.isTargetComponent(detector),
-            msg=f"determineTargetComponent failed to recognize intended component: {detector}",
-        )
-
     def test_specifyTargetComponet_MultipleFound(self):
         """ensure RuntimeError is hit when multiple target components are found
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -769,7 +769,10 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         """
         b = HexBlock("detector", height=10.0)
         detectorDims = {"Tinput": 25.0, "Thot": 25.0, "widthOuter": 1.1, "mult": 1.0}
-        detector = Rectangle("detector", "FakeMat", **detectorDims)
+        ductDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
+        detector = Rectangle("detector neutron", "FakeMat", **detectorDims)
+        duct = Hexagon("duct", "FakeMat", **ductDims)
+        b.add(duct)
         b.add(detector)
         b.add(self.coolant)
         b.setType("detector")

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -629,6 +629,8 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
 
     def test_AssemblyAxialExpansionException(self):
         """test that negative height exception is caught"""
+        # manually set axial exp target component for code coverage
+        self.a[0].axialExpTargetComponent = self.a[0][0]
         temp = Temperature(self.a.getTotalHeight(), numTempGridPts=11, tempSteps=10)
         with self.assertRaises(ArithmeticError) as cm:
             for idt in range(temp.tempSteps):
@@ -637,42 +639,6 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
                 )
                 self.obj.expansionData.computeThermalExpansionFactors()
                 self.obj.axiallyExpandAssembly()
-
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
-
-    def test_determineTargetComponentRuntimeErrorFirst(self):
-        # build block for testing
-        b = HexBlock("test", height=10.0)
-        fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.76, "id": 0.00, "mult": 127.0}
-        cladDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.80, "id": 0.77, "mult": 127.0}
-        mainType = Circle("main", "FakeMat", **fuelDims)
-        clad = Circle("clad", "FakeMat", **cladDims)
-        b.add(mainType)
-        b.add(clad)
-        b.setType("test")
-        b.getVolumeFractions()
-        # do test
-        with self.assertRaises(RuntimeError) as cm:
-            self.obj.expansionData.determineTargetComponent(b)
-
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
-
-    def test_determineTargetComponentRuntimeErrorSecond(self):
-        # build block for testing
-        b = HexBlock("test", height=10.0)
-        fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.76, "id": 0.00, "mult": 127.0}
-        cladDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.80, "id": 0.77, "mult": 127.0}
-        mainType = Circle("test", "FakeMat", **fuelDims)
-        clad = Circle("test", "FakeMat", **cladDims)
-        b.add(mainType)
-        b.add(clad)
-        b.setType("test")
-        b.getVolumeFractions()
-        # do test
-        with self.assertRaises(RuntimeError) as cm:
-            self.obj.expansionData.determineTargetComponent(b)
 
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -19,6 +19,7 @@ What's new in ARMI
 #. createRepresentativeBlocksFromExistingBlocks() now returns the mapping of original to new XS IDs. (`PR#1217 <https://github.com/terrapower/armi/pull/1217>`_)
 #. Added a capability to prioritize mpi action execution and exclusivity.  (`PR#1237 <https://github.com/terrapower/armi/pull/1237>`_)
 #. Use ``minimumNuclideDensity`` setting when generating macroscopic XS.  (`PR#1248 <https://github.com/terrapower/armi/pull/1248>`_)
+#. Improve support for single component axial expansion and general cleanup of axial expansion unit tests. (`PR#1230 <https://github.com/terrapower/armi/pull/1230>`_) 
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description
This PR brings in various improvements to axialExpansionChanger.py::ExpansionData::determineTargetComponent. 
1. ~if Flags do not produce a target component, the component and block types are now checked. This is useful for the case where you have a target component that does not have a flag defined.~ 
   Rolled this back and users should use the block attribute `axial expansion target component` introduced in #777 .
3. Closes #1197.
4. Overhauled and improved the unit testing for the method.

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

