### PR TITLE
Fixing iPython version Bug

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,5 @@
 numpy>=1.21,<=1.23.5
+ipython>=7.34.0,<=8.12.0
 
 # docutils 0.17 introduced a bug that prevents bullets from rendering
 # see https://github.com/terrapower/armi/issues/274


### PR DESCRIPTION
## Description

The latest iPython dropped support for Python 3.8.  And since we (tentatively) still support Python 3.7 and 3.8, we are fixing our PIP versions of these libraries.

> This is a bit of a rush. So I have assigned 3 reviewers. Once the tests pass and I get one reviewer signing, I'm merging.

Thanks to @mgjarrett for the fix!

```
This PR went in 4 days ago: https://github.com/ipython/ipython/pull/14023/
 
And an issue was opened earlier today! we are definitely not the only ones: https://github.com/ipython/ipython/issues/14053
```

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
