### PR TITLE
add ax expansion tag to breed and conv ratios

### DIFF
--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -827,6 +827,7 @@ def getBlockParameterDefinitions():
             "breedRatio",
             units="None",
             description="Breeding ratio",
+            categories=["detailedAxialExpansion"],
             location=ParamLocation.AVERAGE,
         )
 
@@ -864,6 +865,7 @@ def getBlockParameterDefinitions():
             "convRatio",
             units="None",
             description="Conversion ratio",
+            categories=["detailedAxialExpansion"],
             location=ParamLocation.AVERAGE,
         )
 


### PR DESCRIPTION
## Description

The category "detailedAxialExpansion" was added to the block parameters "convRatio" and "breedRatio" so they are mapped from the uniform to the non-uniform reactor.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [ ] The documentation is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `setup.py`.

