### PR TITLE
Pinning the versions of yamlize and ruamel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Setup.py script for the Advanced Reactor Modeling Interface (ARMI)"""
+"""Setup.py script for the Advanced Reactor Modeling Interface (ARMI)."""
 from setuptools import setup, find_packages
 import os
 import pathlib
@@ -59,45 +59,46 @@ setup(
         "coverage<=6.5.0",
         "future",
         "h5py>=3.0",
+        "htmltree",
         "matplotlib",
         "numpy>=1.21,<=1.23.5",
         "ordered-set",
         "pillow",
         "pluggy",
+        "pyDOE",
         "pyevtk",
+        "ruamel.yaml<=0.17.21",
+        "ruamel.yaml.clib<=0.2.7",
         "scipy",
         "tabulate",
         "voluptuous",
         "xlrd",
-        "yamlize",
-        "htmltree",
-        "pyDOE",
+        "yamlize==0.7.1",
     ],
     extras_require={
         "mpi": ["mpi4py==3.0.3"],
         "grids": ["wxpython<=4.1.1"],
         "memprof": ["psutil"],
         "dev": [
-            "mako",
-            "pytest",
-            "pytest-xdist",
-            "pytest-cov",
-            "pytest-html",
-            "pylint",
-            "docutils",
-            "sphinx",
-            "sphinx-rtd-theme",
-            "click==8.0.1",  # fixing click problem in black
             "black==20.8b1",
-            # for running jupyter dynamically in docs
-            "sphinxcontrib-apidoc",
-            "jupyter_client",
-            "jupyter-contrib-nbextensions",
+            "click==8.0.1",  # fixing click problem in black
+            "docutils",
             "ipykernel",
+            "jupyter-contrib-nbextensions",
+            "jupyter_client",
+            "mako",
             "nbsphinx",
             "nbsphinx-link",
-            "sphinxext-opengraph",
+            "pylint",
+            "pytest",
+            "pytest-cov",
+            "pytest-html",
+            "pytest-xdist",
+            "sphinx",
             "sphinx-gallery",
+            "sphinx-rtd-theme",
+            "sphinxcontrib-apidoc",  # for running Jupyter in docs
+            "sphinxext-opengraph",
         ],
     },
     tests_require=["nbconvert", "jupyter_client", "ipykernel"],


### PR DESCRIPTION
## Description

Over the weekend, the ARMI unit tests broke. There were no commits, but it turns out our dependencies on `ruamel.yaml` and `ruamel.yaml.clib` were updated on pypi.org.  So we will need to pin (or partially) pin our YAML dependencies for our code to continue working.

We can look into supporting a wider range of `ruamel` versions, of course. But that will be somewhat longer term, so the changes to `ruamel.yaml` broke their API, so that would be a much bigger change.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
