### PR TITLE
Removing unnecessary unittest main functions

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -303,7 +303,3 @@ class TestCompareDB3(unittest.TestCase):
             # there should be no difference
             _compareAuxData(out, refData, srcData, dr)
             self.assertEqual(dr.nDiffs(), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -650,7 +650,3 @@ class TestDatabase3(unittest.TestCase):
         bp = self.db.loadBlueprints()
         self.assertIsNone(bp.nuclideFlags)
         self.assertEqual(len(bp.assemblies), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -499,7 +499,3 @@ class TestStandardFollowOn(unittest.TestCase):
                         firstEndTime, o.r.p.time
                     ),
                 )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/bookkeeping/report/tests/test_newReport.py
+++ b/armi/bookkeeping/report/tests/test_newReport.py
@@ -156,7 +156,3 @@ class TestReportContentCreation(unittest.TestCase):
             env.writeHTML()
             self.assertIn("Writing HTML document", mock.getStdout())
             self.assertIn("[info] HTML document", mock.getStdout())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -196,7 +196,3 @@ class TestReportInterface(unittest.TestCase):
             repInt.interactEOL()
             self.assertIn("Comprehensive Core Report", mock.getStdout())
             self.assertIn("Assembly Area Fractions", mock.getStdout())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -235,8 +235,3 @@ class TestHistoryTrackerNoModel(unittest.TestCase):
             ),  # pylint:disable=protected-access
             "{}-blockName7-bHist.txt".format(self.history.cs.caseTitle),
         )
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ["", "TestHistoryTracker.test_historyReport"]
-    unittest.main()

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -163,7 +163,3 @@ class KlassCounterTests(unittest.TestCase):
         self.assertEqual(counter[dict].count, 2)
         self.assertEqual(counter[tuple].count, 2)
         self.assertEqual(counter[int].count, 7)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/bookkeeping/tests/test_snapshot.py
+++ b/armi/bookkeeping/tests/test_snapshot.py
@@ -84,7 +84,3 @@ class TestSnapshotInterface(unittest.TestCase):
 
         self.si.activateDefaultSnapshots()
         self.assertEqual(["000000", "008000", "016005"], self.si.cs["dumpSnapshot"])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/cases/inputModifiers/tests/test_inputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_inputModifiers.py
@@ -253,7 +253,3 @@ class TestFullCoreModifier(unittest.TestCase):
         self.assertEqual(case.bp.gridDesigns["core"].symmetry, "third periodic")
         case, case.bp, _ = mod(case, case.bp, None)
         self.assertEqual(case.bp.gridDesigns["core"].symmetry, "full")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/cases/inputModifiers/tests/test_pinTypeInputModifiers.py
+++ b/armi/cases/inputModifiers/tests/test_pinTypeInputModifiers.py
@@ -132,7 +132,3 @@ class TestBlueprintModifiers(unittest.TestCase):
         self.assertEqual(
             1.05, bp.blockDesigns["block 5"]["clad"].id
         )  # modifies all blocks
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -619,7 +619,3 @@ class TestCopyInterfaceInputs(unittest.TestCase):
                 cs, destination=newDir.destination
             )
             self.assertEqual(str(newSettings[testSetting]), absFile)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/cases/tests/test_suiteBuilder.py
+++ b/armi/cases/tests/test_suiteBuilder.py
@@ -73,7 +73,3 @@ class TestLatinHyperCubeSuiteBuilder(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             builder.addDegreeOfFreedom([powerMod, morePowerMod])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -358,7 +358,3 @@ class TestVisFileEntryPointCommand(unittest.TestCase):
 
         self.assertEqual(vf.name, "vis-file")
         self.assertIsNone(vf.settingsArgument)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/cli/tests/test_runSuite.py
+++ b/armi/cli/tests/test_runSuite.py
@@ -48,7 +48,3 @@ class TestRunSuiteSuite(unittest.TestCase):
 
         self.assertIn("armi", out.getvalue())
         self.assertIn(meta.__version__, out.getvalue())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test__init__.py
+++ b/armi/materials/tests/test__init__.py
@@ -39,7 +39,3 @@ class Materials__init__Tests(unittest.TestCase):
 
     def test_packageClassesEqualModuleClasses(self):
         self.assertEqual(materials.UraniumOxide, materials.uraniumOxide.UraniumOxide)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_air.py
+++ b/armi/materials/tests/test_air.py
@@ -263,7 +263,3 @@ class Test_Air(unittest.TestCase):
         tc0 = air.thermalConductivity(Tk=201)
         tcf = air.thermalConductivity(Tk=849)
         self.assertGreater(tcf, tc0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_b4c.py
+++ b/armi/materials/tests/test_b4c.py
@@ -51,7 +51,3 @@ class B4C_TestCase(_Material_Test, unittest.TestCase):
 
     def test_propertyValidTemperature(self):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_be9.py
+++ b/armi/materials/tests/test_be9.py
@@ -32,7 +32,3 @@ class Test_Be9(test_materials._Material_Test, unittest.TestCase):
 
     def test_propertyValidTemperature(self):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_graphite.py
+++ b/armi/materials/tests/test_graphite.py
@@ -67,7 +67,3 @@ class Graphite_TestCase(unittest.TestCase):
             error = math.fabs((ref_rho - test_rho) / ref_rho)
 
             self.assertLess(error, uncertainty)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_lithium.py
+++ b/armi/materials/tests/test_lithium.py
@@ -79,7 +79,3 @@ class Lithium_TestCase(_Material_Test, unittest.TestCase):
 
     def test_propertyValidTemperature(self):
         self.assertEqual(len(self.mat.propertyValidTemperature), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -1926,7 +1926,3 @@ assemblies:
             class2_custom_isotopics: [fakeIsotopic]
         """
             )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_sic.py
+++ b/armi/materials/tests/test_sic.py
@@ -49,7 +49,3 @@ class Test_SiC(test_materials._Material_Test, unittest.TestCase):
 
     def test_propertyValidTemperature(self):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_sulfur.py
+++ b/armi/materials/tests/test_sulfur.py
@@ -51,7 +51,3 @@ class Sulfur_TestCase(_Material_Test, unittest.TestCase):
 
     def test_propertyValidTemperature(self):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_thoriumOxide.py
+++ b/armi/materials/tests/test_thoriumOxide.py
@@ -42,7 +42,3 @@ class ThoriumOxide_TestCase(_Material_Test, unittest.TestCase):
 
     def test_propertyValidTemperature(self):
         self.assertGreater(len(self.mat.propertyValidTemperature), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_uZr.py
+++ b/armi/materials/tests/test_uZr.py
@@ -31,7 +31,3 @@ class UZR_TestCase(test_materials._Material_Test, unittest.TestCase):
 
     def test_propertyValidTemperature(self):
         self.assertEqual(len(self.mat.propertyValidTemperature), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/materials/tests/test_water.py
+++ b/armi/materials/tests/test_water.py
@@ -208,7 +208,3 @@ class Test_Water(unittest.TestCase):
 
         steam = SaturatedSteam()
         self.assertEqual(len(steam.propertyValidTemperature), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/nucDirectory/tests/test_elements.py
+++ b/armi/nucDirectory/tests/test_elements.py
@@ -110,8 +110,3 @@ class TestElement(unittest.TestCase):
                 self.assertTrue(ee.isHeavyMetal())
             else:
                 self.assertFalse(ee.isHeavyMetal())
-
-
-if __name__ == "__main__":
-    #     import sys;sys.argv = ['', 'TestElement.test_abundancesAddToOne']
-    unittest.main()

--- a/armi/nucDirectory/tests/test_nucDirectory.py
+++ b/armi/nucDirectory/tests/test_nucDirectory.py
@@ -64,7 +64,3 @@ class TestNucDirectory(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             nucDir.getThresholdDisplacementEnergy("fail")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -422,8 +422,3 @@ class test_getAAAZZZSId(unittest.TestCase):
             nb = nuclideBases.byName[nucName]
             if refAaazzzs:
                 self.assertEqual(refAaazzzs, nb.getAAAZZZSId())
-
-
-if __name__ == "__main__":
-    #     import sys;sys.argv = ['', 'TestNuclide.test_nucBases_factoryIsFast']
-    unittest.main()

--- a/armi/nucDirectory/tests/test_thermalScattering.py
+++ b/armi/nucDirectory/tests/test_thermalScattering.py
@@ -161,7 +161,3 @@ def getNuclideThermalScatteringData(armiObj):
         )
 
     return tslByNuclideBase
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/nucDirectory/tests/test_transmutations.py
+++ b/armi/nucDirectory/tests/test_transmutations.py
@@ -80,7 +80,3 @@ class DecayModeTests(unittest.TestCase):
             else:
                 with self.assertRaises(KeyError):
                     transmutations.DecayMode(nuclideBases.byName["AM242M"], data)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/nuclearDataIO/cccc/tests/test_cccc.py
+++ b/armi/nuclearDataIO/cccc/tests/test_cccc.py
@@ -106,8 +106,3 @@ class CcccAsciiRecordTests(CcccBinaryRecordTests):
 
     def setUp(self):
         self.streamCls = six.StringIO
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()

--- a/armi/nuclearDataIO/cccc/tests/test_compxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_compxs.py
@@ -327,7 +327,3 @@ class TestCompxs(unittest.TestCase):
             nuclearDataIO.getExpectedCOMPXSFileName(cycle=23), "COMPXS-c23"
         )
         self.assertEqual(nuclearDataIO.getExpectedCOMPXSFileName(), "COMPXS")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/nuclearDataIO/cccc/tests/test_isotxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_isotxs.py
@@ -181,8 +181,3 @@ class Isotxs_merge_Tests(unittest.TestCase):
             del someIsotxs[key]
         someIsotxs.merge(isotxs.readBinary(ISOAA_PATH))
         self.assertEqual(None, someIsotxs.isotxsMetadata["chi"])
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'TestIsotxs.test_getNuclide']
-    unittest.main()  # verbosity=2)

--- a/armi/nuclearDataIO/cccc/tests/test_labels.py
+++ b/armi/nuclearDataIO/cccc/tests/test_labels.py
@@ -59,8 +59,3 @@ class TestLabels(unittest.TestCase):
                 expectedData = f.read().splitlines()
             for expected, actual in zip(expectedData, actualData):
                 self.assertEqual(expected, actual)
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'TestLabels.test_writeLabelsAscii']
-    unittest.main()

--- a/armi/nuclearDataIO/cccc/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_nhflux.py
@@ -192,7 +192,3 @@ class TestNhfluxVariant(unittest.TestCase):
                 actualData = f2.read()
             for expected, actual in zip(expectedData, actualData):
                 self.assertEqual(expected, actual)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
+++ b/armi/nuclearDataIO/cccc/tests/test_pmatrx.py
@@ -239,7 +239,3 @@ class TestProductionMatrix_FromWrittenAscii(TestPmatrx):
 
     def tearDown(self):
         self.td.__exit__(None, None, None)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/nuclearDataIO/tests/test_xsCollections.py
+++ b/armi/nuclearDataIO/tests/test_xsCollections.py
@@ -152,8 +152,3 @@ class MockBlock(HexBlock):
 
     def getNuclides(self):
         return self.density.keys()
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'TestXsCollections.test_generateTotalScatteringMatrix']
-    unittest.main()

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -541,7 +541,3 @@ class Combined_merge_Tests(unittest.TestCase):
 
 # Remove the abstract class, so that it does not run (all tests would fail)
 del TestXSlibraryMerging
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -181,7 +181,3 @@ class NuclideTests(unittest.TestCase):
             ref_FissionXS = u235Nuc.micros.fission[i]
             cur_FissionXS = u235Nuc.getMicroXS("fission", i)
             self.assertAlmostEqual(ref_FissionXS, cur_FissionXS)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/operators/tests/test_inspectors.py
+++ b/armi/operators/tests/test_inspectors.py
@@ -191,7 +191,3 @@ class TestInspector(unittest.TestCase):
         )
         self.inspector._assignCS("cycleLength", 666)
         self.assertTrue(self.inspector._checkForBothSimpleAndDetailedCyclesInputs())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/operators/tests/test_operatorSnapshots.py
+++ b/armi/operators/tests/test_operatorSnapshots.py
@@ -98,7 +98,3 @@ class TestOperatorSnapshotsSettings(unittest.TestCase):
         cs = cs.modified(newSettings={"runType": RunTypes.SNAPSHOTS})
         clazz = getOperatorClassFromSettings(cs)
         self.assertEqual(clazz, OperatorSnapshots)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -413,7 +413,3 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
             ),
             f" - cycle {cycle}, node {timeNode}",
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/fuelCycle/tests/test_assemblyRotationAlgorithms.py
+++ b/armi/physics/fuelCycle/tests/test_assemblyRotationAlgorithms.py
@@ -63,7 +63,3 @@ class TestFuelHandlerMgmtTools(FuelHandlerTestHelper):
         rotAlgos.simpleAssemblyRotation(fh)
         rotAlgos.simpleAssemblyRotation(fh)
         self.assertEqual(b.getRotationNum(), rotNum + 2)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -804,7 +804,3 @@ class TestFuelPlugin(unittest.TestCase):
 def addSomeDetailAssemblies(hist, assems):
     for a in assems:
         hist.detailAssemblyNames.append(a.getName())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/fuelCycle/tests/test_hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/tests/test_hexAssemblyFuelMgmtUtils.py
@@ -112,7 +112,3 @@ class TestHexAssemMgmtTools(ArmiTestHelper):
         )
         self.assertEqual(schedule, [9, 8, 7, 4, 5, 6, 3, 2, 1])
         self.assertEqual(widths, zeroWidths)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/fuelPerformance/tests/test_executers.py
+++ b/armi/physics/fuelPerformance/tests/test_executers.py
@@ -30,7 +30,3 @@ class TestFuelPerformanceOptions(unittest.TestCase):
         cs = Settings()
         fpo.fromUserSettings(cs)
         self.assertEqual(fpo.bondRemoval, cs[CONF_BOND_REMOVAL])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
+++ b/armi/physics/fuelPerformance/tests/test_fuelPerformancePlugin.py
@@ -21,7 +21,3 @@ from armi.tests.test_plugins import TestPlugin
 
 class TestFuelPerformancePlugin(TestPlugin):
     plugin = FuelPerformancePlugin
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
@@ -160,8 +160,3 @@ class TestFissionProductModelExplicitMC2Library(unittest.TestCase):
                     self.assertIn(nb.name, nuclideList)
             else:
                 self.assertLess(len(b.getNuclides()), len(nuclideBases.byMcc3Id))
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()

--- a/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
@@ -249,8 +249,3 @@ class TestMo99LFP(unittest.TestCase):
         self.assertIn("MO99", names)
         self.assertNotIn("KR85", names)
         self.assertAlmostEqual(self.lfps["LFP35"].getTotalYield(), 2.0)
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -357,7 +357,3 @@ def applyDummyFlux(r, ng=33):
     for b in r.core.getBlocks():
         b.p.power = 1.0
         b.p.mgFlux = numpy.arange(ng, dtype=numpy.float64)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -288,7 +288,3 @@ class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
         )
         self.assembly[0].p.xsType = "B"
         return self.latticeInterface._getBlocksAndXsIds()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -179,7 +179,3 @@ class TestLatticePhysicsWriter(unittest.TestCase):
     def test_getDriverBlock(self):
         b = self.w._getDriverBlock()
         self.assertIsNone(b)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -688,8 +688,3 @@ def makeBlocks(howMany=20):
     return r.core.getBlocks(Flags.FUEL)[
         3 : howMany + 3
     ]  # shift y 3 to skip central assemblies 1/3 volume
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test_CrossSectionGroupManager.test_createRepresentativeBlocksUsingExistingBlocks']
-    unittest.main()

--- a/armi/physics/neutronics/tests/test_crossSectionSettings.py
+++ b/armi/physics/neutronics/tests/test_crossSectionSettings.py
@@ -382,7 +382,3 @@ class Test_XSSettings(unittest.TestCase):
         self.assertEqual(
             cs[CONF_CROSS_SECTION]["AA"].validBlockTypes, ["control", "fuel", "plenum"]
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/neutronics/tests/test_crossSectionTable.py
+++ b/armi/physics/neutronics/tests/test_crossSectionTable.py
@@ -57,7 +57,3 @@ class TestCrossSectionTable(unittest.TestCase):
 
         self.assertEqual(len(aid.getToDeplete()), 0)
         self.assertEqual(ORDER, 5.0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/neutronics/tests/test_energyGroups.py
+++ b/armi/physics/neutronics/tests/test_energyGroups.py
@@ -45,7 +45,3 @@ class TestEnergyGroups(unittest.TestCase):
                     energyGroups.getGroupStructure(groupStructureType)
                 ),
             )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/neutronics/tests/test_macroXSGenerationInterface.py
+++ b/armi/physics/neutronics/tests/test_macroXSGenerationInterface.py
@@ -31,7 +31,3 @@ class TestMacroXSGenerationInterface(unittest.TestCase):
         self.assertIsNone(i.macrosLastBuiltAt)
         self.assertEqual(i.minimumNuclideDensity, 1e-15)
         self.assertEqual(i.name, "macroXsGen")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -348,7 +348,3 @@ class NeutronicsReactorTests(unittest.TestCase):
         self.assertEqual(
             inspector.cs[CONF_LATTICE_PHYSICS_FREQUENCY], "firstCoupledIteration"
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/physics/tests/test_executers.py
+++ b/armi/physics/tests/test_executers.py
@@ -110,7 +110,3 @@ class TestExecuters(unittest.TestCase):
         self.executer.dcType = directoryChangers.ForcedCreationDirectoryChanger
         self.executer._updateRunDir("notThisString")
         self.assertEqual(self.executer.options.runDir, "runDir")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/blueprints/tests/test_assemblyBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_assemblyBlueprints.py
@@ -202,7 +202,3 @@ assemblies:
 
         with self.assertRaises(ValueError):
             a = self.loadCustomAssembly(self.twoBlockInput_wrongMatMods)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -339,8 +339,3 @@ class TestGriddedBlock(unittest.TestCase):
             clad.density(),
             programaticClad.density(),
         )
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -554,7 +554,3 @@ assemblies:
         componentGroup = design.componentGroups["group1"]
         self.assertEqual(componentGroup["freefuel"].name, "freefuel")
         self.assertEqual(componentGroup["freefuel"].mult, 1.0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -335,8 +335,3 @@ assemblies:
         expectedNuclides = ["TH232"]
         for nuc in expectedNuclides:
             self.assertIn(nuc, a[0][0].getNuclides())
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'TestComponentBlueprint.test_componentInitializationAmericiumCustomIsotopics']
-    unittest.main()

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -364,7 +364,3 @@ assemblies:
         self.assertNotIn("FE56", nd)  # natural isotopic not requested
         self.assertNotIn("FE51", nd)  # un-natural
         self.assertNotIn("FE", nd)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -469,7 +469,3 @@ class TestRZTGridBlueprint(unittest.TestCase):
         self.assertEqual(gridDesign.geom, "thetarz")
         self.assertEqual(gridDesign.symmetry, "eighth periodic")
         self.assertEqual(gridDesign.geom, "thetarz")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/blueprints/tests/test_materialModifications.py
+++ b/armi/reactor/blueprints/tests/test_materialModifications.py
@@ -286,7 +286,3 @@ custom isotopics:
         U: 1
 """
             )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/blueprints/tests/test_reactorBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_reactorBlueprints.py
@@ -117,7 +117,3 @@ class TestReactorBlueprints(unittest.TestCase):
         materialData = reactorBlueprint.summarizeMaterialData(core)
         for actual, expected in zip(materialData, expectedMaterialData):
             self.assertEqual(actual, expected)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -393,8 +393,3 @@ def buildControlBlockWithLinkedNegativeAreaComponent():
     b.getVolumeFractions()  # TODO: remove, should be no-op when removed self.cached
 
     return b
-
-
-if __name__ == "__main__":
-    #     import sys;sys.argv = ['', 'TestBlockConverter.test_convertHexWithFuelDriver']
-    unittest.main()

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -422,11 +422,3 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
         changer.restorePreviousGeometry(self.r)
         self.assertEqual(initialNumBlocks, len(self.r.core.getBlocks()))
         self.assertEqual(self.r.core.symmetry.domain, geometry.DomainType.FULL_CORE)
-
-
-if __name__ == "__main__":
-    # import sys
-    # import armi
-    # armi.configure()
-    # sys.argv = ["", "TestEdgeAssemblyChanger"]
-    unittest.main()

--- a/armi/reactor/converters/tests/test_meshConverters.py
+++ b/armi/reactor/converters/tests/test_meshConverters.py
@@ -148,8 +148,3 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         self.assertListEqual(meshConvert.radialMesh, expectedRadialMesh)
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
         self.assertListEqual(meshConvert.thetaMesh, expectedThetaMesh)
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'TestRZReactorMeshConverter.test_meshByRingCompositionAxialBinsSmallCore']
-    unittest.main()

--- a/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
+++ b/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
@@ -99,8 +99,3 @@ class MassConservationTests(unittest.TestCase):
 
         adjustSmearDensity(self.b, 0.733, bolBlock=bolBlock)
         self.assertAlmostEqual(0.733, self.b.getSmearDensity(), 8)
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -714,7 +714,3 @@ class TestUniformMeshNonUniformAssemFlags(unittest.TestCase):
             for b in a:
                 self.assertTrue(b.p.rateCap)
                 self.assertTrue(b.p.rateAbs)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1380,7 +1380,3 @@ assemblies:
         actualAssemblyArea = math.sqrt(3) / 2.0 * intercoolant.p.op ** 2
 
         self.assertAlmostEqual(bpAssemblyArea, actualAssemblyArea)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2422,7 +2422,3 @@ class MassConservationTests(unittest.TestCase):
             10,
             "Sum of component mass {0} != total block mass {1}. ".format(tMass, bMass),
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -1512,8 +1512,3 @@ class TestMaterialAdjustments(unittest.TestCase):
     def test_getEnrichment(self):
         self.fuel.adjustMassEnrichment(0.3)
         self.assertAlmostEqual(self.fuel.getEnrichment(), 0.3)
-
-
-if __name__ == "__main__":
-    # import sys; sys.argv = ['', 'TestMaterialAdjustments.test_adjustMassFrac_U235']
-    unittest.main()

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -661,7 +661,3 @@ class TestGetReactionRateDict(unittest.TestCase):
             nucName="PU239", lib=lib, xsSuffix="AA", mgFlux=1, nDens=1
         )
         self.assertEqual(rxRatesDict["nG"], sum(lib["PU39AA"].micros.nGamma))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/tests/test_flags.py
+++ b/armi/reactor/tests/test_flags.py
@@ -105,7 +105,3 @@ class TestFlags(unittest.TestCase):
         stream = pickle.dumps(flags.Flags.BOND | flags.Flags.A)
         flag = pickle.loads(stream)
         self.assertEqual(flag, flags.Flags.BOND | flags.Flags.A)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/tests/test_geometry.py
+++ b/armi/reactor/tests/test_geometry.py
@@ -318,8 +318,3 @@ class TestSystemLayoutInputTRZ(unittest.TestCase):
                 geom2 = SystemLayoutInput()
                 geom2._readYaml(f)  # pylint: disable=protected-access
             self.assertEqual(geom2.assemTypeByIndices[2.0, 3.0, 0.0, 180.0, 1, 1], "MC")
-
-
-if __name__ == "__main__":
-    #  import sys; sys.argv = ['', 'TestLoadingReactorTRZ.test_loadTRZGeom']
-    unittest.main()

--- a/armi/reactor/tests/test_grids.py
+++ b/armi/reactor/tests/test_grids.py
@@ -658,8 +658,3 @@ class TestCartesianGrid(unittest.TestCase):
         )
         with self.assertRaises(NotImplementedError):
             grid.getSymmetricEquivalents((5, 6))
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ["", "TestHexGrid.testPositions"]
-    unittest.main()

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -659,10 +659,3 @@ class SynchronizationTests:
             del self.r
             self.r = context.MPI_COMM.bcast(None)
             do()
-
-
-if __name__ == "__main__":
-    if context.MPI_SIZE == 1:
-        unittest.main()
-    else:
-        SynchronizationTests().run()

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -1066,7 +1066,3 @@ class CartesianReactorTests(ReactorTests):
 
         self.assertIn("Nuclide categorization", messages)
         self.assertIn("Structure", messages)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/tests/test_rz_reactors.py
+++ b/armi/reactor/tests/test_rz_reactors.py
@@ -85,7 +85,3 @@ class Test_RZT_Reactor_modern(unittest.TestCase):
         """
         error = math.fabs((refFuelVolume - sum(fuelVolumes)) / refFuelVolume)
         self.assertLess(error, tolerance)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/reactor/tests/test_zones.py
+++ b/armi/reactor/tests/test_zones.py
@@ -310,7 +310,3 @@ class TestZones(unittest.TestCase):
         self.assertEqual(list(zs._zones.keys())[0], "ring-1")
         self.assertEqual(list(zs._zones.keys())[1], "ring-2")
         self.assertEqual(list(zs._zones.keys())[2], "ring-3")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/settings/fwSettings/tests/test_fwSettings.py
+++ b/armi/settings/fwSettings/tests/test_fwSettings.py
@@ -137,7 +137,3 @@ class TestSchema(unittest.TestCase):
             expectedError = settingVal["error"]
             with self.assertRaises(expectedError):
                 self.cs = self.cs.modified(newSettings={settingName: invalidOption})
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/settings/fwSettings/tests/test_tightCouplingSettings.py
+++ b/armi/settings/fwSettings/tests/test_tightCouplingSettings.py
@@ -141,7 +141,3 @@ class TestTightCouplingSettings(unittest.TestCase):
         outBuf.seek(0)
         inp2 = yaml.load(outBuf)
         self.assertEqual(inp.keys(), inp2.keys())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -484,7 +484,3 @@ class TestSettingsValidationUtils(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             validateVersion("1.2.3", "zzz")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/tests/test_armiTestHelper.py
+++ b/armi/tests/test_armiTestHelper.py
@@ -60,7 +60,3 @@ class TestArmiTestHelper(ArmiTestHelper):
         self.compareFilesLineByLine(
             self.goodFilePath, self.badFilePath, falseNegList=["NEGATIVE"]
         )
-
-
-if __name__ == "_main__":
-    unittest.main()

--- a/armi/tests/test_cartesian.py
+++ b/armi/tests/test_cartesian.py
@@ -52,8 +52,3 @@ class CartesianReactorTests(unittest.TestCase):
         self.assertEqual(self.r.core.geomType, geometry.GeomType.CARTESIAN)
         # from blueprints input file
         self.assertAlmostEqual(custom.getNumberDensity("U238"), 0.0134125)
-
-
-if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
-    unittest.main()

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -145,7 +145,3 @@ class TestTightCoupler(unittest.TestCase):
         self.assertEqual(interfaces.TightCoupler.getListDimension(a), 2)
         a = [[[1, 2, 3]]]
         self.assertEqual(interfaces.TightCoupler.getListDimension(a), 3)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -239,7 +239,3 @@ class QueueActionsTests(unittest.TestCase):
 def passer():
     """Helper function, to do nothing, for unit tests."""
     pass
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -301,12 +301,3 @@ class MpiPathToolsTests(unittest.TestCase):
             pathTools.cleanPath(dir3, mpiRank=context.MPI_RANK)
             MPI_COMM.barrier()
             self.assertFalse(os.path.exists(dir3))
-
-
-if __name__ == "__main__":
-    # these tests must be run from the command line using MPI:
-    #
-    # mpiexec -n 2 python -m pytest armi/tests/test_mpiFeatures.py
-    # or
-    # mpiexec.exe -n 2 python -m pytest armi/tests/test_mpiFeatures.py
-    pass

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -73,7 +73,3 @@ class TestPlugin(unittest.TestCase):
             self.assertIsInstance(order, (int, float))
             self.assertTrue(issubclass(interface, interfaces.Interface))
             self.assertIsInstance(kwargs, dict)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -383,7 +383,3 @@ class TestRunLogger(unittest.TestCase):
         # test what was logged
         streamVal = stream.getvalue()
         self.assertIn(testName, streamVal, msg=streamVal)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_codeTiming.py
+++ b/armi/utils/tests/test_codeTiming.py
@@ -133,7 +133,3 @@ class CodeTimingTest(unittest.TestCase):
         self.assertIn(name, table)
         self.assertIn("CUMULATIVE", table)
         self.assertIn("ACTIVE", table)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_custom_exceptions.py
+++ b/armi/utils/tests/test_custom_exceptions.py
@@ -73,7 +73,3 @@ class CustomExceptionTests(unittest.TestCase):
                 self.exampleWarnWhenRootMessage()
                 self.assertEqual(msg, mock.getStdout())
                 armi.MPI_RANK = 0
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_densityTools.py
+++ b/armi/utils/tests/test_densityTools.py
@@ -15,9 +15,9 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring,abstract-method,protected-access,no-member,disallowed-name,invalid-name
 import unittest
 
-from armi.utils import densityTools
-from armi.nucDirectory import elements, nuclideBases
 from armi.materials.uraniumOxide import UO2
+from armi.nucDirectory import elements, nuclideBases
+from armi.utils import densityTools
 
 
 class Test_densityTools(unittest.TestCase):
@@ -180,7 +180,3 @@ class Test_densityTools(unittest.TestCase):
         )
         refMatCard = []
         self.assertEqual(refMatCard, matCard)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_directoryChangers.py
+++ b/armi/utils/tests/test_directoryChangers.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 """Module for testing directoryChangers."""
-import os
-import unittest
 from pathlib import Path
+import os
 import shutil
+import unittest
 
 from armi.utils import directoryChangers
 from armi.utils import directoryChangersMpi

--- a/armi/utils/tests/test_dochelpers.py
+++ b/armi/utils/tests/test_dochelpers.py
@@ -74,7 +74,3 @@ class TestDocHelpers(unittest.TestCase):
         self.assertIn("width: 250", table)
         self.assertIn("widths: [200, 300]", table)
         self.assertIn("thing", table)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_flags.py
+++ b/armi/utils/tests/test_flags.py
@@ -122,7 +122,3 @@ class TestFlag(unittest.TestCase):
 
     def test_getitem(self):
         self.assertEqual(ExampleFlag["FOO"], ExampleFlag.FOO)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_gridGui.py
+++ b/armi/utils/tests/test_gridGui.py
@@ -191,7 +191,3 @@ class Test(GuiTestCase):
         # Assert that the grid cell contains "0, 0'
         labels = [self.gui.clicker._getLabel(idx)[0] for idx in gridCellIndices]
         self.assertEqual("0, 0", labels[0])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_iterables.py
+++ b/armi/utils/tests/test_iterables.py
@@ -177,7 +177,3 @@ class TestIterables(unittest.TestCase):
         self.assertEqual(vals[0], 0)
         self.assertEqual(vals[-1], 5)
         self.assertEqual(len(vals), 6)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_mathematics.py
+++ b/armi/utils/tests/test_mathematics.py
@@ -534,7 +534,3 @@ class TestMath(unittest.TestCase):
         self.assertAlmostEqual(yr[0], sqrt(2))
         self.assertAlmostEqual(xr[1], -sqrt(2))
         self.assertAlmostEqual(yr[1], 0.0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_outputCache.py
+++ b/armi/utils/tests/test_outputCache.py
@@ -128,7 +128,3 @@ class TestOutputCache(unittest.TestCase):
                 fakeExe, inputPaths, cacheDir, newFolder
             )
             self.assertFalse(result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_parsing.py
+++ b/armi/utils/tests/test_parsing.py
@@ -81,7 +81,3 @@ class LiteralEvalTest(unittest.TestCase):
             parsing.parseValue("5", str)
         with self.assertRaises(ValueError):
             parsing.parseValue("5", bool)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -141,7 +141,3 @@ class PathToolsTests(unittest.TestCase):
                 f1.write("test")
 
             self.assertTrue(pathTools.isAccessible(path1))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -117,7 +117,3 @@ class TestPlotting(unittest.TestCase):
 
     def _checkExists(self, fName):
         self.assertTrue(os.path.exists(fName))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_properties.py
+++ b/armi/utils/tests/test_properties.py
@@ -50,7 +50,3 @@ class ImmutablePropertyTests(unittest.TestCase):
         with self.assertRaises(properties.ImmutablePropertyError):
             ic.initialize(3.4)
         self.assertEqual(ic.myNum, 7.7)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_reportPlotting.py
+++ b/armi/utils/tests/test_reportPlotting.py
@@ -144,7 +144,3 @@ class TestRadar(unittest.TestCase):
         xsHistoryVsTime(name, history, [], "png")
         self.assertTrue(os.path.exists(figName))
         self.assertGreater(os.path.getsize(figName), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_textProcessors.py
+++ b/armi/utils/tests/test_textProcessors.py
@@ -104,7 +104,3 @@ X  Y  0.0"""
         with textProcessors.SequentialReader(self._DUMMY_FILE_NAME) as sr:
             self.assertTrue(sr.searchForPattern("(X\s+Y\s+\d+\.\d+)"))
             self.assertEqual(float(sr.line.split()[2]), 3.5)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_triangle.py
+++ b/armi/utils/tests/test_triangle.py
@@ -153,7 +153,3 @@ class TestTriangle(unittest.TestCase):
             xT1, yT1, xT2, yT2, xT3, yT3, xP, yP
         )
         self.assertFalse(generalTriangleInOrOut)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -371,7 +371,3 @@ settings:
 
         self.assertEqual(getCumulativeNodeNum(2, 0, self.standaloneDetailedCS), 10)
         self.assertEqual(getCumulativeNodeNum(1, 0, self.standaloneDetailedCS), 4)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
## What is the change?

About half of the `test_whatever.py` files in ARMI had these empty placeholder `if __name__ == "__main__":` statements at the bottom.  I am removing these here.

## Why is the change being made?

As @opotowsky and I were discussing recently, these statements are completely unused and defunct.  Especially since we use `PyTest` in ARMI, and can run any single test via the commandline using something like:

```bash
pytest armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py::TestLatticePhysicsWriter::test_getDetailedFPDensitiesaile
```

And most people use an IDE for their development, where these `main()` statements are also completely bipassed.

I would rather remove these than have to keep explaining to people what defunct, historical use they once had for a small set of developers.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
