### PR TITLE
Expanding ruff application of docstring rules

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -197,16 +197,12 @@ def getDefaultPluginManager() -> pluginManager.ArmiPluginManager:
 
 
 def isConfigured():
-    """
-    Returns whether ARMI has been configured with an App.
-    """
+    """Returns whether ARMI has been configured with an App."""
     return _app is not None
 
 
 def getPluginManager() -> Optional[pluginManager.ArmiPluginManager]:
-    """
-    Return the plugin manager, if there is one.
-    """
+    """Return the plugin manager, if there is one."""
     global _app
     if _app is None:
         return None
@@ -214,9 +210,7 @@ def getPluginManager() -> Optional[pluginManager.ArmiPluginManager]:
 
 
 def getPluginManagerOrFail() -> pluginManager.ArmiPluginManager:
-    """
-    Return the plugin manager. Raise an error if there is none.
-    """
+    """Return the plugin manager. Raise an error if there is none."""
     global _app
     assert _app is not None, (
         "The ARMI plugin manager was requested, no App has been configured. Ensure "
@@ -246,9 +240,7 @@ def _cleanupOnCancel(signum, _frame):
 
 
 def _liveInterpreter():
-    """
-    Return whether we are running within a live/interactive python interpreter.
-    """
+    """Return whether we are running within a live/interactive python interpreter."""
     return not hasattr(main, "__file__")
 
 

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -120,9 +120,7 @@ class App:
         return self._pm
 
     def getSettings(self) -> Dict[str, Setting]:
-        """
-        Return a dictionary containing all Settings defined by the framework and all plugins.
-        """
+        """Return a dictionary containing all Settings defined by the framework and all plugins."""
         # Start with framework settings
         settingDefs = {
             setting.name: setting for setting in fwSettings.getFrameworkSettings()
@@ -231,7 +229,7 @@ class App:
         return renames
 
     def registerUserPlugins(self, pluginPaths):
-        """
+        r"""
         Register additional plugins passed in by importable paths.
         These plugins may be provided e.g. by an application during startup
         based on user input.
@@ -269,7 +267,7 @@ class App:
                 self.__registerUserPluginsInternalImport(pluginPath)
 
     def _isPluginRegistered(self, pluginPath: str):
-        """
+        r"""
         Check if the plugin at the provided path is already registered.
 
         The expected path formats are:

--- a/armi/bookkeeping/__init__.py
+++ b/armi/bookkeeping/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-The bookkeeping package handles data persistence, reporting, and some debugging.
-"""
+"""The bookkeeping package handles data persistence, reporting, and some debugging."""
 from armi import plugins
 
 

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -555,9 +555,7 @@ class Database3:
     def genTimeStepGroups(
         self, timeSteps: Sequence[Tuple[int, int]] = None
     ) -> Generator[h5py._hl.group.Group, None, None]:
-        """
-        Returns a generator of HDF5 Groups for all time nodes, or for the passed selection.
-        """
+        """Returns a generator of HDF5 Groups for all time nodes, or for the passed selection."""
         assert (
             self.h5db is not None
         ), "Must open the database before calling genTimeStepGroups"
@@ -571,18 +569,14 @@ class Database3:
                 yield self.h5db[getH5GroupName(*step)]
 
     def getLayout(self, cycle, node):
-        """
-        Return a Layout object representing the requested cycle and time node.
-        """
+        """Return a Layout object representing the requested cycle and time node."""
         version = (self._versionMajor, self._versionMinor)
         timeGroupName = getH5GroupName(cycle, node)
 
         return Layout(version, self.h5db[timeGroupName])
 
     def genTimeSteps(self) -> Generator[Tuple[int, int], None, None]:
-        """
-        Returns a generator of (cycle, node) tuples that are present in the DB.
-        """
+        """Returns a generator of (cycle, node) tuples that are present in the DB."""
         assert (
             self.h5db is not None
         ), "Must open the database before calling genTimeSteps"
@@ -594,9 +588,7 @@ class Database3:
                 yield (cycle, node)
 
     def genAuxiliaryData(self, ts: Tuple[int, int]) -> Generator[str, None, None]:
-        """
-        Returns a generator of names of auxiliary data on the requested time point.
-        """
+        """Returns a generator of names of auxiliary data on the requested time point."""
         assert (
             self.h5db is not None
         ), "Must open the database before calling genAuxiliaryData"
@@ -631,9 +623,7 @@ class Database3:
             return group
 
     def hasTimeStep(self, cycle, timeNode, statePointName=""):
-        """
-        Returns True if (cycle, timeNode, statePointName) is contained in the database.
-        """
+        """Returns True if (cycle, timeNode, statePointName) is contained in the database."""
         return getH5GroupName(cycle, timeNode, statePointName) in self.h5db
 
     def writeToDB(self, reactor, statePointName=None):

--- a/armi/bookkeeping/db/databaseInterface.py
+++ b/armi/bookkeeping/db/databaseInterface.py
@@ -86,9 +86,7 @@ class DatabaseInterface(interfaces.Interface):
 
     @property
     def database(self):
-        """
-        Presents the internal database object, if it exists.
-        """
+        """Presents the internal database object, if it exists."""
         if self._db is not None:
             return self._db
         else:

--- a/armi/bookkeeping/db/layout.py
+++ b/armi/bookkeeping/db/layout.py
@@ -584,9 +584,7 @@ def _packLocationsV1(
 def _packLocationsV2(
     locations: List[grids.LocationBase],
 ) -> Tuple[List[str], List[Tuple[int, int, int]]]:
-    """
-    Location packing implementation for minor version 3. See release notes above.
-    """
+    """Location packing implementation for minor version 3. See release notes above."""
     locTypes = []
     locData: List[Tuple[int, int, int]] = []
     for loc in locations:
@@ -613,9 +611,7 @@ def _packLocationsV2(
 def _packLocationsV3(
     locations: List[grids.LocationBase],
 ) -> Tuple[List[str], List[Tuple[int, int, int]]]:
-    """
-    Location packing implementation for minor version 4. See release notes above.
-    """
+    """Location packing implementation for minor version 4. See release notes above."""
     locTypes = []
     locData: List[Tuple[int, int, int]] = []
 
@@ -674,9 +670,7 @@ def _unpackLocationsV1(locationTypes, locData):
 
 
 def _unpackLocationsV2(locationTypes, locData):
-    """
-    Location unpacking implementation for minor version 3+. See release notes above.
-    """
+    """Location unpacking implementation for minor version 3+. See release notes above."""
     locsIter = iter(locData)
     unpackedLocs = []
     for lt in locationTypes:

--- a/armi/bookkeeping/db/tests/__init__.py
+++ b/armi/bookkeeping/db/tests/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Database tests.
-"""
+"""Database tests."""
 # Copyright 2009-2019 TerraPower, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Tests for the Database3 class."""
+"""Tests for the Database3 class."""
 import subprocess
 import unittest
 

--- a/armi/bookkeeping/db/tests/test_layout.py
+++ b/armi/bookkeeping/db/tests/test_layout.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Tests for the db Layout and associated tools."""
+"""Tests for the db Layout and associated tools."""
 import os
 import unittest
 

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -140,9 +140,7 @@ class HistoryTrackerInterface(interfaces.Interface):
         self._writeDetailAssemblyHistories()
 
     def addDetailAssembliesBOL(self):
-        """
-        Find and activate assemblies that the user requested detailed treatment of.
-        """
+        """Find and activate assemblies that the user requested detailed treatment of."""
         if self.cs["detailAssemLocationsBOL"]:
             for locLabel in self.cs["detailAssemLocationsBOL"]:
                 ring, pos, _axial = grids.locatorLabelToIndices(locLabel)
@@ -193,9 +191,7 @@ class HistoryTrackerInterface(interfaces.Interface):
                 self.addDetailAssembly(a)
 
     def _writeDetailAssemblyHistories(self):
-        """
-        Write data file with assembly histories.
-        """
+        """Write data file with assembly histories."""
         for a in self.getDetailAssemblies():
             self.writeAssemHistory(a)
 

--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -124,7 +124,6 @@ class MainInterface(interfaces.Interface):
 
     def interactBOC(self, cycle=None):
         """Typically the first interface to interact beginning of cycle."""
-
         runLog.important("Beginning of Cycle {0}".format(cycle))
         runLog.LOG.clearSingleWarnings()
 

--- a/armi/bookkeeping/report/__init__.py
+++ b/armi/bookkeeping/report/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Package for generating reports as printable groups and HTML in ARMI.
-"""
+"""Package for generating reports as printable groups and HTML in ARMI."""
 from armi.bookkeeping.report import data
 
 

--- a/armi/bookkeeping/report/html.py
+++ b/armi/bookkeeping/report/html.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-HTML-formatted reports.
-"""
+"""HTML-formatted reports."""
 import base64
 import datetime
 import html

--- a/armi/bookkeeping/report/newReports.py
+++ b/armi/bookkeeping/report/newReports.py
@@ -39,7 +39,6 @@ class ReportContent:
 
     def writeReports(self):
         """Renders each report into a document for viewing."""
-
         body = htmltree.Body()
         head = htmltree.Head()
 
@@ -341,7 +340,6 @@ class Image(ReportNode):
 
     def render(self, level, idPrefix="") -> htmltree.HtmlElement:
         """Wraps an image file into an html Img tag. (With caption included in the figure)."""
-
         figure = htmltree.Figure()
         if self.encode:
             self.imagePath = encode64(os.path.abspath(self.imagePath))
@@ -393,7 +391,6 @@ class Table(ReportNode):
         """Converts a TableSection object into a html table representation htmltree element with
         header as heading if not None.
         """
-
         table = htmltree.Table()
         table.C.append(htmltree.Caption(self.title, id=idPrefix))
         if self.header is not None:
@@ -558,7 +555,8 @@ class TimeSeries(ReportNode):
 
     def render(self, level, idPrefix="") -> htmltree.HtmlElement:
         """Renders the Timeseries into a graph and places that Image into an html Img tag and returns a div
-        containing that image and the images caption if it has one stored."""
+        containing that image and the images caption if it has one stored.
+        """
         figName = self.plot()
         if self.encode:
             img = htmltree.Img(
@@ -591,7 +589,6 @@ def encode64(file_path):
     ------
     String that is the embedded HTML src attribute for an image in base64
     """
-
     xtn = os.path.splitext(file_path)[1][1:]  # [1:] to cut out the period
     with open(file_path, "rb") as img_src:
         if xtn == "svg":

--- a/armi/bookkeeping/snapshotInterface.py
+++ b/armi/bookkeeping/snapshotInterface.py
@@ -53,17 +53,13 @@ class SnapshotInterface(interfaces.Interface):
             self.activateDefaultSnapshots()
 
     def interactEveryNode(self, cycle, node):
-        """
-        Call the snapshot interface to copy files at each node, if requested
-        """
+        """Call the snapshot interface to copy files at each node, if requested"""
         snapText = getCycleNodeStamp(cycle, node)  # CCCNNN
         if self.cs["dumpSnapshot"] and snapText in self.cs["dumpSnapshot"]:
             self.o.snapshotRequest(cycle, node)
 
     def interactCoupled(self, iteration):
-        """
-        Call the snapshot interface to copy files for coupled iterations, if requested
-        """
+        """Call the snapshot interface to copy files for coupled iterations, if requested"""
         snapText = getCycleNodeStamp(self.r.p.cycle, self.r.p.timeNode)  # CCCNNN
         if self.cs["dumpSnapshot"] and snapText in self.cs["dumpSnapshot"]:
             self.o.snapshotRequest(self.r.p.cycle, self.r.p.timeNode, iteration)

--- a/armi/bookkeeping/visualization/dumper.py
+++ b/armi/bookkeeping/visualization/dumper.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Abstract base class for visualization file dumpers.
-"""
+"""Abstract base class for visualization file dumpers."""
 from abc import ABC, abstractmethod
 
 from armi.reactor import reactors
@@ -26,12 +24,8 @@ class VisFileDumper(ABC):
 
     @abstractmethod
     def __enter__(self):
-        """
-        Invoke initialize when entering a context manager.
-        """
+        """Invoke initialize when entering a context manager."""
 
     @abstractmethod
     def __exit__(self, type, value, traceback):
-        """
-        Invoke initialize when entering a context manager.
-        """
+        """Invoke initialize when entering a context manager."""

--- a/armi/bookkeeping/visualization/tests/test_vis.py
+++ b/armi/bookkeeping/visualization/tests/test_vis.py
@@ -62,9 +62,7 @@ class TestVtkMesh(unittest.TestCase):
 
 
 class TestVisDump(unittest.TestCase):
-    """
-    Test dumping a whole reactor and some specific block types.
-    """
+    """Test dumping a whole reactor and some specific block types."""
 
     @classmethod
     def setUpClass(cls):

--- a/armi/bookkeeping/visualization/utils.py
+++ b/armi/bookkeeping/visualization/utils.py
@@ -90,9 +90,7 @@ class VtkMesh:
         return numpy.array(self.vertices[:, 2])
 
     def append(self, other):
-        """
-        Add more cells to the mesh.
-        """
+        """Add more cells to the mesh."""
         connectOffset = self.vertices.shape[0]
         offsetOffset = self.offsets[-1] if self.offsets.size > 0 else 0
 
@@ -108,7 +106,6 @@ class VtkMesh:
         Write this mesh and the passed data to a VTK file. Returns the base path, plus
         relevant extension.
         """
-
         fullPath = unstructuredGridToVTK(
             path,
             self.x,

--- a/armi/bookkeeping/visualization/vtk.py
+++ b/armi/bookkeeping/visualization/vtk.py
@@ -79,7 +79,6 @@ class VtkDumper(dumper.VisFileDumper):
         excludeParams : list of str, optional
             A list of parameter names to exclude from the output. Defaults to no params.
         """
-
         cycle = r.p.cycle
         timeNode = r.p.timeNode
 

--- a/armi/bookkeeping/visualization/xdmf.py
+++ b/armi/bookkeeping/visualization/xdmf.py
@@ -278,9 +278,7 @@ class XdmfDumper(dumper.VisFileDumper):
         includeParams: Optional[Set[str]] = None,
         excludeParams: Optional[Set[str]] = None,
     ):
-        """
-        Produce a ``<Grid>`` for a single timestep, as well as supporting HDF5 datasets.
-        """
+        """Produce a ``<Grid>`` for a single timestep, as well as supporting HDF5 datasets."""
         cycle = r.p.cycle
         node = r.p.timeNode
 

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -254,7 +254,6 @@ class Case:
 
     def _getPotentialDependencies(self, dirName, title):
         """Get a parent case based on a directory and case title."""
-
         if dirName is None:
             dirName = self.directory
         elif not os.path.isabs(dirName):

--- a/armi/cases/inputModifiers/pinTypeInputModifiers.py
+++ b/armi/cases/inputModifiers/pinTypeInputModifiers.py
@@ -105,9 +105,7 @@ class SmearDensityModifier(_PinTypeAssemblyModifier):
 
 
 class CladThicknessByODModifier(_PinTypeAssemblyModifier):
-    """
-    Adjust the cladding thickness by adjusting the inner diameter of all cladding components.
-    """
+    """Adjust the cladding thickness by adjusting the inner diameter of all cladding components."""
 
     FAIL_IF_AFTER = (SmearDensityModifier,)
 
@@ -120,9 +118,7 @@ class CladThicknessByODModifier(_PinTypeAssemblyModifier):
 
 
 class CladThicknessByIDModifier(_PinTypeAssemblyModifier):
-    """
-    Adjust the cladding thickness by adjusting the outer diameter of the cladding component.
-    """
+    """Adjust the cladding thickness by adjusting the outer diameter of the cladding component."""
 
     FAIL_IF_AFTER = (SmearDensityModifier,)
 

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -91,9 +91,7 @@ class EntryPointsPlugin(plugins.ArmiPlugin):
 
 
 class ArmiParser(argparse.ArgumentParser):
-    """
-    Subclass of default ArgumentParser to better handle application splash text.
-    """
+    """Subclass of default ArgumentParser to better handle application splash text."""
 
     def print_help(self, file=None):
         splash()

--- a/armi/cli/checkInputs.py
+++ b/armi/cli/checkInputs.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Entry point into ARMI to check inputs of a case or a whole folder of cases.
-"""
+"""Entry point into ARMI to check inputs of a case or a whole folder of cases."""
 
 import pathlib
 import sys

--- a/armi/cli/database.py
+++ b/armi/cli/database.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Entry point into ARMI for manipulating output databases.
-"""
+"""Entry point into ARMI for manipulating output databases."""
 import os
 import pathlib
 import re

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -171,9 +171,7 @@ class EntryPoint:
         runLog.setVerbosity(self.cs["verbosity"])
 
     def parse(self, args):
-        """
-        Parse the command line arguments, with the command specific arguments.
-        """
+        """Parse the command line arguments, with the command specific arguments."""
         self.addOptions()
         self.parse_args(args)
 

--- a/armi/cli/gridGui.py
+++ b/armi/cli/gridGui.py
@@ -20,9 +20,7 @@ from armi.cli import entryPoint
 
 
 class GridGuiEntryPoint(entryPoint.EntryPoint):
-    """
-    Load the grid editor GUI.
-    """
+    """Load the grid editor GUI."""
 
     name = "grids"
 

--- a/armi/cli/migrateInputs.py
+++ b/armi/cli/migrateInputs.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Entry point into ARMI to migrate inputs to the latest version of ARMI.
-"""
+"""Entry point into ARMI to migrate inputs to the latest version of ARMI."""
 
 import os
 
@@ -43,9 +41,7 @@ class MigrateInputs(EntryPoint):
         )
 
     def invoke(self):
-        """
-        Run the entry point.
-        """
+        """Run the entry point."""
         if self.args.settings_path:
             path, _fname = os.path.split(self.args.settings_path)
             with directoryChangers.DirectoryChanger(path, dumpOnException=False):

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -249,9 +249,7 @@ class Interface:
 
     @classmethod
     def getInputFiles(cls, cs):
-        """
-        Return a MergeableDict containing files that should be considered "input".
-        """
+        """Return a MergeableDict containing files that should be considered "input"."""
         return utils.MergeableDict()
 
     name: Union[str, None] = None

--- a/armi/materials/air.py
+++ b/armi/materials/air.py
@@ -91,9 +91,7 @@ class Air(material.Fluid):
         return rho_kgPerM3 / G_PER_CM3_TO_KG_PER_M3
 
     def specificVolumeLiquid(self, Tk=None, Tc=None):
-        """
-        Returns the liquid specific volume in m^3/kg of this material given Tk in K or Tc in C.
-        """
+        """Returns the liquid specific volume in m^3/kg of this material given Tk in K or Tc in C."""
         return 1 / (1000.0 * self.pseudoDensity(Tk, Tc))
 
     def thermalConductivity(self, Tk=None, Tc=None):

--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Alloy-200 are wrought commercially pure nickel.
-"""
+"""Alloy-200 are wrought commercially pure nickel."""
 from numpy import interp
 
 from armi.materials.material import Material

--- a/armi/materials/caH2.py
+++ b/armi/materials/caH2.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Calcium Hydride.
-"""
+"""Calcium Hydride."""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/californium.py
+++ b/armi/materials/californium.py
@@ -30,7 +30,5 @@ class Californium(SimpleSolid):
         self.setMassFrac("CF252", 1.0)
 
     def density(self, Tk=None, Tc=None):
-        """
-        https://en.wikipedia.org/wiki/Californium.
-        """
+        """https://en.wikipedia.org/wiki/Californium."""
         return 15.1  # g/cm3

--- a/armi/materials/copper.py
+++ b/armi/materials/copper.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Copper metal.
-"""
+"""Copper metal."""
 
 from armi.utils.units import getTk
 from armi.materials.material import Material

--- a/armi/materials/cs.py
+++ b/armi/materials/cs.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Cesium.
-"""
+"""Cesium."""
 
 from armi.materials.material import Fluid
 from armi.utils.units import getTk

--- a/armi/materials/custom.py
+++ b/armi/materials/custom.py
@@ -25,9 +25,7 @@ from armi.materials.material import Material
 
 
 class Custom(Material):
-    """
-    Custom Materials have user input properties.
-    """
+    """Custom Materials have user input properties."""
 
     name = "Custom"
     enrichedNuclide = "U235"

--- a/armi/materials/graphite.py
+++ b/armi/materials/graphite.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Graphite is often used as a moderator in gas-cooled nuclear reactors.
-"""
+"""Graphite is often used as a moderator in gas-cooled nuclear reactors."""
 
 from armi.materials.material import Material
 from armi.utils import units

--- a/armi/materials/hafnium.py
+++ b/armi/materials/hafnium.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Hafnium is an element that has high capture cross section across multiple isotopes.
-"""
+"""Hafnium is an element that has high capture cross section across multiple isotopes."""
 
 from armi.nucDirectory import nucDir
 from armi.materials.material import SimpleSolid
@@ -28,7 +26,5 @@ class Hafnium(SimpleSolid):
             self.setMassFrac("HF{0}".format(a), abund)
 
     def density(self, Tk=None, Tc=None):
-        r"""
-        http://www.lenntech.com/periodic/elements/hf.htm.
-        """
+        r"""http://www.lenntech.com/periodic/elements/hf.htm."""
         return 13.07

--- a/armi/materials/hastelloyN.py
+++ b/armi/materials/hastelloyN.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Hastelloy-N is a high-nickel structural material invented by ORNL for handling molten fluoride salts.
-"""
+"""Hastelloy-N is a high-nickel structural material invented by ORNL for handling molten fluoride salts."""
 
 from armi.materials.material import Material
 from armi.utils.units import getTk, getTc
@@ -32,6 +30,7 @@ class HastelloyN(Material):
         INL/EXT-11-23076, 2011
 
     """
+
     name = "HastelloyN"
 
     materialIntro = (

--- a/armi/materials/inconel.py
+++ b/armi/materials/inconel.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Inconel is a austenitic nickel-chromium superalloy.
-"""
+"""Inconel is a austenitic nickel-chromium superalloy."""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/inconel600.py
+++ b/armi/materials/inconel600.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Inconel600.
-"""
+"""Inconel600."""
 import numpy
 
 from armi.materials.material import Material

--- a/armi/materials/inconel625.py
+++ b/armi/materials/inconel625.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Inconel625.
-"""
+"""Inconel625."""
 import numpy
 
 from armi.materials.material import Material

--- a/armi/materials/inconel800.py
+++ b/armi/materials/inconel800.py
@@ -25,6 +25,7 @@ class Inconel800(Material):
     .. [SM] Special Metals - Incoloy alloy 800
         (https://www.specialmetals.com/assets/smc/documents/alloys/incoloy/incoloy-alloy-800.pdf)
     """
+
     name = "Inconel800"
     propertyValidTemperature = {"thermal expansion": ((20.0, 800.0), "C")}
     refTempK = 294.15

--- a/armi/materials/inconelPE16.py
+++ b/armi/materials/inconelPE16.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Inconel PE16.
-"""
+"""Inconel PE16."""
 
 from armi import runLog
 from armi.materials.material import SimpleSolid

--- a/armi/materials/inconelX750.py
+++ b/armi/materials/inconelX750.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Inconel X750.
-"""
+"""Inconel X750."""
 import numpy
 
 from armi.utils.units import getTc

--- a/armi/materials/lead.py
+++ b/armi/materials/lead.py
@@ -20,6 +20,7 @@ from armi.utils.units import getTk
 
 class Lead(material.Fluid):
     r"""Natural lead."""
+
     name = "Lead"
     propertyValidTemperature = {
         "density": ((600, 1700), "K"),

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -221,9 +221,7 @@ class Material:
     def getThermalExpansionDensityReduction(
         self, prevTempInC: float, newTempInC: float
     ) -> float:
-        """
-        Return the factor required to update thermal expansion going from temperatureInC to temperatureInCNew.
-        """
+        """Return the factor required to update thermal expansion going from temperatureInC to temperatureInCNew."""
         dLL = self.linearExpansionFactor(Tc=newTempInC, T0=prevTempInC)
         return 1.0 / (1 + dLL) ** 2
 
@@ -666,9 +664,7 @@ class Fluid(Material):
     name = "Fluid"
 
     def getThermalExpansionDensityReduction(self, prevTempInC, newTempInC):
-        """
-        Return the factor required to update thermal expansion going from temperatureInC to temperatureInCNew.
-        """
+        """Return the factor required to update thermal expansion going from temperatureInC to temperatureInCNew."""
         rho0 = self.pseudoDensity(Tc=prevTempInC)
         if not rho0:
             return 1.0
@@ -677,7 +673,8 @@ class Fluid(Material):
 
     def linearExpansion(self, Tk=None, Tc=None):
         """For void, lets just not allow temperature changes to change dimensions
-        since it is a liquid it will fill its space."""
+        since it is a liquid it will fill its space.
+        """
         return 0.0
 
     def getTempChangeForDensityChange(

--- a/armi/materials/mgO.py
+++ b/armi/materials/mgO.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Magnesium Oxide.
-"""
+"""Magnesium Oxide."""
 from armi.utils.units import getTc, getTk
 from armi.materials.material import Material
 
 
 class MgO(Material):
     r"""MagnesiumOxide."""
+
     name = "MgO"
     propertyValidTemperature = {
         "density": ((273, 1273), "K"),

--- a/armi/materials/mixture.py
+++ b/armi/materials/mixture.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Homogenized mixture material.
-"""
+"""Homogenized mixture material."""
 
 from armi import materials
 

--- a/armi/materials/molybdenum.py
+++ b/armi/materials/molybdenum.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Molybdenum.
-"""
+"""Molybdenum."""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/nZ.py
+++ b/armi/materials/nZ.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Niobium Zirconium Alloy.
-"""
+"""Niobium Zirconium Alloy."""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Silicon Carbide.
-"""
+"""Silicon Carbide."""
 
 import math
 
@@ -26,6 +24,7 @@ from armi.utils.units import getTc
 
 class SiC(Material):
     r"""Silicon Carbide."""
+
     name = "SiC"
     thermalScatteringLaws = (
         tsl.byNbAndCompound[nb.byName["C"], tsl.SIC],

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -86,9 +86,7 @@ class Sodium(material.Fluid):
         ) / 1000.0  # convert from kg/m^3 to g/cc.
 
     def specificVolumeLiquid(self, Tk=None, Tc=None):
-        """
-        Returns the liquid specific volume in m^3/kg of this material given Tk in K or Tc in C.
-        """
+        """Returns the liquid specific volume in m^3/kg of this material given Tk in K or Tc in C."""
         return 1 / (1000.0 * self.pseudoDensity(Tk, Tc))
 
     def enthalpy(self, Tk=None, Tc=None):

--- a/armi/materials/sulfur.py
+++ b/armi/materials/sulfur.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Sulfur.
-"""
+"""Sulfur."""
 
 from armi import runLog
 from armi.materials import material
@@ -74,7 +72,8 @@ class Sulfur(material.Fluid):
 
     def volumetricExpansion(self, Tk=None, Tc=None):
         r"""P. Espeau, R. Ceolin "density of molten sulfur in the 334-508K range"
-        This is just a two-point interpolation."""
+        This is just a two-point interpolation.
+        """
         Tk = getTk(Tc, Tk)
         (Tmin, Tmax) = self.propertyValidTemperature["volumetric expansion"][0]
         self.checkPropertyTempRange("volumetric expansion", Tk)

--- a/armi/materials/tests/test_air.py
+++ b/armi/materials/tests/test_air.py
@@ -178,9 +178,7 @@ REFERENCE_THERMAL_CONDUCTIVITY_mJ_PER_M_K = [
 
 
 class Test_Air(unittest.TestCase):
-    """
-    unit tests for air materials.
-    """
+    """unit tests for air materials."""
 
     def test_pseudoDensity(self):
         """

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Uranium Thorium Zirconium alloy metal.
-"""
+"""Uranium Thorium Zirconium alloy metal."""
 from armi.utils.units import getTk
 from armi.materials.material import FuelMaterial
 from armi import runLog

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -131,9 +131,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
         material.FuelMaterial.applyInputParams(self, *args, **kwargs)
 
     def setDefaultMassFracs(self) -> None:
-        r"""
-        UO2 mass fractions. Using Natural Uranium without U234.
-        """
+        r"""UO2 mass fractions. Using Natural Uranium without U234."""
         u235 = nb.byName["U235"]
         u238 = nb.byName["U238"]
         oxygen = nb.byName["O"]
@@ -235,4 +233,5 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
 
 class UO2(UraniumOxide):
     r"""Another name for UraniumOxide."""
+
     pass

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Zirconium metal.
-"""
+"""Zirconium metal."""
 
 from numpy import interp
 

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -126,15 +126,12 @@ class MpiAction:
         r : :py:class:`armi.operators.Reactor`
             If a reactor is not necessary, supply :code:`None`.
         """
-
         instance = cls()
         instance.broadcast()
         return instance.invoke(o, r, cs)
 
     def _mpiOperationHelper(self, obj, mpiFunction):
-        """
-        Strips off the operator, reactor, cs from the mpiAction before.
-        """
+        """Strips off the operator, reactor, cs from the mpiAction before."""
         if obj is None or obj is self:
             # prevent sending o, r, and cs, they should be handled appropriately by the other nodes
             # reattach with finally

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -146,9 +146,7 @@ class TestNuclide(unittest.TestCase):
         self.assertGreater(count, 10)
 
     def test_nucBases_imposeBurnChainDecayBulkStatistics(self):
-        """
-        Test must be updated manually when burn chain is modified.
-        """
+        """Test must be updated manually when burn chain is modified."""
         decayers = list(nuclideBases.where(lambda nn: len(nn.decays) > 0))
         self.assertTrue(decayers)
         for nuc in decayers:

--- a/armi/nuclearDataIO/__init__.py
+++ b/armi/nuclearDataIO/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Read and/or write data files associated with nuclear data and reactor physics data.
-"""
+"""Read and/or write data files associated with nuclear data and reactor physics data."""
 # ruff: noqa: F401
 
 from armi.physics import neutronics

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -228,9 +228,7 @@ class IORecord:
         return self._rwMatrix(contents, self.rwDouble, *shape)
 
     def rwIntMatrix(self, contents, *shape):
-        """
-        Read or write a matrix of int values.
-        """
+        """Read or write a matrix of int values."""
         return self._rwMatrix(contents, self.rwInt, *shape)
 
     @staticmethod
@@ -349,7 +347,8 @@ class BinaryRecordReader(IORecord):
 class BinaryRecordWriter(IORecord):
     r"""a single record from a CCCC file.
 
-    Reads binary information sequentially."""
+    Reads binary information sequentially.
+    """
 
     def __init__(self, stream, hasRecordBoundaries=True):
         IORecord.__init__(self, stream, hasRecordBoundaries)
@@ -442,7 +441,7 @@ class AsciiRecordReader(BinaryRecordReader):
 
 
 class AsciiRecordWriter(IORecord):
-    """Writes a single CCCC record in ASCII format.
+    r"""Writes a single CCCC record in ASCII format.
 
     Since there is no specific format of an ASCII CCCC record, the format is roughly the same as
     the :py:class:`BinaryRecordWriter`, except that the :class:`AsciiRecordReader` puts a space in

--- a/armi/nuclearDataIO/cccc/compxs.py
+++ b/armi/nuclearDataIO/cccc/compxs.py
@@ -225,7 +225,6 @@ class _CompxsIO(cccc.Stream):
         --------
         armi.nuclearDataIO.cccc.isotxs._IsotxsIO.readWrite : reading/writing ISOTXS files
         """
-
         runLog.info(
             "{} macroscopic cross library {}".format(
                 "Reading" if self._isReading else "Writing", self

--- a/armi/nuclearDataIO/cccc/fixsrc.py
+++ b/armi/nuclearDataIO/cccc/fixsrc.py
@@ -40,9 +40,7 @@ def writeBinary(fileName, fixSrcArray):
 
 
 class FIXSRC(cccc.Stream):
-    r"""
-    Read or write a binary FIXSRC file from DIF3D fixed source input.
-    """
+    r"""Read or write a binary FIXSRC file from DIF3D fixed source input."""
 
     def __init__(self, fileName, fileMode, fixSrc):
         r"""
@@ -64,7 +62,6 @@ class FIXSRC(cccc.Stream):
             from a neutron RTFLUX file (requires reactor geometry and settings).
 
         """
-
         cccc.Stream.__init__(self, fileName, fileMode)
 
         # copied from a sample FIXSRC output from "type 19" DIF3D input
@@ -93,11 +90,7 @@ class FIXSRC(cccc.Stream):
         )
 
     def readWrite(self):
-        r"""
-        Read or write a binary FIXSRC file for DIF3D fixed source input.
-
-        """
-
+        r"""Read or write a binary FIXSRC file for DIF3D fixed source input."""
         runLog.info(
             "{} gamma fixed source file {}".format(
                 "Reading" if "r" in self._fileMode else "Writing", self
@@ -114,17 +107,13 @@ class FIXSRC(cccc.Stream):
                 self._rw3DRecord(g, z)
 
     def _rwFileID(self):
-        r"""
-        Read file identification information.
-        """
+        r"""Read file identification information."""
         with self.createRecord() as fileIdRecord:
             self.label = fileIdRecord.rwString(self.label, 24)
             self.fileId = fileIdRecord.rwInt(self.fileId)
 
     def _rw1DRecord(self):
-        r"""
-        Read/write parameters from/to the FIXSRC 1D block (file control).
-        """
+        r"""Read/write parameters from/to the FIXSRC 1D block (file control)."""
         with self.createRecord() as record:
             for var in self.fc.keys():
                 self.fc[var] = record.rwInt(self.fc[var])
@@ -142,7 +131,6 @@ class FIXSRC(cccc.Stream):
             The DIF3D axial node index.
 
         """
-
         with self.createRecord() as record:
 
             ni = self.fc["ninti"]

--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -375,9 +375,7 @@ class NhfluxStream(cccc.StreamWithDataContainer):
             self._metadata["label"] = record.rwString(self._metadata["label"], 28)
 
     def _rwBasicFileData1D(self):
-        """
-        Read basic data parameters (number of energy groups, assemblies, axial nodes, etc.).
-        """
+        """Read basic data parameters (number of energy groups, assemblies, axial nodes, etc.)."""
         # Dummy values are stored because sometimes they get assigned
         # unexpected values anyway, and so we still want to preserve those values anyway
         if self._metadata["variantFlag"]:
@@ -625,7 +623,6 @@ class NhfluxStream(cccc.StreamWithDataContainer):
         Real fluxes stored in NHFLUX have "normal" (or "forward") energy groups.
         Also see the subclass method NAFLUX.getEnergyGroupIndex().
         """
-
         return g
 
 
@@ -637,9 +634,7 @@ class NafluxStream(NhfluxStream):
     """
 
     def _getEnergyGroupIndex(self, g):
-        r"""
-        Adjoint fluxes stored in NAFLUX have "reversed" (or "backward") energy groups.
-        """
+        r"""Adjoint fluxes stored in NAFLUX have "reversed" (or "backward") energy groups."""
         ng = self._metadata["ngroup"]
         return ng - g - 1
 

--- a/armi/nuclearDataIO/cccc/pwdint.py
+++ b/armi/nuclearDataIO/cccc/pwdint.py
@@ -96,9 +96,7 @@ class PwdintStream(cccc.StreamWithDataContainer):
             self._metadata["mult"] = record.rwInt(self._metadata["mult"])
 
     def _rw1DRecord(self):
-        """
-        Read/write File specifications on 1D record.
-        """
+        """Read/write File specifications on 1D record."""
         with self.createRecord() as record:
             self._metadata.update(
                 record.rwImplicitlyTypedMap(FILE_SPEC_1D_KEYS, self._metadata)

--- a/armi/nuclearDataIO/cccc/rtflux.py
+++ b/armi/nuclearDataIO/cccc/rtflux.py
@@ -92,9 +92,7 @@ class RtfluxStream(cccc.StreamWithDataContainer):
         return RtfluxData()
 
     def readWrite(self):
-        """
-        Step through the structure of the file and read/write it.
-        """
+        """Step through the structure of the file and read/write it."""
         self._rwFileID()
         self._rw1DRecord()
         if self._metadata["NDIM"] == 1:
@@ -117,18 +115,14 @@ class RtfluxStream(cccc.StreamWithDataContainer):
             self._metadata["label"] = record.rwString(self._metadata["label"], 28)
 
     def _rw1DRecord(self):
-        """
-        Read/write File specifications on 1D record.
-        """
+        """Read/write File specifications on 1D record."""
         with self.createRecord() as record:
             self._metadata.update(
                 record.rwImplicitlyTypedMap(FILE_SPEC_1D_KEYS, self._metadata)
             )
 
     def _rw2DRecord(self):
-        """
-        Read/write 1-dimensional regular total flux.
-        """
+        """Read/write 1-dimensional regular total flux."""
         raise NotImplementedError("1-D RTFLUX files are not yet implemented.")
 
     def _rw3DRecord(self):
@@ -137,7 +131,6 @@ class RtfluxStream(cccc.StreamWithDataContainer):
 
         The records contain blocks of values in the i-j planes.
         """
-
         ng = self._metadata["NGROUP"]
         imax = self._metadata["NINTI"]
         jmax = self._metadata["NINTJ"]
@@ -187,7 +180,6 @@ class AtfluxStream(RtfluxStream):
 
         0 based, so if NG=33 and you want the third group (g=2), this returns 30.
         """
-
         ng = self._metadata["NGROUP"]
         return ng - g - 1
 
@@ -197,7 +189,6 @@ def getFDFluxReader(adjointFlag):
     Returns the appropriate DIF3D FD flux binary file reader class,
     either RTFLUX (real) or ATFLUX (adjoint).
     """
-
     if adjointFlag:
         return AtfluxStream
     else:

--- a/armi/nuclearDataIO/cccc/tests/test_rtflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_rtflux.py
@@ -24,9 +24,7 @@ SIMPLE_RTFLUX = os.path.join(THIS_DIR, "fixtures", "simple_cartesian.rtflux")
 
 
 class Testrtflux(unittest.TestCase):
-    r"""
-    Tests the rtflux class.
-    """
+    r"""Tests the rtflux class."""
 
     def test_readrtflux(self):
         """Ensure we can read a rtflux file."""

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -496,7 +496,6 @@ class MacroscopicCrossSectionCreator:
             The block attribute containing the desired microscopic XS for this block:
             either "micros" for neutron XS or "gammaXS" for gamma XS.
         """
-
         if not self.buildScatterMatrix:
             return
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -331,9 +331,7 @@ class Operator:
         self._mainOperate()
 
     def _mainOperate(self):
-        """
-        Main loop for a standard ARMI run. Steps through time interacting with the interfaces.
-        """
+        """Main loop for a standard ARMI run. Steps through time interacting with the interfaces."""
         self.interactAllBOL()
         startingCycle = self.r.p.cycle  # may be starting at t != 0 in restarts
         for cycle in range(startingCycle, self.cs["nCycles"]):
@@ -699,7 +697,8 @@ class Operator:
 
         Notes
         -----
-        This is split off from self.interactAllCoupled to accomodate testing"""
+        This is split off from self.interactAllCoupled to accomodate testing
+        """
         # Summarize the coupled results and the convergence status.
         converged = []
         for interface in activeInterfaces:

--- a/armi/operators/tests/__init__.py
+++ b/armi/operators/tests/__init__.py
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tests for built-in operators.
-"""
+"""Tests for built-in operators."""

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -106,7 +106,6 @@ class OperatorTests(unittest.TestCase):
 
     def test_loadStateError(self):
         """The ``loadTestReactor()`` test tool does not have any history in the DB to load from."""
-
         # a first, simple test that this method fails correctly
         with self.assertRaises(RuntimeError):
             self.o.loadState(0, 1)
@@ -281,9 +280,7 @@ class TestTightCoupling(unittest.TestCase):
 
 
 class CyclesSettingsTests(unittest.TestCase):
-    """
-    Check that we can correctly access the various cycle settings from the operator.
-    """
+    """Check that we can correctly access the various cycle settings from the operator."""
 
     detailedCyclesSettings = """
 metadata:

--- a/armi/physics/constants.py
+++ b/armi/physics/constants.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Some constants.
-"""
+"""Some constants."""
 
 DPA_CROSS_SECTIONS = {}
 """Multigroup dpa cross sections.

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -678,9 +678,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
             self.assertIn("top elevation of stationary", mock.getStdout())
 
     def test_dischargeSwap(self):
-        """
-        Test the dischargeSwap method.
-        """
+        """Test the dischargeSwap method."""
         # grab stationary block flags
         sBFList = self.r.core.stationaryBlockFlagsList
 

--- a/armi/physics/fuelPerformance/plugin.py
+++ b/armi/physics/fuelPerformance/plugin.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Generic Fuel Performance Plugin.
-"""
+"""Generic Fuel Performance Plugin."""
 
 from armi import plugins
 from armi import interfaces

--- a/armi/physics/fuelPerformance/utils.py
+++ b/armi/physics/fuelPerformance/utils.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Fuel performance utilities.
-"""
+"""Fuel performance utilities."""
 
 from armi.reactor.flags import Flags
 

--- a/armi/physics/neutronics/__init__.py
+++ b/armi/physics/neutronics/__init__.py
@@ -42,16 +42,12 @@ from armi.physics.neutronics.const import CONF_CROSS_SECTION
 
 
 class NeutronicsPlugin(plugins.ArmiPlugin):
-    """
-    The built-in neutronics plugin with a few capabilities and a lot of state parameter definitions.
-    """
+    """The built-in neutronics plugin with a few capabilities and a lot of state parameter definitions."""
 
     @staticmethod
     @plugins.HOOKIMPL
     def exposeInterfaces(cs):
-        """
-        Collect and expose all of the interfaces that live under the built-in neutronics package.
-        """
+        """Collect and expose all of the interfaces that live under the built-in neutronics package."""
         from armi.physics.neutronics import crossSectionGroupManager
         from armi.physics.neutronics.fissionProductModel import fissionProductModel
 

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -210,9 +210,7 @@ class BlockCollection(list):
         raise NotImplementedError
 
     def getWeight(self, block):
-        """
-        Get value of weighting function for this block.
-        """
+        """Get value of weighting function for this block."""
         vol = block.getVolume() or 1.0
         if not self.weightingParam:
             weight = 1.0
@@ -256,9 +254,7 @@ class BlockCollection(list):
 
 
 class MedianBlockCollection(BlockCollection):
-    """
-    Returns the median burnup block. This is a simple and often accurate approximation.
-    """
+    """Returns the median burnup block. This is a simple and often accurate approximation."""
 
     def _makeRepresentativeBlock(self):
         """Get the median burnup block."""
@@ -319,9 +315,7 @@ class AverageBlockCollection(BlockCollection):
     """
 
     def _makeRepresentativeBlock(self):
-        """
-        Generate a block that best represents all blocks in group.
-        """
+        """Generate a block that best represents all blocks in group."""
         newBlock = self._getNewBlock()
         lfpCollection = self._getAverageFuelLFP()
         newBlock.setLumpedFissionProducts(lfpCollection)
@@ -681,9 +675,7 @@ class SlabComponentsAverageBlockCollection(BlockCollection):
 
 
 class FluxWeightedAverageBlockCollection(AverageBlockCollection):
-    """
-    Flux-weighted AverageBlockCollection.
-    """
+    """Flux-weighted AverageBlockCollection."""
 
     def __init__(self, *args, **kwargs):
         AverageBlockCollection.__init__(self, *args, **kwargs)
@@ -772,7 +764,6 @@ class CrossSectionGroupManager(interfaces.Interface):
         --------
         :py:meth:`Assembly <armi.physics.neutronics.latticePhysics.latticePhysics.LatticePhysicsInterface.interactCoupled>`
         """
-
         if (
             iteration == 0
             and self._latticePhysicsFrequency
@@ -1140,9 +1131,7 @@ class CrossSectionGroupManager(interfaces.Interface):
         return unrepresentedBlocks
 
     def makeCrossSectionGroups(self):
-        """
-        Make cross section groups for all blocks in reactor and unrepresented blocks from blueprints.
-        """
+        """Make cross section groups for all blocks in reactor and unrepresented blocks from blueprints."""
         bCollectXSGroup = {}  # clear old groups (in case some are no longer existent)
         bCollectXSGroup = self._addXsGroupsFromBlocks(
             bCollectXSGroup, self.r.core.getBlocks()
@@ -1316,9 +1305,7 @@ BLOCK_COLLECTIONS = {
 
 
 def blockCollectionFactory(xsSettings, allNuclidesInProblem):
-    """
-    Build a block collection based on user settings and input.
-    """
+    """Build a block collection based on user settings and input."""
     blockRepresentation = xsSettings.blockRepresentation
     validBlockTypes = xsSettings.validBlockTypes
     return BLOCK_COLLECTIONS[blockRepresentation](

--- a/armi/physics/neutronics/diffIsotxs.py
+++ b/armi/physics/neutronics/diffIsotxs.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This script is used to compare ISOTXS files.
-"""
+"""This script is used to compare ISOTXS files."""
 from armi import runLog
 from armi.cli.entryPoint import EntryPoint
 

--- a/armi/physics/neutronics/energyGroups.py
+++ b/armi/physics/neutronics/energyGroups.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Energy group structures for multigroup neutronics calculations.
-"""
+"""Energy group structures for multigroup neutronics calculations."""
 
 import copy
 import itertools
@@ -85,9 +83,7 @@ def getGroupStructure(name):
 
 
 def getGroupStructureType(neutronEnergyBoundsInEv):
-    """
-    Return neutron energy group structure name for a given set of neutron energy group bounds in eV.
-    """
+    """Return neutron energy group structure name for a given set of neutron energy group bounds in eV."""
     neutronEnergyBoundsInEv = numpy.array(neutronEnergyBoundsInEv)
     for groupStructureType in GROUP_STRUCTURE:
         refNeutronEnergyBoundsInEv = numpy.array(getGroupStructure(groupStructureType))

--- a/armi/physics/neutronics/fissionProductModel/__init__.py
+++ b/armi/physics/neutronics/fissionProductModel/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-The Fission product model subpackage.
-"""
+"""The Fission product model subpackage."""
 
 import os
 from armi.context import RES

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -113,7 +113,6 @@ ORDER = interfaces.STACK_ORDER.AFTER + interfaces.STACK_ORDER.PREPROCESSING
 
 def describeInterfaces(_cs):
     """Function for exposing interface(s) to other code."""
-
     return (FissionProductModel, {})
 
 
@@ -228,7 +227,6 @@ class FissionProductModel(interfaces.Interface):
         --------
         armi.reactor.blocks.Block.getLumpedFissionProductCollection : same thing, but block-level compatible. Use this
         """
-
         self._globalLFPs = lfps
 
     def interactBOC(self, cycle=None):

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModelSettings.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModelSettings.py
@@ -92,7 +92,6 @@ def defineSettings():
 
 def getFissionProductModelSettingValidators(inspector):
     """The standard helper method, to provide validators to the fission product model."""
-
     # Import the Query class here to avoid circular imports.
     from armi.operators.settingsValidation import Query
 

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -66,9 +66,7 @@ class LumpedFissionProduct:
         self.yld = {}
 
     def duplicate(self):
-        """
-        Make a copy of this w/o using deepcopy.
-        """
+        """Make a copy of this w/o using deepcopy."""
         new = self.__class__(self.name)
         for key, val in self.yld.items():
             new.yld[key] = val
@@ -260,9 +258,7 @@ class LumpedFissionProductCollection(dict):
         return fpDensities
 
     def getMassFrac(self, oldMassFrac=None):
-        """
-        returns the mass fraction vector of the collection of lumped fission products.
-        """
+        """returns the mass fraction vector of the collection of lumped fission products."""
         if not oldMassFrac:
             raise ValueError("You must define a massFrac vector")
 
@@ -319,9 +315,7 @@ class FissionProductDefinitionFile:
         return lfps
 
     def createSingleLFPFromFile(self, name):
-        """
-        Read one LFP from the file.
-        """
+        """Read one LFP from the file."""
         lfpLines = self._splitIntoIndividualLFPLines(name)
         lfp = self._readOneLFP(lfpLines[0])  # only one LFP expected. Use it.
         return lfp

--- a/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Test the fission product module to ensure all FP are available.
-"""
+"""Test the fission product module to ensure all FP are available."""
 import unittest
 
 from armi import nuclideBases
@@ -93,9 +91,7 @@ class TestFissionProductModelLumpedFissionProducts(unittest.TestCase):
 
 
 class TestFissionProductModelExplicitMC2Library(unittest.TestCase):
-    """
-    Tests the fission product model interface behavior when explicit fission products are enabled.
-    """
+    """Tests the fission product model interface behavior when explicit fission products are enabled."""
 
     def setUp(self):
         o, r = loadTestReactor(
@@ -131,7 +127,6 @@ class TestFissionProductModelExplicitMC2Library(unittest.TestCase):
 
     def test_nuclidesInModelAllDepletableBlocks(self):
         """Test that the depletable blocks contain all the MC2-3 modeled nuclides."""
-
         # Check that there are some fuel and control blocks in the core model.
         fuelBlocks = self.r.core.getBlocks(Flags.FUEL)
         controlBlocks = self.r.core.getBlocks(Flags.CONTROL)

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-The Global flux interface provide a base class for all neutronics tools that compute the neutron and/or photon flux.
-"""
+"""The Global flux interface provide a base class for all neutronics tools that compute the neutron and/or photon flux."""
 import math
 from typing import Dict, Optional
 
@@ -635,9 +633,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
         raise NotImplementedError()
 
     def clearFlux(self):
-        """
-        Delete flux on all blocks. Needed to prevent stale flux when partially reloading.
-        """
+        """Delete flux on all blocks. Needed to prevent stale flux when partially reloading."""
         for b in self.r.core.getBlocks():
             b.p.mgFlux = []
             b.p.adjMgFlux = []

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -81,9 +81,7 @@ class MockGlobalFluxWithExecuters(
 
 class MockGlobalFluxWithExecutersNonUniform(MockGlobalFluxWithExecuters):
     def getExecuterOptions(self, label=None):
-        """
-        Return modified executerOptions.
-        """
+        """Return modified executerOptions."""
         opts = globalFluxInterface.GlobalFluxInterfaceUsingExecuters.getExecuterOptions(
             self, label=label
         )

--- a/armi/physics/neutronics/isotopicDepletion/__init__.py
+++ b/armi/physics/neutronics/isotopicDepletion/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-The depletion physics package contains utility/framework code related to the physics of transmutation and decay.
-"""
+"""The depletion physics package contains utility/framework code related to the physics of transmutation and decay."""
 # ruff: noqa: F401
 import os
 

--- a/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
+++ b/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
@@ -115,9 +115,7 @@ class CrossSectionTable(collections.OrderedDict):
         self.add(nucName, **oneGroupXSbyName)
 
     def hasValues(self):
-        """
-        determines if there are non-zero values in this cross section table.
-        """
+        """determines if there are non-zero values in this cross section table."""
         for nuclideCrossSectionSet in self.values():
             if any(nuclideCrossSectionSet.values()):
                 return True
@@ -180,7 +178,6 @@ def makeReactionRateTable(obj, nuclides: List = None):
     --------
     armi.physics.neutronics.isotopicDepletion.isotopicDepletionInterface.CrossSectionTable
     """
-
     if nuclides is None:
         nuclides = obj.getNuclides()
 

--- a/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
+++ b/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-An abstract class for interfaces between ARMI and programs that simulate transmutation and decay.
-"""
+"""An abstract class for interfaces between ARMI and programs that simulate transmutation and decay."""
 import collections
 
 from armi import interfaces
@@ -57,7 +55,6 @@ def isDepletable(obj: composites.ArmiObject):
     --------
     armi.reactor.blueprints.componentBlueprint.insertDepletableNuclideKeys
     """
-
     return obj.hasFlags(Flags.DEPLETABLE) or obj.containsAtLeastOneChildWithFlags(
         Flags.DEPLETABLE
     )
@@ -78,6 +75,7 @@ class AbstractIsotopicDepleter:
 
     _depleteByName contains a ARMI objects to deplete keyed by name.
     """
+
     name = None
     function = "depletion"
 
@@ -181,14 +179,10 @@ def makeXsecTable(
 
 
 class AbstractIsotopicDepletionReader(interfaces.OutputReader):
-    r"""
-    Read number density output produced by the isotopic depletion.
-    """
+    r"""Read number density output produced by the isotopic depletion."""
 
     def read(self):
-        r"""
-        read a isotopic depletion Output File and applies results to armi objects in the ``ToDepletion`` attribute.
-        """
+        r"""read a isotopic depletion Output File and applies results to armi objects in the ``ToDepletion`` attribute."""
         raise NotImplementedError
 
 
@@ -218,7 +212,5 @@ class Csrc:
         return self._chemicalVector
 
     def write(self):
-        """
-        return a list of lines to write for a csrc card.
-        """
+        """return a list of lines to write for a csrc card."""
         raise NotImplementedError

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -453,7 +453,6 @@ class LatticePhysicsWriter(interfaces.InputWriter):
             new = number density of Pu-239 after adjustment
 
         """
-
         minFrac = self.cs[CONF_MINIMUM_FISSILE_FRACTION]
         fiss = sum(dens[0] for nuc, dens in nucDensities.items() if nuc.isFissile())
         hm = sum(dens[0] for nuc, dens in nucDensities.items() if nuc.isHeavyMetal())

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -140,9 +140,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         self.assertTrue(self.latticeInterface.testVerification)
 
     def test_interactEveryNode(self):
-        """
-        Test interactEveryNode() with different update frequencies.
-        """
+        """Test interactEveryNode() with different update frequencies."""
         self.latticeInterface._latticePhysicsFrequency = LatticePhysicsFrequency.BOC
         self.latticeInterface.interactEveryNode()
         self.assertEqual(self.o.r.core.lib, "Nonsense")
@@ -153,9 +151,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         self.assertIsNone(self.o.r.core.lib)
 
     def test_interactEveryNodeFirstCoupled(self):
-        """
-        Test interactEveryNode() with LatticePhysicsFrequency.firstCoupledIteration.
-        """
+        """Test interactEveryNode() with LatticePhysicsFrequency.firstCoupledIteration."""
         self.latticeInterface._latticePhysicsFrequency = (
             LatticePhysicsFrequency.firstCoupledIteration
         )
@@ -163,17 +159,13 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         self.assertIsNone(self.o.r.core.lib)
 
     def test_interactEveryNodeAll(self):
-        """
-        Test interactEveryNode() with LatticePhysicsFrequency.all.
-        """
+        """Test interactEveryNode() with LatticePhysicsFrequency.all."""
         self.latticeInterface._latticePhysicsFrequency = LatticePhysicsFrequency.all
         self.latticeInterface.interactEveryNode()
         self.assertIsNone(self.o.r.core.lib)
 
     def test_interactFirstCoupledIteration(self):
-        """
-        Test interactCoupled() with different update frequencies on first iteration.
-        """
+        """Test interactCoupled() with different update frequencies on first iteration."""
         self.latticeInterface._latticePhysicsFrequency = (
             LatticePhysicsFrequency.everyNode
         )
@@ -186,9 +178,7 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         self.assertIsNone(self.o.r.core.lib)
 
     def test_interactAll(self):
-        """
-        Test interactCoupled() with different update frequencies on non-first iteration.
-        """
+        """Test interactCoupled() with different update frequencies on non-first iteration."""
         self.latticeInterface._latticePhysicsFrequency = (
             LatticePhysicsFrequency.firstCoupledIteration
         )

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -121,9 +121,7 @@ class TestBlockCollectionAverage(unittest.TestCase):
 
 
 class TestBlockCollectionComponentAverage(unittest.TestCase):
-    r"""
-    tests for ZPPR 1D XS gen cases.
-    """
+    r"""tests for ZPPR 1D XS gen cases."""
 
     def setUp(self):
         r"""
@@ -211,9 +209,7 @@ class TestBlockCollectionComponentAverage(unittest.TestCase):
 
 
 class TestBlockCollectionComponentAverage1DCylinder(unittest.TestCase):
-    r"""
-    tests for 1D cylinder XS gen cases.
-    """
+    r"""tests for 1D cylinder XS gen cases."""
 
     def setUp(self):
         r"""

--- a/armi/physics/tests/test_executers.py
+++ b/armi/physics/tests/test_executers.py
@@ -71,9 +71,7 @@ class TestExecuters(unittest.TestCase):
         self.executer = executers.DefaultExecuter(e, MockReactor())
 
     def test_collectInputsAndOutputs(self):
-        """
-        Verify that the executer can select to not copy back output.
-        """
+        """Verify that the executer can select to not copy back output."""
         self.executer.options.inputFile = "test.inp"
         self.executer.options.outputFile = "test.out"
         self.executer.options.copyOutput = False
@@ -97,7 +95,6 @@ class TestExecuters(unittest.TestCase):
         Verify that runDir is updated when TemporaryDirectoryChanger is used and
         not updated when ForcedCreationDirectoryChanger is used.
         """
-
         self.assertEqual(
             self.executer.dcType, directoryChangers.TemporaryDirectoryChanger
         )

--- a/armi/pluginManager.py
+++ b/armi/pluginManager.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Slightly customized version of the stock pluggy ``PluginManager``.
-"""
+"""Slightly customized version of the stock pluggy ``PluginManager``."""
 
 import pluggy
 

--- a/armi/reactor/__init__.py
+++ b/armi/reactor/__init__.py
@@ -44,9 +44,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class ReactorPlugin(plugins.ArmiPlugin):
-    """
-    Plugin exposing built-in reactor components, blocks, assemblies, etc.
-    """
+    """Plugin exposing built-in reactor components, blocks, assemblies, etc."""
 
     @staticmethod
     @plugins.HOOKIMPL

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -220,9 +220,7 @@ class Assembly(composites.Composite):
         )
 
     def coords(self):
-        """
-        Return the location of the assembly in the plane using cartesian global coordinates.
-        """
+        """Return the location of the assembly in the plane using cartesian global coordinates."""
         x, y, _z = self.spatialLocator.getGlobalCoordinates()
         return (x, y)
 
@@ -315,9 +313,7 @@ class Assembly(composites.Composite):
         self.reestablishBlockOrder()
 
     def adjustResolution(self, refA):
-        """
-        Split the blocks in this assembly to have the same mesh structure as refA.
-        """
+        """Split the blocks in this assembly to have the same mesh structure as refA."""
         newBlockStack = []
 
         newBlocks = 0  # number of new blocks we've added so far.
@@ -643,7 +639,6 @@ class Assembly(composites.Composite):
         armi.assemblies.Assembly.setBlockMesh
 
         """
-
         if b.hasFlags(Flags.FUEL):
             # fuel block
             conserveMass = True
@@ -812,7 +807,6 @@ class Assembly(composites.Composite):
         for block, bottomZ in a.getBlocksAndZ(returnBottomZ=True):
             print({0}'s bottom mesh point is {1}'.format(block, bottomZ))
         """
-
         if returnBottomZ and returnTopZ:
             raise ValueError("Both returnTopZ and returnBottomZ are set to `True`")
 
@@ -903,7 +897,6 @@ class Assembly(composites.Composite):
             The axial index (beginning with 0) of the ARMI block containing the
             DIF3D node corresponding to zIndex.
         """
-
         zIndexTot = -1
         for bIndex, b in enumerate(self):
             zIndexTot += b.p.axMesh
@@ -1180,7 +1173,6 @@ class Assembly(composites.Composite):
 
         Example: getDim(Flags.WIRE, 'od') will return a wire's OD in cm.
         """
-
         # prefer fuel blocks.
         bList = self.getBlocks(Flags.FUEL)
         if not bList:
@@ -1286,7 +1278,8 @@ class ThRZAssembly(RZAssembly):
     Notes
     -----
     This is a subclass of RZAssemblies, which is its a subclass of the Generics Assembly
-    Object"""
+    Object
+    """
 
     def __init__(self, assemType, assemNum=None):
         RZAssembly.__init__(self, assemType, assemNum)

--- a/armi/reactor/assemblyLists.py
+++ b/armi/reactor/assemblyLists.py
@@ -43,9 +43,7 @@ class AutoFiller(abc.ABC):
     """
 
     def getNextLocation(self, a) -> grids.LocationBase:
-        """
-        Return the next automatic location.
-        """
+        """Return the next automatic location."""
 
     def assemblyAdded(self, a):
         """
@@ -141,7 +139,6 @@ class AssemblyList(composites.Composite):
             be automatically located in the grid using the associated ``AutoFiller``
             object.
         """
-
         if loc is not None and loc.grid is not self.spatialGrid:
             raise ValueError(
                 "An assembly cannot be added to {} using a spatial locator "

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -201,7 +201,6 @@ class Block(composites.Composite):
         ValueError
             If the parent of the block's ``core`` is not an ``armi.reactor.reactors.Reactor``.
         """
-
         from armi.reactor.reactors import Reactor
 
         core = self.core
@@ -1101,7 +1100,6 @@ class Block(composites.Composite):
         when a control rod is specified as a certain length but that length does not fit exactly
         into a full block.
         """
-
         numDensities = self.getNumberDensities()
         otherBlockDensities = otherBlock.getNumberDensities()
         newDensities = {}
@@ -1416,7 +1414,6 @@ class Block(composites.Composite):
         armi.reactor.components.Parameters
         armi.physics.optimize.OptimizationInterface.modifyCase (look up 'ThRZReflectorThickness')
         """
-
         for c in self.getComponentsInLinkedOrder():
             try:
                 c.updateDims()
@@ -1500,7 +1497,6 @@ class Block(composites.Composite):
         integratedFlux : numpy.array
             multigroup neutron tracklength in [n-cm/s]
         """
-
         if adjoint:
             if gamma:
                 raise ValueError("Adjoint gamma flux is currently unsupported.")
@@ -1626,7 +1622,6 @@ class HexBlock(Block):
         --------
         armi.reactor.converters.uniformMesh.UniformMeshGeometryConverter.makeAssemWithUniformMesh
         """
-
         b = self.__class__(self.getName(), height=self.getHeight())
         b.setType(self.getType(), self.p.flags)
 
@@ -2036,9 +2031,7 @@ class HexBlock(Block):
         return pinToDuctGap
 
     def getRotationNum(self):
-        """
-        Get index 0 through 5 indicating number of rotations counterclockwise around the z-axis.
-        """
+        """Get index 0 through 5 indicating number of rotations counterclockwise around the z-axis."""
         return (
             numpy.rint(self.p.orientation[2] / 360.0 * 6) % 6
         )  # assume rotation only in Z
@@ -2212,7 +2205,6 @@ class HexBlock(Block):
 
     def getWettedPerimeter(self):
         """Return the total wetted perimeter of the block in cm."""
-
         # flags pertaining to hexagon components where the interior of the hexagon is wetted
         wettedHollowHexagonComponentFlags = (
             Flags.DUCT,
@@ -2285,9 +2277,7 @@ class HexBlock(Block):
         )
 
     def getFlowArea(self):
-        """
-        Return the total flowing coolant area of the block in cm^2.
-        """
+        """Return the total flowing coolant area of the block in cm^2."""
         return self.getComponent(Flags.COOLANT, exact=True).getArea()
 
     def getHydraulicDiameter(self):
@@ -2340,9 +2330,7 @@ class CartesianBlock(Block):
         return 1.0
 
     def getPinCenterFlatToFlat(self, cold=False):
-        """
-        Return the flat-to-flat distance between the centers of opposing pins in the outermost ring.
-        """
+        """Return the flat-to-flat distance between the centers of opposing pins in the outermost ring."""
         clad = self.getComponent(Flags.CLAD)
         nRings = hexagon.numRingsToHoldNumCells(clad.getDimension("mult"))
         pinPitch = self.getPinPitch(cold=cold)

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This module defines the ARMI input for a block definition, and code for constructing an ARMI ``Block``.
-"""
+"""This module defines the ARMI input for a block definition, and code for constructing an ARMI ``Block``."""
 import collections
 from inspect import signature
 
@@ -345,9 +343,7 @@ for paramDef in parameters.forType(blocks.Block).inCategory(
 
 
 def _setBlueprintNumberOfAxialMeshes(meshPoints, factor):
-    """
-    Set the blueprint number of axial mesh based on the axial mesh refinement factor.
-    """
+    """Set the blueprint number of axial mesh based on the axial mesh refinement factor."""
     if factor <= 0:
         raise ValueError(
             "A positive axial mesh refinement factor "

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -136,9 +136,7 @@ class NuclideFlag(yamlize.Object):
 
 
 class NuclideFlags(yamlize.KeyedList):
-    """
-    An OrderedDict of ``NuclideFlags``, keyed by their ``nuclideName``.
-    """
+    """An OrderedDict of ``NuclideFlags``, keyed by their ``nuclideName``."""
 
     item_type = NuclideFlag
     key_attr = NuclideFlag.nuclideName
@@ -372,9 +370,7 @@ class CustomIsotopic(yamlize.Map):
 
 
 class CustomIsotopics(yamlize.KeyedList):
-    """
-    OrderedDict of CustomIsotopic objects, keyed by their name.
-    """
+    """OrderedDict of CustomIsotopic objects, keyed by their name."""
 
     item_type = CustomIsotopic
 

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -328,7 +328,7 @@ class DerivedShape(UnshapedComponent):
 
     def _deriveVolumeAndArea(self):
         """
-        Derive the volume and area of ``DerivedShape``\ s.
+        Derive the volume and area of a ``DerivedShape``.
 
         Notes
         -----
@@ -344,7 +344,6 @@ class DerivedShape(UnshapedComponent):
         with purely 2D components. Thus we track area and volume fractions here
         when possible.
         """
-
         if self.parent is None:
             raise ValueError(
                 f"Cannot compute volume/area of {self} without a parent object."

--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -137,9 +137,7 @@ class HexHoledCircle(basicShapes.Circle):
         return area
 
     def getCircleInnerDiameter(self, Tc=None, cold=False):
-        """
-        Returns the diameter of the hole equal to the hexagon outer pitch.
-        """
+        """Returns the diameter of the hole equal to the hexagon outer pitch."""
         return self.getDimension("holeOP", Tc, cold)
 
 
@@ -196,9 +194,7 @@ class HoledRectangle(basicShapes.Rectangle):
         return area
 
     def getCircleInnerDiameter(self, Tc=None, cold=False):
-        """
-        Returns the ``holeOD``.
-        """
+        """Returns the ``holeOD``."""
         return self.getDimension("holeOD", Tc, cold)
 
 
@@ -248,9 +244,7 @@ class HoledSquare(basicShapes.Square):
         return area
 
     def getCircleInnerDiameter(self, Tc=None, cold=False):
-        """
-        Returns the ``holeOD``.
-        """
+        """Returns the ``holeOD``."""
         return self.getDimension("holeOD", Tc, cold)
 
 

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -402,9 +402,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         self.parent.p.gasPorosity = porosity
 
     def __copy__(self):
-        """
-        Duplicate a component, used for breaking fuel into separate components.
-        """
+        """Duplicate a component, used for breaking fuel into separate components."""
         linkedDims = self._getLinkedDimsAndValues()
         newC = copy.deepcopy(self)
         self._restoreLinkedDims(linkedDims)

--- a/armi/reactor/components/componentParameters.py
+++ b/armi/reactor/components/componentParameters.py
@@ -121,7 +121,6 @@ def getComponentParameterDefinitions():
 
 def getCircleParameterDefinitions():
     """Return parameters for Circle."""
-
     pDefs = parameters.ParameterDefinitionCollection()
 
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
@@ -136,7 +135,6 @@ def getCircleParameterDefinitions():
 
 def getHexagonParameterDefinitions():
     """Return parameters for Hexagon."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("ip", units="cm", description="Inner pitch", default=0.0)
@@ -148,7 +146,6 @@ def getHexagonParameterDefinitions():
 
 def getHoledHexagonParameterDefinitions():
     """Return parameters for HoledHexagon."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("holeOD", units="cm", description="Diameter of interior hole(s)")
@@ -162,7 +159,6 @@ def getHoledHexagonParameterDefinitions():
 
 def getHexHoledCircleParameterDefinitions():
     """Return parameters for HexHoledCircle."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("holeOP", units="cm", description="Pitch of interior hole")
@@ -172,7 +168,6 @@ def getHexHoledCircleParameterDefinitions():
 
 def getHoledRectangleParameterDefinitions():
     """Return parameters for HoledRectangle."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("holeOD", units="cm", description="Diameter of interior hole")
@@ -182,7 +177,6 @@ def getHoledRectangleParameterDefinitions():
 
 def getHelixParameterDefinitions():
     """Return parameters for Helix."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("od", units="cm", description="Outer diameter")
@@ -204,7 +198,6 @@ def getHelixParameterDefinitions():
 
 def getRectangleParameterDefinitions():
     """Return parameters for Rectangle."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("lengthInner", units="cm", description="Inner length")
@@ -220,7 +213,6 @@ def getRectangleParameterDefinitions():
 
 def getCubeParameterDefinitions():
     """Return parameters for Cube."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("lengthInner", units="cm", description="Inner length")
@@ -240,7 +232,6 @@ def getCubeParameterDefinitions():
 
 def getTriangleParameterDefinitions():
     """Return parameters for Triangle."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("base", units="?", description="?")
@@ -252,7 +243,6 @@ def getTriangleParameterDefinitions():
 
 def getUnshapedParameterDefinitions():
     """Return parameters for UnshapedComponent."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("op", units="cm", description="Outer pitch")
@@ -266,7 +256,6 @@ def getUnshapedParameterDefinitions():
 
 def getRadialSegmentParameterDefinitions():
     """Return parameters for RadialSegment."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("inner_theta", units="?", description="?")
@@ -292,7 +281,6 @@ def getRadialSegmentParameterDefinitions():
 
 def getTorusParameterDefinitions():
     """Return parameters for Torus."""
-
     pDefs = parameters.ParameterDefinitionCollection()
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, saveToDB=True) as pb:
         pb.defParam("inner_theta", units="?", description="?")

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -89,9 +89,7 @@ class Sphere(ShapedComponent):
 
 
 class Cube(ShapedComponent):
-    """
-    More correctly, a rectangular cuboid.
-    """
+    """More correctly, a rectangular cuboid."""
 
     is3D = True
 
@@ -143,9 +141,7 @@ class Cube(ShapedComponent):
         raise NotImplementedError("Cannot compute area of a cube component.")
 
     def getComponentVolume(self):
-        r"""
-        Computes the volume of the cube in cm^3.
-        """
+        r"""Computes the volume of the cube in cm^3."""
         lengthO = self.getDimension("lengthOuter")
         widthO = self.getDimension("widthOuter")
         heightO = self.getDimension("heightOuter")
@@ -285,7 +281,6 @@ class Torus(ShapedComponent):
         Since area fractions are being used as a proxy for volume fractions, this method returns the reference
         area normalized to the volume ratio of the torus within reference volume
         """
-
         refPhi = self.getDimension("reference_phi", cold=cold)
         height = self.getDimension("height", cold=cold)
         if refArea is None:

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -824,7 +824,6 @@ class ArmiObject(metaclass=CompositeModelType):
         negative areas are intended to account for overlapping positive areas to insure
         the total area of components inside the clad is accurate. See
         test_block.Block_TestCase.test_consistentAreaWithOverlappingComponents
-
         """
         children = self.getChildren()
         numerator = [c.getVolume() for c in children]
@@ -848,7 +847,7 @@ class ArmiObject(metaclass=CompositeModelType):
         )
 
     def getMaxArea(self):
-        """ "
+        """
         The maximum area of this object if it were totally full.
 
         See Also
@@ -2047,7 +2046,6 @@ class ArmiObject(metaclass=CompositeModelType):
         This was needed so that HM moles mass did not change based on if the
         block/assembly was on a symmetry line or not.
         """
-
         return (
             self.getHMDens()
             / units.MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
@@ -2393,7 +2391,6 @@ class ArmiObject(metaclass=CompositeModelType):
         componentsWithThisMat : list
 
         """
-
         if materialName is None:
             materialName = material.getName()
         else:
@@ -2558,9 +2555,7 @@ class ArmiObject(metaclass=CompositeModelType):
                 )
 
     def getAverageTempInC(self, typeSpec: TypeSpec = None, exact=False):
-        """
-        Return the average temperature of the ArmiObject in C by averaging all components.
-        """
+        """Return the average temperature of the ArmiObject in C by averaging all components."""
         tempNumerator = 0.0
         totalVol = 0.0
         for component in self.iterComponents(typeSpec, exact):

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Convert block geometry from one to another, etc.
-"""
+"""Convert block geometry from one to another, etc."""
 import copy
 import math
 
@@ -649,7 +647,6 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
         Also needs to add final coolant layer between the outer pins and the non-pins.
         Will crash if there are things that are not circles or hexes.
         """
-
         # fill in the last ring of coolant using the rest
         coolInnerDiam = self.convertedBlock[-1].getDimension("od")
         coolantOD = getOuterDiamFromIDAndArea(

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -960,9 +960,7 @@ class HexToRZThetaConverter(GeometryConverter):
         return assignedMixtureBlockType
 
     def _createBlendedXSID(self, newBlock):
-        """
-        Generate the blended XS id using the most common XS id in the hexIdList.
-        """
+        """Generate the blended XS id using the most common XS id in the hexIdList."""
         ids = [hexBlock.getMicroSuffix() for hexBlock in self.blockMap[newBlock]]
         xsTypeList, buGroupList = zip(*ids)
 
@@ -1005,9 +1003,7 @@ class HexToRZThetaConverter(GeometryConverter):
         )
 
     def _writeRadialThetaZoneInfo(self, axIdx, axialSegmentHeight, blockObj):
-        """
-        Create a summary of the mapping between the converted reactor block ids to the hex reactor block ids.
-        """
+        """Create a summary of the mapping between the converted reactor block ids to the hex reactor block ids."""
         self._newBlockNum += 1
         hexBlockXsIds = []
         for hexBlock in self.blockMap[blockObj]:
@@ -1025,9 +1021,7 @@ class HexToRZThetaConverter(GeometryConverter):
         )
 
     def _expandSourceReactorGeometry(self):
-        """
-        Expansion of the reactor geometry to build the R-Z-Theta core model.
-        """
+        """Expansion of the reactor geometry to build the R-Z-Theta core model."""
         runLog.info("Expanding source reactor core to a full core model")
         reactorExpander = ThirdCoreHexToFullCoreChanger(self._cs)
         reactorExpander.convert(self._sourceReactor)

--- a/armi/reactor/converters/meshConverters.py
+++ b/armi/reactor/converters/meshConverters.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Mesh specifiers update the mesh structure of a reactor by increasing or decreasing the number of mesh coordinates.
-"""
+"""Mesh specifiers update the mesh structure of a reactor by increasing or decreasing the number of mesh coordinates."""
 
 import math
 import collections
@@ -259,9 +257,7 @@ class _RZThetaReactorMeshConverterByAxialBins(RZThetaReactorMeshConverter):
 
 
 class _RZThetaReactorMeshConverterByAxialFlags(RZThetaReactorMeshConverter):
-    """
-    Generate an axial mesh based on examining the block flags axially across the core.
-    """
+    """Generate an axial mesh based on examining the block flags axially across the core."""
 
     def setAxialMesh(self, core):
         """
@@ -396,9 +392,7 @@ class RZThetaReactorMeshConverterByRingCompositionAxialFlags(
 def checkLastValueInList(
     inputList, listName, expectedValue, eps=0.001, adjustLastValue=False
 ):
-    """
-    Check that the last value in the list is equal to the expected value within +/- eps.
-    """
+    """Check that the last value in the list is equal to the expected value within +/- eps."""
     msg = "The last value in {} is {} and should be {}".format(
         listName, inputList[-1], expectedValue
     )
@@ -416,9 +410,7 @@ def checkLastValueInList(
 
 
 def checkListBounds(inputList, listName, minVal, maxVal, eps=0.001):
-    """
-    Ensure that each value in a list does not exceed the allowable bounds.
-    """
+    """Ensure that each value in a list does not exceed the allowable bounds."""
     for value in inputList:
         minDiff = value - minVal
         maxDiff = value - maxVal
@@ -431,9 +423,7 @@ def checkListBounds(inputList, listName, minVal, maxVal, eps=0.001):
 
 
 def generateBins(totalNumDataPoints, numPerBin, minNum):
-    """
-    Fill in a list based on the total number of data points and the number of data points per bin.
-    """
+    """Fill in a list based on the total number of data points and the number of data points per bin."""
     listToFill = []
     if numPerBin >= totalNumDataPoints:
         listToFill.append(totalNumDataPoints)

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -342,7 +342,8 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
     @staticmethod
     def _getMass(a):
         """get the mass of an assembly. The conservation of HT9 pins in shield assems
-        are accounted for in FE56 conservation checks."""
+        are accounted for in FE56 conservation checks.
+        """
         newMass = None
         if a.hasFlags(Flags.FUEL):
             newMass = a.getMass("U235")
@@ -800,7 +801,6 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
 
     def setUp(self):
         """This test uses a different armiRun.yaml than the default."""
-
         o, r = loadTestReactor(
             os.path.join(TEST_ROOT, "detailedAxialExpansion"),
             customSettings={"inputHeightsConsideredHot": True},

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -40,9 +40,7 @@ class TestGeometryConverters(unittest.TestCase):
         self.cs = self.o.cs
 
     def test_addRing(self):
-        r"""
-        Tests that the addRing method adds the correct number of fuel assemblies to the test reactor.
-        """
+        r"""Tests that the addRing method adds the correct number of fuel assemblies to the test reactor."""
         converter = geometryConverters.FuelAssemNumModifier(self.cs)
         converter.numFuelAssems = 7
         converter.ringsToAdd = 1 * ["radial shield"]
@@ -67,9 +65,7 @@ class TestGeometryConverters(unittest.TestCase):
         )  # should wind up with 11 reflector assemblies per 1/3rd core
 
     def test_setNumberOfFuelAssems(self):
-        r"""
-        Tests that the setNumberOfFuelAssems method properly changes the number of fuel assemblies.
-        """
+        r"""Tests that the setNumberOfFuelAssems method properly changes the number of fuel assemblies."""
         # tests ability to add fuel assemblies
         converter = geometryConverters.FuelAssemNumModifier(self.cs)
         converter.numFuelAssems = 60
@@ -279,9 +275,7 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
         del self.r
 
     def test_edgeAssemblies(self):
-        r"""
-        Sanity check on adding edge assemblies.
-        """
+        r"""Sanity check on adding edge assemblies."""
         converter = geometryConverters.EdgeAssemblyChanger()
         converter.addEdgeAssemblies(self.r.core)
 

--- a/armi/reactor/converters/tests/test_meshConverters.py
+++ b/armi/reactor/converters/tests/test_meshConverters.py
@@ -22,9 +22,7 @@ from armi.tests import TEST_ROOT
 
 
 class TestRZReactorMeshConverter(unittest.TestCase):
-    """
-    Loads a hex reactor and converts its mesh to RZTheta coordinates.
-    """
+    """Loads a hex reactor and converts its mesh to RZTheta coordinates."""
 
     def setUp(self):
         self.o, self.r = loadTestReactor(TEST_ROOT)

--- a/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
+++ b/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
@@ -55,18 +55,13 @@ class TestPinTypeConverters(unittest.TestCase):
 
 
 class MassConservationTests(unittest.TestCase):
-    r"""
-    Tests designed to verify mass conservation during thermal expansion.
-    """
+    r"""Tests designed to verify mass conservation during thermal expansion."""
 
     def setUp(self):
         self.b = buildSimpleFuelBlock()
 
     def test_adjustSmearDensity(self):
-        r"""
-        Tests the getting, setting, and getting of smear density functions.
-
-        """
+        r"""Tests the getting, setting, and getting of smear density functions."""
         bolBlock = copy.deepcopy(self.b)
 
         s = self.b.getSmearDensity(cold=False)

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -113,7 +113,6 @@ class TestAssemblyUniformMesh(unittest.TestCase):
 
     def test_makeAssemWithUniformMeshSubmesh(self):
         """If sourceAssem has submesh, check that newAssem splits into separate blocks."""
-
         # assign axMesh to blocks randomly
         sourceAssem = self.r.core.refAssem
         for i, b in enumerate(sourceAssem):
@@ -252,9 +251,7 @@ class TestUniformMeshGenerator(unittest.TestCase):
         self.assertNotEqual(refMesh[4], avgMesh[4], "Not equal above the fuel.")
 
     def test_filterMesh(self):
-        """
-        Test that the mesh can be correctly filtered.
-        """
+        """Test that the mesh can be correctly filtered."""
         meshList = [1.0, 3.0, 4.0, 7.0, 9.0, 12.0, 16.0, 19.0, 20.0]
         anchorPoints = [4.0, 16.0]
         combinedMesh = self.generator._filterMesh(
@@ -298,9 +295,7 @@ class TestUniformMeshGenerator(unittest.TestCase):
         self.assertListEqual(ctrlAndFuelTops, [75.0, 101.25, 105.0])
 
     def test_generateCommonMesh(self):
-        """
-        Covers generateCommonmesh() and _decuspAxialMesh().
-        """
+        """Covers generateCommonmesh() and _decuspAxialMesh()."""
         self.generator.generateCommonMesh()
         expectedMesh = [
             25.0,

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -38,7 +38,6 @@ Requirements
     finer meshes will help. Always perform mesh sensitivity studies to ensure appropriate
     convergence for your needs.
 
-
 Examples
 --------
 converter = uniformMesh.NeutronicsUniformMeshConverter()
@@ -720,7 +719,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         mapNumberDensities=False,
         calcReactionRates=False,
     ):
-        """
+        r"""
         Set state data (i.e., number densities and block-level parameters) on a assembly based on a source
         assembly with a different axial mesh.
 
@@ -764,7 +763,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
         --------
         setNumberDensitiesFromOverlaps : does this but does smarter caching for number densities.
         """
-
         for destBlock in destinationAssembly:
             zLower = destBlock.p.zbottom
             zUpper = destBlock.p.ztop
@@ -1004,7 +1002,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
         This is a basic parameter mapping routine that can be used by most sub-classes.
         If special mapping logic is required, this method can be defined on sub-classes as necessary.
         """
-
         # Map reactor core parameters
         for paramName in self.paramMapper.reactorParamNames:
             # Check if the source reactor has a value assigned for this

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -190,9 +190,7 @@ def _toString(cls, typeSpec):
 
 
 class Flags(Flag):
-    """
-    Defines the valid flags used in the framework.
-    """
+    """Defines the valid flags used in the framework."""
 
     # basic classifiers
     PRIMARY = auto()

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -119,9 +119,7 @@ class GeomType(enum.Enum):
 
 
 class DomainType(enum.Enum):
-    """
-    Enumeration of shape types.
-    """
+    """Enumeration of shape types."""
 
     NULL = 0
     FULL_CORE = 1
@@ -215,9 +213,7 @@ class DomainType(enum.Enum):
 
 
 class BoundaryType(enum.Enum):
-    """
-    Enumeration of boundary types.
-    """
+    """Enumeration of boundary types."""
 
     NO_SYMMETRY = 0
     PERIODIC = 1

--- a/armi/reactor/grids.py
+++ b/armi/reactor/grids.py
@@ -127,9 +127,7 @@ class LocationBase:
         )
 
     def __getstate__(self):
-        """
-        Used in pickling and deepcopy, this detaches the grid.
-        """
+        """Used in pickling and deepcopy, this detaches the grid."""
         return (self._i, self._j, self._k, None)
 
     def __setstate__(self, state):
@@ -420,9 +418,7 @@ class MultiIndexLocation(IndexLocation):
         self._locations = []
 
     def __getstate__(self):
-        """
-        Used in pickling and deepcopy, this detaches the grid.
-        """
+        """Used in pickling and deepcopy, this detaches the grid."""
         return self._locations
 
     def __setstate__(self, state):
@@ -994,9 +990,7 @@ class Grid:
     ) -> Tuple[
         Optional[Sequence[float]], Optional[Sequence[float]], Optional[Sequence[float]]
     ]:
-        """
-        Return the grid bounds for each dimension, if present.
-        """
+        """Return the grid bounds for each dimension, if present."""
         return self._bounds
 
     def getLocatorFromRingAndPos(self, ring, pos, k=0):
@@ -1049,9 +1043,7 @@ class Grid:
         raise NotImplementedError("Base grid does not know about rings")
 
     def getPositionsInRing(self, ring: int) -> int:
-        """
-        Return the number of positions within a ring.
-        """
+        """Return the number of positions within a ring."""
         raise NotImplementedError("Base grid does not know about rings")
 
     def getRingPos(self, indices) -> Tuple[int, int]:
@@ -1062,7 +1054,6 @@ class Grid:
 
         A tuple is returned so that it is easy to compare pairs of indices.
         """
-
         # Regular grids dont really know about ring and position. We can try to see if
         # their parent does!
         if (
@@ -1501,9 +1492,7 @@ class HexGrid(Grid):
         return hexagon.numRingsToHoldNumCells(n)
 
     def getPositionsInRing(self, ring):
-        """
-        Return the number of positions within a ring.
-        """
+        """Return the number of positions within a ring."""
         return hexagon.numPositionsInRing(ring)
 
     def getNeighboringCellIndices(self, i, j=0, k=0):

--- a/armi/reactor/parameters/parameterCollections.py
+++ b/armi/reactor/parameters/parameterCollections.py
@@ -284,7 +284,6 @@ class ParameterCollection(metaclass=_ParameterCollectionType):
         ArmiObject to which it may belong. In this case, serialNum needs to be
         incremented so that the objects are unique. serialNum is special.
         """
-
         # Grabbing state first and passing it into __init__() as a performance
         # optimization. This avoids the extra work in __init__() of defaulting all of
         # the parameters, only to set them in __setstate__(). Instead we pass them in,

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -209,6 +209,7 @@ def isNumpyArray(paramStr):
 @functools.total_ordering
 class Parameter:
     r"""Metadata about a specific parameter."""
+
     _validName = re.compile("^[a-zA-Z0-9_]+$")
 
     # Using slots because Parameters are pretty static and mostly POD. __slots__ make
@@ -461,9 +462,7 @@ class ParameterDefinitionCollection:
         return self._paramDefDict.items()
 
     def extend(self, other):
-        """
-        Grow a parameter definition collection by another parameter definition collection.
-        """
+        """Grow a parameter definition collection by another parameter definition collection."""
         assert (
             not self._locked
         ), "This ParameterDefinitionCollection ({}) has been locked.".format(

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -631,7 +631,6 @@ class Core(composites.Composite):
         This uses the reactor's cycle parameter and the assemblies' chargeCycle
         parameters.
         """
-
         for a in self:
             if a.p.chargeCycle == self.r.p.cycle:
                 yield a
@@ -657,9 +656,7 @@ class Core(composites.Composite):
             return self.getNumHexRings()
 
     def getNumHexRings(self):
-        """
-        Returns the number of hex rings in this reactor. Based on location so indexing will start at 1.
-        """
+        """Returns the number of hex rings in this reactor. Based on location so indexing will start at 1."""
         maxRing = 0
         for a in self.getAssemblies():
             ring, _pos = self.spatialGrid.getRingPos(a.spatialLocator)
@@ -915,7 +912,6 @@ class Core(composites.Composite):
             A list of assemblies that match the criteria within the ring
 
         """
-
         if self.geomType == geometry.GeomType.CARTESIAN:
             # a ring in cartesian is basically a square.
             raise RuntimeError(
@@ -1147,9 +1143,7 @@ class Core(composites.Composite):
     # This will likely fail, but it will help diagnose why property approach
     # wasn't working correctly
     def genBlocksByLocName(self):
-        """
-        If self.blocksByLocName is deleted, then this will regenerate it or update it if things change.
-        """
+        """If self.blocksByLocName is deleted, then this will regenerate it or update it if things change."""
         self.blocksByLocName = {
             block.getLocation(): block for block in self.getBlocks(includeAll=True)
         }
@@ -1370,7 +1364,6 @@ class Core(composites.Composite):
         --------
         makeLocationLookup : allows caching to speed this up if you call it a lot.
         """
-
         # Why isn't locContents an attribute of reactor? It could be another
         # property that is generated on demand
         if not locContents:
@@ -1521,9 +1514,7 @@ class Core(composites.Composite):
         return self.getAssembly(assemNum=assemNum)
 
     def getAssemblyWithStringLocation(self, locationString):
-        """
-        Returns an assembly or none if given a location string like 'B0014'.
-        """
+        """Returns an assembly or none if given a location string like 'B0014'."""
         ring, pos, _ = grids.locatorLabelToIndices(locationString)
         loc = self.spatialGrid.getLocatorFromRingAndPos(ring, pos)
         assem = self.childrenByLocator.get(loc)
@@ -1782,9 +1773,7 @@ class Core(composites.Composite):
                     )
 
     def getAssembliesOnSymmetryLine(self, symmetryLineID):
-        """
-        Find assemblies that are on a symmetry line in a symmetric core.
-        """
+        """Find assemblies that are on a symmetry line in a symmetric core."""
         assembliesOnLine = []
         for a in self:
             if a.isOnWhichSymmetryLine() == symmetryLineID:
@@ -1934,9 +1923,7 @@ class Core(composites.Composite):
         )
 
     def addMoreNodes(self, meshList):
-        """
-        Add additional mesh points in the the meshList so that the ratio of mesh sizes does not vary too fast.
-        """
+        """Add additional mesh points in the the meshList so that the ratio of mesh sizes does not vary too fast."""
         ratio = self._minMeshSizeRatio
         for i, innerMeshVal in enumerate(meshList[1:-1], start=1):
             dP0 = innerMeshVal - meshList[i - 1]
@@ -2171,9 +2158,7 @@ class Core(composites.Composite):
         return converter
 
     def setPitchUniform(self, pitchInCm):
-        """
-        set the pitch in all blocks.
-        """
+        """set the pitch in all blocks."""
         for b in self.getBlocks():
             b.setPitch(pitchInCm)
 
@@ -2234,7 +2219,6 @@ class Core(composites.Composite):
             The height (cm) of the lowest fuel in this core model.
 
         """
-
         lowestFuelHeightInCm = self[0].getHeight()
         fuelBottoms = []
         for a in self.getAssemblies(Flags.FUEL):

--- a/armi/reactor/systemLayoutInput.py
+++ b/armi/reactor/systemLayoutInput.py
@@ -345,9 +345,7 @@ class SystemLayoutInput:
         self.eqPathInput.update(modifiedPaths)
 
     def _getModifiedFileName(self, originalFileName, suffix):
-        """
-        Generates the modified geometry file name based on the requested suffix.
-        """
+        """Generates the modified geometry file name based on the requested suffix."""
         originalFileName = originalFileName.split(self._GEOM_FILE_EXTENSION)[0]
         suffix = suffix.split(self._GEOM_FILE_EXTENSION)[0]
         self.modifiedFileName = originalFileName + suffix + self._GEOM_FILE_EXTENSION

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2229,9 +2229,7 @@ class CartesianBlock_TestCase(unittest.TestCase):
 
 
 class MassConservationTests(unittest.TestCase):
-    r"""
-    Tests designed to verify mass conservation during thermal expansion.
-    """
+    r"""Tests designed to verify mass conservation during thermal expansion."""
 
     def setUp(self):
         self.b = buildSimpleFuelBlock()

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -960,7 +960,7 @@ class HexReactorTests(ReactorTests):
         self.assertEqual(originalHeights, heights)
 
     def test_applyThermalExpansion_CoreConstruct(self):
-        """Test that assemblies in core are correctly expanded.
+        r"""Test that assemblies in core are correctly expanded.
 
         Notes
         -----
@@ -1011,11 +1011,11 @@ class HexReactorTests(ReactorTests):
                     self.assertAlmostEqual(p, coldHeightP)
 
     def test_updateBlockBOLHeights_DBLoad(self):
-        """Test that blueprints assemblies are expanded in DB load.
+        r"""Test that blueprints assemblies are expanded in DB load.
 
         Notes
         -----
-        - all assertions skip the first block as it has no $\Delta T$ and does not expand
+        All assertions skip the first block as it has no $\Delta T$ and does not expand.
         """
         originalAssems = sorted(a for a in self.r.blueprints.assemblies.values())
         nonEqualParameters = ["heightBOL", "molesHmBOL", "massHmBOL"]

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -405,7 +405,6 @@ class Zones:
         reverse : bool, optional
             Whether to sort in reverse order, by default False
         """
-
         self._zones = dict(sorted(self._zones.items(), reverse=reverse))
 
     def summary(self) -> None:

--- a/armi/scripts/migration/m0_1_3.py
+++ b/armi/scripts/migration/m0_1_3.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Cleans up blueprints.
-"""
+"""Cleans up blueprints."""
 import re
 import io
 

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -397,7 +397,6 @@ class Settings:
         userSettingsNames : list
             The settings names read in from a yaml settings file
         """
-
         # We do not want to load these as settings, but just grab the dictionary straight
         # from the settings file to know which settings are user-defined
         with open(fPath, "r") as stream:

--- a/armi/settings/fwSettings/__init__.py
+++ b/armi/settings/fwSettings/__init__.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This package contains the settings that control the base/framework-level ARMI functionality.
-"""
+"""This package contains the settings that control the base/framework-level ARMI functionality."""
 from typing import List
 
 from armi.settings import setting

--- a/armi/settings/fwSettings/tests/test_tightCouplingSettings.py
+++ b/armi/settings/fwSettings/tests/test_tightCouplingSettings.py
@@ -86,7 +86,6 @@ class TestTightCouplingSettings(unittest.TestCase):
 
     def test_invalidArgumentTypes(self):
         """Tests failure when the values of the parameters do not match the expected schema."""
-
         # Fails because `parameter` value is required to be a string
         with self.assertRaises(vol.MultipleInvalid):
             tc = {}

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -298,7 +298,8 @@ class Setting:
         """
         Additional hack, residual from when settings system could write settings definitions.
 
-        This is only needed here due to the unit tests in test_settings."""
+        This is only needed here due to the unit tests in test_settings.
+        """
         return {
             "value": self.value,
             "type": type(self.default),

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -182,7 +182,6 @@ class SettingsReader:
 
     def readFromFile(self, path, handleInvalids=True):
         """Load file and read it."""
-
         with open(path, "r") as f:
             # make sure that we can actually open the file before trying to guess its
             # format. This will yield better error messages when things go awry.

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -135,7 +135,8 @@ class SettingsWriterTests(unittest.TestCase):
 
     def test_writeMedium(self):
         """Setting output as a sparse file that only includes defaults if they are
-        user-specified."""
+        user-specified.
+        """
         with open(self.filepathYaml, "w") as stream:
             # Specify a setting that is also a default
             self.cs.writeToYamlStream(stream, "medium", ["numProcessors"])

--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -249,7 +249,6 @@ class ArmiTestHelper(unittest.TestCase):
             is in the value of something that can be parsed into a float, and the
             relative difference between the two floats is below the passed epsilon.
         """
-
         if falseNegList is None:
             falseNegList = []
         elif isinstance(falseNegList, str):

--- a/armi/tests/refSmallReactorShuffleLogic.py
+++ b/armi/tests/refSmallReactorShuffleLogic.py
@@ -16,9 +16,7 @@ from armi.physics.fuelCycle.fuelHandlers import FuelHandler
 
 
 class EquilibriumShuffler(FuelHandler):
-    r"""
-    Convergent divergent equilibrium shuffler.
-    """
+    r"""Convergent divergent equilibrium shuffler."""
 
     def chooseSwaps(self, factorList):
         cycleMoves = [

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -116,7 +116,8 @@ class AsciiMap:
         """
         Read ascii representation from a stream.
 
-        Update placeholder size according to largest thing read."""
+        Update placeholder size according to largest thing read.
+        """
         text = text.strip().splitlines()
 
         self.asciiLines = []
@@ -162,9 +163,7 @@ class AsciiMap:
 
     @staticmethod
     def fromReactor(reactor):
-        """
-        Populate mapping from a reactor in preparation of writing out to ascii.
-        """
+        """Populate mapping from a reactor in preparation of writing out to ascii."""
         raise NotImplementedError
 
     def _getLineNumsToWrite(self):
@@ -370,9 +369,7 @@ class AsciiMapHexThirdFlatsUp(AsciiMap):
             return 1 - indexOnRay, 2 * indexOnRay + 1
 
     def _getIJFromColAndBase(self, columnNum, iBase, jBase):
-        """
-        Map ascii column and base to i,j hex indices.
-        """
+        """Map ascii column and base to i,j hex indices."""
         # To move n columns right, i increases by 2n, j decreases by n
         return iBase + 2 * columnNum, jBase - columnNum
 
@@ -389,9 +386,7 @@ class AsciiMapHexThirdFlatsUp(AsciiMap):
         return self._getIJFromColAndBase(columnNum, iBase, jBase)
 
     def _makeOffsets(self):
-        """
-        One third hex grids have larger offsets at the bottom so the overhanging top fits.
-        """
+        """One third hex grids have larger offsets at the bottom so the overhanging top fits."""
         self.asciiOffsets = []
         for li, _line in enumerate(self.asciiLines):
             iBase, _ = self._getIJBaseByAsciiLine(li)
@@ -594,9 +589,7 @@ class AsciiMapHexFullTipsUp(AsciiMap):
         return iBase, jBase
 
     def _updateDimensionsFromAsciiLines(self):
-        """
-        Update dimension metadata when reading ascii.
-        """
+        """Update dimension metadata when reading ascii."""
         # ijmax here can be inferred directly from the max number of columns
         # in the asciimap text
         self._ijMax = (self._asciiMaxCol - 1) // 2

--- a/armi/utils/codeTiming.py
+++ b/armi/utils/codeTiming.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Utilities related to profiling code.
-"""
+"""Utilities related to profiling code."""
 
 import copy
 import os

--- a/armi/utils/customExceptions.py
+++ b/armi/utils/customExceptions.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Globally accessible exception definitions for better granularity on exception behavior and exception handling behavior.
-"""
+"""Globally accessible exception definitions for better granularity on exception behavior and exception handling behavior."""
 from armi import runLog
 from inspect import stack, getframeinfo
 

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -34,7 +34,7 @@ def _changeDirectory(destination):
 
 
 class DirectoryChanger:
-    """
+    r"""
     Utility to change directory.
 
     Use with 'with' statements to execute code in a different dir, guaranteeing a clean
@@ -125,9 +125,7 @@ class DirectoryChanger:
             _changeDirectory(self.initial)
 
     def moveFiles(self):
-        """
-        Copy ``filesToMove`` into the destination directory on entry.
-        """
+        """Copy ``filesToMove`` into the destination directory on entry."""
         initialPath = self.initial
         destinationPath = self.destination
         self._transferFiles(initialPath, destinationPath, self._filesToMove)
@@ -136,9 +134,7 @@ class DirectoryChanger:
             self._transferFiles(initialPath, destinationPath, self._filesToMove)
 
     def retrieveFiles(self):
-        """
-        Copy ``filesToRetrieve`` back into the initial directory on exit.
-        """
+        """Copy ``filesToRetrieve`` back into the initial directory on exit."""
         initialPath = self.destination
         destinationPath = self.initial
         self._transferFiles(initialPath, destinationPath, self._filesToRetrieve)

--- a/armi/utils/dynamicImporter.py
+++ b/armi/utils/dynamicImporter.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Dynamic importing help.
-"""
+"""Dynamic importing help."""
 
 
 def getEntireFamilyTree(cls):

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -182,9 +182,7 @@ class Flag(metaclass=_FlagMeta):
 
     @classmethod
     def _resolveAutos(cls, fields: Sequence[str]) -> List[Tuple[str, int]]:
-        """
-        Assign values to autos, based on the current state of the class.
-        """
+        """Assign values to autos, based on the current state of the class."""
         # There is some opportunity for code re-use between this and the metaclass...
         resolved = []
         for field in fields:
@@ -197,23 +195,17 @@ class Flag(metaclass=_FlagMeta):
 
     @classmethod
     def width(cls):
-        """
-        Return the number of bytes needed to store all of the flags on this class.
-        """
+        """Return the number of bytes needed to store all of the flags on this class."""
         return cls._width
 
     @classmethod
     def fields(cls):
-        """
-        Return a dictionary containing a mapping from field name to integer value.
-        """
+        """Return a dictionary containing a mapping from field name to integer value."""
         return cls._nameToValue
 
     @classmethod
     def sortedFields(cls):
-        """
-        Return a list of all field names, sorted by increasing integer value.
-        """
+        """Return a list of all field names, sorted by increasing integer value."""
         return [
             i[0] for i in sorted(cls._nameToValue.items(), key=lambda item: item[1])
         ]
@@ -269,9 +261,7 @@ class Flag(metaclass=_FlagMeta):
 
     @classmethod
     def from_bytes(cls, bytes, byteorder="little"):
-        """
-        Return a Flags instance given a byte stream.
-        """
+        """Return a Flags instance given a byte stream."""
         return cls(int.from_bytes(bytes, byteorder=byteorder))
 
     def __int__(self):

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -104,9 +104,7 @@ LUMINANCE_WEIGHTS = numpy.array([0.3, 0.59, 0.11])
 
 
 def _translationMatrix(x, y):
-    """
-    Return an affine transformation matrix representing an x- and y-translation.
-    """
+    """Return an affine transformation matrix representing an x- and y-translation."""
     return numpy.array([[1.0, 0.0, x], [0.0, 1.0, y], [0.0, 0.0, 1.0]])
 
 
@@ -129,9 +127,7 @@ def _desaturate(c: Sequence[float]):
 
 
 def _getColorAndBrushFromFlags(f, bold=True):
-    """
-    Given a set of Flags, return a wx.Pen and wx.Brush with which to draw a shape.
-    """
+    """Given a set of Flags, return a wx.Pen and wx.Brush with which to draw a shape."""
     c = numpy.array([0.0, 0.0, 0.0])
     nColors = 0
 
@@ -223,9 +219,7 @@ def _drawShape(
 
 
 class _GridControls(wx.Panel):
-    """
-    Collection of controls for the main Grid editor. Save/Open, num rings, etc.
-    """
+    """Collection of controls for the main Grid editor. Save/Open, num rings, etc."""
 
     def __init__(self, parent):
         wx.Panel.__init__(
@@ -334,9 +328,7 @@ class _GridControls(wx.Panel):
 
 
 class _PathControl(wx.Panel):
-    """
-    Collection of controls for manipulating fuel shuffling paths.
-    """
+    """Collection of controls for manipulating fuel shuffling paths."""
 
     def __init__(self, parent, viewer=None):
         wx.Panel.__init__(self, parent, id=wx.ID_ANY)
@@ -521,9 +513,7 @@ class _AssemblyPalette(wx.ScrolledWindow):
         self.SetSizerAndFit(sizer)
 
     def _setActiveAssemID(self, id: Optional[int]):
-        """
-        Make sure the appropriate button is on, but none others.
-        """
+        """Make sure the appropriate button is on, but none others."""
         if self.activeAssemID is not None and self.activeAssemID != id:
             # there is currently an active assem, and it isnt the requested one. Turn
             # its button off.
@@ -570,9 +560,7 @@ class _AssemblyPalette(wx.ScrolledWindow):
         self.pathControl.maybeIncrement()
 
     def getSelectedAssem(self) -> Optional[Union[AssemblyBlueprint, Tuple[int, int]]]:
-        """
-        Return the currently-selected assembly design or fuel path indices.
-        """
+        """Return the currently-selected assembly design or fuel path indices."""
         if self.activeAssemID in self.assemDesignsById:
             # We have an assembly design activated. return it
             return self.assemDesignsById[self.activeAssemID]
@@ -601,9 +589,7 @@ class _AssemblyPalette(wx.ScrolledWindow):
             return None
 
     def setActiveAssem(self, assemDesign: Optional[Union[AssemblyBlueprint, tuple]]):
-        """
-        Override the selected assembly design from above.
-        """
+        """Override the selected assembly design from above."""
         specifier = None
         if isinstance(assemDesign, AssemblyBlueprint):
             specifier = assemDesign.specifier
@@ -847,9 +833,7 @@ class GridGui(wx.ScrolledWindow):
         return min(sortableObjectIds)[1]
 
     def drawGrid(self):
-        """
-        Wipe out anything in the drawing and re-draw everything.
-        """
+        """Wipe out anything in the drawing and re-draw everything."""
         self.pdc.Clear()
         self.pdc.RemoveAll()
 
@@ -914,9 +898,7 @@ class GridGui(wx.ScrolledWindow):
             self.pdc.SetIdBounds(id, boundingBox)
 
     def drawArrows(self):
-        """
-        Draw fuel path arrows.
-        """
+        """Draw fuel path arrows."""
         if self.mode != GridGui.Mode.PATH:
             return
 
@@ -1016,9 +998,7 @@ class GridGui(wx.ScrolledWindow):
         return label, description, bold
 
     def setNumRings(self, n: int):
-        """
-        Change the number of rings that should be drawn.
-        """
+        """Change the number of rings that should be drawn."""
         self.numRings = n
         if self.grid.geomType == geometry.GeomType.HEX:
             grid = grids.HexGrid.fromPitch(1, numRings=self.numRings)
@@ -1475,9 +1455,7 @@ class GridBlueprintControl(wx.Panel):
                 self.bp = self.bp
 
     def loadFile(self, fName, cs=None):
-        """
-        Load a new blueprints file, refreshing pretty much everything.
-        """
+        """Load a new blueprints file, refreshing pretty much everything."""
         self._fName = fName
         self._cs = cs
         with open(fName, "r") as bpYaml:
@@ -1691,9 +1669,7 @@ class NewGridBlueprintDialog(wx.Dialog):
         self.Fit()
 
     def selectGeomType(self, geom):
-        """
-        Enable/disable relevant controls for the selected geom type.
-        """
+        """Enable/disable relevant controls for the selected geom type."""
         # make sure the geom type Choice is in sync. This function doesn't have to be
         # called from the event handler.
         self.geomType.SetSelection(self._idxFromGeom[geom])
@@ -1706,9 +1682,7 @@ class NewGridBlueprintDialog(wx.Dialog):
         self.selectGeomType(self._geomFromIdx[self.geomType.GetSelection()])
 
     def _toggleControls(self):
-        """
-        Make sure that the appropriate controls are enabled/disabled.
-        """
+        """Make sure that the appropriate controls are enabled/disabled."""
         geom = self._geomFromIdx[self.geomType.GetSelection()]
         full = self.domainFull.GetValue()
         self.throughCenter.Enable(enable=geom == geometry.GeomType.CARTESIAN)
@@ -1729,9 +1703,7 @@ class NewGridBlueprintDialog(wx.Dialog):
         self._toggleControls()
 
     def getGridBlueprint(self):
-        """
-        Using the state of the dialog controls, return a corresponding GridBlueprint.
-        """
+        """Using the state of the dialog controls, return a corresponding GridBlueprint."""
         name = self.gridName.GetValue()
         geom = self._geomFromIdx[self.geomType.GetSelection()]
 

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Module of utilities to help dealing with iterable objects in Python.
-"""
+"""Module of utilities to help dealing with iterable objects in Python."""
 from itertools import tee, chain
 import struct
 

--- a/armi/utils/parsing.py
+++ b/armi/utils/parsing.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-
-This file contains tools for common tasks in parsing in python strings into non-string values.
-
-"""
+"""This file contains tools for common tasks in parsing in python strings into non-string values."""
 
 import ast
 import copy

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This module contains methods for adding properties with custom behaviors to classes.
-"""
+"""This module contains methods for adding properties with custom behaviors to classes."""
 
 import numpy
 
@@ -29,9 +27,7 @@ def areEqual(val1, val2, relativeTolerance=0.0):
 
 
 def numpyHackForEqual(val1, val2):
-    r"""
-    checks lots of types for equality like strings and dicts.
-    """
+    r"""checks lots of types for equality like strings and dicts."""
     # when doing this with numpy arrays you get an array of booleans which causes the value error
     notEqual = val1 != val2
 

--- a/armi/utils/tests/test_gridGui.py
+++ b/armi/utils/tests/test_gridGui.py
@@ -107,7 +107,6 @@ class GuiTestCase(unittest.TestCase):
         Note: This method is called in self.run(), before super().run. We deliberately avoid naming this 'setUp',
         because super().run internally calls self.setUp, which would be too late.
         """
-
         self.app = wx.App()
         self.frame = wx.Frame(
             None, wx.ID_ANY, title="Grid Blueprints UI", pos=(0, 0), size=(1000, 1000)

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -56,7 +56,6 @@ class PathToolsTests(unittest.TestCase):
 
     def test_moduleAndAttributeExist(self):
         """Test that determination of existence of module attribute works."""
-
         # test that no `:` doesn't raise an exception
         self.assertFalse(pathTools.moduleAndAttributeExist(r"path/that/not/exist.py"))
         # test that multiple `:` doesn't raise an exception
@@ -72,9 +71,7 @@ class PathToolsTests(unittest.TestCase):
 
     @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")
     def test_cleanPathNoMpi(self):
-        """
-        Simple tests of cleanPath(), in the no-MPI scenario.
-        """
+        """Simple tests of cleanPath(), in the no-MPI scenario."""
         with TemporaryDirectoryChanger():
             # TEST 0: File is not safe to delete, due to name pathing
             filePath0 = "test0_cleanPathNoMpi"

--- a/armi/utils/tests/test_triangle.py
+++ b/armi/utils/tests/test_triangle.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Test the basic triangle math."""
+"""Test the basic triangle math."""
 import unittest
 from armi.utils import triangle
 
@@ -87,7 +87,6 @@ class TestTriangle(unittest.TestCase):
 
     def test_checkIfPointIsInTriangle2(self):
         """Test that barycentricCheckIfPointIsInTriangle can identify if a point is inside or outside of a triangle."""
-
         # First check the right triangle case
         xT1 = 0.0
         yT1 = 0.0

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Testing some utility functions."""
+"""Testing some utility functions."""
 from collections import defaultdict
 import unittest
 

--- a/armi/utils/textProcessors.py
+++ b/armi/utils/textProcessors.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Utility classes and functions for manipulating text files.
-"""
+"""Utility classes and functions for manipulating text files."""
 import os
 import re
 import io
@@ -40,13 +38,10 @@ Matches:
 """
 
 FLOATING_PATTERN = r"[+-]?\d+\.*\d*"
-"""
-Matches 1, 100, 1.0, -1.2, +12.234
-"""
+"""Matches 1, 100, 1.0, -1.2, +12.234"""
 
 DECIMAL_PATTERN = r"[+-]?\d*\.\d+"
-"""Matches .1, 1.213423, -23.2342, +.023
-"""
+"""Matches .1, 1.213423, -23.2342, +.023"""
 
 
 class FileMark:
@@ -476,7 +471,7 @@ class SequentialReader:
 
 
 class SequentialStringIOReader(SequentialReader):
-    """
+    r"""
     Fast sequential reader that must be used within a with statement.
 
     Attributes
@@ -576,7 +571,6 @@ class TextProcessor:
         huge speedup (10x or so probably, but that's just a guess.) pattern and killOn
         must be pure text if you do this.
         """
-
         current = 0
         result = ""
         if textFlag:
@@ -620,7 +614,8 @@ class TextProcessor:
 
 class SmartList:
     r"""A list that does stuff like files do i.e. remembers where it was, can seek, etc.
-    Actually this is pretty slow. so much for being smart. nice idea though."""
+    Actually this is pretty slow. so much for being smart. nice idea though.
+    """
 
     def __init__(self, f):
         self.lines = f.readlines()

--- a/doc/gallery-src/framework/run_programmaticReactorDefinition.py
+++ b/doc/gallery-src/framework/run_programmaticReactorDefinition.py
@@ -199,7 +199,6 @@ def buildAssemblies(blockDesigns):
 
 def buildGrids():
     """Build the core map grid"""
-
     coreGrid = gridBlueprint.GridBlueprint("core")
     coreGrid.geom = "hex"
     coreGrid.symmetry = "third periodic"

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,7 +6,8 @@ required-version = "0.0.272"
 
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 # D104 - missing docstring in public package
-# D300 - docstrings need to use triple quotes
+# D2 - docstring formatting
+# D3 - docstrings quotes and escape types
 # D405-D409 - NumPy docstrings
 # D419 - no empty docstrings
 # TID252 - no relative imports
@@ -15,7 +16,7 @@ required-version = "0.0.272"
 # SIM3** - simplify code: yoda-conditions
 # SIM4** - simplify code: if-else-blocks
 # SIM9** - simplify code: dict-get-with-none-default
-select = ["E", "F", "D104", "D300", "D405", "D406", "D407", "D408", "D409", "D41", "SIM103", "SIM2", "SIM3", "SIM4", "SIM9", "TID"]
+select = ["E", "F", "D104", "D2", "D3", "D405", "D406", "D407", "D408", "D409", "D41", "SIM103", "SIM2", "SIM3", "SIM4", "SIM9", "TID"]
 
 # D105 - we don't need to document well-known magic methods
 # D205 - 1 blank line required between summary line and description


### PR DESCRIPTION
## What is the change?

I added blanket coverage to all `D2` and `D3` docstring rules in `ruff`.  

ALMOST all of these were fully automatable via `ruff --fix .`. 

## Why is the change being made?

This is part of the on-going work to get the ARMI `ruff.toml` up-to-date. But I am also doing it one (or two) rules at a time, so my reviewers can actually review all these changes.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
