### PR TITLE
Fixing the Settings Report in the Docs

### DIFF
--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -285,8 +285,8 @@ def defineSettings():
             default=1e-15,
             label="Minimum nuclide density",
             description="Density to use for nuclides and fission products at infinite dilution. "
-            "This is also used as the minimum density considered for computing macroscopic cross "
-            "sections. It can also be passed to physics plugins.",
+            + "This is also used as the minimum density considered for computing macroscopic cross "
+            + "sections. It can also be passed to physics plugins.",
         ),
         setting.Setting(
             CONF_INFINITE_DILUTE_CUTOFF,

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -284,11 +284,9 @@ def defineSettings():
             CONF_MINIMUM_NUCLIDE_DENSITY,
             default=1e-15,
             label="Minimum nuclide density",
-            description=(
-                "Density to use for nuclides and fission products at infinite dilution. "
-                "This is also used as the minimum density considered for computing macroscopic cross "
-                "sections. It can also be passed to physics plugins.",
-            ),
+            description="Density to use for nuclides and fission products at infinite dilution. "
+            "This is also used as the minimum density considered for computing macroscopic cross "
+            "sections. It can also be passed to physics plugins.",
         ),
         setting.Setting(
             CONF_INFINITE_DILUTE_CUTOFF,

--- a/doc/user/inputs/settings_report.rst
+++ b/doc/user/inputs/settings_report.rst
@@ -21,7 +21,7 @@ through the :py:class:`armi.settings.caseSettings.Settings` object, which is typ
 
     for setting in sorted(cs.values(), key=lambda s: s.name):
         content += '   * - {}\n'.format(' '.join(wrapper.wrap(setting.name)))
-        content += '     - {}\n'.format(' '.join(wrapper.wrap(setting.description or '')))
+        content += '     - {}\n'.format(' '.join(wrapper.wrap(str(setting.description) or '')))
         content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper2.wrap(str(getattr(setting, 'default', None)).split("/")[-1])]))
         content += '     - {}\n'.format(' '.join(['``{}``'.format(wrapped) for wrapped in wrapper.wrap(str(getattr(setting,'options','') or ''))]))
 


### PR DESCRIPTION
## Description

The Settings Report has been broken in the docs for a while.  After some debugging I found the problem:

```
/home/runner/work/armi/armi/doc/user/inputs/settings_report.rst:10: ERROR: Unable to execute embedded
doc code at user/inputs/settings_report:10 ... 2023-05-16 21:05:42.386690
'tuple' object has no attribute 'expandtabs'
```

It appears the problem was that the Setting `minimumNuclideDensity` incorrectly had a description that was a `tuple` instead of a `str`.  Thus the above error.

Also, I added some future-proofing, so this wouldn't bite us again.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
