### PR TITLE
Unifying the Reactor sorting

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -712,8 +712,8 @@ class Database3:
 
         Returns
         -------
-        root : ArmiObject
-            The top-level object stored in the database; usually a Reactor.
+        root : Reactor
+            The top-level object stored in the database; a Reactor.
         """
         runLog.info("Loading reactor state for time node ({}, {})".format(cycle, node))
 
@@ -756,7 +756,8 @@ class Database3:
         if updateGlobalAssemNum:
             updateGlobalAssemblyNum(root)
 
-        # usually a reactor object
+        # return a Reactor object
+        root.sort()
         return root
 
     @staticmethod

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -67,22 +67,23 @@ from armi.bookkeeping.db.layout import (
     replaceNonesWithNonsense,
     replaceNonsenseWithNones,
 )
-from armi.reactor import parameters
-from armi.reactor.parameters import parameterCollections
-from armi.reactor.flags import Flags
-from armi.reactor.reactors import Core
+from armi.bookkeeping.db.typedefs import History, Histories
+from armi.nucDirectory import nuclideBases
+from armi.physics.neutronics.settings import CONF_LOADING_FILE
 from armi.reactor import assemblies
+from armi.reactor import grids
+from armi.reactor import parameters
+from armi.reactor import systemLayoutInput
 from armi.reactor.assemblies import Assembly
 from armi.reactor.blocks import Block
 from armi.reactor.components import Component
 from armi.reactor.composites import ArmiObject
-from armi.reactor import grids
-from armi.bookkeeping.db.typedefs import History, Histories
-from armi.reactor import systemLayoutInput
+from armi.reactor.flags import Flags
+from armi.reactor.parameters import parameterCollections
+from armi.reactor.reactors import Core
+from armi.settings.fwSettings.globalSettings import CONF_SORT_REACTOR
 from armi.utils import getNodesPerCycle
 from armi.utils.textProcessors import resolveMarkupInclusions
-from armi.nucDirectory import nuclideBases
-from armi.physics.neutronics.settings import CONF_LOADING_FILE
 
 # CONSTANTS
 _SERIALIZER_NAME = "serializerName"
@@ -757,7 +758,14 @@ class Database3:
             updateGlobalAssemblyNum(root)
 
         # return a Reactor object
-        root.sort()
+        if cs[CONF_SORT_REACTOR]:
+            root.sort()
+        else:
+            runLog.warning(
+                "DeprecationWarning: This Reactor is not being sorted on DB load. "
+                f"Due to the setting {CONF_SORT_REACTOR}, this Reactor is unsorted. "
+                "But this feature is temporary and will be removed by 2024."
+            )
         return root
 
     @staticmethod

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -161,7 +161,6 @@ class FuelHandler:
             numMoved = 0
 
         self.o.r.core.p.numMoves = numMoved
-
         self.o.r.core.setBlockMassParams()
 
         runLog.important(
@@ -201,7 +200,7 @@ class FuelHandler:
         return defaultFactorList, factorSearchFlags
 
     def prepCore(self):
-        """Aux. function to run before XS generation (do moderation, etc. here)"""
+        """Aux function to run before XS generation (do moderation, etc)."""
 
     def prepSearch(self, *args, **kwargs):
         """
@@ -916,7 +915,7 @@ class FuelHandler:
     @staticmethod
     def readMoves(fname):
         r"""
-        reads a shuffle output file and sets up the moves dictionary
+        Reads a shuffle output file and sets up the moves dictionary.
 
         Parameters
         ----------
@@ -1014,7 +1013,7 @@ class FuelHandler:
     @staticmethod
     def trackChain(moveList, startingAt, alreadyDone=None):
         r"""
-        builds a chain of locations based on starting location
+        Builds a chain of locations based on starting location.
 
         Notes
         -----
@@ -1222,7 +1221,7 @@ class FuelHandler:
         self, loadChains, loopChains, enriches, loadChargeTypes, loadNames
     ):
         r"""
-        Actually does the fuel movements required to repeat a shuffle order
+        Actually does the fuel movements required to repeat a shuffle order.
 
         Parameters
         ----------

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -348,7 +348,6 @@ class ArmiObject(metaclass=CompositeModelType):
         sense to sort things across containers or scopes. If this ends up being too
         restrictive, it can probably be relaxed or overridden on specific classes.
         """
-
         if self.spatialLocator is None or other.spatialLocator is None:
             runLog.error("could not compare {} and {}".format(self, other))
             raise ValueError(
@@ -387,7 +386,6 @@ class ArmiObject(metaclass=CompositeModelType):
         Special treatment of ``parent`` is not enough, since the spatialGrid also
         contains a reference back to the armiObject. Consequently, the ``spatialGrid``
         needs to be reassigned in ``__setstate__``.
-
         """
         state = self.__dict__.copy()
         state["parent"] = None
@@ -2649,7 +2647,6 @@ class Composite(ArmiObject):
     mixed with siblings in a grid. This allows mixing grid-representation with
     explicit representation, often useful in advanced assemblies and thermal
     reactors.
-
     """
 
     def __init__(self, name):
@@ -2676,9 +2673,18 @@ class Composite(ArmiObject):
         This does not use quality checks for membership checking because equality
         operations can be fairly heavy. Rather, this only checks direct identity
         matches.
-
         """
         return id(item) in set(id(c) for c in self._children)
+
+    def sort(self):
+        """Sort the children of this object."""
+        # sort the top-level children of this Composite
+        self._children.sort()
+
+        # recursively sort the children below it.
+        for c in self._children:
+            if issubclass(Composite, c.__class__):
+                c.sort()
 
     def index(self, obj):
         """Obtain the list index of a particular child."""

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -47,10 +47,10 @@ from armi.reactor import geometry
 from armi.reactor import grids
 from armi.reactor import parameters
 from armi.reactor import reactorParameters
-from armi.reactor import systemLayoutInput
 from armi.reactor import zones
 from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 from armi.reactor.flags import Flags
+from armi.reactor.systemLayoutInput import SystemLayoutInput
 from armi.settings.fwSettings.globalSettings import CONF_MATERIAL_NAMESPACE_ORDER
 from armi.utils import createFormattedStrWithDelimiter, units
 from armi.utils import directoryChangers
@@ -81,7 +81,7 @@ class Reactor(composites.Composite):
         self.blueprints = blueprints
 
     def __getstate__(self):
-        r"""applies a settings and parent to the reactor and components."""
+        """Applies a settings and parent to the reactor and components."""
         state = composites.Composite.__getstate__(self)
         state["o"] = None
         return state
@@ -110,9 +110,19 @@ class Reactor(composites.Composite):
             self.core = cores[0]
 
 
-def loadFromCs(cs):
+def loadFromCs(cs) -> Reactor:
     """
     Load a Reactor based on the input settings.
+
+    Parameters
+    ----------
+    cs: CaseSettings
+        A relevant settings object
+
+    Returns
+    -------
+    Reactor
+        Reactor loaded from settings file
     """
     from armi.reactor import blueprints
 
@@ -120,7 +130,7 @@ def loadFromCs(cs):
     return factory(cs, bp)
 
 
-def factory(cs, bp, geom: Optional[systemLayoutInput.SystemLayoutInput] = None):
+def factory(cs, bp, geom: Optional[SystemLayoutInput] = None) -> Reactor:
     """Build a reactor from input settings, blueprints and geometry."""
     from armi.reactor import blueprints
 
@@ -147,6 +157,8 @@ def factory(cs, bp, geom: Optional[systemLayoutInput.SystemLayoutInput] = None):
                 structure.construct(cs, bp, r)
 
     runLog.debug("Reactor: {}".format(r))
+
+    r.sort()
     return r
 
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -164,10 +164,11 @@ def factory(cs, bp, geom: Optional[SystemLayoutInput] = None) -> Reactor:
         r.sort()
     else:
         runLog.warning(
-            "DeprecationWarning: This Reactor is not being sorted on DB load. "
+            "DeprecationWarning: This Reactor is not being sorted on blueprint read. "
             f"Due to the setting {CONF_SORT_REACTOR}, this Reactor is unsorted. "
             "But this feature is temporary and will be removed by 2024."
         )
+
     return r
 
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -52,6 +52,7 @@ from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 from armi.reactor.flags import Flags
 from armi.reactor.systemLayoutInput import SystemLayoutInput
 from armi.settings.fwSettings.globalSettings import CONF_MATERIAL_NAMESPACE_ORDER
+from armi.settings.fwSettings.globalSettings import CONF_SORT_REACTOR
 from armi.utils import createFormattedStrWithDelimiter, units
 from armi.utils import directoryChangers
 from armi.utils.iterables import Sequence
@@ -158,7 +159,15 @@ def factory(cs, bp, geom: Optional[SystemLayoutInput] = None) -> Reactor:
 
     runLog.debug("Reactor: {}".format(r))
 
-    r.sort()
+    # return a Reactor object
+    if cs[CONF_SORT_REACTOR]:
+        r.sort()
+    else:
+        runLog.warning(
+            "DeprecationWarning: This Reactor is not being sorted on DB load. "
+            f"Due to the setting {CONF_SORT_REACTOR}, this Reactor is unsorted. "
+            "But this feature is temporary and will be removed by 2024."
+        )
     return r
 
 

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -62,25 +62,19 @@ _testGrid = grids.CartesianGrid.fromRectangle(0.01, 0.01)
 class DummyComposite(composites.Composite):
     pDefs = getDummyParamDefs()
 
-    def __init__(self, name):
+    def __init__(self, name, i=0):
         composites.Composite.__init__(self, name)
         self.p.type = name
-        x = 1000 * random()
-        y = 1000 * random()
-        z = 1000 * random()
-        self.spatialLocator = grids.IndexLocation(x, y, z, _testGrid)
+        self.spatialLocator = grids.IndexLocation(i, i, i, _testGrid)
 
 
 class DummyLeaf(composites.Composite):
     pDefs = getDummyParamDefs()
 
-    def __init__(self, name):
+    def __init__(self, name, i=0):
         composites.Composite.__init__(self, name)
         self.p.type = name
-        x = 1000 * random()
-        y = 1000 * random()
-        z = 1000 * random()
-        self.spatialLocator = grids.IndexLocation(x, y, z, _testGrid)
+        self.spatialLocator = grids.IndexLocation(i, i, i, _testGrid)
 
     def getChildren(
         self, deep=False, generationNum=1, includeMaterials=False, predicate=None
@@ -104,15 +98,15 @@ class TestCompositePattern(unittest.TestCase):
     def setUp(self):
         self.cs = settings.Settings()
         runLog.setVerbosity("error")
-        container = DummyComposite("inner test fuel")
+        container = DummyComposite("inner test fuel", 99)
         for i in range(5):
-            leaf = DummyLeaf("duct {}".format(i))
+            leaf = DummyLeaf("duct {}".format(i), i + 100)
             leaf.setType("duct")
             container.add(leaf)
-        nested = DummyComposite("clad")
+        nested = DummyComposite("clad", 98)
         nested.setType("clad")
-        self.secondGen = DummyComposite("liner")
-        self.thirdGen = DummyLeaf("pin 77")
+        self.secondGen = DummyComposite("liner", 97)
+        self.thirdGen = DummyLeaf("pin 77", 33)
         self.secondGen.add(self.thirdGen)
         nested.add(self.secondGen)
         container.add(nested)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -49,8 +49,8 @@ def buildOperatorOfEmptyHexBlocks(customSettings=None):
 
     Doesn't depend on inputs and loads quickly.
 
-    Params
-    ------
+    Parameters
+    ----------
     customSettings : dict
         Dictionary of off-default settings to update
     """
@@ -90,8 +90,8 @@ def buildOperatorOfEmptyCartesianBlocks(customSettings=None):
 
     Doesn't depend on inputs and loads quickly.
 
-    Params
-    ------
+    Parameters
+    ----------
     customSettings : dict
         Off-default settings to update
     """

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""
-testing for reactors.py
-"""
+"""Testing for reactors.py."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
 import os
@@ -37,9 +35,9 @@ from armi.reactor.components import Hexagon, Rectangle
 from armi.reactor.converters import geometryConverters
 from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 from armi.reactor.flags import Flags
+from armi.settings.fwSettings.globalSettings import CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP
 from armi.tests import ARMI_RUN_PATH, mockRunLogs, TEST_ROOT
 from armi.utils import directoryChangers
-from armi.settings.fwSettings.globalSettings import CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP
 
 TEST_REACTOR = None  # pickled string of test reactor (for fast caching)
 
@@ -81,6 +79,7 @@ def buildOperatorOfEmptyHexBlocks(customSettings=None):
     a.add(b)
     a.spatialLocator = r.core.spatialGrid[1, 0, 0]
     o.r.core.add(a)
+    o.r.sort()
     return o
 
 
@@ -129,6 +128,7 @@ def buildOperatorOfEmptyCartesianBlocks(customSettings=None):
     a.add(b)
     a.spatialLocator = r.core.spatialGrid[1, 0, 0]
     o.r.core.add(a)
+    o.r.sort()
     return o
 
 
@@ -179,6 +179,7 @@ def loadTestReactor(
         assemblies.setAssemNumCounter(assemNum)
         settings.setMasterCs(o.cs)
         o.reattach(r, o.cs)
+        r.sort()
         return o, r
 
     cs = settings.Settings(fName=fName)
@@ -211,6 +212,7 @@ def loadTestReactor(
         # protocol=2 allows for classes with __slots__ but not __getstate__ to be pickled
         TEST_REACTOR = cPickle.dumps((o, o.r, assemblies.getAssemNum()), protocol=2)
 
+    o.r.sort()
     return o, o.r
 
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -36,6 +36,7 @@ from armi.reactor.converters import geometryConverters
 from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 from armi.reactor.flags import Flags
 from armi.settings.fwSettings.globalSettings import CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP
+from armi.settings.fwSettings.globalSettings import CONF_SORT_REACTOR
 from armi.tests import ARMI_RUN_PATH, mockRunLogs, TEST_ROOT
 from armi.utils import directoryChangers
 
@@ -92,7 +93,7 @@ def buildOperatorOfEmptyCartesianBlocks(customSettings=None):
     Params
     ------
     customSettings : dict
-        Dictionary of off-default settings to update
+        Off-default settings to update
     """
     settings.setMasterCs(None)  # clear
     cs = settings.Settings()  # fetch new
@@ -251,6 +252,25 @@ class HexReactorTests(ReactorTests):
         self.o, self.r = loadTestReactor(
             self.directoryChanger.destination, customSettings={"trackAssems": True}
         )
+
+    def test_factorySortSetting(self):
+        # get a sorted Reactor (the default)
+        cs = settings.Settings(fName="armiRun.yaml")
+        r0 = reactors.loadFromCs(cs)
+
+        # get an unsorted Reactor (for whatever reason)
+        customSettings = {CONF_SORT_REACTOR: False}
+        cs = cs.modified(newSettings=customSettings)
+        r1 = reactors.loadFromCs(cs)
+
+        # the reactor / core should be the same size
+        self.assertEqual(len(r0), len(r1))
+        self.assertEqual(len(r0.core), len(r1.core))
+
+        # the reactor / core should be in a different order
+        a0 = [a.name for a in r0.core]
+        a1 = [a.name for a in r1.core]
+        self.assertNotEqual(a0, a1)
 
     def test_getTotalParam(self):
         # verify that the block params are being read.

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -99,6 +99,7 @@ CONF_REALLY_SMALL_RUN = "reallySmallRun"
 CONF_RUN_TYPE = "runType"
 CONF_SKIP_CYCLES = "skipCycles"
 CONF_SMALL_RUN = "smallRun"
+CONF_SORT_REACTOR = "sortReactor"
 CONF_START_CYCLE = "startCycle"
 CONF_START_NODE = "startNode"
 CONF_STATIONARY_BLOCK_FLAGS = "stationaryBlockFlags"
@@ -688,6 +689,12 @@ def defineSettings() -> List[setting.Setting]:
             default=False,
             label="Clean Up Files at EOL",
             description="Clean up intermediate files after the run completes (EOL)",
+        ),
+        setting.Setting(
+            CONF_SORT_REACTOR,
+            default=True,
+            label="Do we want to automatically sort the Reactor?",
+            description="Deprecation Warning! This setting will be remove by 2024.",
         ),
         setting.Setting(
             CONF_REALLY_SMALL_RUN,

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -8,6 +8,7 @@ Release Date: TBD
 
 What's new in ARMI
 ------------------
+#. Added ``Composite.sort()`` to allow the user to recursively sort any piece of the ``Reactor``. (`PR#1280 <https://github.com/terrapower/armi/pull/1280>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

In #1018, it was noted that if you iterate through the parts of a Reactor using different helper methods, you get the reactor parts in different order. 

This is obviously not idea. But it was a side effect of an early attempt at sorting the Reactor pieces by over-riding the `__iter__()` method in the `Core` object:

https://github.com/terrapower/armi/blob/23bb1c3cd2b1322dafc4f025d7f9c5dbf11b3665/armi/reactor/reactors.py#L243-L251

I _like_ the idea of sorting the Reactor Composites (parts), but I don't like the inconsistency of iteration order that arrises.

My first idea was to force the Reactor to always be fully sorted. This seems ideal. But that leads to some REAL headaches every time someone tries to `Reactor.add()` or `Assembly.add()`.  Aside from slowing down the code, it means if you do a `Block.add()`, you need to reach up to the entire Reactor to re-sort it. And that kind of backwards code design leads to impenetrable nightmares of code. 

The solution given here means:

1. In 99% of cases, the Reactor will be fully sorted.
2. At any time, the user / developer can fully sort the Reactor (or any sub-part) with `x.sort()`.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
