### PR TITLE
Adding some basic ruff Docstring rules

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -284,12 +284,12 @@ class App:
         ``C:\\path\\to\\pluginMod.py:pluginCls``
 
         Parameters
-        -----------
+        ----------
         pluginPath : str
             String path to a userPlugin.
 
         Returns
-        --------
+        -------
         bool
             Whether or not the plugin name is already registered with the manager.
         """

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -952,7 +952,7 @@ class Database3:
         """
         Create on-the-fly block homog. number density params for XTVIEW viewing.
 
-        See also
+        See Also
         --------
         collectBlockNumberDensities
         """
@@ -1068,6 +1068,7 @@ class Database3:
          - All requested objects must have the same type.
 
         Parameters
+        ----------
         ==========
         comps : list of ArmiObject
             The components/composites that currently occupy the location that you want
@@ -1261,6 +1262,7 @@ class Database3:
         DatabaseInterface may be more useful.
 
         Parameters
+        ----------
         ==========
         comps
             Something that is iterable multiple times
@@ -1270,6 +1272,7 @@ class Database3:
             Selection of time nodes to get data for. If omitted, return full history
 
         Returns
+        -------
         =======
         dict
             Dictionary ArmiObject (input): dict of str/list pairs containing ((cycle,

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -31,8 +31,8 @@ NOTE: Psutil and sys.getsizeof will certainly report slightly different results.
 NOTE: In Windows, it seems that even if your garbage is collected, Windows does not de-allocate all the memory.
 So if you are a worker and you just got a 2GB reactor but then deleted it, Windows will keep you at 2GB for a while.
 
-See Also:
-
+See Also
+--------
 https://pythonhosted.org/psutil/
 https://docs.python.org/3/library/gc.html#gc.garbage
 """

--- a/armi/bookkeeping/report/data.py
+++ b/armi/bookkeeping/report/data.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-
-"""
-import re
-import copy
+"""Data formats for reports."""
 import collections
+import copy
+import re
 
 from armi import runLog
 from armi.bookkeeping.report import html

--- a/armi/bookkeeping/report/newReportUtils.py
+++ b/armi/bookkeeping/report/newReportUtils.py
@@ -43,7 +43,8 @@ def insertGeneralReportContent(cs, r, report, stage):
     Creates Report content that is not plugin specific. Various things for the Design
     and Comprehensive sections of the report.
 
-    Parameters:
+    Parameters
+    ----------
         cs : case settings
         r : reactor
         report : ReportContents object
@@ -106,7 +107,6 @@ def insertBlockDesignReport(blueprint, report, cs):
 
     Parameters
     ----------
-
     blueprint : Blueprint
     report: ReportContent
     cs: Case Settings

--- a/armi/bookkeeping/report/newReports.py
+++ b/armi/bookkeeping/report/newReports.py
@@ -487,7 +487,6 @@ class TimeSeries(ReportNode):
 
         Parameters
         ----------
-
         lineToAddTo: String
             Label associated with the line we are adding ths point to
         time: float

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -918,7 +918,6 @@ def copyInterfaceInputs(
 
     Notes
     -----
-
     Regarding the handling of relative file paths: In the future this could be
     simplified by adding a concept for a suite root directory, below which it is safe
     to copy files without needing to update settings that point with a relative path

--- a/armi/cases/inputModifiers/inputModifiers.py
+++ b/armi/cases/inputModifiers/inputModifiers.py
@@ -145,7 +145,6 @@ class MultiSettingModifier(InputModifier):
 
     Examples
     --------
-
     >>> inputModifiers.MultiSettingModifier(
     ...    {CONF_NEUTRONICS_TYPE: "both", CONF_COARSE_MESH_REBALANCE: -1}
     ... )

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -202,7 +202,7 @@ class EntryPoint:
         This will override whatever is in the settings file.
 
         Parameters
-        ---------
+        ----------
         settingName : str
             the setting name
 

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -602,7 +602,7 @@ class Interface:
         This existed before the advent of ARMI plugins. Perhaps it can be better served
         as a plugin hook. Potential future work.
 
-        See also
+        See Also
         --------
         armi.cases.Case.clone() : Main user of this interface.
 

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -456,6 +456,7 @@ class DistributionAction(MpiAction):
         Overrides invokeHook to distribute work amongst available resources as requested.
 
         Notes
+        -----
         =====
         Two things about this method make it non-recursive
         """

--- a/armi/nucDirectory/nucDir.py
+++ b/armi/nucDirectory/nucDir.py
@@ -288,7 +288,6 @@ def getAtomicWeight(lab=None, z=None, a=None):
 
     Examples
     --------
-
     >>> from armi.nucDirectory import nucDir
     >>> nucDir.getAtomicWeight('U235')
     235.0439299

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -1051,7 +1051,7 @@ class Operator:
         """
         Convenience method reroute to the database interface state reload method.
 
-        See also
+        See Also
         --------
         armi.bookeeping.db.loadOperator:
             A method for loading an operator given a database. loadOperator does not

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -74,7 +74,7 @@ class FuelHandler:
         Link to the current cycle number.
 
         Notes
-        ------
+        -----
         This retains backwards compatibility with previous fuel handler inputs.
         """
         return self.o.r.p.cycle

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -192,7 +192,7 @@ def buildRingSchedule(
         A list of integers corresponding to the ringSchedule determining the widths of each ring area
 
     Examples
-    -------
+    --------
     >>> f.buildRingSchedule(17,1,jumpRingFrom=14)
     ([13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 14, 15, 16, 17],
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -32,7 +32,6 @@ Generally, the cross section manager is a attribute of the lattice physics code 
 
 Examples
 --------
-
     csm = CrossSectionGroupManager()
     csm._setBuGroupBounds(cs['buGroups'])
     csm._addXsGroupsFromBlocks(blockList)
@@ -792,7 +791,7 @@ class CrossSectionGroupManager(interfaces.Interface):
         Set the burnup group structure.
 
         Parameters
-        ---------
+        ----------
         upperBuGroupBounds : list
             List of upper burnup values in percent.
 

--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -226,7 +226,6 @@ class XSSettings(dict):
 
         Notes
         -----
-
         1. If ``AA`` and ``AB`` exist, but ``AC`` is created, then the intended behavior
            is that ``AC`` settings will be set to the settings in ``AA``.
 

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -331,6 +331,7 @@ class FissionProductDefinitionFile:
         The lfp file can contain one or more LFPs. This splits them.
 
         Ignores DUMPs.
+
         Parameters
         ----------
         lfpName : str, optional

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -383,7 +383,7 @@ class LatticePhysicsWriter(interfaces.InputWriter):
         Expands the nuclides in the LFP based on their yields.
 
         Returns
-        --------
+        -------
         dfpDensities : dict
             Detailed Fission Product Densities. keys are FP names, values are block number densities in atoms/bn-cm.
 

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -378,7 +378,7 @@ class ArmiPlugin:
         list
             A list of Settings, Options, or Defaults to be registered.
 
-        See also
+        See Also
         --------
         armi.physics.neutronics.NeutronicsPlugin.defineSettings
         armi.settings.setting.Setting

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -128,7 +128,7 @@ class Assembly(composites.Composite):
         same grid. It may be beneficial in the future to maintain the more strict behavior
         of ArmiObject's ``__lt__`` implementation once the SFP situation is cleared up.
 
-        See also
+        See Also
         --------
         armi.reactor.composites.ArmiObject.__lt__
         """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -260,7 +260,7 @@ class Block(composites.Composite):
         inner cladding area.
 
         Parameters
-        -----------
+        ----------
         cold : bool, optional
             If false, returns the smear density at hot temperatures
 
@@ -1124,7 +1124,7 @@ class Block(composites.Composite):
             Component types to look up
 
         Examples
-        ---------
+        --------
         >>> b.getComponentAreaFrac(Flags.CLAD)
         0.15
 

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -36,7 +36,6 @@ armi.utils.asciimaps
 
 Examples
 --------
-
 ::
 
     grids:

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -43,7 +43,7 @@ def factory(shape, bcomps, kwargs):
     Build a new component object.
 
     Parameters
-    ---------
+    ----------
     shape : str
         lowercase string corresponding to the component type name
     bcomps : list(Component)
@@ -290,7 +290,7 @@ class DerivedShape(UnshapedComponent):
     This a component that does have specific dimensions, but they're complicated.
 
     Notes
-    ----
+    -----
     - This component type is "derived" through the addition or
       subtraction of other shaped components (e.g. Coolant)
     - Because its area and volume are defined by other components,

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -448,7 +448,6 @@ class DifferentialRadialSegment(RadialSegment):
 
     See Also
     --------
-
     geometry purturbation:
     armi.physics.optimize.OptimizationInterface.modifyCase (ThRZReflectorThickness,ThRZActiveHeight,ThRZActiveRadius)
 

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -103,6 +103,7 @@ class FlagSerializer(parameters.Serializer):
         on the passed mapping.
 
         Parameters
+        ----------
         ==========
         inp : int
             input bitfield
@@ -965,7 +966,7 @@ class ArmiObject(metaclass=CompositeModelType):
         Adjust the composition of this object so the mass fraction of nucName is val.
 
         See Also
-        ---------
+        --------
         setMassFracs : efficiently set multiple mass fractions at the same time.
         """
         self.setMassFracs({nucName: val})
@@ -3125,7 +3126,7 @@ class Composite(ArmiObject):
             dictionary of reaction rates (rxn/s) for nG, nF, n2n, nA and nP
 
         Notes
-        ----
+        -----
         If you set nDensity to 1/CM2_PER_BARN this makes 1 group cross section generation easier
         """
         from armi.reactor.blocks import Block

--- a/armi/reactor/converters/__init__.py
+++ b/armi/reactor/converters/__init__.py
@@ -37,6 +37,7 @@ This subpackage contains code that does a certain subset of conversions along th
     In other words, some of these converters may at some point migrate to a more
     design-specific plugin.
     
+
 See Also
 --------
 armi.cases.inputModifiers 

--- a/armi/reactor/converters/pinTypeBlockConverters.py
+++ b/armi/reactor/converters/pinTypeBlockConverters.py
@@ -45,7 +45,6 @@ def adjustSmearDensity(obj, value, bolBlock=None):
 
     Parameters
     ----------
-
     value : float
         new smear density as a fraction.  This fraction must
         evaluate between 0.0 and 1.0

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -624,7 +624,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
         """Ensures that the RuntimeError statement in ExpansionData::_isFuelLocked is raised appropriately.
 
         Notes
-        ------
+        -----
         This is implemented by creating a fuel block that contains no fuel component
         and passing it to ExpansionData::_isFuelLocked.
         """

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -792,7 +792,6 @@ class Grid:
 
         Parameters
         ----------
-
         ijk : tuple of indices or list of the same
             If provided a tuple, an IndexLocation will be created (if necessary) and
             returned. If provided a list, each element will create a new IndexLocation
@@ -802,7 +801,6 @@ class Grid:
 
         Notes
         -----
-
         The method is defaultdict-like, in that it will create a new location on the fly. However,
         the class itself is not really a dictionary, it is just index-able. For example, there is no
         desire to have a ``__setitem__`` method, because the only way to create a location is by

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -962,8 +962,8 @@ class HexReactorTests(ReactorTests):
     def test_applyThermalExpansion_CoreConstruct(self):
         """Test that assemblies in core are correctly expanded.
 
-        Notes:
-        ------
+        Notes
+        -----
         - all assertions skip the first block as it has no $\Delta T$ and does not expand
         """
         originalAssems = self.r.core.getAssemblies()
@@ -1013,8 +1013,8 @@ class HexReactorTests(ReactorTests):
     def test_updateBlockBOLHeights_DBLoad(self):
         """Test that blueprints assemblies are expanded in DB load.
 
-        Notes:
-        ------
+        Notes
+        -----
         - all assertions skip the first block as it has no $\Delta T$ and does not expand
         """
         originalAssems = sorted(a for a in self.r.blueprints.assemblies.values())

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -169,6 +169,7 @@ def fixture(refDirectory=None, targets=None, dependencies=None):
     Decorator to run function based on targets and dependencies similar to GNU Make.
 
     Parameters
+    ----------
     ==========
     refDirectory : str
         String reference directory for all targets/dependencies. This makes it possible to simplify file paths.
@@ -193,12 +194,14 @@ def requires_fixture(fixtureFunction):
     Decorator to require a fixture to have been completed.
 
     Parameters
+    ----------
     ==========
     fixtureFunction : function without any parameters
         Fixture function is a function that has been decorated with ``fixture`` and is called prior to running
         the decorated function.
 
     Notes
+    -----
     =====
     This cannot be used on classes.
     """

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -572,7 +572,7 @@ class AsciiMapHexFullTipsUp(AsciiMap):
         Map indices from ascii.
 
         Notes
-        ----
+        -----
         Not used in reading from file b/c inefficient/repeated base calc
         but required for writing from ij data
         """

--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -35,7 +35,7 @@ Storing a file to the cache::
     crc.store(exe, inp, outFiles)
 
 Notes
-------
+-----
 Could probably be, like, a decorate on subprocess but we call subprocess a bunch of
 different ways.
 """

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -552,7 +552,7 @@ def _radarFactory(numVars, frame="circle"):
     This function creates a RadarAxes projection and registers it.
 
     Raises
-    -------
+    ------
     ValueError
         If value of the frame is unknown.
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,13 +7,15 @@ required-version = "0.0.272"
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 # D104 - missing docstring in public package
 # D300 - docstrings need to use triple quotes
+# D405-D409 - NumPy docstrings
+# D419 - no empty docstrings
 # TID252 - no relative imports
 # SIM103 - simplify code: needless-bool
 # SIM2** - simplify code: complex equality statements
 # SIM3** - simplify code: yoda-conditions
 # SIM4** - simplify code: if-else-blocks
 # SIM9** - simplify code: dict-get-with-none-default
-select = ["E", "F", "D104", "D300", "SIM103", "SIM2", "SIM3", "SIM4", "SIM9", "TID"]
+select = ["E", "F", "D104", "D300", "D405", "D406", "D407", "D408", "D409", "D41", "SIM103", "SIM2", "SIM3", "SIM4", "SIM9", "TID"]
 
 # D205 - 1 blank line required between summary line and description
 # E501 - line length, because we use Black for that


### PR DESCRIPTION
## What is the change?

I am adding some basic docstring rules from `ruff`:

* **D405-D409** - NumPy docstrings
* **D419** - no empty docstrings

## Why is the change being made?

This is part of the on-going work to get the ARMI `ruff.toml` up-to-date.  But I am also doing it one (or two) rules at a time, so my reviewers can actually review all these changes.

This PR implements some basic NumPy docstring rules which I like and were all 100% fixed using an automated process:

```bash
ruff --sellect=405 --fix .
```

I am biased towards `ruff` rules which can be fully automated.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
