### PR TITLE
simplify runLogs + only link solid components

### DIFF
--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -390,7 +390,7 @@ class AssemblyAxialLinkage:
         """Gets the block and component based linkage."""
         for b in self.a:
             self._getLinkedBlocks(b)
-            for c in b:
+            for c in getSolidComponents(b):
                 self._getLinkedComponents(b, c)
 
     def _getLinkedBlocks(self, b):
@@ -467,16 +467,14 @@ class AssemblyAxialLinkage:
         lstLinkedC = [None, None]
         for ib, linkdBlk in enumerate(self.linkedBlocks[b]):
             if linkdBlk is not None:
-                for otherC in linkdBlk.getChildren():
+                for otherC in getSolidComponents(linkdBlk.getChildren()):
                     if _determineLinked(c, otherC):
                         if lstLinkedC[ib] is not None:
                             errMsg = (
-                                "Multiple component axial linkages have been found for "
-                                "Component {0}; Block {1}; Assembly {2}."
-                                " This is indicative of an error in the blueprints! Linked components found are"
-                                "{3} and {4}".format(
-                                    c, b, b.parent, lstLinkedC[ib], otherC
-                                )
+                                f"Multiple component axial linkages have been found for "
+                                f"Component {c}; Block {b}; Assembly {b.parent}."
+                                f" This is indicative of an error in the blueprints! Linked components found are"
+                                f"{lstLinkedC[ib]} and {otherC}"
                             )
                             runLog.error(msg=errMsg)
                             raise RuntimeError(errMsg)
@@ -486,24 +484,12 @@ class AssemblyAxialLinkage:
 
         if lstLinkedC[0] is None:
             runLog.debug(
-                "Assembly {0:22s} at location {1:22s}, Block {2:22s}, Component {3:22s} "
-                "has nothing linked below it!".format(
-                    str(self.a.getName()),
-                    str(self.a.getLocation()),
-                    str(b.p.flags),
-                    str(c.p.flags),
-                ),
+                f"Assembly {self.a}, Block {b}, Component {c} has nothing linked below it!",
                 single=True,
             )
         if lstLinkedC[1] is None:
             runLog.debug(
-                "Assembly {0:22s} at location {1:22s}, Block {2:22s}, Component {3:22s} "
-                "has nothing linked above it!".format(
-                    str(self.a.getName()),
-                    str(self.a.getLocation()),
-                    str(b.p.flags),
-                    str(c.p.flags),
-                ),
+                f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
                 single=True,
             )
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -855,7 +855,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                             matDens = cExp.material.density(Tc=cExp.temperatureInC)
                             compDens = cExp.density()
                             msg = (
-                                f"{cExp} {cExp.material} in {bExp} was not at correct density. \n"
+                                f"{cExp} {cExp.material} in {bExp} in {aExp} was not at correct density. \n"
                                 + f"expansion = {bExp.p.height / bStd.p.height} \n"
                                 + f"density = {matDens}, component density = {compDens} \n"
                             )

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -795,6 +795,18 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         self.assertTrue(self.expData.isTargetComponent(duct))
 
 
+class TestGetSolidComponents(unittest.TestCase):
+    """verify that getSolidComponents returns just solid components"""
+
+    def setUp(self):
+        self.a = buildTestAssemblyWithFakeMaterial(name="HT9")
+
+    def test_getSolidComponents(self):
+        for b in self.a:
+            for c in getSolidComponents(b):
+                self.assertNotEqual(c.material.name, "Sodium")
+
+
 class TestInputHeightsConsideredHot(unittest.TestCase):
     """Verify thermal expansion for process loading of core."""
 


### PR DESCRIPTION
## What is the change?
1. Closes #1285. The axial expansion changer only considers solid components. So it shouldn't waste time axially linking fluid components. This also greatly simplifies the information that gets printed in the runLogs when running a `debug` case and makes them much more useful.
2. In test_axialExpansionChanger.py, 1) a unit test explicitly for `getSolidComponents` is added, and 2) the assembly is added to an error message. For the latter, since there are multiple assemblies being checked, adding which assembly is failing helps with diagnostics. 

## Why is the change being made?
To improve the debugging experience when dealing with the axial expansion changer.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- ~The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.~ Can add if requested. 
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
