### PR TITLE
Fix bug in PR #1237

### DIFF
--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -77,7 +77,7 @@ class MpiAction:
     """Base of all MPI actions.
 
     MPI Actions are tasks that can be executed without needing lots of other
-    information. When a worker node sits in it's main loop, and receives an MPI Action, it will
+    information. When a worker node sits in its main loop, and receives an MPI Action, it will
     simply call :py:meth:`~armi.mpiActions.MpiAction.invoke`.
     """
 

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -357,7 +357,9 @@ def runActions(o, r, cs, actions, numPerNode=None, serial=False):
 def _disableForExclusiveTasks(actionsThisRound, useForComputation):
     # disable processors that are exclusive for next
     indicesToDisable = [
-        i for i, action in enumerate(actionsThisRound) if action.runActionExclusive
+        i
+        for i, action in enumerate(actionsThisRound)
+        if action is not None and action.runActionExclusive
     ]
     for i in indicesToDisable:
         useForComputation[i] = False

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -174,7 +174,8 @@ class MpiIterTests(unittest.TestCase):
 class QueueActionsTests(unittest.TestCase):
     def test_disableForExclusiveTasks(self):
         num = 5
-        actionsThisRound = [MpiAction() for _ in range(num)]
+        actionsThisRound = [MpiAction() for _ in range(num - 1)]
+        actionsThisRound.append(None)
         useForComputation = [True] * num
         exclusiveIndices = [1, 3]
         for i in exclusiveIndices:


### PR DESCRIPTION
## Description
---

PR #1237 had a bug uncovered by internal integration tests. Need to check that an `mpiAction` is deifned before querying `runActionExclusive`.

The unit test was updated to replicate the situation that caused the internal integration tests to fail.

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

