### PR TITLE
Building helper tool for when Parameters need to be NumPy arrays

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -20,11 +20,12 @@ which will enable modular construction of apps.
 """
 import numpy
 
-from armi.reactor import parameters
-from armi.reactor.parameters import ParamLocation
-from armi.reactor.blocks import Block
-from armi.reactor.reactors import Core
 from armi.physics.neutronics.settings import CONF_DPA_PER_FLUENCE
+from armi.reactor import parameters
+from armi.reactor.blocks import Block
+from armi.reactor.parameters import ParamLocation
+from armi.reactor.parameters.parameterDefinitions import isNumpyArray
+from armi.reactor.reactors import Core
 
 
 def getNeutronicsParameterDefinitions():
@@ -270,15 +271,9 @@ def _getNeutronicsBlockParams():
             ],
         )
 
-        def linPowByPin(self, value):
-            if value is None or isinstance(value, numpy.ndarray):
-                self._p_linPowByPin = value
-            else:
-                self._p_linPowByPin = numpy.array(value)
-
         pb.defParam(
             "linPowByPin",
-            setter=linPowByPin,
+            setter=isNumpyArray("linPowByPin"),
             units="W/cm",
             description=(
                 "Pin linear linear heat rate, which is calculated through flux reconstruction and "
@@ -292,16 +287,10 @@ def _getNeutronicsBlockParams():
             default=None,
         )
 
-        def linPowByPinNeutron(self, value):
-            if value is None or isinstance(value, numpy.ndarray):
-                self._p_linPowByPinNeutron = value
-            else:
-                self._p_linPowByPinNeutron = numpy.array(value)
-
         # gamma category because linPowByPin is only split by neutron/gamma when gamma is activated
         pb.defParam(
             "linPowByPinNeutron",
-            setter=linPowByPinNeutron,
+            setter=isNumpyArray("linPowByPinNeutron"),
             units="W/cm",
             description="Pin linear neutron heat rate. This is the neutron heating component of `linPowByPin`",
             location=ParamLocation.CHILDREN,
@@ -309,15 +298,9 @@ def _getNeutronicsBlockParams():
             default=None,
         )
 
-        def linPowByPinGamma(self, value):
-            if value is None or isinstance(value, numpy.ndarray):
-                self._p_linPowByPinGamma = value
-            else:
-                self._p_linPowByPinGamma = numpy.array(value)
-
         pb.defParam(
             "linPowByPinGamma",
-            setter=linPowByPinGamma,
+            setter=isNumpyArray("linPowByPinGamma"),
             units="W/cm",
             description="Pin linear gamma heat rate. This is the gamma heating component of `linPowByPin`",
             location=ParamLocation.CHILDREN,

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -45,13 +45,6 @@ def _getNeutronicsBlockParams():
             categories=[parameters.Category.retainOnReplacement],
         )
 
-        def mgFlux(self, value):
-            self._p_mgFlux = (
-                value
-                if value is None or isinstance(value, numpy.ndarray)
-                else numpy.array(value)
-            )
-
         pb.defParam(
             "mgFlux",
             setter=isNumpyArray("mgFlux"),

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -332,6 +332,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "pointsEdgeDpa",
+            setter=isNumpyArray("pointsEdgeDpa"),
             units="dpa",
             description="displacements per atom at edges of the block",
             categories=["cumulative", "detailedAxialExpansion", "depletion"],
@@ -339,6 +340,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "pointsEdgeDpaRate",
+            setter=isNumpyArray("pointsEdgeDpaRate"),
             units="dpa/s",
             description="Current time derivative of the displacement per atoms at edges of the block",
         )
@@ -366,6 +368,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "pointsCornerDpa",
+            setter=isNumpyArray("pointsCornerDpa"),
             units="dpa",
             description="displacements per atom at corners of the block",
             location=ParamLocation.CORNERS,
@@ -374,6 +377,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "pointsCornerDpaRate",
+            setter=isNumpyArray("pointsCornerDpaRate"),
             units="dpa/s",
             description="Current time derivative of the displacement per atoms at corners of the block",
         )

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -54,7 +54,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "mgFlux",
-            setter=mgFlux,
+            setter=isNumpyArray("mgFlux"),
             units="n-cm/s",
             description="multigroup volume-integrated flux",
             location=ParamLocation.VOLUME_INTEGRATED,

--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -17,9 +17,10 @@ import numpy
 
 from armi import runLog
 from armi.reactor import parameters
-from armi.reactor.parameters import ParamLocation
-from armi.utils import units
 from armi.reactor.flags import Flags  # non-standard import to avoid name conflict below
+from armi.reactor.parameters import ParamLocation
+from armi.reactor.parameters.parameterDefinitions import isNumpyArray
+from armi.utils import units
 
 
 def getAssemblyParameterDefinitions():
@@ -27,15 +28,9 @@ def getAssemblyParameterDefinitions():
 
     with pDefs.createBuilder() as pb:
 
-        def powerDecay(self, value):
-            if value is None or isinstance(value, numpy.ndarray):
-                self._p_powerDecay = value
-            else:
-                self._p_powerDecay = numpy.array(value)
-
         pb.defParam(
             "powerDecay",
-            setter=powerDecay,
+            setter=isNumpyArray("powerDecay"),
             units="W",
             description="List of decay heats at each time step specified in "
             "decayHeatCalcTimesInSeconds setting.",
@@ -133,16 +128,9 @@ def getAssemblyParameterDefinitions():
 
     with pDefs.createBuilder(location=ParamLocation.AVERAGE) as pb:
 
-        def detailedNDens(self, value):
-            """Ensures that data is stored in an numpy array to save memory/space."""
-            if value is None or isinstance(value, numpy.ndarray):
-                self._p_detailedNDens = value
-            else:
-                self._p_detailedNDens = numpy.array(value)
-
         pb.defParam(
             "detailedNDens",
-            setter=detailedNDens,
+            setter=isNumpyArray("detailedNDens"),
             units="atoms/bn-cm",
             description=(
                 "High-fidelity number density vector with up to thousands of nuclides. "

--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -17,7 +17,7 @@ import numpy
 
 from armi import runLog
 from armi.reactor import parameters
-from armi.reactor.flags import Flags  # non-standard import to avoid name conflict below
+from armi.reactor.flags import Flags
 from armi.reactor.parameters import ParamLocation
 from armi.reactor.parameters.parameterDefinitions import isNumpyArray
 from armi.utils import units

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -18,11 +18,11 @@ import six
 
 from armi import runLog
 from armi.physics.neutronics import crossSectionGroupManager
-from armi.utils import units
-from armi.utils.units import ASCII_LETTER_A
-
 from armi.reactor import parameters
 from armi.reactor.parameters import ParamLocation, Parameter, NoDefault
+from armi.reactor.parameters.parameterDefinitions import isNumpyArray
+from armi.utils import units
+from armi.utils.units import ASCII_LETTER_A
 
 
 def getBlockParameterDefinitions():
@@ -49,16 +49,9 @@ def getBlockParameterDefinitions():
             location=ParamLocation.CHILDREN,
         )
 
-        def detailedNDens(self, value):
-            """Ensures that data is stored in an numpy array to save memory/space."""
-            if value is None or isinstance(value, numpy.ndarray):
-                self._p_detailedNDens = value
-            else:
-                self._p_detailedNDens = numpy.array(value)
-
         pb.defParam(
             "detailedNDens",
-            setter=detailedNDens,
+            setter=isNumpyArray("detailedNDens"),
             units="atoms/bn-cm",
             description=(
                 "High-fidelity number density vector with up to thousands of nuclides. "

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -184,7 +184,7 @@ class Serializer:
 
 
 def isNumpyArray(paramStr):
-    """Helper meta-method to return a method that sets a Parameter value to a NumPy array.
+    """Helper meta-function to create a method that sets a Parameter value to a NumPy array.
 
     Parameters
     ----------

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -26,16 +26,15 @@ See Also
 --------
 armi.reactor.parameters
 """
-import enum
-import re
-import functools
 from typing import Any, Dict, Optional, Sequence, Tuple, Type
+import enum
+import functools
+import re
 
 import numpy
 
 from armi.reactor.flags import Flags
-
-from .exceptions import ParameterError, ParameterDefinitionError
+from armi.reactor.parameters.exceptions import ParameterError, ParameterDefinitionError
 
 # bitwise masks for high-speed operations on the `assigned` attribute
 # (see http://www.vipan.com/htdocs/bitwisehelp.html)
@@ -182,6 +181,24 @@ class Serializer:
     ) -> Sequence[any]:
         """Given packed data and attributes, return the unpacked data."""
         raise NotImplementedError()
+
+
+def isNumpyArray(paramStr):
+    """Helper meta-method to return a method that sets a Parameter value to a NumPy array.
+
+    Parameters
+    ----------
+    paramStr : str
+        Name of the Parameter we want to set.
+    """
+
+    def setParameter(selfObj, value):
+        if value is None or isinstance(value, numpy.ndarray):
+            setattr(selfObj, "_p_" + paramStr, value)
+        else:
+            setattr(selfObj, "_p_" + paramStr, numpy.array(value))
+
+    return setParameter
 
 
 @functools.total_ordering

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -190,6 +190,11 @@ def isNumpyArray(paramStr):
     ----------
     paramStr : str
         Name of the Parameter we want to set.
+
+    Returns
+    -------
+    function
+        A setter method on the Parameter class to force the value to be a NumPy array.
     """
 
     def setParameter(selfObj, value):

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -17,9 +17,10 @@ Reactor parameter definitions.
 """
 import numpy
 
-from armi.utils import units
 from armi.reactor import parameters
 from armi.reactor.parameters import ParamLocation
+from armi.reactor.parameters.parameterDefinitions import isNumpyArray
+from armi.utils import units
 
 
 def defineReactorParameters():
@@ -111,15 +112,9 @@ def defineCoreParameters():
 
     with pDefs.createBuilder() as pb:
 
-        def detailedNucKeys(self, value):
-            if value is None or isinstance(value, numpy.ndarray):
-                self._p_detailedNucKeys = value
-            else:
-                self._p_detailedNucKeys = numpy.array(value)
-
         pb.defParam(
             "detailedNucKeys",
-            setter=detailedNucKeys,
+            setter=isNumpyArray("detailedNucKeys"),
             units="ZZZAAA (ZZZ atomic number, AAA mass number, + 100 * m for metastable states",
             description="Nuclide vector keys, used to map densities in b.p.detailedNDens and a.p.detailedNDens",
             saveToDB=True,


### PR DESCRIPTION
## Description

The request was made (https://github.com/terrapower/armi/issues/1286) to enforce that these parameters were NumPy arrays (and not lists): `pointsCornerDpa`, `pointsCornerDpaRate`, `pointsEdgeDpa`, and `pointsEdgeDpaRate`.

While @Nebbychadnezzar was hoping we could force all such parameters to NumPy arrays by default, I think that is a half-measure and the real solution is to fix the types of all ARMI Parameters. That would lead to a much more stream-lined solution that would help with ALL Parameters, and would yield a much more time/space efficient ARMI model in general.

But, until we get there, I have generated a helper function (`isNumpyArray()`) that I think streamlines the code we have, and makes supporting more such parameters easier.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
