### PR TITLE
Cleaning up TODOs

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -869,8 +869,7 @@ class Database3:
                 if any(linkedDims):
                     attrs["linkedDims"] = numpy.array(linkedDims).astype("S")
             else:
-                # XXX: side effect is that after loading previously unset values will be
-                # the default
+                # NOTE: after loading, the previously unset values will be defaulted
                 temp = [c.p.get(paramDef.name, paramDef.default) for c in comps]
                 if paramDef.serializer is not None:
                     data, sAttrs = paramDef.serializer.pack(temp)
@@ -1527,7 +1526,7 @@ def packSpecialData(
     if len(nones) > 0:
         attrs["nones"] = True
 
-    # XXX: this whole if/then/elif/else can be optimized by looping once and then
+    # TODO: this whole if/then/elif/else can be optimized by looping once and then
     #      determining the correct action
     # A robust solution would need
     # to do this on a case-by-case basis, and re-do it any time we want to

--- a/armi/bookkeeping/db/layout.py
+++ b/armi/bookkeeping/db/layout.py
@@ -356,8 +356,7 @@ class Layout:
             elif issubclass(Klass, Core):
                 comp = Klass(name)
             elif issubclass(Klass, Component):
-                # XXX: initialize all dimensions to 0, they will be loaded and assigned
-                # after load
+                # TODO: init all dimensions to 0, they will be loaded and assigned after load
                 kwargs = dict.fromkeys(Klass.DIMENSION_NAMES, 0)
                 kwargs["material"] = material
                 kwargs["name"] = name

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -540,7 +540,7 @@ class DistributeStateAction(MpiAction):
             # the operator/interface attachment may invalidate some of the cache, but since
             # all the underlying data is the same, ultimately all state should be (initially) the
             # same.
-            # XXX: this is an indication we need to revamp either how the operator attachment works
+            # TODO: this is an indication we need to revamp either how the operator attachment works
             # or how the interfaces are distributed.
             self.r._markSynchronized()  # pylint: disable=protected-access
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1406,9 +1406,9 @@ class Block(composites.Composite):
             "Creating {} individual {} components on {}".format(nPins, fuel, self)
         )
 
-        # handle all other components that may be linked to the fuel multiplicity.
-        # by unlinking them and setting them directly
-        # XXX: what about other (actual) dimensions? This is a limitation in that only fuel
+        # Handle all other components that may be linked to the fuel multiplicity
+        # by unlinking them and setting them directly.
+        # TODO: What about other (actual) dimensions? This is a limitation in that only fuel
         # compuents are duplicated, and not the entire pin. It is also a reasonable assumption with
         # current/historical usage of ARMI.
         for comp, dim in self.getComponentsThatAreLinkedTo(fuel, "mult"):

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -393,7 +393,7 @@ class ArmiObject(metaclass=CompositeModelType):
         state["parent"] = None
 
         if "r" in state:
-            # XXX: This should never happen, it might make sense to raise an exception.
+            # TODO: This should never happen, it might make sense to raise an exception.
             del state["r"]
 
         return state

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -561,7 +561,6 @@ def _radarFactory(numVars, frame="circle"):
         Number of variables for radar chart.
     frame : {'circle' | 'polygon'}
         Shape of frame surrounding axes.
-
     """
     # calculate evenly-spaced axis angles
     # rotate theta such that the first axis is at the top
@@ -581,8 +580,6 @@ def _radarFactory(numVars, frame="circle"):
     def close_line(line):
         """Closes the input line."""
         x, y = line.get_data()
-        # pylint: disable=fixme
-        # FIXME: markers at x[0], y[0] get doubled-up
         if x[0] != x[-1]:
             x = numpy.concatenate((x, [x[0]]))
             y = numpy.concatenate((y, [y[0]]))

--- a/armi/utils/tests/test_triangle.py
+++ b/armi/utils/tests/test_triangle.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-r""" Test the basic triangle math.
-"""
+""" Test the basic triangle math."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,unused-variable
 import unittest
 from armi.utils import triangle
@@ -88,7 +87,9 @@ class TestTriangle(unittest.TestCase):
         y3 = 0.376
         xP = 0.0
         yP = 0.17
-        # FIXME: generalTriangleInOrOut = triangle.checkIfPointIsInTriangle(xT1, yT1, xT2, yT2, xT3, yT3, xP, yP)
+        generalTriangleInOrOut = triangle.checkIfPointIsInTriangle(
+            xT1, yT1, xT2, yT2, xT3, yT3, xP, yP
+        )
         self.assertFalse(generalTriangleInOrOut)
 
     def test_checkIfPointIsInTriangle2(self):

--- a/doc/developer/standards_and_practices.rst
+++ b/doc/developer/standards_and_practices.rst
@@ -303,4 +303,4 @@ do not use ``print``
     ARMI code should not use the ``print`` function; use one of the methods within ``armi.runLog``.
 
 Do not add new ``TODO`` statements in your commits and PRs.
-    If your new ``TODO`` statement is important, it should be a GitHub Issue. Yes, we have existing ``TODO`` statements in the code, those are relic and should be handled.
+    If your new ``TODO`` statement is important, it should be a GitHub Issue. Yes, we have existing ``TODO`` statements in the code, those are relic and need to be removed. Also, never mark the code with ``FIXME`` or ``XXX```; open a ticket.

--- a/pylintrc
+++ b/pylintrc
@@ -103,4 +103,4 @@ ignored-classes = argparse.Namespace
 
 [MISCELLANEOUS]
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX
+notes=TODO


### PR DESCRIPTION
## Description

ARMI has like 50 `TODO`s, which I want to remove and make tickets (or just fix).  But since we have a code freeze, that will have to wait.  

We also had like 3 `FIXME`s and a few `XXX`s.   But some of those were meant to be `TODO`s, and some were meant to be `NOTE`s.  Since even _I_ found it confusing, I am just replacing all `FIXME` and `XXX` with `NOTE` or `TODO`, and putting it in the docs that we don't allow `FIXME` or `XXX` any more.

I am just aiming to make the project more clear.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
