### PR TITLE
Applying more ruff rules to the repo

### DIFF
--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -132,13 +132,10 @@ class FissionProductModel(interfaces.Interface):
 
     @property
     def _useGlobalLFPs(self):
-        if (
+        return not (
             self.cs[CONF_MAKE_ALL_BLOCK_LFPS_INDEPENDENT]
             or self._explicitFissionProducts
-        ):
-            return False
-        else:
-            return True
+        )
 
     @property
     def _fissionProductBlockType(self):

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -321,10 +321,7 @@ def isMonotonic(inputIter, relation):
     except KeyError:
         raise ValueError(f"Valid relation not specified: {relation}")
 
-    if not all([op(x, y) for x, y in zip(inputIter, inputIter[1:])]):
-        return False
-    else:
-        return True
+    return all([op(x, y) for x, y in zip(inputIter, inputIter[1:])])
 
 
 def linearInterpolation(x0, y0, x1, y1, targetX=None, targetY=None):

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -252,7 +252,4 @@ def cleanPath(path, mpiRank=0):
             break
         sleep(waitTime)
 
-    if os.path.exists(path):
-        return False
-    else:
-        return True
+    return not os.path.exists(path)

--- a/ruff.toml
+++ b/ruff.toml
@@ -9,9 +9,11 @@ required-version = "0.0.272"
 # D300 - docstrings need to use triple quotes
 # RUF100 - no unused noqa statements
 # TID252 - no relative imports
-select = ["E", "F", "D104", "D300", "RUF100", "TID252"]
-# Want: "SIM"
+# SIM103 - needless-bool
+# SIM9** - dict-get-with-none-default
+select = ["E", "F", "D104", "D300", "RUF100", "SIM103", "SIM9", "TID"]
 
+# D205 - 1 blank line required between summary line and description
 # E501 - line length, because we use Black for that
 # E731 - we can use lambdas however we want
 # N802 - lowercase function naming, we use camel case
@@ -20,7 +22,7 @@ select = ["E", "F", "D104", "D300", "RUF100", "TID252"]
 # N815 - mixed case in class header, we use camel case
 # N816 - mixed case in global, scripts can use mixed case
 # N999 - lowercase variable naming, we use camel case
-ignore = ["E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999"]
+ignore = ["D205", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -58,7 +60,7 @@ line-length = 88
 # D1XX - enforces writing docstrings
 # E741 - ambiguous variable name
 # SLF001 - private member access
-"*/tests/*" = ["D100", "D101", "D102", "D103", "D104", "E741", "SLF001"]
+"*/tests/*" = ["D1", "E741", "SLF001"]
 
 [pydocstyle]
 # Use numpy-style docstrings.


### PR DESCRIPTION
## What is the change?

Applying more `ruff` rule "SIM103" to the `ruff.toml` file, and to the codebase. This rule helps us "simplify" code:

Removing needless boolean statements during `return`.

## Why is the change being made?

I am going to start bringing more and more "SIM" rules in to our code from `ruff`.  This is the first rule I found.

Also, please note I made some other changes to the `ruff.toml` file because they were free, and required no code changes in ARMI.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
