### PR TITLE
Setting Burnup Peaking Factor to 0.0 when Undefined

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -749,6 +749,8 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
             burnupPeakingFactor = b.p.fluxPeak / b.p.flux
         elif not burnupPeakingFactor:
             # no peak available. Finite difference model?
+            # Use 0.0 for peaking so that there isn't misuse of peaking values that don't actually have peaking applied.
+            # Uet self.cs["burnupPeakingFactor"] or b.p.fluxPeak for different behavior
             burnupPeakingFactor = 0.0
 
         return burnupPeakingFactor

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -749,7 +749,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
             burnupPeakingFactor = b.p.fluxPeak / b.p.flux
         elif not burnupPeakingFactor:
             # no peak available. Finite difference model?
-            burnupPeakingFactor = 1.0
+            burnupPeakingFactor = 0.0
 
         return burnupPeakingFactor
 

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -337,11 +337,8 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
     def test_getBurnupPeakingFactorZero(self):
         mapper = globalFluxInterface.GlobalFluxResultMapper()
 
-        # test fuel block with fluxPeak set to None
-        mapper.cs["burnupPeakingFactor"] = 0.0
+        # test fuel block without any peaking factor set
         b = HexBlock("fuel", height=10.0)
-        b.p.flux = 100.0
-        b.p.fluxPeak = None
         factor = mapper.getBurnupPeakingFactor(b)
         self.assertEqual(factor, 0.0)
 

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -334,6 +334,16 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         factor = mapper.getBurnupPeakingFactor(b)
         self.assertEqual(factor, 2.5)
 
+    def test_getBurnupPeakingFactorZero(self):
+        mapper = globalFluxInterface.GlobalFluxResultMapper()
+
+        # test fuel block with fluxPeak set to None
+        mapper.cs["burnupPeakingFactor"] = 0.0
+        b = HexBlock("fuel", height=10.0)
+        b.p.flux = 100.0
+        b.p.fluxPeak = None
+        factor = mapper.getBurnupPeakingFactor(b)
+        self.assertEqual(factor, 0.0)
 
 class TestGlobalFluxUtils(unittest.TestCase):
     def test_calcReactionRates(self):

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -345,6 +345,7 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         factor = mapper.getBurnupPeakingFactor(b)
         self.assertEqual(factor, 0.0)
 
+
 class TestGlobalFluxUtils(unittest.TestCase):
     def test_calcReactionRates(self):
         """


### PR DESCRIPTION
## What is the change?
Originally, the `GlobalFluxInterface` block method `getBurnupPeakingFactor` was set to return `1.0` for the block burnup peaking factor if the factor was not already defined. The factor is changed to return `0.0` if no burnup peaking factor is already set.
<!-- MANDATORY: Describe the change -->

## Why is the change being made?
To eliminate confusion around what peaking parameters should be used for downstream analyses, the peaking factor is now set to `0.0` so that if the `burnupPeakingFactor` is undefined, the block burnup peaking factor will be `0.0` and this will propagate to other block properties that use the burnup peaking factor.  Any parameter using this peaking value when `burnupPeakingFactor` is undefined will return `0.0` so that it is clear to not use the results of the parameter. 
<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->



---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
