### PR TITLE
Make eps an optional parameter for getBlocksBetweenElevations

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -912,7 +912,7 @@ class Assembly(composites.Composite):
                 return bIndex
         return -1  # no block index found
 
-    def getBlocksBetweenElevations(self, zLower, zUpper):
+    def getBlocksBetweenElevations(self, zLower, zUpper, EPS=1e-10):
         """
         Return block(s) between two axial elevations and their corresponding heights
 
@@ -920,6 +920,8 @@ class Assembly(composites.Composite):
         ----------
         zLower, zUpper : float
             Elevations in cm where blocks should be found.
+        EPS : float, optional
+            Tolerance for ignoring small, negligible pieces of a block
 
 
         Returns
@@ -943,7 +945,6 @@ class Assembly(composites.Composite):
         [(Block1, 25.0), (Block2, 5.0)]
 
         """
-        EPS = 1e-10
         blocksHere = []
         allMeshPoints = set()
 
@@ -969,7 +970,7 @@ class Assembly(composites.Composite):
 
         # Verify that the heights of all the blocks are equal to the expected
         # height for the given zUpper and zLower.
-        if abs(totalHeight - expectedHeight) > 1e-5:
+        if abs(totalHeight - expectedHeight) > 1e-3:
             raise ValueError(
                 f"The cumulative height of {blocksHere} is {totalHeight} cm "
                 f"and does not equal the expected height of {expectedHeight} cm.\n"

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -970,7 +970,7 @@ class Assembly(composites.Composite):
 
         # Verify that the heights of all the blocks are equal to the expected
         # height for the given zUpper and zLower.
-        if abs(totalHeight - expectedHeight) > 1e-3:
+        if abs(totalHeight - expectedHeight) > 1e-5:
             raise ValueError(
                 f"The cumulative height of {blocksHere} is {totalHeight} cm "
                 f"and does not equal the expected height of {expectedHeight} cm.\n"

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -969,8 +969,8 @@ class Assembly(composites.Composite):
             totalHeight += height
 
         # Verify that the heights of all the blocks are equal to the expected
-        # height for the given zUpper and zLower.
-        if abs(totalHeight - expectedHeight) > 1e-5:
+        # height for the given zUpper and zLower, within 0.001 cm (10 microns).
+        if abs(totalHeight - expectedHeight) > 1e-3:
             raise ValueError(
                 f"The cumulative height of {blocksHere} is {totalHeight} cm "
                 f"and does not equal the expected height of {expectedHeight} cm.\n"

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -677,7 +677,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         for topMeshPoint in newMesh:
             overlappingBlockInfo = sourceAssem.getBlocksBetweenElevations(
-                bottom, topMeshPoint
+                bottom, topMeshPoint, EPS=1e-5
             )
             # This is not expected to occur given that the assembly mesh is consistent with
             # the blocks within it, but this is added for defensive programming and to
@@ -804,7 +804,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
             destinationBlockHeight = destBlock.getHeight()
             # Determine which blocks in the uniform mesh source assembly are
             # within the lower and upper bounds of the destination block.
-            sourceBlocksInfo = sourceAssembly.getBlocksBetweenElevations(zLower, zUpper)
+            sourceBlocksInfo = sourceAssembly.getBlocksBetweenElevations(
+                zLower, zUpper, EPS=1e-5
+            )
 
             if abs(zUpper - zLower) < 1e-6 and not sourceBlocksInfo:
                 continue

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -918,6 +918,10 @@ class Assembly_TestCase(unittest.TestCase):
         blocksAndHeights = self.assembly.getBlocksBetweenElevations(
             9.9999, 21.0, EPS=1e-3
         )
+        with self.assertRaises(ValueError):
+            blocksAndHeights = self.assembly.getBlocksBetweenElevations(
+                9.99, 21.0, EPS=1e-2
+            )
         self.assertEqual(blocksAndHeights[0], (self.assembly[1], 10.0))
         self.assertEqual(blocksAndHeights[1], (self.assembly[2], 1.0))
 

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -914,6 +914,11 @@ class Assembly_TestCase(unittest.TestCase):
         self.assertEqual(blocksAndHeights[1], (self.assembly[1], 10.0))
         self.assertEqual(blocksAndHeights[2], (self.assembly[2], 1.0))
 
+        # tests EPS option
+        blocksAndHeights = self.assembly.getBlocksBetweenElevations(9.9999, 21.0, EPS=1e-3)
+        self.assertEqual(blocksAndHeights[0], (self.assembly[1], 10.0))
+        self.assertEqual(blocksAndHeights[1], (self.assembly[2], 1.0))
+
         blocksAndHeights = self.assembly.getBlocksBetweenElevations(-10, 1000.0)
         self.assertEqual(len(blocksAndHeights), len(self.assembly))
         self.assertAlmostEqual(

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -915,7 +915,9 @@ class Assembly_TestCase(unittest.TestCase):
         self.assertEqual(blocksAndHeights[2], (self.assembly[2], 1.0))
 
         # tests EPS option
-        blocksAndHeights = self.assembly.getBlocksBetweenElevations(9.9999, 21.0, EPS=1e-3)
+        blocksAndHeights = self.assembly.getBlocksBetweenElevations(
+            9.9999, 21.0, EPS=1e-3
+        )
         self.assertEqual(blocksAndHeights[0], (self.assembly[1], 10.0))
         self.assertEqual(blocksAndHeights[1], (self.assembly[2], 1.0))
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -22,6 +22,7 @@ What's new in ARMI
 #. Use ``minimumNuclideDensity`` setting when generating macroscopic XS.  (`PR#1248 <https://github.com/terrapower/armi/pull/1248>`_)
 #. Improve support for single component axial expansion and general cleanup of axial expansion unit tests. (`PR#1230 <https://github.com/terrapower/armi/pull/1230>`_)
 #. New cross section group representative block type for 1D cylindrical models. (`PR#1238 <https://github.com/terrapower/armi/pull/1238>`_)
+#. Make tolerance on assemblies.getBlocksBetweenElevations() an optional parameter. (`PR#1253 <https://github.com/terrapower/armi/pull/1253>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description
---

The `EPS` value for filtering out small blocks from `assemblies.getBlocksBetweenElevations()` was hard-corded to 1-e10. This PR makes it an optional parameter with a default of 1e-10, which gives the user more flexibility to get blocks with a different tolerance.

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

