### PR TITLE
Removing Component.getMassDensity

### DIFF
--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -331,13 +331,13 @@ class TestGriddedBlock(unittest.TestCase):
         programmaticBlock = test_blocks.buildSimpleFuelBlock()
         programaticClad = programmaticBlock.getComponent(Flags.CLAD)
         self.assertAlmostEqual(
-            clad.getMassDensity(),
+            clad.density(),
             clad.material.density(Tc=clad.temperatureInC),
         )
 
         self.assertAlmostEqual(
-            clad.getMassDensity(),
-            programaticClad.getMassDensity(),
+            clad.density(),
+            programaticClad.density(),
         )
 
 

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -753,29 +753,11 @@ class Component(composites.Composite, metaclass=ComponentType):
         volume = self.getVolume() / (
             self.parent.getSymmetryFactor() if self.parent else 1.0
         )
-        return self.getMassDensity(nuclideNames) * volume
-
-    def getMassDensity(self, nuclideNames=None):
-        """
-        Return the mass density of the component, in g/cc.
-
-        Parameters
-        ----------
-        nuclideNames : str, optional
-            The nuclide/element specifier to get the partial density of in
-            the object. If omitted, total density is returned.
-
-        Returns
-        -------
-        density : float
-            The density in grams/cc.
-        """
         nuclideNames = self._getNuclidesFromSpecifier(nuclideNames)
         # densities comes from self.p.numberDensities
         densities = self.getNuclideNumberDensities(nuclideNames)
         nDens = {nuc: dens for nuc, dens in zip(nuclideNames, densities)}
-        massDensity = densityTools.calculateMassDensity(nDens)
-        return massDensity
+        return densityTools.calculateMassDensity(nDens) * volume
 
     def setDimension(self, key, val, retainLink=False, cold=True):
         """

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -877,7 +877,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                     for cExp in bExp:
                         if not isinstance(cExp.material, custom.Custom):
                             matDens = cExp.material.density(Tc=cExp.temperatureInC)
-                            compDens = cExp.getMassDensity()
+                            compDens = cExp.density()
                             msg = (
                                 f"{cExp} {cExp.material} in {bExp} was not at correct density. \n"
                                 + f"expansion = {bExp.p.height / bStd.p.height} \n"

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -546,7 +546,7 @@ class TestComponentExpansion(unittest.TestCase):
         circle2 = Circle("circle", mat, self.tCold + 200, self.tHot, hotterDim)
         self.assertAlmostEqual(circle1.getDimension("od"), circle2.getDimension("od"))
         self.assertAlmostEqual(circle1.getArea(), circle2.getArea())
-        self.assertAlmostEqual(circle1.getMassDensity(), circle2.getMassDensity())
+        self.assertAlmostEqual(circle1.density(), circle2.density())
 
     def expansionConservationHotHeightDefined(self, mat: str, isotope: str):
         """
@@ -566,13 +566,13 @@ class TestComponentExpansion(unittest.TestCase):
         # all the number densities and atomic masses
         self.assertAlmostEqual(
             circle1.p.numberDensities[isotope] / circle2.p.numberDensities[isotope],
-            circle1.getMassDensity() / circle2.getMassDensity(),
+            circle1.density() / circle2.density(),
         )
 
         # the colder one has more because it is the same cold outer diameter
         # but it would be taller at the same temperature
-        mass1 = circle1.getMassDensity() * circle1.getArea() * hotHeight
-        mass2 = circle2.getMassDensity() * circle2.getArea() * hotHeight
+        mass1 = circle1.density() * circle1.getArea() * hotHeight
+        mass2 = circle2.density() * circle2.getArea() * hotHeight
         self.assertGreater(mass1, mass2)
 
         # they are off by factor of thermal exp
@@ -587,33 +587,33 @@ class TestComponentExpansion(unittest.TestCase):
             # 2D density is not equal after application of coldMatAxialExpansionFactor
             # which happens during construction
             self.assertNotAlmostEqual(
-                circle.getMassDensity(),
+                circle.density(),
                 circle.material.pseudoDensity(Tc=circle.temperatureInC),
             )
             # 2D density is off by the material thermal exp factor
             percent = circle.material.linearExpansionPercent(Tc=circle.temperatureInC)
             thermalExpansionFactorFromColdMatTemp = 1 + percent / 100
             self.assertAlmostEqual(
-                circle.getMassDensity() * thermalExpansionFactorFromColdMatTemp,
+                circle.density() * thermalExpansionFactorFromColdMatTemp,
                 circle.material.pseudoDensity(Tc=circle.temperatureInC),
             )
             self.assertAlmostEqual(
-                circle.getMassDensity(),
+                circle.density(),
                 circle.material.density(Tc=circle.temperatureInC),
             )
 
         # brief 2D expansion with set temp to show mass is conserved
         # hot height would come from block value
-        warmMass = circle1.getMassDensity() * circle1.getArea() * hotHeight
+        warmMass = circle1.density() * circle1.getArea() * hotHeight
         circle1.setTemperature(self.tHot)
-        hotMass = circle1.getMassDensity() * circle1.getArea() * hotHeight
+        hotMass = circle1.density() * circle1.getArea() * hotHeight
         self.assertAlmostEqual(warmMass, hotMass)
         circle1.setTemperature(self.tWarm)
 
         # Change temp to circle 2 temp  to show equal to circle2
         # and then change back to show recoverable to original values
         oldArea = circle1.getArea()
-        initialDens = circle1.getMassDensity()
+        initialDens = circle1.density()
 
         # when block.setHeight is called (which effectively changes component height)
         # component.setNumberDensity is called (for solid isotopes) to adjust the number
@@ -625,18 +625,18 @@ class TestComponentExpansion(unittest.TestCase):
 
         # now its density is same as hot component
         self.assertAlmostEqual(
-            circle1.getMassDensity(),
-            circle2.getMassDensity(),
+            circle1.density(),
+            circle2.density(),
         )
 
         # show that mass is conserved after expansion
         circle1NewHotHeight = hotHeight * heightFactor
         self.assertAlmostEqual(
-            mass1, circle1.getMassDensity() * circle1.getArea() * circle1NewHotHeight
+            mass1, circle1.density() * circle1.getArea() * circle1NewHotHeight
         )
 
         self.assertAlmostEqual(
-            circle1.getMassDensity(),
+            circle1.density(),
             circle1.material.density(Tc=circle1.temperatureInC),
         )
         # change back to old temp
@@ -644,11 +644,9 @@ class TestComponentExpansion(unittest.TestCase):
         circle1.setTemperature(self.tWarm)
 
         # check for consistency
-        self.assertAlmostEqual(initialDens, circle1.getMassDensity())
+        self.assertAlmostEqual(initialDens, circle1.density())
         self.assertAlmostEqual(oldArea, circle1.getArea())
-        self.assertAlmostEqual(
-            mass1, circle1.getMassDensity() * circle1.getArea() * hotHeight
-        )
+        self.assertAlmostEqual(mass1, circle1.density() * circle1.getArea() * hotHeight)
 
     def expansionConservationColdHeightDefined(self, mat: str):
         """
@@ -671,15 +669,13 @@ class TestComponentExpansion(unittest.TestCase):
         circle1AdjustTo2.adjustDensityForHeightExpansion(self.tHot)
         circle1AdjustTo2.setTemperature(self.tHot)
         # check that its like 2
-        self.assertAlmostEqual(
-            circle2.getMassDensity(), circle1AdjustTo2.getMassDensity()
-        )
+        self.assertAlmostEqual(circle2.density(), circle1AdjustTo2.density())
         self.assertAlmostEqual(circle2.getArea(), circle1AdjustTo2.getArea())
 
         for circle in [circle1, circle2, circle1AdjustTo2]:
 
             self.assertAlmostEqual(
-                circle.getMassDensity(),
+                circle.density(),
                 circle.material.density(Tc=circle.temperatureInC),
             )
             # total mass consistent between hot and cold
@@ -689,7 +685,7 @@ class TestComponentExpansion(unittest.TestCase):
                 coldHeight
                 * circle.getArea(cold=True)
                 * circle.material.density(Tc=circle.inputTemperatureInC),
-                hotHeight * circle.getArea() * circle.getMassDensity(),
+                hotHeight * circle.getArea() * circle.density(),
             )
 
 


### PR DESCRIPTION
## Description

The major goal of this PR is to elliminate confusion with `Component.density()`.  (This undoes refactor in #818).

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

