### PR TITLE
Add detailed isotopes to all blocks when non-uniform reactor

### DIFF
--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -194,19 +194,22 @@ class FissionProductModel(interfaces.Interface):
             b.setLumpedFissionProducts(None)
 
             # If detailed axial expansion is active, mapping between blocks occurs on uniform mesh
-            # and this can cause blocks to have isotopes that they dont have cross sections for
-            # fix this by adding all isotopes to all blocks.
+            # and this can cause blocks to have isotopes that they dont have cross sections for/
+            # Fix this by adding all isotopes to all blocks so they are present it lattice physics.
             allBlocksNeedAllNucs = self.cs[CONF_DETAILED_AXIAL_EXPANSION]
+
             compsToAddIso = b.getComponents(Flags.DEPLETABLE)
             if allBlocksNeedAllNucs and not compsToAddIso:
-                # add the isotopics to the smallest solid since that is usually the most "intersting"
+                # add the isotopics to the smallest solid since that is usually the most "interesting"
                 # sorted() calls getBoundingCircleOuterDiameter under the hood
                 solidsOrderedBySize = sorted(c for c in b if c.containsSolidMaterial())
                 if solidsOrderedBySize:
-                    compsToAddIso = solidsOrderedBySize[0]
+                    compsToAddIso = [solidsOrderedBySize[0]]
                 else:
                     # no solids, so just add to smallest component
-                    compsToAddIso = sorted(c for c in b if c.containsSolidMaterial())[0]
+                    compsToAddIso = [
+                        sorted(c for c in b if c.containsSolidMaterial())[0]
+                    ]
             for c in compsToAddIso:
                 updatedNDens = c.getNumberDensities()
                 for nuc in self.r.blueprints.allNuclidesInProblem:

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -207,9 +207,7 @@ class FissionProductModel(interfaces.Interface):
                     compsToAddIso = [solidsOrderedBySize[0]]
                 else:
                     # no solids, so just add to smallest component
-                    compsToAddIso = [
-                        sorted(c for c in b if c.containsSolidMaterial())[0]
-                    ]
+                    compsToAddIso = [sorted(c for c in b)[0]]
             for c in compsToAddIso:
                 updatedNDens = c.getNumberDensities()
                 for nuc in self.r.blueprints.allNuclidesInProblem:

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -181,7 +181,7 @@ class FissionProductModel(interfaces.Interface):
 
     def setAllComponentFissionProducts(self):
         """
-        Initialize all nuclides for each ``DEPLETABLE`` component in the core, or all blocks if detailedAxialExpansion is enable.
+        Initialize all nuclides for each ``DEPLETABLE`` component in the core, or all blocks if detailedAxialExpansion is enabled.
 
         Notes
         -----

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -126,7 +126,7 @@ class FissionProductModel(interfaces.Interface):
         interfaces.Interface.__init__(self, r, cs)
         self._globalLFPs = lumpedFissionProduct.lumpedFissionProductFactory(self.cs)
         # If detailed axial expansion is active, mapping between blocks occurs on uniform mesh
-        # and this can cause blocks to have isotopes that they dont have cross sections for/
+        # and this can cause blocks to have isotopes that they don't have cross sections for.
         # Fix this by adding all isotopes to all blocks so they are present it lattice physics.
         self.allBlocksNeedAllNucs = self.cs[CONF_DETAILED_AXIAL_EXPANSION]
 
@@ -181,7 +181,7 @@ class FissionProductModel(interfaces.Interface):
 
     def setAllComponentFissionProducts(self):
         """
-        Initialize all nuclides for each ``DEPLETABLE`` component in the core, or all blocks if mesh conversion.
+        Initialize all nuclides for each ``DEPLETABLE`` component in the core, or all blocks if detailedAxialExpansion is enable.
 
         Notes
         -----
@@ -192,7 +192,7 @@ class FissionProductModel(interfaces.Interface):
         When detailedAxialExpansion is also enabled, all regions will have fission/activation
         products added to avoid missing cross sections during mesh conversion (since converted
         blocks only have one xsID but may have isotopes from multiple blocks with different IDs.)
-        Setting density to zero her enables small number densities is XS generation.
+        Setting density to zero here enables small number densities is XS generation.
 
         When explicit fission products are enabled and the user has not already included
         all fission products in the blueprints (in ``nuclideFlags``), the ``fpModelLibrary`` setting is used

--- a/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
@@ -33,6 +33,7 @@ from armi.physics.neutronics.fissionProductModel.fissionProductModelSettings imp
     CONF_MAKE_ALL_BLOCK_LFPS_INDEPENDENT,
     CONF_FISSION_PRODUCT_LIBRARY_NAME,
 )
+from armi.settings.fwSettings.globalSettings import CONF_DETAILED_AXIAL_EXPANSION
 
 
 class TestFissionProductModelLumpedFissionProducts(unittest.TestCase):
@@ -137,6 +138,15 @@ class TestFissionProductModelExplicitMC2Library(unittest.TestCase):
                     self.assertIn(nb.name, nuclideList)
             else:
                 self.assertLess(len(b.getNuclides()), len(nuclideBases.byMcc3Id))
+
+        # now check if deatiled axial expanion that all blocks have detailed nuclides
+        self.fpModel.cs[CONF_DETAILED_AXIAL_EXPANSION] = True
+
+        self.fpModel.interactBOL()
+        for b in self.r.core.getBlocks():
+            nuclideList = b.getNuclides()
+            for nb in nuclideBases.byMcc3Id.values():
+                self.assertIn(nb.name, nuclideList)
 
 
 if __name__ == "__main__":

--- a/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
@@ -139,7 +139,7 @@ class TestFissionProductModelExplicitMC2Library(unittest.TestCase):
             else:
                 self.assertLess(len(b.getNuclides()), len(nuclideBases.byMcc3Id))
 
-        # now check if deatiled axial expanion that all blocks have detailed nuclides
+        # now check if detailed axial expansion that all blocks have detailed nuclides
         self.fpModel.cs[CONF_DETAILED_AXIAL_EXPANSION] = True
 
         self.fpModel.interactBOL()

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -22,6 +22,7 @@ What's new in ARMI
 #. Use ``minimumNuclideDensity`` setting when generating macroscopic XS.  (`PR#1248 <https://github.com/terrapower/armi/pull/1248>`_)
 #. Improve support for single component axial expansion and general cleanup of axial expansion unit tests. (`PR#1230 <https://github.com/terrapower/armi/pull/1230>`_)
 #. New cross section group representative block type for 1D cylindrical models. (`PR#1238 <https://github.com/terrapower/armi/pull/1238>`_)
+#. When using non-uniform mesh, detailed fission/activation products have cross sections generated to avoid blocks without xs data. (`PR#1257 <https://github.com/terrapower/armi/pull/1257>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

Code update to add all isotopes to all blocks when the reactor is non-uniform.

This is a more stable way of fixing isotopes missing in cross section ids than using tolerancing (eg #1248)

it maybe make some lattice physics computations a little more expensive, so the ultimate solution might be to allow blocks to have 2+ xsIDs to check, and if the nuc wasn't in the first one go down the list and check the next XSID, but this would be a much more significant framework change.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.

