### PR TITLE
Adding unit tests to the LatticePhysicsWriter

### DIFF
--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -60,7 +60,7 @@ class TestLatticePhysicsWriter(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(TEST_ROOT)
         self.cs = self.o.cs
-        self.o.cs[CONF_CROSS_SECTION].setDefaults(
+        self.cs[CONF_CROSS_SECTION].setDefaults(
             self.cs[CONF_XS_BLOCK_REPRESENTATION],
             self.cs[CONF_DISABLE_BLOCK_TYPE_EXCLUSION_IN_XS_GENERATION],
         )
@@ -159,7 +159,6 @@ class TestLatticePhysicsWriter(unittest.TestCase):
 
     def test_getDetailedFissionProductsPass(self):
         self.cs[CONF_FP_MODEL] = "noFissionProducts"
-        self.o.cs[CONF_FP_MODEL] = "noFissionProducts"
 
         prods = self.w._getDetailedFissionProducts({})
         self.assertEqual(len(prods), 0)

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -14,9 +14,13 @@
 
 """Test the Lattice Physics Writer."""
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access,invalid-name,no-self-use,no-method-argument,import-outside-toplevel
+from collections import defaultdict
 import unittest
 
 from armi.physics.neutronics.const import CONF_CROSS_SECTION
+from armi.physics.neutronics.fissionProductModel.fissionProductModelSettings import (
+    CONF_FP_MODEL,
+)
 from armi.physics.neutronics.latticePhysics.latticePhysicsWriter import (
     LatticePhysicsWriter,
 )
@@ -53,31 +57,129 @@ class FakeLatticePhysicsWriter(LatticePhysicsWriter):
 class TestLatticePhysicsWriter(unittest.TestCase):
     """Test Lattice Physics Writer."""
 
-    def test_LatticePhysicsWriter(self):
-        """Super basic test of the LatticePhysicsWriter."""
-        o, r = loadTestReactor(TEST_ROOT)
-        cs = o.cs
-        o.cs[CONF_CROSS_SECTION].setDefaults(
-            cs[CONF_XS_BLOCK_REPRESENTATION],
-            cs[CONF_DISABLE_BLOCK_TYPE_EXCLUSION_IN_XS_GENERATION],
+    def setUp(self):
+        self.o, self.r = loadTestReactor(TEST_ROOT)
+        self.cs = self.o.cs
+        self.o.cs[CONF_CROSS_SECTION].setDefaults(
+            self.cs[CONF_XS_BLOCK_REPRESENTATION],
+            self.cs[CONF_DISABLE_BLOCK_TYPE_EXCLUSION_IN_XS_GENERATION],
         )
-        block = r.core.getFirstBlock()
-        w = FakeLatticePhysicsWriter(block, r, o)
+        self.block = self.r.core.getFirstBlock()
+        self.w = FakeLatticePhysicsWriter(self.block, self.r, self.o)
 
-        self.assertEqual(w.xsId, "AA")
-        self.assertFalse(w.modelFissionProducts)
-        self.assertEqual(w.driverXsID, "")
-        self.assertAlmostEqual(w.minimumNuclideDensity, 1e-15, delta=1e-16)
+    def test_latticePhysicsWriter(self):
+        """Super basic test of the LatticePhysicsWriter."""
+        self.assertEqual(self.w.xsId, "AA")
+        self.assertFalse(self.w.modelFissionProducts)
+        self.assertEqual(self.w.driverXsID, "")
+        self.assertAlmostEqual(self.w.minimumNuclideDensity, 1e-15, delta=1e-16)
 
-        self.assertEqual(w.testOut, "")
-        self.assertEqual(str(w), "<FakeLatticePhysicsWriter - XS ID AA (Neutron XS)>")
+        self.assertEqual(self.w.testOut, "")
+        self.assertEqual(
+            str(self.w), "<FakeLatticePhysicsWriter - XS ID AA (Neutron XS)>"
+        )
 
-        w._writeTitle(None)
-        self.assertIn("ARMI generated case for caseTitle armiRun", w.testOut)
+        self.w._writeTitle(None)
+        self.assertIn("ARMI generated case for caseTitle armiRun", self.w.testOut)
 
-        nucs = w._getAllNuclidesByTemperatureInC(None)
+        nucs = self.w._getAllNuclidesByTemperatureInC(None)
         self.assertEqual(len(nucs.keys()), 1)
         self.assertAlmostEqual(list(nucs.keys())[0], 450.0, delta=0.1)
+
+    def test_writeTitle(self):
+        self.w._writeTitle("test_writeTitle")
+        self.assertIn("ARMI generated case for caseTitle", self.w.testOut)
+
+    def test_isSourceDriven(self):
+        self.assertFalse(self.w._isSourceDriven)
+        self.w.driverXsID = True
+        self.assertTrue(self.w._isSourceDriven)
+
+    def test_isGammaXSGenerationEnabled(self):
+        self.assertFalse(self.w._isGammaXSGenerationEnabled)
+
+    def test_getAllNuclidesByTemperatureInCNone(self):
+        nucsByTemp = self.w._getAllNuclidesByTemperatureInC(None)
+        keys0 = list(nucsByTemp.keys())
+        self.assertEqual(len(keys0), 1)
+        self.assertEqual(keys0[0], 450.0)
+        keys1 = nucsByTemp[keys0[0]]
+        self.assertGreater(len(keys1), 1)
+        names = [k.name for k in keys1]
+        self.assertIn("AM241", names)
+        self.assertIn("U238", names)
+
+    def test_getAllNuclidesByTemperatureInC(self):
+        self.w.explicitFissionProducts = False
+        c = self.r.core[0][0]
+        nucsByTemp = self.w._getAllNuclidesByTemperatureInC(c)
+        keys0 = list(nucsByTemp.keys())
+        self.assertEqual(len(keys0), 1)
+        self.assertEqual(keys0[0], 450.0)
+        keys1 = nucsByTemp[keys0[0]]
+        self.assertGreater(len(keys1), 1)
+        names = [k.name for k in keys1]
+        self.assertIn("AM241", names)
+        self.assertIn("U238", names)
+
+    def test_getAllNuclidesByTemperatureInCExplicitFissionProducts(self):
+        self.w.explicitFissionProducts = True
+        c = self.r.core[0][0]
+        nucsByTemp = self.w._getAllNuclidesByTemperatureInC(c)
+        keys0 = list(nucsByTemp.keys())
+        self.assertEqual(len(keys0), 1)
+        self.assertEqual(keys0[0], 450.0)
+        keys1 = nucsByTemp[keys0[0]]
+        self.assertGreater(len(keys1), 1)
+        names = [k.name for k in keys1]
+        self.assertIn("AM241", names)
+        self.assertIn("U238", names)
+
+    def test_getAvgNuclideTemperatureInC(self):
+        temp = self.w._getAvgNuclideTemperatureInC("U238")
+        self.assertAlmostEqual(temp, 450, delta=0.001)
+
+        temp = self.w._getAvgNuclideTemperatureInC("U235")
+        self.assertAlmostEqual(temp, 450, delta=0.001)
+
+    def test_getFuelTemperature(self):
+        temp = self.w._getFuelTemperature()
+        self.assertAlmostEqual(temp, 450, delta=0.001)
+
+    def test_getDetailedFissionProducts(self):
+        dfpDen = defaultdict(int)
+        dfpDen["U238"] = 1.2
+        dfpDen["U235"] = 2.3
+        dfpDen["AM241"] = 3.4
+        prods = self.w._getDetailedFissionProducts(dfpDen)
+        self.assertEqual(len(prods), 3)
+        self.assertIn("U238", prods)
+        self.assertIn("U235", prods)
+        self.assertIn("AM241", prods)
+
+    def test_getDetailedFissionProductsPass(self):
+        self.cs[CONF_FP_MODEL] = "noFissionProducts"
+        self.o.cs[CONF_FP_MODEL] = "noFissionProducts"
+
+        prods = self.w._getDetailedFissionProducts({})
+        self.assertEqual(len(prods), 0)
+
+    def test_getDetailedFPDensities(self):
+        self.w.modelFissionProducts = False
+        dens = self.w._getDetailedFPDensities()
+        self.assertEqual(len(dens), 0)
+
+        self.w.modelFissionProducts = True
+        with self.assertRaises(AttributeError):
+            dens = self.w._getDetailedFPDensities()
+
+    def test_isCriticalBucklingSearchActive(self):
+        isActive = self.w._isCriticalBucklingSearchActive
+        self.assertTrue(isActive)
+
+    def test_getDriverBlock(self):
+        b = self.w._getDriverBlock()
+        self.assertIsNone(b)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What is the change?

I am adding unit tests to the `LatticePhysicsWriter` class.

## Why is the change being made?

This was requested by @opotowsky in ticket #1303

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
