### PR TITLE
Fix #1207

### DIFF
--- a/doc/user/inputs/settings_report.rst
+++ b/doc/user/inputs/settings_report.rst
@@ -22,7 +22,7 @@ through the :py:class:`armi.settings.caseSettings.Settings` object, which is typ
     for setting in sorted(cs.values(), key=lambda s: s.name):
         content += '   * - {}\n'.format(' '.join(wrapper.wrap(setting.name)))
         content += '     - {}\n'.format(' '.join(wrapper.wrap(setting.description or '')))
-        content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper2.wrap((z if (z:=str(getattr(setting,'default',None))) is not None else '').split("/")[-1])])) # need to be able to print falsey booleans, so this looks a bit complicated
+        content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper2.wrap(str(getattr(setting, 'default', None)).split("/")[-1])]))
         content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper.wrap(str(getattr(setting,'options','') or ''))]))
 
     content += '\n'

--- a/doc/user/inputs/settings_report.rst
+++ b/doc/user/inputs/settings_report.rst
@@ -22,7 +22,7 @@ through the :py:class:`armi.settings.caseSettings.Settings` object, which is typ
     for setting in sorted(cs.values(), key=lambda s: s.name):
         content += '   * - {}\n'.format(' '.join(wrapper.wrap(setting.name)))
         content += '     - {}\n'.format(' '.join(wrapper.wrap(setting.description or '')))
-        content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper2.wrap((z if (z:=str(getattr(setting,'default',None)) is not None else '').split("/")[-1])])) # need to be able to print falsey booleans, so this looks a bit complicated
+        content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper2.wrap((z if (z:=str(getattr(setting,'default',None))) is not None else '').split("/")[-1])])) # need to be able to print falsey booleans, so this looks a bit complicated
         content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper.wrap(str(getattr(setting,'options','') or ''))]))
 
     content += '\n'


### PR DESCRIPTION
## Description

#1207 included a syntax bug, namely a missing closing parenthesis. This was a bit difficult to see originally because python syntax highlighting won't work in this instance of code embedded in an rst file.

It was discovered that the logic implemented in #1207 also didn't work anyways, so this PR fixes it.

Before #1207 , an empty string was printed if the default value was `None`. This was the initial problem that was identified. Now `None` values are printed when there is no default, `None` values are printed if the default is `None`, and an empty string will be printed if the default is an empty string. This is what is desired.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

