### PR TITLE
Make all actinide-containing material classes subclass from FuelMaterial

### DIFF
--- a/armi/materials/californium.py
+++ b/armi/materials/californium.py
@@ -19,10 +19,10 @@ It is interesting in that it has a large spontaneous fission decay mode that
 produces lots of neutrons. It's often used as a neutron source.
 """
 
-from armi.materials.material import SimpleSolid
+from armi.materials.material import SimpleSolid, FuelMaterial
 
 
-class Californium(SimpleSolid):
+class Californium(SimpleSolid, FuelMaterial):
 
     name = "Californium"
 

--- a/armi/materials/californium.py
+++ b/armi/materials/californium.py
@@ -19,10 +19,10 @@ It is interesting in that it has a large spontaneous fission decay mode that
 produces lots of neutrons. It's often used as a neutron source.
 """
 
-from armi.materials.material import SimpleSolid, FuelMaterial
+from armi.materials.material import SimpleSolid
 
 
-class Californium(SimpleSolid, FuelMaterial):
+class Californium(SimpleSolid):
 
     name = "Californium"
 

--- a/armi/materials/thU.py
+++ b/armi/materials/thU.py
@@ -22,17 +22,17 @@ Data is from [#IAEA-TECDOCT-1450]_.
 """
 
 from armi.utils.units import getTk
-from armi.materials import material
+from armi.materials.material import FuelMaterial
 from armi import runLog
 
 
-class ThU(material.Material):
+class ThU(FuelMaterial):
     name = "ThU"
     enrichedNuclide = "U233"
     propertyValidTemperature = {"linear expansion": ((30, 600), "K")}
 
     def __init__(self):
-        material.Material.__init__(self)
+        FuelMaterial.__init__(self)
         """g/cc from IAEA TE 1450"""
         self.refDens = 11.68
 
@@ -50,7 +50,8 @@ class ThU(material.Material):
 
         if U233_wt_frac is not None:
             self.adjustMassEnrichment(U233_wt_frac)
-        material.FuelMaterial.applyInputParams(self, *args, **kwargs)
+
+        FuelMaterial.applyInputParams(self, *args, **kwargs)
 
     def setDefaultMassFracs(self):
         self.setMassFrac("TH232", 1.0)

--- a/armi/materials/thorium.py
+++ b/armi/materials/thorium.py
@@ -20,16 +20,16 @@ Data is from [#IAEA-TECDOCT-1450]_.
 .. [#IAEA-TECDOCT-1450] Thorium fuel cycle -- Potential benefits and challenges, IAEA-TECDOC-1450 (2005).
     https://www-pub.iaea.org/mtcd/publications/pdf/te_1450_web.pdf
 """
-from armi.materials.material import Material
+from armi.materials.material import FuelMaterial
 from armi.utils.units import getTk
 
 
-class Thorium(Material):
+class Thorium(FuelMaterial):
     name = "Thorium metal"
     propertyValidTemperature = {"linear expansion": ((30, 600), "K")}
 
     def __init__(self):
-        Material.__init__(self)
+        FuelMaterial.__init__(self)
         self.refDens = 11.68
 
     def setDefaultMassFracs(self):

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -16,11 +16,11 @@
 Uranium Thorium Zirconium alloy metal
 """
 from armi.utils.units import getTk
-from armi.materials.material import Material
+from armi.materials.material import FuelMaterial
 from armi import runLog
 
 
-class UThZr(Material):
+class UThZr(FuelMaterial):
     """
     U-235 enriched uranium with Thorium 232 - Zirc fuel.
 
@@ -35,6 +35,8 @@ class UThZr(Material):
         self.parent.adjustMassFrac("ZR", elementToHoldConstant="TH", val=ZR_wt_frac)
         self.parent.adjustMassFrac(elementToAdjust="TH", nuclideToHoldConstant="ZR")
         self.zrFrac = ZR_wt_frac
+
+        FuelMaterial.applyInputParams(self, *args, **kwargs)
 
     def setDefaultMassFracs(self):
         r"""U-ZR mass fractions"""

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -30,7 +30,7 @@ class UThZr(FuelMaterial):
     name = "UThZr"
     enrichedNuclide = "U235"
 
-    def applyInputParams(self, U235_wt_frac=None, ZR_wt_frac=None):
+    def applyInputParams(self, U235_wt_frac=None, ZR_wt_frac=None, *args, **kwargs):
         self.parent.adjustMassEnrichment(U235_wt_frac)
         self.parent.adjustMassFrac("ZR", elementToHoldConstant="TH", val=ZR_wt_frac)
         self.parent.adjustMassFrac(elementToAdjust="TH", nuclideToHoldConstant="ZR")

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -20,11 +20,11 @@ Much info is from [AAAFuels]_.
 .. [AAAFuels]  Kim, Y S, and Hofman, G L. AAA fuels handbook.. United States: N. p., 2003. Web. doi:10.2172/822554. .
 """
 
-from armi.materials.material import Material
+from armi.materials.material import FuelMaterial
 from armi.utils.units import getTk
 
 
-class Uranium(Material):
+class Uranium(FuelMaterial):
     name = "Uranium"
 
     materialIntro = ""


### PR DESCRIPTION
## Description

It is commonplace for people to interrogate the materials in a block to determine what kind of block it might be. This is usually done with Flags, but nonetheless, sometimes it is necessary to resort to looking at the actual materials.

We have the concept of the `FuelMaterial` class, which is supposed to be the parent of all materials that are fuels, but there are a number of lesser-used fuel material classes in the framework that do not do this.

This PR just updates those fuel material classes to subclass from `FuelMaterial`. Their behavior should not change except that they can now be classified correctly and that they will have access to the `FuelMaterial.applyInputParams()` method.

To my knowledge, I am the only person who is using any of these classes (and I'm only using `Uranium`).

---

## Checklist

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

