### PR TITLE
Adding more ruff simplify rules

### DIFF
--- a/armi/materials/tests/test_air.py
+++ b/armi/materials/tests/test_air.py
@@ -221,7 +221,7 @@ class Test_Air(unittest.TestCase):
         for Tk, thermalConductivity in zip(
             REFERENCE_Tk, REFERENCE_THERMAL_CONDUCTIVITY_mJ_PER_M_K
         ):
-            if 200 < Tk and Tk < 850:
+            if Tk > 200 and Tk < 850:
                 error = math.fabs(
                     (air.thermalConductivity(Tk=Tk) - thermalConductivity * 1e-3)
                     / (thermalConductivity * 1e-3)

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -271,7 +271,7 @@ class MpiAction:
         """
         ntasks = len(objectsForAllCoresToIter)
         numLocalObjects, deficit = divmod(ntasks, context.MPI_SIZE)
-        if context.MPI_RANK < deficit:
+        if deficit > context.MPI_RANK:
             numLocalObjects += 1
             first = context.MPI_RANK * numLocalObjects
         else:

--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -630,7 +630,7 @@ class XSModelingOptions:
                 crossSectionGroupManager.AVERAGE_BLOCK_COLLECTION,
                 crossSectionGroupManager.FLUX_WEIGHTED_AVERAGE_BLOCK_COLLECTION,
             ]
-            bucklingSearch = False if self.fluxIsPregenerated else True
+            bucklingSearch = not self.fluxIsPregenerated
             defaults = {
                 CONF_GEOM: self.geometry,
                 CONF_BUCKLING: bucklingSearch,

--- a/armi/physics/neutronics/reports.py
+++ b/armi/physics/neutronics/reports.py
@@ -188,7 +188,7 @@ def generateLinePlot(subsectionHeading, r, report, yaxis, name, caption=""):
     maxValue = defaultdict(float)
     # dictionary for a specific time step.
     for a in r.core.getAssemblies(Flags.FUEL):
-        if BURNUP_PLOT == subsectionHeading:
+        if subsectionHeading == BURNUP_PLOT:
             maxValue[a.p.type] = max(maxValue[a.p.type], a.p.maxPercentBu)
         else:
             maxValue[a.p.type] = max(maxValue[a.p.type], a.p.maxDpaPeak)

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -726,7 +726,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
         """
         if not typeID:
-            return False if exact else True
+            return not exact
         if isinstance(typeID, six.string_types):
             raise TypeError(
                 "Must pass Flags, or an iterable of Flags; Strings are no longer "

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -704,10 +704,7 @@ class ExpansionData:
         c : :py:class:`Component <armi.reactor.components.component.Component>`
             Component to retrive expansion factor for
         """
-        if c in self._expansionFactors:
-            value = self._expansionFactors[c]
-        else:
-            value = 1.0
+        value = self._expansionFactors.get(c, 1.0)
         return value
 
     def _setTargetComponents(self, setFuel):

--- a/armi/reactor/converters/pinTypeBlockConverters.py
+++ b/armi/reactor/converters/pinTypeBlockConverters.py
@@ -54,7 +54,7 @@ def adjustSmearDensity(obj, value, bolBlock=None):
         See completeInitialLoading. Required for ECPT cases
 
     """
-    if 0.0 >= value or value > 1.0:
+    if value <= 0.0 or value > 1.0:
         raise ValueError(
             "Cannot modify smear density of {0} to {1}. Must be a positive fraction"
             "".format(obj, value)

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -131,7 +131,7 @@ class DirectoryChanger:
         initialPath = self.initial
         destinationPath = self.destination
         self._transferFiles(initialPath, destinationPath, self._filesToMove)
-        if not self.outputPath == self.initial:
+        if self.outputPath != self.initial:
             destinationPath = self.outputPath
             self._transferFiles(initialPath, destinationPath, self._filesToMove)
 
@@ -142,7 +142,7 @@ class DirectoryChanger:
         initialPath = self.destination
         destinationPath = self.initial
         self._transferFiles(initialPath, destinationPath, self._filesToRetrieve)
-        if not self.outputPath == self.initial:
+        if self.outputPath != self.initial:
             destinationPath = self.outputPath
             self._transferFiles(initialPath, destinationPath, self._filesToRetrieve)
 

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -235,7 +235,7 @@ def cleanPath(path, mpiRank=0):
         )
 
     # delete the file/directory from only one process
-    if context.MPI_RANK == mpiRank:
+    if mpiRank == context.MPI_RANK:
         if os.path.exists(path) and os.path.isdir(path):
             shutil.rmtree(path)
         elif not os.path.isdir(path):

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -778,7 +778,7 @@ def plotAssemblyTypes(
     # Setup figure
     fig, ax = plt.subplots(figsize=(15, 15), dpi=300)
     for index, assem in enumerate(assems):
-        isLastAssem = True if index == (numAssems - 1) else False
+        isLastAssem = index == numAssems - 1
         (xBlockLoc, yBlockHeights, yBlockAxMesh) = _plotBlocksInAssembly(
             ax,
             assem,
@@ -1005,7 +1005,7 @@ def plotBlockFlux(core, fName=None, bList=None, peak=False, adjoint=False, bList
                 _, self.peakHistogram = makeHistogram(self.E, self.peakFlux)
 
         def checkSize(self):
-            if not len(self.E) == len(self.avgFlux):
+            if len(self.E) != len(self.avgFlux):
                 runLog.error(self.avgFlux)
                 raise
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,11 +7,13 @@ required-version = "0.0.272"
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 # D104 - missing docstring in public package
 # D300 - docstrings need to use triple quotes
-# RUF100 - no unused noqa statements
 # TID252 - no relative imports
-# SIM103 - needless-bool
-# SIM9** - dict-get-with-none-default
-select = ["E", "F", "D104", "D300", "RUF100", "SIM103", "SIM9", "TID"]
+# SIM103 - simplify code: needless-bool
+# SIM2** - simplify code: complex equality statements
+# SIM3** - simplify code: yoda-conditions
+# SIM4** - simplify code: if-else-blocks
+# SIM9** - simplify code: dict-get-with-none-default
+select = ["E", "F", "D104", "D300", "SIM103", "SIM2", "SIM3", "SIM4", "SIM9", "TID"]
 
 # D205 - 1 blank line required between summary line and description
 # E501 - line length, because we use Black for that
@@ -22,7 +24,8 @@ select = ["E", "F", "D104", "D300", "RUF100", "SIM103", "SIM9", "TID"]
 # N815 - mixed case in class header, we use camel case
 # N816 - mixed case in global, scripts can use mixed case
 # N999 - lowercase variable naming, we use camel case
-ignore = ["D205", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999"]
+# RUF100 - no unused noqa statements (not consistent enough yet)
+ignore = ["D205", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,7 +25,8 @@ select = ["E", "F", "D104", "D300", "SIM103", "SIM2", "SIM3", "SIM4", "SIM9", "T
 # N816 - mixed case in global, scripts can use mixed case
 # N999 - lowercase variable naming, we use camel case
 # RUF100 - no unused noqa statements (not consistent enough yet)
-ignore = ["D205", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100"]
+# SIM118 - this does not work where we overload the .keys() method
+ignore = ["D205", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM118"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [


### PR DESCRIPTION
## What is the change?

Adding the `ruff` simplify rules to the repo:

* **SIM2** - simplify code: complex equality statements
* **SIM3** - simplify code: yoda-conditions
* **SIM4** - simplify code: if-else-blocks
* **SIM9** - simplify code: dict-get-with-none-default

Ignoring the `ruff` simplify rule: `SIM118`. This checks against the `.keys()` method. But we overload that method in fun and unique ways that the linter just can't understand.

## Why is the change being made?

This is part of my on-going work to find the final set of `ruff` rules we want to use in ARMI.  Also, to figure out the sweet spot for what `ruff` rules we want to support.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
