### PR TITLE
block converter preserve flags

### DIFF
--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -639,7 +639,6 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             bigComponent = self._addSolidMaterialRing(
                 bcs, innerDiameter, outerDiameter, name
             )
-            bigComponent.p.flags = bcs.p.flags
             self.convertedBlock.add(bigComponent)
             innerDiameter = outerDiameter
 
@@ -667,7 +666,6 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             circularHexagon = self._addSolidMaterialRing(
                 hexagon, innerDiameter, outerDiam, name
             )
-            circularHexagon.p.flags = hexagon.p.flags
             self.convertedBlock.add(circularHexagon)
             innerDiameter = outerDiam
 
@@ -683,6 +681,7 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             mult=1,
         )
         circle.setNumberDensities(baseComponent.getNumberDensities())
+        circle.p.flags = baseComponent.p.flags
         return circle
 
     def _addCoolantRing(self, coolantOD, nameSuffix):

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -388,6 +388,7 @@ class BlockAvgToCylConverter(BlockConverter):
                 mult=1,
             )
             driverRing.setNumberDensities(blockToAdd.getNumberDensities())
+            # no flag set here since its block level, and its a block, not component...
             self.convertedBlock.add(driverRing)
             innerDiam = driverOuterDiam
 
@@ -602,10 +603,11 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
 
     def _buildFirstRing(self, pinComponents):
         """Add first ring of components to new block."""
-        newComps = copy.deepcopy(pinComponents)
-        for c in newComps:
+        for oldC in pinComponents:
+            c = copy.deepcopy(oldC)
             c.setName(c.name + " 1")
             c.setDimension("mult", 1.0)  # first ring will have dims of 1 pin
+            c.p.flags = oldC.p.flags
             self.convertedBlock.add(c)
 
     def _buildNthRing(self, pinComponents, ringNum):  # pylint: disable=too-many-locals
@@ -637,6 +639,7 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             bigComponent = self._addSolidMaterialRing(
                 bcs, innerDiameter, outerDiameter, name
             )
+            bigComponent.p.flags = bcs.p.flags
             self.convertedBlock.add(bigComponent)
             innerDiameter = outerDiameter
 
@@ -664,6 +667,7 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             circularHexagon = self._addSolidMaterialRing(
                 hexagon, innerDiameter, outerDiam, name
             )
+            circularHexagon.p.flags = hexagon.p.flags
             self.convertedBlock.add(circularHexagon)
             innerDiameter = outerDiam
 
@@ -694,6 +698,7 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             mult=1,
         )
         interRing.setNumberDensities(irc.getNumberDensities())
+        interRing.p.flags = irc.p.flags
         self.convertedBlock.add(interRing)
         self._remainingCoolantFillArea -= interRing.getArea()
 

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -28,6 +28,9 @@ from armi.reactor.tests.test_reactors import loadTestReactor, TEST_ROOT
 from armi.utils import hexagon
 from armi.reactor import grids
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
+from armi.physics.neutronics.isotopicDepletion.isotopicDepletionInterface import (
+    isDepletable,
+)
 
 
 class TestBlockConverter(unittest.TestCase):
@@ -128,15 +131,27 @@ class TestBlockConverter(unittest.TestCase):
         )
 
         block = loadTestReactor(TEST_ROOT)[1].core.getFirstBlock(Flags.CONTROL)
+        control = block.getComponent(Flags.CONTROL)
+
+        # add depletable flag to see if it is carried
+        control.p.flags |= Flags.DEPLETABLE
 
         driverBlock.spatialGrid = None
         block.spatialGrid = grids.HexGrid.fromPitch(1.0)
 
-        self._testConvertWithDriverRings(
+        convertedWithoutDriver = self._testConvertWithDriverRings(
             block,
             driverBlock,
             blockConverters.HexComponentsToCylConverter,
             hexagon.numPositionsInRing,
+        )
+
+        self.assertEqual(5, len([c for c in convertedWithoutDriver if isDepletable(c)]))
+        self.assertEqual(
+            5, len([c for c in convertedWithoutDriver if c.hasFlags(Flags.CONTROL)])
+        )
+        self.assertEqual(
+            9, len([c for c in convertedWithoutDriver if c.hasFlags(Flags.CLAD)])
         )
 
         # This should fail because a spatial grid is required
@@ -157,12 +172,14 @@ class TestBlockConverter(unittest.TestCase):
         driverBlock.spatialGrid = None
         block.spatialGrid = None
 
-        self._testConvertWithDriverRings(
+        convertedWithoutDriver = self._testConvertWithDriverRings(
             block,
             driverBlock,
             blockConverters.BlockAvgToCylConverter,
             hexagon.numPositionsInRing,
         )
+        # block went to 1 component
+        self.assertEqual(1, len([c for c in convertedWithoutDriver]))
 
     def test_convertHexWithFuelDriverOnNegativeComponentAreaBlock(self):
         """
@@ -228,8 +245,10 @@ class TestBlockConverter(unittest.TestCase):
                 self.assertTrue(c.isFuel(), "c was {}".format(c.name))
                 # remove external driver rings in preperation to check composition
                 convertedBlock.remove(c)
+            convBlockWithoutDriver = convertedBlock
+            self._checkAreaAndComposition(block, convBlockWithoutDriver)
 
-            self._checkAreaAndComposition(block, convertedBlock)
+        return convBlockWithoutDriver
 
     def _checkAreaAndComposition(self, block, convertedBlock):
         self.assertAlmostEqual(block.getArea(), convertedBlock.getArea())


### PR DESCRIPTION
## Description

Fixed a bug where block converter did not preserve flags
---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.

