### PR TITLE
Fix a bug in database compare.

### DIFF
--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -377,7 +377,9 @@ def _diffSpecialData(
         if isinstance(dSrc, numpy.ndarray) and isinstance(dRef, numpy.ndarray):
             if dSrc.shape != dRef.shape:
                 out.writeln("Shapes did not match for {}".format(refData))
-                diffResults.addDiff(compName, paramName, numpy.inf, numpy.inf, numpy.inf)
+                diffResults.addDiff(
+                    compName, paramName, numpy.inf, numpy.inf, numpy.inf
+                )
                 return
 
             # make sure not to try to compare empty arrays. Numpy is mediocre at

--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -329,7 +329,6 @@ def _diffSpecialData(
     diffResults.addStructureDiffs(nDiffs)
 
     if not keysMatch:
-        print("Keys don't match!")
         diffResults.addDiff(name, name, numpy.inf, numpy.inf, numpy.inf)
         return
 

--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -329,7 +329,7 @@ def _diffSpecialData(
     diffResults.addStructureDiffs(nDiffs)
 
     if not keysMatch:
-        diffResults.addDiff(name, name, [numpy.inf], [numpy.inf], [numpy.inf])
+        diffResults.addDiff(name, name, numpy.inf, numpy.inf, numpy.inf)
         return
 
     if srcData.attrs.get("dict", False):
@@ -377,7 +377,7 @@ def _diffSpecialData(
         if isinstance(dSrc, numpy.ndarray) and isinstance(dRef, numpy.ndarray):
             if dSrc.shape != dRef.shape:
                 out.writeln("Shapes did not match for {}".format(refData))
-                diffResults.add([numpy.inf], [numpy.inf], [numpy.inf], [numpy.inf])
+                diffResults.addDiff(compName, paramName, numpy.inf, numpy.inf, numpy.inf)
                 return
 
             # make sure not to try to compare empty arrays. Numpy is mediocre at

--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -323,12 +323,13 @@ def _diffSpecialData(
     compName = refData.name.split("/")[-2]
 
     nDiffs = _compareSets(
-        set(srcData.attrs.keys()), set(refData.attrs.keys()), "formatting data"
+        set(srcData.attrs.keys()), set(refData.attrs.keys()), out, "formatting data"
     )
     keysMatch = nDiffs == 0
     diffResults.addStructureDiffs(nDiffs)
 
     if not keysMatch:
+        print("Keys don't match!")
         diffResults.addDiff(name, name, numpy.inf, numpy.inf, numpy.inf)
         return
 

--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -235,6 +235,17 @@ class TestCompareDB3(unittest.TestCase):
                 _diffSpecialData(refData4, srcData5, out, dr)
                 self.assertIn("Unable to unpack special data for paramName", e)
 
+            # make an H5 datasets that will add a np.inf diff because keys don't match
+            f6 = h5py.File("test_diffSpecialData6.hdf5", "w")
+            refData6 = f6.create_dataset("numberDensities", data=a2)
+            refData6.attrs["shapes"] = "2"
+            refData6.attrs["numDens"] = a2
+            f7 = h5py.File("test_diffSpecialData7.hdf5", "w")
+            srcData7 = f7.create_dataset("densities", data=a2)
+            srcData7.attrs["colors"] = "2"
+            srcData7.attrs["numberDens"] = a2
+            _diffSpecialData(refData6, srcData7, out, dr)
+
     def test_diffSimpleData(self):
         dr = DiffResults(0.01)
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -22,6 +22,7 @@ What's new in ARMI
 #. Use ``minimumNuclideDensity`` setting when generating macroscopic XS.  (`PR#1248 <https://github.com/terrapower/armi/pull/1248>`_)
 #. Improve support for single component axial expansion and general cleanup of axial expansion unit tests. (`PR#1230 <https://github.com/terrapower/armi/pull/1230>`_)
 #. New cross section group representative block type for 1D cylindrical models. (`PR#1238 <https://github.com/terrapower/armi/pull/1238>`_)
+#. Fix a bug in database comparison. (`PR#1258 <https://github.com/terrapower/armi/pull/1258>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description
---

There's a line in compareDB3.py that tries to call a method that doesn't exist, `DiffResults.add()`

This has been around for a long time, but we have somehow just coincidentally not been hitting it.

Also, another call to `addDiff` needed to be updated to pass `numpy.inf` as a scalar instead of a list.

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

