### PR TITLE
Docstring Improvements - linting

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -102,13 +102,13 @@ _ignoreConfigures = False
 
 
 def disableFutureConfigures():
-    """Exposed function to ensure armi.configure() isn't called more than once"""
+    """Exposed function to ensure armi.configure() isn't called more than once."""
     global _ignoreConfigures
     _ignoreConfigures = True
 
 
 def isStableReleaseVersion(version=None):
-    """Determine if the version should be considered a stable release"""
+    """Determine if the version should be considered a stable release."""
     version = version or __version__
     return "-" not in version
 

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -303,8 +303,9 @@ class App:
         return self._pm.has_plugin(pluginName)
 
     def __registerUserPluginsAbsPath(self, pluginPath):
-        """Helper method to register a single UserPlugin where
-        the given path is of the form: /path/to/why.py:MyPlugin
+        """Helper method to register a single UserPlugin via absolute path.
+
+        Here the given path is of the form: /path/to/why.py:MyPlugin
         """
         assert pluginPath.count(".py:") == 1, f"Invalid plugin path: {pluginPath}"
 
@@ -326,8 +327,9 @@ class App:
             Flags.extend(newFlags)
 
     def __registerUserPluginsInternalImport(self, pluginPath):
-        """Helper method to register a single UserPlugin where
-        the given path is of the form: armi.thing.what.MyPlugin
+        """Helper method to register a single UserPlugin via internal import.
+
+        Here the given path is of the form: armi.thing.what.MyPlugin
         """
         names = pluginPath.strip().split(".")
         modPath = ".".join(names[:-1])

--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -62,7 +62,7 @@ from armi.reactor.composites import ArmiObject
 
 
 class OutputWriter:
-    """Basically a tee to writeln to runLog and the output file"""
+    """Basically a tee to writeln to runLog and the output file."""
 
     def __init__(self, fname):
         self.fname = fname
@@ -138,7 +138,7 @@ class DiffResults:
         return [None] * (len(self._columns) - 1)
 
     def reportDiffs(self, stream: OutputWriter) -> None:
-        """Print out a well-formatted table of the non-zero diffs"""
+        """Print out a well-formatted table of the non-zero diffs."""
         # filter out empty rows
         diffsToPrint = {
             key: value

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -377,7 +377,7 @@ class Database3:
         self._fileName = fName
 
     def loadCS(self):
-        """Attempt to load settings from the database file
+        """Attempt to load settings from the database file.
 
         Notes
         -----
@@ -402,7 +402,7 @@ class Database3:
         return cs
 
     def loadBlueprints(self):
-        """Attempt to load reactor blueprints from the database file
+        """Attempt to load reactor blueprints from the database file.
 
         Notes
         -----
@@ -528,7 +528,7 @@ class Database3:
                     destTs[key].attrs[attr] = "@{}".format(path)
 
     def __enter__(self):
-        """Context management support"""
+        """Context management support."""
         if self._openCount == 0:
             # open also increments _openCount
             self.open()
@@ -537,7 +537,7 @@ class Database3:
         return self
 
     def __exit__(self, type, value, traceback):
-        """Typically we don't care why it broke but we want the DB to close"""
+        """Typically we don't care why it broke but we want the DB to close."""
         self._openCount -= 1
         # always close if there is a traceback.
         if self._openCount == 0 or traceback:

--- a/armi/bookkeeping/db/databaseInterface.py
+++ b/armi/bookkeeping/db/databaseInterface.py
@@ -45,7 +45,7 @@ ORDER = interfaces.STACK_ORDER.BOOKKEEPING
 
 
 def describeInterfaces(cs):
-    """Function for exposing interface(s) to other code"""
+    """Function for exposing interface(s) to other code."""
     return (DatabaseInterface, {"enabled": cs["db"]})
 
 
@@ -98,7 +98,7 @@ class DatabaseInterface(interfaces.Interface):
             )
 
     def interactBOL(self):
-        """Initialize the database if the main interface was not available. (Begining of Life)"""
+        """Initialize the database if the main interface was not available. (Begining of Life)."""
         if not self._db:
             self.initDB()
 
@@ -156,7 +156,7 @@ class DatabaseInterface(interfaces.Interface):
         self.writeDBEveryNode(cycle, node)
 
     def writeDBEveryNode(self, cycle, node):
-        """write the database at the end of the time node"""
+        """write the database at the end of the time node."""
         # skip writing for last burn step since it will be written at interact EOC
         if node < self.o.burnSteps[cycle]:
             self.r.core.p.minutesSinceStart = (
@@ -167,7 +167,7 @@ class DatabaseInterface(interfaces.Interface):
                 self._db.syncToSharedFolder()
 
     def interactEOC(self, cycle=None):
-        """In case anything changed since last cycle (e.g. rxSwing), update DB. (End of Cycle)"""
+        """In case anything changed since last cycle (e.g. rxSwing), update DB. (End of Cycle)."""
         # We cannot presume whether we are at EOL based on cycle and cs["nCycles"],
         # since cs["nCycles"] is not a difinitive indicator of EOL; ultimately the
         # Operator has the final say.
@@ -178,7 +178,7 @@ class DatabaseInterface(interfaces.Interface):
             self._db.writeToDB(self.r)
 
     def interactEOL(self):
-        """DB's should be closed at run's end. (End of Life)"""
+        """DB's should be closed at run's end. (End of Life)."""
         # minutesSinceStarts should include as much of the ARMI run as possible so EOL
         # is necessary, too.
         self.r.core.p.minutesSinceStart = (time.time() - self.r.core.timeOfStart) / 60.0
@@ -186,7 +186,7 @@ class DatabaseInterface(interfaces.Interface):
         self._db.close(True)
 
     def interactError(self):
-        r"""Get shutdown state information even if the run encounters an error"""
+        r"""Get shutdown state information even if the run encounters an error."""
         try:
             self.r.core.p.minutesSinceStart = (
                 time.time() - self.r.core.timeOfStart

--- a/armi/bookkeeping/db/databaseInterface.py
+++ b/armi/bookkeeping/db/databaseInterface.py
@@ -156,7 +156,7 @@ class DatabaseInterface(interfaces.Interface):
         self.writeDBEveryNode(cycle, node)
 
     def writeDBEveryNode(self, cycle, node):
-        """write the database at the end of the time node."""
+        """Write the database at the end of the time node."""
         # skip writing for last burn step since it will be written at interact EOC
         if node < self.o.burnSteps[cycle]:
             self.r.core.p.minutesSinceStart = (

--- a/armi/bookkeeping/db/permissions.py
+++ b/armi/bookkeeping/db/permissions.py
@@ -14,7 +14,7 @@
 
 
 class Permissions:
-    """Mappings to HDF5 permissions flags"""
+    """Mappings to HDF5 permissions flags."""
 
     READ_ONLY_FME = "r"  # File Must Exist
     READ_WRITE_FME = "r+"  # File Must Exist

--- a/armi/bookkeeping/db/tests/__init__.py
+++ b/armi/bookkeeping/db/tests/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Database tests
+Database tests.
 """
 # Copyright 2009-2019 TerraPower, LLC
 #

--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the compareDB3 module"""
+"""Tests for the compareDB3 module."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import unittest
 
@@ -35,7 +35,7 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestCompareDB3(unittest.TestCase):
-    """Tests for the compareDB3 module"""
+    """Tests for the compareDB3 module."""
 
     def setUp(self):
         self.td = TemporaryDirectoryChanger()
@@ -95,7 +95,7 @@ class TestCompareDB3(unittest.TestCase):
         self.assertEqual(dr.nDiffs(), 10)
 
     def test_compareDatabaseDuplicate(self):
-        """end-to-end test of compareDatabases() on a photocopy database"""
+        """end-to-end test of compareDatabases() on a photocopy database."""
         # build two super-simple H5 files for testing
         o, r = test_reactors.loadTestReactor(
             TEST_ROOT, customSettings={"reloadDBName": "reloadingDB.h5"}
@@ -126,7 +126,7 @@ class TestCompareDB3(unittest.TestCase):
         self.assertEqual(diffs.nDiffs(), 0)
 
     def test_compareDatabaseSim(self):
-        """end-to-end test of compareDatabases() on very simlar databases"""
+        """end-to-end test of compareDatabases() on very simlar databases."""
         # build two super-simple H5 files for testing
         o, r = test_reactors.loadTestReactor(
             TEST_ROOT, customSettings={"reloadDBName": "reloadingDB.h5"}

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -31,7 +31,7 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestDatabase3(unittest.TestCase):
-    r"""Tests for the Database3 class."""
+    """Tests for the Database3 class."""
 
     def setUp(self):
         self.td = TemporaryDirectoryChanger()
@@ -542,7 +542,7 @@ class TestDatabase3(unittest.TestCase):
             )
 
     def test_grabLocalCommitHash(self):
-        """test of static method to grab a local commit hash with ARMI version."""
+        """Test of static method to grab a local commit hash with ARMI version."""
         # 1. test outside a Git repo
         localHash = database3.Database3.grabLocalCommitHash()
         self.assertEqual(localHash, "unknown")

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r""" Tests for the Database3 class"""
+r""" Tests for the Database3 class."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import subprocess
 import unittest
@@ -31,7 +31,7 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestDatabase3(unittest.TestCase):
-    r"""Tests for the Database3 class"""
+    r"""Tests for the Database3 class."""
 
     def setUp(self):
         self.td = TemporaryDirectoryChanger()
@@ -426,7 +426,7 @@ class TestDatabase3(unittest.TestCase):
 
     # TODO: This should be expanded.
     def test_replaceNones(self):
-        """Super basic test that we handle Nones correctly in database read/writes"""
+        """Super basic test that we handle Nones correctly in database read/writes."""
         data3 = numpy.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         data1 = numpy.array([1, 2, 3, 4, 5, 6, 7, 8])
         data1iNones = numpy.array([1, 2, None, 5, 6])
@@ -542,7 +542,7 @@ class TestDatabase3(unittest.TestCase):
             )
 
     def test_grabLocalCommitHash(self):
-        """test of static method to grab a local commit hash with ARMI version"""
+        """test of static method to grab a local commit hash with ARMI version."""
         # 1. test outside a Git repo
         localHash = database3.Database3.grabLocalCommitHash()
         self.assertEqual(localHash, "unknown")

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -100,7 +100,7 @@ class TestDatabaseInterface(unittest.TestCase):
         self.td.__exit__(None, None, None)
 
     def test_interactEveryNodeReturn(self):
-        """test that the DB is NOT written to if cs["tightCoupling"] = True."""
+        """Test that the DB is NOT written to if cs["tightCoupling"] = True."""
         self.o.cs["tightCoupling"] = True
         self.dbi.interactEveryNode(0, 0)
         self.assertFalse(self.dbi.database.hasTimeStep(0, 0))

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r""" Tests of the Database Interface"""
+"""Tests of the Database Interface."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-method-argument,import-outside-toplevel
 import os
 import types
@@ -82,7 +82,7 @@ class MockInterface(interfaces.Interface):
 
 
 class TestDatabaseInterface(unittest.TestCase):
-    r"""Tests for the DatabaseInterface class"""
+    """Tests for the DatabaseInterface class."""
 
     def setUp(self):
         self.td = directoryChangers.TemporaryDirectoryChanger()
@@ -100,7 +100,7 @@ class TestDatabaseInterface(unittest.TestCase):
         self.td.__exit__(None, None, None)
 
     def test_interactEveryNodeReturn(self):
-        """test that the DB is NOT written to if cs["tightCoupling"] = True"""
+        """test that the DB is NOT written to if cs["tightCoupling"] = True."""
         self.o.cs["tightCoupling"] = True
         self.dbi.interactEveryNode(0, 0)
         self.assertFalse(self.dbi.database.hasTimeStep(0, 0))
@@ -120,7 +120,7 @@ class TestDatabaseInterface(unittest.TestCase):
         self.assertEqual(self.dbi.distributable(), 4)
 
     def test_timeNodeLoop_tightCoupling(self):
-        """test that database is written out after the coupling loop has completed"""
+        """Test that database is written out after the coupling loop has completed."""
         # clear out interfaces (no need to run physics) but leave database
         self.o.interfaces = [self.dbi]
         self.o.cs["tightCoupling"] = True
@@ -294,7 +294,6 @@ class TestDatabaseReading(unittest.TestCase):
         cls.r = None
 
     def _fullCoreSizeChecker(self, r):
-        """TODO"""
         self.assertEqual(r.core.numRings, 3)
         self.assertEqual(r.p.cycle, 0)
         self.assertEqual(len(r.core.assembliesByName), 19)

--- a/armi/bookkeeping/db/tests/test_layout.py
+++ b/armi/bookkeeping/db/tests/test_layout.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r""" Tests for the db Layout and associated tools"""
+r""" Tests for the db Layout and associated tools."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import os
 import unittest
@@ -25,7 +25,7 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestLocationPacking(unittest.TestCase):
-    r"""Tests for database location"""
+    r"""Tests for database location."""
 
     def setUp(self):
         self.td = TemporaryDirectoryChanger()

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -216,9 +216,7 @@ class HistoryTrackerInterface(interfaces.Interface):
         return "{0}-{1}-{2}Hist.txt".format(self.cs.caseTitle, label, letter)
 
     def getTrackedParams(self):
-        """
-        Give the list of block parameters that are being tracked.
-        """
+        """Give the list of block parameters that are being tracked."""
         trackedParams = {"residence", "ztop", "zbottom"}
 
         # loop through interfaces to allow them to add custom params.
@@ -235,7 +233,7 @@ class HistoryTrackerInterface(interfaces.Interface):
             self.detailAssemblyNames.append(aName)
 
     def getDetailAssemblies(self):
-        r"""returns the assemblies that have been signaled as detail assemblies."""
+        """Returns the assemblies that have been signaled as detail assemblies."""
         assems = []
         if not self.detailAssemblyNames:
             runLog.info("No detail assemblies HistoryTrackerInterface")
@@ -425,7 +423,7 @@ class HistoryTrackerInterface(interfaces.Interface):
 
     def getTimeSteps(self, a=None):
         r"""
-        return list of time steps values (in years) that are available.
+        Return list of time steps values (in years) that are available.
 
         Parameters
         ----------

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -82,7 +82,7 @@ ORDER = 2 * interfaces.STACK_ORDER.BEFORE + interfaces.STACK_ORDER.BOOKKEEPING
 
 
 def describeInterfaces(cs):
-    """Function for exposing interface(s) to other code"""
+    """Function for exposing interface(s) to other code."""
     if cs["runType"] not in (operators.RunTypes.EQUILIBRIUM):
         klass = HistoryTrackerInterface
         return (klass, {})
@@ -193,7 +193,7 @@ class HistoryTrackerInterface(interfaces.Interface):
 
     def _writeDetailAssemblyHistories(self):
         """
-        Write data file with assembly histories
+        Write data file with assembly histories.
         """
         for a in self.getDetailAssemblies():
             self.writeAssemHistory(a)

--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -37,7 +37,7 @@ ORDER = interfaces.STACK_ORDER.PREPROCESSING
 
 
 def describeInterfaces(_cs):
-    """Function for exposing interface(s) to other code"""
+    """Function for exposing interface(s) to other code."""
     return (MainInterface, {"reverseAtEOL": True})
 
 

--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -124,7 +124,7 @@ class MainInterface(interfaces.Interface):
             raise InputError("Failed to process copyFilesTo/copyFilesFrom")
 
     def interactBOC(self, cycle=None):
-        r"""typically the first interface to interact beginning of cycle."""
+        """Typically the first interface to interact beginning of cycle."""
 
         runLog.important("Beginning of Cycle {0}".format(cycle))
         runLog.LOG.clearSingleWarnings()
@@ -195,8 +195,9 @@ class MainInterface(interfaces.Interface):
 
     # pylint: disable=no-self-use
     def cleanLastCycleFiles(self):
-        r"""Delete ARMI files from previous cycle that aren't necessary for the next cycle.
-        Unless you're doing reloads, of course."""
+        """Delete ARMI files from previous cycle that aren't necessary for the next cycle.
+        Unless you're doing reloads, of course.
+        """
         runLog.important("Cleaning ARMI files due to reallySmallRun option")
         for fileName in os.listdir(os.getcwd()):
             # clean MC**2 and REBUS inputs and outputs

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -64,7 +64,7 @@ REPORT_COUNT = 100000
 
 
 def describeInterfaces(cs):
-    """Function for exposing interface(s) to other code"""
+    """Function for exposing interface(s) to other code."""
     return (MemoryProfiler, {})
 
 
@@ -101,7 +101,7 @@ class MemoryProfiler(interfaces.Interface):
             mpiAction.broadcast().invoke(self.o, self.r, self.cs)
 
     def interactEOL(self):
-        r"""End of life hook. Good place to wrap up or print out summary outputs"""
+        r"""End of life hook. Good place to wrap up or print out summary outputs."""
         if self.cs["debugMem"]:
             mpiAction = ProfileMemoryUsageAction("EOL")
             mpiAction.broadcast().invoke(self.o, self.r, self.cs)
@@ -144,7 +144,7 @@ class MemoryProfiler(interfaces.Interface):
         runLog.important("SFP has {:4d} ArmiObjects".format(len(self.r.core.sfp)))
 
     def checkForDuplicateObjectsOnArmiModel(self, attrName, refObject):
-        """Scans thorugh ARMI model for duplicate objects"""
+        """Scans thorugh ARMI model for duplicate objects."""
         if self.r is None:
             return
         uniqueIds = set()
@@ -188,7 +188,7 @@ class MemoryProfiler(interfaces.Interface):
 
     def _printFullMemoryBreakdown(self, reportSize=True, printReferrers=False):
         """
-        looks for any class from any module in the garbage collector and prints their count and size
+        looks for any class from any module in the garbage collector and prints their count and size.
 
         Parameters
         ----------
@@ -241,7 +241,7 @@ class MemoryProfiler(interfaces.Interface):
 
     @staticmethod
     def getReferrers(obj):
-        """Print referrers in a useful way (as opposed to gigabytes of text"""
+        """Print referrers in a useful way (as opposed to gigabytes of text."""
         runLog.info("Printing first 100 character of first 100 referrers")
         for ref in gc.get_referrers(obj)[:100]:
             runLog.important("ref for {}: {}".format(obj, repr(ref)[:100]))

--- a/armi/bookkeeping/report/data.py
+++ b/armi/bookkeeping/report/data.py
@@ -27,7 +27,7 @@ from armi.bookkeeping.report import html
 #                REPORTS
 # --------------------------------------------
 class Report:
-    """Storage for data separated out for a particular kind of user"""
+    """Storage for data separated out for a particular kind of user."""
 
     # stubs for "further stylization" in the report package init
     groupsOrderFirst = []
@@ -40,7 +40,7 @@ class Report:
 
     @property
     def _groupRenderOrder(self):
-        """Helper method to the rendering methods on this class for rendering order of contained info"""
+        """Helper method to the rendering methods on this class for rendering order of contained info."""
         presentGroupsOrderFirst = [
             group for group in self.groupsOrderFirst if group in self.groups
         ]
@@ -65,7 +65,7 @@ class Report:
         return str_
 
     def addToReport(self, group, name, value):
-        """Inserts the datum into the correct group of the report"""
+        """Inserts the datum into the correct group of the report."""
         if group not in self.groups:
             self.groups[group] = copy.deepcopy(group)
         self.groups[group][name] = value
@@ -80,7 +80,7 @@ class Report:
             return None
 
     def writeHTML(self):
-        """Renders this report as a standalone HTML file"""
+        """Renders this report as a standalone HTML file."""
         filename = "{}.html".format(self.title)
         runLog.debug("Writing HTML document {}.".format(filename))
 
@@ -90,7 +90,7 @@ class Report:
         runLog.info("HTML document {} written".format(filename))
 
     def writeGroupsHTML(self, f):
-        """A helper method to the writeHTML method process
+        """A helper method to the writeHTML method process.
 
         Composes the group html content, intended for use in the midst of the html document generation
         """
@@ -149,7 +149,7 @@ class Report:
 #                GROUPS
 # --------------------------------------------
 class Group:
-    """Abstract class, when extended is used for storage for data within a report
+    """Abstract class, when extended is used for storage for data within a report.
 
     Only accepts things wrapped in the ReportDatum class
 
@@ -194,7 +194,7 @@ class Table(Group):
         self.header = header
 
     def __str__(self):
-        """Truer to content representation"""
+        """Truer to content representation."""
         # set up
         prototypical_data = list(self.data.values())[0]
         num_cols = len(prototypical_data) + 1
@@ -220,11 +220,7 @@ class Table(Group):
 
     @staticmethod
     def _lowerCaseSortForTuples(nameValPair):
-        """This unfortunate method is made so the sort in the __str__ method complies with cython and python,
-
-        previous attempts with lambdas have been unsuccessful in bridging the gap.
-
-        """
+        """Force the key in a key-value pair to lower case."""
         return nameValPair[0].lower()
 
     def __setitem__(self, name, value):
@@ -234,7 +230,6 @@ class Table(Group):
         Group.__setitem__(self, name, value)
 
     def writeHTML(self, f):
-
         with html.Table(f, attrs={"class": "table table-striped table-hover "}):
             with html.H4(f, attrs={"style": self.titleStyle}):
                 f.writeEscaped(self.title)
@@ -272,7 +267,6 @@ class Image(Group):
         if len(self.data.keys()) == 1:
 
             # single images don't get the standard Header as the same information is moved to it's Figure Caption
-
             with html.Img(
                 f,
                 attrs={

--- a/armi/bookkeeping/report/html.py
+++ b/armi/bookkeeping/report/html.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-HTML-formatted reports
+HTML-formatted reports.
 """
 import base64
 import datetime
@@ -177,7 +177,7 @@ class Link(Tag):
 
 
 def encode64(file_path):
-    """Return the embedded HTML src attribute for an image in base64"""
+    """Return the embedded HTML src attribute for an image in base64."""
     xtn = os.path.splitext(file_path)[1][1:]  # [1:] to cut out the period
     if xtn == "pdf":
         from armi import runLog

--- a/armi/bookkeeping/report/newReportUtils.py
+++ b/armi/bookkeeping/report/newReportUtils.py
@@ -627,7 +627,6 @@ def createDimensionReport(comp):
 def insertCoreAndAssemblyMaps(
     r, cs, report, blueprint, generateFullCoreMap=False, showBlockAxMesh=True
 ):
-
     r"""Create core and assembly design plots
 
     Parameters
@@ -639,7 +638,6 @@ def insertCoreAndAssemblyMaps(
     generateFullCoreMap : bool, default False
     showBlockAxMesh : bool, default True
     """
-
     assemPrototypes = set()
     for aKey in blueprint.assemDesigns.keys():
         assemPrototypes.add(blueprint.constructAssem(cs, name=aKey))

--- a/armi/bookkeeping/report/newReportUtils.py
+++ b/armi/bookkeeping/report/newReportUtils.py
@@ -56,7 +56,7 @@ def insertGeneralReportContent(cs, r, report, stage):
 
 
 def comprehensiveBOLContent(cs, r, report):
-    """Adds BOL content to the Comprehensive section of the report
+    """Adds BOL content to the Comprehensive section of the report.
 
     Parameters
     ----------
@@ -102,7 +102,7 @@ def insertDesignContent(r, report):
 
 
 def insertBlockDesignReport(blueprint, report, cs):
-    r"""Summarize the block designs from the loading file
+    r"""Summarize the block designs from the loading file.
 
     Parameters
     ----------
@@ -170,7 +170,7 @@ def insertBlockDesignReport(blueprint, report, cs):
 
 
 def insertCoreDesignReport(core, cs, report):
-    r"""Builds report to summarize core design inputs
+    r"""Builds report to summarize core design inputs.
 
     Parameters
     ----------
@@ -207,7 +207,7 @@ def _setGeneralCoreDesignData(cs, coreDesignTable):
 
 
 def _setGeneralCoreParametersData(core, cs, coreDesignTable):
-    """Sets the general Core Parameter Data
+    """Sets the general Core Parameter Data.
 
     Parameters
     ----------
@@ -316,7 +316,7 @@ def _setGeneralSimulationData(core, cs, coreDesignTable):
 
 def insertEndOfLifeContent(r, report):
     """
-    Generate End of Life Content for the report
+    Generate End of Life Content for the report.
 
     Parameters
     ----------
@@ -348,7 +348,7 @@ def insertEndOfLifeContent(r, report):
 
 
 def insertBlockDiagrams(cs, blueprint, report, cold):
-    """Adds Block Diagrams to the report
+    """Adds Block Diagrams to the report.
 
     Parameters
     ----------
@@ -389,7 +389,7 @@ def insertBlockDiagrams(cs, blueprint, report, cold):
 
 
 def insertMetaTable(cs, report):
-    """Generates part of the Settings table
+    """Generates part of the Settings table.
 
     Parameters
     ----------
@@ -409,7 +409,7 @@ def insertMetaTable(cs, report):
 
 
 def insertSettingsData(cs, report):
-    """Creates tableSections of Parameters (Case Parameters, Reactor Parameters, Case Controls and Snapshots of the run
+    """Creates tableSections of Parameters (Case Parameters, Reactor Parameters, Case Controls and Snapshots of the run.
 
     Parameters
     ----------
@@ -456,7 +456,7 @@ def insertSettingsData(cs, report):
 
 
 def getPinDesignTable(core):
-    """Summarizes Pin and Assembly Design for the input
+    """Summarizes Pin and Assembly Design for the input.
 
     Parameters
     ----------
@@ -521,7 +521,7 @@ def getPinDesignTable(core):
 
 def insertAreaFractionsReport(block, report):
     """
-    Adds to an Assembly Area Fractions
+    Adds to an Assembly Area Fractions.
 
     Adds to the table subsection of the Comprehensive Section
     of the report.
@@ -627,7 +627,7 @@ def createDimensionReport(comp):
 def insertCoreAndAssemblyMaps(
     r, cs, report, blueprint, generateFullCoreMap=False, showBlockAxMesh=True
 ):
-    r"""Create core and assembly design plots
+    r"""Create core and assembly design plots.
 
     Parameters
     ----------

--- a/armi/bookkeeping/report/newReports.py
+++ b/armi/bookkeeping/report/newReports.py
@@ -31,7 +31,7 @@ from armi import runLog
 
 
 class ReportContent:
-    """Holds the report contents"""
+    """Holds the report contents."""
 
     def __init__(self, title):
         self.title = title
@@ -119,7 +119,7 @@ class ReportContent:
             self.sections[key] = item
 
     def tableOfContents(self):
-        """Creates a Table of Contents at the top of the document that links to later Sections
+        """Creates a Table of Contents at the top of the document that links to later Sections.
 
         Parameters
         ----------
@@ -191,7 +191,7 @@ class ReportNode(ABC):
 
     @abstractmethod
     def render(self, level, idPrefix):
-        """Renders the section to a htmltree element for inserting into HTML document tree
+        """Renders the section to a htmltree element for inserting into HTML document tree.
 
         Parameters
         ----------
@@ -268,7 +268,7 @@ class Section(ReportNode):
         return self.title
 
     def render(self, level, idPrefix="") -> htmltree.HtmlElement:
-        """Renders a Section into the appropriate html representation
+        """Renders a Section into the appropriate html representation.
 
         Parameters
         ----------
@@ -306,7 +306,7 @@ class Section(ReportNode):
 
 class Image(ReportNode):
     """For Images within the report (such as Hexplots premade and not time dependent)
-    (For time dependent images see TimeSeries)
+    (For time dependent images see TimeSeries).
 
     Parameters
     ----------
@@ -340,7 +340,7 @@ class Image(ReportNode):
         return self.caption
 
     def render(self, level, idPrefix="") -> htmltree.HtmlElement:
-        """Wraps an image file into an html Img tag. (With caption included in the figure)"""
+        """Wraps an image file into an html Img tag. (With caption included in the figure)."""
 
         figure = htmltree.Figure()
         if self.encode:
@@ -355,7 +355,7 @@ class Image(ReportNode):
 
 
 class Table(ReportNode):
-    """For Table Objects that are then later converted to htmltree tables
+    """For Table Objects that are then later converted to htmltree tables.
 
     Parameters
     ----------
@@ -586,7 +586,7 @@ class ReportStage(Enum):
 
 
 def encode64(file_path):
-    """Encodes the contents of the file indicated by the path
+    """Encodes the contents of the file indicated by the path.
 
     Return
     ------

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -32,14 +32,14 @@ ORDER = interfaces.STACK_ORDER.BEFORE + interfaces.STACK_ORDER.BOOKKEEPING
 
 
 def describeInterfaces(cs):
-    """Function for exposing interface(s) to other code"""
+    """Function for exposing interface(s) to other code."""
     if cs["genReports"]:
         return (ReportInterface, {})
     return None
 
 
 class ReportInterface(interfaces.Interface):
-    """An interface to manage the use of the report system"""
+    """An interface to manage the use of the report system."""
 
     name = "report"
 
@@ -116,7 +116,7 @@ class ReportInterface(interfaces.Interface):
         reportingUtils.makeBlockDesignReport(self.r)
 
     def interactEOL(self):
-        """Adds the data to the report, and generates it"""
+        """Adds the data to the report, and generates it."""
         b = self.r.core.getFirstBlock(Flags.FUEL)
         b.setAreaFractionsReport()
 
@@ -167,7 +167,7 @@ class ReportInterface(interfaces.Interface):
     #        Misc Summaries
     # --------------------------------------------
     def writeRunSummary(self):
-        """Make a summary of the run"""
+        """Make a summary of the run."""
         # spent fuel pool report
         self.r.core.sfp.report()
         self.r.core.sfp.count()

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -14,7 +14,7 @@
 
 r"""
 A collection of miscellaneous functions used by ReportInterface to generate
-various reports
+various reports.
 """
 from copy import copy
 import collections
@@ -387,7 +387,7 @@ def _makeTotalAssemblyMassSummary(massSum):
 
 
 def writeCycleSummary(core):
-    r"""Prints a cycle summary to the runLog
+    r"""Prints a cycle summary to the runLog.
 
     Parameters
     ----------
@@ -407,7 +407,7 @@ def writeCycleSummary(core):
 
 
 def setNeutronBalancesReport(core):
-    """Determines the various neutron balances over the full core
+    """Determines the various neutron balances over the full core.
 
     Parameters
     ----------
@@ -547,7 +547,7 @@ def summarizePinDesign(core):
 
 
 def summarizePowerPeaking(core):
-    r"""prints reactor Fz, Fxy, Fq
+    r"""prints reactor Fz, Fxy, Fq.
 
     Parameters
     ----------
@@ -605,7 +605,7 @@ def summarizePower(core):
 
 
 def makeCoreDesignReport(core, cs):
-    r"""Builds report to summarize core design inputs
+    r"""Builds report to summarize core design inputs.
 
     Parameters
     ----------
@@ -808,7 +808,7 @@ def _setGeneralSimulationData(core, cs, coreDesignTable):
 
 
 def makeBlockDesignReport(r):
-    r"""Summarize the block designs from the loading file
+    r"""Summarize the block designs from the loading file.
 
     Parameters
     ----------
@@ -842,7 +842,7 @@ def makeBlockDesignReport(r):
 
 
 def _getComponentInputDimensions(cDesign):
-    """Get the input dimensions of a component and place them in a dictionary with labels and units"""
+    """Get the input dimensions of a component and place them in a dictionary with labels and units."""
     dims = collections.OrderedDict()
     dims["Shape"] = (cDesign.shape, "")
     dims["Material"] = (cDesign.material, "")
@@ -863,7 +863,7 @@ def _getComponentInputDimensions(cDesign):
 
 
 def makeCoreAndAssemblyMaps(r, cs, generateFullCoreMap=False, showBlockAxMesh=True):
-    r"""Create core and assembly design plots
+    r"""Create core and assembly design plots.
 
     Parameters
     ----------

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -547,7 +547,7 @@ def summarizePinDesign(core):
 
 
 def summarizePowerPeaking(core):
-    r"""prints reactor Fz, Fxy, Fq.
+    r"""Prints reactor Fz, Fxy, Fq.
 
     Parameters
     ----------
@@ -580,7 +580,7 @@ def summarizePowerPeaking(core):
 
 
 def summarizePower(core):
-    r"""provide an edit showing where the power is based on assembly types.
+    r"""Provide an edit showing where the power is based on assembly types.
 
     Parameters
     ----------

--- a/armi/bookkeeping/report/tests/test_newReport.py
+++ b/armi/bookkeeping/report/tests/test_newReport.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test new reports"""
+"""Test new reports."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import collections
 import os

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -134,7 +134,7 @@ class TestReport(unittest.TestCase):
 
 class TestReportInterface(unittest.TestCase):
     def test_printReports(self):
-        """testing printReports method."""
+        """Testing printReports method."""
         repInt = reportInterface.ReportInterface(None, None)
         rep = repInt.printReports()
 

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Really basic tests of the report Utils"""
+"""Really basic tests of the report Utils."""
 import logging
 import unittest
 
@@ -73,7 +73,7 @@ class TestReport(unittest.TestCase):
         self.assertIn("plain", data)
 
     def test_reactorSpecificReporting(self):
-        """Test a number of reporting utils that require reactor/core information"""
+        """Test a number of reporting utils that require reactor/core information."""
         o, r = loadTestReactor()
 
         with mockRunLogs.BufferLog() as mock:
@@ -134,7 +134,7 @@ class TestReport(unittest.TestCase):
 
 class TestReportInterface(unittest.TestCase):
     def test_printReports(self):
-        """testing printReports method"""
+        """testing printReports method."""
         repInt = reportInterface.ReportInterface(None, None)
         rep = repInt.printReports()
 

--- a/armi/bookkeeping/snapshotInterface.py
+++ b/armi/bookkeeping/snapshotInterface.py
@@ -37,12 +37,12 @@ ORDER = interfaces.STACK_ORDER.POSTPROCESSING
 
 
 def describeInterfaces(cs):
-    """Function for exposing interface(s) to other code"""
+    """Function for exposing interface(s) to other code."""
     return (SnapshotInterface, {})
 
 
 class SnapshotInterface(interfaces.Interface):
-    """Snapshot managerial interface"""
+    """Snapshot managerial interface."""
 
     name = "snapshot"
 
@@ -106,7 +106,7 @@ class SnapshotInterface(interfaces.Interface):
 
 def extractCycleNodeFromStamp(stamp):
     """
-    Returns cycle and node from a CCCNNN stamp
+    Returns cycle and node from a CCCNNN stamp.
 
     See Also
     --------

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests for memoryProfiler
+Tests for memoryProfiler.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import logging

--- a/armi/bookkeeping/tests/test_snapshot.py
+++ b/armi/bookkeeping/tests/test_snapshot.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test Snapshots"""
+"""Test Snapshots."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 

--- a/armi/bookkeeping/visualization/dumper.py
+++ b/armi/bookkeeping/visualization/dumper.py
@@ -27,11 +27,11 @@ class VisFileDumper(ABC):
     @abstractmethod
     def __enter__(self):
         """
-        Invoke initialize when entering a context manager
+        Invoke initialize when entering a context manager.
         """
 
     @abstractmethod
     def __exit__(self, type, value, traceback):
         """
-        Invoke initialize when entering a context manager
+        Invoke initialize when entering a context manager.
         """

--- a/armi/bookkeeping/visualization/tests/test_vis.py
+++ b/armi/bookkeeping/visualization/tests/test_vis.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test report visutalizaion"""
+"""Test report visutalizaion."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
@@ -32,7 +32,7 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 class TestVtkMesh(unittest.TestCase):
     """
-    Test the VtkMesh utility class
+    Test the VtkMesh utility class.
     """
 
     def test_testVtkMesh(self):
@@ -66,7 +66,7 @@ class TestVtkMesh(unittest.TestCase):
 
 class TestVisDump(unittest.TestCase):
     """
-    Test dumping a whole reactor and some specific block types
+    Test dumping a whole reactor and some specific block types.
     """
 
     @classmethod

--- a/armi/bookkeeping/visualization/tests/test_vis.py
+++ b/armi/bookkeeping/visualization/tests/test_vis.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test report visutalizaion."""
+"""Test report visualization."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -14,7 +14,7 @@
 
 r"""
 The ``Case`` object is responsible for running, and executing a set of user inputs.  Many
-entry points redirect into ``Case`` methods, such as ``clone``, ``compare``, and ``run``
+entry points redirect into ``Case`` methods, such as ``clone``, ``compare``, and ``run``.
 
 The ``Case`` object provides an abstraction around ARMI inputs to allow for manipulation and
 collection of cases.
@@ -212,7 +212,7 @@ class Case:
 
     def addExplicitDependency(self, case):
         """
-        Register an explicit dependency
+        Register an explicit dependency.
 
         When evaluating the ``dependency`` property, dynamic dependencies are probed
         using the current case settings and plugin hooks. Sometimes, it is necessary to

--- a/armi/cases/inputModifiers/inputModifiers.py
+++ b/armi/cases/inputModifiers/inputModifiers.py
@@ -74,7 +74,7 @@ class SamplingInputModifier(InputModifier):
     def __init__(
         self, name: str, paramType: str, bounds: list, independentVariable=None
     ):
-        """[summary]
+        """Constructor for the Sampling input modifier.
 
         Parameters
         ----------
@@ -116,7 +116,7 @@ class FullCoreModifier(InputModifier):
     """
 
     def __call__(self, cs, bp, geom):
-        """Core might be on a geom object or a grid blueprint"""
+        """Core might be on a geom object or a grid blueprint."""
         if geom:
             geom.growToFullCore()
         else:
@@ -127,9 +127,7 @@ class FullCoreModifier(InputModifier):
 
 
 class SettingsModifier(InputModifier):
-    """
-    Adjust setting to specified value.
-    """
+    """Adjust setting to specified value."""
 
     def __init__(self, settingName, value):
         InputModifier.__init__(self, independentVariable={settingName: value})

--- a/armi/cases/inputModifiers/neutronicsModifiers.py
+++ b/armi/cases/inputModifiers/neutronicsModifiers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Modifies inputs related to neutronics controls
+Modifies inputs related to neutronics controls.
 
 Notes
 -----

--- a/armi/cases/inputModifiers/tests/test_inputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_inputModifiers.py
@@ -174,7 +174,7 @@ class TestsuiteBuilderIntegrations(unittest.TestCase):
             self.assertTrue(os.path.exists("case-suite"))
 
     def test_bluePrintBlockModifier(self):
-        """test BluePrintBlockModifier with build suite naming function argument."""
+        """Test BluePrintBlockModifier with build suite naming function argument."""
         case_nbr = 1
         builder = suiteBuilder.FullFactorialSuiteBuilder(self.baseCase)
 

--- a/armi/cases/inputModifiers/tests/test_inputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_inputModifiers.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for input modifiers"""
+"""Unit tests for input modifiers."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 from ruamel import yaml
 import io
@@ -174,7 +174,7 @@ class TestsuiteBuilderIntegrations(unittest.TestCase):
             self.assertTrue(os.path.exists("case-suite"))
 
     def test_bluePrintBlockModifier(self):
-        """test BluePrintBlockModifier with build suite naming function argument"""
+        """test BluePrintBlockModifier with build suite naming function argument."""
         case_nbr = 1
         builder = suiteBuilder.FullFactorialSuiteBuilder(self.baseCase)
 
@@ -244,7 +244,7 @@ class NeutronicsKernelOpts(inputModifiers.InputModifier):
 
 
 class TestFullCoreModifier(unittest.TestCase):
-    """Ensure full core conversion works"""
+    """Ensure full core conversion works."""
 
     def test_fullCoreConversion(self):
         cs = settings.Settings(os.path.join(test_reactors.TEST_ROOT, "armiRun.yaml"))

--- a/armi/cases/inputModifiers/tests/test_pinTypeInputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_pinTypeInputModifiers.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for input modifiers"""
+"""Unit tests for input modifiers."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
 import unittest

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -14,7 +14,7 @@
 
 r"""
 The ``CaseSuite`` object is responsible for running, and executing a set of user inputs.  Many
-entry points redirect into ``CaseSuite`` methods, such as ``clone``, ``compare``, and ``submit``
+entry points redirect into ``CaseSuite`` methods, such as ``clone``, ``compare``, and ``submit``.
 
 Used in conjunction with the :py:class:`~armi.cases.case.Case` object, ``CaseSuite`` can
 be used to collect a series of cases
@@ -57,7 +57,7 @@ class CaseSuite:
 
     def add(self, case):
         """
-        Add a Case object to the CaseSuite
+        Add a Case object to the CaseSuite.
 
         Case objects within a CaseSuite must have unique ``title`` attributes, a
         KeyError will be raised

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for Case and CaseSuite objects"""
+"""Unit tests for Case and CaseSuite objects."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import copy
 import cProfile
@@ -84,7 +84,7 @@ assemblies: {}
 
 
 class TestArmiCase(unittest.TestCase):
-    """Class to tests armi.cases.Case methods"""
+    """Class to tests armi.cases.Case methods."""
 
     def test_summarizeDesign(self):
         """
@@ -257,7 +257,7 @@ class TestArmiCase(unittest.TestCase):
 
 
 class TestCaseSuiteDependencies(unittest.TestCase):
-    """CaseSuite tests"""
+    """CaseSuite tests."""
 
     def setUp(self):
         self.suite = cases.CaseSuite(settings.Settings())
@@ -275,7 +275,7 @@ class TestCaseSuiteDependencies(unittest.TestCase):
         self.suite.add(self.c2)
 
     def test_clone(self):
-        """if you pass an invalid path, the clone can't happen, but it won't do any damage either"""
+        """if you pass an invalid path, the clone can't happen, but it won't do any damage either."""
         with self.assertRaises(RuntimeError):
             _clone = self.suite.clone("test_clone")
 
@@ -478,7 +478,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
         self._backupApp = copy.deepcopy(getApp())
 
     def tearDown(self):
-        """Restore the App to its original state"""
+        """Restore the App to its original state."""
         import armi
 
         armi._app = self._backupApp

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -275,7 +275,7 @@ class TestCaseSuiteDependencies(unittest.TestCase):
         self.suite.add(self.c2)
 
     def test_clone(self):
-        """if you pass an invalid path, the clone can't happen, but it won't do any damage either."""
+        """If you pass an invalid path, the clone can't happen, but it won't do any damage either."""
         with self.assertRaises(RuntimeError):
             _clone = self.suite.clone("test_clone")
 

--- a/armi/cases/tests/test_suiteBuilder.py
+++ b/armi/cases/tests/test_suiteBuilder.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the SuiteBuilder"""
+"""Unit tests for the SuiteBuilder."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import unittest

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -107,7 +107,7 @@ class ArmiCLI:
     ARMI CLI -- The main entry point into ARMI. There are various commands
     available, to get help for the individual commands, run again with
     `<command> --help`. Generically, the CLI implements functions that already
-    exists within ARMI
+    exists within ARMI.
     """
 
     def __init__(self):
@@ -148,7 +148,7 @@ class ArmiCLI:
 
     @staticmethod
     def showVersion():
-        """Print the App name and version on the command line"""
+        """Print the App name and version on the command line."""
         from armi import getApp  # pylint: disable=import-outside-toplevel
 
         prog = context.APP_NAME

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -202,7 +202,7 @@ class ArmiCLI:
         return self.executeCommand(args.command, args.args)
 
     def executeCommand(self, command, args) -> Optional[int]:
-        r"""execute `command` with arguments `args`, return optional exit code."""
+        r"""Execute `command` with arguments `args`, return optional exit code."""
         command = command.lower()
         if command not in self._entryPoints:
             print(

--- a/armi/cli/compareCases.py
+++ b/armi/cli/compareCases.py
@@ -121,7 +121,7 @@ class CompareCases(EntryPoint):
 
 
 class CompareSuites(CompareCases):
-    """Do a case-by-case comparison between two CaseSuites"""
+    """Do a case-by-case comparison between two CaseSuites."""
 
     name = "compare-suites"
 

--- a/armi/cli/database.py
+++ b/armi/cli/database.py
@@ -26,7 +26,7 @@ from armi.utils.textProcessors import resolveMarkupInclusions
 
 
 class ConvertDB(EntryPoint):
-    """Convert databases between different versions"""
+    """Convert databases between different versions."""
 
     name = "convert-db"
     mode = context.Mode.BATCH

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -300,7 +300,7 @@ def storeBool(boolDefault, ep):
 def setSetting(ep):
     class _SetSettingAction(argparse.Action):
         """This class loads the command line supplied setting values into the
-        :py:data:`armi.settings.cs`
+        :py:data:`armi.settings.cs`.
         """
 
         def __call__(self, parser, namespace, values, option_string=None):
@@ -318,7 +318,7 @@ def setSetting(ep):
 def setCaseTitle(cs):
     class _SetCaseTitleAction(argparse.Action):
         """This class sets the case title to the supplied value of the
-        :py:data:`armi.settings.cs`
+        :py:data:`armi.settings.cs`.
         """
 
         def __call__(self, parser, namespace, value, option_string=None):
@@ -331,7 +331,7 @@ def setCaseTitle(cs):
 def loadSettings(cs):
     class LoadSettingsAction(argparse.Action):
         """This class loads the command line supplied settings file into the
-        :py:data:`armi.settings.cs`
+        :py:data:`armi.settings.cs`.
         """
 
         def __call__(self, parser, namespace, values, option_string=None):

--- a/armi/cli/gridGui.py
+++ b/armi/cli/gridGui.py
@@ -21,7 +21,7 @@ from armi.cli import entryPoint
 
 class GridGuiEntryPoint(entryPoint.EntryPoint):
     """
-    Load the grid editor GUI
+    Load the grid editor GUI.
     """
 
     name = "grids"

--- a/armi/cli/migrateInputs.py
+++ b/armi/cli/migrateInputs.py
@@ -24,7 +24,7 @@ from armi.utils import directoryChangers
 
 
 class MigrateInputs(EntryPoint):
-    """Migrate ARMI Inputs and/or outputs to Latest ARMI Code Base"""
+    """Migrate ARMI Inputs and/or outputs to Latest ARMI Code Base."""
 
     name = "migrate-inputs"
 
@@ -44,7 +44,7 @@ class MigrateInputs(EntryPoint):
 
     def invoke(self):
         """
-        Run the entry point
+        Run the entry point.
         """
         if self.args.settings_path:
             path, _fname = os.path.split(self.args.settings_path)

--- a/armi/cli/run.py
+++ b/armi/cli/run.py
@@ -17,7 +17,7 @@ from armi.cli.entryPoint import EntryPoint
 
 
 class RunEntryPoint(EntryPoint):
-    """Run an ARMI case"""
+    """Run an ARMI case."""
 
     name = "run"
     settingsArgument = "required"

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -329,7 +329,8 @@ class TestRunEntryPoint(unittest.TestCase):
         self.assertEqual(excinfo.exception.code, 0)
 
     def test_executeCommand(self):
-        """use executeCommand to call run,
+        """Use executeCommand to call run.
+
         But we expect it to fail because we provide a fictional settings YAML.
         """
         with self.assertRaises(SystemExit) as excinfo:

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Test for run cli entry point
+Test for run cli entry point.
 """
 # pylint: disable=protected-access,missing-function-docstring,missing-class-docstring
 from shutil import copyfile
@@ -330,7 +330,7 @@ class TestRunEntryPoint(unittest.TestCase):
 
     def test_executeCommand(self):
         """use executeCommand to call run,
-        But we expect it to fail because we provide a fictional settings YAML
+        But we expect it to fail because we provide a fictional settings YAML.
         """
         with self.assertRaises(SystemExit) as excinfo:
             # override the pytest args

--- a/armi/cli/tests/test_runSuite.py
+++ b/armi/cli/tests/test_runSuite.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test for runsuite cli entry point"""
+"""Test for runsuite cli entry point."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import io
 import sys
@@ -37,7 +37,7 @@ class TestRunSuiteSuite(unittest.TestCase):
         self.assertIn("run-suite", out.getvalue())
 
     def test_showVersion(self):
-        """Test the ArmiCLI.showVersion method"""
+        """Test the ArmiCLI.showVersion method."""
         origout = sys.stdout
         try:
             out = io.StringIO()

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -41,7 +41,7 @@ def pytest_sessionstart(session):
 
 def bootstrapArmiTestEnv():
     """
-    Perform ARMI config appropriate for running unit tests
+    Perform ARMI config appropriate for running unit tests.
 
     .. tip:: This can be imported and run from other ARMI applications
         for test support.

--- a/armi/context.py
+++ b/armi/context.py
@@ -287,7 +287,7 @@ def cleanAllArmiTempDirs(olderThanDays: int) -> None:
 
 def disconnectAllHdfDBs() -> None:
     """
-    Forcibly disconnect all instances of HdfDB objects
+    Forcibly disconnect all instances of HdfDB objects.
 
     Notes
     -----

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -209,7 +209,7 @@ class TightCoupler:
 
     @staticmethod
     def getListDimension(listToCheck: list, dim: int = 1) -> int:
-        """return the dimension of a python list
+        """return the dimension of a python list.
 
         Parameters
         ----------
@@ -252,7 +252,7 @@ class Interface:
     @classmethod
     def getInputFiles(cls, cs):  # pylint: disable=unused-argument
         """
-        Return a MergeableDict containing files that should be considered "input"
+        Return a MergeableDict containing files that should be considered "input".
         """
         return utils.MergeableDict()
 
@@ -313,7 +313,7 @@ class Interface:
         return "<Interface {0}>".format(self.name)
 
     def _checkSettings(self):
-        """Raises an exception if interface settings requirements are not met"""
+        """Raises an exception if interface settings requirements are not met."""
         pass
 
     def nameContains(self, name):
@@ -333,7 +333,7 @@ class Interface:
 
     def preDistributeState(self):  # pylint: disable=no-self-use
         """
-        Prepare for distribute state by returning all non-distributable attributes
+        Prepare for distribute state by returning all non-distributable attributes.
 
         Examples
         --------
@@ -342,12 +342,12 @@ class Interface:
         return {}
 
     def postDistributeState(self, toRestore):  # pylint: disable=no-self-use
-        """Restore non-distributable attributes after a distributeState"""
+        """Restore non-distributable attributes after a distributeState."""
         pass
 
     def attachReactor(self, o, r):
         """
-        Set this interfaces' reactor to the reactor passed in and sets default settings
+        Set this interfaces' reactor to the reactor passed in and sets default settings.
 
         Parameters
         ----------

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -209,7 +209,7 @@ class TightCoupler:
 
     @staticmethod
     def getListDimension(listToCheck: list, dim: int = 1) -> int:
-        """return the dimension of a python list.
+        """Return the dimension of a python list.
 
         Parameters
         ----------

--- a/armi/materials/__init__.py
+++ b/armi/materials/__init__.py
@@ -53,7 +53,7 @@ def setMaterialNamespaceOrder(order):
 
 def importMaterialsIntoModuleNamespace(path, name, namespace, updateSource=None):
     """
-    Import all Material subclasses into the top subpackage
+    Import all Material subclasses into the top subpackage.
 
     This allows devs to use ``from armi.materials import HT9``
     Disadvantage: pylint can't tell if the module is available here.

--- a/armi/materials/air.py
+++ b/armi/materials/air.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Simple air material"""
+"""Simple air material."""
 from armi.materials import material
 from armi.utils.units import getTk, G_PER_CM3_TO_KG_PER_M3
 
 
 class Air(material.Fluid):
     """
-    Dry, Near Sea Level
+    Dry, Near Sea Level.
 
     Correlations based off of values in Incropera, Frank P., et al.
     Fundamentals of heat and mass transfer. Vol. 5. New York: Wiley, 2002.
@@ -41,7 +41,7 @@ class Air(material.Fluid):
 
     def setDefaultMassFracs(self):
         """
-        Set mass fractions
+        Set mass fractions.
 
         Notes
         -----

--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -86,7 +86,7 @@ class Alloy200(Material):
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""
-        Returns instantaneous coefficient of thermal expansion of Alloy 200
+        Returns instantaneous coefficient of thermal expansion of Alloy 200.
 
         Parameters
         ----------

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -122,7 +122,7 @@ class B4C(material.Material):
     def setDefaultMassFracs(self) -> None:
         r"""B4C mass fractions. Using Natural B4C. 19.9% B-10/ 80.1% B-11
         Boron: 10.811 g/mol
-        Carbon:  12.0107 g/mol
+        Carbon:  12.0107 g/mol.
 
         4 moles of boron/1 mole of carbon
 
@@ -184,7 +184,7 @@ class B4C(material.Material):
         return material.Material.density(self, Tk, Tc) * self.theoreticalDensityFrac
 
     def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
-        """Boron carbide expansion. Very preliminary"""
+        """Boron carbide expansion. Very preliminary."""
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tc)
         deltaT = Tc - 25

--- a/armi/materials/be9.py
+++ b/armi/materials/be9.py
@@ -40,7 +40,7 @@ class Be9(Material):
         Finds the linear expansion coefficient of Be9. given T in C
         returns m/m-K
         Based on http://www-ferp.ucsd.edu/LIB/PROPS/PANOS/be.html
-        which is in turn based on Fusion Engineering and Design . FEDEEE 5(2), 141-234 (1987)
+        which is in turn based on Fusion Engineering and Design . FEDEEE 5(2), 141-234 (1987).
         """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tk)

--- a/armi/materials/caH2.py
+++ b/armi/materials/caH2.py
@@ -20,7 +20,7 @@ from armi.materials.material import SimpleSolid
 
 
 class CaH2(SimpleSolid):
-    """CalciumHydride"""
+    """CalciumHydride."""
 
     name = "CaH2"
 
@@ -51,7 +51,7 @@ class CaH2(SimpleSolid):
         self.setMassFrac("H", 0.047884869)
 
     def density(self, Tk=None, Tc=None):
-        """Mass density
+        """Mass density.
 
         http://en.wikipedia.org/wiki/Calcium_hydride
 

--- a/armi/materials/californium.py
+++ b/armi/materials/californium.py
@@ -31,6 +31,6 @@ class Californium(SimpleSolid):
 
     def density(self, Tk=None, Tc=None):
         """
-        https://en.wikipedia.org/wiki/Californium
+        https://en.wikipedia.org/wiki/Californium.
         """
         return 15.1  # g/cm3

--- a/armi/materials/copper.py
+++ b/armi/materials/copper.py
@@ -34,7 +34,7 @@ class Cu(Material):
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         """
-        Return the linear expansion percent for Copper
+        Return the linear expansion percent for Copper.
 
         Notes
         -----

--- a/armi/materials/cs.py
+++ b/armi/materials/cs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Cesium
+Cesium.
 """
 
 from armi.materials.material import Fluid
@@ -21,7 +21,7 @@ from armi.utils.units import getTk
 
 
 class Cs(Fluid):
-    """Cesium"""
+    """Cesium."""
 
     name = "Cs"
 

--- a/armi/materials/hafnium.py
+++ b/armi/materials/hafnium.py
@@ -29,6 +29,6 @@ class Hafnium(SimpleSolid):
 
     def density(self, Tk=None, Tc=None):
         r"""
-        http://www.lenntech.com/periodic/elements/hf.htm
+        http://www.lenntech.com/periodic/elements/hf.htm.
         """
         return 13.07

--- a/armi/materials/hastelloyN.py
+++ b/armi/materials/hastelloyN.py
@@ -22,7 +22,7 @@ from armi.utils.units import getTk, getTc
 
 class HastelloyN(Material):
     r"""
-    Hastelloy N alloy (UNS N10003)
+    Hastelloy N alloy (UNS N10003).
 
     .. [Haynes] Haynes International, H-2052D 2020
         (http://haynesintl.com/docs/default-source/pdfs/new-alloy-brochures/corrosion-resistant-alloys/brochures/n-brochure.pdf)
@@ -50,7 +50,7 @@ class HastelloyN(Material):
 
     def setDefaultMassFracs(self):
         r"""
-        Hastelloy N mass fractions
+        Hastelloy N mass fractions.
 
         From [Haynes]_.
         """
@@ -124,7 +124,7 @@ class HastelloyN(Material):
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         r"""
-        average thermal expansion dL/L. Used for computing hot dimensions
+        average thermal expansion dL/L. Used for computing hot dimensions.
 
         Parameters
         ----------

--- a/armi/materials/ht9.py
+++ b/armi/materials/ht9.py
@@ -43,7 +43,7 @@ class HT9(materials.Material):
 
     def setDefaultMassFracs(self):
         """
-        HT9 mass fractions
+        HT9 mass fractions.
 
         From E.2-1 of [MFH]_.
         https://www.osti.gov/biblio/1506477-metallic-fuels-handbook
@@ -72,7 +72,7 @@ class HT9(materials.Material):
 
     def thermalConductivity(self, Tk=None, Tc=None):
         """
-        Thermal conductivity in W/m-K)
+        Thermal conductivity in W/m-K).
 
         From [MFH]_, E.2.2.3, eq 5.
 

--- a/armi/materials/inconel.py
+++ b/armi/materials/inconel.py
@@ -49,7 +49,7 @@ class Inconel617(Inconel):
     """
     Note: historically the 'Inconel' material represented the high-nickel alloy
     Inconel 617. This material enables the user to know with certainty that
-    this material represents Inconel 617 and doesn't break any older models
+    this material represents Inconel 617 and doesn't break any older models.
     """
 
     name = "Inconel617"

--- a/armi/materials/inconel600.py
+++ b/armi/materials/inconel600.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Inconel600
+Inconel600.
 """
 import numpy
 
@@ -142,7 +142,7 @@ class Inconel600(Material):
     def polyfitLinearExpansionPercent(self, power=2):
         r"""
         Calculates the coefficients of a polynomial fit for linearExpansionPercent.
-        Based on data from http://www.specialmetals.com/documents/Inconel%20alloy%20600.pdf
+        Based on data from http://www.specialmetals.com/documents/Inconel%20alloy%20600.pdf.
 
         Uses mean CTE values to find percent thermal strain values. Fits a polynomial
         to the data set and returns the coefficients.
@@ -203,7 +203,7 @@ class Inconel600(Material):
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""
-        From http://www.specialmetals.com/documents/Inconel%20alloy%20600.pdf
+        From http://www.specialmetals.com/documents/Inconel%20alloy%20600.pdf.
 
         Using the correlation for linearExpansionPercent, the 2nd order polynomial is divided by 100 to convert
         from percent strain to strain, then differentiated with respect to temperature to find the correlation

--- a/armi/materials/inconel625.py
+++ b/armi/materials/inconel625.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Inconel625
+Inconel625.
 """
 import numpy
 
@@ -171,7 +171,7 @@ class Inconel625(Material):
     def polyfitLinearExpansionPercent(self, power=2):
         r"""
         Calculates the coefficients of a polynomial fit for linearExpansionPercent.
-        Based on data from http://www.specialmetals.com/assets/documents/alloys/inconel/inconel-alloy-625.pdf
+        Based on data from http://www.specialmetals.com/assets/documents/alloys/inconel/inconel-alloy-625.pdf.
 
         Uses mean CTE values to find percent thermal strain values. Fits a polynomial
         to the data set and returns the coefficients.
@@ -232,7 +232,7 @@ class Inconel625(Material):
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""
-        From http://www.specialmetals.com/assets/documents/alloys/inconel/inconel-alloy-625.pdf
+        From http://www.specialmetals.com/assets/documents/alloys/inconel/inconel-alloy-625.pdf.
 
         Using the correlation for linearExpansionPercent, the 2nd order polynomial is divided by 100 to convert
         from percent strain to strain, then differentiated with respect to temperature to find the correlation

--- a/armi/materials/inconel800.py
+++ b/armi/materials/inconel800.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Incoloy 800"""
+"""Incoloy 800."""
 
 from armi.materials.material import Material
 from armi.utils.units import getTc
@@ -20,7 +20,7 @@ from armi.utils.units import getTc
 
 class Inconel800(Material):
     r"""
-    Incoloy 800/800H (UNS N08800/N08810)
+    Incoloy 800/800H (UNS N08800/N08810).
 
     .. [SM] Special Metals - Incoloy alloy 800
         (https://www.specialmetals.com/assets/smc/documents/alloys/incoloy/incoloy-alloy-800.pdf)
@@ -31,7 +31,7 @@ class Inconel800(Material):
 
     def setDefaultMassFracs(self):
         r"""
-        Incoloy 800H mass fractions
+        Incoloy 800H mass fractions.
 
         From [SM]_.
         """
@@ -50,7 +50,7 @@ class Inconel800(Material):
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         r"""
-        average thermal expansion dL/L. Used for computing hot dimensions
+        average thermal expansion dL/L. Used for computing hot dimensions.
 
         Parameters
         ----------

--- a/armi/materials/inconelPE16.py
+++ b/armi/materials/inconelPE16.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Inconel PE16
+Inconel PE16.
 """
 
 from armi import runLog

--- a/armi/materials/inconelX750.py
+++ b/armi/materials/inconelX750.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Inconel X750
+Inconel X750.
 """
 import numpy
 
@@ -174,7 +174,7 @@ class InconelX750(Material):
     def polyfitLinearExpansionPercent(self, power=2):
         r"""
         Calculates the coefficients of a polynomial fit for linearExpansionPercent.
-        Based on data from http://www.specialmetals.com/documents/Inconel%20alloy%20X-750.pdf
+        Based on data from http://www.specialmetals.com/documents/Inconel%20alloy%20X-750.pdf.
 
         Uses mean CTE values to find percent thermal strain values. Fits a polynomial
         to the data set and returns the coefficients.
@@ -235,7 +235,7 @@ class InconelX750(Material):
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""
-        From http://www.specialmetals.com/documents/Inconel%20alloy%20X-750.pdf
+        From http://www.specialmetals.com/documents/Inconel%20alloy%20X-750.pdf.
 
         Using the correlation for linearExpansionPercent, the 2nd order polynomial is divided by 100 to convert
         from percent strain to strain, then differentiated with respect to temperature to find the correlation

--- a/armi/materials/lead.py
+++ b/armi/materials/lead.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Lead.
-"""
+"""Lead."""
 
 from armi.materials import material
 from armi.utils.units import getTk
@@ -30,27 +28,29 @@ class Lead(material.Fluid):
     }
 
     def volumetricExpansion(self, Tk=None, Tc=None):
-        r"""volumetric expansion inferred from density.
+        r"""Volumetric expansion inferred from density.
+
         NOT BASED ON MEASUREMENT.
-        Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
+        Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247
+        """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("volumetric expansion", Tk)
 
         return 1.0 / (9516.9 - Tk)
 
     def setDefaultMassFracs(self):
-        r"""mass fractions."""
+        r"""Mass fractions."""
         self.setMassFrac("PB", 1)
 
     def pseudoDensity(self, Tk=None, Tc=None):
-        r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
+        r"""Density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 
         return 11.367 - 0.0011944 * Tk  # pre-converted from kg/m^3 to g/cc
 
     def heatCapacity(self, Tk=None, Tc=None):
-        r"""heat ccapacity in J/kg/K from Sobolev."""
+        r"""Heat ccapacity in J/kg/K from Sobolev."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 

--- a/armi/materials/lead.py
+++ b/armi/materials/lead.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Lead
+Lead.
 """
 
 from armi.materials import material
@@ -21,7 +21,7 @@ from armi.utils.units import getTk
 
 
 class Lead(material.Fluid):
-    r"""Natural lead"""
+    r"""Natural lead."""
     name = "Lead"
     propertyValidTemperature = {
         "density": ((600, 1700), "K"),
@@ -32,25 +32,25 @@ class Lead(material.Fluid):
     def volumetricExpansion(self, Tk=None, Tc=None):
         r"""volumetric expansion inferred from density.
         NOT BASED ON MEASUREMENT.
-        Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
+        Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("volumetric expansion", Tk)
 
         return 1.0 / (9516.9 - Tk)
 
     def setDefaultMassFracs(self):
-        r"""mass fractions"""
+        r"""mass fractions."""
         self.setMassFrac("PB", 1)
 
     def pseudoDensity(self, Tk=None, Tc=None):
-        r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
+        r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 
         return 11.367 - 0.0011944 * Tk  # pre-converted from kg/m^3 to g/cc
 
     def heatCapacity(self, Tk=None, Tc=None):
-        r"""heat ccapacity in J/kg/K from Sobolev"""
+        r"""heat ccapacity in J/kg/K from Sobolev."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 

--- a/armi/materials/lead.py
+++ b/armi/materials/lead.py
@@ -50,7 +50,7 @@ class Lead(material.Fluid):
         return 11.367 - 0.0011944 * Tk  # pre-converted from kg/m^3 to g/cc
 
     def heatCapacity(self, Tk=None, Tc=None):
-        r"""Heat ccapacity in J/kg/K from Sobolev."""
+        r"""Heat capacity in J/kg/K from Sobolev."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 

--- a/armi/materials/leadBismuth.py
+++ b/armi/materials/leadBismuth.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Lead-Bismuth eutectic
+Lead-Bismuth eutectic.
 
 This is a great coolant for superfast neutron reactors. It's heavy though.
 """
@@ -25,7 +25,7 @@ from armi.utils.units import getTk
 
 
 class LeadBismuth(material.Fluid):
-    r"""Lead bismuth eutectic"""
+    r"""Lead bismuth eutectic."""
     name = "LeadBismuth"
     propertyValidTemperature = {
         "density": ((400, 1300), "K"),
@@ -36,12 +36,12 @@ class LeadBismuth(material.Fluid):
     }
 
     def setDefaultMassFracs(self):
-        r"""mass fractions"""
+        r"""mass fractions."""
         self.setMassFrac("PB", 0.445)
         self.setMassFrac("BI209", 0.555)
 
     def pseudoDensity(self, Tk=None, Tc=None):
-        r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
+        r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 
@@ -49,14 +49,14 @@ class LeadBismuth(material.Fluid):
 
     def dynamicVisc(self, Tk=None, Tc=None):
         r"""dynamic viscosity in Pa-s from Sobolev. Accessed online at
-        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12"""
+        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("dynamic visc", Tk)
 
         return 4.94e-4 * math.exp(754.1 / Tk)
 
     def heatCapacity(self, Tk=None, Tc=None):
-        r"""heat ccapacity in J/kg/K from Sobolev. Expected acuracy 5%"""
+        r"""heat ccapacity in J/kg/K from Sobolev. Expected acuracy 5%."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 
@@ -64,7 +64,7 @@ class LeadBismuth(material.Fluid):
 
     def thermalConductivity(self, Tk=None, Tc=None):
         r"""thermal conductivity in W/m/K from Sobolev. Accessed online at
-        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12"""
+        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tk)
 
@@ -73,7 +73,7 @@ class LeadBismuth(material.Fluid):
     def volumetricExpansion(self, Tk=None, Tc=None):
         r"""volumetric expansion inferred from density.
         NOT BASED ON MEASUREMENT.
-        Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247"""
+        Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("volumetric expansion", Tk)
 

--- a/armi/materials/leadBismuth.py
+++ b/armi/materials/leadBismuth.py
@@ -25,7 +25,8 @@ from armi.utils.units import getTk
 
 
 class LeadBismuth(material.Fluid):
-    r"""Lead bismuth eutectic."""
+    """Lead bismuth eutectic."""
+
     name = "LeadBismuth"
     propertyValidTemperature = {
         "density": ((400, 1300), "K"),
@@ -36,44 +37,52 @@ class LeadBismuth(material.Fluid):
     }
 
     def setDefaultMassFracs(self):
-        r"""mass fractions."""
+        r"""Mass fractions."""
         self.setMassFrac("PB", 0.445)
         self.setMassFrac("BI209", 0.555)
 
     def pseudoDensity(self, Tk=None, Tc=None):
-        r"""density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
+        r"""Density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 
         return 11.096 - 0.0013236 * Tk  # pre-converted from kg/m^3 to g/cc
 
     def dynamicVisc(self, Tk=None, Tc=None):
-        r"""dynamic viscosity in Pa-s from Sobolev. Accessed online at
-        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12."""
+        r"""Dynamic viscosity in Pa-s from Sobolev.
+
+        Accessed online at:
+        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12
+        """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("dynamic visc", Tk)
 
         return 4.94e-4 * math.exp(754.1 / Tk)
 
     def heatCapacity(self, Tk=None, Tc=None):
-        r"""heat ccapacity in J/kg/K from Sobolev. Expected acuracy 5%."""
+        r"""Heat ccapacity in J/kg/K from Sobolev. Expected acuracy 5%."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 
         return 159 - 2.72e-2 * Tk + 7.12e-6 * Tk ** 2
 
     def thermalConductivity(self, Tk=None, Tc=None):
-        r"""thermal conductivity in W/m/K from Sobolev. Accessed online at
-        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12."""
+        r"""Thermal conductivity in W/m/K from Sobolev.
+
+        Accessed online at:
+        http://www.oecd-nea.org/science/reports/2007/nea6195-handbook.html on 11/9/12
+        """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tk)
 
         return 2.45 * Tk / (86.334 + 0.0511 * Tk)
 
     def volumetricExpansion(self, Tk=None, Tc=None):
-        r"""volumetric expansion inferred from density.
+        r"""Volumetric expansion inferred from density.
+
         NOT BASED ON MEASUREMENT.
-        Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
+        Done by V. sobolev/ J Nucl Mat 362 (2007) 235-247
+        """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("volumetric expansion", Tk)
 

--- a/armi/materials/leadBismuth.py
+++ b/armi/materials/leadBismuth.py
@@ -60,7 +60,7 @@ class LeadBismuth(material.Fluid):
         return 4.94e-4 * math.exp(754.1 / Tk)
 
     def heatCapacity(self, Tk=None, Tc=None):
-        r"""Heat ccapacity in J/kg/K from Sobolev. Expected acuracy 5%."""
+        r"""Heat ccapacity in J/kg/K from Sobolev. Expected accuracy 5%."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 

--- a/armi/materials/lithium.py
+++ b/armi/materials/lithium.py
@@ -74,7 +74,7 @@ class Lithium(material.Fluid):
         return 1615.0  # K
 
     def thermalConductivity(self, Tk=None, Tc=None):
-        r"""Wikipedia"""
+        r"""Wikipedia."""
         return 84.8  # W/m-K
 
     def heatCapacity(self, Tk=None, Tc=None):

--- a/armi/materials/magnesium.py
+++ b/armi/materials/magnesium.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Magnesium"""
+"""Magnesium."""
 
 from armi.materials import material
 from armi.utils.units import getTk

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -137,7 +137,7 @@ class Material:
         self.cached[name] = val
 
     def duplicate(self):
-        r"""copy without needing a deepcopy."""
+        """Copy without needing a deepcopy."""
         m = self.__class__()
 
         m.massFrac = {}
@@ -151,8 +151,8 @@ class Material:
         return m
 
     def linearExpansion(self, Tk: float = None, Tc: float = None) -> float:
-        r"""
-        the instantaneous linear expansion coefficient (dL/L)/dT.
+        """
+        The instantaneous linear expansion coefficient (dL/L)/dT.
 
         This is used for reactivity coefficients, etc. but will not affect
         density or dimensions.
@@ -229,7 +229,7 @@ class Material:
         return 1.0 / (1 + dLL) ** 2
 
     def setDefaultMassFracs(self):
-        r"""mass fractions."""
+        r"""Mass fractions."""
         pass
 
     def setMassFrac(self, nucName: str, massFrac: float) -> None:
@@ -459,23 +459,21 @@ class Material:
         return self.density(Tk, Tc) * 1000.0
 
     def getCorrosionRate(self, Tk: float = None, Tc: float = None) -> float:
-        r"""
-        given a temperature, get the corrosion rate of the material.
-        """
+        """Given a temperature, get the corrosion rate of the material."""
         return 0.0
 
     def yieldStrength(self, Tk: float = None, Tc: float = None) -> float:
-        r"""returns yield strength at given T in MPa."""
+        """Returns yield strength at given T in MPa."""
         pass
 
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
-        r"""thermal conductivity in given T in K."""
+        """Thermal conductivity in given T in K."""
         pass
 
     def getProperty(
         self, propName: str, Tk: float = None, Tc: float = None, **kwargs
     ) -> float:
-        r"""gets properties in a way that caches them."""
+        """Gets properties in a way that caches them."""
         Tk = getTk(Tc, Tk)
 
         cached = self._getCached(propName)
@@ -525,7 +523,7 @@ class Material:
         return self.massFrac.get(nucName, 0.0)
 
     def clearMassFrac(self) -> None:
-        r"""zero out all nuclide mass fractions."""
+        r"""Zero out all nuclide mass fractions."""
         self.massFrac.clear()
 
     def removeNucMassFrac(self, nuc: str) -> None:
@@ -679,7 +677,7 @@ class Fluid(Material):
         return rho1 / rho0
 
     def linearExpansion(self, Tk=None, Tc=None):
-        """for void, lets just not allow temperature changes to change dimensions
+        """For void, lets just not allow temperature changes to change dimensions
         since it is a liquid it will fill its space."""
         return 0.0
 
@@ -846,7 +844,7 @@ class FuelMaterial(Material):
         densityTools.applyIsotopicsMix(self, class1Isotopics, class2Isotopics)
 
     def duplicate(self):
-        r"""copy without needing a deepcopy."""
+        r"""Copy without needing a deepcopy."""
         m = self.__class__()
 
         m.massFrac = {}

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -152,7 +152,7 @@ class Material:
 
     def linearExpansion(self, Tk: float = None, Tc: float = None) -> float:
         r"""
-        the instantaneous linear expansion coefficient (dL/L)/dT
+        the instantaneous linear expansion coefficient (dL/L)/dT.
 
         This is used for reactivity coefficients, etc. but will not affect
         density or dimensions.
@@ -229,7 +229,7 @@ class Material:
         return 1.0 / (1 + dLL) ** 2
 
     def setDefaultMassFracs(self):
-        r"""mass fractions"""
+        r"""mass fractions."""
         pass
 
     def setMassFrac(self, nucName: str, massFrac: float) -> None:
@@ -414,7 +414,7 @@ class Material:
 
     def pseudoDensityKgM3(self, Tk: float = None, Tc: float = None) -> float:
         """
-        Return density that preserves mass when thermally expanded in 2D in units of kg/m^3
+        Return density that preserves mass when thermally expanded in 2D in units of kg/m^3.
 
         See Also
         --------
@@ -460,16 +460,16 @@ class Material:
 
     def getCorrosionRate(self, Tk: float = None, Tc: float = None) -> float:
         r"""
-        given a temperature, get the corrosion rate of the material
+        given a temperature, get the corrosion rate of the material.
         """
         return 0.0
 
     def yieldStrength(self, Tk: float = None, Tc: float = None) -> float:
-        r"""returns yield strength at given T in MPa"""
+        r"""returns yield strength at given T in MPa."""
         pass
 
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
-        r"""thermal conductivity in given T in K"""
+        r"""thermal conductivity in given T in K."""
         pass
 
     def getProperty(
@@ -714,7 +714,7 @@ class Fluid(Material):
 
 class SimpleSolid(Material):
     """
-    Base material for a simple material that primarily defines density
+    Base material for a simple material that primarily defines density.
 
     See Also
     --------

--- a/armi/materials/mgO.py
+++ b/armi/materials/mgO.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 """
-Magnesium Oxide
+Magnesium Oxide.
 """
 from armi.utils.units import getTc, getTk
 from armi.materials.material import Material
 
 
 class MgO(Material):
-    r"""MagnesiumOxide"""
+    r"""MagnesiumOxide."""
     name = "MgO"
     propertyValidTemperature = {
         "density": ((273, 1273), "K"),

--- a/armi/materials/mixture.py
+++ b/armi/materials/mixture.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Homogenized mixture material
+Homogenized mixture material.
 """
 
 from armi import materials
@@ -21,7 +21,7 @@ from armi import materials
 
 class _Mixture(materials.Material):
     """
-    Homogenized mixture of materials
+    Homogenized mixture of materials.
 
     .. warning:: This class is meant to be used for homogenized block models for neutronics and other
        physics solvers.

--- a/armi/materials/molybdenum.py
+++ b/armi/materials/molybdenum.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Molybdenum
+Molybdenum.
 """
 
 from armi.materials.material import SimpleSolid

--- a/armi/materials/mox.py
+++ b/armi/materials/mox.py
@@ -167,7 +167,7 @@ class MOX(UraniumOxide):
 
     def meltingPoint(self):
         """
-        Melting point in K - ORNL/TM-2000/351
+        Melting point in K - ORNL/TM-2000/351.
 
         Melting point is a function of PuO2 mol fraction.
         The liquidus Tl and solidus Ts temperatures in K are given by:

--- a/armi/materials/nZ.py
+++ b/armi/materials/nZ.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Niobium Zirconium Alloy
+Niobium Zirconium Alloy.
 """
 
 from armi.materials.material import SimpleSolid

--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Potassium"""
+"""Potassium."""
 
 from armi.materials import material
 from armi.utils.units import getTc, getTk

--- a/armi/materials/scandiumOxide.py
+++ b/armi/materials/scandiumOxide.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Scandium Oxide"""
+"""Scandium Oxide."""
 
 from armi.materials.material import Material
 from armi.utils.units import getTk

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Silicon Carbide
+Silicon Carbide.
 """
 
 import math
@@ -25,7 +25,7 @@ from armi.utils.units import getTc
 
 
 class SiC(Material):
-    r"""Silicon Carbide"""
+    r"""Silicon Carbide."""
     name = "SiC"
     thermalScatteringLaws = (
         tsl.byNbAndCompound[nb.byName["C"], tsl.SIC],

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Simple sodium material"""
+"""Simple sodium material."""
 
 from armi import runLog
 from armi.materials import material
@@ -42,7 +42,7 @@ class Sodium(material.Fluid):
     }
 
     def setDefaultMassFracs(self):
-        """It's just sodium"""
+        """It's just sodium."""
         self.setMassFrac("NA", 1.0)
         self.refDens = 0.968
 
@@ -111,7 +111,7 @@ class Sodium(material.Fluid):
 
     def thermalConductivity(self, Tk=None, Tc=None):
         """
-        Returns thermal conductivity of Sodium
+        Returns thermal conductivity of Sodium.
 
         From [ANL-RE-95-2]_, Table 2.1-2
 

--- a/armi/materials/sodiumChloride.py
+++ b/armi/materials/sodiumChloride.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Sodium Chloride salt
+Sodium Chloride salt.
 
 .. note:: This is a very simple description of this material.
 """

--- a/armi/materials/sulfur.py
+++ b/armi/materials/sulfur.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Sulfur
+Sulfur.
 """
 
 from armi import runLog
@@ -51,7 +51,7 @@ class Sulfur(material.Fluid):
         self.fullDensFrac = float(TD)
 
     def setDefaultMassFracs(self):
-        """Mass fractions"""
+        """Mass fractions."""
         self.fullDensFrac = 1.0
         self.setMassFrac("S32", 0.9493)
         self.setMassFrac("S33", 0.0076)

--- a/armi/materials/tZM.py
+++ b/armi/materials/tZM.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""TZM"""
+"""TZM."""
 from numpy import interp
 
 from armi.materials.material import Material

--- a/armi/materials/tantalum.py
+++ b/armi/materials/tantalum.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tantalum"""
+"""Tantalum."""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/tests/test_air.py
+++ b/armi/materials/tests/test_air.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""unit tests for air materials"""
+"""unit tests for air materials."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 
 import math
@@ -180,7 +180,7 @@ REFERENCE_THERMAL_CONDUCTIVITY_mJ_PER_M_K = [
 
 class Test_Air(unittest.TestCase):
     """
-    unit tests for air materials
+    unit tests for air materials.
     """
 
     def test_pseudoDensity(self):

--- a/armi/materials/tests/test_b4c.py
+++ b/armi/materials/tests/test_b4c.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Tests for boron carbide
+Tests for boron carbide.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest

--- a/armi/materials/tests/test_be9.py
+++ b/armi/materials/tests/test_be9.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit test for Beryllium"""
+"""Unit test for Beryllium."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
@@ -20,7 +20,7 @@ from armi.materials.tests import test_materials
 
 
 class Test_Be9(test_materials._Material_Test, unittest.TestCase):
-    """Be tests"""
+    """Be tests."""
 
     MAT_CLASS = Be9
 

--- a/armi/materials/tests/test_graphite.py
+++ b/armi/materials/tests/test_graphite.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Tests for graphite material
+Tests for graphite material.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
@@ -48,7 +48,7 @@ class Graphite_TestCase(unittest.TestCase):
     def test_density(self):
         """
         test to reproduce density measurements results in table 2 from
-        [INL-EXT-16-38241]
+        [INL-EXT-16-38241].
         """
         uncertainty = 0.01
 

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""Tests materials.py"""
+r"""Tests materials.py."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,invalid-name
 
 import math
@@ -47,7 +47,7 @@ class _Material_Test:
         )
 
     def test_density(self):
-        """Test that all materials produce a zero density from density"""
+        """Test that all materials produce a zero density from density."""
         self.assertNotEqual(self.mat.density(500), 0)
 
     def test_TD(self):
@@ -667,7 +667,7 @@ class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
     def test_heatCapacity(self):
-        """Check against Figure 4.2 from ORNL 2000-1723 EFG"""
+        """Check against Figure 4.2 from ORNL 2000-1723 EFG."""
         self.assertAlmostEqual(self.mat.heatCapacity(300), 230.0, delta=20)
         self.assertAlmostEqual(self.mat.heatCapacity(1000), 320.0, delta=20)
         self.assertAlmostEqual(self.mat.heatCapacity(2000), 380.0, delta=20)
@@ -820,7 +820,7 @@ class Void_TestCase(_Material_Test, unittest.TestCase):
 
     def test_density(self):
         """
-        this material has no density function
+        this material has no density function.
         """
         self.assertEqual(self.mat.density(500), 0)
 
@@ -842,7 +842,7 @@ class Mixture_TestCase(_Material_Test, unittest.TestCase):
 
     def test_density(self):
         """
-        this material has no density function
+        this material has no density function.
         """
         self.assertEqual(self.mat.density(500), 0)
 
@@ -1603,7 +1603,7 @@ class Alloy200_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Alloy200
 
     def test_nickleContent(self):
-        """Assert alloy 200 has more than 99% nickle per its spec"""
+        """Assert alloy 200 has more than 99% nickle per its spec."""
         self.assertGreater(self.mat.massFrac["NI"], 0.99)
 
     def test_linearExpansion(self):

--- a/armi/materials/tests/test_sic.py
+++ b/armi/materials/tests/test_sic.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test for SiC"""
+"""Test for SiC."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
@@ -20,7 +20,7 @@ from armi.materials.tests import test_materials
 
 
 class Test_SiC(test_materials._Material_Test, unittest.TestCase):
-    """SiC tests"""
+    """SiC tests."""
 
     MAT_CLASS = SiC
 

--- a/armi/materials/tests/test_thoriumOxide.py
+++ b/armi/materials/tests/test_thoriumOxide.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Tests for ThO2
+Tests for ThO2.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest

--- a/armi/materials/tests/test_water.py
+++ b/armi/materials/tests/test_water.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""unit tests for water materials"""
+"""unit tests for water materials."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 from armi.materials.water import SaturatedWater, SaturatedSteam
@@ -20,12 +20,13 @@ from armi.materials.water import SaturatedWater, SaturatedSteam
 
 class Test_Water(unittest.TestCase):
     """
-    unit tests for water materials
+    Unit tests for water materials.
     """
 
     def test_water_at_freezing(self):
         """
-        Reproduce verification results from IAPWS-IF97 for water at 0C
+        Reproduce verification results from IAPWS-IF97 for water at 0C.
+
         http://www.iapws.org/relguide/supsat.pdf
         """
         water = SaturatedWater()
@@ -80,10 +81,10 @@ class Test_Water(unittest.TestCase):
 
     def test_water_at_boiling(self):
         """
-        Reproduce verification results from IAPWS-IF97 for water at 100C
+        Reproduce verification results from IAPWS-IF97 for water at 100C.
+
         http://www.iapws.org/relguide/supsat.pdf
         """
-
         water = SaturatedWater()
         steam = SaturatedSteam()
 
@@ -138,10 +139,10 @@ class Test_Water(unittest.TestCase):
 
     def test_water_at_critcalPoint(self):
         """
-        Reproduce verification results from IAPWS-IF97 for water at 647.096K
+        Reproduce verification results from IAPWS-IF97 for water at 647.096K.
+
         http://www.iapws.org/relguide/supsat.pdf
         """
-
         water = SaturatedWater()
         steam = SaturatedSteam()
 

--- a/armi/materials/thU.py
+++ b/armi/materials/thU.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Thorium Uranium metal
+Thorium Uranium metal.
 
 Data is from [#IAEA-TECDOCT-1450]_.
 
@@ -58,16 +58,16 @@ class ThU(FuelMaterial):
         self.setMassFrac("U233", 0.0)
 
     def linearExpansion(self, Tk=None, Tc=None):
-        r"""m/m/K from IAEA TE 1450"""
+        r"""m/m/K from IAEA TE 1450."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion", Tk)
         return 11.9e-6
 
     def thermalConductivity(self, Tk=None, Tc=None):
-        r"""W/m-K from IAEA TE 1450"""
+        r"""W/m-K from IAEA TE 1450."""
         Tk = getTk(Tc, Tk)
         return 43.1
 
     def meltingPoint(self):
-        r"""melting point in K from IAEA TE 1450"""
+        r"""melting point in K from IAEA TE 1450."""
         return 2025.0

--- a/armi/materials/thU.py
+++ b/armi/materials/thU.py
@@ -64,7 +64,7 @@ class ThU(FuelMaterial):
         return 11.9e-6
 
     def thermalConductivity(self, Tk=None, Tc=None):
-        """Thermal conductivityW/m-K from IAEA TE 1450."""
+        """Thermal conductivity in W/m-K from IAEA TE 1450."""
         Tk = getTk(Tc, Tk)
         return 43.1
 

--- a/armi/materials/thU.py
+++ b/armi/materials/thU.py
@@ -21,9 +21,9 @@ Data is from [#IAEA-TECDOCT-1450]_.
     https://www-pub.iaea.org/mtcd/publications/pdf/te_1450_web.pdf
 """
 
-from armi.utils.units import getTk
-from armi.materials.material import FuelMaterial
 from armi import runLog
+from armi.materials.material import FuelMaterial
+from armi.utils.units import getTk
 
 
 class ThU(FuelMaterial):
@@ -33,7 +33,7 @@ class ThU(FuelMaterial):
 
     def __init__(self):
         FuelMaterial.__init__(self)
-        """g/cc from IAEA TE 1450"""
+        # density in g/cc from IAEA TE 1450
         self.refDens = 11.68
 
     def getEnrichment(self):
@@ -58,16 +58,16 @@ class ThU(FuelMaterial):
         self.setMassFrac("U233", 0.0)
 
     def linearExpansion(self, Tk=None, Tc=None):
-        r"""m/m/K from IAEA TE 1450."""
+        """Linear expansion in m/m/K from IAEA TE 1450."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion", Tk)
         return 11.9e-6
 
     def thermalConductivity(self, Tk=None, Tc=None):
-        r"""W/m-K from IAEA TE 1450."""
+        """Thermal conductivityW/m-K from IAEA TE 1450."""
         Tk = getTk(Tc, Tk)
         return 43.1
 
     def meltingPoint(self):
-        r"""melting point in K from IAEA TE 1450."""
+        """Melting point in K from IAEA TE 1450."""
         return 2025.0

--- a/armi/materials/thorium.py
+++ b/armi/materials/thorium.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Thorium Metal
+Thorium Metal.
 
 Data is from [#IAEA-TECDOCT-1450]_.
 
@@ -36,16 +36,16 @@ class Thorium(FuelMaterial):
         self.setMassFrac("TH232", 1.0)
 
     def linearExpansion(self, Tk=None, Tc=None):
-        r"""m/m/K from IAEA TECDOC 1450"""
+        r"""m/m/K from IAEA TECDOC 1450."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion", Tk)
 
         return 11.9e-6
 
     def thermalConductivity(self, Tk=None, Tc=None):
-        r"""W/m-K from IAEA TE 1450"""
+        r"""W/m-K from IAEA TE 1450."""
         return 43.1
 
     def meltingPoint(self):
-        r"""melting point in K from IAEA TE 1450"""
+        r"""melting point in K from IAEA TE 1450."""
         return 2025.0

--- a/armi/materials/thorium.py
+++ b/armi/materials/thorium.py
@@ -36,7 +36,7 @@ class Thorium(FuelMaterial):
         self.setMassFrac("TH232", 1.0)
 
     def linearExpansion(self, Tk=None, Tc=None):
-        r"""m/m/K from IAEA TECDOC 1450."""
+        r"""Linear Expansion in m/m/K from IAEA TECDOC 1450."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion", Tk)
 
@@ -47,5 +47,5 @@ class Thorium(FuelMaterial):
         return 43.1
 
     def meltingPoint(self):
-        r"""melting point in K from IAEA TE 1450."""
+        r"""Melting point in K from IAEA TE 1450."""
         return 2025.0

--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -58,7 +58,8 @@ class ThoriumOxide(FuelMaterial, SimpleSolid):
         FuelMaterial.applyInputParams(self, *args, **kwargs)
 
     def setDefaultMassFracs(self):
-        r"""ThO2 mass fractions. Using Pure Th-232. 100% 232
+        r"""ThO2 mass fractions. Using Pure Th-232. 100% 232.
+
         Thorium: 232.030806 g/mol
         Oxygen:  15.9994 g/mol
 
@@ -73,7 +74,7 @@ class ThoriumOxide(FuelMaterial, SimpleSolid):
         self.setMassFrac("O16", 0.1212)
 
     def linearExpansion(self, Tk=None, Tc=None):
-        r"""m/m/K from IAEA TE 1450"""
+        r"""Linear expansion in m/m/K from IAEA TE 1450."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion", Tk)
 
@@ -90,11 +91,11 @@ class ThoriumOxide(FuelMaterial, SimpleSolid):
         return 100 * (linearExpansionCoef * (Tk - 298))
 
     def thermalConductivity(self, Tk=None, Tc=None):
-        r"""W/m-K from IAEA TE 1450"""
+        r"""W/m-K from IAEA TE 1450."""
         return 6.20
 
     def meltingPoint(self):
-        r"""melting point in K from IAEA TE 1450"""
+        r"""Melting point in K from IAEA TE 1450."""
         return 3643.0
 
     def density(self, Tk=None, Tc=None):

--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -91,7 +91,7 @@ class ThoriumOxide(FuelMaterial, SimpleSolid):
         return 100 * (linearExpansionCoef * (Tk - 298))
 
     def thermalConductivity(self, Tk=None, Tc=None):
-        r"""W/m-K from IAEA TE 1450."""
+        r"""Thermal conductivity in W/m-K from IAEA TE 1450."""
         return 6.20
 
     def meltingPoint(self):

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Uranium Thorium Zirconium alloy metal
+Uranium Thorium Zirconium alloy metal.
 """
 from armi.utils.units import getTk
 from armi.materials.material import FuelMaterial
@@ -39,7 +39,7 @@ class UThZr(FuelMaterial):
         FuelMaterial.applyInputParams(self, *args, **kwargs)
 
     def setDefaultMassFracs(self):
-        r"""U-ZR mass fractions"""
+        r"""U-ZR mass fractions."""
         self.setMassFrac("U238", 0.8)
         self.setMassFrac("U235", 0.1)
         self.setMassFrac("ZR", 0.09999)
@@ -49,7 +49,7 @@ class UThZr(FuelMaterial):
         self.thFrac = 0.00001
 
     def pseudoDensity(self, Tk=None, Tc=None):
-        """Calculate the mass density in g/cc of U-Zr alloy with various percents"""
+        """Calculate the mass density in g/cc of U-Zr alloy with various percents."""
         zrFrac = self.zrFrac
         thFrac = self.thFrac
         uFrac = 1 - zrFrac - thFrac

--- a/armi/materials/uZr.py
+++ b/armi/materials/uZr.py
@@ -50,7 +50,7 @@ class UZr(material.FuelMaterial):
         material.Material.__init__(self)
 
     def setDefaultMassFracs(self):
-        r"""U-Pu-Zr mass fractions"""
+        r"""U-Pu-Zr mass fractions."""
         u235Enrichment = 0.1
         self.uFrac = self.uFracDefault
         self.zrFrac = self.zrFracDefault
@@ -75,7 +75,7 @@ class UZr(material.FuelMaterial):
 
     def _calculateReferenceDensity(self):
         """
-        Calculates the reference mass density in g/cc of a U-Pu-Zr alloy at 293K with Vergard's law
+        Calculates the reference mass density in g/cc of a U-Pu-Zr alloy at 293K with Vergard's law.
 
         .. warning:: the zrFrac, uFrac, etc. may seem redundant with massFrac data.
             But it's complicated to update material fractions one at a time when density

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Uranium metal
+Uranium metal.
 
 Much info is from [AAAFuels]_.
 
@@ -226,7 +226,7 @@ class Uranium(FuelMaterial):
         return kU
 
     def heatCapacity(self, Tk: float = None, Tc: float = None) -> float:
-        """Heat capacity in J/kg-K"""
+        """Heat capacity in J/kg-K."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 
@@ -270,29 +270,29 @@ class Uranium(FuelMaterial):
         FuelMaterial.applyInputParams(self, *args, **kwargs)
 
     def meltingPoint(self):
-        """Melting point in K"""
+        """Melting point in K."""
         return 1408
 
     def density(self, Tk: float = None, Tc: float = None) -> float:
-        """Density in g/cc"""
+        """Density in g/cc."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 
         return interp(Tk, self._densityTableK, self._densityTable) * self.getTD()
 
     def pseudoDensity(self, Tk: float = None, Tc: float = None) -> float:
-        """2D-expanded density in g/cc"""
+        """2D-expanded density in g/cc."""
         return super().pseudoDensity(Tk=Tk, Tc=Tc) * self.getTD()
 
     def linearExpansion(self, Tk: float = None, Tc: float = None) -> float:
-        """Linear expansion coefficient in 1/K"""
+        """Linear expansion coefficient in 1/K."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion", Tk)
 
         return interp(Tk, self._densityTableK, self._linearExpansionTable) / 1e6
 
     def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
-        """Linear expansion percent"""
+        """Linear expansion percent."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tk)
 

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -132,7 +132,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
 
     def setDefaultMassFracs(self) -> None:
         r"""
-        UO2 mass fractions. Using Natural Uranium without U234
+        UO2 mass fractions. Using Natural Uranium without U234.
         """
         u235 = nb.byName["U235"]
         u238 = nb.byName["U238"]
@@ -153,7 +153,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
 
     def meltingPoint(self):
         """
-        Melting point in K
+        Melting point in K.
 
         From [#ornltm2000]_.
         """
@@ -161,7 +161,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
 
     def density(self, Tk: float = None, Tc: float = None) -> float:
         """
-        Density in (g/cc)
+        Density in (g/cc).
 
         Polynomial line fit to data from [#ornltm2000]_ on page 11.
         """
@@ -204,7 +204,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
 
     def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
         """
-        Return dL/L
+        Return dL/L.
 
         From Section 3.3 of [#ornltm2000]_
         """
@@ -222,7 +222,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
 
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
         """
-        Thermal conductivity
+        Thermal conductivity.
 
         Ref: Thermal conductivity of uranium dioxide by nonequilibrium molecular dynamics
         simulation. S. Motoyama. Physical Review B, Volume 60, Number 1, July 1999
@@ -234,5 +234,5 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
 
 
 class UO2(UraniumOxide):
-    r"""Another name for UraniumOxide"""
+    r"""Another name for UraniumOxide."""
     pass

--- a/armi/materials/water.py
+++ b/armi/materials/water.py
@@ -24,7 +24,7 @@ from armi.utils.units import getTk
 
 class Water(Fluid):
     """
-    Water
+    Water.
 
     This is a good faith implementation of the Revised Supplementary Properties
     of Ordinary Water Substance (1992) by IAPWS -- International Association for
@@ -83,14 +83,12 @@ class Water(Fluid):
             self.setMassFrac(nucName, mfrac)
 
     def theta(self, Tk: float = None, Tc: float = None) -> float:
-        """
-        returns temperature normalized to the critical temperature
-        """
+        """Returns temperature normalized to the critical temperature."""
         return getTk(Tc=Tc, Tk=Tk) / self.TEMPERATURE_CRITICAL_K
 
     def tau(self, Tc: float = None, Tk: float = None) -> float:
         """
-        returns 1 - temperature normalized to the critical temperature
+        Returns 1 - temperature normalized to the critical temperature.
 
         Note
         ----
@@ -100,7 +98,7 @@ class Water(Fluid):
 
     def vaporPressure(self, Tk: float = None, Tc: float = None) -> float:
         """
-        Returns vapor pressure in (Pa)
+        Returns vapor pressure in (Pa).
 
         Parameters
         ----------
@@ -150,7 +148,7 @@ class Water(Fluid):
         self, Tk: float = None, Tc: float = None, dT: float = 1e-6
     ) -> float:
         """
-        approximation of derivative of vapor pressure wrt temperature
+        Approximation of derivative of vapor pressure wrt temperature.
 
         Parameters
         ----------
@@ -161,7 +159,7 @@ class Water(Fluid):
 
         Note
         ----
-        this uses a numerical approximation
+        This uses a numerical approximation
         """
         Tcold = getTk(Tc=Tc, Tk=Tk) - dT / 2.0
         Thot = Tcold + dT
@@ -173,7 +171,7 @@ class Water(Fluid):
         self, Tk: float = None, Tc: float = None
     ) -> float:
         """
-        Returns the auxiliary quantity for specific enthalpy
+        Returns the auxiliary quantity for specific enthalpy.
 
         Parameters
         ----------
@@ -215,7 +213,7 @@ class Water(Fluid):
         self, Tk: float = None, Tc: float = None
     ) -> float:
         """
-        Returns the auxiliary quantity for specific entropy
+        Returns the auxiliary quantity for specific entropy.
 
         Parameters
         ----------
@@ -255,7 +253,7 @@ class Water(Fluid):
 
     def enthalpy(self, Tk: float = None, Tc: float = None) -> float:
         """
-        Returns enthalpy of saturated water
+        Returns enthalpy of saturated water.
 
         Parameters
         ----------
@@ -285,7 +283,7 @@ class Water(Fluid):
 
     def entropy(self, Tk: float = None, Tc: float = None) -> float:
         """
-        Returns entropy of saturated water
+        Returns entropy of saturated water.
 
         Parameters
         ----------
@@ -327,7 +325,7 @@ class Water(Fluid):
 
 class SaturatedWater(Water):
     """
-    Saturated Water
+    Saturated Water.
 
     This is a good faith implementation of the Revised Supplementary Properties
     of Ordinary Water Substance (1992) by IAPWS -- International Association for
@@ -341,7 +339,7 @@ class SaturatedWater(Water):
 
     def pseudoDensity(self, Tk: float = None, Tc: float = None) -> float:
         """
-        returns density in g/cc
+        Returns density in g/cc.
 
         Parameters
         ----------
@@ -387,7 +385,7 @@ class SaturatedWater(Water):
 
 class SaturatedSteam(Water):
     """
-    Saturated Steam
+    Saturated Steam.
 
     This is a good faith implementation of the Revised Supplementary Properties
     of Ordinary Water Substance (1992) by IAPWS -- International Association for
@@ -401,7 +399,7 @@ class SaturatedSteam(Water):
 
     def pseudoDensity(self, Tk: float = None, Tc: float = None) -> float:
         """
-        returns density in g/cc
+        Returns density in g/cc.
 
         Parameters
         ----------

--- a/armi/materials/water.py
+++ b/armi/materials/water.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+"""Basic water material."""
 import math
 
 from armi.materials.material import Fluid

--- a/armi/materials/yttriumOxide.py
+++ b/armi/materials/yttriumOxide.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Yttrium Oxide"""
+"""Yttrium Oxide."""
 
 from armi.materials.material import Material
 from armi.utils.units import getTk

--- a/armi/materials/zincOxide.py
+++ b/armi/materials/zincOxide.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Zinc Oxide"""
+"""Zinc Oxide."""
 
 from armi.materials.material import Material
 from armi.utils.units import getTk
@@ -32,7 +32,7 @@ class ZnO(Material):
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         """
-        Return the linear expansion percent for Polycrystalline ZnO
+        Return the linear expansion percent for Polycrystalline ZnO.
 
         Notes
         -----

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Zirconium metal
+Zirconium metal.
 """
 
 from numpy import interp
@@ -23,7 +23,7 @@ from armi.utils.units import getTk
 
 
 class Zr(Material):
-    """Metallic zirconium"""
+    """Metallic zirconium."""
 
     name = "Zr"
 
@@ -87,7 +87,7 @@ class Zr(Material):
         self.setMassFrac("ZR", 1.0)
 
     def _computeReferenceDensity(self, Tk=None, Tc=None):
-        r"""AAA Materials Handbook 45803"""
+        r"""AAA Materials Handbook 45803."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 
@@ -107,7 +107,7 @@ class Zr(Material):
         return 8.853 + (0.007082 * Tk) + (0.000002533 * Tk ** 2) + (2992.0 / Tk)
 
     def linearExpansion(self, Tk=None, Tc=None):
-        r"""linear expansion in m/mK
+        r"""linear expansion in m/mK.
 
         Reference: Y.S. Touloukian, R.K. Kirby, R.E. Taylor and P.D. Desai, Thermal Expansion,
                    Thermophysical Properties of Matter, Vol. 12, IFI/Plenum, New York-Washington (1975)
@@ -119,7 +119,7 @@ class Zr(Material):
         return interp(Tk, self.linearExpansionTableK, self.linearExpansionTable)
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
-        r"""linear expansion in dL/L
+        r"""linear expansion in dL/L.
 
         Reference: Y.S. Touloukian, R.K. Kirby, R.E. Taylor and P.D. Desai, Thermal Expansion,
                    Thermophysical Properties of Matter, Vol. 12, IFI/Plenum, New York-Washington (1975)

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -107,7 +107,7 @@ class Zr(Material):
         return 8.853 + (0.007082 * Tk) + (0.000002533 * Tk ** 2) + (2992.0 / Tk)
 
     def linearExpansion(self, Tk=None, Tc=None):
-        r"""linear expansion in m/mK.
+        r"""Linear expansion in m/mK.
 
         Reference: Y.S. Touloukian, R.K. Kirby, R.E. Taylor and P.D. Desai, Thermal Expansion,
                    Thermophysical Properties of Matter, Vol. 12, IFI/Plenum, New York-Washington (1975)
@@ -119,7 +119,7 @@ class Zr(Material):
         return interp(Tk, self.linearExpansionTableK, self.linearExpansionTable)
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
-        r"""linear expansion in dL/L.
+        r"""Linear expansion in dL/L.
 
         Reference: Y.S. Touloukian, R.K. Kirby, R.E. Taylor and P.D. Desai, Thermal Expansion,
                    Thermophysical Properties of Matter, Vol. 12, IFI/Plenum, New York-Washington (1975)

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This module provides an abstract class to be used to implement "MPI actions."
+This module provides an abstract class to be used to implement "MPI actions.".
 
 MPI actions are tasks, activities, or work that can be executed on the worker nodes. The standard
 workflow is essentially that the primary node creates an :py:class:`~armi.mpiActions.MpiAction`,
@@ -133,7 +133,7 @@ class MpiAction:
 
     def _mpiOperationHelper(self, obj, mpiFunction):
         """
-        Strips off the operator, reactor, cs from the mpiAction before
+        Strips off the operator, reactor, cs from the mpiAction before.
         """
         if obj is None or obj is self:
             # prevent sending o, r, and cs, they should be handled appropriately by the other nodes

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -273,7 +273,7 @@ def getElementsByChemicalGroup(group: ChemicalGroup) -> List[Element]:
 
 def getName(z: int = None, symbol: str = None) -> str:
     r"""
-    Returns element name
+    Returns element name.
 
     Parameters
     ----------
@@ -299,7 +299,7 @@ def getName(z: int = None, symbol: str = None) -> str:
 
 def getSymbol(z: int = None, name: str = None) -> str:
     r"""
-    Returns element abbreviation given atomic number Z
+    Returns element abbreviation given atomic number Z.
 
     Parameters
     ----------

--- a/armi/nucDirectory/nucDir.py
+++ b/armi/nucDirectory/nucDir.py
@@ -67,7 +67,7 @@ def getNuclideFromName(name):
 
 def getNaturalIsotopics(elementSymbol=None, z=None):
     r"""
-    determines the atom fractions of all natural isotopes.
+    Determines the atom fractions of all natural isotopes.
 
     Parameters
     ----------
@@ -90,7 +90,7 @@ def getNaturalIsotopics(elementSymbol=None, z=None):
 
 
 def getNaturalMassIsotopics(elementSymbol=None, z=None):
-    r"""return mass fractions of all natural isotopes.
+    r"""Return mass fractions of all natural isotopes.
     To convert number fractions to mass fractions, we multiply by A.
     """
     numIso = getNaturalIsotopics(elementSymbol, z)
@@ -224,7 +224,7 @@ def getNuclide(nucName):
 
 def getNuclides(nucName=None, elementSymbol=None):
     r"""
-    returns a list of nuclide names in a particular nuclide or element.
+    Returns a list of nuclide names in a particular nuclide or element.
 
     If no arguments, returns all nuclideBases in the directory
 
@@ -251,7 +251,7 @@ def getNuclides(nucName=None, elementSymbol=None):
 
 def getNuclideNames(nucName=None, elementSymbol=None):
     r"""
-    returns a list of nuclide names in a particular nuclide or element.
+    Returns a list of nuclide names in a particular nuclide or element.
 
     If no arguments, returns all nuclideBases in the directory.
 
@@ -270,7 +270,7 @@ def getNuclideNames(nucName=None, elementSymbol=None):
 
 def getAtomicWeight(lab=None, z=None, a=None):
     r"""
-    returns atomic weight in g/mole.
+    Returns atomic weight in g/mole.
 
     Parameters
     ----------
@@ -301,7 +301,6 @@ def getAtomicWeight(lab=None, z=None, a=None):
 
     >>> nucDir.getAtomicWeight(z=94,a=239)
     239.0521634
-
     """
     if lab:
         nuclide = None
@@ -342,7 +341,7 @@ def isFissile(name):
 
 def getThresholdDisplacementEnergy(nuc):
     r"""
-    return the Lindhard cutoff; the energy required to displace an atom.
+    Return the Lindhard cutoff; the energy required to displace an atom.
 
     From SPECTER.pdf Table II
     Greenwood, "SPECTER: Neutron Damage Calculations for Materials Irradiations",
@@ -358,7 +357,6 @@ def getThresholdDisplacementEnergy(nuc):
     Ed : float
         The cutoff energy in eV
     """
-
     nuc = getNuclide(nuc)
     el = elements.byZ[nuc.z]
     try:
@@ -369,4 +367,5 @@ def getThresholdDisplacementEnergy(nuc):
             "".format(el, nuc)
         )
         raise
+
     return ed

--- a/armi/nucDirectory/nucDir.py
+++ b/armi/nucDirectory/nucDir.py
@@ -67,7 +67,7 @@ def getNuclideFromName(name):
 
 def getNaturalIsotopics(elementSymbol=None, z=None):
     r"""
-    determines the atom fractions of all natural isotopes
+    determines the atom fractions of all natural isotopes.
 
     Parameters
     ----------
@@ -91,7 +91,7 @@ def getNaturalIsotopics(elementSymbol=None, z=None):
 
 def getNaturalMassIsotopics(elementSymbol=None, z=None):
     r"""return mass fractions of all natural isotopes.
-    To convert number fractions to mass fractions, we multiply by A
+    To convert number fractions to mass fractions, we multiply by A.
     """
     numIso = getNaturalIsotopics(elementSymbol, z)
     terms = []
@@ -108,7 +108,7 @@ def getNaturalMassIsotopics(elementSymbol=None, z=None):
 
 def getMc2Label(name):
     r"""
-    Return a MC2 prefix label without a xstype suffix
+    Return a MC2 prefix label without a xstype suffix.
 
     MC**2 has labels and library names. The labels are like
     U235IA, ZIRCFB, etc. and the library names are references
@@ -147,7 +147,7 @@ def getMc2Label(name):
 
 def getElementName(z=None, symbol=None):
     r"""
-    Returns element name
+    Returns element name.
 
     Parameters
     ----------
@@ -174,7 +174,7 @@ def getElementName(z=None, symbol=None):
 
 def getElementSymbol(z=None, name=None):
     r"""
-    Returns element abbreviation given atomic number Z
+    Returns element abbreviation given atomic number Z.
 
     Parameters
     ----------
@@ -201,7 +201,7 @@ def getElementSymbol(z=None, name=None):
 
 def getNuclide(nucName):
     r"""
-    Looks up the ARMI nuclide object that has this name
+    Looks up the ARMI nuclide object that has this name.
 
     Parameters
     ----------
@@ -224,7 +224,7 @@ def getNuclide(nucName):
 
 def getNuclides(nucName=None, elementSymbol=None):
     r"""
-    returns a list of nuclide names in a particular nuclide or element
+    returns a list of nuclide names in a particular nuclide or element.
 
     If no arguments, returns all nuclideBases in the directory
 
@@ -251,7 +251,7 @@ def getNuclides(nucName=None, elementSymbol=None):
 
 def getNuclideNames(nucName=None, elementSymbol=None):
     r"""
-    returns a list of nuclide names in a particular nuclide or element
+    returns a list of nuclide names in a particular nuclide or element.
 
     If no arguments, returns all nuclideBases in the directory.
 
@@ -270,7 +270,7 @@ def getNuclideNames(nucName=None, elementSymbol=None):
 
 def getAtomicWeight(lab=None, z=None, a=None):
     r"""
-    returns atomic weight in g/mole
+    returns atomic weight in g/mole.
 
     Parameters
     ----------
@@ -342,7 +342,7 @@ def isFissile(name):
 
 def getThresholdDisplacementEnergy(nuc):
     r"""
-    return the Lindhard cutoff; the energy required to displace an atom
+    return the Lindhard cutoff; the energy required to displace an atom.
 
     From SPECTER.pdf Table II
     Greenwood, "SPECTER: Neutron Damage Calculations for Materials Irradiations",

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -146,7 +146,7 @@ class NuclideInterface:
     """An abstract nuclide implementation which defining various methods required for a nuclide object."""
 
     def getDatabaseName(self):
-        """Return the the nuclide label for the ARMI database (i.e. "nPu239")"""
+        """Return the the nuclide label for the ARMI database (i.e. "nPu239")."""
         raise NotImplementedError
 
     def getDecay(self, decayType):
@@ -190,7 +190,7 @@ class NuclideInterface:
 
 
 class NuclideWrapper(NuclideInterface):
-    """A nuclide wrapper class, used as a base class for nuclear data file nuclides"""
+    """A nuclide wrapper class, used as a base class for nuclear data file nuclides."""
 
     def __init__(self, container, key):
         self._base = None
@@ -474,7 +474,7 @@ class INuclide(NuclideInterface):
         raise NotImplementedError
 
     def getDatabaseName(self):
-        """Get the name of the nuclide used in the database (i.e. "nPu239")"""
+        """Get the name of the nuclide used in the database (i.e. "nPu239")."""
         return f"n{self.name.capitalize()}"
 
     def isHeavyMetal(self):
@@ -568,7 +568,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
 
     def getMcnpId(self):
         """
-        Gets the MCNP label for this nuclide
+        Gets the MCNP label for this nuclide.
 
         Returns
         -------
@@ -617,7 +617,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
 
     def getEndfMatNum(self):
         """
-        Gets the ENDF MAT number
+        Gets the ENDF MAT number.
 
         MAT numbers are defined as described in section 0.4.1 of the NJOY manual.
         Basically, it's Z * 100 + I where I is an isotope number. I=25 is defined
@@ -969,7 +969,7 @@ def fromName(name):
 
 
 def isMonoIsotopicElement(name):
-    """Return true if this is the only naturally occurring isotope of its element"""
+    """Return true if this is the only naturally occurring isotope of its element."""
     base = byName[name]
     return (
         base.abundance > 0

--- a/armi/nucDirectory/tests/test_elements.py
+++ b/armi/nucDirectory/tests/test_elements.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for elements"""
+"""Tests for elements."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import unittest

--- a/armi/nucDirectory/tests/test_nucDirectory.py
+++ b/armi/nucDirectory/tests/test_nucDirectory.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests nuclide directory"""
+"""Tests nuclide directory."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for nuclideBases"""
+"""Tests for nuclideBases."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
 import os

--- a/armi/nucDirectory/tests/test_thermalScattering.py
+++ b/armi/nucDirectory/tests/test_thermalScattering.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for thermal scattering metadata"""
+"""Tests for thermal scattering metadata."""
 # pylint: disable=protected-access
 import unittest
 
@@ -41,7 +41,7 @@ def buildBlockWithTSL():
 
 
 class TestThermalScattering(unittest.TestCase):
-    """Tests for thermal scattering on the reactor model"""
+    """Tests for thermal scattering on the reactor model."""
 
     def test_graphiteOnReactor(self):
         b = buildBlockWithTSL()
@@ -94,7 +94,7 @@ class TestThermalScattering(unittest.TestCase):
         self.assertEqual(fe56tsl._genACELabel(), "fe-56")
 
     def test_failOnMultiple(self):
-        """HT9 has carbon in it with no TSL, while graphite has C with TSL. This should crash"""
+        """HT9 has carbon in it with no TSL, while graphite has C with TSL. This should crash."""
         b = buildBlockWithTSL()
         cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.79, "mult": 127.0}
         clad2 = components.Circle("clad", "HT9", **cladDims)

--- a/armi/nucDirectory/tests/test_transmutations.py
+++ b/armi/nucDirectory/tests/test_transmutations.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""Unit tests for transmutations"""
+r"""Unit tests for transmutations."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import random
 import string

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -348,7 +348,7 @@ class BinaryRecordReader(IORecord):
 
 
 class BinaryRecordWriter(IORecord):
-    r"""a single record from a CCCC file
+    r"""a single record from a CCCC file.
 
     Reads binary information sequentially."""
 
@@ -577,12 +577,12 @@ class Stream:
 
     @classmethod
     def readBinary(cls, fileName: str):
-        """Read data from a binary file into a data structure"""
+        """Read data from a binary file into a data structure."""
         return cls._read(fileName, "rb")
 
     @classmethod
     def readAscii(cls, fileName: str):
-        """Read data from an ASCII file into a data structure"""
+        """Read data from an ASCII file into a data structure."""
         return cls._read(fileName, "r")
 
     @classmethod
@@ -591,12 +591,12 @@ class Stream:
 
     @classmethod
     def writeBinary(cls, data: DataContainer, fileName: str):
-        """Write the contents of a data container to a binary file"""
+        """Write the contents of a data container to a binary file."""
         return cls._write(data, fileName, "wb")
 
     @classmethod
     def writeAscii(cls, data: DataContainer, fileName: str):
-        """Write the contents of a data container to an ASCII file"""
+        """Write the contents of a data container to an ASCII file."""
         return cls._write(data, fileName, "w")
 
     @classmethod

--- a/armi/nuclearDataIO/cccc/compxs.py
+++ b/armi/nuclearDataIO/cccc/compxs.py
@@ -305,7 +305,7 @@ class _CompxsIO(cccc.Stream):
         )
 
     def _rw5DRecord(self):
-        """Write power conversion factors"""
+        """Write power conversion factors."""
         numComps = self._getFileMetadata()["numComps"]
         with self.createRecord() as record:
             for factor in COMPXS_POWER_CONVERSION_FACTORS:
@@ -355,7 +355,7 @@ class _CompxsRegionIO:
         self._rw4DRecord()
 
     def _rw3DRecord(self):
-        r"""Write the composition specifications block"""
+        r"""Write the composition specifications block."""
         with self._compxsIO.createRecord() as record:
             self._getRegionMetadata()["chiFlag"] = record.rwInt(
                 self._getRegionMetadata()["chiFlag"]
@@ -376,7 +376,7 @@ class _CompxsRegionIO:
                 )
 
     def _rw4DRecord(self):
-        r"""Write the composition macroscopic cross sections"""
+        r"""Write the composition macroscopic cross sections."""
         if self._isReading:
             self._region.allocateXS(self._getFileMetadata()["numGroups"])
 

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -167,7 +167,7 @@ class Dlayxs(collections.OrderedDict):
 
     def generateAverageDelayedNeutronConstants(self):
         """
-        Use externally-computed nuclideContributionFractions to produce an average ``DelayedNeutronData`` obj.
+        Use externally-computed ``nuclideContributionFractions`` to produce an average ``DelayedNeutronData`` obj.
 
         Solves typical averaging equation but weights already sum to 1.0 so we
         can skip normalization at the end.

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -167,7 +167,7 @@ class Dlayxs(collections.OrderedDict):
 
     def generateAverageDelayedNeutronConstants(self):
         """
-        Use externally-computed nuclideContributionFractions to produce an average ``DelayedNeutronData`` obj
+        Use externally-computed nuclideContributionFractions to produce an average ``DelayedNeutronData`` obj.
 
         Solves typical averaging equation but weights already sum to 1.0 so we
         can skip normalization at the end.
@@ -267,7 +267,7 @@ class _DlayxsIO(cccc.Stream):
 
     def _rwSpectra(self, numNuclides):
         """
-        Read or write precursor decay constants and emission spectra, as well as energy group structure for each family
+        Read or write precursor decay constants and emission spectra, as well as energy group structure for each family.
 
         nkfam is the number of families to which fission in a given nuclide contributes delayed neutron precursors
         """
@@ -321,7 +321,7 @@ class _DlayxsIO(cccc.Stream):
 
     def _rwYield(self):
         """
-        Read or write delayed neutron precursor yield data (3D record)
+        Read or write delayed neutron precursor yield data (3D record).
 
         Also reads the family numbers, which represent the family number of the
         k-th yield vector in delayNeutronsPerFission

--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Module for reading GAMISO files which contains gamma cross section data
+Module for reading GAMISO files which contains gamma cross section data.
 
 GAMISO is a binary file created by MC**2-v3 that contains multigroup microscopic gamma cross sections. GAMISO data is
 contained within a :py:class:`~armi.nuclearDataIO.xsLibraries.XSLibrary`.

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -550,7 +550,7 @@ class _IsotxsNuclideIO:
                 micros.strpd = micros.getDefaultXs(numGroups)
 
     def _rw6DRecord(self):
-        """reads nuclide-level chi dist."""
+        """Reads nuclide-level chi dist."""
         raise NotImplementedError
 
     def _rw7DRecord(self, blockNumIndex, subBlock):

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -685,7 +685,7 @@ class _IsotxsNuclideIO:
 
     def _setScatterMatrix(self, blockNumIndex, scatterMatrix):
         """
-        Sets scatter matrix data to the proper scatterMatrix for this blockNum.
+        Sets scatter matrix data to the proper ``scatterMatrix`` for this ``blockNum``.
 
         blockNumIndex : int
             Index of a scattering block.

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -59,7 +59,7 @@ N2N_SCATTER = 300  # 300 + NN, (N,2N) SCATTERING
 
 def compareSet(fileNames, tolerance=0.0, verbose=False):
     """
-    takes a list of strings and reads all binaries with that name comparing them in all combinations
+    takes a list of strings and reads all binaries with that name comparing them in all combinations.
 
     Notes
     -----
@@ -550,12 +550,12 @@ class _IsotxsNuclideIO:
                 micros.strpd = micros.getDefaultXs(numGroups)
 
     def _rw6DRecord(self):
-        """reads nuclide-level chi dist"""
+        """reads nuclide-level chi dist."""
         raise NotImplementedError
 
     def _rw7DRecord(self, blockNumIndex, subBlock):
         """
-        Read scatter matrix
+        Read scatter matrix.
 
         Parameters
         ----------
@@ -685,7 +685,7 @@ class _IsotxsNuclideIO:
 
     def _setScatterMatrix(self, blockNumIndex, scatterMatrix):
         """
-        Sets scatter matrix data to the proper scatterMatrix for this blockNum
+        Sets scatter matrix data to the proper scatterMatrix for this blockNum.
 
         blockNumIndex : int
             Index of a scattering block.
@@ -705,7 +705,7 @@ class _IsotxsNuclideIO:
 
     def _getScatterMatrix(self, blockNumIndex):
         """
-        Get the scatter matrix for a particular blockNum
+        Get the scatter matrix for a particular blockNum.
 
         Note: This is stupid and the logic should be combined with _setScatterMatrix.
         Please recommend a better way to do it during code review.

--- a/armi/nuclearDataIO/cccc/labels.py
+++ b/armi/nuclearDataIO/cccc/labels.py
@@ -164,7 +164,7 @@ class LabelsStream(cccc.StreamWithDataContainer):
             self._metadata["dummy"] = record.rwList(self._metadata["dummy"], "int", 2)
 
     def _rw2DRecord(self):
-        """Read/write the label and area data"""
+        """Read/write the label and area data."""
         with self.createRecord() as record:
             self._data.zoneLabels = record.rwList(
                 self._data.zoneLabels, "string", self._metadata["numZones"], 8

--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -376,7 +376,7 @@ class NhfluxStream(cccc.StreamWithDataContainer):
 
     def _rwBasicFileData1D(self):
         """
-        Read basic data parameters (number of energy groups, assemblies, axial nodes, etc.)
+        Read basic data parameters (number of energy groups, assemblies, axial nodes, etc.).
         """
         # Dummy values are stored because sometimes they get assigned
         # unexpected values anyway, and so we still want to preserve those values anyway

--- a/armi/nuclearDataIO/cccc/tests/test_cccc.py
+++ b/armi/nuclearDataIO/cccc/tests/test_cccc.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""test CCCC"""
+"""test CCCC."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import io
 import unittest

--- a/armi/nuclearDataIO/cccc/tests/test_compxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_compxs.py
@@ -30,7 +30,7 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestCompxs(unittest.TestCase):
-    """Test the compxs reader/writer"""
+    """Test the compxs reader/writer."""
 
     @property
     def binaryWritePath(self):
@@ -56,7 +56,7 @@ class TestCompxs(unittest.TestCase):
         self.assertAlmostEqual(0.41745778918, min(self.lib.neutronEnergyUpperBounds))
 
     def test_regionPrimaryXS(self):
-        """Test the primary cross sections for the second region - fissile"""
+        """Test the primary cross sections for the second region - fissile."""
         expectedMacros = {
             "absorption": [
                 0.00810444,

--- a/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests for DELAYXS
+Tests for DELAYXS.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import copy
@@ -36,7 +36,7 @@ class DlayxsTests(unittest.TestCase):
 
     def test_decayConstants(self):
         """
-        test that all emission spectrum delayEmissionSpectrum is normalized
+        test that all emission spectrum delayEmissionSpectrum is normalized.
         """
         delay = self.dlayxs3
         self.assertTrue(
@@ -54,7 +54,7 @@ class DlayxsTests(unittest.TestCase):
 
     def test_chi_delay(self):
         """
-        test that all emission spectrum delayEmissionSpectrum is normalized
+        test that all emission spectrum delayEmissionSpectrum is normalized.
         """
         delay = self.dlayxs3
         self.assertTrue(
@@ -312,7 +312,7 @@ class DlayxsTests(unittest.TestCase):
         "The TH232, U232, PU238 and PU242 numbers do not agree, likely because they are from ENDV/B VI.8."
     )
     def test_ENDFVII1DecayConstants(self):
-        """Test ENDF/B VII.1 decay constants. Retrieved from ENDF/B VII.1"""
+        """Test ENDF/B VII.1 decay constants. Retrieved from ENDF/B VII.1."""
         self._assertDC(
             "TH227  ",
             [

--- a/armi/nuclearDataIO/cccc/tests/test_gamiso.py
+++ b/armi/nuclearDataIO/cccc/tests/test_gamiso.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test GAMISO reading and writing"""
+"""Test GAMISO reading and writing."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 from copy import deepcopy
 import os

--- a/armi/nuclearDataIO/cccc/tests/test_isotxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_isotxs.py
@@ -25,7 +25,7 @@ from armi.nuclearDataIO import xsLibraries
 
 class TestIsotxs(unittest.TestCase):
     r"""
-    Tests the ISOTXS class
+    Tests the ISOTXS class.
     """
 
     @classmethod

--- a/armi/nuclearDataIO/cccc/tests/test_labels.py
+++ b/armi/nuclearDataIO/cccc/tests/test_labels.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Test the reading and writing of the DIF3D/VARIANT LABELS interface file
+Test the reading and writing of the DIF3D/VARIANT LABELS interface file.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os

--- a/armi/nuclearDataIO/cccc/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_nhflux.py
@@ -182,7 +182,7 @@ class TestNhfluxVariant(unittest.TestCase):
         )
 
     def test_write(self):
-        """Verify binary equivalence of written binary file"""
+        """Verify binary equivalence of written binary file."""
         with TemporaryDirectoryChanger():
             nhflux.NhfluxStreamVariant.writeBinary(self.nhf, "NHFLUX2")
             with open(SIMPLE_HEXZ_NHFLUX_VARIANT, "rb") as f1, open(

--- a/armi/nuclearDataIO/cccc/tests/test_pwdint.py
+++ b/armi/nuclearDataIO/cccc/tests/test_pwdint.py
@@ -39,7 +39,7 @@ class TestGeodst(unittest.TestCase):
         self.assertGreater(pwr.powerDensity.min(), 0.0)
 
     def test_writeGeodst(self):
-        """Ensure that we can write a modified PWDINT"""
+        """Ensure that we can write a modified PWDINT."""
         with TemporaryDirectoryChanger():
             pwr = pwdint.readBinary(SIMPLE_PWDINT)
             pwdint.writeBinary(pwr, "PWDINT2")

--- a/armi/nuclearDataIO/cccc/tests/test_rzflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_rzflux.py
@@ -27,7 +27,7 @@ SIMPLE_RZFLUX = os.path.join(THIS_DIR, "fixtures", "simple_cartesian.rzflux")
 
 
 class TestRzflux(unittest.TestCase):
-    """Tests the rzflux class"""
+    """Tests the rzflux class."""
 
     def test_readRzflux(self):
         """Ensure we can read a RZFLUX file."""

--- a/armi/nuclearDataIO/nuclearFileMetadata.py
+++ b/armi/nuclearDataIO/nuclearFileMetadata.py
@@ -230,7 +230,7 @@ class NuclideXSMetadata(FileMetadata):
 
 
 class RegionXSMetadata(FileMetadata):
-    """Metadata for library files containing region cross sections, e.g. ``COMPXS``"""
+    """Metadata for library files containing region cross sections, e.g. ``COMPXS``."""
 
     def _mergeLibrarySpecificData(
         self, other, selfContainer, otherContainer, mergedData

--- a/armi/nuclearDataIO/tests/test_xsCollections.py
+++ b/armi/nuclearDataIO/tests/test_xsCollections.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module that tests methods within xsCollections"""
+"""Module that tests methods within xsCollections."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
@@ -83,7 +83,7 @@ class TestXsCollections(unittest.TestCase):
 
     def test_collapseCrossSection(self):
         """
-        Tests cross section collapsing
+        Tests cross section collapsing.
 
         Notes
         -----

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for xsLibraries.IsotxsLibrary"""
+"""Tests for xsLibraries.IsotxsLibrary."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,unused-variable
 import copy
 import filecmp
@@ -55,7 +55,7 @@ UFG_FLUX_EDIT = os.path.join(FIXTURE_DIR, "mc2v3-AA.flux_ufg")
 
 
 class TempFileMixin:
-    """really a test case"""
+    """really a test case."""
 
     def setUp(self):
         self.td = TemporaryDirectoryChanger()
@@ -277,7 +277,7 @@ class Test_GetISOTXSFilesInWorkingDirectory(unittest.TestCase):
 
     def assert_contains_only(self, container, shouldBeThere, shouldNotBeThere):
         """
-        Utility method for saying what things contain
+        Utility method for saying what things contain.
 
         This could just check the contents and the length, but the error produced when you pass shouldNotBeThere
         is much nicer.

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -103,7 +103,7 @@ class NuclideTests(unittest.TestCase):
         self.assertEqual(0.008091875669521187, sum(nuc.micros.nGamma))
 
     def test_nuclide_2dXsArrangementIsCorrect(self):
-        """manually compare some 2d XS data to ensure the correct coordinates"""
+        """manually compare some 2d XS data to ensure the correct coordinates."""
         u235 = self.lib["U235AA"]
         self.assertAlmostEqual(5.76494979858, u235.micros.total[0, 0])
         self.assertAlmostEqual(6.5928812027, u235.micros.total[1, 0])
@@ -124,7 +124,7 @@ class NuclideTests(unittest.TestCase):
         self.assertAlmostEqual(973.399902343, pu239.micros.total[32, 1])
 
     def test_nuclide_scatterXsArrangementIsCorrect(self):
-        """manually compare scatter XS data to ensure the correct coordinates"""
+        """manually compare scatter XS data to ensure the correct coordinates."""
         u235 = self.lib["U235AA"]
         elasticScatter = u235.micros.elasticScatter
         n2nScatter = u235.micros.n2nScatter

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
-"""
+"""Test for xs nuclides."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import unittest
 
@@ -103,7 +102,7 @@ class NuclideTests(unittest.TestCase):
         self.assertEqual(0.008091875669521187, sum(nuc.micros.nGamma))
 
     def test_nuclide_2dXsArrangementIsCorrect(self):
-        """manually compare some 2d XS data to ensure the correct coordinates."""
+        """Manually compare some 2d XS data to ensure the correct coordinates."""
         u235 = self.lib["U235AA"]
         self.assertAlmostEqual(5.76494979858, u235.micros.total[0, 0])
         self.assertAlmostEqual(6.5928812027, u235.micros.total[1, 0])
@@ -124,7 +123,7 @@ class NuclideTests(unittest.TestCase):
         self.assertAlmostEqual(973.399902343, pu239.micros.total[32, 1])
 
     def test_nuclide_scatterXsArrangementIsCorrect(self):
-        """manually compare scatter XS data to ensure the correct coordinates."""
+        """Manually compare scatter XS data to ensure the correct coordinates."""
         u235 = self.lib["U235AA"]
         elasticScatter = u235.micros.elasticScatter
         n2nScatter = u235.micros.n2nScatter

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -391,7 +391,7 @@ class MacroscopicCrossSectionCreator:
         self, microLibrary, block, nucNames=None, libType="micros"
     ):
         """
-        Creates a macroscopic cross section set based on a microscopic XS library using a block object
+        Creates a macroscopic cross section set based on a microscopic XS library using a block object.
 
         Micro libraries have lots of nuclides, but macros only have 1.
 
@@ -527,7 +527,7 @@ class MacroscopicCrossSectionCreator:
 
     def _computeRemovalXS(self):
         """
-        Compute removal cross section (things that remove a neutron from this phase space)
+        Compute removal cross section (things that remove a neutron from this phase space).
 
         This includes all absorptions and outscattering.
         Outscattering is represented by columns of the total scatter matrix.
@@ -684,7 +684,7 @@ def computeGammaEnergyDepositionConstants(numberDensities, lib, microSuffix):
 
 def computeFissionEnergyGenerationConstants(numberDensities, lib, microSuffix):
     r"""
-    Get the fission energy generation group constant of a block
+    Get the fission energy generation group constant of a block.
 
     .. math::
 
@@ -724,7 +724,7 @@ def computeFissionEnergyGenerationConstants(numberDensities, lib, microSuffix):
 
 def computeCaptureEnergyGenerationConstants(numberDensities, lib, microSuffix):
     r"""
-    Get the energy generation group constant of a block
+    Get the energy generation group constant of a block.
 
     .. math::
 

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -430,7 +430,7 @@ class IsotxsLibrary(_XSLibrary):
 
     @property
     def numGroupsGamma(self):
-        """get the number of gamma energy groups."""
+        """Get the number of gamma energy groups."""
         # This unlocks the immutable property so that it can be
         # read prior to not being set to check the number of groups
         # that are defined. If the property is not unlocked before

--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -103,7 +103,7 @@ def getSuffixFromNuclideLabel(nucLabel):
 
 def getISOTXSLibrariesToMerge(xsLibrarySuffix, xsLibFileNames):
     """
-    Find ISOTXS libraries out of a list that should be merged based on the provided ``xsLibrarySuffix``
+    Find ISOTXS libraries out of a list that should be merged based on the provided ``xsLibrarySuffix``.
 
     Parameters
     ----------
@@ -412,7 +412,7 @@ class IsotxsLibrary(_XSLibrary):
 
     @property
     def numGroups(self):
-        """Get the number of neutron energy groups"""
+        """Get the number of neutron energy groups."""
         # This unlocks the immutable property so that it can be
         # read prior to not being set to check the number of groups
         # that are defined. If the property is not unlocked before
@@ -430,7 +430,7 @@ class IsotxsLibrary(_XSLibrary):
 
     @property
     def numGroupsGamma(self):
-        """get the number of gamma energy groups"""
+        """get the number of gamma energy groups."""
         # This unlocks the immutable property so that it can be
         # read prior to not being set to check the number of groups
         # that are defined. If the property is not unlocked before
@@ -521,7 +521,7 @@ class IsotxsLibrary(_XSLibrary):
         return [self[name] for name in self._orderedNuclideLabels]
 
     def getNuclides(self, suffix):
-        """Returns a list of the nuclide objects in the library"""
+        """Returns a list of the nuclide objects in the library."""
         nucs = []
         # nucName is U235IA, etc.. nuc.name is U235, etc
         for nucLabel, nuc in self.items():
@@ -533,7 +533,7 @@ class IsotxsLibrary(_XSLibrary):
         return nucs
 
     def merge(self, other):
-        """Merge two XSLibraries"""
+        """Merge two XSLibraries."""
         runLog.debug("Merging XS library {} into XS library {}".format(other, self))
         self._mergeProperties(other)
         # merging meta data may raise an exception before knowing anything about the contained nuclides
@@ -582,7 +582,7 @@ class IsotxsLibrary(_XSLibrary):
 
     def getScatterWeights(self, scatterMatrixKey="elasticScatter"):
         """
-        Build or retrieve pre-built scatter weight data
+        Build or retrieve pre-built scatter weight data.
 
         This acts like a cache for _buildScatterWeights
 

--- a/armi/nuclearDataIO/xsNuclides.py
+++ b/armi/nuclearDataIO/xsNuclides.py
@@ -229,7 +229,7 @@ def _mergeAttributes(this, other, attrName):
 
 
 def plotScatterMatrix(scatterMatrix, scatterTypeLabel="", fName=None):
-    r"""plots a matrix to show scattering."""
+    """Plots a matrix to show scattering."""
     from matplotlib import pyplot
 
     pyplot.imshow(scatterMatrix.todense(), interpolation="nearest")

--- a/armi/nuclearDataIO/xsNuclides.py
+++ b/armi/nuclearDataIO/xsNuclides.py
@@ -95,7 +95,7 @@ class XSNuclide(nuclideBases.NuclideWrapper):
         self._base = nuclideBase
 
     def getMicroXS(self, interaction, group):
-        r"""Returns the microscopic xs as the ISOTXS value if it exists or a 0 since it doesn't"""
+        r"""Returns the microscopic xs as the ISOTXS value if it exists or a 0 since it doesn't."""
         if interaction in self.micros.__dict__:
             try:
                 return self.micros[interaction][group]

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -212,7 +212,7 @@ class Operator:  # pylint: disable=too-many-public-methods
     @staticmethod
     def _initFastPath():
         """
-        Create the FAST_PATH directory for fast local operations
+        Create the FAST_PATH directory for fast local operations.
 
         Notes
         -----
@@ -386,7 +386,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         self._performTightCoupling(cycle, timeNode)
 
     def _performTightCoupling(self, cycle: int, timeNode: int, writeDB: bool = True):
-        """if requested, perform tight coupling and write out database
+        """if requested, perform tight coupling and write out database.
 
         Notes
         -----
@@ -687,7 +687,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         return self._checkTightCouplingConvergence(activeInterfaces)
 
     def _checkTightCouplingConvergence(self, activeInterfaces: list):
-        """check if interfaces are converged
+        """check if interfaces are converged.
 
         Parameters
         ----------
@@ -866,7 +866,7 @@ class Operator:  # pylint: disable=too-many-public-methods
             raise RuntimeError("Interface dependency resolution did not converge.")
 
     def removeAllInterfaces(self):
-        """Removes all of the interfaces"""
+        """Removes all of the interfaces."""
         for interface in self.interfaces:
             interface.detachReactor()
         self.interfaces = []
@@ -1049,7 +1049,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         self, cycle, timeNode, timeStepName="", fileName=None, updateMassFractions=None
     ):
         """
-        Convenience method reroute to the database interface state reload method
+        Convenience method reroute to the database interface state reload method.
 
         See also
         --------
@@ -1159,7 +1159,7 @@ class Operator:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def setStateToDefault(cs):
-        """Update the state of ARMI to fit the kind of run this operator manages"""
+        """Update the state of ARMI to fit the kind of run this operator manages."""
         return cs.modified(newSettings={"runType": RunTypes.STANDARD})
 
     def couplingIsActive(self):

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -386,7 +386,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         self._performTightCoupling(cycle, timeNode)
 
     def _performTightCoupling(self, cycle: int, timeNode: int, writeDB: bool = True):
-        """if requested, perform tight coupling and write out database.
+        """If requested, perform tight coupling and write out database.
 
         Notes
         -----
@@ -687,7 +687,7 @@ class Operator:  # pylint: disable=too-many-public-methods
         return self._checkTightCouplingConvergence(activeInterfaces)
 
     def _checkTightCouplingConvergence(self, activeInterfaces: list):
-        """check if interfaces are converged.
+        """Check if interfaces are converged.
 
         Parameters
         ----------
@@ -785,7 +785,6 @@ class Operator:  # pylint: disable=too-many-public-methods
             If an interface of the same name or function is already attached to the
             Operator.
         """
-
         if self.getInterface(interface.name):
             raise RuntimeError(
                 "An interface with name {0} is already attached.".format(interface.name)
@@ -887,7 +886,6 @@ class Operator:  # pylint: disable=too-many-public-methods
         success : boolean
             True if the interface was removed
             False if it was not (because it wasn't there to be removed)
-
         """
         if interfaceName:
             interface = self.getInterface(interfaceName)
@@ -1007,7 +1005,6 @@ class Operator:  # pylint: disable=too-many-public-methods
         -----
         This allows the ARMI to do the same shuffles that it did last time, assuming fuel management logic
         has not changed. Note, it would be better if the moves were just read from a table in the database.
-
         """
         restartName = self.cs.caseTitle + ".restart.dat"
         if not os.path.exists(restartName):

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -231,7 +231,7 @@ class OperatorMPI(Operator):
         context.MPI_COMM.bcast("finished", root=0)
 
     def collapseAllStderrs(self):
-        """Takes all the individual stderr files from each processor and arranges them nicely into one file"""
+        """Takes all the individual stderr files from each processor and arranges them nicely into one file."""
         stderrFiles = []
         for fName in os.listdir("."):
             match = re.search(r"_(\d\d\d\d)\.stderr", fName)

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -92,7 +92,7 @@ class Query:
         return self.correction is not Inspector.NO_ACTION
 
     def resolve(self):
-        """Standard i/o prompt for resolution of an individual query"""
+        """Standard i/o prompt for resolution of an individual query."""
         if context.MPI_RANK != 0:
             return
 
@@ -242,7 +242,7 @@ class Inspector:
         return correctionsMade
 
     def addQuery(self, condition, statement, question, correction):
-        """Convenience method, query must be resolved, else run fails"""
+        """Convenience method, query must be resolved, else run fails."""
         if not callable(correction):
             raise ValueError(
                 'Query for "{}" malformed. Expecting callable.'.format(statement)
@@ -277,7 +277,7 @@ class Inspector:
         )
 
     def _assignCS(self, key, value):
-        """Lambda assignment workaround"""
+        """Lambda assignment workaround."""
         # this type of assignment works, but be mindful of
         # scoping when trying different methods
         runLog.extra(f"Updating setting `{key}` to `{value}`")

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -94,7 +94,7 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
 
     @staticmethod
     def setStateToDefault(cs):
-        """Update the state of ARMI to fit the kind of run this operator manages"""
+        """Update the state of ARMI to fit the kind of run this operator manages."""
         from armi.operators.runTypes import RunTypes
 
         return cs.modified(newSettings={"runType": RunTypes.STANDARD})

--- a/armi/operators/tests/test_inspectors.py
+++ b/armi/operators/tests/test_inspectors.py
@@ -27,7 +27,7 @@ from armi import context
 
 
 class TestInspector(unittest.TestCase):
-    """Test case"""
+    """Test case."""
 
     def setUp(self):
         self.td = directoryChangers.TemporaryDirectoryChanger()

--- a/armi/operators/tests/test_operatorSnapshots.py
+++ b/armi/operators/tests/test_operatorSnapshots.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for operator snapshots"""
+"""Tests for operator snapshots."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-method-argument,import-outside-toplevel
 import unittest
 

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -106,7 +106,7 @@ class OperatorTests(unittest.TestCase):
         self.assertFalse(self.o.interfaceIsActive("Fake-o"))
 
     def test_loadStateError(self):
-        """The loadTestReactor() test tool does not have any history in the DB to load from."""
+        """The ``loadTestReactor()`` test tool does not have any history in the DB to load from."""
 
         # a first, simple test that this method fails correctly
         with self.assertRaises(RuntimeError):

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -146,7 +146,7 @@ class TestTightCoupling(unittest.TestCase):
         self.o.r.core = Core("empty")
 
     def test_couplingIsActive(self):
-        """Ensure that cs[CONF_TIGHT_COUPLING] controls couplingIsActive."""
+        """Ensure that ``cs[CONF_TIGHT_COUPLING]`` controls ``couplingIsActive``."""
         self.assertTrue(self.o.couplingIsActive())
         self.o.cs[CONF_TIGHT_COUPLING] = False
         self.assertFalse(self.o.couplingIsActive())

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -152,7 +152,7 @@ class TestTightCoupling(unittest.TestCase):
         self.assertFalse(self.o.couplingIsActive())
 
     def test_performTightCoupling_Inactive(self):
-        """Ensures no action by _performTightCoupling if cs[CONF_TIGHT_COUPLING] = false."""
+        """Ensures no action by ``_performTightCoupling`` if ``cs[CONF_TIGHT_COUPLING] = false``."""
         self.o.cs[CONF_TIGHT_COUPLING] = False
         self.o._performTightCoupling(0, 0, writeDB=False)
         self.assertEqual(self.o.r.core.p.coupledIteration, 0)

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -166,7 +166,7 @@ class TestTightCoupling(unittest.TestCase):
             self.assertEqual(self.o.r.core.p.coupledIteration, 0)
 
     def test_performTightCoupling_notConverged(self):
-        """Ensure that the appropriate runLog.warning is addressed in tight coupling reaches max num of iters."""
+        """Ensure that the appropriate ``runLog.warning`` is addressed in tight coupling reaches max num of iters."""
 
         class NoConverge(TightCoupler):
             def isConverged(self, _val: TightCoupler._SUPPORTED_TYPES) -> bool:

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for operators"""
+"""Tests for operators."""
 
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-method-argument,import-outside-toplevel
 import os
@@ -46,7 +46,7 @@ class InterfaceA(Interface):
 
 
 class InterfaceB(InterfaceA):
-    """Dummy Interface that extends A"""
+    """Dummy Interface that extends A."""
 
     function = "A"
     name = "Second"
@@ -106,7 +106,7 @@ class OperatorTests(unittest.TestCase):
         self.assertFalse(self.o.interfaceIsActive("Fake-o"))
 
     def test_loadStateError(self):
-        """The loadTestReactor() test tool does not have any history in the DB to load from"""
+        """The loadTestReactor() test tool does not have any history in the DB to load from."""
 
         # a first, simple test that this method fails correctly
         with self.assertRaises(RuntimeError):
@@ -146,19 +146,19 @@ class TestTightCoupling(unittest.TestCase):
         self.o.r.core = Core("empty")
 
     def test_couplingIsActive(self):
-        """ensure that cs[CONF_TIGHT_COUPLING] controls couplingIsActive"""
+        """ensure that cs[CONF_TIGHT_COUPLING] controls couplingIsActive."""
         self.assertTrue(self.o.couplingIsActive())
         self.o.cs[CONF_TIGHT_COUPLING] = False
         self.assertFalse(self.o.couplingIsActive())
 
     def test_performTightCoupling_Inactive(self):
-        """ensures no action by _performTightCoupling if cs[CONF_TIGHT_COUPLING] = false"""
+        """ensures no action by _performTightCoupling if cs[CONF_TIGHT_COUPLING] = false."""
         self.o.cs[CONF_TIGHT_COUPLING] = False
         self.o._performTightCoupling(0, 0, writeDB=False)
         self.assertEqual(self.o.r.core.p.coupledIteration, 0)
 
     def test_performTightCoupling_skip(self):
-        """ensure that cycles within cs[CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION] are skipped"""
+        """ensure that cycles within cs[CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION] are skipped."""
         self.o.cs[CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION] = [1]
         with mockRunLogs.BufferLog() as mock:
             self.o._performTightCoupling(1, 0, writeDB=False)
@@ -166,7 +166,7 @@ class TestTightCoupling(unittest.TestCase):
             self.assertEqual(self.o.r.core.p.coupledIteration, 0)
 
     def test_performTightCoupling_notConverged(self):
-        """ensure that the appropriate runLog.warning is addressed in tight coupling reaches max num of iters"""
+        """ensure that the appropriate runLog.warning is addressed in tight coupling reaches max num of iters."""
 
         class NoConverge(TightCoupler):
             def isConverged(self, _val: TightCoupler._SUPPORTED_TYPES) -> bool:
@@ -191,7 +191,7 @@ class TestTightCoupling(unittest.TestCase):
             )
 
     def test_performTightCoupling_WriteDB(self):
-        """ensure a tight coupling iteration accours and that a DB WILL be written if requested"""
+        """ensure a tight coupling iteration accours and that a DB WILL be written if requested."""
         hasCouplingInteraction = 1
         with directoryChangers.TemporaryDirectoryChanger():
             with mockRunLogs.BufferLog() as mock:
@@ -202,7 +202,7 @@ class TestTightCoupling(unittest.TestCase):
                 )
 
     def test_performTightCoupling_NoWriteDB(self):
-        """ensure a tight coupling iteration accours and that a DB WILL NOT be written if requested"""
+        """ensure a tight coupling iteration accours and that a DB WILL NOT be written if requested."""
         hasCouplingInteraction = 1
         with directoryChangers.TemporaryDirectoryChanger():
             with mockRunLogs.BufferLog() as mock:
@@ -228,7 +228,7 @@ class TestTightCoupling(unittest.TestCase):
         dbi.database.close()
 
     def test_computeTightCouplingConvergence(self):
-        """ensure that tight coupling convergence can be computed and checked
+        """ensure that tight coupling convergence can be computed and checked.
 
         Notes
         -----
@@ -355,14 +355,14 @@ settings:
 
 class TestInterfaceAndEventHeaders(unittest.TestCase):
     def test_expandCycleAndTimeNodeArgs_Empty(self):
-        """when *args are empty, cycleNodeInfo should be an empty string"""
+        """when *args are empty, cycleNodeInfo should be an empty string."""
         for task in ["Init", "BOL", "EOL"]:
             self.assertEqual(
                 Operator._expandCycleAndTimeNodeArgs(interactionName=task), ""
             )
 
     def test_expandCycleAndTimeNodeArgs_OneArg(self):
-        """when *args is a single value, cycleNodeInfo should return the right string"""
+        """when *args is a single value, cycleNodeInfo should return the right string."""
         cycle = 0
         for task in ["BOC", "EOC"]:
             self.assertEqual(
@@ -375,7 +375,7 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
         )
 
     def test_expandCycleAndTimeNodeArgs_TwoArg(self):
-        """when *args is two values, cycleNodeInfo should return the right string"""
+        """when *args is two values, cycleNodeInfo should return the right string."""
         cycle, timeNode = 0, 0
         self.assertEqual(
             Operator._expandCycleAndTimeNodeArgs(

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -146,19 +146,19 @@ class TestTightCoupling(unittest.TestCase):
         self.o.r.core = Core("empty")
 
     def test_couplingIsActive(self):
-        """ensure that cs[CONF_TIGHT_COUPLING] controls couplingIsActive."""
+        """Ensure that cs[CONF_TIGHT_COUPLING] controls couplingIsActive."""
         self.assertTrue(self.o.couplingIsActive())
         self.o.cs[CONF_TIGHT_COUPLING] = False
         self.assertFalse(self.o.couplingIsActive())
 
     def test_performTightCoupling_Inactive(self):
-        """ensures no action by _performTightCoupling if cs[CONF_TIGHT_COUPLING] = false."""
+        """Ensures no action by _performTightCoupling if cs[CONF_TIGHT_COUPLING] = false."""
         self.o.cs[CONF_TIGHT_COUPLING] = False
         self.o._performTightCoupling(0, 0, writeDB=False)
         self.assertEqual(self.o.r.core.p.coupledIteration, 0)
 
     def test_performTightCoupling_skip(self):
-        """ensure that cycles within cs[CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION] are skipped."""
+        """Ensure that cycles within cs[CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION] are skipped."""
         self.o.cs[CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION] = [1]
         with mockRunLogs.BufferLog() as mock:
             self.o._performTightCoupling(1, 0, writeDB=False)
@@ -166,7 +166,7 @@ class TestTightCoupling(unittest.TestCase):
             self.assertEqual(self.o.r.core.p.coupledIteration, 0)
 
     def test_performTightCoupling_notConverged(self):
-        """ensure that the appropriate runLog.warning is addressed in tight coupling reaches max num of iters."""
+        """Ensure that the appropriate runLog.warning is addressed in tight coupling reaches max num of iters."""
 
         class NoConverge(TightCoupler):
             def isConverged(self, _val: TightCoupler._SUPPORTED_TYPES) -> bool:
@@ -191,7 +191,7 @@ class TestTightCoupling(unittest.TestCase):
             )
 
     def test_performTightCoupling_WriteDB(self):
-        """ensure a tight coupling iteration accours and that a DB WILL be written if requested."""
+        """Ensure a tight coupling iteration accours and that a DB WILL be written if requested."""
         hasCouplingInteraction = 1
         with directoryChangers.TemporaryDirectoryChanger():
             with mockRunLogs.BufferLog() as mock:
@@ -202,7 +202,7 @@ class TestTightCoupling(unittest.TestCase):
                 )
 
     def test_performTightCoupling_NoWriteDB(self):
-        """ensure a tight coupling iteration accours and that a DB WILL NOT be written if requested."""
+        """Ensure a tight coupling iteration accours and that a DB WILL NOT be written if requested."""
         hasCouplingInteraction = 1
         with directoryChangers.TemporaryDirectoryChanger():
             with mockRunLogs.BufferLog() as mock:
@@ -228,7 +228,7 @@ class TestTightCoupling(unittest.TestCase):
         dbi.database.close()
 
     def test_computeTightCouplingConvergence(self):
-        """ensure that tight coupling convergence can be computed and checked.
+        """Ensure that tight coupling convergence can be computed and checked.
 
         Notes
         -----
@@ -355,14 +355,14 @@ settings:
 
 class TestInterfaceAndEventHeaders(unittest.TestCase):
     def test_expandCycleAndTimeNodeArgs_Empty(self):
-        """when *args are empty, cycleNodeInfo should be an empty string."""
+        """When *args are empty, cycleNodeInfo should be an empty string."""
         for task in ["Init", "BOL", "EOL"]:
             self.assertEqual(
                 Operator._expandCycleAndTimeNodeArgs(interactionName=task), ""
             )
 
     def test_expandCycleAndTimeNodeArgs_OneArg(self):
-        """when *args is a single value, cycleNodeInfo should return the right string."""
+        """When *args is a single value, cycleNodeInfo should return the right string."""
         cycle = 0
         for task in ["BOC", "EOC"]:
             self.assertEqual(
@@ -375,7 +375,7 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
         )
 
     def test_expandCycleAndTimeNodeArgs_TwoArg(self):
-        """when *args is two values, cycleNodeInfo should return the right string."""
+        """When *args is two values, cycleNodeInfo should return the right string."""
         cycle, timeNode = 0, 0
         self.assertEqual(
             Operator._expandCycleAndTimeNodeArgs(

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -158,7 +158,7 @@ class TestTightCoupling(unittest.TestCase):
         self.assertEqual(self.o.r.core.p.coupledIteration, 0)
 
     def test_performTightCoupling_skip(self):
-        """Ensure that cycles within cs[CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION] are skipped."""
+        """Ensure that cycles within ``cs[CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION]`` are skipped."""
         self.o.cs[CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION] = [1]
         with mockRunLogs.BufferLog() as mock:
             self.o._performTightCoupling(1, 0, writeDB=False)

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -216,7 +216,7 @@ class DefaultExecuter(Executer):
 
     def _updateRunDir(self, directory):
         """
-        If a TemporaryDirectoryChanger is used, the runDir needs to be updated
+        If a TemporaryDirectoryChanger is used, the runDir needs to be updated.
 
         If a ForcedCreationDirectoryChanger is used instead, nothing needs to be done.
 

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -216,7 +216,7 @@ class DefaultExecuter(Executer):
 
     def _updateRunDir(self, directory):
         """
-        If a TemporaryDirectoryChanger is used, the runDir needs to be updated.
+        If a ``TemporaryDirectoryChanger`` is used, the ``runDir`` needs to be updated.
 
         If a ForcedCreationDirectoryChanger is used instead, nothing needs to be done.
 

--- a/armi/physics/fuelCycle/__init__.py
+++ b/armi/physics/fuelCycle/__init__.py
@@ -51,7 +51,7 @@ class FuelHandlerPlugin(plugins.ArmiPlugin):
     @plugins.HOOKIMPL
     def exposeInterfaces(cs):
         """
-        Implementation of the exposeInterfaces plugin hookspec
+        Implementation of the exposeInterfaces plugin hookspec.
 
         Notes
         -----

--- a/armi/physics/fuelCycle/assemblyRotationAlgorithms.py
+++ b/armi/physics/fuelCycle/assemblyRotationAlgorithms.py
@@ -30,7 +30,7 @@ from armi.physics.fuelCycle.settings import CONF_ASSEM_ROTATION_STATIONARY
 
 def buReducingAssemblyRotation(fh):
     r"""
-    Rotates all detail assemblies to put the highest bu pin in the lowest power orientation
+    Rotates all detail assemblies to put the highest bu pin in the lowest power orientation.
 
     Parameters
     ----------
@@ -75,7 +75,7 @@ def buReducingAssemblyRotation(fh):
 
 def simpleAssemblyRotation(fh):
     """
-    Rotate all pin-detail assemblies that were just shuffled by 60 degrees
+    Rotate all pin-detail assemblies that were just shuffled by 60 degrees.
 
     Parameters
     ----------

--- a/armi/physics/fuelCycle/fuelHandlerFactory.py
+++ b/armi/physics/fuelCycle/fuelHandlerFactory.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""factory for the FuelHandler"""
+"""factory for the FuelHandler."""
 from armi.physics.fuelCycle import fuelHandlers
 from armi.physics.fuelCycle.settings import CONF_FUEL_HANDLER_NAME
 from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC

--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A place for the FuelHandler's Interface"""
+"""A place for the FuelHandler's Interface."""
 
 from armi import interfaces
 from armi import runLog
@@ -96,7 +96,7 @@ class FuelHandlerInterface(interfaces.Interface):
         )
 
     def interactEOL(self):
-        """Make reports at EOL"""
+        """Make reports at EOL."""
         self.makeShuffleReport()
 
     def manageFuel(self, cycle):

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -201,7 +201,7 @@ class FuelHandler:
         return defaultFactorList, factorSearchFlags
 
     def prepCore(self):
-        """Aux. function to run before XS generation (do moderation, etc. here)"""
+        """Aux. function to run before XS generation (do moderation, etc. here)."""
 
     def prepSearch(self, *args, **kwargs):
         """
@@ -626,7 +626,7 @@ class FuelHandler:
         circularRingFlag=False,
     ):
         r"""
-        find assemblies in particular rings
+        find assemblies in particular rings.
 
         Parameters
         ----------
@@ -701,7 +701,7 @@ class FuelHandler:
 
     def swapAssemblies(self, a1, a2):
         r"""
-        Moves a whole assembly from one place to another
+        Moves a whole assembly from one place to another.
 
         Parameters
         ----------
@@ -732,7 +732,7 @@ class FuelHandler:
 
     def _transferStationaryBlocks(self, assembly1, assembly2):
         """
-        Exchange the stationary blocks (e.g. grid plate) between the moving assemblies
+        Exchange the stationary blocks (e.g. grid plate) between the moving assemblies.
 
         These blocks in effect are not moved at all.
         """
@@ -867,7 +867,7 @@ class FuelHandler:
 
     def repeatShufflePattern(self, explicitRepeatShuffles):
         r"""
-        Repeats the fuel management from a previous ARMI run
+        Repeats the fuel management from a previous ARMI run.
 
         Parameters
         ----------
@@ -916,7 +916,7 @@ class FuelHandler:
     @staticmethod
     def readMoves(fname):
         r"""
-        reads a shuffle output file and sets up the moves dictionary
+        reads a shuffle output file and sets up the moves dictionary.
 
         Parameters
         ----------
@@ -1014,7 +1014,7 @@ class FuelHandler:
     @staticmethod
     def trackChain(moveList, startingAt, alreadyDone=None):
         r"""
-        builds a chain of locations based on starting location
+        builds a chain of locations based on starting location.
 
         Notes
         -----
@@ -1222,7 +1222,7 @@ class FuelHandler:
         self, loadChains, loopChains, enriches, loadChargeTypes, loadNames
     ):
         r"""
-        Actually does the fuel movements required to repeat a shuffle order
+        Actually does the fuel movements required to repeat a shuffle order.
 
         Parameters
         ----------

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -456,7 +456,7 @@ def _assemAngle(a):
 
 def buildEqRingSchedule(core, ringSchedule, circularRingOrder):
     r"""
-    Expands simple ringSchedule input into full-on location schedule.
+    Expands simple ``ringSchedule`` input into full-on location schedule.
 
     Parameters
     ----------

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -302,7 +302,7 @@ def buildRingSchedule(
 
 def buildConvergentRingSchedule(chargeRing, dischargeRing=1, coarseFactor=0.0):
     r"""
-    Builds a ring schedule for convergent shuffling from chargeRing to dischargeRing
+    Builds a ring schedule for convergent shuffling from chargeRing to dischargeRing.
 
     Parameters
     ----------
@@ -349,7 +349,7 @@ def buildConvergentRingSchedule(chargeRing, dischargeRing=1, coarseFactor=0.0):
 
 def _buildEqRingScheduleHelper(ringSchedule, numRings):
     r"""
-    turns ringScheduler into explicit list of rings
+    turns ringScheduler into explicit list of rings.
 
     Pulled out of buildEqRingSchedule for testing.
 
@@ -456,7 +456,7 @@ def _assemAngle(a):
 
 def buildEqRingSchedule(core, ringSchedule, circularRingOrder):
     r"""
-    Expands simple ringSchedule input into full-on location schedule
+    Expands simple ringSchedule input into full-on location schedule.
 
     Parameters
     ----------

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -349,7 +349,7 @@ def buildConvergentRingSchedule(chargeRing, dischargeRing=1, coarseFactor=0.0):
 
 def _buildEqRingScheduleHelper(ringSchedule, numRings):
     r"""
-    turns ringScheduler into explicit list of rings.
+    turns ``ringScheduler`` into explicit list of rings.
 
     Pulled out of buildEqRingSchedule for testing.
 

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -302,7 +302,7 @@ def buildRingSchedule(
 
 def buildConvergentRingSchedule(chargeRing, dischargeRing=1, coarseFactor=0.0):
     r"""
-    Builds a ring schedule for convergent shuffling from chargeRing to dischargeRing.
+    Builds a ring schedule for convergent shuffling from ``chargeRing`` to ``dischargeRing``.
 
     Parameters
     ----------

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -227,7 +227,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         )
 
     def test_findMany(self):
-        """Tests the findMany and type aspects of the fuel handler"""
+        """Tests the findMany and type aspects of the fuel handler."""
         fh = fuelHandlers.FuelHandler(self.o)
 
         igniters = fh.findAssembly(typeSpec=Flags.IGNITER | Flags.FUEL, findMany=True)
@@ -256,7 +256,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         )
 
     def test_findInSFP(self):
-        """Tests ability to pull from the spent fuel pool"""
+        """Tests ability to pull from the spent fuel pool."""
         fh = fuelHandlers.FuelHandler(self.o)
         spent = fh.findAssembly(
             findMany=True,
@@ -391,7 +391,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
 
     def test_readMoves(self):
         """
-        Depends on the shuffleLogic created by repeatShuffles
+        Depends on the shuffleLogic created by repeatShuffles.
 
         See Also
         --------

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -227,7 +227,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         )
 
     def test_findMany(self):
-        """Tests the findMany and type aspects of the fuel handler."""
+        """Tests the ``findMany`` and type aspects of the fuel handler."""
         fh = fuelHandlers.FuelHandler(self.o)
 
         igniters = fh.findAssembly(typeSpec=Flags.IGNITER | Flags.FUEL, findMany=True)

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -391,7 +391,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
 
     def test_readMoves(self):
         """
-        Depends on the shuffleLogic created by repeatShuffles.
+        Depends on the ``shuffleLogic`` created by ``repeatShuffles``.
 
         See Also
         --------

--- a/armi/physics/fuelCycle/tests/test_hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/tests/test_hexAssemblyFuelMgmtUtils.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-TODO
-
-Tests some capabilities of the fuel handling tools,
-specific to hex-assembly reactors.
+Tests some fuel handling tools, specific to hex-assembly reactors.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest

--- a/armi/physics/fuelPerformance/plugin.py
+++ b/armi/physics/fuelPerformance/plugin.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Generic Fuel Performance Plugin
+Generic Fuel Performance Plugin.
 """
 
 from armi import plugins

--- a/armi/physics/fuelPerformance/settings.py
+++ b/armi/physics/fuelPerformance/settings.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Settings related to fuel performance"""
+"""Settings related to fuel performance."""
 
 from armi.operators.settingsValidation import Query
 from armi.settings import setting

--- a/armi/physics/fuelPerformance/tests/test_executers.py
+++ b/armi/physics/fuelPerformance/tests/test_executers.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for generic fuel performance executers"""
+"""Tests for generic fuel performance executers."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 

--- a/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
+++ b/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for generic fuel performance plugin"""
+"""Tests for generic fuel performance plugin."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 

--- a/armi/physics/fuelPerformance/utils.py
+++ b/armi/physics/fuelPerformance/utils.py
@@ -50,7 +50,7 @@ def applyFuelDisplacement(block, displacementInCm):
 
 def gasConductivityCorrection(tempInC: float, porosity: float, morphology: int = 2):
     """
-    Calculate the correction to conductivity for a porous, gas-filled solid
+    Calculate the correction to conductivity for a porous, gas-filled solid.
 
     Parameters
     ----------

--- a/armi/physics/neutronics/__init__.py
+++ b/armi/physics/neutronics/__init__.py
@@ -51,7 +51,7 @@ class NeutronicsPlugin(plugins.ArmiPlugin):
     @plugins.HOOKIMPL
     def exposeInterfaces(cs):
         """
-        Collect and expose all of the interfaces that live under the built-in neutronics package
+        Collect and expose all of the interfaces that live under the built-in neutronics package.
         """
         from armi.physics.neutronics import crossSectionGroupManager
         from armi.physics.neutronics.fissionProductModel import fissionProductModel
@@ -118,7 +118,7 @@ class NeutronicsPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def getReportContents(r, cs, report, stage, blueprint):
-        """Generates the Report Content for the Neutronics Report"""
+        """Generates the Report Content for the Neutronics Report."""
         from armi.physics.neutronics import reports
 
         return reports.insertNeutronicsReport(r, cs, report, stage)

--- a/armi/physics/neutronics/const.py
+++ b/armi/physics/neutronics/const.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Constants and Enums
+Constants and Enums.
 
 In an independent file to minimize circular imports.
 """

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -72,7 +72,7 @@ ORDER = interfaces.STACK_ORDER.BEFORE + interfaces.STACK_ORDER.FUEL_MANAGEMENT
 
 
 def describeInterfaces(cs):
-    """Function for exposing interface(s) to other code"""
+    """Function for exposing interface(s) to other code."""
     # pylint: disable=import-outside-toplevel # avoid cyclic import
     from armi.physics.neutronics.settings import CONF_NEUTRONICS_KERNEL
 
@@ -117,7 +117,7 @@ def getXSTypeLabelFromNumber(xsTypeNumber: int) -> int:
 
 class BlockCollection(list):
     """
-    Controls which blocks are representative of a particular cross section type/BU group
+    Controls which blocks are representative of a particular cross section type/BU group.
 
     This is a list with special methods.
     """
@@ -213,7 +213,7 @@ class BlockCollection(list):
 
     def getWeight(self, block):
         """
-        Get value of weighting function for this block
+        Get value of weighting function for this block.
         """
         vol = block.getVolume() or 1.0
         if not self.weightingParam:
@@ -296,7 +296,7 @@ class MedianBlockCollection(BlockCollection):
 
 class AverageBlockCollection(BlockCollection):
     """
-    Block collection that builds a new block based on others in collection
+    Block collection that builds a new block based on others in collection.
 
     Averages number densities, fission product yields, and fission gas
     removal fractions.
@@ -442,7 +442,7 @@ class CylindricalComponentsAverageBlockCollection(BlockCollection):
     @staticmethod
     def _checkComponentConsistency(b, repBlock):
         """
-        Verify that all components being homogenized have same multiplicity and nuclides
+        Verify that all components being homogenized have same multiplicity and nuclides.
 
         Raises
         ------
@@ -663,7 +663,7 @@ class SlabComponentsAverageBlockCollection(BlockCollection):
 
 class FluxWeightedAverageBlockCollection(AverageBlockCollection):
     """
-    Flux-weighted AverageBlockCollection
+    Flux-weighted AverageBlockCollection.
     """
 
     def __init__(self, *args, **kwargs):
@@ -770,7 +770,7 @@ class CrossSectionGroupManager(interfaces.Interface):
 
     def _setBuGroupBounds(self, upperBuGroupBounds):
         """
-        Set the burnup group structure
+        Set the burnup group structure.
 
         Parameters
         ---------
@@ -795,7 +795,7 @@ class CrossSectionGroupManager(interfaces.Interface):
 
     def _updateBurnupGroups(self, blockList):
         """
-        Update the burnup group of each block based on its burnup
+        Update the burnup group of each block based on its burnup.
 
         If only one burnup group exists, then this is skipped so as to accomodate the possibility
         of 2-character xsGroup values (useful for detailed V&V models w/o depletion).
@@ -822,7 +822,7 @@ class CrossSectionGroupManager(interfaces.Interface):
 
     def _addXsGroupsFromBlocks(self, blockCollectionsByXsGroup, blockList):
         """
-        Build all the cross section groups based on their XS type and BU group
+        Build all the cross section groups based on their XS type and BU group.
 
         Also ensures that their BU group is up to date with their burnup.
         """
@@ -1141,7 +1141,7 @@ class CrossSectionGroupManager(interfaces.Interface):
 
     def _modifyUnrepresentedXSIDs(self, blockCollectionsByXsGroup):
         """
-        adjust the xsID of blocks in the groups that are not represented
+        adjust the xsID of blocks in the groups that are not represented.
 
         Try to just adjust the burnup group up to something that is represented
         (can happen to structure in AA when only AB, AC, AD still remain).
@@ -1214,7 +1214,7 @@ class CrossSectionGroupManager(interfaces.Interface):
 
     def disableBuGroupUpdates(self):
         """
-        Turn off updating bu groups based on burnup
+        Turn off updating bu groups based on burnup.
 
         Useful during reactivity coefficient calculations to be consistent with ref. run.
 
@@ -1229,7 +1229,7 @@ class CrossSectionGroupManager(interfaces.Interface):
 
     def enableBuGroupUpdates(self):
         """
-        Turn on updating bu groups based on burnup
+        Turn on updating bu groups based on burnup.
 
         See Also
         --------

--- a/armi/physics/neutronics/diffIsotxs.py
+++ b/armi/physics/neutronics/diffIsotxs.py
@@ -20,7 +20,7 @@ from armi.cli.entryPoint import EntryPoint
 
 
 class CompareIsotxsLibraries(EntryPoint):
-    """Compare two ISOTXS files"""
+    """Compare two ISOTXS files."""
 
     name = "diff-isotxs"
 

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -112,7 +112,7 @@ ORDER = interfaces.STACK_ORDER.AFTER + interfaces.STACK_ORDER.PREPROCESSING
 
 
 def describeInterfaces(_cs):
-    """Function for exposing interface(s) to other code"""
+    """Function for exposing interface(s) to other code."""
 
     return (FissionProductModel, {})
 

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -56,7 +56,7 @@ class LumpedFissionProduct:
 
     def __init__(self, name=None):
         """
-        Make a LFP
+        Make a LFP.
 
         Parameters
         ----------
@@ -69,7 +69,7 @@ class LumpedFissionProduct:
 
     def duplicate(self):
         """
-        Make a copy of this w/o using deepcopy
+        Make a copy of this w/o using deepcopy.
         """
         new = self.__class__(self.name)
         for key, val in self.yld.items():
@@ -133,7 +133,7 @@ class LumpedFissionProduct:
 
     def getTotalYield(self):
         """
-        Get the fractional yield of all nuclides in this lumped fission product
+        Get the fractional yield of all nuclides in this lumped fission product.
 
         Accounts for any fission gas that may be removed.
 
@@ -202,7 +202,7 @@ class LumpedFissionProduct:
 
 class LumpedFissionProductCollection(dict):
     """
-    A set of lumped fission products
+    A set of lumped fission products.
 
     Typically there would be one of these on a block or on a global level.
     """
@@ -220,7 +220,7 @@ class LumpedFissionProductCollection(dict):
         return self.keys()
 
     def getAllFissionProductNames(self):
-        """Gets names of all fission products in this collection"""
+        """Gets names of all fission products in this collection."""
         fpNames = set()
         for lfp in self.values():
             for fp in lfp.keys():
@@ -228,7 +228,7 @@ class LumpedFissionProductCollection(dict):
         return sorted(fpNames)
 
     def getAllFissionProductNuclideBases(self):
-        """Gets names of all fission products in this collection"""
+        """Gets names of all fission products in this collection."""
         nucs = set()
         for _lfpName, lfp in self.items():
             for fp in lfp.keys():
@@ -237,7 +237,7 @@ class LumpedFissionProductCollection(dict):
 
     def getNumberDensities(self, objectWithParentDensities=None, densFunc=None):
         """
-        Gets all FP number densities in collection
+        Gets all FP number densities in collection.
 
         Parameters
         ----------
@@ -264,7 +264,7 @@ class LumpedFissionProductCollection(dict):
 
     def getMassFrac(self, oldMassFrac=None):
         """
-        returns the mass fraction vector of the collection of lumped fission products
+        returns the mass fraction vector of the collection of lumped fission products.
         """
         if not oldMassFrac:
             raise ValueError("You must define a massFrac vector")
@@ -284,7 +284,7 @@ class LumpedFissionProductCollection(dict):
 
 class FissionProductDefinitionFile:
     """
-    Reads a file that has definitions of one or more LFPs in it to produce LFPs
+    Reads a file that has definitions of one or more LFPs in it to produce LFPs.
 
     The format for this file is as follows::
 
@@ -308,7 +308,7 @@ class FissionProductDefinitionFile:
 
     def createLFPsFromFile(self):
         """
-        Read the file and create LFPs from the contents
+        Read the file and create LFPs from the contents.
 
         Returns
         -------
@@ -323,7 +323,7 @@ class FissionProductDefinitionFile:
 
     def createSingleLFPFromFile(self, name):
         """
-        Read one LFP from the file
+        Read one LFP from the file.
         """
         lfpLines = self._splitIntoIndividualLFPLines(name)
         lfp = self._readOneLFP(lfpLines[0])  # only one LFP expected. Use it.

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -56,7 +56,7 @@ class LumpedFissionProduct:
 
     def __init__(self, name=None):
         """
-        Make a LFP.
+        Make an LFP.
 
         Parameters
         ----------

--- a/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests for lumpedFissionProduce module
+Tests for lumpedFissionProduce module.
 """
 import unittest
 import io
@@ -52,13 +52,13 @@ def getDummyLFPFile():
 
 
 class TestFissionProductDefinitionFile(unittest.TestCase):
-    """Test of the fission product model"""
+    """Test of the fission product model."""
 
     def setUp(self):
         self.fpd = getDummyLFPFile()
 
     def test_createLFPs(self):
-        """Test of the fission product model creation"""
+        """Test of the fission product model creation."""
         lfps = self.fpd.createLFPsFromFile()
         xe135 = nuclideBases.fromName("XE135")
         self.assertEqual(len(lfps), 3)
@@ -67,7 +67,7 @@ class TestFissionProductDefinitionFile(unittest.TestCase):
             self.assertIn(xe135, lfp)
 
     def test_createReferenceLFPs(self):
-        """Test of the reference fission product model creation"""
+        """Test of the reference fission product model creation."""
         with open(REFERENCE_LUMPED_FISSION_PRODUCT_FILE, "r") as LFP_FILE:
             LFP_TEXT = LFP_FILE.read()
         fpd = lumpedFissionProduct.FissionProductDefinitionFile(io.StringIO(LFP_TEXT))
@@ -98,7 +98,7 @@ class TestFissionProductDefinitionFile(unittest.TestCase):
 
 
 class TestLumpedFissionProduct(unittest.TestCase):
-    """Test of the lumped fission product yields"""
+    """Test of the lumped fission product yields."""
 
     def setUp(self):
         self.fpd = lumpedFissionProduct.FissionProductDefinitionFile(
@@ -106,7 +106,7 @@ class TestLumpedFissionProduct(unittest.TestCase):
         )
 
     def test_getYield(self):
-        """Test of the yield of a fission product"""
+        """Test of the yield of a fission product."""
         xe135 = nuclideBases.fromName("XE135")
         lfp = self.fpd.createSingleLFPFromFile("LFP39")
         lfp[xe135] = 1.2
@@ -145,20 +145,20 @@ class TestLumpedFissionProduct(unittest.TestCase):
 
 
 class TestLumpedFissionProductCollection(unittest.TestCase):
-    """Test of the fission product collection"""
+    """Test of the fission product collection."""
 
     def setUp(self):
         fpd = lumpedFissionProduct.FissionProductDefinitionFile(io.StringIO(LFP_TEXT))
         self.lfps = fpd.createLFPsFromFile()
 
     def test_getAllFissionProductNames(self):
-        """Test to ensure the fission product names are present"""
+        """Test to ensure the fission product names are present."""
         names = self.lfps.getAllFissionProductNames()
         self.assertIn("XE135", names)
         self.assertIn("KR85", names)
 
     def test_getAllFissionProductNuclideBases(self):
-        """Test to ensure the fission product nuclide bases are present"""
+        """Test to ensure the fission product nuclide bases are present."""
         clideBases = self.lfps.getAllFissionProductNuclideBases()
         xe135 = nuclideBases.fromName("XE135")
         kr85 = nuclideBases.fromName("KR85")
@@ -166,7 +166,7 @@ class TestLumpedFissionProductCollection(unittest.TestCase):
         self.assertIn(kr85, clideBases)
 
     def test_duplicate(self):
-        """Test to ensure that when we duplicate, we don't adjust the original file"""
+        """Test to ensure that when we duplicate, we don't adjust the original file."""
         newLfps = self.lfps.duplicate()
         ba = nuclideBases.fromName("XE135")
         lfp1 = self.lfps["LFP39"]
@@ -213,7 +213,7 @@ class TestLumpedFissionProductsFromReferenceFile(unittest.TestCase):
     """Tests loading from the `referenceFissionProducts.dat` file."""
 
     def test_fissionProductYields(self):
-        """Test that the fission product yields for the lumped fission products sums to 2.0"""
+        """Test that the fission product yields for the lumped fission products sums to 2.0."""
         cs = Settings()
         cs[CONF_FP_MODEL] = "infinitelyDilute"
         cs[CONF_LFP_COMPOSITION_FILE_PATH] = os.path.join(
@@ -236,7 +236,7 @@ class TestLumpedFissionProductsExplicit(unittest.TestCase):
 
 
 class TestMo99LFP(unittest.TestCase):
-    """Test of the fission product model from Mo99"""
+    """Test of the fission product model from Mo99."""
 
     def setUp(self):
         self.lfps = (
@@ -244,7 +244,7 @@ class TestMo99LFP(unittest.TestCase):
         )  # pylint: disable=protected-access
 
     def test_getAllFissionProductNames(self):
-        """Test to ensure that Mo99 is present, but other FP are not"""
+        """Test to ensure that Mo99 is present, but other FP are not."""
         names = self.lfps.getAllFissionProductNames()
         self.assertIn("MO99", names)
         self.assertNotIn("KR85", names)

--- a/armi/physics/neutronics/globalFlux/__init__.py
+++ b/armi/physics/neutronics/globalFlux/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Global flux solvers"""
+"""Global flux solvers."""

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -80,7 +80,7 @@ class GlobalFluxInterface(interfaces.Interface):
         self._setTightCouplingDefaults()
 
     def _setTightCouplingDefaults(self):
-        """enable tight coupling defaults for the interface.
+        """Enable tight coupling defaults for the interface.
 
         - allows users to set tightCoupling: true in settings without
           having to specify the specific tightCouplingSettings for this interface.

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -80,7 +80,7 @@ class GlobalFluxInterface(interfaces.Interface):
         self._setTightCouplingDefaults()
 
     def _setTightCouplingDefaults(self):
-        """enable tight coupling defaults for the interface
+        """enable tight coupling defaults for the interface.
 
         - allows users to set tightCoupling: true in settings without
           having to specify the specific tightCouplingSettings for this interface.
@@ -203,7 +203,7 @@ class GlobalFluxInterface(interfaces.Interface):
 
     def calculateKeff(self, label="keff"):
         """
-        Runs neutronics tool and returns keff without applying it to the reactor
+        Runs neutronics tool and returns keff without applying it to the reactor.
 
         Used for things like direct-eigenvalue reactivity coefficients and CR worth iterations.
         For anything more complicated than getting keff, clients should
@@ -251,7 +251,7 @@ class GlobalFluxInterfaceUsingExecuters(GlobalFluxInterface):
         GlobalFluxInterface.interactCoupled(self, iteration)
 
     def getTightCouplingValue(self):
-        """Return the parameter value"""
+        """Return the parameter value."""
         if self.coupler.parameter == "keff":
             return self.r.core.p.keff
         if self.coupler.parameter == "power":
@@ -296,7 +296,7 @@ class GlobalFluxInterfaceUsingExecuters(GlobalFluxInterface):
 
     def getExecuter(self, options=None, label=None):
         """
-        Get executer object for performing custom client calcs
+        Get executer object for performing custom client calcs.
 
         This allows plugins to update options in a somewhat generic
         way. For example, reactivity coefficients plugin may want to
@@ -326,7 +326,7 @@ class GlobalFluxInterfaceUsingExecuters(GlobalFluxInterface):
     @staticmethod
     def getLabel(caseTitle, cycle, node, iteration=None):
         """
-        Make a label (input/output file name) for the executer based on cycle, node, iteration
+        Make a label (input/output file name) for the executer based on cycle, node, iteration.
 
         Parameters
         ----------
@@ -346,7 +346,7 @@ class GlobalFluxInterfaceUsingExecuters(GlobalFluxInterface):
 
 
 class GlobalFluxOptions(executers.ExecutionOptions):
-    """Data structure representing common options in Global Flux Solvers
+    """Data structure representing common options in Global Flux Solvers.
 
     Attributes
     ----------
@@ -512,7 +512,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
     @codeTiming.timed
     def _performGeometryTransformations(self, makePlots=False):
         """
-        Apply geometry conversions to make reactor work in neutronics
+        Apply geometry conversions to make reactor work in neutronics.
 
         There are two conditions where things must happen:
 
@@ -603,7 +603,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
 
     def edgeAssembliesAreNeeded(self) -> bool:
         """
-        True if edge assemblies are needed in this calculation
+        True if edge assemblies are needed in this calculation.
 
         We only need them in finite difference cases that are not full core.
         """
@@ -725,7 +725,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
 
     def getBurnupPeakingFactor(self, b: Block):
         """
-        Get the radial peaking factor to be applied to burnup and DPA for a Block
+        Get the radial peaking factor to be applied to burnup and DPA for a Block.
 
         This may be informed by previous runs which used
         detailed pin reconstruction and rotation. In that case,
@@ -755,7 +755,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
 
     def updateDpaRate(self, blockList=None):
         """
-        Update state parameters that can be known right after the flux is computed
+        Update state parameters that can be known right after the flux is computed.
 
         See Also
         --------
@@ -870,7 +870,7 @@ class DoseResultsMapper(GlobalFluxResultMapper):
 
     def updateFluenceAndDpa(self, stepTimeInSeconds, blockList=None):
         r"""
-        Updates the fast fluence and the DPA of the blocklist
+        Updates the fast fluence and the DPA of the blocklist.
 
         The dpa rate from the previous timestep is used to compute the dpa here.
 
@@ -956,13 +956,14 @@ class DoseResultsMapper(GlobalFluxResultMapper):
         self.updateLoadpadDose()
 
     def updateCycleDoseParams(self):
-        r"""Updates reactor params based on the amount of dose (detailedDpa) accrued this cycle
+        r"""Updates reactor params based on the amount of dose (detailedDpa) accrued this cycle.
+
         Params updated include:
 
-        maxDetailedDpaThisCycle
-        dpaFullWidthHalfMax
-        elevationOfACLP3Cycles
-        elevationOfACLP7Cycles
+        * maxDetailedDpaThisCycle
+        * dpaFullWidthHalfMax
+        * elevationOfACLP3Cycles
+        * elevationOfACLP7Cycles
 
         These parameters are left as zeroes at BOC because no dose has been accumulated yet.
         """
@@ -1134,7 +1135,7 @@ class DoseResultsMapper(GlobalFluxResultMapper):
 
 def computeDpaRate(mgFlux, dpaXs):
     r"""
-    Compute the DPA rate incurred by exposure of a certain flux spectrum
+    Compute the DPA rate incurred by exposure of a certain flux spectrum.
 
     Parameters
     ----------
@@ -1213,7 +1214,7 @@ def computeDpaRate(mgFlux, dpaXs):
 
 def calcReactionRates(obj, keff, lib):
     r"""
-    Compute 1-group reaction rates for this object (usually a block.)
+    Compute 1-group reaction rates for this object (usually a block).
 
     Parameters
     ----------
@@ -1256,7 +1257,6 @@ def calcReactionRates(obj, keff, lib):
     .. math::
 
         \sigma_g = \frac{\int_{E g}^{E_{g+1}} \phi(E)  \sigma(E) dE}{\int_{E_g}^{E_{g+1}} \phi(E) dE}
-
     """
     rate = {}
     for simple in RX_PARAM_NAMES:

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for generic global flux interface"""
+"""Tests for generic global flux interface."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
@@ -83,7 +83,7 @@ class MockGlobalFluxWithExecuters(
 class MockGlobalFluxWithExecutersNonUniform(MockGlobalFluxWithExecuters):
     def getExecuterOptions(self, label=None):
         """
-        Return modified executerOptions
+        Return modified executerOptions.
         """
         opts = globalFluxInterface.GlobalFluxInterfaceUsingExecuters.getExecuterOptions(
             self, label=label
@@ -138,7 +138,7 @@ class TestGlobalFluxOptions(unittest.TestCase):
 class TestGlobalFluxInterface(unittest.TestCase):
     def test_interaction(self):
         """
-        Ensure the basic interaction hooks work
+        Ensure the basic interaction hooks work.
 
         Check that a 1000 pcm rx swing is observed due to the mock.
         """
@@ -197,14 +197,14 @@ class TestGlobalFluxInterfaceWithExecuters(unittest.TestCase):
         self.assertEqual(class0, globalFluxInterface.GlobalFluxExecuter)
 
     def test_setTightCouplingDefaults(self):
-        """assert that tight coupling defaults are only set if cs["tightCoupling"]=True"""
+        """assert that tight coupling defaults are only set if cs["tightCoupling"]=True."""
         self.assertIsNone(self.gfi.coupler)
         self._setTightCouplingTrue()
         self.assertEqual(self.gfi.coupler.parameter, "keff")
         self._setTightCouplingFalse()
 
     def test_getTightCouplingValue(self):
-        """test getTightCouplingValue returns the correct value for keff and type for power"""
+        """test getTightCouplingValue returns the correct value for keff and type for power."""
         self._setTightCouplingTrue()
         self.assertEqual(self.gfi.getTightCouplingValue(), 1.0)  # set in setUp
         self.gfi.coupler.parameter = "power"

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -197,14 +197,14 @@ class TestGlobalFluxInterfaceWithExecuters(unittest.TestCase):
         self.assertEqual(class0, globalFluxInterface.GlobalFluxExecuter)
 
     def test_setTightCouplingDefaults(self):
-        """assert that tight coupling defaults are only set if cs["tightCoupling"]=True."""
+        """Assert that tight coupling defaults are only set if cs["tightCoupling"]=True."""
         self.assertIsNone(self.gfi.coupler)
         self._setTightCouplingTrue()
         self.assertEqual(self.gfi.coupler.parameter, "keff")
         self._setTightCouplingFalse()
 
     def test_getTightCouplingValue(self):
-        """test getTightCouplingValue returns the correct value for keff and type for power."""
+        """Test getTightCouplingValue returns the correct value for keff and type for power."""
         self._setTightCouplingTrue()
         self.assertEqual(self.gfi.getTightCouplingValue(), 1.0)  # set in setUp
         self.gfi.coupler.parameter = "power"

--- a/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
+++ b/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
@@ -55,7 +55,7 @@ class CrossSectionTable(collections.OrderedDict):
 
     def add(self, nucName, nG=0.0, nF=0.0, n2n=0.0, nA=0.0, nP=0.0, n3n=0.0):
         """
-        Add one group cross secitons to the table.
+        Add one group cross sections to the table.
 
         Parameters
         ----------

--- a/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
+++ b/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
@@ -55,7 +55,7 @@ class CrossSectionTable(collections.OrderedDict):
 
     def add(self, nucName, nG=0.0, nF=0.0, n2n=0.0, nA=0.0, nP=0.0, n3n=0.0):
         """
-        Add one group cross secitons to the table
+        Add one group cross secitons to the table.
 
         Parameters
         ----------
@@ -116,7 +116,7 @@ class CrossSectionTable(collections.OrderedDict):
 
     def hasValues(self):
         """
-        determines if there are non-zero values in this cross section table
+        determines if there are non-zero values in this cross section table.
         """
         for nuclideCrossSectionSet in self.values():
             if any(nuclideCrossSectionSet.values()):
@@ -129,7 +129,7 @@ class CrossSectionTable(collections.OrderedDict):
         tableFormat="\n{{mcnpId}} {nG:.5e} {nF:.5e} {n2n:.5e} {n3n:.5e} {nA:.5e} {nP:.5e}",
     ):
         """
-        make a cross section table for external depletion physics code input decks
+        make a cross section table for external depletion physics code input decks.
 
         Parameters
         ----------

--- a/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
+++ b/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
@@ -65,7 +65,7 @@ def isDepletable(obj: composites.ArmiObject):
 
 class AbstractIsotopicDepleter:
     r"""
-    Interact with a depletion code
+    Interact with a depletion code.
 
     This interface and subClasses deplete under a flux defined outside this
     interface
@@ -182,12 +182,12 @@ def makeXsecTable(
 
 class AbstractIsotopicDepletionReader(interfaces.OutputReader):
     r"""
-    Read number density output produced by the isotopic depletion
+    Read number density output produced by the isotopic depletion.
     """
 
     def read(self):
         r"""
-        read a isotopic depletion Output File and applies results to armi objects in the ToDepletion attribute
+        read a isotopic depletion Output File and applies results to armi objects in the ToDepletion attribute.
         """
         raise NotImplementedError
 
@@ -219,6 +219,6 @@ class Csrc:
 
     def write(self):
         """
-        return a list of lines to write for a csrc card
+        return a list of lines to write for a csrc card.
         """
         raise NotImplementedError

--- a/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
+++ b/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
@@ -187,7 +187,7 @@ class AbstractIsotopicDepletionReader(interfaces.OutputReader):
 
     def read(self):
         r"""
-        read a isotopic depletion Output File and applies results to armi objects in the ToDepletion attribute.
+        read a isotopic depletion Output File and applies results to armi objects in the ``ToDepletion`` attribute.
         """
         raise NotImplementedError
 

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """"
-Lattice Physics Interface
+Lattice Physics Interface.
 
 Parent classes for codes responsible for generating broad-group cross sections
 """

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Lattice Physics Writer
+Lattice Physics Writer.
 
 Parent class for lattice physics writers.
 
@@ -351,7 +351,7 @@ class LatticePhysicsWriter(interfaces.InputWriter):
         return fuelTemperatureInC
 
     def _getDetailedFissionProducts(self, dfpDensities):
-        """Return a dictionary of fission products not provided in the reactor blueprint nuclides
+        """Return a dictionary of fission products not provided in the reactor blueprint nuclides.
 
         Notes
         -----

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the Lattice Interface"""
+"""Test the Lattice Interface."""
 # pylint: disable=abstract-method,missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-method-argument,import-outside-toplevel
 import unittest
 from collections import OrderedDict
@@ -50,7 +50,7 @@ class LatticeInterfaceTester(LatticePhysicsInterface):
 
 
 class LatticeInterfaceTesterLibFalse(LatticeInterfaceTester):
-    """subclass setting _newLibraryShouldBeCreated = False"""
+    """subclass setting _newLibraryShouldBeCreated = False."""
 
     def _newLibraryShouldBeCreated(self, cycle, representativeBlockList, xsIDs):
         self.testVerification = True
@@ -89,7 +89,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         self.latticeInterface.testVerification = False
 
     def test_LatticePhysicsInterface(self):
-        """Super basic test of the LatticePhysicsInterface"""
+        """Super basic test of the LatticePhysicsInterface."""
         self.assertEqual(self.latticeInterface._updateBlockNeutronVelocities, True)
         self.assertEqual(self.latticeInterface.executablePath, "/tmp/fake_path")
         self.assertEqual(self.latticeInterface.executableRoot, "/tmp")
@@ -98,7 +98,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
 
     def test_interactBOL(self):
         """
-        Test interactBOL() with different update frequencies
+        Test interactBOL() with different update frequencies.
 
         Notes
         -----
@@ -120,7 +120,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
 
     def test_interactBOC(self):
         """
-        Test interactBOC() with different update frequencies
+        Test interactBOC() with different update frequencies.
 
         Notes
         -----
@@ -143,7 +143,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
 
     def test_interactEveryNode(self):
         """
-        Test interactEveryNode() with different update frequencies
+        Test interactEveryNode() with different update frequencies.
         """
         self.latticeInterface._latticePhysicsFrequency = LatticePhysicsFrequency.BOC
         self.latticeInterface.interactEveryNode()
@@ -156,7 +156,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
 
     def test_interactEveryNodeFirstCoupled(self):
         """
-        Test interactEveryNode() with LatticePhysicsFrequency.firstCoupledIteration
+        Test interactEveryNode() with LatticePhysicsFrequency.firstCoupledIteration.
         """
         self.latticeInterface._latticePhysicsFrequency = (
             LatticePhysicsFrequency.firstCoupledIteration
@@ -166,7 +166,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
 
     def test_interactEveryNodeAll(self):
         """
-        Test interactEveryNode() with LatticePhysicsFrequency.all
+        Test interactEveryNode() with LatticePhysicsFrequency.all.
         """
         self.latticeInterface._latticePhysicsFrequency = LatticePhysicsFrequency.all
         self.latticeInterface.interactEveryNode()
@@ -174,7 +174,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
 
     def test_interactFirstCoupledIteration(self):
         """
-        Test interactCoupled() with different update frequencies on first iteration
+        Test interactCoupled() with different update frequencies on first iteration.
         """
         self.latticeInterface._latticePhysicsFrequency = (
             LatticePhysicsFrequency.everyNode
@@ -189,7 +189,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
 
     def test_interactAll(self):
         """
-        Test interactCoupled() with different update frequencies on non-first iteration
+        Test interactCoupled() with different update frequencies on non-first iteration.
         """
         self.latticeInterface._latticePhysicsFrequency = (
             LatticePhysicsFrequency.firstCoupledIteration
@@ -202,7 +202,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
 
 
 class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
-    """test variations of _newLibraryShouldBeCreated"""
+    """test variations of _newLibraryShouldBeCreated."""
 
     @classmethod
     def setUpClass(cls):
@@ -213,7 +213,7 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
         cls.b, cls.xsIDs = cls.latticeInterface._getBlocksAndXsIds()
 
     def setUp(self):
-        """reset representativeBlocks and CONF_GEN_XS"""
+        """reset representativeBlocks and CONF_GEN_XS."""
         self.xsGroupInterface.representativeBlocks = OrderedDict(
             {"AA": self.assembly[0]}
         )
@@ -222,7 +222,7 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
         self.o.r.core.lib = isotxs.readBinary(ISOAA_PATH)
 
     def test_libCreation_NoGenXS(self):
-        """no ISOTXS and xs gen not requested"""
+        """no ISOTXS and xs gen not requested."""
         self.o.r.core.lib = None
         with mockRunLogs.BufferLog() as mock:
             xsGen = self.latticeInterface._newLibraryShouldBeCreated(
@@ -234,7 +234,7 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
             self.assertFalse(xsGen)
 
     def test_libCreation_GenXS(self):
-        """no ISOTXS and xs gen requested"""
+        """no ISOTXS and xs gen requested."""
         self.o.cs[CONF_GEN_XS] = "Neutron"
         self.o.r.core.lib = None
         with mockRunLogs.BufferLog() as mock:
@@ -248,7 +248,7 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
             self.assertTrue(xsGen)
 
     def test_libCreation_NoGenXS_2(self):
-        """ISOTXS present and has all of the necessary information"""
+        """ISOTXS present and has all of the necessary information."""
         with mockRunLogs.BufferLog() as mock:
             xsGen = self.latticeInterface._newLibraryShouldBeCreated(
                 1, self.b, self.xsIDs
@@ -260,7 +260,7 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
             self.assertFalse(xsGen)
 
     def test_libCreation_GenXS_2(self):
-        """ISOTXS present and does not have all of the necessary information"""
+        """ISOTXS present and does not have all of the necessary information."""
         self.xsGroupInterface.representativeBlocks = OrderedDict(
             {"BB": self.assembly[0]}
         )
@@ -274,7 +274,7 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
             self.assertTrue(xsGen)
 
     def test_libCreation_GenXS_3(self):
-        """ISOTXS present and does not have all of the necessary information"""
+        """ISOTXS present and does not have all of the necessary information."""
         self.o.cs[CONF_GEN_XS] = "Neutron"
         b, xsIDs = self._modifyXSType()
         with mockRunLogs.BufferLog() as mock:

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -50,7 +50,7 @@ class LatticeInterfaceTester(LatticePhysicsInterface):
 
 
 class LatticeInterfaceTesterLibFalse(LatticeInterfaceTester):
-    """subclass setting _newLibraryShouldBeCreated = False."""
+    """Subclass setting _newLibraryShouldBeCreated = False."""
 
     def _newLibraryShouldBeCreated(self, cycle, representativeBlockList, xsIDs):
         self.testVerification = True
@@ -202,7 +202,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
 
 
 class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
-    """test variations of _newLibraryShouldBeCreated."""
+    """Test variations of _newLibraryShouldBeCreated."""
 
     @classmethod
     def setUpClass(cls):
@@ -213,7 +213,7 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
         cls.b, cls.xsIDs = cls.latticeInterface._getBlocksAndXsIds()
 
     def setUp(self):
-        """reset representativeBlocks and CONF_GEN_XS."""
+        """Reset representativeBlocks and CONF_GEN_XS."""
         self.xsGroupInterface.representativeBlocks = OrderedDict(
             {"AA": self.assembly[0]}
         )
@@ -222,7 +222,7 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
         self.o.r.core.lib = isotxs.readBinary(ISOAA_PATH)
 
     def test_libCreation_NoGenXS(self):
-        """no ISOTXS and xs gen not requested."""
+        """No ISOTXS and xs gen not requested."""
         self.o.r.core.lib = None
         with mockRunLogs.BufferLog() as mock:
             xsGen = self.latticeInterface._newLibraryShouldBeCreated(
@@ -234,7 +234,7 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
             self.assertFalse(xsGen)
 
     def test_libCreation_GenXS(self):
-        """no ISOTXS and xs gen requested."""
+        """No ISOTXS and xs gen requested."""
         self.o.cs[CONF_GEN_XS] = "Neutron"
         self.o.r.core.lib = None
         with mockRunLogs.BufferLog() as mock:

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test the Lattice Physics Writer"""
+"""Test the Lattice Physics Writer."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
@@ -29,7 +29,7 @@ from armi.tests import TEST_ROOT
 
 
 class FakeLatticePhysicsWriter(LatticePhysicsWriter):
-    """LatticePhysicsWriter is abstract, so it must be subclassed to be tested"""
+    """LatticePhysicsWriter is abstract, so it must be subclassed to be tested."""
 
     def __init__(self, block, r, eci):
         self.testOut = ""
@@ -54,7 +54,7 @@ class TestLatticePhysicsWriter(unittest.TestCase):
     """Test Lattice Physics Writer."""
 
     def test_LatticePhysicsWriter(self):
-        """Super basic test of the LatticePhysicsWriter"""
+        """Super basic test of the LatticePhysicsWriter."""
         o, r = loadTestReactor(TEST_ROOT)
         cs = o.cs
         o.cs[CONF_CROSS_SECTION].setDefaults(

--- a/armi/physics/neutronics/reports.py
+++ b/armi/physics/neutronics/reports.py
@@ -28,7 +28,7 @@ from armi.physics.neutronics.settings import (
 
 
 def insertNeutronicsReport(r, cs, report, stage):
-    """Generate the Neutronics section of the Report
+    """Generate the Neutronics section of the Report.
 
     Parameters
     ----------
@@ -75,7 +75,7 @@ def insertNeutronicsBOLContent(r, cs, report):
 
 
 def neutronicsPlotting(r, report, cs):
-    """Keeps track of plotting content which is collected when Standard Stage of the report
+    """Keeps track of plotting content which is collected when Standard Stage of the report.
 
     Parameters
     ----------
@@ -131,7 +131,7 @@ def neutronicsPlotting(r, report, cs):
 
 
 def insertInitialCoreFuelAssem(r, report):
-    """Creates table of initial core fuel assemblies
+    """Creates table of initial core fuel assemblies.
 
     Parameters
     ----------
@@ -163,7 +163,7 @@ def insertInitialCoreFuelAssem(r, report):
 
 
 def generateLinePlot(subsectionHeading, r, report, yaxis, name, caption=""):
-    """Creates the TimeSeries in the Report for finding peak values vs. time
+    """Creates the TimeSeries in the Report for finding peak values vs. time.
 
     Parameters
     ----------

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Some generic neutronics-related settings"""
+"""Some generic neutronics-related settings."""
 import os
 
 from armi import runLog
@@ -86,7 +86,7 @@ CONF_LATTICE_PHYSICS_FREQUENCY = "latticePhysicsFrequency"
 
 
 def defineSettings():
-    """standard function to define settings - for neutronics"""
+    """standard function to define settings - for neutronics."""
     settings = [
         setting.Setting(
             CONF_GROUP_STRUCTURE,
@@ -372,7 +372,7 @@ def _blueprintsHasOldXSInput(inspector):
 
 
 def getNeutronicsSettingValidators(inspector):
-    """The standard helper method, to provide validators to neutronics settings"""
+    """The standard helper method, to provide validators to neutronics settings."""
     queries = []
 
     def migrateXSOption(name0):
@@ -389,11 +389,11 @@ def getNeutronicsSettingValidators(inspector):
         inspector.cs = inspector.cs.modified(newSettings={name0: value})
 
     def migrateXSOptionGenXS():
-        """pass-through to migrateXSOption(), because Query functions cannot take arguements"""
+        """pass-through to migrateXSOption(), because Query functions cannot take arguements."""
         migrateXSOption(CONF_GEN_XS)
 
     def migrateXSOptionGlobalFluxActive():
-        """pass-through to migrateXSOption(), because Query functions cannot take arguements"""
+        """pass-through to migrateXSOption(), because Query functions cannot take arguements."""
         migrateXSOption(CONF_GLOBAL_FLUX_ACTIVE)
 
     queries.append(
@@ -438,7 +438,7 @@ def getNeutronicsSettingValidators(inspector):
     )
 
     def updateXSGroupStructure():
-        """Trying to migrate to a valid XS group structure name"""
+        """Trying to migrate to a valid XS group structure name."""
         value = inspector.cs[CONF_GROUP_STRUCTURE]
         newValue = value.upper()
 
@@ -472,7 +472,7 @@ def getNeutronicsSettingValidators(inspector):
     )
 
     def migrateDpa(name0):
-        """migrating some common shortened names for dpa XS sets"""
+        """migrating some common shortened names for dpa XS sets."""
         value = inspector.cs[name0]
         if value == "dpaHT9_33":
             value = "dpaHT9_ANL33_TwrBol"
@@ -482,11 +482,11 @@ def getNeutronicsSettingValidators(inspector):
         inspector.cs = inspector.cs.modified(newSettings={name0: value})
 
     def migrateDpaDpaXsSet():
-        """pass-through to migrateDpa(), because Query functions cannot take arguements"""
+        """pass-through to migrateDpa(), because Query functions cannot take arguements."""
         migrateDpa(CONF_DPA_XS_SET)
 
     def migrateDpaGridPlate():
-        """pass-through to migrateDpa(), because Query functions cannot take arguements"""
+        """pass-through to migrateDpa(), because Query functions cannot take arguements."""
         migrateDpa(CONF_GRID_PLATE_DPA_XS_SET)
 
     queries.append(

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -86,7 +86,7 @@ CONF_LATTICE_PHYSICS_FREQUENCY = "latticePhysicsFrequency"
 
 
 def defineSettings():
-    """standard function to define settings - for neutronics."""
+    """Standard function to define settings - for neutronics."""
     settings = [
         setting.Setting(
             CONF_GROUP_STRUCTURE,
@@ -472,7 +472,7 @@ def getNeutronicsSettingValidators(inspector):
     )
 
     def migrateDpa(name0):
-        """migrating some common shortened names for dpa XS sets."""
+        """Migrating some common shortened names for dpa XS sets."""
         value = inspector.cs[name0]
         if value == "dpaHT9_33":
             value = "dpaHT9_ANL33_TwrBol"
@@ -482,11 +482,11 @@ def getNeutronicsSettingValidators(inspector):
         inspector.cs = inspector.cs.modified(newSettings={name0: value})
 
     def migrateDpaDpaXsSet():
-        """pass-through to migrateDpa(), because Query functions cannot take arguements."""
+        """Pass-through to migrateDpa(), because Query functions cannot take arguements."""
         migrateDpa(CONF_DPA_XS_SET)
 
     def migrateDpaGridPlate():
-        """pass-through to migrateDpa(), because Query functions cannot take arguements."""
+        """Pass-through to migrateDpa(), because Query functions cannot take arguements."""
         migrateDpa(CONF_GRID_PLATE_DPA_XS_SET)
 
     queries.append(

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Test the cross section manager
+Test the cross section manager.
 
 :py:mod:`armi.physics.neutronics.crossSectionGroupManager`
 """
@@ -124,14 +124,14 @@ class TestBlockCollectionAverage(unittest.TestCase):
 
 class TestBlockCollectionComponentAverage(unittest.TestCase):
     r"""
-    tests for ZPPR 1D XS gen cases
+    tests for ZPPR 1D XS gen cases.
     """
 
     def setUp(self):
         r"""
         First part of setup same as test_Cartesian.
         Second part of setup builds lists/dictionaries of expected values to compare to.
-        has expected values for component isotopic atom density and component area
+        has expected values for component isotopic atom density and component area.
         """
         self.o, self.r = test_reactors.loadTestReactor(
             TEST_ROOT, inputFileName="zpprTest.yaml"
@@ -214,14 +214,14 @@ class TestBlockCollectionComponentAverage(unittest.TestCase):
 
 class TestBlockCollectionComponentAverage1DCylinder(unittest.TestCase):
     r"""
-    tests for 1D cylinder XS gen cases
+    tests for 1D cylinder XS gen cases.
     """
 
     def setUp(self):
         r"""
         First part of setup same as test_Cartesian.
         Second part of setup builds lists/dictionaries of expected values to compare to.
-        has expected values for component isotopic atom density and component area
+        has expected values for component isotopic atom density and component area.
         """
         self.o, self.r = test_reactors.loadTestReactor(TEST_ROOT)
 
@@ -472,14 +472,14 @@ class Test_CrossSectionGroupManager(unittest.TestCase):
         self.assertEqual(origXSIDsFromNew["BA"], "AA")
 
     def test_interactBOL(self):
-        """Test `BOL` lattice physics update frequency"""
+        """Test `BOL` lattice physics update frequency."""
         self.blockList[0].r.p.timeNode = 0
         self.csm.cs[CONF_LATTICE_PHYSICS_FREQUENCY] = "BOL"
         self.csm.interactBOL()
         self.assertTrue(self.csm.representativeBlocks)
 
     def test_interactBOC(self):
-        """Test `BOC` lattice physics update frequency"""
+        """Test `BOC` lattice physics update frequency."""
         self.blockList[0].r.p.timeNode = 0
         self.csm.cs[CONF_LATTICE_PHYSICS_FREQUENCY] = "BOC"
         self.csm.interactBOL()
@@ -487,7 +487,7 @@ class Test_CrossSectionGroupManager(unittest.TestCase):
         self.assertTrue(self.csm.representativeBlocks)
 
     def test_interactEveryNode(self):
-        """Test `everyNode` lattice physics update frequency"""
+        """Test `everyNode` lattice physics update frequency."""
         self.csm.cs[CONF_LATTICE_PHYSICS_FREQUENCY] = "BOC"
         self.csm.interactBOL()
         self.csm.interactEveryNode()
@@ -498,7 +498,7 @@ class Test_CrossSectionGroupManager(unittest.TestCase):
         self.assertTrue(self.csm.representativeBlocks)
 
     def test_interactFirstCoupledIteration(self):
-        """Test `firstCoupledIteration` lattice physics update frequency"""
+        """Test `firstCoupledIteration` lattice physics update frequency."""
         self.csm.cs[CONF_LATTICE_PHYSICS_FREQUENCY] = "everyNode"
         self.csm.interactBOL()
         self.csm.interactCoupled(iteration=0)
@@ -509,7 +509,7 @@ class Test_CrossSectionGroupManager(unittest.TestCase):
         self.assertTrue(self.csm.representativeBlocks)
 
     def test_interactAllCoupled(self):
-        """Test `all` lattice physics update frequency"""
+        """Test `all` lattice physics update frequency."""
         self.csm.cs[CONF_LATTICE_PHYSICS_FREQUENCY] = "firstCoupledIteration"
         self.csm.interactBOL()
         self.csm.interactCoupled(iteration=1)

--- a/armi/physics/neutronics/tests/test_crossSectionSettings.py
+++ b/armi/physics/neutronics/tests/test_crossSectionSettings.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""XS Settings tests"""
+"""XS Settings tests."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,unused-variable
 import io
 import unittest
@@ -210,7 +210,7 @@ class TestCrossSectionSettings(unittest.TestCase):
 
 class Test_XSSettings(unittest.TestCase):
     def test_yamlIO(self):
-        """Ensure we can read/write this custom setting object to yaml"""
+        """Ensure we can read/write this custom setting object to yaml."""
         yaml = YAML()
         inp = yaml.load(io.StringIO(XS_EXAMPLE))
         xs = XSSettingDef("TestSetting")

--- a/armi/physics/neutronics/tests/test_crossSectionTable.py
+++ b/armi/physics/neutronics/tests/test_crossSectionTable.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for cross section table for depletion"""
+"""Tests for cross section table for depletion."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""unit tests for the neutronics plugin"""
+"""unit tests for the neutronics plugin."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import io
 import unittest
@@ -90,7 +90,7 @@ class Test_NeutronicsPlugin(TestPlugin):
         self.assertIn("geometry: 1D", outText)
 
     def test_neutronicsSettingsLoaded(self):
-        """Check that various special neutronics-specifics settings are loaded"""
+        """Check that various special neutronics-specifics settings are loaded."""
         cs = caseSettings.Settings()
 
         self.assertIn(CONF_INNERS_, cs)
@@ -250,7 +250,7 @@ class NeutronicsReactorTests(unittest.TestCase):
 
     @staticmethod
     def __autoCorrectAllQueries(settingsValidator):
-        """Force-Correct (resolve() to "YES") all queries in a Settings Validator"""
+        """Force-Correct (resolve() to "YES") all queries in a Settings Validator."""
         for query in settingsValidator:
             try:
                 query.correction()

--- a/armi/physics/tests/test_executers.py
+++ b/armi/physics/tests/test_executers.py
@@ -96,7 +96,7 @@ class TestExecuters(unittest.TestCase):
     def test_updateRunDir(self):
         """
         Verify that runDir is updated when TemporaryDirectoryChanger is used and
-        not updated when ForcedCreationDirectoryChanger is used
+        not updated when ForcedCreationDirectoryChanger is used.
         """
 
         self.assertEqual(

--- a/armi/physics/thermalHydraulics/plugin.py
+++ b/armi/physics/thermalHydraulics/plugin.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Generic Thermal/Hydraulics Plugin
+Generic Thermal/Hydraulics Plugin.
 
 Thermal/hydraulics is concerned with temperatures, flows, pressures,
 and heat transfer.

--- a/armi/physics/thermalHydraulics/settings.py
+++ b/armi/physics/thermalHydraulics/settings.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Settings related to Thermal Hydraulics"""
+"""Settings related to Thermal Hydraulics."""
 
 from armi.settings import setting
 

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -345,7 +345,7 @@ class ArmiPlugin:
     @HOOKSPEC
     def defineEntryPoints() -> List:
         """
-        Return new entry points for the ARMI CLI
+        Return new entry points for the ARMI CLI.
 
         This hook allows plugins to provide their own ARMI entry points, which each
         serve as a command in the command-line interface.
@@ -585,7 +585,7 @@ class ArmiPlugin:
     @HOOKSPEC
     def defineSystemBuilders() -> Dict[str, Callable[[str], "Composite"]]:
         """
-        Convert a user-string from the systems section into a valid composite builder
+        Convert a user-string from the systems section into a valid composite builder.
 
         Parameters
         ----------
@@ -728,7 +728,7 @@ def getNewPluginManager() -> pluginManager.ArmiPluginManager:
 
 def collectInterfaceDescriptions(mod, cs):
     """
-    Adapt old-style describeInterfaces to the new plugin interface
+    Adapt old-style describeInterfaces to the new plugin interface.
 
     Old describeInterfaces implementations would return an interface class and kwargs
     for adding to an operator. Now we expect an ORDER as well. This takes a module and

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -728,7 +728,7 @@ def getNewPluginManager() -> pluginManager.ArmiPluginManager:
 
 def collectInterfaceDescriptions(mod, cs):
     """
-    Adapt old-style describeInterfaces to the new plugin interface.
+    Adapt old-style ``describeInterfaces`` to the new plugin interface.
 
     Old describeInterfaces implementations would return an interface class and kwargs
     for adding to an operator. Now we expect an ORDER as well. This takes a module and

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1207,8 +1207,9 @@ class Assembly(composites.Composite):
 
         Parameters
         ----------
-        rad - float
-            number (in radians) specifying the angle of counter clockwise rotation"""
+        rad: float
+            number (in radians) specifying the angle of counter clockwise rotation
+        """
         for b in self.getBlocks():
             b.rotate(rad)
 

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -537,7 +537,6 @@ class Assembly(composites.Composite):
         -------
         heights : list
             z-coordinates where the specified param takes the specified value
-
         """
         heights = []
         # loop from bottom to top
@@ -566,7 +565,7 @@ class Assembly(composites.Composite):
         return heights
 
     def getAge(self):
-        """gets a height-averaged residence time of this assembly in days."""
+        """Gets a height-averaged residence time of this assembly in days."""
         at = 0.0
         for b in self:
             at += b.p.residence * b.getHeight()

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -196,7 +196,7 @@ class Assembly(composites.Composite):
         obj.spatialLocator = self.spatialGrid[0, 0, index]
 
     def getNum(self):
-        """Return unique integer for this assembly"""
+        """Return unique integer for this assembly."""
         return int(self.p.assemNum)
 
     def getLocation(self):
@@ -442,7 +442,7 @@ class Assembly(composites.Composite):
 
     def getTotalHeight(self, typeSpec=None):
         """
-        Determine the height of this assembly in cm
+        Determine the height of this assembly in cm.
 
         Parameters
         ----------
@@ -483,7 +483,7 @@ class Assembly(composites.Composite):
 
     def getElevationBoundariesByBlockType(self, blockType=None):
         """
-        Gets of list of elevations, ordered from bottom to top of all boundaries of the block of specified type
+        Gets of list of elevations, ordered from bottom to top of all boundaries of the block of specified type.
 
         Useful for determining location of the top of the upper grid plate or active
         fuel, etc by using [0] to get the lowest boundary and [-1] to get highest
@@ -566,7 +566,7 @@ class Assembly(composites.Composite):
         return heights
 
     def getAge(self):
-        """gets a height-averaged residence time of this assembly in days"""
+        """gets a height-averaged residence time of this assembly in days."""
         at = 0.0
         for b in self:
             at += b.p.residence * b.getHeight()
@@ -574,7 +574,7 @@ class Assembly(composites.Composite):
 
     def makeAxialSnapList(self, refAssem=None, refMesh=None, force=False):
         """
-        Creates a list of block indices that should track axially with refAssem's
+        Creates a list of block indices that should track axially with refAssem's.
 
         When axially expanding, the control rods, shields etc. need to maintain mesh
         lines with the rest of the core. To do this, we'll just keep track of which
@@ -617,7 +617,7 @@ class Assembly(composites.Composite):
 
     def _shouldMassBeConserved(self, belowFuelColumn, b):
         """
-        Determine from a rule set if the mass of a block should be conserved during axial expansion
+        Determine from a rule set if the mass of a block should be conserved during axial expansion.
 
         Parameters
         ----------
@@ -760,7 +760,7 @@ class Assembly(composites.Composite):
         self.setBlockMesh(mesh)
 
     def dump(self, fName=None):
-        """Pickle the assembly and write it to a file"""
+        """Pickle the assembly and write it to a file."""
         if not fName:
             fName = self.getName() + ".dump.pkl"
 
@@ -860,7 +860,7 @@ class Assembly(composites.Composite):
 
     def getBlockAtElevation(self, elevation):
         """
-        Returns the block at a specified axial dimension elevation (given in cm)
+        Returns the block at a specified axial dimension elevation (given in cm).
 
         If height matches the exact top of the block, the block is considered at that
         height.
@@ -914,7 +914,7 @@ class Assembly(composites.Composite):
 
     def getBlocksBetweenElevations(self, zLower, zUpper):
         """
-        Return block(s) between two axial elevations and their corresponding heights
+        Return block(s) between two axial elevations and their corresponding heights.
 
         Parameters
         ----------
@@ -1036,7 +1036,7 @@ class Assembly(composites.Composite):
 
     def getParamOfZFunction(self, param, interpType="linear", fillValue=numpy.NaN):
         """
-        Interpolates a param axially to find it at any value of elevation z
+        Interpolates a param axially to find it at any value of elevation z.
 
         By default, assumes that all parameters are for the center of a block. So for
         parameters such as THoutletTemperature that are defined on the top, this may be
@@ -1161,7 +1161,7 @@ class Assembly(composites.Composite):
 
     def countBlocksWithFlags(self, blockTypeSpec=None):
         """
-        Returns the number of blocks of a specified type
+        Returns the number of blocks of a specified type.
 
         blockTypeSpec : Flags or list
             Restrict to only these types of blocks. typeSpec is None, return all of the
@@ -1226,7 +1226,7 @@ class RZAssembly(Assembly):
     """
     RZAssembly are assemblies in RZ geometry; they need to be different objects than
     HexAssembly because they use different locations and need to have Radial Meshes in
-    their setting
+    their setting.
 
     note ThRZAssemblies should be a subclass of Assemblies (similar to Hex-Z) because
     they should have a common place to put information about subdividing the global mesh
@@ -1239,7 +1239,7 @@ class RZAssembly(Assembly):
 
     def radialOuter(self):
         """
-        returns the outer radial boundary of this assembly
+        returns the outer radial boundary of this assembly.
 
         See Also
         --------

--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Assembly Parameter Definitions"""
+"""Assembly Parameter Definitions."""
 import numpy
 
 from armi import runLog

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Parameter definitions for Blocks"""
+"""Parameter definitions for Blocks."""
 import numpy
 import six
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1493,7 +1493,7 @@ class Block(composites.Composite):
         raise NotImplementedError
 
     def setAxialExpTargetComp(self, targetComponent):
-        """sets the targetComponent for the axial expansion changer.
+        """Sets the targetComponent for the axial expansion changer.
 
         Parameter
         ---------

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -80,7 +80,7 @@ class Block(composites.Composite):
 
     def __init__(self, name: str, height: float = 1.0):
         """
-        Builds a new ARMI block
+        Builds a new ARMI block.
 
         name : str
             The name of this block
@@ -159,7 +159,7 @@ class Block(composites.Composite):
 
     def _createHomogenizedCopy(self, pinSpatialLocators=False):
         """
-        Create a copy of a block
+        Create a copy of a block.
 
         Notes
         -----
@@ -347,7 +347,7 @@ class Block(composites.Composite):
 
     def getMgFlux(self, adjoint=False, average=False, volume=None, gamma=False):
         """
-        Returns the multigroup neutron flux in [n/cm^2/s]
+        Returns the multigroup neutron flux in [n/cm^2/s].
 
         The first entry is the first energy group (fastest neutrons). Each additional
         group is the next energy group, as set in the ISOTXS library.
@@ -385,7 +385,7 @@ class Block(composites.Composite):
 
     def setPinMgFluxes(self, fluxes, adjoint=False, gamma=False):
         """
-        Store the pin-detailed multi-group neutron flux
+        Store the pin-detailed multi-group neutron flux.
 
         The [g][i] indexing is transposed to be a list of lists, one for each pin. This makes it
         simple to do depletion for each pin, etc.
@@ -556,7 +556,7 @@ class Block(composites.Composite):
 
     def adjustUEnrich(self, newEnrich):
         """
-        Adjust U-235/U-238 mass ratio to a mass enrichment
+        Adjust U-235/U-238 mass ratio to a mass enrichment.
 
         Parameters
         ----------
@@ -1036,7 +1036,7 @@ class Block(composites.Composite):
 
     def mergeWithBlock(self, otherBlock, fraction):
         """
-        Turns this block into a mixture of this block and some other block
+        Turns this block into a mixture of this block and some other block.
 
         Parameters
         ----------
@@ -1356,7 +1356,7 @@ class Block(composites.Composite):
 
     def updateComponentDims(self):
         """
-        This method updates all the dimensions of the components
+        This method updates all the dimensions of the components.
 
         Notes
         -----
@@ -1493,7 +1493,7 @@ class Block(composites.Composite):
         raise NotImplementedError
 
     def setAxialExpTargetComp(self, targetComponent):
-        """sets the targetComponent for the axial expansion changer
+        """sets the targetComponent for the axial expansion changer.
 
         Parameter
         ---------

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -118,7 +118,7 @@ class AssemblyBlueprint(yamlize.Object):
     @classmethod
     def getAssemClass(cls, blocks):
         """
-        Get the ARMI ``Assembly`` class for the specified blocks
+        Get the ARMI ``Assembly`` class for the specified blocks.
 
         Parameters
         ----------
@@ -271,5 +271,5 @@ class AssemblyKeyedList(yamlize.KeyedList):
 
     @property
     def bySpecifier(self):
-        """Used by the reactor to _loadAssembliesIntoCore later, specifiers are two character strings"""
+        """Used by the reactor to _loadAssembliesIntoCore later, specifiers are two character strings."""
         return {aDesign.specifier: aDesign for aDesign in self}

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -271,5 +271,5 @@ class AssemblyKeyedList(yamlize.KeyedList):
 
     @property
     def bySpecifier(self):
-        """Used by the reactor to _loadAssembliesIntoCore later, specifiers are two character strings."""
+        """Used by the reactor to ``_loadAssembliesIntoCore`` later, specifiers are two character strings."""
         return {aDesign.specifier: aDesign for aDesign in self}

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -287,7 +287,7 @@ class BlockBlueprint(yamlize.KeyedList):
 
     def _getGridDesign(self, blueprint):
         """
-        Get the appropriate grid design
+        Get the appropriate grid design.
 
         This happens when a lattice input is provided on the block. Otherwise all
         components are ambiguously defined in the block.

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -158,7 +158,7 @@ class ComponentBlueprint(yamlize.Object):
     area = yamlize.Attribute(type=float, default=None)
 
     def construct(self, blueprint, matMods):
-        """Construct a component or group"""
+        """Construct a component or group."""
         runLog.debug("Constructing component {}".format(self.name))
         kwargs = self._conformKwargs(blueprint, matMods)
         shape = self.shape.lower().strip()
@@ -181,7 +181,7 @@ class ComponentBlueprint(yamlize.Object):
         return constructedObject
 
     def _conformKwargs(self, blueprint, matMods):
-        """This method gets the relevant kwargs to construct the component"""
+        """This method gets the relevant kwargs to construct the component."""
         kwargs = {"mergeWith": self.mergeWith or "", "isotopics": self.isotopics or ""}
 
         for attr in self.attributes:  # yamlize magic
@@ -332,7 +332,7 @@ class GroupedComponent(yamlize.Object):
 
 class ComponentGroup(yamlize.KeyedList):
     """
-    A single component group containing multiple GroupedComponents
+    A single component group containing multiple GroupedComponents.
 
     Example
     -------
@@ -379,7 +379,7 @@ for dimName in set(
 
 
 def _setComponentFlags(component, flags, blueprint):
-    """Update component flags based on user input in blueprint"""
+    """Update component flags based on user input in blueprint."""
     # the component __init__ calls setType(), which gives us our initial guess at
     # what the flags should be.
     if flags is not None:

--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -266,13 +266,13 @@ class TestGriddedBlock(unittest.TestCase):
             self.blueprints._prepConstruction(self.cs)
 
     def test_constructSpatialGrid(self):
-        """Test intermediate grid construction function"""
+        """Test intermediate grid construction function."""
         bDesign = self.blueprints.blockDesigns["fuel"]
         gridDesign = bDesign._getGridDesign(self.blueprints)
         self.assertEqual(gridDesign.gridContents[0, 0], "2")
 
     def test_getLocatorsAtLatticePositions(self):
-        """Ensure extraction of specifiers results in locators"""
+        """Ensure extraction of specifiers results in locators."""
         bDesign = self.blueprints.blockDesigns["fuel"]
         gridDesign = bDesign._getGridDesign(self.blueprints)
         grid = gridDesign.construct()
@@ -294,7 +294,7 @@ class TestGriddedBlock(unittest.TestCase):
         self.assertTrue(seen)
 
     def test_nonLatticeComponentHasRightMult(self):
-        """Make sure non-grid components in blocks with grids get the right multiplicity"""
+        """Make sure non-grid components in blocks with grids get the right multiplicity."""
         aDesign = self.blueprints.assemDesigns.bySpecifier["IC"]
         a = aDesign.construct(self.cs, self.blueprints)
         fuelBlock = a.getFirstBlock(Flags.FUEL)

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests the blueprints (loading input) file"""
+"""Tests the blueprints (loading input) file."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import pathlib
@@ -66,7 +66,7 @@ class TestBlueprints(unittest.TestCase):
         cls.directoryChanger.close()
 
     def test_nuclides(self):
-        """Tests the available sets of nuclides work as expected
+        """Tests the available sets of nuclides work as expected.
 
         .. test:: Tests that users can define their nuclides of interest.
             :id: TEST_REACTOR_0
@@ -119,7 +119,7 @@ class TestBlueprints(unittest.TestCase):
 
 
 class TestBlueprintsSchema(unittest.TestCase):
-    """Test the blueprint schema checks"""
+    """Test the blueprint schema checks."""
 
     _yamlString = r"""blocks:
     fuel: &block_fuel

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Module for testing componentBlueprint
+Module for testing componentBlueprint.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import inspect

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""unit test custom isotopics"""
+"""unit test custom isotopics."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
@@ -200,7 +200,7 @@ assemblies:
         )
 
     def test_unmodified(self):
-        """Ensure that unmodified components have the correct isotopics"""
+        """Ensure that unmodified components have the correct isotopics."""
         fuel = self.a[0].getComponent(Flags.FUEL)
         self.assertEqual(
             self.numUZrNuclides,

--- a/armi/reactor/blueprints/tests/test_reactorBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_reactorBlueprints.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for reactor blueprints"""
+"""Tests for reactor blueprints."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import unittest

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -25,7 +25,6 @@ These objects hold the dimensions, temperatures, composition, and shape of react
     :width: 100%
 
     Class inheritance diagram for :py:mod:`armi.reactor.components`.
-
 """
 
 import math
@@ -91,17 +90,17 @@ def _removeDimensionNameSpaces(attrs):
 
 
 class NullComponent(Component):
-    r"""returns zero for all dimensions. is none."""
+    r"""Returns zero for all dimensions. is none."""
 
     def __cmp__(self, other):
-        r"""be smaller than everything."""
+        r"""Be smaller than everything."""
         return -1
 
     def __lt__(self, other):
         return True
 
     def __bool__(self):
-        r"""handles truth testing."""
+        r"""Handles truth testing."""
         return False
 
     __nonzero__ = __bool__  # Python2 compatibility

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -255,7 +255,7 @@ class UnshapedVolumetricComponent(UnshapedComponent):
 class ZeroMassComponent(UnshapedVolumetricComponent):
     """
     A component that never has mass -- it always returns zero for getMass and
-    getNumberDensity
+    getNumberDensity.
 
     Useful for situations where you want to give a block integrated flux, but ensure
     mass is never added to it
@@ -266,17 +266,17 @@ class ZeroMassComponent(UnshapedVolumetricComponent):
     """
 
     def getNumberDensity(self, *args, **kwargs):
-        """Always return 0 because this component has not mass"""
+        """Always return 0 because this component has not mass."""
         return 0.0
 
     def setNumberDensity(self, *args, **kwargs):
-        """Never add mass"""
+        """Never add mass."""
         pass
 
 
 class PositiveOrNegativeVolumeComponent(UnshapedVolumetricComponent):
     """
-    A component that may have negative mass for removing mass from batches
+    A component that may have negative mass for removing mass from batches.
 
     See Also
     --------

--- a/armi/reactor/components/basicShapes.py
+++ b/armi/reactor/components/basicShapes.py
@@ -84,7 +84,7 @@ class Circle(ShapedComponent):
         return area
 
     def isEncapsulatedBy(self, other):
-        """Return True if this ring lies completely inside the argument component"""
+        """Return True if this ring lies completely inside the argument component."""
         otherID, otherOD = other.getDimension("id"), other.getDimension("od")
         myID, myOD = self.getDimension("id"), self.getDimension("od")
         return otherID <= myID < otherOD and otherID < myOD <= otherOD

--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -138,7 +138,7 @@ class HexHoledCircle(basicShapes.Circle):
 
     def getCircleInnerDiameter(self, Tc=None, cold=False):
         """
-        Returns the diameter of the hole equal to the hexagon outer pitch
+        Returns the diameter of the hole equal to the hexagon outer pitch.
         """
         return self.getDimension("holeOP", Tc, cold)
 
@@ -315,13 +315,13 @@ class Helix(ShapedComponent):
         )
 
     def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
-        """the diameter of a circle which is encompassed by the exterior of the wire-wrap"""
+        """the diameter of a circle which is encompassed by the exterior of the wire-wrap."""
         return self.getDimension("helixDiameter", Tc, cold=cold) + self.getDimension(
             "od", Tc, cold
         )
 
     def getCircleInnerDiameter(self, Tc=None, cold=False):
-        """the diameter of a circle which is encompassed by the interior of the wire-wrap
+        """the diameter of a circle which is encompassed by the interior of the wire-wrap.
 
         - should be equal to the outer diameter of the pin in which the wire is wrapped around
         """

--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -315,13 +315,13 @@ class Helix(ShapedComponent):
         )
 
     def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
-        """the diameter of a circle which is encompassed by the exterior of the wire-wrap."""
+        """The diameter of a circle which is encompassed by the exterior of the wire-wrap."""
         return self.getDimension("helixDiameter", Tc, cold=cold) + self.getDimension(
             "od", Tc, cold
         )
 
     def getCircleInnerDiameter(self, Tc=None, cold=False):
-        """the diameter of a circle which is encompassed by the interior of the wire-wrap.
+        """The diameter of a circle which is encompassed by the interior of the wire-wrap.
 
         - should be equal to the outer diameter of the pin in which the wire is wrapped around
         """

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -55,7 +55,7 @@ _NICE_DIM_NAMES = {
 
 def componentTypeIsValid(component, name):
     """
-    Checks that the component assigned component type is valid
+    Checks that the component assigned component type is valid.
 
     Notes
     -----
@@ -274,7 +274,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         self.material.parent = self
 
     def _linkAndStoreDimensions(self, components, **dims):
-        """Link dimensions to another component"""
+        """Link dimensions to another component."""
         for key, val in dims.items():
             self.setDimension(key, val)
 
@@ -412,7 +412,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         return newC
 
     def setLumpedFissionProducts(self, lfpCollection):
-        """Sets lumped fission product collection on a lfp compatible material if possible"""
+        """Sets lumped fission product collection on a lfp compatible material if possible."""
         try:
             self.getProperties().setLumpedFissionProducts(lfpCollection)
         except AttributeError:
@@ -519,7 +519,7 @@ class Component(composites.Composite, metaclass=ComponentType):
                 raise ArithmeticError(negAreaFailure)
 
     def _checkNegativeVolume(self, volume):
-        """Check for negative volume
+        """Check for negative volume.
 
         See Also
         --------
@@ -794,7 +794,7 @@ class Component(composites.Composite, metaclass=ComponentType):
 
     def getDimension(self, key, Tc=None, cold=False):
         """
-        Return a specific dimension at temperature as determined by key
+        Return a specific dimension at temperature as determined by key.
 
         Parameters
         ----------
@@ -1104,7 +1104,7 @@ class Component(composites.Composite, metaclass=ComponentType):
 
     def getIntegratedMgFlux(self, adjoint=False, gamma=False):
         """
-        Return the multigroup neutron tracklength in [n-cm/s]
+        Return the multigroup neutron tracklength in [n-cm/s].
 
         The first entry is the first energy group (fastest neutrons). Each additional
         group is the next energy group, as set in the ISOTXS library.

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""3-dimensional shapes
+"""3-dimensional shapes.
 
 
 .. impl:: ARMI supports a reasonable set of basic shapes.
@@ -72,7 +72,7 @@ class Sphere(ShapedComponent):
         return self.getDimension("od")
 
     def getComponentArea(self, cold=False):
-        """Compute an average area over the height"""
+        """Compute an average area over the height."""
         from armi.reactor.blocks import Block  # avoid circular import
 
         block = self.getAncestor(lambda c: isinstance(c, Block))
@@ -90,7 +90,7 @@ class Sphere(ShapedComponent):
 
 class Cube(ShapedComponent):
     """
-    More correctly, a rectangular cuboid
+    More correctly, a rectangular cuboid.
     """
 
     is3D = True
@@ -440,7 +440,7 @@ class DifferentialRadialSegment(RadialSegment):
     This component class represents a volume element with thicknesses in the
     azimuthal, radial and axial directions. Furthermore it has dependent
     dimensions: (outer theta, outer radius, outer axial) that can be updated
-    depending on the 'differential' in the corresponding directions
+    depending on the 'differential' in the corresponding directions.
 
     This component class is super useful for defining ThRZ reactors and
     perturbing its dimensions using the optimization modules

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -121,7 +121,7 @@ class FlagSerializer(parameters.Serializer):
     @classmethod
     def unpack(cls, data, version, attrs):
         """
-        Reverse the pack operation
+        Reverse the pack operation.
 
         This will allow for some degree of conversion from old flags to a new set of
         flags, as long as all of the source flags still exist in the current set of
@@ -430,7 +430,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def __bool__(self):
         """
-        Flag that says this is non-zero in a boolean context
+        Flag that says this is non-zero in a boolean context.
 
         Notes
         -----
@@ -491,7 +491,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def copyParamsFrom(self, other):
         """
-        Overwrite this object's params with other object's
+        Overwrite this object's params with other object's.
 
         Parameters
         ----------
@@ -642,7 +642,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def nameContains(self, s):
         """
-        True if s is in this object's name (eg. nameContains('fuel')==True for 'testfuel'
+        True if s is in this object's name (eg. nameContains('fuel')==True for 'testfuel'.
 
         Notes
         -----
@@ -1714,12 +1714,12 @@ class ArmiObject(metaclass=CompositeModelType):
         return u5 / (u8 + u5)
 
     def getPuN(self):
-        """Returns total number density of Pu isotopes"""
+        """Returns total number density of Pu isotopes."""
         nucNames = [nuc.name for nuc in elements.byZ[94].nuclides]
         return sum(self.getNuclideNumberDensities(nucNames))
 
     def getPuMoles(self):
-        """Returns total number of moles of Pu isotopes"""
+        """Returns total number of moles of Pu isotopes."""
         return (
             self.getPuN()
             / units.MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
@@ -1895,7 +1895,7 @@ class ArmiObject(metaclass=CompositeModelType):
         returnObj=False,
     ):
         """
-        Find the maximum value for the parameter in this container
+        Find the maximum value for the parameter in this container.
 
         Parameters
         ----------
@@ -1997,7 +1997,7 @@ class ArmiObject(metaclass=CompositeModelType):
         return self.hasFlags(Flags.FUEL)
 
     def containsHeavyMetal(self):
-        """True if this has HM"""
+        """True if this has HM."""
         for nucName in self.getNuclides():
             # these already have non-zero density
             if nucDir.isHeavyMetal(nucName):
@@ -2023,7 +2023,7 @@ class ArmiObject(metaclass=CompositeModelType):
         return self.getMass(nuclideBases.NuclideBase.fissile)
 
     def getHMMass(self):
-        """Returns heavy metal mass in grams"""
+        """Returns heavy metal mass in grams."""
         nucs = []
         for nucName in self.getNuclides():
             if nucDir.isHeavyMetal(nucName):
@@ -2099,7 +2099,7 @@ class ArmiObject(metaclass=CompositeModelType):
             return pu / hm
 
     def getZrFrac(self):
-        """return the total zr/(hm+zr) fraction in this assembly"""
+        """return the total zr/(hm+zr) fraction in this assembly."""
         hm = self.getHMMass()
         zrNucs = [nuc.name for nuc in elements.bySymbol["ZR"].nuclides]
         zr = self.getMass(zrNucs)
@@ -2117,7 +2117,7 @@ class ArmiObject(metaclass=CompositeModelType):
         return maxV
 
     def getFPMass(self):
-        """Returns mass of fission products in this block in grams"""
+        """Returns mass of fission products in this block in grams."""
         nucs = []
         for nucName in self.getNuclides():
             if "LFP" in nucName:
@@ -2130,7 +2130,7 @@ class ArmiObject(metaclass=CompositeModelType):
         return sum([fuel.getMass() for fuel in self.iterComponents(Flags.FUEL)], 0.0)
 
     def constituentReport(self):
-        """A print out of some pertinent constituent information"""
+        """A print out of some pertinent constituent information."""
         from armi.utils import iterables
 
         rows = [["Constituent", "HMFrac", "FuelFrac"]]
@@ -2214,7 +2214,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def getMgFlux(self, adjoint=False, average=False, volume=None, gamma=False):
         """
-        Return the multigroup neutron flux in [n/cm^2/s]
+        Return the multigroup neutron flux in [n/cm^2/s].
 
         The first entry is the first energy group (fastest neutrons). Each additional
         group is the next energy group, as set in the ISOTXS library.
@@ -2381,7 +2381,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def getComponentsOfMaterial(self, material=None, materialName=None):
         """
-        Return list of components in this block that are made of a particular material
+        Return list of components in this block that are made of a particular material.
 
         Only one of the selectors may be used
 
@@ -2434,7 +2434,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def getComponentByName(self, name):
         """
-        Gets a particular component from this object, based on its name
+        Gets a particular component from this object, based on its name.
 
         Parameters
         ----------
@@ -2563,7 +2563,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def getAverageTempInC(self, typeSpec: TypeSpec = None, exact=False):
         """
-        Return the average temperature of the ArmiObject in C by averaging all components
+        Return the average temperature of the ArmiObject in C by averaging all components.
         """
         tempNumerator = 0.0
         totalVol = 0.0
@@ -3238,7 +3238,7 @@ class StateRetainer:
 
     def __init__(self, composite, paramsToApply=None):
         """
-        Create an instance of a StateRetainer
+        Create an instance of a StateRetainer.
 
         Parameters
         ----------
@@ -3261,7 +3261,7 @@ class StateRetainer:
         self._enterExitHelper(lambda obj: obj.restoreBackup(self.paramsToApply))
 
     def _enterExitHelper(self, func):
-        """Helper method for __enter__ and __exit__. func is a lambda to either backUp() or restoreBackup()"""
+        """Helper method for __enter__ and __exit__. func is a lambda to either backUp() or restoreBackup()."""
         paramDefs = set()
         for child in [self.composite] + self.composite.getChildren(
             deep=True, includeMaterials=True
@@ -3319,7 +3319,7 @@ def getDominantMaterial(
     objects: List[ArmiObject], typeSpec: TypeSpec = None, exact=False
 ):
     """
-    Return the first sample of the most dominant material (by volume) in a set of objects
+    Return the first sample of the most dominant material (by volume) in a set of objects.
 
     .. warning:: This is a **composition** related helper method that will likely be filed into
         classes/modules that deal specifically with the composition of things in the data model.

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1681,7 +1681,7 @@ class ArmiObject(metaclass=CompositeModelType):
             c.setLumpedFissionProducts(lfpCollection)
 
     def getFissileMassEnrich(self):
-        r"""returns the fissile mass enrichment."""
+        """Returns the fissile mass enrichment."""
         hm = self.getHMMass()
         if hm > 0:
             return self.getFissileMass() / hm
@@ -1698,7 +1698,7 @@ class ArmiObject(metaclass=CompositeModelType):
         return b10 / total
 
     def getUraniumMassEnrich(self):
-        """returns U-235 mass fraction assuming U-235 and U-238 only."""
+        """Returns U-235 mass fraction assuming U-235 and U-238 only."""
         u5 = self.getMass("U235")
         if u5 < 1e-10:
             return 0.0
@@ -1852,7 +1852,6 @@ class ArmiObject(metaclass=CompositeModelType):
         -------
         float
             The average parameter value.
-
         """
         total = 0.0
         weightSum = 0.0
@@ -2099,7 +2098,7 @@ class ArmiObject(metaclass=CompositeModelType):
             return pu / hm
 
     def getZrFrac(self):
-        """return the total zr/(hm+zr) fraction in this assembly."""
+        """Return the total zr/(hm+zr) fraction in this assembly."""
         hm = self.getHMMass()
         zrNucs = [nuc.name for nuc in elements.bySymbol["ZR"].nuclides]
         zr = self.getMass(zrNucs)
@@ -2126,7 +2125,7 @@ class ArmiObject(metaclass=CompositeModelType):
         return mass
 
     def getFuelMass(self):
-        """returns mass of fuel in grams."""
+        """Returns mass of fuel in grams."""
         return sum([fuel.getMass() for fuel in self.iterComponents(Flags.FUEL)], 0.0)
 
     def constituentReport(self):
@@ -2180,7 +2179,6 @@ class ArmiObject(metaclass=CompositeModelType):
         .. math::
 
             A =  \frac{\sum_i N_i A_i }{\sum_i N_i}
-
         """
         numerator = 0.0
         denominator = 0.0
@@ -2256,7 +2254,8 @@ class ArmiObject(metaclass=CompositeModelType):
         self.addMass(nucName, -mass)
 
     def addMass(self, nucName, mass):
-        """
+        """Add mass to a particular nuclide.
+
         Parameters
         ----------
         nucName : str

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -3260,7 +3260,7 @@ class StateRetainer:
         self._enterExitHelper(lambda obj: obj.restoreBackup(self.paramsToApply))
 
     def _enterExitHelper(self, func):
-        """Helper method for __enter__ and __exit__. func is a lambda to either backUp() or restoreBackup()."""
+        """Helper method for ``__enter__`` and ``__exit__``. ``func`` is a lambda to either ``backUp()`` or ``restoreBackup()``."""
         paramDefs = set()
         for child in [self.composite] + self.composite.getChildren(
             deep=True, includeMaterials=True

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -192,7 +192,7 @@ class AxialExpansionChanger:
         self.expansionData = None
 
     def setAssembly(self, a, setFuel=True):
-        """set the armi assembly to be changed and init expansion data class for assembly.
+        """Set the armi assembly to be changed and init expansion data class for assembly.
 
         Parameters
         ----------
@@ -224,7 +224,7 @@ class AxialExpansionChanger:
             c.changeNDensByFactor(axialExpansionFactor)
 
     def _isTopDummyBlockPresent(self):
-        """determines if top most block of assembly is a dummy block.
+        """Determines if top most block of assembly is a dummy block.
 
         Notes
         -----
@@ -305,8 +305,7 @@ class AxialExpansionChanger:
         self.linked.a.spatialGrid._bounds = tuple(bounds)
 
     def manageCoreMesh(self, r):
-        """
-        manage core mesh post assembly-level expansion.
+        """Manage core mesh post assembly-level expansion.
 
         Parameters
         ----------
@@ -345,7 +344,6 @@ class AxialExpansionChanger:
         oldVolume : list of floats
             list containing component volumes pre-expansion
         """
-
         solidComponents = _getSolidComponents(b)
         for ic, c in enumerate(b):
             c.p.volume = oldVolume[ic] * b.getHeight() / oldHeight
@@ -417,7 +415,6 @@ class AssemblyAxialLinkage:
         values --> list of axially linked components; index 0 = lower linked component; index 1: upper linked component.
 
         see also: self._getLinkedComponents
-
     """
 
     def __init__(self, StdAssem):
@@ -427,14 +424,14 @@ class AssemblyAxialLinkage:
         self._determineAxialLinkage()
 
     def _determineAxialLinkage(self):
-        """gets the block and component based linkage."""
+        """Gets the block and component based linkage."""
         for b in self.a:
             self._getLinkedBlocks(b)
             for c in b:
                 self._getLinkedComponents(b, c)
 
     def _getLinkedBlocks(self, b):
-        """retrieve the axial linkage for block b.
+        """Retrieve the axial linkage for block b.
 
         Parameters
         ----------
@@ -490,7 +487,7 @@ class AssemblyAxialLinkage:
             )
 
     def _getLinkedComponents(self, b, c):
-        """retrieve the axial linkage for component c.
+        """Retrieve the axial linkage for component c.
 
         Parameters
         ----------
@@ -549,7 +546,7 @@ class AssemblyAxialLinkage:
 
 
 def _determineLinked(componentA, componentB):
-    """determine axial component linkage for two components.
+    """Determine axial component linkage for two components.
 
     Parameters
     ----------
@@ -611,7 +608,7 @@ def _determineLinked(componentA, componentB):
 
 
 class ExpansionData:
-    """object containing data needed for axial expansion."""
+    """Object containing data needed for axial expansion."""
 
     def __init__(self, a, setFuel):
         self._a = a
@@ -621,7 +618,7 @@ class ExpansionData:
         self._setTargetComponents(setFuel)
 
     def setExpansionFactors(self, componentLst, percents):
-        """sets user defined expansion factors.
+        """Sets user defined expansion factors.
 
         Parameters
         ----------
@@ -654,7 +651,7 @@ class ExpansionData:
     def updateComponentTempsBy1DTempField(
         self, tempGrid, tempField, updateNDensForRadialExp: bool = True
     ):
-        """assign a block-average axial temperature to components.
+        """Assign a block-average axial temperature to components.
 
         Parameters
         ----------
@@ -711,7 +708,7 @@ class ExpansionData:
     def updateComponentTemp(
         self, b, c, temp: float, updateNDensForRadialExp: bool = True
     ):
-        """update component temperatures with a provided temperature.
+        """Update component temperatures with a provided temperature.
 
         Parameters
         ----------
@@ -747,8 +744,7 @@ class ExpansionData:
             c.p.volume = c.getArea(cold=False) * b.getHeight()
 
     def computeThermalExpansionFactors(self):
-        """computes expansion factors for all components via thermal expansion."""
-
+        """Computes expansion factors for all components via thermal expansion."""
         for b in self._a:
             for c in b:
                 if c in self.componentReferenceTemperature:
@@ -767,13 +763,12 @@ class ExpansionData:
                     self._expansionFactors[c] = c.getThermalExpansionFactor() - 1.0
 
     def getExpansionFactor(self, c):
-        """retrieves expansion factor for c.
+        """Retrieves expansion factor for c.
 
         Parameters
         ----------
         c : :py:class:`Component <armi.reactor.components.component.Component>`
             Component to retrive expansion factor for
-
         """
         if c in self._expansionFactors:
             value = self._expansionFactors[c]
@@ -782,7 +777,7 @@ class ExpansionData:
         return value
 
     def _setTargetComponents(self, setFuel):
-        """sets target component for each block.
+        """Sets target component for each block.
 
         Parameters
         ----------
@@ -805,7 +800,7 @@ class ExpansionData:
                 self.determineTargetComponent(b)
 
     def determineTargetComponent(self, b, flagOfInterest=None):
-        """determines target component, stores it on the block, and appends it to self._componentDeterminesBlockHeight.
+        """Determines target component, stores it on the block, and appends it to self._componentDeterminesBlockHeight.
 
         Parameters
         ----------
@@ -827,7 +822,6 @@ class ExpansionData:
         RuntimeError
             multiple target components found
         """
-
         if flagOfInterest is None:
             # Follow expansion of most neutronically important component, fuel first then control/poison
             for targetFlag in TARGET_FLAGS_IN_PREFERRED_ORDER:
@@ -857,7 +851,7 @@ class ExpansionData:
         b.p.axialExpTargetComponent = componentWFlag[0].name
 
     def _isFuelLocked(self, b):
-        """physical/realistic implementation reserved for ARMI plugin.
+        """Physical/realistic implementation reserved for ARMI plugin.
 
         Parameters
         ----------
@@ -881,7 +875,7 @@ class ExpansionData:
         b.p.axialExpTargetComponent = c.name
 
     def isTargetComponent(self, c):
-        """returns bool if c is a target component.
+        """Returns bool if c is a target component.
 
         Parameters
         ----------

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Enable component-wise axial expansion for assemblies and/or a reactor"""
+"""Enable component-wise axial expansion for assemblies and/or a reactor."""
 
 from statistics import mean
 from numpy import array
@@ -61,7 +61,7 @@ def expandColdDimsToHot(
     referenceAssembly=None,
 ):
     """
-    Expand BOL assemblies, resolve disjoint axial mesh (if needed), and update block BOL heights
+    Expand BOL assemblies, resolve disjoint axial mesh (if needed), and update block BOL heights.
 
     Parameters
     ----------
@@ -126,7 +126,7 @@ class AxialExpansionChanger:
     def performPrescribedAxialExpansion(
         self, a, componentLst: list, percents: list, setFuel=True
     ):
-        """Perform axial expansion of an assembly given prescribed expansion percentages
+        """Perform axial expansion of an assembly given prescribed expansion percentages.
 
         Parameters
         ----------
@@ -156,7 +156,7 @@ class AxialExpansionChanger:
         setFuel: bool = True,
         updateNDensForRadialExp: bool = True,
     ):
-        """Perform thermal expansion for an assembly given an axial temperature grid and field
+        """Perform thermal expansion for an assembly given an axial temperature grid and field.
 
         Parameters
         ----------
@@ -192,7 +192,7 @@ class AxialExpansionChanger:
         self.expansionData = None
 
     def setAssembly(self, a, setFuel=True):
-        """set the armi assembly to be changed and init expansion data class for assembly
+        """set the armi assembly to be changed and init expansion data class for assembly.
 
         Parameters
         ----------
@@ -208,7 +208,7 @@ class AxialExpansionChanger:
 
     def applyColdHeightMassIncrease(self):
         """
-        Increase component mass because they are declared at cold dims
+        Increase component mass because they are declared at cold dims.
 
         Notes
         -----
@@ -224,7 +224,7 @@ class AxialExpansionChanger:
             c.changeNDensByFactor(axialExpansionFactor)
 
     def _isTopDummyBlockPresent(self):
-        """determines if top most block of assembly is a dummy block
+        """determines if top most block of assembly is a dummy block.
 
         Notes
         -----
@@ -245,7 +245,7 @@ class AxialExpansionChanger:
                 raise RuntimeError(msg)
 
     def axiallyExpandAssembly(self):
-        """Utilizes assembly linkage to do axial expansion"""
+        """Utilizes assembly linkage to do axial expansion."""
         mesh = [0.0]
         numOfBlocks = self.linked.a.countBlocksWithFlags()
         runLog.debug(
@@ -306,7 +306,7 @@ class AxialExpansionChanger:
 
     def manageCoreMesh(self, r):
         """
-        manage core mesh post assembly-level expansion
+        manage core mesh post assembly-level expansion.
 
         Parameters
         ----------
@@ -333,7 +333,7 @@ class AxialExpansionChanger:
                 runLog.extra(f"{old:.6e}\t{new:.6e}")
 
     def _conserveComponentDensity(self, b, oldHeight, oldVolume):
-        """Update block height dependent component parameters
+        """Update block height dependent component parameters.
 
         1) update component volume for all materials (used to compute block volume)
         2) update number density for solid materials only (no fluid)
@@ -375,7 +375,7 @@ def _getSolidComponents(b):
 
 def _checkBlockHeight(b):
     """
-    Do some basic block height validation
+    Do some basic block height validation.
 
     Notes
     -----
@@ -397,7 +397,7 @@ def _checkBlockHeight(b):
 
 
 class AssemblyAxialLinkage:
-    """Determines and stores the block- and component-wise axial linkage for an assembly
+    """Determines and stores the block- and component-wise axial linkage for an assembly.
 
     Attributes
     ----------
@@ -427,14 +427,14 @@ class AssemblyAxialLinkage:
         self._determineAxialLinkage()
 
     def _determineAxialLinkage(self):
-        """gets the block and component based linkage"""
+        """gets the block and component based linkage."""
         for b in self.a:
             self._getLinkedBlocks(b)
             for c in b:
                 self._getLinkedComponents(b, c)
 
     def _getLinkedBlocks(self, b):
-        """retrieve the axial linkage for block b
+        """retrieve the axial linkage for block b.
 
         Parameters
         ----------
@@ -490,7 +490,7 @@ class AssemblyAxialLinkage:
             )
 
     def _getLinkedComponents(self, b, c):
-        """retrieve the axial linkage for component c
+        """retrieve the axial linkage for component c.
 
         Parameters
         ----------
@@ -549,7 +549,7 @@ class AssemblyAxialLinkage:
 
 
 def _determineLinked(componentA, componentB):
-    """determine axial component linkage for two components
+    """determine axial component linkage for two components.
 
     Parameters
     ----------
@@ -611,7 +611,7 @@ def _determineLinked(componentA, componentB):
 
 
 class ExpansionData:
-    """object containing data needed for axial expansion"""
+    """object containing data needed for axial expansion."""
 
     def __init__(self, a, setFuel):
         self._a = a
@@ -621,7 +621,7 @@ class ExpansionData:
         self._setTargetComponents(setFuel)
 
     def setExpansionFactors(self, componentLst, percents):
-        """sets user defined expansion factors
+        """sets user defined expansion factors.
 
         Parameters
         ----------
@@ -654,7 +654,7 @@ class ExpansionData:
     def updateComponentTempsBy1DTempField(
         self, tempGrid, tempField, updateNDensForRadialExp: bool = True
     ):
-        """assign a block-average axial temperature to components
+        """assign a block-average axial temperature to components.
 
         Parameters
         ----------
@@ -711,7 +711,7 @@ class ExpansionData:
     def updateComponentTemp(
         self, b, c, temp: float, updateNDensForRadialExp: bool = True
     ):
-        """update component temperatures with a provided temperature
+        """update component temperatures with a provided temperature.
 
         Parameters
         ----------
@@ -747,7 +747,7 @@ class ExpansionData:
             c.p.volume = c.getArea(cold=False) * b.getHeight()
 
     def computeThermalExpansionFactors(self):
-        """computes expansion factors for all components via thermal expansion"""
+        """computes expansion factors for all components via thermal expansion."""
 
         for b in self._a:
             for c in b:
@@ -767,7 +767,7 @@ class ExpansionData:
                     self._expansionFactors[c] = c.getThermalExpansionFactor() - 1.0
 
     def getExpansionFactor(self, c):
-        """retrieves expansion factor for c
+        """retrieves expansion factor for c.
 
         Parameters
         ----------
@@ -782,7 +782,7 @@ class ExpansionData:
         return value
 
     def _setTargetComponents(self, setFuel):
-        """sets target component for each block
+        """sets target component for each block.
 
         Parameters
         ----------
@@ -805,7 +805,7 @@ class ExpansionData:
                 self.determineTargetComponent(b)
 
     def determineTargetComponent(self, b, flagOfInterest=None):
-        """determines target component, stores it on the block, and appends it to self._componentDeterminesBlockHeight
+        """determines target component, stores it on the block, and appends it to self._componentDeterminesBlockHeight.
 
         Parameters
         ----------
@@ -857,7 +857,7 @@ class ExpansionData:
         b.p.axialExpTargetComponent = componentWFlag[0].name
 
     def _isFuelLocked(self, b):
-        """physical/realistic implementation reserved for ARMI plugin
+        """physical/realistic implementation reserved for ARMI plugin.
 
         Parameters
         ----------
@@ -881,7 +881,7 @@ class ExpansionData:
         b.p.axialExpTargetComponent = c.name
 
     def isTargetComponent(self, c):
-        """returns bool if c is a target component
+        """returns bool if c is a target component.
 
         Parameters
         ----------

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -256,7 +256,7 @@ class FuelAssemNumModifier(GeometryChanger):
 
     def addRing(self, assemType="big shield"):
         r"""
-        Add a ring of fuel assemblies around the outside of an existing core
+        Add a ring of fuel assemblies around the outside of an existing core.
 
         Works by first finding the assembly furthest from the center, then filling in
         all assemblies that are within one pitch further with the specified assembly type
@@ -401,7 +401,7 @@ class HexToRZThetaConverter(GeometryConverter):
         self._homogenizeAxiallyByFlags = False
 
     def _generateConvertedReactorMesh(self):
-        """Convert the source reactor using the converterSettings"""
+        """Convert the source reactor using the converterSettings."""
         runLog.info("Generating mesh coordinates for the reactor conversion")
         self._radialMeshConversionType = self.converterSettings["radialConversionType"]
         self._axialMeshConversionType = self.converterSettings["axialConversionType"]
@@ -596,7 +596,7 @@ class HexToRZThetaConverter(GeometryConverter):
 
     def _setAssemsInRadialZone(self, radialIndex, lowerRing, upperRing):
         """
-        Retrieve a list of assemblies in the reactor between (lowerRing, upperRing)
+        Retrieve a list of assemblies in the reactor between (lowerRing, upperRing).
 
         Notes
         -----
@@ -709,7 +709,7 @@ class HexToRZThetaConverter(GeometryConverter):
         self, innerDiameter, thetaIndex, radialIndex, lowerTheta, upperTheta, zoneAssems
     ):
         """
-        Add a new stack of circles to the TRZ reactor by homogenizing assems
+        Add a new stack of circles to the TRZ reactor by homogenizing assems.
 
         Parameters
         ----------
@@ -963,7 +963,7 @@ class HexToRZThetaConverter(GeometryConverter):
 
     def _createBlendedXSID(self, newBlock):
         """
-        Generate the blended XS id using the most common XS id in the hexIdList
+        Generate the blended XS id using the most common XS id in the hexIdList.
         """
         ids = [hexBlock.getMicroSuffix() for hexBlock in self.blockMap[newBlock]]
         xsTypeList, buGroupList = zip(*ids)
@@ -1008,7 +1008,7 @@ class HexToRZThetaConverter(GeometryConverter):
 
     def _writeRadialThetaZoneInfo(self, axIdx, axialSegmentHeight, blockObj):
         """
-        Create a summary of the mapping between the converted reactor block ids to the hex reactor block ids
+        Create a summary of the mapping between the converted reactor block ids to the hex reactor block ids.
         """
         self._newBlockNum += 1
         hexBlockXsIds = []
@@ -1028,7 +1028,7 @@ class HexToRZThetaConverter(GeometryConverter):
 
     def _expandSourceReactorGeometry(self):
         """
-        Expansion of the reactor geometry to build the R-Z-Theta core model
+        Expansion of the reactor geometry to build the R-Z-Theta core model.
         """
         runLog.info("Expanding source reactor core to a full core model")
         reactorExpander = ThirdCoreHexToFullCoreChanger(self._cs)
@@ -1204,7 +1204,7 @@ class HexToRZThetaConverter(GeometryConverter):
 
 class HexToRZConverter(HexToRZThetaConverter):
     r"""
-    Create a new reactor with R-Z coordinates from the Hexagonal-Z reactor
+    Create a new reactor with R-Z coordinates from the Hexagonal-Z reactor.
 
     This is a subclass of the HexToRZThetaConverter. See the HexToRZThetaConverter for explanation and setup of
     the converterSettings.
@@ -1215,7 +1215,7 @@ class HexToRZConverter(HexToRZThetaConverter):
 
 class ThirdCoreHexToFullCoreChanger(GeometryChanger):
     """
-    Change third-core models to full core in place
+    Change third-core models to full core in place.
 
     Does not generate a new reactor object.
 
@@ -1362,7 +1362,7 @@ class ThirdCoreHexToFullCoreChanger(GeometryChanger):
 
 class EdgeAssemblyChanger(GeometryChanger):
     """
-    Add/remove "edge assemblies" for Finite difference or MCNP cases
+    Add/remove "edge assemblies" for Finite difference or MCNP cases.
 
     Examples
     --------
@@ -1372,7 +1372,7 @@ class EdgeAssemblyChanger(GeometryChanger):
 
     def addEdgeAssemblies(self, core):
         """
-        Add the assemblies on the 120 degree symmetric line to 1/3 symmetric cases
+        Add the assemblies on the 120 degree symmetric line to 1/3 symmetric cases.
 
         Needs to be called before a finite difference (DIF3D, DIFNT) or MCNP calculation
 
@@ -1437,7 +1437,7 @@ class EdgeAssemblyChanger(GeometryChanger):
 
     def removeEdgeAssemblies(self, core):
         r"""
-        remove the edge assemblies in preparation for the nodal diffusion approximation
+        remove the edge assemblies in preparation for the nodal diffusion approximation.
 
         This makes use of the assemblies knowledge of if it is in a region that it
         needs to be removed.
@@ -1478,7 +1478,7 @@ class EdgeAssemblyChanger(GeometryChanger):
     @staticmethod
     def scaleParamsRelatedToSymmetry(reactor, paramsToScaleSubset=None):
         """
-        Scale volume-dependent params like power to account for cut-off edges
+        Scale volume-dependent params like power to account for cut-off edges.
 
         These params are at half their full hex value. Scale them right before deleting their
         symmetric identicals. The two operations (scaling them and then removing others) is

--- a/armi/reactor/converters/meshConverters.py
+++ b/armi/reactor/converters/meshConverters.py
@@ -394,7 +394,7 @@ def checkLastValueInList(
     inputList, listName, expectedValue, eps=0.001, adjustLastValue=False
 ):
     """
-    Check that the last value in the list is equal to the expected value within +/- eps
+    Check that the last value in the list is equal to the expected value within +/- eps.
     """
     msg = "The last value in {} is {} and should be {}".format(
         listName, inputList[-1], expectedValue
@@ -414,7 +414,7 @@ def checkLastValueInList(
 
 def checkListBounds(inputList, listName, minVal, maxVal, eps=0.001):
     """
-    Ensure that each value in a list does not exceed the allowable bounds
+    Ensure that each value in a list does not exceed the allowable bounds.
     """
     for value in inputList:
         minDiff = value - minVal
@@ -429,7 +429,7 @@ def checkListBounds(inputList, listName, minVal, maxVal, eps=0.001):
 
 def generateBins(totalNumDataPoints, numPerBin, minNum):
     """
-    Fill in a list based on the total number of data points and the number of data points per bin
+    Fill in a list based on the total number of data points and the number of data points per bin.
     """
     listToFill = []
     if numPerBin >= totalNumDataPoints:

--- a/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
+++ b/armi/reactor/converters/parameterSweeps/generalParameterSweepConverters.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Module for general core parameter sweeps
+Module for general core parameter sweeps.
 """
 from armi.reactor.converters.geometryConverters import GeometryConverter
 from armi.physics.neutronics.settings import (

--- a/armi/reactor/converters/parameterSweeps/tests/test_paramSweepConverters.py
+++ b/armi/reactor/converters/parameterSweeps/tests/test_paramSweepConverters.py
@@ -44,7 +44,7 @@ class TestParamSweepConverters(unittest.TestCase):
         self.cs = self.o.cs
 
     def test_paramSweepConverter(self):
-        """basic test of the param sweep converter."""
+        """Basic test of the param sweep converter."""
         con = ParameterSweepConverter(self.cs, "FakeParam")
         self.assertEqual(con._parameter, "FakeParam")
 
@@ -52,7 +52,7 @@ class TestParamSweepConverters(unittest.TestCase):
         self.assertEqual(con._sourceReactor, self.r)
 
     def test_neutronicConvergenceModifier(self):
-        """super basic test of the Neutronic Convergence Modifier."""
+        """Super basic test of the Neutronic Convergence Modifier."""
         custom = NeutronicConvergenceModifier(self.cs, 1000)
         self.assertEqual(custom._parameter, 1000)
 

--- a/armi/reactor/converters/parameterSweeps/tests/test_paramSweepConverters.py
+++ b/armi/reactor/converters/parameterSweeps/tests/test_paramSweepConverters.py
@@ -44,7 +44,7 @@ class TestParamSweepConverters(unittest.TestCase):
         self.cs = self.o.cs
 
     def test_paramSweepConverter(self):
-        """basic test of the param sweep converter"""
+        """basic test of the param sweep converter."""
         con = ParameterSweepConverter(self.cs, "FakeParam")
         self.assertEqual(con._parameter, "FakeParam")
 
@@ -52,7 +52,7 @@ class TestParamSweepConverters(unittest.TestCase):
         self.assertEqual(con._sourceReactor, self.r)
 
     def test_neutronicConvergenceModifier(self):
-        """super basic test of the Neutronic Convergence Modifier"""
+        """super basic test of the Neutronic Convergence Modifier."""
         custom = NeutronicConvergenceModifier(self.cs, 1000)
         self.assertEqual(custom._parameter, 1000)
 
@@ -60,7 +60,7 @@ class TestParamSweepConverters(unittest.TestCase):
         self.assertAlmostEqual(custom._cs[CONF_EPS_FSPOINT], 1, delta=1e-3)
 
     def test_settingsModifier(self):
-        """Super basic test of the Settings Modifier"""
+        """Super basic test of the Settings Modifier."""
         con = SettingsModifier(self.cs, "comment", "FakeParam")
         self.assertEqual(con._parameter, "FakeParam")
         val = self.cs["comment"]
@@ -73,7 +73,7 @@ class TestParamSweepConverters(unittest.TestCase):
         self.assertEqual(con._cs["comment"], "FakeParam")
 
     def test_customModifier(self):
-        """Super basic test of the Custom Modifier"""
+        """Super basic test of the Custom Modifier."""
         con = CustomModifier(self.cs, "FakeParam")
         self.assertEqual(con._parameter, "FakeParam")
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -46,7 +46,7 @@ from armi.utils import units
 
 
 class AxialExpansionTestBase(unittest.TestCase):
-    """common methods and variables for unit tests."""
+    """Common methods and variables for unit tests."""
 
     Steel_Component_Lst = [
         Flags.DUCT,
@@ -78,7 +78,7 @@ class AxialExpansionTestBase(unittest.TestCase):
         materials.setMaterialNamespaceOrder(self.origNameSpace)
 
     def _getConservationMetrics(self, a):
-        """retrieves and stores various conservation metrics.
+        """Retrieves and stores various conservation metrics.
 
         - useful for verification and unittesting
         - Finds and stores:
@@ -121,7 +121,7 @@ class AxialExpansionTestBase(unittest.TestCase):
 
 
 class Temperature:
-    """create and store temperature grid/field."""
+    """Create and store temperature grid/field."""
 
     def __init__(
         self,
@@ -154,8 +154,7 @@ class Temperature:
         self._generateTempField(coldTemp, hotInletTemp, uniform)
 
     def _generateTempField(self, coldTemp, hotInletTemp, uniform):
-        """
-        generate temperature field and grid.
+        """Generate temperature field and grid.
 
         - all temperatures are in C
         - temperature field : temperature readings (e.g., from T/H calculation)
@@ -178,7 +177,7 @@ class Temperature:
 
 
 class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
-    """verify that test assembly is expanded correctly."""
+    """Verify that test assembly is expanded correctly."""
 
     def setUp(self):
         AxialExpansionTestBase.setUp(self)
@@ -204,7 +203,7 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
         AxialExpansionTestBase.tearDown(self)
 
     def test_AssemblyAxialExpansionHeight(self):
-        """test the axial expansion gives correct heights for component-based expansion."""
+        """Test the axial expansion gives correct heights for component-based expansion."""
         for idt in range(self.temp.tempSteps):
             for ib, b in enumerate(self.a):
                 self.assertAlmostEqual(
@@ -218,7 +217,7 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
                 )
 
     def test_AxialMesh(self):
-        """test that mesh aligns with block tops for component-based expansion."""
+        """Test that mesh aligns with block tops for component-based expansion."""
         for idt in range(self.temp.tempSteps):
             for ib, b in enumerate(self.a):
                 self.assertEqual(
@@ -236,7 +235,7 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
                 )
 
     def _generateComponentWiseExpectedHeight(self):
-        """calculate the expected height, external of AssemblyAxialExpansion()."""
+        """Calculate the expected height, external of AssemblyAxialExpansion()."""
         assem = buildTestAssemblyWithFakeMaterial(name="FakeMat")
         aveBlockTemp = zeros((len(assem), self.temp.tempSteps))
         self.trueZtop = zeros((len(assem), self.temp.tempSteps))
@@ -275,7 +274,7 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
 
 
 class TestConservation(AxialExpansionTestBase, unittest.TestCase):
-    """verify that conservation is maintained in assembly-level axial expansion."""
+    """Verify that conservation is maintained in assembly-level axial expansion."""
 
     def setUp(self):
         AxialExpansionTestBase.setUp(self)
@@ -285,7 +284,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         AxialExpansionTestBase.tearDown(self)
 
     def expandAssemForMassConservationTest(self):
-        """initialize class variables for mass conservation checks."""
+        """Initialize class variables for mass conservation checks."""
         # pylint: disable=attribute-defined-outside-init
         self.oldMass = {}
         for b in self.a:
@@ -306,10 +305,11 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
             self._getConservationMetrics(self.a)
 
     def test_ColdThermalExpansionContractionConservation(self):
-        """thermally expand and then contract to ensure original state is recovered.
+        r"""Thermally expand and then contract to ensure original state is recovered.
 
-        Notes:
-        - temperature field is isothermal and initially at 25 C
+        Notes
+        -----
+        Temperature field is isothermal and initially at 25 C.
         """
         isothermalTempList = [20.0, 25.0, 30.0]
         a = buildTestAssemblyWithFakeMaterial(name="FakeMat")
@@ -350,10 +350,11 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
                     )
 
     def test_HotThermalExpansionContractionConservation(self):
-        """thermally expand and then contract to ensure original state is recovered.
+        r"""Thermally expand and then contract to ensure original state is recovered.
 
-        Notes:
-        - temperature field is isothermal and initially at 250 C
+        Notes
+        -----
+        Temperature field is isothermal and initially at 250 C.
         """
         isothermalTempList = [200.0, 250.0, 300.0]
         a = buildTestAssemblyWithFakeMaterial(name="FakeMat", hot=True)
@@ -394,7 +395,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
                     )
 
     def test_PrescribedExpansionContractionConservation(self):
-        """expand all components and then contract back to original state.
+        """Expand all components and then contract back to original state.
 
         Notes
         -----
@@ -437,7 +438,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         )
 
     def test_TargetComponentMassConservation(self):
-        """tests mass conservation for target components."""
+        """Tests mass conservation for target components."""
         self.expandAssemForMassConservationTest()
         for idt in range(self.temp.tempSteps):
             for b in self.a[:-1]:  # skip the dummy sodium block
@@ -457,7 +458,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
                 self.oldMass[b.name] = self.massAndDens[b.name][idt][0]
 
     def test_SteelConservation(self):
-        """tests mass conservation for total assembly steel.
+        """Tests mass conservation for total assembly steel.
 
         Component list defined by, Steel_Component_List, in GetSteelMass()
         """
@@ -471,7 +472,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
             )
 
     def test_NoMovementACLP(self):
-        """ensures that above core load pad (ACLP) does not move during fuel-only expansion."""
+        """Ensures that above core load pad (ACLP) does not move during fuel-only expansion."""
         # build test assembly with ACLP
         assembly = HexAssembly("testAssemblyType")
         assembly.spatialGrid = grids.axialUnitGrid(numCells=1)
@@ -520,7 +521,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         self.assertIsNone(self.obj.expansionData)
 
     def test_computeThermalExpansionFactors(self):
-        """ensure expansion factors are as expected."""
+        """Ensure expansion factors are as expected."""
         self.obj.setAssembly(self.a)
         stdThermExpFactor = {}
         newTemp = 500.0
@@ -550,7 +551,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
 
 
 class TestManageCoreMesh(unittest.TestCase):
-    """verify that manage core mesh unifies the mesh for detailedAxialExpansion: False."""
+    """Verify that manage core mesh unifies the mesh for detailedAxialExpansion: False."""
 
     def setUp(self):
         self.axialExpChngr = AxialExpansionChanger()
@@ -628,7 +629,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_AssemblyAxialExpansionException(self):
-        """test that negative height exception is caught."""
+        """Test that negative height exception is caught."""
         # manually set axial exp target component for code coverage
         self.a[0].p.axialExpTargetComponent = self.a[0][0].name
         temp = Temperature(self.a.getTotalHeight(), numTempGridPts=11, tempSteps=10)
@@ -644,7 +645,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_isFuelLocked(self):
-        """ensures that the RuntimeError statement in ExpansionData::_isFuelLocked is raised appropriately.
+        """Ensures that the RuntimeError statement in ExpansionData::_isFuelLocked is raised appropriately.
 
         Notes
         ------
@@ -674,7 +675,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
         self.assertFalse(_determineLinked(compA, compB))
 
     def test_getLinkedComponents(self):
-        """test for multiple component axial linkage."""
+        """Test for multiple component axial linkage."""
         shieldBlock = self.obj.linked.a[0]
         shieldComp = shieldBlock[0]
         shieldComp.setDimension("od", 0.785, cold=True)
@@ -684,7 +685,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
 
 
 class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
-    """verify determineTargetComponent method is properly updating _componentDeterminesBlockHeight."""
+    """Verify determineTargetComponent method is properly updating _componentDeterminesBlockHeight."""
 
     def setUp(self):
         AxialExpansionTestBase.setUp(self)
@@ -696,7 +697,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         AxialExpansionTestBase.tearDown(self)
 
     def test_determineTargetComponent(self):
-        """provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER."""
+        """Provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER."""
         b = HexBlock("fuel", height=10.0)
         fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.76, "id": 0.00, "mult": 127.0}
         cladDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.80, "id": 0.77, "mult": 127.0}
@@ -720,7 +721,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         )
 
     def test_determineTargetComponentBlockWithMultipleFlags(self):
-        """provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER with multiple flags."""
+        """Provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER with multiple flags."""
         # build a block that has two flags as well as a component matching each
         b = HexBlock("fuel poison", height=10.0)
         fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.9, "id": 0.5, "mult": 200.0}
@@ -738,7 +739,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         )
 
     def test_specifyTargetComponent_NotFound(self):
-        """ensure RuntimeError gets raised when no target component is found."""
+        """Ensure RuntimeError gets raised when no target component is found."""
         b = HexBlock("fuel", height=10.0)
         b.add(self.coolant)
         b.setType("fuel")
@@ -752,7 +753,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_specifyTargetComponent_singleSolid(self):
-        """ensures that specifyTargetComponent is smart enough to set the only solid as the target component."""
+        """Ensures that specifyTargetComponent is smart enough to set the only solid as the target component."""
         b = HexBlock("plenum", height=10.0)
         ductDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
         duct = Hexagon("duct", "FakeMat", **ductDims)
@@ -767,7 +768,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         )
 
     def test_specifyTargetComponet_MultipleFound(self):
-        """ensure RuntimeError is hit when multiple target components are found.
+        """Ensure RuntimeError is hit when multiple target components are found.
 
         Notes
         -----
@@ -795,7 +796,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_manuallySetTargetComponent(self):
-        """ensures that target components can be manually set (is done in practice via blueprints)."""
+        """Ensures that target components can be manually set (is done in practice via blueprints)."""
         b = HexBlock("dummy", height=10.0)
         ductDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
         duct = Hexagon("duct", "FakeMat", **ductDims)
@@ -819,7 +820,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
 
 
 class TestInputHeightsConsideredHot(unittest.TestCase):
-    """verify thermal expansion for process loading of core."""
+    """Verify thermal expansion for process loading of core."""
 
     def setUp(self):
         """This test uses a different armiRun.yaml than the default."""
@@ -841,7 +842,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
         self.testAssems = [a for a in rCold.core.getAssemblies()]
 
     def test_coldAssemblyExpansion(self):
-        """block heights are cold and should be expanded.
+        """Block heights are cold and should be expanded.
 
         Notes
         -----
@@ -893,7 +894,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
     def checkColdHeightBlockMass(
         self, bStd: HexBlock, bExp: HexBlock, flagType: Flags, nuclide: str
     ):
-        """checks that nuclide masses for blocks with input cold heights and "inputHeightsConsideredHot": True are underpredicted.
+        """Checks that nuclide masses for blocks with input cold heights and "inputHeightsConsideredHot": True are underpredicted.
 
         Notes
         -----
@@ -923,10 +924,10 @@ def checkColdBlockHeight(bStd, bExp, assertType, strForAssertion):
 
 
 class TestLinkage(AxialExpansionTestBase, unittest.TestCase):
-    """test axial linkage between components."""
+    """Test axial linkage between components."""
 
     def setUp(self):
-        """contains common dimensions for all component class types."""
+        """Contains common dimensions for all component class types."""
         AxialExpansionTestBase.setUp(self)
         self.common = ("test", "FakeMat", 25.0, 25.0)  # name, material, Tinput, Thot
 
@@ -940,7 +941,7 @@ class TestLinkage(AxialExpansionTestBase, unittest.TestCase):
         name: str,
         commonArgs: tuple = None,
     ):
-        """runs various linkage tests.
+        """Runs various linkage tests.
 
         Parameters
         ----------
@@ -1127,7 +1128,6 @@ def _buildTestBlock(blockType: str, name: str, hotTemp: float, height: float):
     ----------
     blockType : string
         determines which type of block you're building
-
     name : string
         determines which fake material to use
     """

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test axialExpansionChanger"""
+"""Test axialExpansionChanger."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 from statistics import mean
 import os
@@ -46,7 +46,7 @@ from armi.utils import units
 
 
 class AxialExpansionTestBase(unittest.TestCase):
-    """common methods and variables for unit tests"""
+    """common methods and variables for unit tests."""
 
     Steel_Component_Lst = [
         Flags.DUCT,
@@ -78,7 +78,7 @@ class AxialExpansionTestBase(unittest.TestCase):
         materials.setMaterialNamespaceOrder(self.origNameSpace)
 
     def _getConservationMetrics(self, a):
-        """retrieves and stores various conservation metrics
+        """retrieves and stores various conservation metrics.
 
         - useful for verification and unittesting
         - Finds and stores:
@@ -121,7 +121,7 @@ class AxialExpansionTestBase(unittest.TestCase):
 
 
 class Temperature:
-    """create and store temperature grid/field"""
+    """create and store temperature grid/field."""
 
     def __init__(
         self,
@@ -155,7 +155,7 @@ class Temperature:
 
     def _generateTempField(self, coldTemp, hotInletTemp, uniform):
         """
-        generate temperature field and grid
+        generate temperature field and grid.
 
         - all temperatures are in C
         - temperature field : temperature readings (e.g., from T/H calculation)
@@ -178,7 +178,7 @@ class Temperature:
 
 
 class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
-    """verify that test assembly is expanded correctly"""
+    """verify that test assembly is expanded correctly."""
 
     def setUp(self):
         AxialExpansionTestBase.setUp(self)
@@ -204,7 +204,7 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
         AxialExpansionTestBase.tearDown(self)
 
     def test_AssemblyAxialExpansionHeight(self):
-        """test the axial expansion gives correct heights for component-based expansion"""
+        """test the axial expansion gives correct heights for component-based expansion."""
         for idt in range(self.temp.tempSteps):
             for ib, b in enumerate(self.a):
                 self.assertAlmostEqual(
@@ -218,7 +218,7 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
                 )
 
     def test_AxialMesh(self):
-        """test that mesh aligns with block tops for component-based expansion"""
+        """test that mesh aligns with block tops for component-based expansion."""
         for idt in range(self.temp.tempSteps):
             for ib, b in enumerate(self.a):
                 self.assertEqual(
@@ -236,7 +236,7 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
                 )
 
     def _generateComponentWiseExpectedHeight(self):
-        """calculate the expected height, external of AssemblyAxialExpansion()"""
+        """calculate the expected height, external of AssemblyAxialExpansion()."""
         assem = buildTestAssemblyWithFakeMaterial(name="FakeMat")
         aveBlockTemp = zeros((len(assem), self.temp.tempSteps))
         self.trueZtop = zeros((len(assem), self.temp.tempSteps))
@@ -275,7 +275,7 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
 
 
 class TestConservation(AxialExpansionTestBase, unittest.TestCase):
-    """verify that conservation is maintained in assembly-level axial expansion"""
+    """verify that conservation is maintained in assembly-level axial expansion."""
 
     def setUp(self):
         AxialExpansionTestBase.setUp(self)
@@ -285,7 +285,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         AxialExpansionTestBase.tearDown(self)
 
     def expandAssemForMassConservationTest(self):
-        """initialize class variables for mass conservation checks"""
+        """initialize class variables for mass conservation checks."""
         # pylint: disable=attribute-defined-outside-init
         self.oldMass = {}
         for b in self.a:
@@ -306,7 +306,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
             self._getConservationMetrics(self.a)
 
     def test_ColdThermalExpansionContractionConservation(self):
-        """thermally expand and then contract to ensure original state is recovered
+        """thermally expand and then contract to ensure original state is recovered.
 
         Notes:
         - temperature field is isothermal and initially at 25 C
@@ -350,7 +350,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
                     )
 
     def test_HotThermalExpansionContractionConservation(self):
-        """thermally expand and then contract to ensure original state is recovered
+        """thermally expand and then contract to ensure original state is recovered.
 
         Notes:
         - temperature field is isothermal and initially at 250 C
@@ -394,7 +394,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
                     )
 
     def test_PrescribedExpansionContractionConservation(self):
-        """expand all components and then contract back to original state
+        """expand all components and then contract back to original state.
 
         Notes
         -----
@@ -437,7 +437,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         )
 
     def test_TargetComponentMassConservation(self):
-        """tests mass conservation for target components"""
+        """tests mass conservation for target components."""
         self.expandAssemForMassConservationTest()
         for idt in range(self.temp.tempSteps):
             for b in self.a[:-1]:  # skip the dummy sodium block
@@ -457,7 +457,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
                 self.oldMass[b.name] = self.massAndDens[b.name][idt][0]
 
     def test_SteelConservation(self):
-        """tests mass conservation for total assembly steel
+        """tests mass conservation for total assembly steel.
 
         Component list defined by, Steel_Component_List, in GetSteelMass()
         """
@@ -471,7 +471,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
             )
 
     def test_NoMovementACLP(self):
-        """ensures that above core load pad (ACLP) does not move during fuel-only expansion"""
+        """ensures that above core load pad (ACLP) does not move during fuel-only expansion."""
         # build test assembly with ACLP
         assembly = HexAssembly("testAssemblyType")
         assembly.spatialGrid = grids.axialUnitGrid(numCells=1)
@@ -520,7 +520,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         self.assertIsNone(self.obj.expansionData)
 
     def test_computeThermalExpansionFactors(self):
-        """ensure expansion factors are as expected"""
+        """ensure expansion factors are as expected."""
         self.obj.setAssembly(self.a)
         stdThermExpFactor = {}
         newTemp = 500.0
@@ -550,7 +550,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
 
 
 class TestManageCoreMesh(unittest.TestCase):
-    """verify that manage core mesh unifies the mesh for detailedAxialExpansion: False"""
+    """verify that manage core mesh unifies the mesh for detailedAxialExpansion: False."""
 
     def setUp(self):
         self.axialExpChngr = AxialExpansionChanger()
@@ -574,7 +574,7 @@ class TestManageCoreMesh(unittest.TestCase):
 
 
 class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
-    """Verify exceptions are caught"""
+    """Verify exceptions are caught."""
 
     def setUp(self):
         AxialExpansionTestBase.setUp(self)
@@ -628,7 +628,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_AssemblyAxialExpansionException(self):
-        """test that negative height exception is caught"""
+        """test that negative height exception is caught."""
         # manually set axial exp target component for code coverage
         self.a[0].p.axialExpTargetComponent = self.a[0][0].name
         temp = Temperature(self.a.getTotalHeight(), numTempGridPts=11, tempSteps=10)
@@ -644,7 +644,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_isFuelLocked(self):
-        """ensures that the RuntimeError statement in ExpansionData::_isFuelLocked is raised appropriately
+        """ensures that the RuntimeError statement in ExpansionData::_isFuelLocked is raised appropriately.
 
         Notes
         ------
@@ -674,7 +674,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
         self.assertFalse(_determineLinked(compA, compB))
 
     def test_getLinkedComponents(self):
-        """test for multiple component axial linkage"""
+        """test for multiple component axial linkage."""
         shieldBlock = self.obj.linked.a[0]
         shieldComp = shieldBlock[0]
         shieldComp.setDimension("od", 0.785, cold=True)
@@ -684,7 +684,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
 
 
 class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
-    """verify determineTargetComponent method is properly updating _componentDeterminesBlockHeight"""
+    """verify determineTargetComponent method is properly updating _componentDeterminesBlockHeight."""
 
     def setUp(self):
         AxialExpansionTestBase.setUp(self)
@@ -696,7 +696,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         AxialExpansionTestBase.tearDown(self)
 
     def test_determineTargetComponent(self):
-        """provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER"""
+        """provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER."""
         b = HexBlock("fuel", height=10.0)
         fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.76, "id": 0.00, "mult": 127.0}
         cladDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.80, "id": 0.77, "mult": 127.0}
@@ -720,7 +720,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         )
 
     def test_determineTargetComponentBlockWithMultipleFlags(self):
-        """provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER with multiple flags"""
+        """provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER with multiple flags."""
         # build a block that has two flags as well as a component matching each
         b = HexBlock("fuel poison", height=10.0)
         fuelDims = {"Tinput": 25.0, "Thot": 25.0, "od": 0.9, "id": 0.5, "mult": 200.0}
@@ -738,7 +738,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         )
 
     def test_specifyTargetComponent_NotFound(self):
-        """ensure RuntimeError gets raised when no target component is found"""
+        """ensure RuntimeError gets raised when no target component is found."""
         b = HexBlock("fuel", height=10.0)
         b.add(self.coolant)
         b.setType("fuel")
@@ -752,7 +752,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_specifyTargetComponent_singleSolid(self):
-        """ensures that specifyTargetComponent is smart enough to set the only solid as the target component"""
+        """ensures that specifyTargetComponent is smart enough to set the only solid as the target component."""
         b = HexBlock("plenum", height=10.0)
         ductDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
         duct = Hexagon("duct", "FakeMat", **ductDims)
@@ -767,7 +767,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         )
 
     def test_specifyTargetComponet_MultipleFound(self):
-        """ensure RuntimeError is hit when multiple target components are found
+        """ensure RuntimeError is hit when multiple target components are found.
 
         Notes
         -----
@@ -795,7 +795,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_manuallySetTargetComponent(self):
-        """ensures that target components can be manually set (is done in practice via blueprints)"""
+        """ensures that target components can be manually set (is done in practice via blueprints)."""
         b = HexBlock("dummy", height=10.0)
         ductDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
         duct = Hexagon("duct", "FakeMat", **ductDims)
@@ -819,10 +819,10 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
 
 
 class TestInputHeightsConsideredHot(unittest.TestCase):
-    """verify thermal expansion for process loading of core"""
+    """verify thermal expansion for process loading of core."""
 
     def setUp(self):
-        """This test uses a different armiRun.yaml than the default"""
+        """This test uses a different armiRun.yaml than the default."""
 
         o, r = loadTestReactor(
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
@@ -841,7 +841,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
         self.testAssems = [a for a in rCold.core.getAssemblies()]
 
     def test_coldAssemblyExpansion(self):
-        """block heights are cold and should be expanded
+        """block heights are cold and should be expanded.
 
         Notes
         -----
@@ -893,7 +893,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
     def checkColdHeightBlockMass(
         self, bStd: HexBlock, bExp: HexBlock, flagType: Flags, nuclide: str
     ):
-        """checks that nuclide masses for blocks with input cold heights and "inputHeightsConsideredHot": True are underpredicted
+        """checks that nuclide masses for blocks with input cold heights and "inputHeightsConsideredHot": True are underpredicted.
 
         Notes
         -----
@@ -923,10 +923,10 @@ def checkColdBlockHeight(bStd, bExp, assertType, strForAssertion):
 
 
 class TestLinkage(AxialExpansionTestBase, unittest.TestCase):
-    """test axial linkage between components"""
+    """test axial linkage between components."""
 
     def setUp(self):
-        """contains common dimensions for all component class types"""
+        """contains common dimensions for all component class types."""
         AxialExpansionTestBase.setUp(self)
         self.common = ("test", "FakeMat", 25.0, 25.0)  # name, material, Tinput, Thot
 
@@ -940,7 +940,7 @@ class TestLinkage(AxialExpansionTestBase, unittest.TestCase):
         name: str,
         commonArgs: tuple = None,
     ):
-        """runs various linkage tests
+        """runs various linkage tests.
 
         Parameters
         ----------
@@ -1093,7 +1093,7 @@ class TestLinkage(AxialExpansionTestBase, unittest.TestCase):
 
 
 def buildTestAssemblyWithFakeMaterial(name: str, hot: bool = False):
-    """Create test assembly consisting of list of fake material
+    """Create test assembly consisting of list of fake material.
 
     Parameters
     ----------
@@ -1178,7 +1178,7 @@ def _buildDummySodium(hotTemp: float, height: float):
 
 
 class FakeMat(materials.ht9.HT9):
-    """Fake material used to verify armi.reactor.converters.axialExpansionChanger
+    """Fake material used to verify armi.reactor.converters.axialExpansionChanger.
 
     Notes
     -----
@@ -1194,13 +1194,13 @@ class FakeMat(materials.ht9.HT9):
         materials.ht9.HT9.__init__(self)
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
-        """A fake linear expansion percent"""
+        """A fake linear expansion percent."""
         Tc = units.getTc(Tc, Tk)
         return 0.02 * Tc
 
 
 class FakeMatException(materials.ht9.HT9):
-    """Fake material used to verify TestExceptions
+    """Fake material used to verify TestExceptions.
 
     Notes
     -----
@@ -1214,6 +1214,6 @@ class FakeMatException(materials.ht9.HT9):
         materials.ht9.HT9.__init__(self)
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
-        """A fake linear expansion percent"""
+        """A fake linear expansion percent."""
         Tc = units.getTc(Tc, Tk)
         return 0.08 * Tc

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test block conversions"""
+"""Test block conversions."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os
 import unittest

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -42,7 +42,7 @@ class TestGeometryConverters(unittest.TestCase):
 
     def test_addRing(self):
         r"""
-        Tests that the addRing method adds the correct number of fuel assemblies to the test reactor
+        Tests that the addRing method adds the correct number of fuel assemblies to the test reactor.
         """
         converter = geometryConverters.FuelAssemNumModifier(self.cs)
         converter.numFuelAssems = 7
@@ -218,7 +218,7 @@ class TestHexToRZConverter(unittest.TestCase):
                 )
 
     def _checkNuclidesMatch(self, expectedNuclideList, newR):
-        """Check that the nuclide lists match before and after conversion"""
+        """Check that the nuclide lists match before and after conversion."""
         actualNuclideList = newR.blueprints.allNuclidesInProblem
         if set(expectedNuclideList) != set(actualNuclideList):
             diffList = sorted(set(expectedNuclideList).difference(actualNuclideList))
@@ -231,7 +231,7 @@ class TestHexToRZConverter(unittest.TestCase):
             )
 
     def _checkNuclideMasses(self, expectedMassDict, newR):
-        """Check that all nuclide masses in the new reactor are equivalent to before the conversion"""
+        """Check that all nuclide masses in the new reactor are equivalent to before the conversion."""
         massMismatchCount = 0
         for nuclide in expectedMassDict.keys():
             expectedMass = expectedMassDict[nuclide]
@@ -271,7 +271,7 @@ class TestHexToRZConverter(unittest.TestCase):
 
 class TestEdgeAssemblyChanger(unittest.TestCase):
     def setUp(self):
-        r"""Use the related setup in the testFuelHandlers module"""
+        r"""Use the related setup in the testFuelHandlers module."""
         self.o, self.r = loadTestReactor(TEST_ROOT)
         reduceTestReactorRings(self.r, self.o.cs, 3)
 

--- a/armi/reactor/converters/tests/test_meshConverters.py
+++ b/armi/reactor/converters/tests/test_meshConverters.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""unit tests of RZ Mesh Converter"""
+"""unit tests of RZ Mesh Converter."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import math
 import unittest
@@ -24,7 +24,7 @@ from armi.tests import TEST_ROOT
 
 class TestRZReactorMeshConverter(unittest.TestCase):
     """
-    Loads a hex reactor and converts its mesh to RZTheta coordinates
+    Loads a hex reactor and converts its mesh to RZTheta coordinates.
     """
 
     def setUp(self):

--- a/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
+++ b/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for pin type block converters
+Unit tests for pin type block converters.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import copy
@@ -59,7 +59,7 @@ class TestPinTypeConverters(unittest.TestCase):
 
 class MassConservationTests(unittest.TestCase):
     r"""
-    Tests designed to verify mass conservation during thermal expansion
+    Tests designed to verify mass conservation during thermal expansion.
     """
 
     def setUp(self):
@@ -67,7 +67,7 @@ class MassConservationTests(unittest.TestCase):
 
     def test_adjustSmearDensity(self):
         r"""
-        Tests the getting, setting, and getting of smear density functions
+        Tests the getting, setting, and getting of smear density functions.
 
         """
         bolBlock = copy.deepcopy(self.b)

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Tests for the uniform mesh geometry converter
+Tests for the uniform mesh geometry converter.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import collections
@@ -58,7 +58,7 @@ class TestConverterFactory(unittest.TestCase):
 
 class TestAssemblyUniformMesh(unittest.TestCase):
     """
-    Tests individual operations of the uniform mesh converter
+    Tests individual operations of the uniform mesh converter.
 
     Uses the test reactor for detailedAxialExpansion
     """
@@ -115,7 +115,7 @@ class TestAssemblyUniformMesh(unittest.TestCase):
             )
 
     def test_makeAssemWithUniformMeshSubmesh(self):
-        """If sourceAssem has submesh, check that newAssem splits into separate blocks"""
+        """If sourceAssem has submesh, check that newAssem splits into separate blocks."""
 
         # assign axMesh to blocks randomly
         sourceAssem = self.r.core.refAssem
@@ -254,7 +254,7 @@ class TestUniformMeshGenerator(unittest.TestCase):
 
     def test_filterMesh(self):
         """
-        Test that the mesh can be correctly filtered
+        Test that the mesh can be correctly filtered.
         """
         meshList = [1.0, 3.0, 4.0, 7.0, 9.0, 12.0, 16.0, 19.0, 20.0]
         anchorPoints = [4.0, 16.0]
@@ -297,7 +297,7 @@ class TestUniformMeshGenerator(unittest.TestCase):
 
     def test_generateCommonMesh(self):
         """
-        Covers generateCommonmesh() and _decuspAxialMesh()
+        Covers generateCommonmesh() and _decuspAxialMesh().
         """
         self.generator.generateCommonMesh()
         expectedMesh = [
@@ -316,7 +316,7 @@ class TestUniformMeshGenerator(unittest.TestCase):
 
 class TestUniformMeshComponents(unittest.TestCase):
     """
-    Tests individual operations of the uniform mesh converter
+    Tests individual operations of the uniform mesh converter.
 
     Only loads reactor once per suite.
     """
@@ -338,7 +338,7 @@ class TestUniformMeshComponents(unittest.TestCase):
         self.converter._sourceReactor = self.r
 
     def test_blueprintCopy(self):
-        """Ensure that necessary blueprint attributes are set"""
+        """Ensure that necessary blueprint attributes are set."""
         convReactor = self.converter.initNewReactor(
             self.converter._sourceReactor, self.o.cs
         )
@@ -358,7 +358,7 @@ class TestUniformMeshComponents(unittest.TestCase):
 
 
 def applyNonUniformHeightDistribution(reactor):
-    """Modifies some assemblies to have non-uniform axial meshes"""
+    """Modifies some assemblies to have non-uniform axial meshes."""
     for a in reactor.core:
         delta = 0.0
         for b in a[:-1]:
@@ -372,7 +372,7 @@ def applyNonUniformHeightDistribution(reactor):
 
 class TestUniformMesh(unittest.TestCase):
     """
-    Tests full uniform mesh converter
+    Tests full uniform mesh converter.
 
     Loads reactor once per test
     """
@@ -468,7 +468,7 @@ class TestUniformMesh(unittest.TestCase):
 
 class TestGammaUniformMesh(unittest.TestCase):
     """
-    Tests gamma uniform mesh converter
+    Tests gamma uniform mesh converter.
 
     Loads reactor once per test
     """

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -236,7 +236,7 @@ class UniformMeshGenerator:
         self, meshList, minimumMeshSize, anchorPoints, preference="bottom", warn=False
     ):
         """
-        Check for mesh violating the minimum mesh size and remove them if necessary
+        Check for mesh violating the minimum mesh size and remove them if necessary.
 
         Parameters
         ----------
@@ -505,7 +505,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
     def _generateUniformMesh(self, minimumMeshSize):
         """
-        Generate a common axial mesh to use for uniform mesh conversion
+        Generate a common axial mesh to use for uniform mesh conversion.
 
         Parameters
         ----------
@@ -520,7 +520,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
     @staticmethod
     def initNewReactor(sourceReactor, cs):
-        """Build a new, yet empty, reactor with the same settings as sourceReactor
+        """Build a new, yet empty, reactor with the same settings as sourceReactor.
 
         Parameters
         ----------
@@ -669,7 +669,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         def checkPriorityFlags(b):
             """
-            Check that a block has the flags that are prioritized for uniform mesh conversion
+            Check that a block has the flags that are prioritized for uniform mesh conversion.
 
             Also check that it's not different type of block that is a superset of the
             priority flags, like "Flags.FUEL | Flags.PLENUM"
@@ -1095,7 +1095,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
     def updateReactionRates(self):
         """
-        Update reaction rates on converted assemblies
+        Update reaction rates on converted assemblies.
 
         Notes
         -----
@@ -1317,7 +1317,7 @@ class ParamMapper:
 
     def __init__(self, reactorParamNames, blockParamNames, b):
         """
-        Initialize the list of parameter defaults
+        Initialize the list of parameter defaults.
 
         The ParameterDefinitionCollection lookup is very slow, so this we do it once
         and store it as a hashed list.
@@ -1405,7 +1405,7 @@ class ParamMapper:
 
 def setNumberDensitiesFromOverlaps(block, overlappingBlockInfo):
     r"""
-    Set number densities on a block based on overlapping blocks
+    Set number densities on a block based on overlapping blocks.
 
     A conservation of number of atoms technique is used to map the non-uniform number densities onto the uniform
     neutronics mesh. When the number density of a height :math:`H` neutronics mesh block :math:`N^{\prime}` is

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -96,7 +96,7 @@ class GeomType(enum.Enum):
 
     @property
     def label(self):
-        """Human-presentable label"""
+        """Human-presentable label."""
         if self == self.HEX:
             return "Hexagonal"
         elif self == self.CARTESIAN:
@@ -107,7 +107,7 @@ class GeomType(enum.Enum):
             return "R-Z"
 
     def __str__(self):
-        """Inverse of fromStr()"""
+        """Inverse of fromStr()."""
         if self == self.HEX:
             return HEX
         elif self == self.CARTESIAN:
@@ -164,7 +164,7 @@ class DomainType(enum.Enum):
 
     @property
     def label(self):
-        """Human-presentable label"""
+        """Human-presentable label."""
         if self == self.FULL_CORE:
             return "Full"
         elif self == self.THIRD_CORE:
@@ -180,7 +180,7 @@ class DomainType(enum.Enum):
             return ""
 
     def __str__(self):
-        """Inverse of fromStr()"""
+        """Inverse of fromStr()."""
         if self == self.FULL_CORE:
             return FULL_CORE
         elif self == self.THIRD_CORE:
@@ -253,7 +253,7 @@ class BoundaryType(enum.Enum):
 
     @property
     def label(self):
-        """Human-presentable label"""
+        """Human-presentable label."""
         if self == self.NO_SYMMETRY:
             return "No Symmetry"
         elif self == self.REFLECTIVE:
@@ -262,7 +262,7 @@ class BoundaryType(enum.Enum):
             return "Periodic"
 
     def __str__(self):
-        """Inverse of fromStr()"""
+        """Inverse of fromStr()."""
         if self == self.NO_SYMMETRY:
             return ""
         elif self == self.PERIODIC:
@@ -325,7 +325,7 @@ class SymmetryType:
 
     @classmethod
     def createValidSymmetryStrings(cls):
-        """Create a list of valid symmetry strings based on the set of tuples in VALID_SYMMETRY"""
+        """Create a list of valid symmetry strings based on the set of tuples in VALID_SYMMETRY."""
         return [
             cls(domain, boundary, isThroughCenter)
             for domain, boundary, isThroughCenter in cls.VALID_SYMMETRY
@@ -333,7 +333,7 @@ class SymmetryType:
 
     @classmethod
     def fromStr(cls, symmetryString: str) -> "SymmetryType":
-        """Construct a SymmetryType object from a valid string"""
+        """Construct a SymmetryType object from a valid string."""
         canonical = symmetryString.lower().strip()
         # ignore "assembly" since it is unnecessary and overly-verbose and too specific
         noAssembly = canonical.replace("assembly", "").strip()
@@ -372,7 +372,7 @@ class SymmetryType:
             raise TypeError("Expected str or SymmetryType; got {}".format(type(source)))
 
     def __str__(self):
-        """Combined string of domain and boundary symmetry type"""
+        """Combined string of domain and boundary symmetry type."""
         strList = [str(self.domain)]
         if self.boundary.hasSymmetry():
             strList.append(str(self.boundary))

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -761,7 +761,7 @@ class Grid:
 
     def __getstate__(self):
         """
-        Pickling removes reference to ``armiObject``
+        Pickling removes reference to ``armiObject``.
 
         Removing the ``armiObject`` allows us to pickle an assembly without pickling the entire
         reactor. An ``Assembly.spatialLocator.grid.armiObject`` is the reactor, by removing the link
@@ -777,7 +777,7 @@ class Grid:
 
     def __setstate__(self, state):
         """
-        Pickling removes reference to ``armiObject``
+        Pickling removes reference to ``armiObject``.
 
         This relies on the ``ArmiObject.__setstate__`` to assign itself.
         """
@@ -849,14 +849,14 @@ class Grid:
         )
 
     def getCellBase(self, indices) -> numpy.ndarray:
-        """Get the mesh base (lower left) of this mesh cell in cm"""
+        """Get the mesh base (lower left) of this mesh cell in cm."""
         indices = numpy.array(indices)
         return self._evaluateMesh(
             indices, self._meshBaseBySteps, self._meshBaseByBounds
         )
 
     def getCellTop(self, indices) -> numpy.ndarray:
-        """Get the mesh top (upper right) of this mesh cell in cm"""
+        """Get the mesh top (upper right) of this mesh cell in cm."""
         indices = numpy.array(indices) + 1
         return self._evaluateMesh(
             indices, self._meshBaseBySteps, self._meshBaseByBounds
@@ -1724,7 +1724,7 @@ class HexGrid(Grid):
     #       in a ring, not the actual positions
     def allPositionsInThird(self, ring, includeEdgeAssems=False):
         """
-        Returns a list of all the positions in a ring (in the first third)
+        Returns a list of all the positions in a ring (in the first third).
 
         Parameters
         ----------

--- a/armi/reactor/parameters/__init__.py
+++ b/armi/reactor/parameters/__init__.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 r"""
-The parameters system holds state information for everything within ARMI's composite
-structure:
+The parameters hold state info for everything in ARMI's composites structure.
 
 .. list-table:: Example Parameters
     :widths: 50 50

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -100,14 +100,14 @@ class ParamLocation(enum.Flag):
 
 
 class NoDefault:
-    r"""Class used to allow distinction between not setting a default and setting a default of ``None``"""
+    r"""Class used to allow distinction between not setting a default and setting a default of ``None``."""
 
     def __init__(self):
         raise NotImplementedError("You cannot create an instance of NoDefault")
 
 
 class _Undefined:
-    r"""Class used to identify a parameter property as being in the undefined state"""
+    r"""Class used to identify a parameter property as being in the undefined state."""
 
     def __init__(self):
         raise NotImplementedError("You cannot create an instance of _Undefined.")
@@ -186,7 +186,7 @@ class Serializer:
 
 @functools.total_ordering
 class Parameter:
-    r"""Metadata about a specific parameter"""
+    r"""Metadata about a specific parameter."""
     _validName = re.compile("^[a-zA-Z0-9_]+$")
 
     # Using slots because Parameters are pretty static and mostly POD. __slots__ make
@@ -269,14 +269,14 @@ class Parameter:
         )
 
     def __eq__(self, other):
-        """Name defines equality"""
+        """Name defines equality."""
         return self.name == other.name
 
     def __ne__(self, other):
         return not (self == other)
 
     def __lt__(self, other):
-        """Sort alphabetically by name"""
+        """Sort alphabetically by name."""
         return self.name < other.name
 
     def __hash__(self):
@@ -440,7 +440,7 @@ class ParameterDefinitionCollection:
 
     def extend(self, other):
         """
-        Grow a parameter definition collection by another parameter definition collection
+        Grow a parameter definition collection by another parameter definition collection.
         """
         assert (
             not self._locked
@@ -523,7 +523,7 @@ class ParameterDefinitionCollection:
 
     @property
     def categories(self):
-        r"""Get the categories of all the :py:class:`~Parameter` instances within this collection"""
+        r"""Get the categories of all the :py:class:`~Parameter` instances within this collection."""
         categories = set()
         for paramDef in self:
             categories |= paramDef.categories
@@ -554,7 +554,7 @@ class ParameterDefinitionCollection:
 
     def createBuilder(self, *args, **kwargs):
         """
-        Create an associated object that can create definitions into this collection
+        Create an associated object that can create definitions into this collection.
 
         Using the returned ParameterBuilder will add all defined parameters to this
         ParameterDefinitionCollection, using the passed arguments as defaults. Arguments
@@ -566,7 +566,7 @@ class ParameterDefinitionCollection:
 
 
 class ParameterBuilder:
-    r"""Factory for creating Parameter and parameter properties"""
+    r"""Factory for creating Parameter and parameter properties."""
 
     def __init__(
         self,
@@ -575,7 +575,7 @@ class ParameterBuilder:
         categories=None,
         saveToDB=True,
     ):
-        r"""Create a :py:class:`ParameterBuilder`"""
+        r"""Create a :py:class:`ParameterBuilder`."""
         self._entered = False
         self._defaultLocation = location
         self._defaultCategories = set(categories or [])  # make sure it is always a set
@@ -607,7 +607,7 @@ class ParameterBuilder:
 
     def associateParameterDefinitionCollection(self, paramDefs):
         """
-        Associate this parameter factory with a specific ParameterDefinitionCollection
+        Associate this parameter factory with a specific ParameterDefinitionCollection.
 
         Subsequent calls to defParam will automatically add the created
         ParameterDefinitions to this ParameterDefinitionCollection. This results in a
@@ -627,7 +627,7 @@ class ParameterBuilder:
         categories=None,
         serializer: Optional[Type[Serializer]] = None,
     ):
-        r"""Create a parameter as a property (with get/set) on a class
+        r"""Create a parameter as a property (with get/set) on a class.
 
         Parameters
         ----------

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -424,7 +424,7 @@ class ParameterDefinitionCollection:
         return matches[0]
 
     def add(self, paramDef):
-        r"""add a :py:class:`Parameter` to this collection."""
+        r"""Add a :py:class:`Parameter` to this collection."""
         assert not self._locked, "This ParameterDefinitionCollection has been locked."
         self._paramDefs.append(paramDef)
         self._paramDefDict[paramDef.name, paramDef.collectionType] = paramDef

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Reactor parameter definitions
+Reactor parameter definitions.
 """
 import numpy
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -376,7 +376,7 @@ class Core(composites.Composite):
         )
 
     def setBlockMassParams(self):
-        """Set the parameters kgHM and kgFis for each block and calculate Pu fraction"""
+        """Set the parameters kgHM and kgFis for each block and calculate Pu fraction."""
         for b in self.getBlocks():
             b.p.kgHM = b.getHMMass() / units.G_PER_KG
             b.p.kgFis = b.getFissileMass() / units.G_PER_KG
@@ -446,7 +446,7 @@ class Core(composites.Composite):
 
     def removeAssembliesInRing(self, ringNum, cs, overrideCircularRingMode=False):
         """
-        Removes all of the assemblies in a given ring
+        Removes all of the assemblies in a given ring.
 
         Parameters
         ----------
@@ -471,7 +471,7 @@ class Core(composites.Composite):
 
     def _removeListFromAuxiliaries(self, assembly):
         """
-        Remove an assembly from all auxiliary reference tables and lists
+        Remove an assembly from all auxiliary reference tables and lists.
 
         Otherwise it will get added back into assembliesByName, etc.
 
@@ -664,7 +664,7 @@ class Core(composites.Composite):
 
     def getNumEnergyGroups(self):
         """
-        Return the number of energy groups used in the problem
+        Return the number of energy groups used in the problem.
 
         See Also
         --------
@@ -675,7 +675,7 @@ class Core(composites.Composite):
     def countBlocksWithFlags(self, blockTypeSpec, assemTypeSpec=None):
         """
         Return the total number of blocks in an assembly in the reactor that
-        meets the specified type
+        meets the specified type.
 
         Parameters
         ----------
@@ -702,7 +702,7 @@ class Core(composites.Composite):
     def countFuelAxialBlocks(self):
         r"""
         return the maximum number of fuel type blocks in any assembly in
-        the reactor
+        the reactor.
 
         See Also
         --------
@@ -818,7 +818,7 @@ class Core(composites.Composite):
     ):
         """
         Returns the assemblies in a specified ring.  Definitions of rings can change
-        with problem parameters
+        with problem parameters.
 
         Parameters
         ----------
@@ -1127,7 +1127,7 @@ class Core(composites.Composite):
     # wasn't working correctly
     def genBlocksByLocName(self):
         """
-        If self.blocksByLocName is deleted, then this will regenerate it or update it if things change
+        If self.blocksByLocName is deleted, then this will regenerate it or update it if things change.
         """
         self.blocksByLocName = {
             block.getLocation(): block for block in self.getBlocks(includeAll=True)
@@ -1135,7 +1135,7 @@ class Core(composites.Composite):
 
     def getBlocks(self, bType=None, **kwargs):
         """
-        Returns an iterator over all blocks in the reactor in order
+        Returns an iterator over all blocks in the reactor in order.
 
         Parameters
         ----------
@@ -1382,7 +1382,7 @@ class Core(composites.Composite):
         self, energyOrder=0, adjoint=False, extSrc=False, volumeIntegrated=True
     ):
         """
-        Return the multigroup real or adjoint flux of the entire reactor as a vector
+        Return the multigroup real or adjoint flux of the entire reactor as a vector.
 
         Order of meshes is based on getBlocks
 
@@ -1672,7 +1672,7 @@ class Core(composites.Composite):
 
     def createAssemblyOfType(self, assemType=None, enrichList=None, cs=None):
         """
-        Create an assembly of a specific type and apply enrichments if they are specified
+        Create an assembly of a specific type and apply enrichments if they are specified.
 
         Parameters
         ----------
@@ -1975,7 +1975,7 @@ class Core(composites.Composite):
         return j
 
     def getMaxBlockParam(self, *args, **kwargs):
-        """Get max param over blocks"""
+        """Get max param over blocks."""
         if "generationNum" in kwargs:
             raise ValueError(
                 "Cannot getMaxBlockParam over anything but blocks. Prefer `getMaxParam`."
@@ -1993,7 +1993,7 @@ class Core(composites.Composite):
         return self.calcTotalParam(*args, **kwargs)
 
     def getMaxNumPins(self):
-        """find max number of pins of any block in the reactor"""
+        """find max number of pins of any block in the reactor."""
         return max(b.getNumPins() for b in self.getBlocks())
 
     def getMinimumPercentFluxInFuel(self, target=0.005):
@@ -2056,7 +2056,7 @@ class Core(composites.Composite):
 
     def getAvgTemp(self, typeSpec, blockList=None, flux2Weight=False):
         r"""
-        get the volume-average fuel, cladding, coolant temperature in core
+        get the volume-average fuel, cladding, coolant temperature in core.
 
         Parameters
         ----------
@@ -2133,7 +2133,7 @@ class Core(composites.Composite):
         return list(allNucNames)
 
     def growToFullCore(self, cs):
-        r"""copies symmetric assemblies to build a full core model out of a 1/3 core model
+        r"""copies symmetric assemblies to build a full core model out of a 1/3 core model.
 
         Returns
         -------
@@ -2153,7 +2153,7 @@ class Core(composites.Composite):
 
     def setPitchUniform(self, pitchInCm):
         """
-        set the pitch in all blocks
+        set the pitch in all blocks.
         """
         for b in self.getBlocks():
             b.setPitch(pitchInCm)
@@ -2163,7 +2163,7 @@ class Core(composites.Composite):
 
     def calcBlockMaxes(self):
         r"""
-        searches all blocks for maximum values of key params
+        searches all blocks for maximum values of key params.
 
         See Also
         --------

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1033,12 +1033,6 @@ class Core(composites.Composite):
 
         zones : iterable, optional
             Only include assemblies that are in this these zones
-
-        Notes
-        -----
-        Attempts have been made to make this a generator but there were some Cython
-        incompatibilities that we could not get around and so we are sticking with a
-        list.
         """
         if includeAll:
             includeBolAssems = includeSFP = True

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -81,7 +81,7 @@ class Reactor(composites.Composite):
         self.blueprints = blueprints
 
     def __getstate__(self):
-        r"""applies a settings and parent to the reactor and components."""
+        """Applies a settings and parent to the reactor and components."""
         state = composites.Composite.__getstate__(self)
         state["o"] = None
         return state
@@ -1940,7 +1940,7 @@ class Core(composites.Composite):
 
     def findAllAziMeshPoints(self, extraAssems=None, applySubMesh=True):
         r"""
-        returns a list of all azimuthal (theta)-mesh positions in the core.
+        Returns a list of all azimuthal (theta)-mesh positions in the core.
 
         Parameters
         ----------
@@ -1993,7 +1993,7 @@ class Core(composites.Composite):
         return self.calcTotalParam(*args, **kwargs)
 
     def getMaxNumPins(self):
-        """find max number of pins of any block in the reactor."""
+        """Find max number of pins of any block in the reactor."""
         return max(b.getNumPins() for b in self.getBlocks())
 
     def getMinimumPercentFluxInFuel(self, target=0.005):
@@ -2133,14 +2133,12 @@ class Core(composites.Composite):
         return list(allNucNames)
 
     def growToFullCore(self, cs):
-        r"""copies symmetric assemblies to build a full core model out of a 1/3 core model.
+        r"""Copies symmetric assemblies to build a full core model out of a 1/3 core model.
 
         Returns
         -------
-
         converter : GeometryConverter
             Geometry converter used to do the conversion.
-
         """
         from armi.reactor.converters.geometryConverters import (
             ThirdCoreHexToFullCoreChanger,
@@ -2163,7 +2161,7 @@ class Core(composites.Composite):
 
     def calcBlockMaxes(self):
         r"""
-        searches all blocks for maximum values of key params.
+        Searches all blocks for maximum values of key params.
 
         See Also
         --------

--- a/armi/reactor/systemLayoutInput.py
+++ b/armi/reactor/systemLayoutInput.py
@@ -346,7 +346,7 @@ class SystemLayoutInput:
 
     def _getModifiedFileName(self, originalFileName, suffix):
         """
-        Generates the modified geometry file name based on the requested suffix
+        Generates the modified geometry file name based on the requested suffix.
         """
         originalFileName = originalFileName.split(self._GEOM_FILE_EXTENSION)[0]
         suffix = suffix.split(self._GEOM_FILE_EXTENSION)[0]
@@ -354,7 +354,7 @@ class SystemLayoutInput:
 
     def writeGeom(self, outputFileName, suffix=""):
         """
-        Write data out as a geometry xml file
+        Write data out as a geometry xml file.
 
         Parameters
         ----------

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests assemblies.py"""
+"""Tests assemblies.py."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,invalid-name
 import pathlib
 import random
@@ -864,7 +864,7 @@ class Assembly_TestCase(unittest.TestCase):
         self.assertEqual(self.assembly.getDominantMaterial().getName(), ref)
 
     def test_iteration(self):
-        r"""Tests the ability to doubly-loop over assemblies (under development)"""
+        r"""Tests the ability to doubly-loop over assemblies (under development)."""
         a = self.assembly
 
         for bi, b in enumerate(a):
@@ -1015,7 +1015,7 @@ class Assembly_TestCase(unittest.TestCase):
         self.assertEqual(averagePlenumTemp, self.assembly.getAveragePlenumTemperature())
 
     def test_rotate(self):
-        """Test rotation of an assembly spatial objects"""
+        """Test rotation of an assembly spatial objects."""
         a = makeTestAssembly(1, 1)
         b = blocks.HexBlock("TestBlock")
         b.p.THcornTemp = [400, 450, 500, 550, 600, 650]
@@ -1289,7 +1289,7 @@ class AssemblyInReactor_TestCase(unittest.TestCase):
 
 
 class AnnularFuelTestCase(unittest.TestCase):
-    """Test fuel with a whole in the center"""
+    """Test fuel with a whole in the center."""
 
     # pylint: disable=locally-disabled,protected-access
     def setUp(self):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""Tests blocks.py"""
+r"""Tests blocks.py."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,invalid-name,consider-using-f-string
 import copy
 import math
@@ -747,7 +747,7 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(cur, ref, places=places)
 
     def test_replaceBlockWithBlock(self):
-        r"""Tests conservation of mass flag in replaceBlockWithBlock"""
+        r"""Tests conservation of mass flag in replaceBlockWithBlock."""
         block = self.block
         ductBlock = block.__class__("duct")
         ductBlock.add(block.getComponent(Flags.COOLANT, exact=True))
@@ -1489,7 +1489,7 @@ class Block_TestCase(unittest.TestCase):
 
     def test_setPitch(self):
         r"""
-        Checks consistency after adjusting pitch
+        Checks consistency after adjusting pitch.
 
         Needed to verify fix to Issue #165.
         """
@@ -1688,7 +1688,7 @@ class Block_TestCase(unittest.TestCase):
 
 class Test_NegativeVolume(unittest.TestCase):
     def test_negativeVolume(self):
-        """Build a block with WAY too many fuel pins and show that the derived volume is negative"""
+        """Build a block with WAY too many fuel pins and show that the derived volume is negative."""
         block = blocks.HexBlock("TestHexBlock")
 
         coldTemp = 20
@@ -2099,7 +2099,7 @@ class ThRZBlock_TestCase(unittest.TestCase):
         self.ThRZBlock.verifyBlockDims()
 
     def test_getThetaRZGrid(self):
-        """Since not applicable to ThetaRZ Grids"""
+        """Since not applicable to ThetaRZ Grids."""
         b = self.ThRZBlock
         with self.assertRaises(NotImplementedError):
             b.autoCreateSpatialGrids()
@@ -2206,7 +2206,7 @@ class CartesianBlock_TestCase(unittest.TestCase):
         self.assertAlmostEqual(sum(c.getArea() for c in cartBlock), rectTotalArea)
 
     def test_getCartesianGrid(self):
-        """Since not applicable to Cartesian Grids"""
+        """Since not applicable to Cartesian Grids."""
         b = self.cartesianBlock
         with self.assertRaises(NotImplementedError):
             b.autoCreateSpatialGrids()
@@ -2222,7 +2222,7 @@ class CartesianBlock_TestCase(unittest.TestCase):
 
 class MassConservationTests(unittest.TestCase):
     r"""
-    Tests designed to verify mass conservation during thermal expansion
+    Tests designed to verify mass conservation during thermal expansion.
     """
 
     def setUp(self):

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -263,7 +263,7 @@ class TestShapedComponent(TestGeneralComponents):
     """Abstract class for all shaped components."""
 
     def test_preserveMassDuringThermalExpansion(self):
-        """Test that when we thermally expand any arbirtray shape, mass is conserved.
+        """Test that when we thermally expand any arbitrary shape, mass is conserved.
 
         .. test:: Test that ARMI can thermally expand any arbitrary shape.
            :id: TEST_REACTOR_THERMAL_EXPANSION_0

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -1252,7 +1252,7 @@ class TestHelix(TestShapedComponent):
             self.assertEqual(cur, ref[i])
 
     def test_validParameters(self):
-        """testing the Helix class performs as expected with various inputs."""
+        """Testing the Helix class performs as expected with various inputs."""
         # stupid/simple inputs
         h = Helix("thing", "Cu", 0, 0, 1, 1, 1)
         self.assertEqual(h.getDimension("axialPitch"), 1)

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests functionalities of components within ARMI
+Tests functionalities of components within ARMI.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-self-use,no-member,invalid-name
 import copy
@@ -260,10 +260,10 @@ class TestUnshapedComponent(TestGeneralComponents):
 
 
 class TestShapedComponent(TestGeneralComponents):
-    """Abstract class for all shaped components"""
+    """Abstract class for all shaped components."""
 
     def test_preserveMassDuringThermalExpansion(self):
-        """Test that when we thermally expand any arbirtray shape, mass is conserved
+        """Test that when we thermally expand any arbirtray shape, mass is conserved.
 
         .. test:: Test that ARMI can thermally expand any arbitrary shape.
            :id: TEST_REACTOR_THERMAL_EXPANSION_0
@@ -329,7 +329,7 @@ class TestShapedComponent(TestGeneralComponents):
         """Testing the Component density gets the correct 3D material density."""
 
         class StrangeMaterial(Material):
-            """material designed to make the test easier to understand"""
+            """material designed to make the test easier to understand."""
 
             def pseduoDensity(self, Tk=None, Tc=None):
                 return 1.0
@@ -397,7 +397,7 @@ class TestCircle(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
-        """Test that ARMI can thermally expands a circle
+        """Test that ARMI can thermally expands a circle.
 
         .. test:: Test that ARMI can thermally expands a circle
            :id: TEST_REACTOR_THERMAL_EXPANSION_2
@@ -453,7 +453,7 @@ class TestCircle(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_badComponentName(self):
-        """This shows that resolveLinkedDims cannot support names with periods in them"""
+        """This shows that resolveLinkedDims cannot support names with periods in them."""
         nPins = 12
         fuelDims = {"Tinput": 25.0, "Thot": 430.0, "od": 0.9, "id": 0.0, "mult": nPins}
         cladDims = {"Tinput": 25.0, "Thot": 430.0, "od": 1.1, "id": 1.0, "mult": nPins}
@@ -650,7 +650,7 @@ class TestComponentExpansion(unittest.TestCase):
 
     def expansionConservationColdHeightDefined(self, mat: str):
         """
-        Demonstrate that material is conserved at during expansion
+        Demonstrate that material is conserved at during expansion.
 
         Notes
         -----
@@ -708,7 +708,7 @@ class TestTriangle(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
-        """Test that ARMI can thermally expands a triangle
+        """Test that ARMI can thermally expands a triangle.
 
         .. test:: Test that ARMI can thermally expands a triangle
            :id: TEST_REACTOR_THERMAL_EXPANSION_3
@@ -776,7 +776,7 @@ class TestRectangle(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
-        """Test that ARMI can thermally expands a rectangle
+        """Test that ARMI can thermally expands a rectangle.
 
         .. test:: Test that ARMI can thermally expands a rectangle
            :id: TEST_REACTOR_THERMAL_EXPANSION_4
@@ -822,7 +822,7 @@ class TestSolidRectangle(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
-        """Test that ARMI can thermally expands a solid rectangle
+        """Test that ARMI can thermally expands a solid rectangle.
 
         .. test:: Test that ARMI can thermally expands a solid rectangle
            :id: TEST_REACTOR_THERMAL_EXPANSION_5
@@ -885,7 +885,7 @@ class TestSquare(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
-        """Test that ARMI can thermally expands a square
+        """Test that ARMI can thermally expands a square.
 
         .. test:: Test that ARMI can thermally expands a square
            :id: TEST_REACTOR_THERMAL_EXPANSION_6
@@ -950,7 +950,7 @@ class TestCube(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
-        """Test that ARMI can thermally expands a cube
+        """Test that ARMI can thermally expands a cube.
 
         .. test:: Test that ARMI can thermally expands a cube
            :id: TEST_REACTOR_THERMAL_EXPANSION_7
@@ -989,7 +989,7 @@ class TestHexagon(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
-        """Test that ARMI can thermally expands a hexagon
+        """Test that ARMI can thermally expands a hexagon.
 
         .. test:: Test that ARMI can thermally expands a hexagon
            :id: TEST_REACTOR_THERMAL_EXPANSION_8
@@ -1053,7 +1053,7 @@ class TestHoledHexagon(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
-        """Test that ARMI can thermally expands a holed hexagon
+        """Test that ARMI can thermally expands a holed hexagon.
 
         .. test:: Test that ARMI can thermally expands a holed hexagon
            :id: TEST_REACTOR_THERMAL_EXPANSION_9
@@ -1104,7 +1104,7 @@ class TestHexHoledCircle(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
-        """Test that ARMI can thermally expands a holed hexagon
+        """Test that ARMI can thermally expands a holed hexagon.
 
         .. test:: Test that ARMI can thermally expands a holed hexagon
            :id: TEST_REACTOR_THERMAL_EXPANSION_10
@@ -1252,7 +1252,7 @@ class TestHelix(TestShapedComponent):
             self.assertEqual(cur, ref[i])
 
     def test_validParameters(self):
-        """testing the Helix class performs as expected with various inputs"""
+        """testing the Helix class performs as expected with various inputs."""
         # stupid/simple inputs
         h = Helix("thing", "Cu", 0, 0, 1, 1, 1)
         self.assertEqual(h.getDimension("axialPitch"), 1)

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -391,7 +391,7 @@ class TestCompositeTree(unittest.TestCase):
         """
         This test creates a dummy assembly and ensures that the assembly, block, and fuel component masses are
         consistent.
-        `getFuelMass` ensures that the fuel component is used to `getMass`
+        `getFuelMass` ensures that the fuel component is used to `getMass`.
         """
         cs = settings.Settings()
         assemDesign = assemblyBlueprint.AssemblyBlueprint.load(self.blueprintYaml)
@@ -406,13 +406,13 @@ class TestCompositeTree(unittest.TestCase):
         self.assertEqual(fuelMass, a.getFuelMass())
 
     def test_getNeutronEnergyDepositionConstants(self):
-        """Until we improve test architecture, this test can not be more interesting"""
+        """Until we improve test architecture, this test can not be more interesting."""
         with self.assertRaises(RuntimeError):
             # fails because this test reactor does not have a cross-section library
             _x = self.r.core.getNeutronEnergyDepositionConstants()
 
     def test_getGammaEnergyDepositionConstants(self):
-        """Until we improve test architecture, this test can not be more interesting"""
+        """Until we improve test architecture, this test can not be more interesting."""
         with self.assertRaises(RuntimeError):
             # fails because this test reactor does not have a cross-section library
             _x = self.r.core.getGammaEnergyDepositionConstants()

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -380,7 +380,7 @@ class TestCompositeTree(unittest.TestCase):
         runLog.info(self.r.core.getFirstBlock().getComponents()[0].constituentReport())
 
     def test_getNuclides(self):
-        """getNuclides should return all keys that have ever been in this block, including values that are at trace."""
+        """The getNuclides should return all keys that have ever been in this block, including values that are at trace."""
         cur = self.Block.getNuclides()
         ref = self.refDict.keys()
         for key in ref:

--- a/armi/reactor/tests/test_flags.py
+++ b/armi/reactor/tests/test_flags.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for flags"""
+"""Tests for flags."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import pickle
 import unittest

--- a/armi/reactor/tests/test_geometry.py
+++ b/armi/reactor/tests/test_geometry.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests the geometry (loading input) file"""
+"""Tests the geometry (loading input) file."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import io
 import os
@@ -278,7 +278,7 @@ class TestSystemLayoutInput(unittest.TestCase):
             self.assertEqual(geom2.assemTypeByIndices[2, 2], "A2")
 
     def test_asciimap(self):  # pylint: disable=no-self-use
-        """Ensure this can write ascii maps"""
+        """Ensure this can write ascii maps."""
         geom = SystemLayoutInput()
         geom.readGeomFromStream(io.StringIO(GEOM_INPUT))
         geom._writeAsciiMap()

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for grids"""
+"""Tests for grids."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-self-use,attribute-defined-outside-init
 from io import BytesIO
 import math
@@ -191,7 +191,7 @@ class TestGrid(unittest.TestCase):
 
 
 class TestHexGrid(unittest.TestCase):
-    """A set of tests for the Hexagonal Grid
+    """A set of tests for the Hexagonal Grid.
 
     .. test: Tests of the Hexagonal grid.
        :id: TEST_REACTOR_MESH_0
@@ -452,7 +452,7 @@ class TestBoundsDefinedGrid(unittest.TestCase):
 
 
 class TestThetaRZGrid(unittest.TestCase):
-    """A set of tests for the RZTheta Grid
+    """A set of tests for the RZTheta Grid.
 
     .. test: Tests of the RZTheta grid.
        :id: TEST_REACTOR_MESH_1
@@ -475,7 +475,7 @@ class TestThetaRZGrid(unittest.TestCase):
 
 
 class TestCartesianGrid(unittest.TestCase):
-    """A set of tests for the Cartesian Grid
+    """A set of tests for the Cartesian Grid.
 
     .. test: Tests of the Cartesian grid.
        :id: TEST_REACTOR_MESH_2

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" tests of the Parameters class """
+""" tests of the Parameters class. """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
 import traceback
@@ -377,7 +377,7 @@ class ParameterTests(unittest.TestCase):
         self.assertEqual(set(pc.paramDefs.inCategory("bacon")), set([p2, p3]))
 
     def test_parameterCollectionsHave__slots__(self):
-        """Make sure something is implemented to prevent accidental creation of attributes"""
+        """Make sure something is implemented to prevent accidental creation of attributes."""
         self.assertEqual(
             set(["_hist", "_backup", "assigned", "_p_serialNum", "serialNum"]),
             set(parameters.ParameterCollection._slots),
@@ -579,7 +579,7 @@ class SynchronizationTests:
             self.r.syncMpiState()
 
     def mpitest_rxCoeffsProcess(self):
-        """This test mimics the process for rxCoeffs when doing distributed doppler"""
+        """This test mimics the process for rxCoeffs when doing distributed doppler."""
 
         def do():
             # we will do this over 4 passes (there are 4 * MPI_SIZE assemblies)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""
-testing for reactors.py
+testing for reactors.py.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
@@ -46,7 +46,7 @@ TEST_REACTOR = None  # pickled string of test reactor (for fast caching)
 
 def buildOperatorOfEmptyHexBlocks(customSettings=None):
     """
-    Builds a operator w/ a reactor object with some hex assemblies and blocks, but all are empty
+    Builds a operator w/ a reactor object with some hex assemblies and blocks, but all are empty.
 
     Doesn't depend on inputs and loads quickly.
 
@@ -86,7 +86,7 @@ def buildOperatorOfEmptyHexBlocks(customSettings=None):
 
 def buildOperatorOfEmptyCartesianBlocks(customSettings=None):
     """
-    Builds a operator w/ a reactor object with some Cartesian assemblies and blocks, but all are empty
+    Builds a operator w/ a reactor object with some Cartesian assemblies and blocks, but all are empty.
 
     Doesn't depend on inputs and loads quickly.
 
@@ -217,7 +217,7 @@ def loadTestReactor(
 def reduceTestReactorRings(r, cs, maxNumRings):
     """Helper method for the test reactor above
     The goal is to reduce the size of the reactor for tests that don't neeed
-    such a large reactor, and would run much faster with a smaller one
+    such a large reactor, and would run much faster with a smaller one.
     """
     maxRings = r.core.getNumRings()
     if maxNumRings > maxRings:
@@ -1028,7 +1028,7 @@ class CartesianReactorTests(ReactorTests):
         self.assertSequenceEqual(actualAssemsInRing, expectedAssemsInRing)
 
     def test_getNuclideCategoriesLogging(self):
-        """Simplest possible test of the getNuclideCategories method and its logging"""
+        """Simplest possible test of the getNuclideCategories method and its logging."""
         log = mockRunLogs.BufferLog()
 
         # this strange namespace-stomping is used to the test to set the logger in reactors.Core

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""
-testing for reactors.py.
-"""
+"""Resting for reactors.py."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
 import os
@@ -215,7 +213,8 @@ def loadTestReactor(
 
 
 def reduceTestReactorRings(r, cs, maxNumRings):
-    """Helper method for the test reactor above
+    """Helper method for the test reactor above.
+
     The goal is to reduce the size of the reactor for tests that don't neeed
     such a large reactor, and would run much faster with a smaller one.
     """
@@ -893,7 +892,7 @@ class HexReactorTests(ReactorTests):
         self.assertEqual(originalHeights, heights)
 
     def test_applyThermalExpansion_CoreConstruct(self):
-        """test that assemblies in core are correctly expanded.
+        """Test that assemblies in core are correctly expanded.
 
         Notes:
         ------

--- a/armi/reactor/tests/test_rz_reactors.py
+++ b/armi/reactor/tests/test_rz_reactors.py
@@ -48,7 +48,7 @@ class Test_RZT_Reactor(unittest.TestCase):
 class Test_RZT_Reactor_modern(unittest.TestCase):
     def test_loadRZT_reactor(self):
         """
-        The Godiva benchmark model is a HEU sphere with a radius of 8.74 cm
+        The Godiva benchmark model is a HEU sphere with a radius of 8.74 cm.
 
         This unit tests loading and verifies the reactor is loaded correctly by
         comparing volumes against expected volumes for full core (including

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test for Zones"""
+"""Test for Zones."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import logging
 import os

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -62,7 +62,7 @@ class Zone:
             yield loc
 
     def __len__(self) -> int:
-        """Return the number of locations"""
+        """Return the number of locations."""
         return len(self.locs)
 
     def __repr__(self) -> str:
@@ -144,7 +144,7 @@ class Zone:
 
     def addItem(self, item: Union[Assembly, Block]) -> None:
         """
-        Adds the location of an Assembly or Block to a zone
+        Adds the location of an Assembly or Block to a zone.
 
         Parameters
         ----------
@@ -158,7 +158,7 @@ class Zone:
 
     def removeItem(self, item: Union[Assembly, Block]) -> None:
         """
-        Removes the location of an Assembly or Block from a zone
+        Removes the location of an Assembly or Block from a zone.
 
         Parameters
         ----------
@@ -172,7 +172,7 @@ class Zone:
 
     def addItems(self, items: List) -> None:
         """
-        Adds the locations of a list of Assemblies or Blocks to a zone
+        Adds the locations of a list of Assemblies or Blocks to a zone.
 
         Parameters
         ----------
@@ -184,7 +184,7 @@ class Zone:
 
     def removeItems(self, items: List) -> None:
         """
-        Removes the locations of a list of Assemblies or Blocks from a zone
+        Removes the locations of a list of Assemblies or Blocks from a zone.
 
         Parameters
         ----------
@@ -229,7 +229,7 @@ class Zones:
             yield self._zones[nm]
 
     def __len__(self) -> int:
-        """Return the number of Zone objects"""
+        """Return the number of Zone objects."""
         return len(self._zones)
 
     def addZone(self, zone: Zone) -> None:
@@ -272,7 +272,7 @@ class Zones:
         self.checkDuplicates()
 
     def removeZone(self, name: str) -> None:
-        """Delete a zone by name
+        """Delete a zone by name.
 
         Parameters
         ----------
@@ -287,7 +287,7 @@ class Zones:
 
     def removeZones(self, names: List) -> None:
         """
-        Delete multiple zones by name
+        Delete multiple zones by name.
 
         Parameters
         ----------
@@ -359,7 +359,7 @@ class Zones:
         return zoneLocs
 
     def getAllLocations(self) -> Set:
-        """Return all locations across every Zone in this Zones object
+        """Return all locations across every Zone in this Zones object.
 
         Returns
         -------

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -547,22 +547,22 @@ class RunLogger(logging.Logger):
         logging.Logger._log(self, *args, **kwargs)
 
     def allowStopDuplicates(self):
-        """helper method to allow us to safely add the deduplication filter at any time."""
+        """Helper method to allow us to safely add the deduplication filter at any time."""
         for f in self.filters:
             if isinstance(f, DeduplicationFilter):
                 return
         self.addFilter(DeduplicationFilter())
 
     def write(self, msg, **kwargs):
-        """the redirect method that allows to do stderr piping."""
+        """The redirect method that allows to do stderr piping."""
         self.error(msg)
 
     def flush(self, *args, **kwargs):
-        """stub, purely to allow stderr piping."""
+        """Stub, purely to allow stderr piping."""
         pass
 
     def close(self):
-        """helper method, to shutdown and delete a Logger."""
+        """Helper method, to shutdown and delete a Logger."""
         self.handlers.clear()
         del self
 
@@ -613,7 +613,7 @@ class NullLogger(RunLogger):
             self.handlers = [logging.StreamHandler(sys.stdout)]
 
     def addHandler(self, *args, **kwargs):
-        """ensure this STAYS a null logger."""
+        """Ensure this STAYS a null logger."""
         pass
 
 

--- a/armi/scripts/migration/m0_1_3.py
+++ b/armi/scripts/migration/m0_1_3.py
@@ -22,7 +22,7 @@ from armi import runLog
 
 
 class RemoveCentersFromBlueprints(BlueprintsMigration):
-    """Removes now-invalid `centers:` lines from auto-generated component inputs"""
+    """Removes now-invalid `centers:` lines from auto-generated component inputs."""
 
     fromVersion = "0.1.2"
     toVersion = "0.1.3"

--- a/armi/scripts/migration/m0_1_6_locationLabels.py
+++ b/armi/scripts/migration/m0_1_6_locationLabels.py
@@ -33,7 +33,7 @@ AXIAL_CHARS = [
 
 
 class ConvertAlphanumLocationSettingsToNum(SettingsMigration):
-    """Convert old location label values to new style"""
+    """Convert old location label values to new style."""
 
     fromVersion = "0.1.6"
     toVersion = "0.1.7"

--- a/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
+++ b/armi/scripts/migration/tests/test_m0_1_6_locationLabels.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Locationlabel migration"""
+"""Test Locationlabel migration."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import io
 import unittest

--- a/armi/settings/__init__.py
+++ b/armi/settings/__init__.py
@@ -131,7 +131,7 @@ def recursivelyLoadSettingsFiles(
 
 def promptForSettingsFile(choice=None):
     """
-    Allows the user to select an ARMI input from the input files in the directory
+    Allows the user to select an ARMI input from the input files in the directory.
 
     Parameters
     ----------

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -107,7 +107,7 @@ class Settings:
 
     @property
     def inputDirectory(self):
-        """getter for settings file path."""
+        """Getter for settings file path."""
         if self.path is None:
             return os.getcwd()
         else:
@@ -115,7 +115,7 @@ class Settings:
 
     @property
     def caseTitle(self):
-        """getter for settings case title."""
+        """Getter for settings case title."""
         if not self.path:
             return self.defaultCaseTitle
         else:
@@ -123,12 +123,12 @@ class Settings:
 
     @caseTitle.setter
     def caseTitle(self, value):
-        """setter for the case title."""
+        """Setter for the case title."""
         self.path = os.path.join(self.inputDirectory, value + ".yaml")
 
     @property
     def environmentSettings(self):
-        """getter for environment settings."""
+        """Getter for environment settings."""
         return [
             setting.name
             for setting in self.__settings.values()
@@ -251,7 +251,7 @@ class Settings:
         return self.__settings.items()
 
     def duplicate(self):
-        """return a duplicate copy of this settings object."""
+        """Return a duplicate copy of this settings object."""
         cs = deepcopy(self)
         cs._failOnLoad = False  # pylint: disable=protected-access
         # it's not really protected access since it is a new Settings object.

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -73,7 +73,7 @@ class Settings:
 
     def __init__(self, fName=None):
         """
-        Instantiate a settings object
+        Instantiate a settings object.
 
         Parameters
         ----------
@@ -107,7 +107,7 @@ class Settings:
 
     @property
     def inputDirectory(self):
-        """getter for settings file path"""
+        """getter for settings file path."""
         if self.path is None:
             return os.getcwd()
         else:
@@ -115,7 +115,7 @@ class Settings:
 
     @property
     def caseTitle(self):
-        """getter for settings case title"""
+        """getter for settings case title."""
         if not self.path:
             return self.defaultCaseTitle
         else:
@@ -123,12 +123,12 @@ class Settings:
 
     @caseTitle.setter
     def caseTitle(self, value):
-        """setter for the case title"""
+        """setter for the case title."""
         self.path = os.path.join(self.inputDirectory, value + ".yaml")
 
     @property
     def environmentSettings(self):
-        """getter for environment settings"""
+        """getter for environment settings."""
         return [
             setting.name
             for setting in self.__settings.values()
@@ -251,7 +251,7 @@ class Settings:
         return self.__settings.items()
 
     def duplicate(self):
-        """return a duplicate copy of this settings object"""
+        """return a duplicate copy of this settings object."""
         cs = deepcopy(self)
         cs._failOnLoad = False  # pylint: disable=protected-access
         # it's not really protected access since it is a new Settings object.
@@ -259,7 +259,7 @@ class Settings:
         return cs
 
     def revertToDefaults(self):
-        """Sets every setting back to its default value"""
+        """Sets every setting back to its default value."""
         for setting in self.__settings.values():
             setting.revertToDefault()
 
@@ -338,7 +338,7 @@ class Settings:
 
     def initLogVerbosity(self):
         """
-        Central location to init logging verbosity
+        Central location to init logging verbosity.
 
         Notes
         -----
@@ -435,7 +435,7 @@ class Settings:
 
     def updateEnvironmentSettingsFrom(self, otherCs):
         r"""Updates the environment settings in this object based on some other cs
-        (from the GUI, most likely)
+        (from the GUI, most likely).
 
         Parameters
         ----------

--- a/armi/settings/fwSettings/tests/test_fwSettings.py
+++ b/armi/settings/fwSettings/tests/test_fwSettings.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the framework settings"""
+"""Tests for the framework settings."""
 import unittest
 
 import voluptuous as vol

--- a/armi/settings/fwSettings/tests/test_tightCouplingSettings.py
+++ b/armi/settings/fwSettings/tests/test_tightCouplingSettings.py
@@ -121,7 +121,7 @@ class TestTightCouplingSettings(unittest.TestCase):
             tc = tightCouplingSettingsValidator(tc)
 
     def test_serializeSettingsException(self):
-        """ensure the TypeError in serializeTightCouplingSettings can be reached."""
+        """Ensure the TypeError in serializeTightCouplingSettings can be reached."""
         tc = ["globalFlux"]
         with self.assertRaises(TypeError) as cm:
             tc = tightCouplingSettingsValidator(tc)

--- a/armi/settings/fwSettings/tests/test_tightCouplingSettings.py
+++ b/armi/settings/fwSettings/tests/test_tightCouplingSettings.py
@@ -15,7 +15,7 @@
 Unit testing for tight coupling settings.
 - The settings example below shows the intended use for these settings in
   an ARMI yaml input file.
-- Note, for these to be recognized, they need to be prefixed with "tightCouplingSettings:"
+- Note, for these to be recognized, they need to be prefixed with "tightCouplingSettings:".
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,unused-variable
 import unittest
@@ -121,7 +121,7 @@ class TestTightCouplingSettings(unittest.TestCase):
             tc = tightCouplingSettingsValidator(tc)
 
     def test_serializeSettingsException(self):
-        """ensure the TypeError in serializeTightCouplingSettings can be reached"""
+        """ensure the TypeError in serializeTightCouplingSettings can be reached."""
         tc = ["globalFlux"]
         with self.assertRaises(TypeError) as cm:
             tc = tightCouplingSettingsValidator(tc)
@@ -129,7 +129,7 @@ class TestTightCouplingSettings(unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_yamlIO(self):
-        """Ensure we can read/write this custom setting object to yaml"""
+        """Ensure we can read/write this custom setting object to yaml."""
         yaml = YAML()
         inp = yaml.load(io.StringIO(TIGHT_COUPLING_SETTINGS_EXAMPLE))
         tcd = TightCouplingSettingDef("TestSetting")

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -279,7 +279,7 @@ class Setting:
 
     def isDefault(self):
         """
-        Returns a boolean based on whether or not the setting equals its default value
+        Returns a boolean based on whether or not the setting equals its default value.
 
         It's possible for a setting to change and not be reported as such when it is changed back to its default.
         That behavior seems acceptable.

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -43,7 +43,7 @@ WRITE_FULL = "full"
 
 
 class Roots:
-    """XML tree root node common strings"""
+    """XML tree root node common strings."""
 
     CUSTOM = "settings"
     VERSION = "version"
@@ -420,7 +420,7 @@ def prompt(statement, question, *options):
 
 
 class RunLogPromptCancel(Exception):
-    """An error that occurs when the user submits a cancel on a runLog prompt which allows for cancellation"""
+    """An error that occurs when the user submits a cancel on a runLog prompt which allows for cancellation."""
 
     pass
 

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -318,7 +318,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
             _ = cs["cycleLength"]
 
     def test_modified(self):
-        """prove that using the modified() method does not mutate the original object."""
+        """Prove that using the modified() method does not mutate the original object."""
         # init settings
         cs = caseSettings.Settings()
 

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for new settings system with plugin import"""
+"""Tests for new settings system with plugin import."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
 import io
@@ -207,7 +207,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         self.assertEqual(listSetting.containedType, float)
 
     def test_csWorks(self):
-        """Ensure plugin settings become available and have defaults"""
+        """Ensure plugin settings become available and have defaults."""
         a = settings.Settings()
         self.assertEqual(a[CONF_CIRCULAR_RING_ORDER], "angle")
 
@@ -300,7 +300,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         self.assertEqual(logger.level, 40)
 
     def test_getFailures(self):
-        """Make sure the correct error is thrown when getting a nonexistent setting"""
+        """Make sure the correct error is thrown when getting a nonexistent setting."""
         cs = caseSettings.Settings()
 
         with self.assertRaises(NonexistentSetting):
@@ -318,7 +318,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
             _ = cs["cycleLength"]
 
     def test_modified(self):
-        """prove that using the modified() method does not mutate the original object"""
+        """prove that using the modified() method does not mutate the original object."""
         # init settings
         cs = caseSettings.Settings()
 
@@ -390,7 +390,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
 
 
 class TestSettingsUtils(unittest.TestCase):
-    """Tests for utility functions"""
+    """Tests for utility functions."""
 
     def setUp(self):
         self.dc = directoryChangers.TemporaryDirectoryChanger()

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License0.
-""" Testing the settingsIO """
+""" Testing the settingsIO. """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import datetime
@@ -128,7 +128,7 @@ class SettingsWriterTests(unittest.TestCase):
         self.td.__exit__(None, None, None)
 
     def test_writeShort(self):
-        """Setting output as a sparse file"""
+        """Setting output as a sparse file."""
         self.cs.writeToYamlFile(self.filepathYaml, style="short")
         self.cs.loadFromInputFile(self.filepathYaml)
         txt = open(self.filepathYaml, "r").read()
@@ -137,7 +137,7 @@ class SettingsWriterTests(unittest.TestCase):
 
     def test_writeMedium(self):
         """Setting output as a sparse file that only includes defaults if they are
-        user-specified"""
+        user-specified."""
         with open(self.filepathYaml, "w") as stream:
             # Specify a setting that is also a default
             self.cs.writeToYamlStream(stream, "medium", ["numProcessors"])
@@ -146,7 +146,7 @@ class SettingsWriterTests(unittest.TestCase):
         self.assertIn("numProcessors: 1", txt)
 
     def test_writeFull(self):
-        """Setting output as a full, all defaults included file"""
+        """Setting output as a full, all defaults included file."""
         self.cs.writeToYamlFile(self.filepathYaml, style="full")
         txt = open(self.filepathYaml, "r").read()
         self.assertIn("nCycles: 55", txt)

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -17,13 +17,13 @@ General framework-wide testing functions and files.
 This package contains some input files that can be used across
 a wide variety of unit tests in other lower-level subpackages.
 """
+from typing import Optional
 import datetime
 import itertools
 import os
 import re
 import shutil
 import unittest
-from typing import Optional
 
 from armi import context
 from armi import runLog

--- a/armi/tests/mockRunLogs.py
+++ b/armi/tests/mockRunLogs.py
@@ -23,7 +23,7 @@ from armi import runLog
 
 
 class BufferLog(runLog._RunLog):
-    r"""Log which captures the output in attributes instead of emitting them
+    r"""Log which captures the output in attributes instead of emitting them.
 
     Used mostly in testing to ensure certain things get output, or to prevent any output
     from showing.

--- a/armi/tests/refSmallReactorShuffleLogic.py
+++ b/armi/tests/refSmallReactorShuffleLogic.py
@@ -17,7 +17,7 @@ from armi.physics.fuelCycle.fuelHandlers import FuelHandler
 
 class EquilibriumShuffler(FuelHandler):
     r"""
-    Convergent divergent equilibrium shuffler
+    Convergent divergent equilibrium shuffler.
     """
 
     def chooseSwaps(self, factorList):

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -75,7 +75,7 @@ class TestApps(unittest.TestCase):
         self._backupApp = copy.deepcopy(getApp())
 
     def tearDown(self):
-        """Restore the App to its original state"""
+        """Restore the App to its original state."""
         import armi
 
         armi._app = self._backupApp

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -29,7 +29,7 @@ from armi.__main__ import main
 
 
 class TestPlugin1(plugins.ArmiPlugin):
-    """This should be fine on its own"""
+    """This should be fine on its own."""
 
     @staticmethod
     @plugins.HOOKIMPL
@@ -56,9 +56,7 @@ class TestPlugin3(plugins.ArmiPlugin):
 
 
 class TestPlugin4(plugins.ArmiPlugin):
-    """This should be fine on its own, and safe to merge with TestPlugin1. And would
-    make for a pretty good rename IRL.
-    """
+    """This should be fine on its own, and safe to merge with TestPlugin1."""
 
     @staticmethod
     @plugins.HOOKIMPL

--- a/armi/tests/test_cartesian.py
+++ b/armi/tests/test_cartesian.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests for Cartesian reactors
+Tests for Cartesian reactors.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -76,7 +76,7 @@ class TestTextProcessor(unittest.TestCase):
 
 
 class TestTightCoupler(unittest.TestCase):
-    """test the tight coupler class."""
+    """Test the tight coupler class."""
 
     def setUp(self):
         cs = settings.Settings()
@@ -106,7 +106,7 @@ class TestTightCoupler(unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_isConverged(self):
-        """ensure TightCoupler.isConverged() works with float, 1D list, and ragged 2D list.
+        """Ensure TightCoupler.isConverged() works with float, 1D list, and ragged 2D list.
 
         Notes
         -----
@@ -129,7 +129,7 @@ class TestTightCoupler(unittest.TestCase):
             self.assertFalse(self.interface.coupler.isConverged(current))
 
     def test_isConvergedRuntimeError(self):
-        """test to ensure 3D arrays do not work."""
+        """Test to ensure 3D arrays do not work."""
         previous = [[[1, 2, 3]], [[1, 2, 3]], [[1, 2, 3]]]
         updatedValues = [[[5, 6, 7]], [[5, 6, 7]], [[5, 6, 7]]]
         self.interface.coupler.storePreviousIterationValue(previous)

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests the Interface"""
+"""Tests the Interface."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 import os
@@ -76,7 +76,7 @@ class TestTextProcessor(unittest.TestCase):
 
 
 class TestTightCoupler(unittest.TestCase):
-    """test the tight coupler class"""
+    """test the tight coupler class."""
 
     def setUp(self):
         cs = settings.Settings()
@@ -106,7 +106,7 @@ class TestTightCoupler(unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_isConverged(self):
-        """ensure TightCoupler.isConverged() works with float, 1D list, and ragged 2D list
+        """ensure TightCoupler.isConverged() works with float, 1D list, and ragged 2D list.
 
         Notes
         -----
@@ -129,7 +129,7 @@ class TestTightCoupler(unittest.TestCase):
             self.assertFalse(self.interface.coupler.isConverged(current))
 
     def test_isConvergedRuntimeError(self):
-        """test to ensure 3D arrays do not work"""
+        """test to ensure 3D arrays do not work."""
         previous = [[[1, 2, 3]], [[1, 2, 3]], [[1, 2, 3]]]
         updatedValues = [[[5, 6, 7]], [[5, 6, 7]], [[5, 6, 7]]]
         self.interface.coupler.storePreviousIterationValue(previous)

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -47,7 +47,7 @@ class C5G7ReactorTests(unittest.TestCase):
     def test_loadC5G7(self):
         """
         Load the C5G7 case from input and check basic counts.
-        (Also, check that we are getting warnings when reading the YAML.)
+        (Also, check that we are getting warnings when reading the YAML).
         """
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -35,12 +35,12 @@ from armi.utils import iterables
 @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")
 class MpiIterTests(unittest.TestCase):
     def setUp(self):
-        """save MPI size on entry."""
+        """Save MPI size on entry."""
         self._mpiSize = context.MPI_SIZE
         self.action = MpiAction()
 
     def tearDown(self):
-        """restore MPI rank and size on exit."""
+        """Restore MPI rank and size on exit."""
         context.MPI_SIZE = self._mpiSize
         context.MPI_RANK = 0
 
@@ -151,6 +151,7 @@ class MpiIterTests(unittest.TestCase):
 
     def test_diagnosePickleErrorTestReactor(self):
         """Run _diagnosePickleError() on the test reactor.
+
         We expect this to run all the way through the pickle diagnoser,
         because the test reactor should be easily picklable.
         """
@@ -236,7 +237,7 @@ class QueueActionsTests(unittest.TestCase):
 
 
 def passer():
-    """helper function, to do nothing, for unit tests."""
+    """Helper function, to do nothing, for unit tests."""
     pass
 
 

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for MPI actions"""
+"""Tests for MPI actions."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 
 import unittest
@@ -35,12 +35,12 @@ from armi.utils import iterables
 @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")
 class MpiIterTests(unittest.TestCase):
     def setUp(self):
-        """save MPI size on entry"""
+        """save MPI size on entry."""
         self._mpiSize = context.MPI_SIZE
         self.action = MpiAction()
 
     def tearDown(self):
-        """restore MPI rank and size on exit"""
+        """restore MPI rank and size on exit."""
         context.MPI_SIZE = self._mpiSize
         context.MPI_RANK = 0
 
@@ -73,7 +73,7 @@ class MpiIterTests(unittest.TestCase):
         return objs
 
     def test_perfectBalancing(self):
-        """Test load balancing when numProcs divides numObjects
+        """Test load balancing when numProcs divides numObjects.
 
         In this case, all processes should get the same number of objects.
         """
@@ -90,7 +90,7 @@ class MpiIterTests(unittest.TestCase):
         self.assertEqual(imbalance, 0)
 
     def test_excessProcesses(self):
-        """Test load balancing when numProcs exceeds numObjects
+        """Test load balancing when numProcs exceeds numObjects.
 
         In this case, some processes should receive a single object and the
         rest should receive no objects
@@ -108,7 +108,7 @@ class MpiIterTests(unittest.TestCase):
         self.assertLessEqual(imbalance, 1)
 
     def test_typicalBalancing(self):
-        """Test load balancing for typical case (numProcs < numObjs)
+        """Test load balancing for typical case (numProcs < numObjs).
 
         In this case, the total imbalance should be 1 (except for the perfectly
         balanced case).
@@ -236,7 +236,7 @@ class QueueActionsTests(unittest.TestCase):
 
 
 def passer():
-    """helper function, to do nothing, for unit tests"""
+    """helper function, to do nothing, for unit tests."""
     pass
 
 

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -54,7 +54,7 @@ MPI_COMM = context.MPI_COMM
 
 
 class FailingInterface1(Interface):
-    """utility classes to make sure the logging system fails properly"""
+    """utility classes to make sure the logging system fails properly."""
 
     name = "failer"
 
@@ -63,7 +63,7 @@ class FailingInterface1(Interface):
 
 
 class FailingInterface2(Interface):
-    """utility class to make sure the logging system fails properly"""
+    """utility class to make sure the logging system fails properly."""
 
     name = "failer"
 
@@ -72,7 +72,7 @@ class FailingInterface2(Interface):
 
 
 class FailingInterface3(Interface):
-    """fails on worker operate"""
+    """fails on worker operate."""
 
     name = "failer"
 
@@ -90,7 +90,7 @@ class FailingInterface3(Interface):
 
 
 class MpiOperatorTests(unittest.TestCase):
-    """Testing the MPI parallelization operator"""
+    """Testing the MPI parallelization operator."""
 
     def setUp(self):
         self.old_op, self.r = test_reactors.loadTestReactor(TEST_ROOT)

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Provides functionality for testing implementations of plugins"""
+"""Provides functionality for testing implementations of plugins."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 from typing import Optional
@@ -25,12 +25,12 @@ from armi import settings
 
 
 class TestPlugin(unittest.TestCase):
-    """This contains some sanity tests that can be used by implementing plugins"""
+    """This contains some sanity tests that can be used by implementing plugins."""
 
     plugin: Optional[plugins.ArmiPlugin] = None
 
     def test_defineBlueprintsSections(self):
-        """Make sure that the defineBlueprintsSections hook is properly implemented"""
+        """Make sure that the defineBlueprintsSections hook is properly implemented."""
         if self.plugin is None:
             return
         if not hasattr(self.plugin, "defineBlueprintsSections"):
@@ -51,7 +51,7 @@ class TestPlugin(unittest.TestCase):
             self.assertTrue(callable(result[2]))
 
     def test_exposeInterfaces(self):
-        """Make sure that the exposeInterfaces hook is properly implemented"""
+        """Make sure that the exposeInterfaces hook is properly implemented."""
         if self.plugin is None:
             return
 

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests of the runLog tooling"""
+"""Tests of the runLog tooling."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 from io import StringIO
 from shutil import rmtree
@@ -44,7 +44,7 @@ class TestRunLog(unittest.TestCase):
         self.assertEqual(verbosityRank, logging.ERROR)
 
     def test_verbosityOutOfRange(self):
-        """Test that the log verbosity setting resets to a canonical value when it is out of range"""
+        """Test that the log verbosity setting resets to a canonical value when it is out of range."""
         runLog.setVerbosity(-50)
         self.assertEqual(
             runLog.LOG.logger.level, min([v[0] for v in runLog.LOG.logLevels.values()])
@@ -64,7 +64,7 @@ class TestRunLog(unittest.TestCase):
             runLog.setVerbosity(["debug"])
 
     def test_parentRunLogging(self):
-        """A basic test of the logging of the parent runLog"""
+        """A basic test of the logging of the parent runLog."""
         # init the _RunLog object
         log = runLog.LOG = runLog._RunLog(0)
         log.startLog("test_parentRunLogging")
@@ -90,7 +90,7 @@ class TestRunLog(unittest.TestCase):
         self.assertIn("world", streamVal, msg=streamVal)
 
     def test_warningReport(self):
-        """A simple test of the warning tracking and reporting logic"""
+        """A simple test of the warning tracking and reporting logic."""
         # create the logger and do some logging
         log = runLog.LOG = runLog._RunLog(321)
         log.startLog("test_warningReport")
@@ -127,7 +127,7 @@ class TestRunLog(unittest.TestCase):
         self.assertEqual(streamVal.count("test_warningReport"), 2, msg=streamVal)
 
     def test_warningReportInvalid(self):
-        """A test of warningReport in an invalid situation"""
+        """A test of warningReport in an invalid situation."""
         # create the logger and do some logging
         testName = "test_warningReportInvalid"
         log = runLog.LOG = runLog._RunLog(323)
@@ -166,10 +166,10 @@ class TestRunLog(unittest.TestCase):
         self.assertEqual(streamVal.count(testName), 1, msg=streamVal)
 
     def test_closeLogging(self):
-        """A basic test of the close() functionality"""
+        """A basic test of the close() functionality."""
 
         def validate_loggers(log):
-            """little test helper, to make sure our loggers still look right"""
+            """little test helper, to make sure our loggers still look right."""
             handlers = [str(h) for h in log.logger.handlers]
             self.assertEqual(len(handlers), 1, msg=",".join(handlers))
 
@@ -193,7 +193,7 @@ class TestRunLog(unittest.TestCase):
         runLog.close(0)
 
     def test_setVerbosity(self):
-        """Let's test the setVerbosity() method carefully"""
+        """Let's test the setVerbosity() method carefully."""
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
             self.assertEqual("", mock.getStdout())
@@ -236,7 +236,7 @@ class TestRunLog(unittest.TestCase):
             self.assertEqual(runLog.LOG.getVerbosity(), logging.WARNING)
 
     def test_setVerbosityBeforeStartLog(self):
-        """The user/dev my accidentally call setVerbosity() before startLog(), this should be mostly supportable"""
+        """The user/dev my accidentally call setVerbosity() before startLog(), this should be mostly supportable."""
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
             self.assertEqual("", mock.getStdout())
@@ -250,7 +250,7 @@ class TestRunLog(unittest.TestCase):
             mock.emptyStdout()
 
     def test_callingStartLogMultipleTimes(self):
-        """calling startLog() multiple times will lead to multiple output files, but logging should still work"""
+        """calling startLog() multiple times will lead to multiple output files, but logging should still work."""
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
             self.assertEqual("", mock.getStdout())
@@ -294,7 +294,7 @@ class TestRunLog(unittest.TestCase):
             mock.emptyStdout()
 
     def test_concatenateLogs(self):
-        """simple test of the concat logs function"""
+        """simple test of the concat logs function."""
         with TemporaryDirectoryChanger():
             # create the log dir
             logDir = "test_concatenateLogs"
@@ -338,7 +338,7 @@ class TestRunLog(unittest.TestCase):
             self.assertFalse(os.path.exists(stderrFile))
 
     def test_createLogDir(self):
-        """Test the createLogDir() method"""
+        """Test the createLogDir() method."""
         with TemporaryDirectoryChanger():
             logDir = "test_createLogDir"
             self.assertFalse(os.path.exists(logDir))

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -236,7 +236,7 @@ class TestRunLog(unittest.TestCase):
             self.assertEqual(runLog.LOG.getVerbosity(), logging.WARNING)
 
     def test_setVerbosityBeforeStartLog(self):
-        """The user/dev my accidentally call setVerbosity() before startLog(), this should be mostly supportable."""
+        """The user/dev may accidentally call ``setVerbosity()`` before ``startLog()``, this should be mostly supportable."""
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
             self.assertEqual("", mock.getStdout())

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -169,7 +169,7 @@ class TestRunLog(unittest.TestCase):
         """A basic test of the close() functionality."""
 
         def validate_loggers(log):
-            """little test helper, to make sure our loggers still look right."""
+            """Little test helper, to make sure our loggers still look right."""
             handlers = [str(h) for h in log.logger.handlers]
             self.assertEqual(len(handlers), 1, msg=",".join(handlers))
 
@@ -250,7 +250,7 @@ class TestRunLog(unittest.TestCase):
             mock.emptyStdout()
 
     def test_callingStartLogMultipleTimes(self):
-        """calling startLog() multiple times will lead to multiple output files, but logging should still work."""
+        """Calling startLog() multiple times will lead to multiple output files, but logging should still work."""
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
             self.assertEqual("", mock.getStdout())
@@ -294,7 +294,7 @@ class TestRunLog(unittest.TestCase):
             mock.emptyStdout()
 
     def test_concatenateLogs(self):
-        """simple test of the concat logs function."""
+        """Simple test of the concat logs function."""
         with TemporaryDirectoryChanger():
             # create the log dir
             logDir = "test_concatenateLogs"

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -70,7 +70,7 @@ class UserPluginFlags4(plugins.UserPlugin):
 
 
 class UserPluginBadDefinesSettings(plugins.UserPlugin):
-    """This is invalid/bad because it implements defineSettings()"""
+    """This is invalid/bad because it implements defineSettings()."""
 
     @staticmethod
     @plugins.HOOKIMPL
@@ -79,7 +79,7 @@ class UserPluginBadDefinesSettings(plugins.UserPlugin):
 
 
 class UserPluginBadDefineParameterRenames(plugins.UserPlugin):
-    """This is invalid/bad because it implements defineParameterRenames()"""
+    """This is invalid/bad because it implements defineParameterRenames()."""
 
     @staticmethod
     @plugins.HOOKIMPL
@@ -105,7 +105,7 @@ class UserPluginOnProcessCoreLoading(plugins.UserPlugin):
 class UpInterface(interfaces.Interface):
     """
     A mostly meaningless little test interface, just to prove that we can affect
-    the reactor state from an interface inside a UserPlugin
+    the reactor state from an interface inside a UserPlugin.
     """
 
     name = "UpInterface"
@@ -115,7 +115,7 @@ class UpInterface(interfaces.Interface):
 
 
 class UserPluginWithInterface(plugins.UserPlugin):
-    """A little test UserPlugin, just to show how to add an Interface through a UserPlugin"""
+    """A little test UserPlugin, just to show how to add an Interface through a UserPlugin."""
 
     @staticmethod
     @plugins.HOOKIMPL
@@ -136,7 +136,7 @@ class TestUserPlugins(unittest.TestCase):
         self._backupApp = copy.deepcopy(getApp())
 
     def tearDown(self):
-        """Restore the App to its original state"""
+        """Restore the App to its original state."""
         import armi
 
         armi._app = self._backupApp
@@ -218,7 +218,7 @@ class TestUserPlugins(unittest.TestCase):
         """
         Test that a UserPlugin can affect the Reactor state,
         by implementing onProcessCoreLoading() to arbitrarily increase the
-        height of all the blocks by 1.0
+        height of all the blocks by 1.0.
         """
         # register the plugin
         app = getApp()
@@ -247,7 +247,7 @@ class TestUserPlugins(unittest.TestCase):
             self.assertEqual(fuels[i].p.height, height + 1.0)
 
     def test_userPluginWithInterfaces(self):
-        """Test that UserPlugins can correctly inject an interface into the stack"""
+        """Test that UserPlugins can correctly inject an interface into the stack."""
         # register the plugin
         app = getApp()
 

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -315,7 +315,7 @@ def getBurnSteps(cs):
 
 
 def hasBurnup(cs):
-    """Is depletion being modeled?
+    """Test if depletion is being modeled.
 
     Parameters
     ----------
@@ -430,7 +430,7 @@ def getNodesPerCycle(cs):
 
 
 def getPreviousTimeNode(cycle, node, cs):
-    """Return the (cycle, node) before the specified (cycle, node)"""
+    """Return the (cycle, node) before the specified (cycle, node)."""
     if (cycle, node) == (0, 0):
         raise ValueError("There is no time step before (0, 0)")
     if node != 0:

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -12,27 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generic ARMI utilities"""
+"""Generic ARMI utilities."""
 import collections
-import datetime
 import getpass
 import hashlib
-import importlib
 import math
 import os
 import pickle
-import pkgutil
 import re
 import shutil
-import subprocess
 import sys
 import tempfile
 import threading
 import time
-import traceback
 
-from armi import __name__ as armi_name
-from armi import __path__ as armi_path
 from armi import runLog
 from armi.utils import iterables
 from armi.utils.flags import Flag
@@ -60,6 +53,7 @@ def getFileSHA1Hash(filePath, digits=40):
             if not data:
                 break
             sha1.update(data)
+
     return sha1.hexdigest()[:digits]
 
 
@@ -113,7 +107,7 @@ def getPowerFractions(cs):
         )
 
         return [
-            [value] * (cs["burnSteps"] if cs["burnSteps"] != None else 0)
+            [value] * (cs["burnSteps"] if cs["burnSteps"] is not None else 0)
             for value in valuePerCycle
         ]
 
@@ -179,18 +173,19 @@ def getAvailabilityFactors(cs):
             if cs["availabilityFactors"] not in [None, []]
             else (
                 [cs["availabilityFactor"]] * cs["nCycles"]
-                if cs["availabilityFactor"] != None
+                if cs["availabilityFactor"] is not None
                 else [1]
             )
         )
 
 
 def _getStepAndCycleLengths(cs):
-    """
-    These need to be gotten together because it is a chicken/egg depending on which
-    style of cycles input the user employs.
+    r"""
+    Get both steps and lengths together to prevent chicken/egg problem.
 
-    Note that using this method directly is more effecient than calling `getStepLengths`
+    Notes
+    -----
+    Using this method directly is more effecient than calling `getStepLengths`
     and `getCycleLengths` separately, but it is probably more clear to the user
     to call each of them separately.
     """
@@ -231,7 +226,7 @@ def _getStepAndCycleLengths(cs):
             if cs["cycleLengths"] not in [None, []]
             else (
                 [cs["cycleLength"]] * cs["nCycles"]
-                if cs["cycleLength"] != None
+                if cs["cycleLength"] is not None
                 else [0]
             )
         )
@@ -381,7 +376,7 @@ def getCycleNodeFromCumulativeStep(timeStepNum, cs):
     stepsPerCycle = getBurnSteps(cs)
 
     if timeStepNum < 1:
-        raise ValueError(f"Cumulative time step cannot be less than 1.")
+        raise ValueError("Cumulative time step cannot be less than 1.")
 
     cSteps = 0  # cumulative steps
     for i in range(len(stepsPerCycle)):
@@ -417,7 +412,7 @@ def getCycleNodeFromCumulativeNode(timeNodeNum, cs):
     nodesPerCycle = getNodesPerCycle(cs)
 
     if timeNodeNum < 0:
-        raise ValueError(f"Cumulative time node cannot be less than 0.")
+        raise ValueError("Cumulative time node cannot be less than 0.")
 
     cNodes = 0  # cumulative nodes
     for i in range(len(nodesPerCycle)):
@@ -482,7 +477,7 @@ def tryPickleOnAllContents(obj, ignore=None, verbose=False):
 
 def doTestPickleOnAllContents2(obj, ignore=None):
     r"""
-    Attempts to find one unpickleable object in a nested object
+    Attempts to find one unpickleable object in a nested object.
 
     Returns
     -------
@@ -530,7 +525,7 @@ class MyPickler(pickle.Pickler):
 
 def tryPickleOnAllContents3(obj):
     """
-    Definitely find pickle errors
+    Definitely find pickle errors.
 
     Notes
     -----
@@ -568,8 +563,9 @@ def classesInHierarchy(obj, classCounts, visited=None):
 
 
 def slantSplit(val, ratio, nodes, order="low first"):
-    r"""
+    """
     Returns a list of values whose sum is equal to the value specified.
+
     The ratio between the highest and lowest value is equal to the specified ratio,
     and the middle values trend linearly between them.
     """
@@ -603,7 +599,6 @@ def prependToList(originalList, listToPrepend):
     -------
     originalList : list
         The original list with the listToPrepend at it's beginning.
-
     """
     listToPrepend.reverse()
     originalList.reverse()
@@ -656,7 +651,6 @@ def list2str(strings, width=None, preStrings=None, fmt=None):
     fmt : str, optional
         The format to apply to each string, such as
         ' >4d', '^12.4E'.
-
     """
     if preStrings is None:
         preStrings = []
@@ -697,7 +691,6 @@ def createFormattedStrWithDelimiter(
         >>> createFormattedStrWithDelimiter(['hello', 'world', '1', '2', '3', '4'],
         ...     maxNumberOfValuesBeforeDelimiter=3, delimiter = '\n')
         "hello, world, 1, \n2, 3, \n4, 5\n"
-
     """
     formattedString = ""
     if not dataList:
@@ -738,7 +731,7 @@ def plotMatrix(
     cmap=None,
     figsize=None,
 ):
-    """Plots a matrix"""
+    """Plots a matrix."""
     import matplotlib
     import matplotlib.pyplot as plt
 

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -96,7 +96,7 @@ class AsciiMap:
         """Number of ascii lines chopped of corners"""
 
     def writeAscii(self, stream):
-        """Write out the ascii representation"""
+        """Write out the ascii representation."""
         if not self.asciiLines:
             raise ValueError("Cannot write ASCII map before ASCII lines are processed")
         if len(self.asciiOffsets) != len(self.asciiLines):
@@ -237,7 +237,7 @@ class AsciiMap:
         return newLine
 
     def _asciiLinesToIndices(self):
-        """Convert read in ASCII lines to a asciiLabelByIndices structure"""
+        """Convert read in ASCII lines to a asciiLabelByIndices structure."""
 
     def _getIJFromColRow(self, columnNum: int, lineNum: int) -> tuple:
         """
@@ -253,7 +253,7 @@ class AsciiMap:
         self.asciiLabelByIndices[ijKey] = item
 
     def _makeOffsets(self):
-        """Build offsets"""
+        """Build offsets."""
 
     def items(self):
         return self.asciiLabelByIndices.items()

--- a/armi/utils/codeTiming.py
+++ b/armi/utils/codeTiming.py
@@ -15,9 +15,9 @@
 Utilities related to profiling code.
 """
 
-import time
 import copy
 import os
+import time
 
 
 def timed(*args):
@@ -35,7 +35,6 @@ def timed(*args):
         @timed('call my timer this instead')
         def mymethod2(stuff)
            do even more stuff
-
     """
 
     def time_decorator(func):
@@ -72,10 +71,9 @@ def timed(*args):
 
 
 def getMasterTimer():
-    """Duplicate function to the MasterTimer.getMasterTimer method
+    """Duplicate function to the MasterTimer.getMasterTimer method.
 
     Provided for convenience and developer preference of which to use
-
     """
     return MasterTimer.getMasterTimer()
 
@@ -106,10 +104,9 @@ class MasterTimer:
 
     @staticmethod
     def getTimer(event_name):
-        """Return a timer with no special action take
+        """Return a timer with no special action take.
 
         ``with timer: ...`` friendly!
-
         """
         master = MasterTimer.getMasterTimer()
 
@@ -121,10 +118,9 @@ class MasterTimer:
 
     @staticmethod
     def startTimer(event_name):
-        """Return a timer with a start call, or a newly made started timer
+        """Return a timer with a start call, or a newly made started timer.
 
         ``with timer: ...`` unfriendly!
-
         """
         master = MasterTimer.getMasterTimer()
 
@@ -137,10 +133,9 @@ class MasterTimer:
 
     @staticmethod
     def endTimer(event_name):
-        """Return a timer with a stop call, or a newly made unstarted timer
+        """Return a timer with a stop call, or a newly made unstarted timer.
 
         ``with timer: ...`` unfriendly!
-
         """
         master = MasterTimer.getMasterTimer()
 
@@ -153,7 +148,7 @@ class MasterTimer:
 
     @staticmethod
     def time():
-        """System time offset by when this master timer was initialized"""
+        """System time offset by when this master timer was initialized."""
         master = MasterTimer.getMasterTimer()
 
         if master.end_time:
@@ -163,7 +158,7 @@ class MasterTimer:
 
     @staticmethod
     def startAll():
-        """Starts all timers, won't work after a stopAll command"""
+        """Starts all timers, won't work after a stopAll command."""
         master = MasterTimer.getMasterTimer()
 
         for timer in master.timers.values():
@@ -171,7 +166,7 @@ class MasterTimer:
 
     @staticmethod
     def stopAll():
-        """Kills the timer run, can't easily be restarted"""
+        """Kills the timer run, can't easily be restarted."""
         master = MasterTimer.getMasterTimer()
 
         for timer in master.timers.values():
@@ -191,7 +186,7 @@ class MasterTimer:
     @staticmethod
     def report(inclusion_cutoff=0.1, total_time=False):
         r"""
-        Write a string report of the timers
+        Write a string report of the timers.
 
         Parameters
         ----------
@@ -204,7 +199,6 @@ class MasterTimer:
         --------
         armi.utils.codeTiming._Timer.__str__ : prints out the results for each individual line item
         """
-
         master = MasterTimer.getMasterTimer()
 
         table = [
@@ -231,7 +225,7 @@ class MasterTimer:
 
     @staticmethod
     def timeline(base_file_name, inclusion_cutoff=0.1, total_time=False):
-        r"""Produces a timeline graphic of the timers
+        r"""Produces a timeline graphic of the timers.
 
         Parameters
         ----------
@@ -242,7 +236,6 @@ class MasterTimer:
             Will not show results that have less than this fraction of the total time.
         total_time : bool, optional
             Use either the ratio of total time or time since last report for consideration against the cutoff
-
         """
         import matplotlib.pyplot as plt
         import numpy as np
@@ -317,10 +310,9 @@ class MasterTimer:
 
 
 class _Timer:
-    r"""Code timer to call at various points to measure performance
+    r"""Code timer to call at various points to measure performance.
 
     see MasterTimer.getTimer() for construction
-
     """
 
     _frozen = False  # if the master timer stops, all timers must freeze, with no thaw (how would that make sense in a run?)
@@ -353,9 +345,8 @@ class _Timer:
             self.pauses,
             self.isActive,
         )
-        self.reportedTotal = (
-            self.time
-        )  # needs to come after str generation because it resets the timeSinceReport
+        # needs to come after str generation because it resets the timeSinceReport
+        self.reportedTotal = self.time
         return str_
 
     def __enter__(self):
@@ -369,24 +360,23 @@ class _Timer:
         return self._active
 
     @property
-    def pauses(
-        self,
-    ):  # if this number seems high remember .start() twice in a row adds a pause
+    def pauses(self):
+        """If this number seems high remember .start() twice in a row adds a pause."""
         return len(self._times) - 1 if self._times else 0
 
     @property
     def time(self):
-        """Total time value"""
+        """Total time value."""
         return sum([t[1] - t[0] for t in self.times])
 
     @property
     def timeSinceReport(self):
-        """The elapsed time since this timer was asked to report itself"""
+        """The elapsed time since this timer was asked to report itself."""
         return self.time - self.reportedTotal
 
     @property
     def times(self):
-        """List of time start and stop pairs, if active the current time is used as the last stop"""
+        """List of time start and stop pairs, if active the current time is used as the last stop."""
         if self.isActive:
             times = copy.deepcopy(self._times)
             times[-1] = (self._times[-1][0], MasterTimer.time())

--- a/armi/utils/customExceptions.py
+++ b/armi/utils/customExceptions.py
@@ -77,8 +77,8 @@ class InputError(Exception):
         self.caller = getframeinfo(stack()[1][0])
 
     def __str__(self):
-        # Check if the call site is sensible enough to warrant printing. For now making the wild assumption that cython
-        # will wrap the fake stack filename in <>
+        # Check if the call site is sensible enough to warrant printing.
+        # In the past, we assumed cython would wrap the fake stack filename in <>
         callSiteIsFake = self.caller.filename.startswith(
             "<"
         ) and self.caller.filename.endswith(">")

--- a/armi/utils/customExceptions.py
+++ b/armi/utils/customExceptions.py
@@ -13,27 +13,27 @@
 # limitations under the License.
 
 """
-Globally accessible exception definitions for better granularity on exception behavior and exception handling behavior
+Globally accessible exception definitions for better granularity on exception behavior and exception handling behavior.
 """
 from armi import runLog
 from inspect import stack, getframeinfo
 
 
 def info(func):
-    r"""Decorator to write to current log, using the info method"""
+    r"""Decorator to write to current log, using the info method."""
 
     def decorated(*args, **kwargs):
-        r"""decorated method"""
+        r"""decorated method."""
         runLog.info(func(*args, **kwargs))
 
     return decorated
 
 
 def important(func):
-    r"""Decorator to write to current log, using the inportant method"""
+    r"""Decorator to write to current log, using the inportant method."""
 
     def decorated(*args, **kwargs):
-        r"""decorated method"""
+        r"""decorated method."""
         runLog.important(func(*args, **kwargs))
 
     return decorated
@@ -43,7 +43,7 @@ def warn(func):
     r"""Decorates a method to produce a repeatable warning message."""
 
     def decorated(*args, **kwargs):
-        r"""decorated method"""
+        r"""decorated method."""
         runLog.warning(func(*args, **kwargs))
 
     return decorated
@@ -94,14 +94,14 @@ class InputError(Exception):
 
 
 class SettingException(Exception):
-    """Standardize behavior of setting-family errors"""
+    """Standardize behavior of setting-family errors."""
 
     def __init__(self, msg):
         Exception.__init__(self, msg)
 
 
 class InvalidSettingsStopProcess(SettingException):
-    """Exception raised when setting file contains invalid settings and user aborts or process is uninteractive"""
+    """Exception raised when setting file contains invalid settings and user aborts or process is uninteractive."""
 
     def __init__(self, reader):
         msg = "Input settings file {}".format(reader.inputPath)
@@ -123,7 +123,7 @@ class InvalidSettingsStopProcess(SettingException):
 
 
 class NonexistentSetting(SettingException):
-    """Exception raised when a non existent setting is asked for"""
+    """Exception raised when a non existent setting is asked for."""
 
     def __init__(self, setting):
         SettingException.__init__(
@@ -132,7 +132,7 @@ class NonexistentSetting(SettingException):
 
 
 class InvalidSettingsFileError(SettingException):
-    """Not a valid settings file"""
+    """Not a valid settings file."""
 
     def __init__(self, path, customMsgEnd=""):
         msg = "Attempted to load an invalid settings file from: {}. ".format(path)
@@ -142,7 +142,7 @@ class InvalidSettingsFileError(SettingException):
 
 
 class NonexistentSettingsFileError(SettingException):
-    """Settings file does not exist"""
+    """Settings file does not exist."""
 
     def __init__(self, path):
         SettingException.__init__(

--- a/armi/utils/customExceptions.py
+++ b/armi/utils/customExceptions.py
@@ -20,37 +20,37 @@ from inspect import stack, getframeinfo
 
 
 def info(func):
-    r"""Decorator to write to current log, using the info method."""
+    """Decorator to write to current log, using the info method."""
 
     def decorated(*args, **kwargs):
-        r"""decorated method."""
+        r"""Decorated method."""
         runLog.info(func(*args, **kwargs))
 
     return decorated
 
 
 def important(func):
-    r"""Decorator to write to current log, using the inportant method."""
+    """Decorator to write to current log, using the inportant method."""
 
     def decorated(*args, **kwargs):
-        r"""decorated method."""
+        """Decorated method."""
         runLog.important(func(*args, **kwargs))
 
     return decorated
 
 
 def warn(func):
-    r"""Decorates a method to produce a repeatable warning message."""
+    """Decorates a method to produce a repeatable warning message."""
 
     def decorated(*args, **kwargs):
-        r"""decorated method."""
+        """Decorated method."""
         runLog.warning(func(*args, **kwargs))
 
     return decorated
 
 
 def _message_when_root(func):
-    r"""Do not use this decorator."""
+    """Do not use this decorator."""
 
     def decorated(*args, **kwargs):
         from armi import MPI_RANK
@@ -70,7 +70,7 @@ def warn_when_root(func):
 
 
 class InputError(Exception):
-    """AN error found in an ARMI input file."""
+    """An error found in an ARMI input file."""
 
     def __init__(self, msg):
         self.msg = msg

--- a/armi/utils/densityTools.py
+++ b/armi/utils/densityTools.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Assorted utilities to help with basic density calculations"""
+"""Assorted utilities to help with basic density calculations."""
 from typing import Tuple, List, Dict
 
 from armi.nucDirectory import nucDir, nuclideBases, elements

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -68,7 +68,7 @@ class DirectoryChanger:
         dumpOnException=True,
         outputPath=None,
     ):
-        """Establish the new and return directories"""
+        """Establish the new and return directories."""
         self.initial = pathTools.armiAbsPath(os.getcwd())
         self.destination = None
         self.outputPath = None
@@ -104,7 +104,7 @@ class DirectoryChanger:
         self.close()
 
     def __repr__(self):
-        """Print the initial and destination paths"""
+        """Print the initial and destination paths."""
         return "<{} {} to {}>".format(
             self.__class__.__name__, self.initial, self.destination
         )
@@ -316,7 +316,7 @@ class TemporaryDirectoryChanger(DirectoryChanger):
 
 
 class ForcedCreationDirectoryChanger(DirectoryChanger):
-    """Creates the directory tree necessary to reach your desired destination"""
+    """Creates the directory tree necessary to reach your desired destination."""
 
     def __init__(
         self,

--- a/armi/utils/directoryChangersMpi.py
+++ b/armi/utils/directoryChangersMpi.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-MPI Directory changers
+MPI Directory changers.
 
 This is a separate module largely to minimize potential cyclic imports
 because the mpi action stuff requires an import of the reactor framework.
@@ -33,7 +33,7 @@ class MpiDirectoryChanger(directoryChangers.DirectoryChanger):
     """
 
     def __init__(self, destination, outputPath=None):
-        """Establish the new and return directories
+        """Establish the new and return directories.
 
         Parameters
         ----------

--- a/armi/utils/dynamicImporter.py
+++ b/armi/utils/dynamicImporter.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Dynamic importing help
+Dynamic importing help.
 """
 
 
 def getEntireFamilyTree(cls):
-    """Returns a list of classes subclassing the input class
+    """Returns a list of classes subclassing the input class.
 
     One large caveat is it can only locate subclasses that had been imported somewhere
     Look to use importEntirePackage before searching for subclasses if not all children

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -46,7 +46,7 @@ class auto:
 
     def __iter__(self):
         """
-        Dummy __iter__ implementation
+        Dummy __iter__ implementation.
 
         This is only needed to make mypy happy when it type checks things that have
         FlagTypes in them, since these can normally be iterated over, but mypy doesn't

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -133,7 +133,7 @@ def _desaturate(c: Sequence[float]):
 
 def _getColorAndBrushFromFlags(f, bold=True):
     """
-    Given a set of Flags, return a wx.Pen and wx.Brush with which to draw a shape
+    Given a set of Flags, return a wx.Pen and wx.Brush with which to draw a shape.
     """
     c = numpy.array([0.0, 0.0, 0.0])
     nColors = 0
@@ -540,7 +540,7 @@ class _AssemblyPalette(wx.ScrolledWindow):
 
     def onToggle(self, event):
         """
-        Respond to toggle events
+        Respond to toggle events.
 
         This makes sure that the right selector button is activated, and switches the
         GUI mode into the proper one based on whether an assembly design is selected, or
@@ -574,7 +574,7 @@ class _AssemblyPalette(wx.ScrolledWindow):
 
     def getSelectedAssem(self) -> Optional[Union[AssemblyBlueprint, Tuple[int, int]]]:
         """
-        Return the currently-selected assembly design or fuel path indices
+        Return the currently-selected assembly design or fuel path indices.
         """
         if self.activeAssemID in self.assemDesignsById:
             # We have an assembly design activated. return it
@@ -970,7 +970,7 @@ class GridGui(wx.ScrolledWindow):
 
     def _getLabel(self, idx) -> Tuple[str, Optional[str], bool]:
         """
-        Given (i, j, k) indices, return information about the object at that location
+        Given (i, j, k) indices, return information about the object at that location.
 
         This will return a tuple containing:
          - The label to actually display in the GUI
@@ -1020,7 +1020,7 @@ class GridGui(wx.ScrolledWindow):
 
     def setNumRings(self, n: int):
         """
-        Change the number of rings that should be drawn
+        Change the number of rings that should be drawn.
         """
         self.numRings = n
         if self.grid.geomType == geometry.GeomType.HEX:
@@ -1710,7 +1710,7 @@ class NewGridBlueprintDialog(wx.Dialog):
 
     def _toggleControls(self):
         """
-        Make sure that the appropriate controls are enabled/disabled
+        Make sure that the appropriate controls are enabled/disabled.
         """
         geom = self._geomFromIdx[self.geomType.GetSelection()]
         full = self.domainFull.GetValue()

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -127,10 +127,12 @@ class Sequence:
     """
     The Sequence class partially implements a list-like interface,
     supporting methods like append and extend and also operations like + and +=.
+
     It also provides some convenience methods such as drop and select to support
     filtering, as well as a transform function to modify the sequence. Note that
     these methods return a "cloned" version of the iterator to support chaining,
-    e.g.,
+    e.g.
+
     >>> s = Sequence(range(1000000))
     >>> tuple(s.drop(lambda i: i%2 == 0).select(lambda i: i < 20).transform(lambda i: i*10))
     (10, 30, 50, 70, 90, 110, 130, 150, 170, 190)

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -118,7 +118,7 @@ def unpackHexStrings(hexRow):
 def packHexStrings(valueDict):
     """Converts a dictionary of lists of floats into a dictionary of lists of hex values arrays."""
     hexes = {}
-    for entry in valueDict:  # uglier loop done for compatability with cython
+    for entry in valueDict:
         hexes[entry] = [" ".join(float.hex(float(value)) for value in valueDict[entry])]
     return hexes
 

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -13,40 +13,38 @@
 # limitations under the License.
 
 """
-Module of utilities to help dealing with iterable objects in python
+Module of utilities to help dealing with iterable objects in Python.
 """
-import struct
 from itertools import tee, chain
+import struct
 
-from builtins import object  # pylint: disable=redefined-builtin
 from six.moves import filterfalse, map, xrange, filter
 
 
-def flatten(l):
-    """Flattens an iterable of iterables by one level
+def flatten(lst):
+    """Flattens an iterable of iterables by one level.
 
     Examples
     --------
     >>> flatten([[1,2,3,4],[5,6,7,8],[9,10]])
     [1,2,3,4,5,6,7,8,9,10]
-
     """
-    return [item for sublist in l for item in sublist]
+    return [item for sublist in lst for item in sublist]
 
 
-def chunk(l, n):
-    r"""Returns a generator object that yields lenght-`n` chunks of `l`.
+def chunk(lst, n):
+    r"""Returns a generator object that yields lenght-`n` chunks of `lst`.
+
     The last chunk may have a length less than `n` if `n` doesn't divide
-    `len(l)`.
+    `len(lst)`.
 
     Examples
     --------
     >>> list(chunk([1,2,3,4,5,6,7,8,9,10], 4))
      [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10]]
-
     """
-    for i in xrange(0, len(l), n):
-        yield l[i : i + n]
+    for i in xrange(0, len(lst), n):
+        yield lst[i : i + n]
 
 
 def split(a, n, padWith=()):
@@ -79,7 +77,6 @@ def split(a, n, padWith=()):
     >>> split([0,1,2], 5, padWith=None)
      [[0], [1], [2], None, None]
     """
-
     a = list(a)  # in case `a` is not list-like
     N = len(a)
 
@@ -92,11 +89,8 @@ def split(a, n, padWith=()):
     return chunked
 
 
-# -------------------------------
-
-
 def unpackBinaryStrings(binaryRow):
-    """Unpacks a row of binary strings to a list of floats"""
+    """Unpacks a row of binary strings to a list of floats."""
     if len(binaryRow) % 8:
         raise ValueError(
             "Cannot unpack binary strings from misformatted row. Expected chunks of size 8."
@@ -105,7 +99,7 @@ def unpackBinaryStrings(binaryRow):
 
 
 def packBinaryStrings(valueDict):
-    """Converts a dictionary of lists of floats into a dictionary of lists of byte arrays"""
+    """Converts a dictionary of lists of floats into a dictionary of lists of byte arrays."""
     bytearrays = {}
     for entry in valueDict:
         bytearrays[entry] = [bytearray()]
@@ -117,19 +111,16 @@ def packBinaryStrings(valueDict):
 
 
 def unpackHexStrings(hexRow):
-    """Unpacks a row of binary strings to a list of floats"""
+    """Unpacks a row of binary strings to a list of floats."""
     return [float.fromhex(ss) for ss in hexRow.split() if ss != ""]
 
 
 def packHexStrings(valueDict):
-    """Converts a dictionary of lists of floats into a dictionary of lists of hex values arrays"""
+    """Converts a dictionary of lists of floats into a dictionary of lists of hex values arrays."""
     hexes = {}
     for entry in valueDict:  # uglier loop done for compatability with cython
         hexes[entry] = [" ".join(float.hex(float(value)) for value in valueDict[entry])]
     return hexes
-
-
-# -------------------------------
 
 
 class Sequence:
@@ -206,7 +197,7 @@ class Sequence:
         return next(self._iter)
 
     def select(self, pred):
-        """Keep only items for which pred(item) evaluates to True
+        """Keep only items for which pred(item) evaluates to True.
 
         Note: returns self so it can be chained with other filters, e.g.,
 
@@ -237,7 +228,7 @@ class Sequence:
         self.extend([item])
 
     def __radd__(self, other):
-        """s1 += s2"""
+        """Basic sequence addition: s1 += s2."""
         new = Sequence(other)
         new += Sequence(self)
         return new

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -109,7 +109,6 @@ def convertToSlice(x, increment=False):
 
     >>> a[utils.convertToSlice(slice(2, 3, None), increment=-1)]
     array([11])
-
     """
     if increment is False:
         increment = 0
@@ -202,7 +201,7 @@ def expandRepeatedFloats(repeatedList):
 
 def findClosest(listToSearch, val, indx=False):
     r"""
-    find closest item in a list.
+    Find closest item in a list.
 
     Parameters
     ----------
@@ -221,7 +220,6 @@ def findClosest(listToSearch, val, indx=False):
         The item in the listToSearch that is closest to val
     minI : int
         The index of the item in listToSearch that is closest to val. Returned if indx=True.
-
     """
     d = float("inf")
     minVal = None
@@ -245,7 +243,8 @@ def findNearestValue(searchList, searchValue):
 
 def findNearestValueAndIndex(searchList, searchValue):
     """Search a given list for the value that is closest to the given search value. Return a tuple
-    containing the value and its index in the list."""
+    containing the value and its index in the list.
+    """
     searchArray = np.array(searchList)
     closestValueIndex = (np.abs(searchArray - searchValue)).argmin()
     return searchArray[closestValueIndex], closestValueIndex
@@ -272,8 +271,9 @@ def fixThreeDigitExp(strToFloat: str) -> float:
 
 
 def getFloat(val):
-    r"""returns float version of val, or None if it's impossible. Useful for converting
-    user-input into floats when '' might be possible."""
+    r"""Returns float version of val, or None if it's impossible. Useful for converting
+    user-input into floats when '' might be possible.
+    """
     try:
         newVal = float(val)
         return newVal
@@ -328,7 +328,7 @@ def isMonotonic(inputIter, relation):
 
 def linearInterpolation(x0, y0, x1, y1, targetX=None, targetY=None):
     r"""
-    does a linear interpolation (or extrapolation) for y=f(x).
+    Does a linear interpolation (or extrapolation) for y=f(x).
 
     Parameters
     ----------
@@ -352,7 +352,6 @@ def linearInterpolation(x0, y0, x1, y1, targetX=None, targetY=None):
     y = m(x-x0) + b
 
     x = (y-b)/m
-
     """
     if x1 == x0:
         raise ZeroDivisionError("The x-values are identical. Cannot interpolate.")
@@ -393,12 +392,10 @@ def minimizeScalarFunc(
     maxIterations : int
         The maximum number of iterations that the Newton's method will be allowed to perform.
 
-
     Returns
     -------
     ans : float
         The guess that when input to the func returns the goal.
-
     """
 
     def goalFunc(guess, func, positiveGuesses):
@@ -483,7 +480,7 @@ def newtonsMethod(
 
 def parabolaFromPoints(p1, p2, p3):
     r"""
-    find the parabola that passes through three points.
+    Find the parabola that passes through three points.
 
     We solve a simultaneous equation with three points.
 
@@ -506,7 +503,6 @@ def parabolaFromPoints(p1, p2, p3):
     Returns
     -------
     a,b,c coefficients of y=ax^2+bx+c
-
     """
     A = np.array(
         [[p1[0] ** 2, p1[0], 1], [p2[0] ** 2, p2[0], 1], [p3[0] ** 2, p3[0], 1]]
@@ -554,7 +550,6 @@ def parabolicInterpolation(ap, bp, cp, targetY):
 
         slope : float
             The slope of the keff vs. time curve at t=newTime
-
     """
     roots = np.roots([ap, bp, cp - targetY])
     realRoots = []
@@ -577,7 +572,7 @@ def parabolicInterpolation(ap, bp, cp, targetY):
 
 
 def relErr(v1: float, v2: float) -> float:
-    """find the relative error between to numbers."""
+    """Find the relative error between to numbers."""
     if v1:
         return (v2 - v1) / v1
     else:

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Various math utilities"""
+"""Various math utilities."""
 import math
 import operator  # the python package, not the ARMI module
 import re
@@ -328,7 +328,7 @@ def isMonotonic(inputIter, relation):
 
 def linearInterpolation(x0, y0, x1, y1, targetX=None, targetY=None):
     r"""
-    does a linear interpolation (or extrapolation) for y=f(x)
+    does a linear interpolation (or extrapolation) for y=f(x).
 
     Parameters
     ----------
@@ -483,7 +483,7 @@ def newtonsMethod(
 
 def parabolaFromPoints(p1, p2, p3):
     r"""
-    find the parabola that passes through three points
+    find the parabola that passes through three points.
 
     We solve a simultaneous equation with three points.
 
@@ -577,7 +577,7 @@ def parabolicInterpolation(ap, bp, cp, targetY):
 
 
 def relErr(v1: float, v2: float) -> float:
-    """find the relative error between to numbers"""
+    """find the relative error between to numbers."""
     if v1:
         return (v2 - v1) / v1
     else:
@@ -662,7 +662,7 @@ def resampleStepwise(xin, yin, xout, avg=True):
 
 def rotateXY(x, y, degreesCounterclockwise=None, radiansCounterclockwise=None):
     """
-    Rotates x, y coordinates
+    Rotates x, y coordinates.
 
     Parameters
     ----------

--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-TerraPower Calculation Results Cache (CRC)
+TerraPower Calculation Results Cache (CRC).
 
 This helps avoid duplicated time/energy in running cases.
 In test systems and analysis, it's possible that the same calc will be done

--- a/armi/utils/parsing.py
+++ b/armi/utils/parsing.py
@@ -14,7 +14,7 @@
 
 """
 
-This file contains tools for common tasks in parsing in python strings into non-string values
+This file contains tools for common tasks in parsing in python strings into non-string values.
 
 """
 
@@ -63,7 +63,7 @@ def _numericSpecialBehavior(source, rt):
 
 
 def parseValue(source, requestedType, allowNone=False, matchingNonetype=True):
-    """Tries parse a python value, expecting input to be the right type or a string"""
+    """Tries parse a python value, expecting input to be the right type or a string."""
     # misuse prevention
     if requestedType == str:
         raise TypeError(
@@ -99,5 +99,5 @@ def parseValue(source, requestedType, allowNone=False, matchingNonetype=True):
 
 
 def datetimeFromStr(string):
-    """Converts an arbitrary string to a datetime object"""
+    """Converts an arbitrary string to a datetime object."""
     return parser.parse(string)

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -1101,7 +1101,7 @@ def plotBlockFlux(core, fName=None, bList=None, peak=False, adjoint=False, bList
 def makeHistogram(x, y):
     """
     Take a list of x and y values, and return a histogram-ified version
-    Good for plotting multigroup flux spectrum or cross sections
+    Good for plotting multigroup flux spectrum or cross sections.
     """
     if not len(x) == len(y):
         raise ValueError(
@@ -1372,7 +1372,7 @@ def _makeComponentPatch(component, position, cold):
 
 def plotBlockDiagram(block, fName, cold, cmapName="RdYlBu", materialList=None):
     """Given a Block with a spatial Grid, plot the diagram of
-    it with all of its components. (wire, duct, coolant, etc...)
+    it with all of its components. (wire, duct, coolant, etc...).
 
     Parameters
     ----------
@@ -1529,7 +1529,7 @@ def plotNucXs(
     isotxs, nucNames, xsNames, fName=None, label=None, noShow=False, title=None
 ):
     """
-    generates a XS plot for a nuclide on the ISOTXS library
+    generates a XS plot for a nuclide on the ISOTXS library.
 
     Parameters
     ----------

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -30,7 +30,7 @@ def areEqual(val1, val2, relativeTolerance=0.0):
 
 def numpyHackForEqual(val1, val2):
     r"""
-    checks lots of types for equality like strings and dicts
+    checks lots of types for equality like strings and dicts.
     """
     # when doing this with numpy arrays you get an array of booleans which causes the value error
     notEqual = val1 != val2

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Plotting Utils specific to reports
+Plotting Utils specific to reports.
 
 This module makes heavy use of matplotlib. Beware that plots generated with matplotlib
 may not free their memory, even after the plot is closed, and excessive use of
@@ -123,7 +123,7 @@ def plotReactorPerformance(reactor, dbi, buGroups, extension=None, history=None)
 
 def valueVsTime(name, x, y, key, yaxis, title, ymin=None, extension=None):
     r"""
-    Plots a value vs. time with a standard graph format
+    Plots a value vs. time with a standard graph format.
 
     Parameters
     ----------
@@ -168,7 +168,7 @@ def valueVsTime(name, x, y, key, yaxis, title, ymin=None, extension=None):
 
 def keffVsTime(name, time, keff, keffUnc=None, ymin=None, extension=None):
     r"""
-    Plots core keff vs. time
+    Plots core keff vs. time.
 
     Parameters
     ----------
@@ -217,7 +217,7 @@ def keffVsTime(name, time, keff, keffUnc=None, ymin=None, extension=None):
 
 def buVsTime(name, scalars, extension=None):
     r"""
-    produces a burnup and DPA vs. time plot for this case
+    produces a burnup and DPA vs. time plot for this case.
 
     Will add a second axis containing DPA if the scalar column maxDPA exists.
 
@@ -318,7 +318,7 @@ def xsHistoryVsTime(name, history, buGroups, extension=None):
 
 def movesVsCycle(name, scalars, extension=None):
     r"""
-    make a bar chart showing the number of moves per cycle in the full core
+    make a bar chart showing the number of moves per cycle in the full core.
 
     A move is defined as an assembly being picked up, moved, and put down. So if
     two assemblies are swapped, that is 2 moves. Note that it does not count
@@ -606,12 +606,12 @@ def _radarFactory(numVars, frame="circle"):
         draw_patch = staticmethod(patchDict[frame])
 
         def fill(self, *args, **kwargs):
-            """Override fill so that line is closed by default"""
+            """Override fill so that line is closed by default."""
             closed = kwargs.pop("closed", True)
             return super(_RadarAxes, self).fill(closed=closed, *args, **kwargs)
 
         def plot(self, *args, **kwargs):
-            """Override plot so that line is closed by default"""
+            """Override plot so that line is closed by default."""
             lines = super(_RadarAxes, self).plot(*args, **kwargs)
             for line in lines:
                 close_line(line)
@@ -660,7 +660,7 @@ def createPlotMetaData(
     title, xLabel, yLabel, xMajorTicks=None, yMajorTicks=None, legendLabels=None
 ):
     """
-    Create plot metadata (title, labels, ticks)
+    Create plot metadata (title, labels, ticks).
 
     Parameters
     ----------

--- a/armi/utils/tests/test_asciimaps.py
+++ b/armi/utils/tests/test_asciimaps.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test ASCII maps"""
+"""Test ASCII maps."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import io
 import unittest
@@ -360,7 +360,7 @@ class TestAsciiMaps(unittest.TestCase):
             self.assertEqual(output, HEX_FULL_MAP_SMALL)
 
     def test_flatHexBases(self):
-        """For the full core with 2 lines chopped, get the first 3 bases"""
+        """For the full core with 2 lines chopped, get the first 3 bases."""
         asciimap = asciimaps.AsciiMapHexFullFlatsUp()
         with io.StringIO() as stream:
             stream.write(HEX_FULL_MAP_FLAT)

--- a/armi/utils/tests/test_codeTiming.py
+++ b/armi/utils/tests/test_codeTiming.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for code timing"""
+"""Unit tests for code timing."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import time
 import unittest

--- a/armi/utils/tests/test_custom_exceptions.py
+++ b/armi/utils/tests/test_custom_exceptions.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r"""Basic tests of the custom exceptions
+r"""Basic tests of the custom exceptions.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-self-use,invalid-name
 import unittest

--- a/armi/utils/tests/test_directoryChangers.py
+++ b/armi/utils/tests/test_directoryChangers.py
@@ -121,7 +121,7 @@ class TestDirectoryChangers(unittest.TestCase):
         """
 
         def f(name):
-            """Utility to avoid test clashes during cleanups"""
+            """Utility to avoid test clashes during cleanups."""
             return self._testMethodName + name
 
         with directoryChangers.TemporaryDirectoryChanger(
@@ -154,7 +154,7 @@ class TestDirectoryChangers(unittest.TestCase):
         """Tests that the directory changer still returns a subset of files even if all do not exist."""
 
         def f(name):
-            """Utility to avoid test clashes during cleanups"""
+            """Utility to avoid test clashes during cleanups."""
             return self._testMethodName + name
 
         with directoryChangers.TemporaryDirectoryChanger(

--- a/armi/utils/tests/test_dochelpers.py
+++ b/armi/utils/tests/test_dochelpers.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for documentation helpers"""
+"""Tests for documentation helpers."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import unittest
 

--- a/armi/utils/tests/test_flags.py
+++ b/armi/utils/tests/test_flags.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r""" Testing flags.py"""
+r""" Testing flags.py."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import unittest
 
@@ -71,7 +71,7 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(f, f2)
 
     def test_collision(self):
-        """Make sure that we catch value collisions"""
+        """Make sure that we catch value collisions."""
         with self.assertRaises(AssertionError):
 
             class F(Flag):  # pylint: disable=unused-variable
@@ -89,7 +89,7 @@ class TestFlag(unittest.TestCase):
         self.assertNotIn(ExampleFlag.BAR, f)
 
     def test_bitwise(self):
-        """Make sure that bitwise operators work right"""
+        """Make sure that bitwise operators work right."""
         f = ExampleFlag.FOO | ExampleFlag.BAR
         self.assertTrue(f & ExampleFlag.FOO)
         self.assertTrue(f & ExampleFlag.BAR)
@@ -108,7 +108,7 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(f2 ^ f, ExampleFlag.BAR | ExampleFlag.BAZ)
 
     def test_iteration(self):
-        """we want to be able to iterate over set flags"""
+        """we want to be able to iterate over set flags."""
         f = ExampleFlag.FOO | ExampleFlag.BAZ
         flagsOn = [val for val in f]
         self.assertIn(ExampleFlag.FOO, flagsOn)

--- a/armi/utils/tests/test_flags.py
+++ b/armi/utils/tests/test_flags.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r""" Testing flags.py."""
+r"""Testing flags.py."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import unittest
 
@@ -29,7 +29,7 @@ class TestFlag(unittest.TestCase):
 
     def test_auto(self):
         """
-        make sure that auto() works right, and that mixing it with explicit values
+        Make sure that auto() works right, and that mixing it with explicit values
         doesnt lead to collision.
         """
 
@@ -108,7 +108,7 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(f2 ^ f, ExampleFlag.BAR | ExampleFlag.BAZ)
 
     def test_iteration(self):
-        """we want to be able to iterate over set flags."""
+        """We want to be able to iterate over set flags."""
         f = ExampleFlag.FOO | ExampleFlag.BAZ
         flagsOn = [val for val in f]
         self.assertIn(ExampleFlag.FOO, flagsOn)

--- a/armi/utils/tests/test_iterables.py
+++ b/armi/utils/tests/test_iterables.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-unittests for iterables.py
+unittests for iterables.py.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import time
@@ -26,7 +26,7 @@ _TEST_DATA = {"turtle": [float(vv) for vv in range(-2000, 2000)]}
 
 
 class TestIterables(unittest.TestCase):
-    """Testing our custom Iterables"""
+    """Testing our custom Iterables."""
 
     def test_flatten(self):
         self.assertEqual(

--- a/armi/utils/tests/test_mathematics.py
+++ b/armi/utils/tests/test_mathematics.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r""" Testing mathematics utilities
+r""" Testing mathematics utilities.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 from math import sqrt
@@ -42,7 +42,7 @@ from armi.utils.mathematics import (
 
 
 class TestMath(unittest.TestCase):
-    """Tests for various math utilities"""
+    """Tests for various math utilities."""
 
     def test_average1DWithinTolerance(self):
         vals = np.array([np.array([1, 2, 3]), np.array([4, 5, 6]), np.array([7, 8, 9])])
@@ -196,7 +196,7 @@ class TestMath(unittest.TestCase):
         self.assertAlmostEqual(relErr(0.00, 1.00), -1e99)
 
     def test_resampleStepwiseAvg0(self):
-        """Test resampleStepwise() averaging when in and out bins match"""
+        """Test resampleStepwise() averaging when in and out bins match."""
         xin = [0, 1, 2, 13.3]
         yin = [4.76, 9.99, -123.456]
         xout = [0, 1, 2, 13.3]
@@ -209,7 +209,7 @@ class TestMath(unittest.TestCase):
         self.assertAlmostEqual(yout[2], -123.456)
 
     def test_resampleStepwiseAvg1(self):
-        """Test resampleStepwise() averaging for one arbitrary case"""
+        """Test resampleStepwise() averaging for one arbitrary case."""
         xin = [0, 1, 2, 3, 4]
         yin = [3, 2, 5, 3]
         xout = [0, 2, 3.5, 4]
@@ -222,7 +222,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[2], 3)
 
     def test_resampleStepwiseAvg2(self):
-        """Test resampleStepwise() averaging for another arbitrary case"""
+        """Test resampleStepwise() averaging for another arbitrary case."""
         xin = [0, 1, 2, 3, 4, 5]
         yin = [3, 2, 5, 3, 4]
         xout = [0, 2, 3.5, 5]
@@ -235,7 +235,7 @@ class TestMath(unittest.TestCase):
         self.assertAlmostEqual(yout[2], 3.6666666666666665)
 
     def test_resampleStepwiseAvg3(self):
-        """Test resampleStepwise() averaging for another arbitrary case"""
+        """Test resampleStepwise() averaging for another arbitrary case."""
         xin = [0, 1, 2, 3, 4, 6]
         yin = [3, 2, 5, 3, 4]
         xout = [0, 2, 3.5, 6]
@@ -248,7 +248,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[2], 3.8)
 
     def test_resampleStepwiseAvg4(self):
-        """Test resampleStepwise() averaging for matching, but uneven intervals"""
+        """Test resampleStepwise() averaging for matching, but uneven intervals."""
         xin = [0, 3, 5, 6.777, 9.123]
         yin = [3.1, 2.2, 5.3, 3.4]
         xout = [0, 3, 5, 6.777, 9.123]
@@ -262,7 +262,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[3], 3.4)
 
     def test_resampleStepwiseAvg5(self):
-        """Test resampleStepwise() averaging for almost matching intervals"""
+        """Test resampleStepwise() averaging for almost matching intervals."""
         xin = [0, 3, 5, 6.777, 9.123]
         yin = [3.1, 2.2, 5.3, 3.4]
         xout = [0, 5, 9.123]
@@ -274,7 +274,7 @@ class TestMath(unittest.TestCase):
         self.assertAlmostEqual(yout[1], 4.21889400921659)
 
     def test_resampleStepwiseAvg6(self):
-        """Test resampleStepwise() averaging when the intervals don't line up"""
+        """Test resampleStepwise() averaging when the intervals don't line up."""
         xin = [0, 1, 2, 3, 4]
         yin = [11, 22, 33, 44]
         xout = [2, 3, 4, 5, 6]
@@ -288,7 +288,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[3], 0)
 
     def test_resampleStepwiseAvg7(self):
-        """Test resampleStepwise() averaging when the intervals don't line up"""
+        """Test resampleStepwise() averaging when the intervals don't line up."""
         xin = [2, 4, 6, 8, 10]
         yin = [11, 22, 33, 44]
         xout = [-1, 0, 1, 2, 3, 4]
@@ -303,7 +303,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[4], 11)
 
     def test_resampleStepwiseSum0(self):
-        """Test resampleStepwise() summing when in and out bins match"""
+        """Test resampleStepwise() summing when in and out bins match."""
         xin = [0, 1, 2, 13.3]
         yin = [4.76, 9.99, -123.456]
         xout = [0, 1, 2, 13.3]
@@ -317,7 +317,7 @@ class TestMath(unittest.TestCase):
         self.assertAlmostEqual(sum(yin), sum(yout))
 
     def test_resampleStepwiseSum1(self):
-        """Test resampleStepwise() summing for one arbitrary case"""
+        """Test resampleStepwise() summing for one arbitrary case."""
         xin = [0, 1, 2, 3, 4]
         yin = [3, 2, 5, 3]
         xout = [0, 2, 3.5, 4]
@@ -331,7 +331,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(sum(yin), sum(yout))
 
     def test_resampleStepwiseSum2(self):
-        """Test resampleStepwise() summing for another arbitrary case"""
+        """Test resampleStepwise() summing for another arbitrary case."""
         xin = [0, 1, 2, 3, 4, 5]
         yin = [3, 2, 5, 3, 4]
         xout = [0, 2, 3.5, 5]
@@ -345,7 +345,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(sum(yin), sum(yout))
 
     def test_resampleStepwiseSum3(self):
-        """Test resampleStepwise() summing for another arbitrary case"""
+        """Test resampleStepwise() summing for another arbitrary case."""
         xin = [0, 1, 2, 3, 4, 6]
         yin = [3, 2, 5, 3, 4]
         xout = [0, 2, 3.5, 6]
@@ -359,7 +359,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(sum(yin), sum(yout))
 
     def test_resampleStepwiseSum4(self):
-        """Test resampleStepwise() summing for matching, but uneven intervals"""
+        """Test resampleStepwise() summing for matching, but uneven intervals."""
         xin = [0, 3, 5, 6.777, 9.123]
         yin = [3.1, 2.2, 5.3, 3.4]
         xout = [0, 3, 5, 6.777, 9.123]
@@ -374,7 +374,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(sum(yin), sum(yout))
 
     def test_resampleStepwiseSum5(self):
-        """Test resampleStepwise() summing for almost matching intervals"""
+        """Test resampleStepwise() summing for almost matching intervals."""
         xin = [0, 3, 5, 6.777, 9.123]
         yin = [3.1, 2.2, 5.3, 3.4]
         xout = [0, 5, 9.123]
@@ -387,7 +387,7 @@ class TestMath(unittest.TestCase):
         self.assertAlmostEqual(sum(yin), sum(yout))
 
     def test_resampleStepwiseSum6(self):
-        """Test resampleStepwise() summing when the intervals don't line up"""
+        """Test resampleStepwise() summing when the intervals don't line up."""
         xin = [0, 1, 2, 3, 4]
         yin = [11, 22, 33, 44]
         xout = [2, 3, 4, 5, 6]
@@ -401,7 +401,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[3], 0)
 
     def test_resampleStepwiseSum7(self):
-        """Test resampleStepwise() summing when the intervals don't line up"""
+        """Test resampleStepwise() summing when the intervals don't line up."""
         xin = [2, 4, 6, 8, 10]
         yin = [11, 22, 33, 44]
         xout = [-1, 0, 1, 2, 3, 4]
@@ -416,7 +416,7 @@ class TestMath(unittest.TestCase):
         self.assertAlmostEqual(yout[4], 11 / 2)
 
     def test_resampleStepwiseAvgAllNones(self):
-        """Test resampleStepwise() averaging when the inputs are all None"""
+        """Test resampleStepwise() averaging when the inputs are all None."""
         xin = [0, 1, 2, 13.3]
         yin = [None, None, None]
         xout = [0, 1, 2, 13.3]
@@ -429,7 +429,7 @@ class TestMath(unittest.TestCase):
         self.assertIsNone(yout[2])
 
     def test_resampleStepwiseAvgOneNone(self):
-        """Test resampleStepwise() averaging when one input is None"""
+        """Test resampleStepwise() averaging when one input is None."""
         xin = [0, 1, 2, 13.3]
         yin = [None, 1, 2]
         xout = [0, 1, 2, 13.3]
@@ -442,7 +442,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[2], 2)
 
     def test_resampleStepwiseSumAllNones(self):
-        """Test resampleStepwise() summing when the inputs are all None"""
+        """Test resampleStepwise() summing when the inputs are all None."""
         xin = [0, 1, 2, 13.3]
         yin = [None, None, None]
         xout = [0, 1, 2, 13.3]
@@ -455,7 +455,7 @@ class TestMath(unittest.TestCase):
         self.assertIsNone(yout[2])
 
     def test_resampleStepwiseSumOneNone(self):
-        """Test resampleStepwise() summing when one inputs is None"""
+        """Test resampleStepwise() summing when one inputs is None."""
         xin = [0, 1, 2, 13.3]
         yin = [None, 1, 2]
         xout = [0, 1, 2, 13.3]
@@ -468,7 +468,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[2], 2)
 
     def test_resampleStepwiseAvgComplicatedNone(self):
-        """Test resampleStepwise() averaging with a None value, when the intervals don't line up"""
+        """Test resampleStepwise() averaging with a None value, when the intervals don't line up."""
         xin = [2, 4, 6, 8, 10]
         yin = [11, None, 33, 44]
         xout = [-1, 0, 1, 2, 4, 7, 9]
@@ -484,7 +484,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[5], 38.5)
 
     def test_resampleStepwiseAvgNpArray(self):
-        """Test resampleStepwise() averaging when some of the values are arrays"""
+        """Test resampleStepwise() averaging when some of the values are arrays."""
         xin = [0, 1, 2, 3, 4]
         yin = [11, np.array([1, 1]), np.array([2, 2]), 44]
         xout = [2, 4, 5, 6, 7]
@@ -500,7 +500,7 @@ class TestMath(unittest.TestCase):
         self.assertEqual(yout[3], 0)
 
     def test_resampleStepwiseAvgNpArrayAverage(self):
-        """Test resampleStepwise() summing when some of the values are arrays"""
+        """Test resampleStepwise() summing when some of the values are arrays."""
         xin = [0, 1, 2, 3, 4]
         yin = [11, np.array([1, 1]), np.array([2, 2]), 44]
         xout = [2, 4, 5, 6, 7]

--- a/armi/utils/tests/test_outputCache.py
+++ b/armi/utils/tests/test_outputCache.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" tests of the output cache tools"""
+""" tests of the output cache tools."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,invalid-name
 import os
 import time

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -76,7 +76,7 @@ class PathToolsTests(unittest.TestCase):
     @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")
     def test_cleanPathNoMpi(self):
         """
-        Simple tests of cleanPath(), in the no-MPI scenario
+        Simple tests of cleanPath(), in the no-MPI scenario.
         """
         with TemporaryDirectoryChanger():
             # TEST 0: File is not safe to delete, due to name pathing

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for basic plotting tools"""
+"""Tests for basic plotting tools."""
 import os
 import unittest
 

--- a/armi/utils/tests/test_properties.py
+++ b/armi/utils/tests/test_properties.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" tests of the propereties class """
+""" tests of the propereties class. """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,invalid-name
 import unittest
 

--- a/armi/utils/tests/test_reportPlotting.py
+++ b/armi/utils/tests/test_reportPlotting.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test plotting"""
+"""Test plotting."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access
 import copy
 import os

--- a/armi/utils/tests/test_textProcessors.py
+++ b/armi/utils/tests/test_textProcessors.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Tests for functions in textProcessors.py
+Tests for functions in textProcessors.py.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import os

--- a/armi/utils/tests/test_triangle.py
+++ b/armi/utils/tests/test_triangle.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r""" Test the basic triangle math
+r""" Test the basic triangle math.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,unused-variable
 import unittest

--- a/armi/utils/tests/test_units.py
+++ b/armi/utils/tests/test_units.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test armi.utils.units.py"""
+"""Test armi.utils.units.py."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
 import unittest
 
@@ -73,7 +73,7 @@ class TestUnits(unittest.TestCase):
             units.getTf(Tc=0, Tk=200)
 
     def test_pressure_converter(self):
-        """Converter Pascals to Pascals should just be a pass-through"""
+        """Converter Pascals to Pascals should just be a pass-through."""
         for val in [0.0, -99.141, 123, 3.14159, -2.51212e-12]:
             self.assertEqual(val, units.PRESSURE_CONVERTERS["Pa"](val))
 

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r""" Testing some utility functions
+r""" Testing some utility functions.
 """
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,too-many-public-methods,invalid-name
 from collections import defaultdict
@@ -139,7 +139,7 @@ class TestGeneralUtils(unittest.TestCase):
             utils.plotMatrix(matrix, fname, xticks=xtick, yticks=ytick)
 
     def test_classesInHierarchy(self):
-        """Tests the classesInHierarchy utility
+        """Tests the classesInHierarchy utility.
 
         .. test:: Tests that the Reactor is stored heirarchically
            :id: TEST_REACTOR_HIERARCHY_0

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -354,6 +354,9 @@ settings:
             getCycleNodeFromCumulativeNode(8, self.standaloneSimpleCS), (2, 0)
         )
 
+        with self.assertRaises(ValueError):
+            getCycleNodeFromCumulativeNode(-1, self.standaloneSimpleCS)
+
     def test_getPreviousTimeNode(self):
         with self.assertRaises(ValueError):
             getPreviousTimeNode(0, 0, "foo")

--- a/armi/utils/textProcessors.py
+++ b/armi/utils/textProcessors.py
@@ -45,7 +45,7 @@ Matches 1, 100, 1.0, -1.2, +12.234
 """
 
 DECIMAL_PATTERN = r"[+-]?\d*\.\d+"
-"""matches .1, 1.213423, -23.2342, +.023
+"""Matches .1, 1.213423, -23.2342, +.023
 """
 
 
@@ -526,7 +526,6 @@ class TextProcessor:
     A general text processing object that extends python's abilities to scan through huge files.
 
     Use this instead of a raw file object to read data out of output files, etc.
-
     """
 
     scipat = SCIENTIFIC_PATTERN
@@ -554,7 +553,7 @@ class TextProcessor:
             self.f = SmartList(f)
 
     def reset(self):
-        r"""rewinds the file so you can search through it again."""
+        r"""Rewinds the file so you can search through it again."""
         self.f.seek(0)
 
     def __repr__(self):

--- a/armi/utils/textProcessors.py
+++ b/armi/utils/textProcessors.py
@@ -554,7 +554,7 @@ class TextProcessor:
             self.f = SmartList(f)
 
     def reset(self):
-        r"""rewinds the file so you can search through it again"""
+        r"""rewinds the file so you can search through it again."""
         self.f.seek(0)
 
     def __repr__(self):
@@ -570,7 +570,7 @@ class TextProcessor:
         r"""
         Searches file f for pattern and displays msg when found. Returns line in which
         pattern is found or FALSE if no pattern is found.
-        Stops searching if finds killOn first
+        Stops searching if finds killOn first.
 
         If you specify textFlag=True, the search won't use a regular expression (and
         can't). The basic result is you get less powerful matching capabilities at a

--- a/armi/utils/triangle.py
+++ b/armi/utils/triangle.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
-Generic triangle math.
-"""
+"""Generic triangle math."""
 
 import math
 
@@ -44,7 +42,6 @@ def getTriangleArea(
     -----
     See `https://en.wikipedia.org/wiki/Heron%27s_formula` for more information.
     """
-
     a = math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
     b = math.sqrt((x2 - x3) ** 2 + (y2 - y3) ** 2)
     c = math.sqrt((x1 - x3) ** 2 + (y1 - y3) ** 2)
@@ -83,9 +80,7 @@ def getTriangleCentroid(x1, y1, x2, y2, x3, y3):
         x coordinate of triangle's centroid
     y : float
         y coordinate of a triangle's centroid
-
     """
-
     x = (x1 + x2 + x3) / 3.0
     y = (y1 + y2 + y3) / 3.0
 
@@ -122,7 +117,6 @@ def checkIfPointIsInTriangle(
     This method uses the barycentric method.
     See `http://totologic.blogspot.com/2014/01/accurate-point-in-triangle-test.html`
     """
-
     a = ((y2 - y3) * (x - x3) + (x3 - x2) * (y - y3)) / (
         (y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3)
     )

--- a/armi/utils/units.py
+++ b/armi/utils/units.py
@@ -132,7 +132,7 @@ def getTk(Tc=None, Tk=None):
 
 def getTc(Tc=None, Tk=None):
     """
-    Return a temperature in Celcius, given a temperature in Celsius or Kelvin.
+    Return a temperature in Celsius, given a temperature in Celsius or Kelvin.
 
     Returns
     -------

--- a/armi/utils/units.py
+++ b/armi/utils/units.py
@@ -110,7 +110,7 @@ REYNOLDS_TURBULENT = 4000.0
 
 def getTk(Tc=None, Tk=None):
     """
-    Return a temperature in Kelvin, given a temperature in Celsius or Kelvin
+    Return a temperature in Kelvin, given a temperature in Celsius or Kelvin.
 
     Returns
     -------
@@ -132,7 +132,7 @@ def getTk(Tc=None, Tk=None):
 
 def getTc(Tc=None, Tk=None):
     """
-    Return a temperature in Celcius, given a temperature in Celsius or Kelvin
+    Return a temperature in Celcius, given a temperature in Celsius or Kelvin.
 
     Returns
     -------
@@ -154,7 +154,7 @@ def getTc(Tc=None, Tk=None):
 
 def getTf(Tc=None, Tk=None):
     """
-    Return a temperature in Fahrenheit, given a temperature in Celsius or Kelvin
+    Return a temperature in Fahrenheit, given a temperature in Celsius or Kelvin.
 
     Returns
     -------
@@ -171,7 +171,7 @@ def getTf(Tc=None, Tk=None):
 
 def getTemperature(Tc=None, Tk=None, tempUnits=None):
     """
-    Returns the temperature in the prescribed temperature units
+    Returns the temperature in the prescribed temperature units.
 
     Parameters
     ----------
@@ -286,7 +286,7 @@ def sanitizeAngle(theta):
 
 def getXYLineParameters(theta, x=0, y=0):
     """
-    returns parameters A B C D for a plane in the XY direction
+    returns parameters A B C D for a plane in the XY direction.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

I finally used the [ruff](https://github.com/charliermarsh/ruff) linter in ARMI (and hand tweaked the results)!  This PR just cleans up our docstrings and unifies them with our standards.  While this is a very large PR in terms of number of files/lines, I believe it is exceptionally safe to merge as it is just docstrings.

(I have spoken to John B and even he agrees that docs-only PRs are safe for the release cycle.)

Tony/Arrielle, this PR is so big I thought maybe two reviewers could split the files they look at?  Maybe splitting all the boring scrolling?

**Low Priority**: I know everyone is busy.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any bug fixes or new features.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
