### PR TITLE
Remove outdated equilibrium setting validator

### DIFF
--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -644,16 +644,6 @@ class Inspector:
         )
 
         self.addQuery(
-            lambda: self.cs["runType"] == operators.RunTypes.EQUILIBRIUM
-            and self.cs["cycles"],
-            "Equilibrium cases cannot use the `cycles` case setting to define detailed"
-            " cycle information. Try instead using the simple cycle history inputs"
-            " `cycleLength(s)`, `burnSteps`, `availabilityFactor(s)`, and/or `powerFractions`",
-            "",
-            self.NO_ACTION,
-        )
-
-        self.addQuery(
             lambda: self.cs["skipCycles"] > 0
             and not os.path.exists(self.cs.caseTitle + ".restart.dat"),
             "This is a restart case, but the required restart file {0}.restart.dat is not found".format(


### PR DESCRIPTION
## Description

There was a setting validator that's purpose was to check if a user had specified the cycle history using the [detailed cycles history](https://terrapower.github.io/armi/user/inputs/settings.html#cycle-history) while performing an equilibrium calculation. This need derived from one of our internal plugins, which lead to the incompatibility.

That internal plugin has now been updated, and so this restriction no longer needs to be enforced.

Side note: this setting validator should have resided in our internal plugin in the first place, I'm not sure why I put it in the framework back during #637 .

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [ ] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

