### PR TITLE
Overwrite settings file when user agrees to corrective query settings changes

### DIFF
--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -187,7 +187,6 @@ class Inspector:
         """
         if context.MPI_RANK != 0:
             return False
-
         # the following attribute changes will alter what the queries investigate when resolved
         correctionsMade = False
         self.cs = cs or self.cs
@@ -198,11 +197,17 @@ class Inspector:
                     self.__class__.__name__
                 )
             )
+
         else:
             for query in self.queries:
                 query.resolve()
                 if query.corrected:
                     correctionsMade = True
+            if correctionsMade:
+                runLog.extra(
+                    f"At least one setting correction detected. Overwriting settings file `{self.cs.path}`."
+                )
+                self.cs.writeToYamlFile(self.cs.path)
             issues = [
                 query
                 for query in self.queries

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -762,6 +762,20 @@ class FuelHandler:
                     assembly1, a1StationaryBlocks, assembly2, a2StationaryBlocks
                 )
             )
+        if a1StationaryBlocks[-1][0].p.ztop != a2StationaryBlocks[-1][0].p.ztop:
+            runLog.warning(
+                """Difference in top elevation of stationary blocks 
+                 between {} (Stationary Blocks: {}, Elevation at top of stationary blocks {}) 
+                 and {} (Stationary Blocks: {}, Elevation at top of stationary blocks {}))""".format(
+                    assembly1,
+                    a1StationaryBlocks,
+                    a1StationaryBlocks[-1][0].p.ztop,
+                    assembly2,
+                    a2StationaryBlocks,
+                    a2StationaryBlocks[-1][0].p.ztop,
+                )
+            )
+            return
 
         # swap stationary blocks
         for (assem1Block, assem1BlockIndex), (assem2Block, assem2BlockIndex) in zip(


### PR DESCRIPTION
## Description

Seeks to resolve https://github.com/terrapower/armi/issues/1221. When a corrective query is implemented by the inspector, the settings file is overwritten to reflect the changes. This is currently how the GUI works. 


<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [ ] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [ ] The documentation is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `setup.py`.

