### PR TITLE
Fixing getTemperatureAtDensity to use non-pseduo density

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -364,12 +364,10 @@ class Material:
         self, targetDensity: float, temperatureGuessInC: float
     ) -> float:
         """Get the temperature at which the perturbed density occurs."""
-        densFunc = (
-            lambda temp: self.pseudoDensity(Tc=temp) - targetDensity
-        )  # 0 at tempertature of targetDensity
-        tAtTargetDensity = float(
-            fsolve(densFunc, temperatureGuessInC)
-        )  # is a numpy array if fsolve is called
+        # 0 at tempertature of targetDensity
+        densFunc = lambda temp: self.density(Tc=temp) - targetDensity
+        # is a numpy array if fsolve is called
+        tAtTargetDensity = float(fsolve(densFunc, temperatureGuessInC))
         return tAtTargetDensity
 
     @property

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -675,7 +675,7 @@ class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
     def test_getTemperatureAtDensity(self):
         expectedTemperature = 100.0
         tAtTargetDensity = self.mat.getTemperatureAtDensity(
-            self.mat.pseudoDensity(Tc=expectedTemperature), 30.0
+            self.mat.density(Tc=expectedTemperature), 30.0
         )
         self.assertAlmostEqual(expectedTemperature, tAtTargetDensity)
 


### PR DESCRIPTION
## Description

The method `Material.getTemperatureAtDensity()` wrongly used `pseudoDensity` instead of `density`. This PR fixes that.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
