### PR TITLE
Improving HexBlock getWettedPerimeter calculation

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2211,12 +2211,27 @@ class HexBlock(Block):
                 6 * c.getDimension("ip") / math.sqrt(3) if c else 0.0
             )
 
+        # account for the wire warp in the wetted perimeter
+        try:
+            wire = self.getComponent(Flags.WIRE)
+            if wire is not None:
+                correctionFactor = numpy.hypot(
+                    1.0,
+                    math.pi
+                    * wire.getDimension("helixDiameter")
+                    / wire.getDimension("axialPitch"),
+                )
+            else:
+                correctionFactor = 1.0
+        except ValueError:
+            correctionFactor = 1.0
+
         # solid circle = od * pi
         # NOTE: since these are pin components, multiply by the number of pins
         wettedPinPerimeter = 0.0
         for c in wettedPinComponents:
             wettedPinPerimeter += c.getDimension("od") if c else 0.0
-        wettedPinPerimeter *= self.getNumPins() * math.pi
+        wettedPinPerimeter *= self.getNumPins() * math.pi * correctionFactor
 
         # hollow circle = (id + od) * pi
         wettedHollowCirclePerimeter = 0.0

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2243,22 +2243,6 @@ class HexBlock(Block):
             + wettedHollowCirclePerimeter
         )
 
-    def whatever(self):
-        wettedPinPerimeter = 0.0
-        for c in wettedPinComponents:
-            if c is None:
-                continue
-            correctionFactor = 1.0
-            if c.hasFlag(Flags.WIRE) and isinstance(Helix):
-                correctionFactor = numpy.hypot(
-                    1.0,
-                    math.pi
-                    * c.getDimension("helixDiameter")
-                    / c.getDimension("axialPitch"),
-                )
-            wettedPinPerimeter += c.getDimension("od") * correctionFactor
-        wettedPinPerimeter *= self.getNumPins() * math.pi
-
     def getFlowArea(self):
         """
         Return the total flowing coolant area of the block in cm^2.

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -27,19 +27,20 @@ import math
 
 import numpy
 
+from armi import nuclideBases
 from armi import runLog
 from armi.bookkeeping import report
-from armi import nuclideBases
 from armi.physics.neutronics import GAMMA
 from armi.physics.neutronics import NEUTRON
-from armi.reactor.components import basicShapes
 from armi.reactor import blockParameters
 from armi.reactor import components
-from armi.reactor.components.basicShapes import Hexagon, Circle
 from armi.reactor import composites
 from armi.reactor import geometry
 from armi.reactor import grids
 from armi.reactor import parameters
+from armi.reactor.components import basicShapes
+from armi.reactor.components.basicShapes import Hexagon, Circle
+from armi.reactor.components.complexShapes import Helix
 from armi.reactor.flags import Flags
 from armi.reactor.parameters import ParamLocation
 from armi.utils import densityTools
@@ -2211,30 +2212,22 @@ class HexBlock(Block):
                 6 * c.getDimension("ip") / math.sqrt(3) if c else 0.0
             )
 
-        # account for the wire warp in the wetted perimeter
-        try:
-            wire = self.getComponent(Flags.WIRE)
-            if wire is not None:
+        # solid circle = NumPins * pi * (Comp Diam + Wire Diam)
+        wettedPinPerimeter = 0.0
+        for c in wettedPinComponents:
+            if c is None:
+                continue
+            correctionFactor = 1.0
+            if c.hasFlags(Flags.WIRE) and isinstance(c, Helix):
+                # account for the wire
                 correctionFactor = numpy.hypot(
                     1.0,
                     math.pi
-                    * wire.getDimension("helixDiameter")
-                    / wire.getDimension("axialPitch"),
+                    * c.getDimension("helixDiameter")
+                    / c.getDimension("axialPitch"),
                 )
-                wireDiameter = wire.getDimension("od") * correctionFactor
-            else:
-                wireDiameter = 0.0
-        except ValueError:
-            wireDiameter = 0.0
-
-        # solid circle = od * pi
-        # NOTE: since these are pin components, multiply by the number of pins
-        wettedPinDiameter = 0.0
-        for c in wettedPinComponents:
-            wettedPinDiameter += c.getDimension("od") if c else 0.0
-        wettedPinPerimeter = (
-            self.getNumPins() * math.pi * (wettedPinDiameter + wireDiameter)
-        )
+            wettedPinPerimeter += c.getDimension("od") * correctionFactor
+        wettedPinPerimeter *= self.getNumPins() * math.pi
 
         # hollow circle = (id + od) * pi
         wettedHollowCirclePerimeter = 0.0
@@ -2249,6 +2242,22 @@ class HexBlock(Block):
             + wettedPinPerimeter
             + wettedHollowCirclePerimeter
         )
+
+    def whatever(self):
+        wettedPinPerimeter = 0.0
+        for c in wettedPinComponents:
+            if c is None:
+                continue
+            correctionFactor = 1.0
+            if c.hasFlag(Flags.WIRE) and isinstance(Helix):
+                correctionFactor = numpy.hypot(
+                    1.0,
+                    math.pi
+                    * c.getDimension("helixDiameter")
+                    / c.getDimension("axialPitch"),
+                )
+            wettedPinPerimeter += c.getDimension("od") * correctionFactor
+        wettedPinPerimeter *= self.getNumPins() * math.pi
 
     def getFlowArea(self):
         """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2221,17 +2221,20 @@ class HexBlock(Block):
                     * wire.getDimension("helixDiameter")
                     / wire.getDimension("axialPitch"),
                 )
+                wireDiameter = wire.getDimension("od") * correctionFactor
             else:
-                correctionFactor = 1.0
+                wireDiameter = 0.0
         except ValueError:
-            correctionFactor = 1.0
+            wireDiameter = 0.0
 
         # solid circle = od * pi
         # NOTE: since these are pin components, multiply by the number of pins
-        wettedPinPerimeter = 0.0
+        wettedPinDiameter = 0.0
         for c in wettedPinComponents:
-            wettedPinPerimeter += c.getDimension("od") if c else 0.0
-        wettedPinPerimeter *= self.getNumPins() * math.pi * correctionFactor
+            wettedPinDiameter += c.getDimension("od") if c else 0.0
+        wettedPinPerimeter = (
+            self.getNumPins() * math.pi * (wettedPinDiameter + wireDiameter)
+        )
 
         # hollow circle = (id + od) * pi
         wettedHollowCirclePerimeter = 0.0

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2215,11 +2215,9 @@ class HexBlock(Block):
         # solid circle = NumPins * pi * (Comp Diam + Wire Diam)
         wettedPinPerimeter = 0.0
         for c in wettedPinComponents:
-            if c is None:
-                continue
             correctionFactor = 1.0
-            if c.hasFlags(Flags.WIRE) and isinstance(c, Helix):
-                # account for the wire
+            if isinstance(c, Helix):
+                # account for the helical wire wrap
                 correctionFactor = numpy.hypot(
                     1.0,
                     math.pi

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -747,7 +747,7 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(cur, ref, places=places)
 
     def test_replaceBlockWithBlock(self):
-        r"""Tests conservation of mass flag in replaceBlockWithBlock."""
+        """Tests conservation of mass flag in replaceBlockWithBlock."""
         block = self.block
         ductBlock = block.__class__("duct")
         ductBlock.add(block.getComponent(Flags.COOLANT, exact=True))
@@ -771,13 +771,25 @@ class Block_TestCase(unittest.TestCase):
 
     def test_getWettedPerimeter(self):
         cur = self.block.getWettedPerimeter()
+
+        wire = self.block.getComponent(Flags.WIRE)
+        correctionFactor = numpy.hypot(
+            1.0,
+            math.pi
+            * wire.getDimension("helixDiameter")
+            / wire.getDimension("axialPitch"),
+        )
+
         ref = math.pi * (
             self.block.getDim(Flags.CLAD, "od") + self.block.getDim(Flags.WIRE, "od")
-        ) * self.block.getDim(Flags.CLAD, "mult") + 6 * self.block.getDim(
+        ) * correctionFactor * self.block.getDim(
+            Flags.CLAD, "mult"
+        ) + 6 * self.block.getDim(
             Flags.DUCT, "ip"
         ) / math.sqrt(
             3
         )
+
         self.assertAlmostEqual(cur, ref)
 
     def test_getFlowAreaPerPin(self):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -771,7 +771,25 @@ class Block_TestCase(unittest.TestCase):
 
     def test_getWettedPerimeter(self):
         cur = self.block.getWettedPerimeter()
-        self.assertAlmostEqual(cur, 910.1118990260776)
+
+        wire = self.block.getComponent(Flags.WIRE)
+        correctionFactor = numpy.hypot(
+            1.0,
+            math.pi
+            * wire.getDimension("helixDiameter")
+            / wire.getDimension("axialPitch"),
+        )
+        wireDiameter = wire.getDimension("od") * correctionFactor
+
+        ref = math.pi * (
+            self.block.getDim(Flags.CLAD, "od") + wireDiameter
+        ) * self.block.getDim(Flags.CLAD, "mult") + 6 * self.block.getDim(
+            Flags.DUCT, "ip"
+        ) / math.sqrt(
+            3
+        )
+
+        self.assertAlmostEqual(cur, ref)
 
     def test_getFlowAreaPerPin(self):
         area = self.block.getComponent(Flags.COOLANT).getArea()

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -771,26 +771,7 @@ class Block_TestCase(unittest.TestCase):
 
     def test_getWettedPerimeter(self):
         cur = self.block.getWettedPerimeter()
-
-        wire = self.block.getComponent(Flags.WIRE)
-        correctionFactor = numpy.hypot(
-            1.0,
-            math.pi
-            * wire.getDimension("helixDiameter")
-            / wire.getDimension("axialPitch"),
-        )
-
-        ref = math.pi * (
-            self.block.getDim(Flags.CLAD, "od") + self.block.getDim(Flags.WIRE, "od")
-        ) * correctionFactor * self.block.getDim(
-            Flags.CLAD, "mult"
-        ) + 6 * self.block.getDim(
-            Flags.DUCT, "ip"
-        ) / math.sqrt(
-            3
-        )
-
-        self.assertAlmostEqual(cur, ref)
+        self.assertAlmostEqual(cur, 910.1118990260776)
 
     def test_getFlowAreaPerPin(self):
         area = self.block.getComponent(Flags.COOLANT).getArea()

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -15,7 +15,7 @@ What's new in ARMI
 Bug fixes
 ---------
 #. Changed units.FLOAT_DIMENSION_DECIMALS from 10 to 8 (`PR#1183 <https://github.com/terrapower/armi/pull/1183>`_)
-#. Improved ``Block.getWettedPerimeter()`` to include wire. (`PR#1298 <https://github.com/terrapower/armi/pull/1298>`_)
+#. Improved ``HexBlock.getWettedPerimeter()`` to include wire. (`PR#1299 <https://github.com/terrapower/armi/pull/1299>`_)
 #. Fixed a bug in the ISOTXS file name used for snapshots. (`PR#1277 <https://github.com/terrapower/armi/pull/1277>`_)
 #. Fix a bug in uniform mesh decusping when assemblies of same type have drastically different height. (`PR#1282 <https://github.com/terrapower/armi/pull/1282>`_)
 #. Sort components on representativeBlock for consistency check. (`PR#1275 <https://github.com/terrapower/armi/pull/1275>`_)

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -15,6 +15,7 @@ What's new in ARMI
 Bug fixes
 ---------
 #. Changed units.FLOAT_DIMENSION_DECIMALS from 10 to 8 (`PR#1183 <https://github.com/terrapower/armi/pull/1183>`_)
+#. Improved ``Block.getWettedPerimeter()`` to include wire. (`PR#1298 <https://github.com/terrapower/armi/pull/1298>`_)
 #. Fixed a bug in the ISOTXS file name used for snapshots. (`PR#1277 <https://github.com/terrapower/armi/pull/1277>`_)
 #. Fix a bug in uniform mesh decusping when assemblies of same type have drastically different height. (`PR#1282 <https://github.com/terrapower/armi/pull/1282>`_)
 #. Sort components on representativeBlock for consistency check. (`PR#1275 <https://github.com/terrapower/armi/pull/1275>`_)


### PR DESCRIPTION
## Description

Improving HexBlock getWettedPerimeter calculation to include wire wrap

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
