### PR TITLE
Fixing circular import in GlobalFluxInterface

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -34,19 +34,6 @@ from armi.reactor.converters import uniformMesh
 from armi.reactor.flags import Flags
 from armi.settings.caseSettings import Settings
 from armi.utils import units, codeTiming, getMaxBurnSteps
-from armi.physics.neutronics.settings import (
-    CONF_BOUNDARIES,
-    CONF_DPA_PER_FLUENCE,
-    CONF_EIGEN_PROB,
-    CONF_NEUTRONICS_KERNEL,
-    CONF_RESTART_NEUTRONICS,
-    CONF_ACLP_DOSE_LIMIT,
-    CONF_DPA_XS_SET,
-    CONF_GRID_PLATE_DPA_XS_SET,
-    CONF_LOAD_PAD_ELEVATION,
-    CONF_LOAD_PAD_LENGTH,
-    CONF_XS_KERNEL,
-)
 
 ORDER = interfaces.STACK_ORDER.FLUX
 
@@ -444,14 +431,31 @@ class GlobalFluxOptions(executers.ExecutionOptions):
 
         This is not required; these options can alternatively be set programmatically.
         """
+        from armi.physics.neutronics.settings import (
+            CONF_ACLP_DOSE_LIMIT,
+            CONF_BOUNDARIES,
+            CONF_DPA_PER_FLUENCE,
+            CONF_EIGEN_PROB,
+            CONF_LOAD_PAD_ELEVATION,
+            CONF_LOAD_PAD_LENGTH,
+            CONF_NEUTRONICS_KERNEL,
+            CONF_RESTART_NEUTRONICS,
+            CONF_XS_KERNEL,
+        )
+        from armi.settings.fwSettings.globalSettings import (
+            CONF_PHYSICS_FILES,
+            CONF_NON_UNIFORM_ASSEM_FLAGS,
+            CONF_DETAILED_AXIAL_EXPANSION,
+        )
+
         self.kernelName = cs[CONF_NEUTRONICS_KERNEL]
         self.setRunDirFromCaseTitle(cs.caseTitle)
         self.isRestart = cs[CONF_RESTART_NEUTRONICS]
         self.adjoint = neutronics.adjointCalculationRequested(cs)
         self.real = neutronics.realCalculationRequested(cs)
-        self.detailedAxialExpansion = cs["detailedAxialExpansion"]
+        self.detailedAxialExpansion = cs[CONF_DETAILED_AXIAL_EXPANSION]
         self.hasNonUniformAssems = any(
-            [Flags.fromStringIgnoreErrors(f) for f in cs["nonUniformAssemFlags"]]
+            [Flags.fromStringIgnoreErrors(f) for f in cs[CONF_NON_UNIFORM_ASSEM_FLAGS]]
         )
         self.eigenvalueProblem = cs[CONF_EIGEN_PROB]
 
@@ -463,7 +467,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
         self.boundaries = cs[CONF_BOUNDARIES]
         self.xsKernel = cs[CONF_XS_KERNEL]
         self.cs = cs
-        self.savePhysicsFilesList = cs["savePhysicsFiles"]
+        self.savePhysicsFilesList = cs[CONF_PHYSICS_FILES]
 
     def fromReactor(self, reactor: reactors.Reactor):
         self.geomType = reactor.core.geomType
@@ -711,6 +715,11 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
         -------
             list : cross section values
         """
+        from armi.physics.neutronics.settings import (
+            CONF_DPA_XS_SET,
+            CONF_GRID_PLATE_DPA_XS_SET,
+        )
+
         if self.cs[CONF_GRID_PLATE_DPA_XS_SET] and b.hasFlags(Flags.GRID_PLATE):
             dpaXsSetName = self.cs[CONF_GRID_PLATE_DPA_XS_SET]
         else:


### PR DESCRIPTION
## What is the change?

We are moving the `CONF_X` string imports in `globalFluxInterface.py` from the module-level to the function level

## Why is the change being made?

This is being made because a downstream project was importing ARMI code and got some circular imports.  Also, making this change is 100% safe, so there isn't a strong reason not to make this change here, for future-proofing reasons.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
