### PR TITLE
Add setting for some assemblies to skip axial expansion

### DIFF
--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -92,9 +92,15 @@ from armi.reactor import systemLayoutInput
 from armi.scripts import migration
 
 from armi.utils import textProcessors
-from armi.physics.neutronics.fissionProductModel import lumpedFissionProduct
+from armi.settings.fwSettings.globalSettings import (
+    CONF_DETAILED_AXIAL_EXPANSION,
+    CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP,
+    CONF_INPUT_HEIGHTS_HOT,
+    CONF_NON_UNIFORM_ASSEM_FLAGS,
+    CONF_ACCEPTABLE_BLOCK_AREA_ERROR,
+    CONF_GEOM_FILE,
+)
 from armi.physics.neutronics.settings import CONF_LOADING_FILE
-from armi.nucDirectory import elements
 
 # NOTE: using non-ARMI-standard imports because these are all a part of this package,
 # and using the module imports would make the attribute definitions extremely long
@@ -329,21 +335,23 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             runLog.header("=========== Verifying Assembly Configurations ===========")
             self._checkAssemblyAreaConsistency(cs)
 
-            if not cs["detailedAxialExpansion"]:
+            if not cs[CONF_DETAILED_AXIAL_EXPANSION]:
                 # this is required to set up assemblies so they know how to snap
                 # to the reference mesh. They wont know the mesh to conform to
                 # otherwise....
                 axialExpansionChanger.makeAssemsAbleToSnapToUniformMesh(
-                    self.assemblies.values(), cs["nonUniformAssemFlags"]
+                    self.assemblies.values(), cs[CONF_NON_UNIFORM_ASSEM_FLAGS]
                 )
-            if not cs["inputHeightsConsideredHot"]:
+            if not cs[CONF_INPUT_HEIGHTS_HOT]:
                 runLog.header(
                     "=========== Axially expanding all assemblies (except control) from Tinput to Thot ==========="
                 )
                 # expand axial heights from cold to hot so dims and masses are consistent
                 # with specified component hot temperatures.
                 axialExpansionChanger.expandColdDimsToHot(
-                    self.assemblies.values(), cs["detailedAxialExpansion"]
+                    self.assemblies.values(),
+                    cs[CONF_DETAILED_AXIAL_EXPANSION],
+                    cs[CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP],
                 )
 
             # pylint: disable=no-member
@@ -518,7 +526,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             for b in a[1:]:
                 if (
                     abs(b.getArea() - blockArea) / blockArea
-                    > cs["acceptableBlockAreaError"]
+                    > cs[CONF_ACCEPTABLE_BLOCK_AREA_ERROR]
                 ):
                     runLog.error("REFERENCE COMPARISON BLOCK:")
                     a[0].printContents(includeNuclides=False)
@@ -594,7 +602,7 @@ def migrate(bp: Blueprints, cs):
         raise ValueError("Cannot auto-create a 2nd `core` grid. Adjust input.")
 
     geom = systemLayoutInput.SystemLayoutInput()
-    geom.readGeomFromFile(os.path.join(cs.inputDirectory, cs["geomFile"]))
+    geom.readGeomFromFile(os.path.join(cs.inputDirectory, cs[CONF_GEOM_FILE]))
     gridDesigns = geom.toGridBlueprints("core")
     for design in gridDesigns:
         bp.gridDesigns[design.name] = design
@@ -616,7 +624,7 @@ def migrate(bp: Blueprints, cs):
                 "The system layout described in {} has non-uniform "
                 "azimuthal and/or radial submeshing. This migration is currently "
                 "only smart enough to handle a single radial and single azimuthal "
-                "submesh for all assemblies.".format(cs["geomFile"])
+                "submesh for all assemblies.".format(cs[CONF_GEOM_FILE])
             )
         radMesh = next(iter(radMeshes))
         aziMesh = next(iter(aziMeshes))

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -89,6 +89,7 @@ from armi.nucDirectory import nuclideBases
 from armi.reactor import assemblies
 from armi.reactor import geometry
 from armi.reactor import systemLayoutInput
+from armi.reactor.flags import Flags
 from armi.scripts import migration
 
 from armi.utils import textProcessors
@@ -348,10 +349,18 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
                 )
                 # expand axial heights from cold to hot so dims and masses are consistent
                 # with specified component hot temperatures.
+                assemsToSkip = [
+                    Flags.fromStringIgnoreErrors(t)
+                    for t in cs[CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP]
+                ]
+                assemsToExpand = list(
+                    a
+                    for a in list(self.assemblies.values())
+                    if not any(a.hasFlags(f) for f in assemsToSkip)
+                )
                 axialExpansionChanger.expandColdDimsToHot(
-                    self.assemblies.values(),
+                    assemsToExpand,
                     cs[CONF_DETAILED_AXIAL_EXPANSION],
-                    cs[CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP],
                 )
 
             # pylint: disable=no-member

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -14,7 +14,6 @@
 """Enable component-wise axial expansion for assemblies and/or a reactor"""
 
 from statistics import mean
-from typing import List
 from numpy import array
 from armi import runLog
 from armi.materials import material
@@ -59,7 +58,6 @@ def makeAssemsAbleToSnapToUniformMesh(
 def expandColdDimsToHot(
     assems: list,
     isDetailedAxialExpansion: bool,
-    assemsToSkip: List[str],
     referenceAssembly=None,
 ):
     """
@@ -71,19 +69,16 @@ def expandColdDimsToHot(
         list of assemblies to be thermally expanded
     isDetailedAxialExpansion: bool
         If False, assemblies will be forced to conform to the reference mesh after expansion
-    assemsToSkip: List[str]
-        list of strings to be converted to flags to indicate which assemblies to skip axial expansion
     referenceAssembly: :py:class:`Assembly <armi.reactor.assemblies.Assembly>`, optional
         Assembly whose mesh other meshes will conform to if isDetailedAxialExpansion is False.
         If not provided, will assume the finest mesh assembly which is typically fuel.
     """
-    aToSkip = list(Flags.fromStringIgnoreErrors(t) for t in assemsToSkip)
     assems = list(assems)
     if not referenceAssembly:
         referenceAssembly = getDefaultReferenceAssem(assems)
     axialExpChanger = AxialExpansionChanger(isDetailedAxialExpansion)
     for a in assems:
-        if a.hasFlags(Flags.CONTROL) or any(a.hasFlags(aFlags) for aFlags in aToSkip):
+        if a.hasFlags(Flags.CONTROL):
             continue
         axialExpChanger.setAssembly(a)
         axialExpChanger.applyColdHeightMassIncrease()

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -82,13 +82,12 @@ def expandColdDimsToHot(
         referenceAssembly = getDefaultReferenceAssem(assems)
     axialExpChanger = AxialExpansionChanger(isDetailedAxialExpansion)
     for a in assems:
-        if not a.hasFlags(Flags.CONTROL) or any(
-            a.hasFlags(aFlags) for aFlags in aToSkip
-        ):
-            axialExpChanger.setAssembly(a)
-            axialExpChanger.applyColdHeightMassIncrease()
-            axialExpChanger.expansionData.computeThermalExpansionFactors()
-            axialExpChanger.axiallyExpandAssembly()
+        if a.hasFlags(Flags.CONTROL) or any(a.hasFlags(aFlags) for aFlags in aToSkip):
+            continue
+        axialExpChanger.setAssembly(a)
+        axialExpChanger.applyColdHeightMassIncrease()
+        axialExpChanger.expansionData.computeThermalExpansionFactors()
+        axialExpChanger.axiallyExpandAssembly()
     if not isDetailedAxialExpansion:
         for a in assems:
             if not a.hasFlags(Flags.CONTROL):

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -14,6 +14,7 @@
 """Enable component-wise axial expansion for assemblies and/or a reactor"""
 
 from statistics import mean
+from typing import List
 from numpy import array
 from armi import runLog
 from armi.materials import material
@@ -58,7 +59,7 @@ def makeAssemsAbleToSnapToUniformMesh(
 def expandColdDimsToHot(
     assems: list,
     isDetailedAxialExpansion: bool,
-    assemsToSkip: list[str],
+    assemsToSkip: List[str],
     referenceAssembly=None,
 ):
     """
@@ -70,7 +71,7 @@ def expandColdDimsToHot(
         list of assemblies to be thermally expanded
     isDetailedAxialExpansion: bool
         If False, assemblies will be forced to conform to the reference mesh after expansion
-    assemsToSkip: list[str]
+    assemsToSkip: List[str]
         list of strings to be converted to flags to indicate which assemblies to skip axial expansion
     referenceAssembly: :py:class:`Assembly <armi.reactor.assemblies.Assembly>`, optional
         Assembly whose mesh other meshes will conform to if isDetailedAxialExpansion is False.

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -112,6 +112,7 @@ CONF_BLOCK_AUTO_GRID = "autoGenerateBlockGrids"
 CONF_INPUT_HEIGHTS_HOT = "inputHeightsConsideredHot"
 CONF_CYCLES = "cycles"
 CONF_USER_PLUGINS = "userPlugins"
+CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP = "assemFlagsToSkipAxialExpansion"
 
 # TODO: Unused by ARMI, slated for removal
 CONF_CONDITIONAL_MODULE_NAME = "conditionalModuleName"  # mcfr
@@ -849,6 +850,14 @@ def defineSettings() -> List[setting.Setting]:
             "You can enter the full armi import path: armi.test.test_what.MyPlugin, "
             "or you can enter the full file path: /path/to/my/pluginz.py:MyPlugin ",
             schema=vol.Any([vol.Coerce(str)], None),
+        ),
+        setting.Setting(
+            CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP,
+            default=[],
+            label="Assembly Flags to Skip Axial Expansion",
+            description=(
+                "Assemblies that match a flag on this list will not be axially expanded."
+            ),
         ),
     ]
     return settings

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -13,6 +13,7 @@ What's new in ARMI
 #. Use TemporaryDirectoryChanger for executer.run() so dirs are cleaned up during run. (`PR#1219 <https://github.com/terrapower/armi/pull/1219>`_)
 #. New option ``copyOutput`` for globalFluxInterface to not copy output back to working directory. (`PR#1218 <https://github.com/terrapower/armi/pull/1218>`_, `PR#1227 <https://github.com/terrapower/armi/pull/1227>`_)
 #. `Executer` class has a ``dcType`` attribute to define the type of ``DirectoryChanger`` it will use. (`PR#1228 <https://github.com/terrapower/armi/pull/1228>`_)
+#. Added new setting ``assemFlagsToSkipAxialExpansion`` to enable users to list flags of assemblies to skip axial expansion. (`PR#1235 <https://github.com/terrapower/armi/pull/1235>`_)
 
 Bug fixes
 ---------


### PR DESCRIPTION
## Description
It may be desired to have some assemblies skip axial expansion routines. This PR adds a setting, `assemFlagsToSkipAxialExpansion` to accomplish this. 

Users can provide assembly flags in a list in the input setting. If an assembly contains a flag that matches those listed, it is skipped for axial expansion.

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

