### PR TITLE
undo setting ndense to 0 for xs gen; move feature to xs gen

### DIFF
--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -161,17 +161,6 @@ class FissionProductModel(interfaces.Interface):
         else:
             self.setAllBlockLFPs()
 
-    def _getComponentToInitDensities(self, b):
-        """Get the component to initialize ndens keys on."""
-        # add the isotopics to the smallest solid since that is usually the most "interesting"
-        # sorted() calls getBoundingCircleOuterDiameter under the hood
-        solidsOrderedBySize = sorted(c for c in b if c.containsSolidMaterial())
-        if solidsOrderedBySize:
-            return solidsOrderedBySize[0]
-        else:
-            # no solids, so just add to smallest component
-            return sorted(c for c in b)[0]
-
     def setAllComponentFissionProducts(self):
         """
         Initialize all nuclides for each ``DEPLETABLE`` component in the core.

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -174,7 +174,7 @@ class FissionProductModel(interfaces.Interface):
 
     def setAllComponentFissionProducts(self):
         """
-        Initialize all nuclides for each ``DEPLETABLE`` component in the core, or all blocks if detailedAxialExpansion is enabled.
+        Initialize all nuclides for each ``DEPLETABLE`` component in the core.
 
         Notes
         -----

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -104,7 +104,7 @@ from armi.physics.neutronics.fissionProductModel.fissionProductModelSettings imp
     CONF_FP_MODEL,
     CONF_MAKE_ALL_BLOCK_LFPS_INDEPENDENT,
 )
-from armi.settings.fwSettings.globalSettings import CONF_DETAILED_AXIAL_EXPANSION
+
 
 NUM_FISSION_PRODUCTS_PER_LFP = 2.0
 
@@ -125,10 +125,6 @@ class FissionProductModel(interfaces.Interface):
     def __init__(self, r, cs):
         interfaces.Interface.__init__(self, r, cs)
         self._globalLFPs = lumpedFissionProduct.lumpedFissionProductFactory(self.cs)
-        # If detailed axial expansion is active, mapping between blocks occurs on uniform mesh
-        # and this can cause blocks to have isotopes that they don't have cross sections for.
-        # Fix this by adding all isotopes to all blocks so they are present it lattice physics.
-        self.allBlocksNeedAllNucs = self.cs[CONF_DETAILED_AXIAL_EXPANSION]
 
     @property
     def _explicitFissionProducts(self):
@@ -156,10 +152,7 @@ class FissionProductModel(interfaces.Interface):
         products be consistent across all blocks, even if fission products are
         not generated when the block is depleted.
         """
-        if self.getInterface("mcnp") or self.allBlocksNeedAllNucs:
-            return None
-        else:
-            return Flags.FUEL
+        return None if self.getInterface("mcnp") is not None else Flags.FUEL
 
     def interactBOL(self):
         interfaces.Interface.interactBOL(self)
@@ -187,12 +180,7 @@ class FissionProductModel(interfaces.Interface):
         -----
         This should be called when explicit fission product modeling is enabled to
         ensure that all isotopes are initialized on the depletable components within
-        the reactor data model so that cross sections are created during depletion.
-
-        When detailedAxialExpansion is also enabled, all regions will have fission/activation
-        products added to avoid missing cross sections during mesh conversion (since converted
-        blocks only have one xsID but may have isotopes from multiple blocks with different IDs.)
-        Setting density to zero here enables small number densities is XS generation.
+        the reactor data model so that there is some density as a starting point.
 
         When explicit fission products are enabled and the user has not already included
         all fission products in the blueprints (in ``nuclideFlags``), the ``fpModelLibrary`` setting is used
@@ -210,28 +198,15 @@ class FissionProductModel(interfaces.Interface):
         """
         for b in self.r.core.getBlocks(includeAll=True):
             b.setLumpedFissionProducts(None)
-            self._initializeIsoDensities(b)
-
-    def _initializeIsoDensities(self, b):
-        """
-        Initialize isotope densities to include all on depletable components.
-
-        Notes
-        -----
-        In non-uniform reactor cases all blocks will get all isotopes so that the
-        global flux solve does not have any missing cross sections.
-        """
-        compsToAddIso = b.getComponents(Flags.DEPLETABLE)
-        if self.allBlocksNeedAllNucs and not compsToAddIso:
-            compsToAddIso = [self._getComponentToInitDensities(b)]
-        for c in compsToAddIso:
-            # Add all isotopes in problem at 0.0 density
-            updatedNDens = c.getNumberDensities()
-            for nuc in self.r.blueprints.allNuclidesInProblem:
-                if nuc in updatedNDens:
-                    continue
-                updatedNDens[nuc] = 0.0
-            c.updateNumberDensities(updatedNDens)
+            for c in b.getComponents(Flags.DEPLETABLE):
+                # Add all isotopes in problem at 0.0 density
+                updatedNDens = c.getNumberDensities()
+                # self.r.blueprints.allNuclidesInProblem contains ~everything in ENDF if _explicitFissionProducts
+                for nuc in self.r.blueprints.allNuclidesInProblem:
+                    if nuc in updatedNDens:
+                        continue
+                    updatedNDens[nuc] = 0.0
+                c.updateNumberDensities(updatedNDens)
 
     def setAllBlockLFPs(self):
         """
@@ -247,8 +222,6 @@ class FissionProductModel(interfaces.Interface):
             else:
                 independentLFPs = self.getGlobalLumpedFissionProducts().duplicate()
                 b.setLumpedFissionProducts(independentLFPs)
-            if self.allBlocksNeedAllNucs:
-                self._initializeIsoDensities(b)
 
     def getGlobalLumpedFissionProducts(self):
         r"""

--- a/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
@@ -93,15 +93,6 @@ class TestFissionProductModelLumpedFissionProducts(unittest.TestCase):
         else:
             self.assertTrue(False, "All blocks have all nuclides!")
 
-        # now check if detailed axial expansion that all blocks have ALL nuclides
-        fpModel.allBlocksNeedAllNucs = True
-        fpModel.interactBOL()
-        for b in r.core.getBlocks():
-            nuclideList = b.getNuclides()
-            for nuc in r.blueprints.allNuclidesInProblem:
-                self.assertIn(nuc, nuclideList)
-            self.assertTrue(b._lumpedFissionProducts is not None)
-
 
 class TestFissionProductModelExplicitMC2Library(unittest.TestCase):
     """
@@ -169,15 +160,6 @@ class TestFissionProductModelExplicitMC2Library(unittest.TestCase):
                     self.assertIn(nb.name, nuclideList)
             else:
                 self.assertLess(len(b.getNuclides()), len(nuclideBases.byMcc3Id))
-
-        # now check if detailed axial expansion that all blocks have detailed nuclides
-        self.fpModel.allBlocksNeedAllNucs = True
-
-        self.fpModel.interactBOL()
-        for b in self.r.core.getBlocks():
-            nuclideList = b.getNuclides()
-            for nb in nuclideBases.byMcc3Id.values():
-                self.assertIn(nb.name, nuclideList)
 
 
 if __name__ == "__main__":

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -25,6 +25,7 @@ import math
 import collections
 
 import numpy
+import ordered_set
 
 from armi import runLog
 from armi import interfaces
@@ -249,7 +250,7 @@ class LatticePhysicsWriter(interfaces.InputWriter):
             if self.cs[CONF_DETAILED_AXIAL_EXPANSION]:
                 nuclides = self.r.blueprints.allNuclidesInProblem
             else:
-                nuclides = sorted(objNuclides)
+                nuclides = ordered_set.OrderedSet(sorted(objNuclides))
         else:
             nuclides = self.r.blueprints.allNuclidesInProblem
 

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -253,7 +253,7 @@ class LatticePhysicsWriter(interfaces.InputWriter):
         else:
             nuclides = self.r.blueprints.allNuclidesInProblem
 
-        nuclides = nuclides.union(self.r.core.blueprints.nucsToForceInXsGen)
+        nuclides = nuclides.union(self.r.blueprints.nucsToForceInXsGen)
 
         numDensities = subjectObject.getNuclideNumberDensities(nuclides)
 

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -245,7 +245,7 @@ class LatticePhysicsWriter(interfaces.InputWriter):
         if self.explicitFissionProducts:
             # If detailed axial expansion is active, mapping between blocks occurs on uniform mesh
             # and this can cause blocks to have isotopes that they don't have cross sections for.
-            # Fix this by adding all isotopes so they are present it lattice physics.
+            # Fix this by adding all isotopes so they are present in lattice physics.
             if self.cs[CONF_DETAILED_AXIAL_EXPANSION]:
                 nuclides = self.r.blueprints.allNuclidesInProblem
             else:
@@ -280,7 +280,7 @@ class LatticePhysicsWriter(interfaces.InputWriter):
             nucCategory = ""
             # Remove nuclides from detailed fission product dictionary if they are a part of the core materials
             # (e.g., Zr in the U10Zr which is at fuel temperature and Mo in HT9 which is at structure temp)
-            if nuc in list(dfpDensities):
+            if nuc in dfpDensities:
                 density += dfpDensities[nuc]
                 nucCategory += self.FISSION_PRODUCT_CATEGORY + self._SEPARATOR
                 del dfpDensities[nuc]

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -440,20 +440,18 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             elif elemental.name in inerts:
                 currentSet = inerts
             else:
-                # This was not specified in the nuclide flags at all.
+                # This was not specified in the nuclide flags at all as burn or xs.
                 # If a material with this in its composition is brought in
                 # it's nice from a user perspective to allow it.
                 # But current behavior is that all nuclides in problem
                 # must be declared up front.
-                if wasInOriginalFlags:
-                    nucsToForceInXsGen.add(elemental.name)
                 continue
 
             self.elementsToExpand.append(elemental.element)
 
             if (
                 elemental.name in self.nuclideFlags
-                and self.nuclideFlags[elemental.name.symbol].expandTo
+                and self.nuclideFlags[elemental.element.symbol].expandTo
             ):
                 # user-input expandTo has precedence
                 newNuclides = [

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -453,7 +453,7 @@ def getDefaultNuclideFlags():
     return nuclideFlags
 
 
-def expansionBasedOnCodeENDF(cs):
+def eleExpandInfoBasedOnCodeENDF(cs):
     """
     Intelligently choose elements to expand based on code and ENDF version.
 

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -565,7 +565,7 @@ def genDefaultNucFlags():
     return flags
 
 
-def autoUpdateNuclideFlags(cs, nuclideFlags):
+def autoUpdateNuclideFlags(cs, nuclideFlags, inerts):
     """
     This function is responsible for examining the fission product model treatment
     that is selected by the user and adding a set of nuclides to the `nuclideFlags`
@@ -591,8 +591,9 @@ def autoUpdateNuclideFlags(cs, nuclideFlags):
             nuc = nb.name
             if nuc in nuclideFlags or elements.byZ[nb.z] in nuclideFlags:
                 continue
-            nuclideFlag = NuclideFlag(nuc, burn=False, xs=True, expandTo=[])
-            nuclideFlags[nuc] = nuclideFlag
+            nuclideFlags[nuc] = NuclideFlag(nuc, burn=False, xs=True, expandTo=[])
+            # inert since burn is False
+            inerts.add(nuc)
 
 
 def getAllNuclideBasesByLibrary(cs):

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -107,9 +107,7 @@ class NuclideFlag(yamlize.Object):
             self.nuclideName, self.burn, self.xs
         )
 
-    def fileAsActiveOrInert(
-        self, activeSet, inertSet, undefinedBurnChainActiveNuclides
-    ):
+    def fileAsActiveOrInert(self, activeSet, inertSet):
         """
         Given a nuclide or element name, file it as either active or inert.
 
@@ -117,6 +115,7 @@ class NuclideFlag(yamlize.Object):
         rather than the NaturalNuclideBase, as the NaturalNuclideBase will never
         occur in such a problem.
         """
+        undefBurnChainActiveNuclides = set()
         nb = nuclideBases.byName[self.nuclideName]
         if self.expandTo:
             nucBases = [nuclideBases.byName[nn] for nn in self.expandTo]
@@ -129,11 +128,11 @@ class NuclideFlag(yamlize.Object):
             if self.burn:
                 if not nuc.trans and not nuc.decays:
                     # DUMPs and LFPs usually
-                    undefinedBurnChainActiveNuclides.add(nuc.name)
+                    undefBurnChainActiveNuclides.add(nuc.name)
                 activeSet.add(nuc.name)
             if self.xs:
                 inertSet.add(nuc.name)
-        return expanded
+        return expanded, undefBurnChainActiveNuclides
 
 
 class NuclideFlags(yamlize.KeyedList):
@@ -454,9 +453,9 @@ def getDefaultNuclideFlags():
     return nuclideFlags
 
 
-def autoSelectElementsToKeepFromSettings(cs):
+def expansionBasedOnCodeENDF(cs):
     """
-    Intelligently choose elements to expand based on settings.
+    Intelligently choose elements to expand based on code and ENDF version.
 
     If settings point to a particular code and library and we know
     that combo requires certain elementals to be expanded, we

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -10,6 +10,7 @@ What's new in ARMI
 ------------------
 #. Calculate weighted-average percent burnup of BlockCollections. (`PR#1265 <https://github.com/terrapower/armi/pull/1265>`_)
 #. Added ``Composite.sort()`` to allow the user to recursively sort any piece of the ``Reactor``. (`PR#1280 <https://github.com/terrapower/armi/pull/1280>`_)
+#  Revert "when using non-uniform mesh, detailed fission/activation products have cross sections generated to avoid blocks without xs data" and move capability to lattice physics (`PR#1280 <https://github.com/terrapower/armi/pull/1298>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## Description

Undo #1257 since it impacts memory and database. Add features to lattice physics

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
