### PR TITLE
Implement warning for misaligned stationary blocks boundary

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -775,7 +775,7 @@ class FuelHandler:
                     a2StationaryBlocks[-1][0].p.ztop,
                 )
             )
-            
+
         # swap stationary blocks
         for (assem1Block, assem1BlockIndex), (assem2Block, assem2BlockIndex) in zip(
             a1StationaryBlocks, a2StationaryBlocks

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -776,7 +776,6 @@ class FuelHandler:
                 )
             )
             
-
         # swap stationary blocks
         for (assem1Block, assem1BlockIndex), (assem2Block, assem2BlockIndex) in zip(
             a1StationaryBlocks, a2StationaryBlocks

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -775,7 +775,7 @@ class FuelHandler:
                     a2StationaryBlocks[-1][0].p.ztop,
                 )
             )
-            return
+            
 
         # swap stationary blocks
         for (assem1Block, assem1BlockIndex), (assem2Block, assem2BlockIndex) in zip(

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -762,6 +762,20 @@ class FuelHandler:
                     assembly1, a1StationaryBlocks, assembly2, a2StationaryBlocks
                 )
             )
+        if a1StationaryBlocks[-1][0].p.ztop != a2StationaryBlocks[-1][0].p.ztop:
+            runLog.warning(
+                """Difference in top elevation of stationary blocks 
+                 between {} (Stationary Blocks: {}, Elevation at top of stationary blocks {}) 
+                 and {} (Stationary Blocks: {}, Elevation at top of stationary blocks {}))""".format(
+                    assembly1,
+                    a1StationaryBlocks,
+                    a1StationaryBlocks[-1][0].p.ztop,
+                    assembly2,
+                    a2StationaryBlocks,
+                    a2StationaryBlocks[-1][0].p.ztop,
+                )
+            )
+            return
 
         # swap stationary blocks
         for (assem1Block, assem1BlockIndex), (assem2Block, assem2BlockIndex) in zip(

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -762,19 +762,20 @@ class FuelHandler:
                     assembly1, a1StationaryBlocks, assembly2, a2StationaryBlocks
                 )
             )
-        if a1StationaryBlocks[-1][0].p.ztop != a2StationaryBlocks[-1][0].p.ztop:
-            runLog.warning(
-                """Difference in top elevation of stationary blocks 
-                 between {} (Stationary Blocks: {}, Elevation at top of stationary blocks {}) 
-                 and {} (Stationary Blocks: {}, Elevation at top of stationary blocks {}))""".format(
-                    assembly1,
-                    a1StationaryBlocks,
-                    a1StationaryBlocks[-1][0].p.ztop,
-                    assembly2,
-                    a2StationaryBlocks,
-                    a2StationaryBlocks[-1][0].p.ztop,
+        if a1StationaryBlocks and a2StationaryBlocks:
+            if a1StationaryBlocks[-1][0].p.ztop != a2StationaryBlocks[-1][0].p.ztop:
+                runLog.warning(
+                    """Difference in top elevation of stationary blocks 
+                     between {} (Stationary Blocks: {}, Elevation at top of stationary blocks {}) 
+                     and {} (Stationary Blocks: {}, Elevation at top of stationary blocks {}))""".format(
+                        assembly1,
+                        a1StationaryBlocks,
+                        a1StationaryBlocks[-1][0].p.ztop,
+                        assembly2,
+                        a2StationaryBlocks,
+                        a2StationaryBlocks[-1][0].p.ztop,
+                    )
                 )
-            )
 
         # swap stationary blocks
         for (assem1Block, assem1BlockIndex), (assem2Block, assem2BlockIndex) in zip(

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -33,6 +33,7 @@ from armi.reactor.tests import test_reactors
 from armi.settings import caseSettings
 from armi.tests import ArmiTestHelper, TEST_ROOT
 from armi.utils import directoryChangers
+from armi.tests import mockRunLogs
 
 
 class FuelHandlerTestHelper(ArmiTestHelper):
@@ -522,12 +523,13 @@ class TestFuelHandler(FuelHandlerTestHelper):
         # validate the stationary blocks have swapped locations and are aligned
         self.assertEqual(a1PostSwapStationaryBlocks, a2PreSwapStationaryBlocks)
         self.assertEqual(a2PostSwapStationaryBlocks, a1PreSwapStationaryBlocks)
-
+        
     def test_transferIncompatibleStationaryBlocks(self):
         """
         Test the _transferStationaryBlocks method
         for the case where the input assemblies have
         different numbers as well as unaligned locations of stationary blocks.
+        Also tests the case where the total height of the stationary blocks does not match.
         """
         # grab stationary block flags
         sBFList = self.r.core.stationaryBlockFlagsList
@@ -593,6 +595,24 @@ class TestFuelHandler(FuelHandlerTestHelper):
         # try to swap stationary blocks between assembly 1 and 2
         with self.assertRaises(ValueError):
             fh._transferStationaryBlocks(a1, a2)
+
+        # re-initialize assemblies
+        self.setUp()
+        assems = self.r.core.getAssemblies(Flags.FUEL)
+        a1 = assems[1]
+        a2 = assems[2]
+
+        # change height of a stationary block in assembly 1
+        for block in a1:
+            if any(block.hasFlags(sbf) for sbf in sBFList):
+                # change height of first identified stationary block
+                nomHeight = block.getHeight()
+                a1[block.spatialLocator.k].setHeight(nomHeight - 1e-5)
+
+        # try to swap stationary blocks between assembly 1 and 2
+        with mockRunLogs.BufferLog() as mock:
+            fh._transferStationaryBlocks(a1, a2)
+            self.assertIn("top elevation of stationary", mock.getStdout())
 
     def test_dischargeSwap(self):
         """

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -528,9 +528,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         """
         Test the _transferStationaryBlocks method
         for the case where the input assemblies have
-        different numbers as well as unaligned locations
-        of stationary blocks. Also tests the case where
-        the total height of the stationary blocks does not match.
+        different numbers of stationary blocks.
         """
         # grab stationary block flags
         sBFList = self.r.core.stationaryBlockFlagsList
@@ -604,6 +602,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
                 break
 
         # try to swap stationary blocks between assembly 1 and 2
+        fh = fuelHandlers.FuelHandler(self.o)
         with self.assertRaises(ValueError):
             fh._transferStationaryBlocks(a1, a2)
 
@@ -631,6 +630,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
                 a1[block.spatialLocator.k].setHeight(nomHeight - 1e-5)
 
         # try to swap stationary blocks between assembly 1 and 2
+        fh = fuelHandlers.FuelHandler(self.o)
         with mockRunLogs.BufferLog() as mock:
             fh._transferStationaryBlocks(a1, a2)
             self.assertIn("top elevation of stationary", mock.getStdout())

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -524,12 +524,13 @@ class TestFuelHandler(FuelHandlerTestHelper):
         self.assertEqual(a1PostSwapStationaryBlocks, a2PreSwapStationaryBlocks)
         self.assertEqual(a2PostSwapStationaryBlocks, a1PreSwapStationaryBlocks)
 
-    def test_transferIncompatibleStationaryBlocks(self):
+    def test_transferDifferentNumberStationaryBlocks(self):
         """
         Test the _transferStationaryBlocks method
         for the case where the input assemblies have
-        different numbers as well as unaligned locations of stationary blocks.
-        Also tests the case where the total height of the stationary blocks does not match.
+        different numbers as well as unaligned locations
+        of stationary blocks. Also tests the case where
+        the total height of the stationary blocks does not match.
         """
         # grab stationary block flags
         sBFList = self.r.core.stationaryBlockFlagsList
@@ -555,9 +556,19 @@ class TestFuelHandler(FuelHandlerTestHelper):
         with self.assertRaises(ValueError):
             fh._transferStationaryBlocks(a1, a2)
 
-        # re-initialize assemblies
-        self.setUp()
+    def test_transferUnalignedLocationStationaryBlocks(self):
+        """
+        Test the _transferStationaryBlocks method
+        for the case where the input assemblies have
+        unaligned locations of stationary blocks.
+        """
+        # grab stationary block flags
+        sBFList = self.r.core.stationaryBlockFlagsList
+
+        # grab the assemblies
         assems = self.r.core.getAssemblies(Flags.FUEL)
+
+        # grab two arbitrary assemblies
         a1 = assems[1]
         a2 = assems[2]
 
@@ -596,9 +607,19 @@ class TestFuelHandler(FuelHandlerTestHelper):
         with self.assertRaises(ValueError):
             fh._transferStationaryBlocks(a1, a2)
 
-        # re-initialize assemblies
-        self.setUp()
+    def test_transferIncompatibleHeightStationaryBlocks(self):
+        """
+        Test the _transferStationaryBlocks method
+        for the case where the total height of the
+        stationary blocks is unequal between input assemblies.
+        """
+        # grab stationary block flags
+        sBFList = self.r.core.stationaryBlockFlagsList
+
+        # grab the assemblies
         assems = self.r.core.getAssemblies(Flags.FUEL)
+
+        # grab two arbitrary assemblies
         a1 = assems[1]
         a2 = assems[2]
 

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -523,7 +523,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         # validate the stationary blocks have swapped locations and are aligned
         self.assertEqual(a1PostSwapStationaryBlocks, a2PreSwapStationaryBlocks)
         self.assertEqual(a2PostSwapStationaryBlocks, a1PreSwapStationaryBlocks)
-        
+
     def test_transferIncompatibleStationaryBlocks(self):
         """
         Test the _transferStationaryBlocks method


### PR DESCRIPTION
Implement a warning callout for the case where the boundary of the stationary blocks between two assemblies have different heights. This PR seeks to resolve: https://github.com/terrapower/armi/issues/1212.

## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] ~The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.~ Not needed, just adding a warning. No bugs or new features (TA).
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

