### PR TITLE
Harmonize material names and class names

### DIFF
--- a/armi/materials/be9.py
+++ b/armi/materials/be9.py
@@ -27,7 +27,7 @@ from armi.nucDirectory import nuclideBases as nb
 class Be9(Material):
     """Beryllium."""
 
-    name = "Be-9"
+    name = "Be9"
     thermalScatteringLaws = (tsl.byNbAndCompound[nb.byName["BE"], tsl.BE_METAL],)
     propertyValidTemperature = {"linear expansion percent": ((50, 1560.0), "K")}
 

--- a/armi/materials/cs.py
+++ b/armi/materials/cs.py
@@ -21,8 +21,8 @@ from armi.utils.units import getTk
 
 
 class Cs(Fluid):
-
-    name = "Cesium"
+    """Cesium"""
+    name = "Cs"
 
     def setDefaultMassFracs(self):
         self.setMassFrac("CS133", 1.0)

--- a/armi/materials/cs.py
+++ b/armi/materials/cs.py
@@ -22,6 +22,7 @@ from armi.utils.units import getTk
 
 class Cs(Fluid):
     """Cesium"""
+
     name = "Cs"
 
     def setDefaultMassFracs(self):

--- a/armi/materials/custom.py
+++ b/armi/materials/custom.py
@@ -29,7 +29,7 @@ class Custom(Material):
     Custom Materials have user input properties.
     """
 
-    name = "Custom Material"
+    name = "Custom"
     enrichedNuclide = "U235"
 
     def __init__(self):

--- a/armi/materials/leadBismuth.py
+++ b/armi/materials/leadBismuth.py
@@ -26,7 +26,7 @@ from armi.utils.units import getTk
 
 class LeadBismuth(material.Fluid):
     r"""Lead bismuth eutectic"""
-    name = "Lead Bismuth"
+    name = "LeadBismuth"
     propertyValidTemperature = {
         "density": ((400, 1300), "K"),
         "dynamic visc": ((400, 1100), "K"),

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -26,7 +26,7 @@ from armi.utils.units import getTc
 
 class SiC(Material):
     r"""Silicon Carbide"""
-    name = "Silicon Carbide"
+    name = "SiC"
     thermalScatteringLaws = (
         tsl.byNbAndCompound[nb.byName["C"], tsl.SIC],
         tsl.byNbAndCompound[nb.byName["SI"], tsl.SIC],

--- a/armi/materials/thorium.py
+++ b/armi/materials/thorium.py
@@ -25,7 +25,7 @@ from armi.utils.units import getTk
 
 
 class Thorium(FuelMaterial):
-    name = "Thorium metal"
+    name = "Thorium"
     propertyValidTemperature = {"linear expansion": ((30, 600), "K")}
 
     def __init__(self):

--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -26,7 +26,7 @@ from armi.materials.material import Material, FuelMaterial, SimpleSolid
 
 
 class ThoriumOxide(FuelMaterial, SimpleSolid):
-    name = "ThO2"
+    name = "ThoriumOxide"
     propertyValidTemperature = {"linear expansion": ((298, 1223), "K")}
 
     def __init__(self):

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -39,7 +39,7 @@ HeatCapacityConstants = collections.namedtuple(
 
 
 class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
-    name = "Uranium Oxide"
+    name = "UraniumOxide"
 
     enrichedNuclide = "U235"
 

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -25,7 +25,7 @@ from armi.utils.units import getTk
 class Zr(Material):
     """Metallic zirconium"""
 
-    name = "Zirconium"
+    name = "Zr"
 
     propertyValidTemperature = {
         "density": ((293, 1800), "K"),

--- a/armi/reactor/blueprints/tests/test_reactorBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_reactorBlueprints.py
@@ -109,7 +109,7 @@ class TestReactorBlueprints(unittest.TestCase):
     def test_materialDataSummary(self):
         """Test that the material data summary for the core is valid as a printout to the stdout."""
         expectedMaterialData = [
-            ("Custom Material", "ARMI", False),
+            ("Custom", "ARMI", False),
             ("HT9", "ARMI", False),
             ("UZr", "ARMI", False),
         ]

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -64,7 +64,7 @@ class C5G7ReactorTests(unittest.TestCase):
             streamVal = mock.getStdout()
             self.assertGreater(streamVal.count("[warn]"), 32, msg=streamVal)
             self.assertGreater(streamVal.count("custom isotopics"), 32, msg=streamVal)
-            self.assertIn("Uranium Oxide", streamVal, msg=streamVal)
+            self.assertIn("UraniumOxide", streamVal, msg=streamVal)
             self.assertIn("SaturatedWater", streamVal, msg=streamVal)
             self.assertIn("invalid settings: fakeBad", streamVal, msg=streamVal)
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -33,7 +33,7 @@ Bug fixes
 #. Force GAMISO/PMATRX file path extensions to be lower case for linux support (`PR#1216 <https://github.com/terrapower/armi/pull/1216>`_)
 #. Fixed an invalid assumption on the lattice physics and cross section manager interfaces when using tight coupling for snapshot runs. (`PR#1206 <https://github.com/terrapower/armi/pull/1206>`_)
 #. Fixed a bug where the precision used to determine the axial submesh was too small. (`PR#1225 <https://github.com/terrapower/armi/pull/1225>`_)
-#. Fixed TBD
+#. Made sure all material classes could be resolved via name (`PR#1270 <https://github.com/terrapower/armi/pull/1270>`)
 
 
 ARMI v0.2.6


### PR DESCRIPTION
## Description

For `materials.resolveMaterialClassByName()` to function, `material.name` and the class name should be the same. This PR ensures that is true for all materials. 

No testing was added as the name field on the material isn't really something to be tested. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

