### PR TITLE
Fixing UserPlugins.defineFlag

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -35,8 +35,9 @@ import sys
 
 from armi import context, plugins, pluginManager, meta, settings
 from armi.reactor import parameters
-from armi.settings import Setting
+from armi.reactor.flags import Flags
 from armi.settings import fwSettings
+from armi.settings import Setting
 
 
 class App:
@@ -294,7 +295,6 @@ class App:
         bool
             Whether or not the plugin name is already registered with the manager.
         """
-
         if ":" in pluginPath:
             pluginName = pluginPath.strip().split(":")[-1]
         else:
@@ -320,6 +320,11 @@ class App:
         assert issubclass(plugin, plugins.UserPlugin)
         self._pm.register(plugin)
 
+        # ensure UserPlugin flags are loaded
+        newFlags = plugin.defineFlags()
+        if newFlags:
+            Flags.extend(newFlags)
+
     def __registerUserPluginsInternalImport(self, pluginPath):
         """Helper method to register a single UserPlugin where
         the given path is of the form: armi.thing.what.MyPlugin
@@ -331,6 +336,11 @@ class App:
         plugin = getattr(mod, clsName)
         assert issubclass(plugin, plugins.UserPlugin)
         self._pm.register(plugin)
+
+        # ensure UserPlugin flags are loaded
+        newFlags = plugin.defineFlags()
+        if newFlags:
+            Flags.extend(newFlags)
 
     @property
     def splashText(self):

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -177,6 +177,7 @@ class TestUserPlugins(unittest.TestCase):
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
         self.assertIn("UserPluginFlags2", pluginNames)
+        self.assertIn("FLAG2", dir(Flags))
 
     def test_registerUserPluginsAbsPath(self):
         app = getApp()
@@ -193,6 +194,7 @@ class TestUserPlugins(unittest.TestCase):
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
         self.assertIn("UserPluginFlags4", pluginNames)
+        self.assertIn("FLAG4", dir(Flags))
 
     def test_registerUserPluginsFromSettings(self):
         app = getApp()
@@ -210,6 +212,7 @@ class TestUserPlugins(unittest.TestCase):
 
         pluginNames = [p[0] for p in app.pluginManager.list_name_plugin()]
         self.assertIn("UserPluginFlags3", pluginNames)
+        self.assertIn("FLAG3", dir(Flags))
 
     def test_userPluginOnProcessCoreLoading(self):
         """


### PR DESCRIPTION
## Description

This is in response to #1191.  @onufer I was able to reproduce your bug locally (though using a stand-alone App), and this fixed the bug for me.  Before we merge this PR I was hoping you would get to run this commit/change through your workflow to make sure this fixes the issue for you as well.  Thanks!

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
