### PR TITLE
quick bug fix for PR 1239

### DIFF
--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -223,7 +223,7 @@ class LatticePhysicsInterface(interfaces.Interface):
         Generate new cross sections based off the case settings and the current state
         of the reactor if the lattice physics frequency is at least everyNode.
         """
-        if self._latticePhysicsFrequency == LatticePhysicsFrequency.everyNode:
+        if self._latticePhysicsFrequency >= LatticePhysicsFrequency.everyNode:
             self.r.core.lib = None
             self.updateXSLibrary(self.r.p.cycle, self.r.p.timeNode)
 

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -154,6 +154,22 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         self.latticeInterface.interactEveryNode()
         self.assertIsNone(self.o.r.core.lib)
 
+    def test_interactEveryNodeFirstCoupled(self):
+        """
+        Test interactEveryNode() with LatticePhysicsFrequency.firstCoupledIteration
+        """
+        self.latticeInterface._latticePhysicsFrequency = LatticePhysicsFrequency.firstCoupledIteration
+        self.latticeInterface.interactEveryNode()
+        self.assertIsNone(self.o.r.core.lib)
+
+    def test_interactEveryNodeAll(self):
+        """
+        Test interactEveryNode() with LatticePhysicsFrequency.all
+        """
+        self.latticeInterface._latticePhysicsFrequency = LatticePhysicsFrequency.all
+        self.latticeInterface.interactEveryNode()
+        self.assertIsNone(self.o.r.core.lib)
+
     def test_interactFirstCoupledIteration(self):
         """
         Test interactCoupled() with different update frequencies on first iteration

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -158,7 +158,9 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         """
         Test interactEveryNode() with LatticePhysicsFrequency.firstCoupledIteration
         """
-        self.latticeInterface._latticePhysicsFrequency = LatticePhysicsFrequency.firstCoupledIteration
+        self.latticeInterface._latticePhysicsFrequency = (
+            LatticePhysicsFrequency.firstCoupledIteration
+        )
         self.latticeInterface.interactEveryNode()
         self.assertIsNone(self.o.r.core.lib)
 

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -333,6 +333,7 @@ def defineSettings():
             label="Frequency of lattice physics updates",
             description="Define the frequency at which cross sections are updated with new lattice physics interactions.",
             options=[opt.name for opt in list(LatticePhysicsFrequency)],
+            enforcedOptions=True,
         ),
         setting.Setting(
             CONF_XS_SCATTERING_ORDER,

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -25,6 +25,7 @@ What's new in ARMI
 #. Store the axial expansion target component name as a block parameter. (`PR#1256 https://github.com/terrapower/armi/pull/1256`_) 
 #. When using non-uniform mesh, detailed fission/activation products have cross sections generated to avoid blocks without xs data. (`PR#1257 <https://github.com/terrapower/armi/pull/1257>`_)
 #. Fix a bug in database comparison. (`PR#1258 <https://github.com/terrapower/armi/pull/1258>`_)
+#. Introduce new LatticePhysicsFrequency setting to control lattice physics calculation. (`PR#1239 <https://github.com/terrapower/armi/pull/1239>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description
---

LatticePhysicsInterface was only triggered on every node when the frequency was exactly `everyNode`, but we want `firstCoupledIteration` and `all` to also trigger on `everyNode`. The unit testing in #1239 covered all of the relevant lines but it didn't cover this scenario.


## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

