### PR TITLE
Finalizing our ruff settings

### DIFF
--- a/.github/workflows/validatemanifest.py
+++ b/.github/workflows/validatemanifest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Validating the MANIFEST.in
+Validating the MANIFEST.in.
 
 Currently, the only validation we do of the MANIFEST.in file is to make sure
 that we are trying to include files that don't exist.

--- a/armi/bookkeeping/snapshotInterface.py
+++ b/armi/bookkeeping/snapshotInterface.py
@@ -47,19 +47,19 @@ class SnapshotInterface(interfaces.Interface):
     name = "snapshot"
 
     def interactBOL(self):
-        """Active the default snapshots at BOL"""
+        """Active the default snapshots at BOL."""
         interfaces.Interface.interactBOL(self)
         if self.cs["defaultSnapshots"]:
             self.activateDefaultSnapshots()
 
     def interactEveryNode(self, cycle, node):
-        """Call the snapshot interface to copy files at each node, if requested"""
+        """Call the snapshot interface to copy files at each node, if requested."""
         snapText = getCycleNodeStamp(cycle, node)  # CCCNNN
         if self.cs["dumpSnapshot"] and snapText in self.cs["dumpSnapshot"]:
             self.o.snapshotRequest(cycle, node)
 
     def interactCoupled(self, iteration):
-        """Call the snapshot interface to copy files for coupled iterations, if requested"""
+        """Call the snapshot interface to copy files for coupled iterations, if requested."""
         snapText = getCycleNodeStamp(self.r.p.cycle, self.r.p.timeNode)  # CCCNNN
         if self.cs["dumpSnapshot"] and snapText in self.cs["dumpSnapshot"]:
             self.o.snapshotRequest(self.r.p.cycle, self.r.p.timeNode, iteration)

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -745,10 +745,7 @@ def getActiveInterfaceInfo(cs):
 
 def isInterfaceActive(klass, cs):
     """Return True if the Interface klass is active."""
-    for k, _kwargs in getActiveInterfaceInfo(cs):
-        if issubclass(k, klass):
-            return True
-    return False
+    return any(issubclass(k, klass) for k, _kwargs in getActiveInterfaceInfo(cs))
 
 
 class InterfaceInfo(NamedTuple):

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -40,7 +40,7 @@ from armi.reactor import parameters
 from armi.utils import textProcessors
 
 
-class STACK_ORDER:
+class STACK_ORDER:  # noqa: invalid-class-name
     """
     Constants that help determine the order of modules in the interface stack.
 

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -250,8 +250,8 @@ class TestNuclide(unittest.TestCase):
         for nb in nuclideBases.where(lambda nn: nn.z <= 89):
             self.assertFalse(nb.isHeavyMetal())
         for nb in nuclideBases.where(lambda nn: nn.z > 89):
-            if isinstance(nb, nuclideBases.DummyNuclideBase) or isinstance(
-                nb, nuclideBases.LumpNuclideBase
+            if isinstance(
+                nb, (nuclideBases.DummyNuclideBase, nuclideBases.LumpNuclideBase)
             ):
                 self.assertFalse(nb.isHeavyMetal())
             else:

--- a/armi/nuclearDataIO/cccc/dif3d.py
+++ b/armi/nuclearDataIO/cccc/dif3d.py
@@ -197,7 +197,7 @@ class Dif3dStream(cccc.StreamWithDataContainer):
                     )
 
     def readWrite(self):
-        """Reads or writes metadata and data from 5 records"""
+        """Reads or writes metadata and data from 5 records."""
         msg = f"{'Reading' if 'r' in self._fileMode else 'Writing'} DIF3D binary data {self}"
         runLog.info(msg)
 

--- a/armi/nuclearDataIO/cccc/tests/test_dif3d.py
+++ b/armi/nuclearDataIO/cccc/tests/test_dif3d.py
@@ -44,7 +44,7 @@ class TestDif3dSimpleHexz(unittest.TestCase):
         self.assertEqual(self.df.metadata["VERSION"], 1)
 
     def test__rwFile1DRecord(self):
-        """Verify the rest of the metadata"""
+        """Verify the rest of the metadata."""
         TITLE_A6 = ["3D Hex", "-Z to", "genera", "te NHF", "LUX fi", "le"]
         EXPECTED_TITLE = TITLE_A6 + [""] * 5
         for i in range(dif3d.TITLE_RANGE):
@@ -54,7 +54,7 @@ class TestDif3dSimpleHexz(unittest.TestCase):
         self.assertEqual(self.df.metadata["IPRINT"], 0)
 
     def test__rw2DRecord(self):
-        """Verify the control parameters"""
+        """Verify the control parameters."""
         EXPECTED_2D = [
             0,
             0,
@@ -108,7 +108,7 @@ class TestDif3dSimpleHexz(unittest.TestCase):
             self.assertEqual(self.df.twoD[param], EXPECTED_2D[i])
 
     def test__rw3DRecord(self):
-        """Verify the convergence criteria and other floating point data"""
+        """Verify the convergence criteria and other floating point data."""
         EXPECTED_3D = [
             1e-7,
             1e-5,
@@ -125,11 +125,11 @@ class TestDif3dSimpleHexz(unittest.TestCase):
             self.assertEqual(self.df.threeD[param], EXPECTED_3D[i])
 
     def test__rw4DRecord(self):
-        """Verify the optimum overrelaxation factors"""
+        """Verify the optimum overrelaxation factors."""
         self.assertEqual(self.df.fourD, None)
 
     def test__rw5DRecord(self):
-        """Verify the axial coarse-mesh rebalance boundaries"""
+        """Verify the axial coarse-mesh rebalance boundaries."""
         self.assertEqual(self.df.fiveD, None)
 
     def test_writeBinary(self):
@@ -145,7 +145,7 @@ class TestDif3dSimpleHexz(unittest.TestCase):
 
 class TestDif3dEmptyRecords(unittest.TestCase):
     def test_empty4and5Records(self):
-        """Since the inputs results in these being None, get test coverage another way"""
+        """Since the inputs results in these being None, get test coverage another way."""
         df = dif3d.Dif3dStream.readBinary(SIMPLE_HEXZ_DIF3D)
         # Hack some values that allow 4 and 5 records to be populated \
         # and then populate them

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -443,7 +443,7 @@ class FuelHandler:
             # separate it
             compareTo, mult = compareTo
 
-        if isinstance(compareTo, float) or isinstance(compareTo, int):
+        if isinstance(compareTo, (float, int)):
             # floating point or int.
             compVal = compareTo * mult
         elif param:

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -58,9 +58,10 @@ class FuelHandlerTestHelper(ArmiTestHelper):
         cls.directoryChanger.close()
 
     def setUp(self):
-        r"""
-        Build a dummy reactor without using input files. There are some igniters and feeds
-        but none of these have any number densities.
+        """
+        Build a dummy reactor without using input files.
+
+        There are some igniters and feeds but none of these have any number densities.
         """
         self.o, self.r = test_reactors.loadTestReactor(
             self.directoryChanger.destination,
@@ -130,7 +131,7 @@ class FuelHandlerTestHelper(ArmiTestHelper):
 
 
 class MockLatticePhysicsInterface(LatticePhysicsInterface):
-    """a mock lattice physics interface that does nothing for interactBOC."""
+    """A mock lattice physics interface that does nothing for interactBOC."""
 
     name = "MockLatticePhysicsInterface"
 
@@ -142,7 +143,7 @@ class MockLatticePhysicsInterface(LatticePhysicsInterface):
 
 
 class MockXSGM(CrossSectionGroupManager):
-    """a mock cross section group manager that does nothing for interactBOC."""
+    """A mock cross section group manager that does nothing for interactBOC."""
 
     def interactBOC(self, cycle=None):
         pass
@@ -384,7 +385,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         fh.interactEOL()
 
     def test_repeatShuffles(self):
-        r"""
+        """
         Builds a dummy core. Does some shuffles. Repeats the shuffles. Checks that it was a perfect repeat.
 
         Checks some other things in the meantime

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -130,7 +130,7 @@ class FuelHandlerTestHelper(ArmiTestHelper):
 
 
 class MockLatticePhysicsInterface(LatticePhysicsInterface):
-    """a mock lattice physics interface that does nothing for interactBOC"""
+    """a mock lattice physics interface that does nothing for interactBOC."""
 
     name = "MockLatticePhysicsInterface"
 
@@ -142,7 +142,7 @@ class MockLatticePhysicsInterface(LatticePhysicsInterface):
 
 
 class MockXSGM(CrossSectionGroupManager):
-    """a mock cross section group manager that does nothing for interactBOC"""
+    """a mock cross section group manager that does nothing for interactBOC."""
 
     def interactBOC(self, cycle=None):
         pass

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -236,7 +236,7 @@ class BlockCollection(list):
 
     def _calcWeightedBurnup(self):
         """
-        For a blockCollection that represents fuel, calculate the weighted average burnup
+        For a blockCollection that represents fuel, calculate the weighted average burnup.
 
         Notes
         -----

--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -258,7 +258,7 @@ class LumpedFissionProductCollection(dict):
         return fpDensities
 
     def getMassFrac(self, oldMassFrac=None):
-        """returns the mass fraction vector of the collection of lumped fission products."""
+        """Returns the mass fraction vector of the collection of lumped fission products."""
         if not oldMassFrac:
             raise ValueError("You must define a massFrac vector")
 

--- a/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
+++ b/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
@@ -115,7 +115,7 @@ class CrossSectionTable(collections.OrderedDict):
         self.add(nucName, **oneGroupXSbyName)
 
     def hasValues(self):
-        """determines if there are non-zero values in this cross section table."""
+        """Determines if there are non-zero values in this cross section table."""
         for nuclideCrossSectionSet in self.values():
             if any(nuclideCrossSectionSet.values()):
                 return True

--- a/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
+++ b/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
@@ -182,7 +182,7 @@ class AbstractIsotopicDepletionReader(interfaces.OutputReader):
     r"""Read number density output produced by the isotopic depletion."""
 
     def read(self):
-        r"""read a isotopic depletion Output File and applies results to armi objects in the ``ToDepletion`` attribute."""
+        r"""Read a isotopic depletion Output File and applies results to armi objects in the ``ToDepletion`` attribute."""
         raise NotImplementedError
 
 
@@ -212,5 +212,5 @@ class Csrc:
         return self._chemicalVector
 
     def write(self):
-        """return a list of lines to write for a csrc card."""
+        """Return a list of lines to write for a csrc card."""
         raise NotImplementedError

--- a/armi/physics/thermalHydraulics/__init__.py
+++ b/armi/physics/thermalHydraulics/__init__.py
@@ -11,5 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Thermal Hydraulics package"""
+"""Thermal Hydraulics package."""
 from .plugin import ThermalHydraulicsPlugin  # noqa: unused-import

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1187,7 +1187,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         )
 
     def getFuelMass(self) -> float:
-        """Return the mass in grams if this is a fueled component"""
+        """Return the mass in grams if this is a fueled component."""
         return self.getMass() if self.hasFlags(flags.Flags.FUEL) else 0.0
 
 

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -649,10 +649,7 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         name = self.name.lower()
         if isinstance(s, list):
-            for n in s:
-                if n.lower() in name:
-                    return True
-            return False
+            return any(n.lower() in name for n in s)
         else:
             return s.lower() in name
 
@@ -1993,11 +1990,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def containsHeavyMetal(self):
         """True if this has HM."""
-        for nucName in self.getNuclides():
-            # these already have non-zero density
-            if nucDir.isHeavyMetal(nucName):
-                return True
-        return False
+        return any(nucDir.isHeavyMetal(nucName) for nucName in self.getNuclides())
 
     def getNuclides(self):
         """
@@ -2419,11 +2412,7 @@ class ArmiObject(metaclass=CompositeModelType):
         except TypeError:
             typeSpec = (typeSpec,)
 
-        for t in typeSpec:
-            # loop b/c getComponents is a OR operation on the flags, but we need AND
-            if not self.getComponents(t, exact):
-                return False
-        return True
+        return all(self.getComponents(t, exact) for t in typeSpec)
 
     def getComponentByName(self, name):
         """

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2120,7 +2120,7 @@ class ArmiObject(metaclass=CompositeModelType):
         return mass
 
     def getFuelMass(self):
-        """returns mass of fuel in grams."""
+        """Returns mass of fuel in grams."""
         return sum((c.getFuelMass() for c in self))
 
     def constituentReport(self):

--- a/armi/reactor/converters/parameterSweeps/__init__.py
+++ b/armi/reactor/converters/parameterSweeps/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Parameter Sweeps package"""
+"""Parameter Sweeps package."""

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -238,7 +238,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         AxialExpansionTestBase.tearDown(self)
 
     def expandAssemForMassConservationTest(self):
-        """do the thermal expansion and store conservation metrics of interest."""
+        """Do the thermal expansion and store conservation metrics of interest."""
         # create a semi-realistic/physical variable temperature grid over the assembly
         temp = Temperature(self.a.getTotalHeight(), numTempGridPts=11, tempSteps=10)
         for idt in range(temp.tempSteps):
@@ -341,7 +341,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
 
     @staticmethod
     def _getMass(a):
-        """get the mass of an assembly. The conservation of HT9 pins in shield assems
+        """Get the mass of an assembly. The conservation of HT9 pins in shield assems
         are accounted for in FE56 conservation checks.
         """
         newMass = None

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -238,7 +238,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         AxialExpansionTestBase.tearDown(self)
 
     def expandAssemForMassConservationTest(self):
-        """do the thermal expansion and store conservation metrics of interest"""
+        """do the thermal expansion and store conservation metrics of interest."""
         # create a semi-realistic/physical variable temperature grid over the assembly
         temp = Temperature(self.a.getTotalHeight(), numTempGridPts=11, tempSteps=10)
         for idt in range(temp.tempSteps):

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -1317,7 +1317,7 @@ class ParamMapper:
             if val is None:
                 continue
 
-            if isinstance(val, list) or isinstance(val, numpy.ndarray):
+            if isinstance(val, (list, numpy.ndarray)):
                 ParamMapper._arrayParamSetter(block, [val], [paramName])
             else:
                 ParamMapper._scalarParamSetter(block, [val], [paramName])
@@ -1332,11 +1332,7 @@ class ParamMapper:
             # Array / list parameters can be have values that are `None`, lists, or numpy arrays. This first
             # checks if the value type is any of these and if so, the block-level parameter is treated as an
             # array.
-            if (
-                isinstance(None, valType)
-                or isinstance(valType, list)
-                or isinstance(valType, numpy.ndarray)
-            ):
+            if isinstance(valType, (list, numpy.ndarray)) or isinstance(None, valType):
                 if val is None or len(val) == 0:
                     paramVals.append(None)
                 else:

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2158,7 +2158,7 @@ class Core(composites.Composite):
         return converter
 
     def setPitchUniform(self, pitchInCm):
-        """set the pitch in all blocks."""
+        """Set the pitch in all blocks."""
         for b in self.getBlocks():
             b.setPitch(pitchInCm)
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -275,7 +275,7 @@ class HexReactorTests(ReactorTests):
         self.assertEqual(self.r.core._children, sorted(self.r.core._children))
 
     def test_sortAssemByRing(self):
-        """Demonstrate ring/pos sorting"""
+        """Demonstrate ring/pos sorting."""
         self.r.core.sortAssemsByRing()
         self.assertEqual((1, 1), self.r.core[0].spatialLocator.getRingPos())
         currentRing = -1
@@ -339,7 +339,7 @@ class HexReactorTests(ReactorTests):
         self.assertEqual(numControlBlocks, 3)
 
     def test_setB10VolOnCreation(self):
-        """test the setting of b.p.initialB10ComponentVol"""
+        """test the setting of b.p.initialB10ComponentVol."""
         for controlBlock in self.r.core.getBlocks(Flags.CONTROL):
             controlComps = [c for c in controlBlock if c.getNumberDensity("B10") > 0]
             self.assertEqual(len(controlComps), 1)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -339,7 +339,7 @@ class HexReactorTests(ReactorTests):
         self.assertEqual(numControlBlocks, 3)
 
     def test_setB10VolOnCreation(self):
-        """test the setting of b.p.initialB10ComponentVol."""
+        """Test the setting of b.p.initialB10ComponentVol."""
         for controlBlock in self.r.core.getBlocks(Flags.CONTROL):
             controlComps = [c for c in controlBlock if c.getNumberDensity("B10") > 0]
             self.assertEqual(len(controlComps), 1)

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -32,7 +32,7 @@ import math
 from typing import Dict, Union, Sequence, List, Tuple
 
 
-class auto:
+class auto:  # noqa: invalid-class-name
     """
     Empty class for requesting a lazily-evaluated automatic field value.
 

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -121,7 +121,7 @@ def convertToSlice(x, increment=False):
     if isinstance(x, list):
         x = np.array(x)
 
-    if isinstance(x, (int, np.integer)) or isinstance(x, (float, np.floating)):
+    if isinstance(x, (int, np.integer, float, np.floating)):
         x = slice(int(x), int(x) + 1, None)
 
     # Correct the slice indices to be group instead of index based.

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -27,7 +27,7 @@ def areEqual(val1, val2, relativeTolerance=0.0):
 
 
 def numpyHackForEqual(val1, val2):
-    r"""checks lots of types for equality like strings and dicts."""
+    r"""Checks lots of types for equality like strings and dicts."""
     # when doing this with numpy arrays you get an array of booleans which causes the value error
     notEqual = val1 != val2
 

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """This module contains methods for adding properties with custom behaviors to classes."""
-
 import numpy
 
 
@@ -27,7 +26,7 @@ def areEqual(val1, val2, relativeTolerance=0.0):
 
 
 def numpyHackForEqual(val1, val2):
-    r"""Checks lots of types for equality like strings and dicts."""
+    """Checks lots of types for equality like strings and dicts."""
     # when doing this with numpy arrays you get an array of booleans which causes the value error
     notEqual = val1 != val2
 

--- a/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
+++ b/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Write MCNP Material Cards
-=========================
+=========================.
 
 Here we load a test reactor and write each component of one fuel block out as
 MCNP material cards.

--- a/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
+++ b/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Write MCNP Material Cards
-=========================.
+Write MCNP Material Cards.
 
 Here we load a test reactor and write each component of one fuel block out as
 MCNP material cards.

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -15,7 +15,7 @@
 # -*- coding: utf-8 -*-
 """
 Computing Component Volume Fractions on a Block with Automatic Thermal Expansion
-================================================================================
+================================================================================.
 
 Given an :py:mod:`Block <armi.reactor.blocks.Block>`, compute
 the component volume fractions. Assess the change in volume

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -14,8 +14,7 @@
 
 # -*- coding: utf-8 -*-
 """
-Computing Component Volume Fractions on a Block with Automatic Thermal Expansion
-================================================================================.
+Computing Component Volume Fractions on a Block with Automatic Thermal Expansion.
 
 Given an :py:mod:`Block <armi.reactor.blocks.Block>`, compute
 the component volume fractions. Assess the change in volume

--- a/doc/gallery-src/framework/run_chartOfNuclides.py
+++ b/doc/gallery-src/framework/run_chartOfNuclides.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Plot a chart of the nuclides
-============================.
+Plot a chart of the nuclides.
 
 Use the nuclide directory of ARMI to plot a chart of the nuclides
 coloring the squares with the natural abundance.

--- a/doc/gallery-src/framework/run_chartOfNuclides.py
+++ b/doc/gallery-src/framework/run_chartOfNuclides.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Plot a chart of the nuclides
-============================
+============================.
 
 Use the nuclide directory of ARMI to plot a chart of the nuclides
 coloring the squares with the natural abundance.

--- a/doc/gallery-src/framework/run_computeReactionRates.py
+++ b/doc/gallery-src/framework/run_computeReactionRates.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Computing Reaction Rates on a Block
-===================================.
+Computing Reaction Rates on a Block.
 
 In this example, a set of 1-group reaction rates (in #/s) are evaluated
 for a dummy fuel block containing UZr fuel, HT9 structure, and
@@ -22,29 +21,25 @@ sodium coolant. A dummy multigroup flux is applied.
 This example also demonstrates how to build a reactor model from code alone
 rather than relying upon input files.
 """
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 from armi import configure, nuclideBases, settings
-
-from armi.reactor.flags import Flags
-from armi.reactor import grids
-from armi.reactor import reactors
-from armi.reactor import blueprints
-from armi.reactor import geometry
-from armi.reactor import assemblies
-from armi.reactor import blocks
-
-from armi.nuclearDataIO.cccc import isotxs
-from armi.tests import ISOAA_PATH
-
-from armi.reactor.components import Hexagon
-from armi.reactor.components import Circle
-from armi.reactor.components import DerivedShape
-
-from armi.materials import uZr
 from armi.materials import ht9
 from armi.materials import sodium
+from armi.materials import uZr
+from armi.nuclearDataIO.cccc import isotxs
+from armi.reactor import assemblies
+from armi.reactor import blocks
+from armi.reactor import blueprints
+from armi.reactor import geometry
+from armi.reactor import grids
+from armi.reactor import reactors
+from armi.reactor.components import Circle
+from armi.reactor.components import DerivedShape
+from armi.reactor.components import Hexagon
+from armi.reactor.flags import Flags
+from armi.tests import ISOAA_PATH
 
 configure(permissive=True)
 

--- a/doc/gallery-src/framework/run_computeReactionRates.py
+++ b/doc/gallery-src/framework/run_computeReactionRates.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Computing Reaction Rates on a Block
-===================================
+===================================.
 
 In this example, a set of 1-group reaction rates (in #/s) are evaluated
 for a dummy fuel block containing UZr fuel, HT9 structure, and

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Fuel management in a LWR
-========================
+========================.
 
 Demo of locating and swapping assemblies in a core with Cartesian geometry. Given a burnup
 distribution, this swaps high burnup assemblies with low ones.

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Fuel management in a LWR
-========================.
+Fuel management in a LWR.
 
 Demo of locating and swapping assemblies in a core with Cartesian geometry. Given a burnup
 distribution, this swaps high burnup assemblies with low ones.

--- a/doc/gallery-src/framework/run_grids1_hex.py
+++ b/doc/gallery-src/framework/run_grids1_hex.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Make a hex grid
-===============.
+Make a hex grid.
 
 This uses a grid factory method to build an infinite 2-D grid of hexagons with pitch
 equal to 1.0 cm.

--- a/doc/gallery-src/framework/run_grids1_hex.py
+++ b/doc/gallery-src/framework/run_grids1_hex.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Make a hex grid
-===============
+===============.
 
 This uses a grid factory method to build an infinite 2-D grid of hexagons with pitch
 equal to 1.0 cm.

--- a/doc/gallery-src/framework/run_grids2_cartesian.py
+++ b/doc/gallery-src/framework/run_grids2_cartesian.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Make a Cartesian grid
-=====================.
+Make a Cartesian grid.
 
 This builds a Cartesian grid with squares 1 cm square, with the z-coordinates
 provided explicitly. It is also offset in 3D space to X, Y, Z = 10, 5, 5 cm.

--- a/doc/gallery-src/framework/run_grids2_cartesian.py
+++ b/doc/gallery-src/framework/run_grids2_cartesian.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Make a Cartesian grid
-=====================
+=====================.
 
 This builds a Cartesian grid with squares 1 cm square, with the z-coordinates
 provided explicitly. It is also offset in 3D space to X, Y, Z = 10, 5, 5 cm.

--- a/doc/gallery-src/framework/run_grids3_rzt.py
+++ b/doc/gallery-src/framework/run_grids3_rzt.py
@@ -14,7 +14,7 @@
 
 """
 Make a Theta-R-Z grid
-=====================
+=====================.
 
 This builds a 3-D grid in Theta-R-Z geometry by specifying the theta, r, and z
 dimension bounds explicitly.

--- a/doc/gallery-src/framework/run_grids3_rzt.py
+++ b/doc/gallery-src/framework/run_grids3_rzt.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 """
-Make a Theta-R-Z grid
-=====================.
+Make a Theta-R-Z grid.
 
 This builds a 3-D grid in Theta-R-Z geometry by specifying the theta, r, and z
 dimension bounds explicitly.

--- a/doc/gallery-src/framework/run_isotxs.py
+++ b/doc/gallery-src/framework/run_isotxs.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Plotting Multi-group XS from ISOTXS
-===================================.
+Plotting Multi-group XS from ISOTXS.
 
 In this example, several cross sections are plotted from
 an existing binary cross section library file in :py:mod:`ISOTXS <armi.nuclearDataIO.isotxs>` format.
-
 """
 import matplotlib.pyplot as plt
 

--- a/doc/gallery-src/framework/run_isotxs.py
+++ b/doc/gallery-src/framework/run_isotxs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Plotting Multi-group XS from ISOTXS
-===================================
+===================================.
 
 In this example, several cross sections are plotted from
 an existing binary cross section library file in :py:mod:`ISOTXS <armi.nuclearDataIO.isotxs>` format.

--- a/doc/gallery-src/framework/run_isotxs2_matrix.py
+++ b/doc/gallery-src/framework/run_isotxs2_matrix.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Plotting a multi-group scatter matrix
-=====================================
+=====================================.
 
 Here we plot scatter matrices from an ISOTXS microscopic cross section library.
 We plot the inelastic scatter cross section of U235 as well as the (n,2n) source

--- a/doc/gallery-src/framework/run_isotxs2_matrix.py
+++ b/doc/gallery-src/framework/run_isotxs2_matrix.py
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Plotting a multi-group scatter matrix
-=====================================.
+Plotting a multi-group scatter matrix.
 
 Here we plot scatter matrices from an ISOTXS microscopic cross section library.
 We plot the inelastic scatter cross section of U235 as well as the (n,2n) source
 matrix.
 
 See Also: :py:mod:`ISOTXS <armi.nuclearDataIO.isotxs>` format.
-
 """
 import matplotlib.pyplot as plt
 

--- a/doc/gallery-src/framework/run_materials.py
+++ b/doc/gallery-src/framework/run_materials.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Listing of Material Library
-===========================.
+Listing of Material Library.
 
 This is a listing of all the elements in all the materials that are included in the ARMI
 material library. Many of the materials in this library are academic in quality and

--- a/doc/gallery-src/framework/run_materials.py
+++ b/doc/gallery-src/framework/run_materials.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Listing of Material Library
-===========================
+===========================.
 
 This is a listing of all the elements in all the materials that are included in the ARMI
 material library. Many of the materials in this library are academic in quality and

--- a/doc/gallery-src/framework/run_programmaticReactorDefinition.py
+++ b/doc/gallery-src/framework/run_programmaticReactorDefinition.py
@@ -147,7 +147,7 @@ def buildComponents():
 
 
 def buildBlocks(components):
-    """Build block blueprints"""
+    """Build block blueprints."""
     blocks = blockBlueprint.BlockKeyedList()
     fuel = blockBlueprint.BlockBlueprint()
     fuel.name = "fuel"
@@ -165,7 +165,7 @@ def buildBlocks(components):
 
 
 def buildAssemblies(blockDesigns):
-    """Build assembly blueprints"""
+    """Build assembly blueprints."""
     fuelBock, reflectorBlock = blockDesigns["fuel"], blockDesigns["reflector"]
 
     assemblies = assemblyBlueprint.AssemblyKeyedList()
@@ -198,7 +198,7 @@ def buildAssemblies(blockDesigns):
 
 
 def buildGrids():
-    """Build the core map grid"""
+    """Build the core map grid."""
     coreGrid = gridBlueprint.GridBlueprint("core")
     coreGrid.geom = "hex"
     coreGrid.symmetry = "third periodic"
@@ -215,7 +215,7 @@ def buildGrids():
 
 
 def buildSystems():
-    """Build the core system"""
+    """Build the core system."""
     systems = reactorBlueprint.Systems()
     core = reactorBlueprint.SystemBlueprint("core", "core", gridBlueprint.Triplet())
     systems["core"] = core

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Plot a reactor facemap
-======================
+======================.
 
 Load a test reactor from the test suite and plot a dummy
 power distribution from it. You can plot any block parameter.

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Plot a reactor facemap
-======================.
+Plot a reactor facemap.
 
 Load a test reactor from the test suite and plot a dummy
 power distribution from it. You can plot any block parameter.

--- a/doc/gallery-src/framework/run_transmutationMatrix.py
+++ b/doc/gallery-src/framework/run_transmutationMatrix.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Transmutation and decay reactions
-=================================.
+Transmutation and decay reactions.
 
 This plots some of the transmutation and decay pathways for the actinides and some light
 nuclides using the burn chain definition that is included with ARMI. Note that many of
@@ -28,7 +27,6 @@ Users can input their own transmutation matrix or use this one.
 
 A Bateman equation/matrix exponential solver is required to actually *solve* transmutation and
 decay problems, which can be provided via a plugin.
-
 """
 import os
 import math

--- a/doc/gallery-src/framework/run_transmutationMatrix.py
+++ b/doc/gallery-src/framework/run_transmutationMatrix.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Transmutation and decay reactions
-=================================
+=================================.
 
 This plots some of the transmutation and decay pathways for the actinides and some light
 nuclides using the burn chain definition that is included with ARMI. Note that many of

--- a/ruff.toml
+++ b/ruff.toml
@@ -10,7 +10,7 @@ required-version = "0.0.272"
 # TID - tidy imports
 select = ["E", "F", "D", "SIM", "TID"]
 
-# Ruff rules we ignore because they are not 100% automatable
+# Ruff rules we ignore (for now) because they are not 100% automatable
 #
 # D100 - Missing docstring in public module
 # D101 - Missing docstring in public class
@@ -32,16 +32,11 @@ select = ["E", "F", "D", "SIM", "TID"]
 # D205 - 1 blank line required between summary line and description
 # E501 - line length, because we use Black for that
 # E731 - we can use lambdas however we want
-# N802 - lowercase function naming, we use camel case
-# N803 - lowercase argument naming, we use camel case
-# N806 - lowercase variable naming, we use camel case
-# N815 - mixed case in class header, we use camel case
-# N816 - mixed case in global, scripts can use mixed case
-# N999 - lowercase variable naming, we use camel case
+# N - PEP8 naming conventions (we use snake_case; too late to change)
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
 #
-ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM102", "SIM105", "SIM108", "SIM114", "SIM115", "SIM117", "SIM118"]
+ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E501", "E731", "N", "RUF100", "SIM102", "SIM105", "SIM108", "SIM114", "SIM115", "SIM117", "SIM118"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -10,7 +10,7 @@ required-version = "0.0.272"
 # TID - tidy imports
 select = ["E", "F", "D", "SIM", "TID"]
 
-# Temporarily ignore ruff rules: TBD if we want to support them (not 100% automatable)
+# Ruff rules we ignore because they are not 100% automatable
 #
 # D100 - Missing docstring in public module
 # D101 - Missing docstring in public class
@@ -19,9 +19,6 @@ select = ["E", "F", "D", "SIM", "TID"]
 # D106 - Missing docstring in public nested class
 # D401 - First line of docstring should be in imperative mood
 # D404 - First word of the docstring should not be "This"
-
-# Temporarily ignore ruff rules: TBD if we want to support them (not 100% automatable)
-#
 # SIM102 - Use a single if statement instead of nested if statements
 # SIM105 - Use contextlib.suppress({exception}) instead of try-except-pass
 # SIM108 - Use ternary operator {contents} instead of if-else-block
@@ -29,7 +26,7 @@ select = ["E", "F", "D", "SIM", "TID"]
 # SIM115 - Use context handler for opening files
 # SIM117 - Use a single with statement with multiple contexts instead of nested with statements
 
-# Permanently ignored ruff rules
+# Ruff rules we ignore because we don't want them
 #
 # D105 - we don't need to document well-known magic methods
 # D205 - 1 blank line required between summary line and description

--- a/ruff.toml
+++ b/ruff.toml
@@ -10,7 +10,7 @@ required-version = "0.0.272"
 # TID - tidy imports
 select = ["E", "F", "D", "SIM", "TID"]
 
-# Temporarily ignore ruff rules: TBD if we want to support them
+# Temporarily ignore ruff rules: TBD if we want to support them (not 100% automatable)
 #
 # D100 - Missing docstring in public module
 # D101 - Missing docstring in public class
@@ -20,12 +20,11 @@ select = ["E", "F", "D", "SIM", "TID"]
 # D401 - First line of docstring should be in imperative mood
 # D404 - First word of the docstring should not be "This"
 
-# Temporarily ignore ruff rules: TBD if we want to support them
+# Temporarily ignore ruff rules: TBD if we want to support them (not 100% automatable)
 #
 # SIM102 - Use a single if statement instead of nested if statements
 # SIM105 - Use contextlib.suppress({exception}) instead of try-except-pass
 # SIM108 - Use ternary operator {contents} instead of if-else-block
-# SIM110 - Use comprehension instead of for loop
 # SIM114 - Combine if branches using logical or operator
 # SIM115 - Use context handler for opening files
 # SIM117 - Use a single with statement with multiple contexts instead of nested with statements
@@ -44,7 +43,8 @@ select = ["E", "F", "D", "SIM", "TID"]
 # N999 - lowercase variable naming, we use camel case
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
-ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM102", "SIM105", "SIM108", "SIM110", "SIM114", "SIM115", "SIM117", "SIM118"]
+#
+ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM102", "SIM105", "SIM108", "SIM114", "SIM115", "SIM117", "SIM118"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,7 +32,7 @@ select = ["E", "F", "D", "SIM", "TID"]
 # D205 - 1 blank line required between summary line and description
 # E501 - line length, because we use Black for that
 # E731 - we can use lambdas however we want
-# N - PEP8 naming conventions (we use snake_case; too late to change)
+# N - PEP8 naming conventions (we use camelCase; too late to change)
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
 #

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,7 +18,6 @@ select = ["E", "F", "D", "SIM", "TID"]
 # D103 - Missing docstring in public function
 # D106 - Missing docstring in public nested class
 # D401 - First line of docstring should be in imperative mood
-# D403 - First word of the first line should be capitalized
 # D404 - First word of the docstring should not be "This"
 
 # Temporarily ignore ruff rules: TBD if we want to support them
@@ -44,7 +43,7 @@ select = ["E", "F", "D", "SIM", "TID"]
 # N999 - lowercase variable naming, we use camel case
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
-ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D403", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM101", "SIM102", "SIM105", "SIM108", "SIM110", "SIM114", "SIM115", "SIM117", "SIM118"]
+ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM101", "SIM102", "SIM105", "SIM108", "SIM110", "SIM114", "SIM115", "SIM117", "SIM118"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,19 +4,34 @@
 # This is the exact version of Ruff we use.
 required-version = "0.0.272"
 
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-# D104 - missing docstring in public package
-# D2 - docstring formatting
-# D3 - docstrings quotes and escape types
-# D405-D409 - NumPy docstrings
-# D419 - no empty docstrings
-# TID252 - no relative imports
-# SIM103 - simplify code: needless-bool
-# SIM2** - simplify code: complex equality statements
-# SIM3** - simplify code: yoda-conditions
-# SIM4** - simplify code: if-else-blocks
-# SIM9** - simplify code: dict-get-with-none-default
-select = ["E", "F", "D104", "D2", "D3", "D405", "D406", "D407", "D408", "D409", "D41", "SIM103", "SIM2", "SIM3", "SIM4", "SIM9", "TID"]
+# Enable pycodestyle (E) and Pyflakes (F) codes by default.
+# D - NumPy docstring rules
+# SIM - code simplification rules
+# TID - tidy imports
+select = ["E", "F", "D", "SIM", "TID"]
+
+# Temporarily ignore ruff rules: TBD if we want to support them
+#
+# D100 - Missing docstring in public module
+# D101 - Missing docstring in public class
+# D102 - Missing docstring in public method
+# D103 - Missing docstring in public function
+# D106 - Missing docstring in public nested class
+# D400 - First line should end with a period
+# D401 - First line of docstring should be in imperative mood
+# D403 - First word of the first line should be capitalized
+# D404 - First word of the docstring should not be "This"
+
+# Temporarily ignore ruff rules: TBD if we want to support them
+#
+# SIM101 - Multiple isinstance calls, merge into a single call
+# SIM102 - Use a single if statement instead of nested if statements
+# SIM105 - Use contextlib.suppress({exception}) instead of try-except-pass
+# SIM108 - Use ternary operator {contents} instead of if-else-block
+# SIM110 - Use comprehension instead of for loop
+# SIM114 - Combine if branches using logical or operator
+# SIM115 - Use context handler for opening files
+# SIM117 - Use a single with statement with multiple contexts instead of nested with statements
 
 # D105 - we don't need to document well-known magic methods
 # D205 - 1 blank line required between summary line and description
@@ -30,7 +45,7 @@ select = ["E", "F", "D104", "D2", "D3", "D405", "D406", "D407", "D408", "D409", 
 # N999 - lowercase variable naming, we use camel case
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
-ignore = ["D105", "D205", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM118"]
+ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D400", "D401", "D403", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM101", "SIM102", "SIM105", "SIM108", "SIM110", "SIM114", "SIM115", "SIM117", "SIM118"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -33,7 +33,6 @@ select = ["E", "F", "D", "N801", "SIM", "TID"]
 # D205 - 1 blank line required between summary line and description
 # E501 - line length, because we use Black for that
 # E731 - we can use lambdas however we want
-# N - PEP8 naming conventions (we use camelCase; too late to change)
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
 #

--- a/ruff.toml
+++ b/ruff.toml
@@ -22,7 +22,6 @@ select = ["E", "F", "D", "SIM", "TID"]
 
 # Temporarily ignore ruff rules: TBD if we want to support them
 #
-# SIM101 - Multiple isinstance calls, merge into a single call
 # SIM102 - Use a single if statement instead of nested if statements
 # SIM105 - Use contextlib.suppress({exception}) instead of try-except-pass
 # SIM108 - Use ternary operator {contents} instead of if-else-block
@@ -31,6 +30,8 @@ select = ["E", "F", "D", "SIM", "TID"]
 # SIM115 - Use context handler for opening files
 # SIM117 - Use a single with statement with multiple contexts instead of nested with statements
 
+# Permanently ignored ruff rules
+#
 # D105 - we don't need to document well-known magic methods
 # D205 - 1 blank line required between summary line and description
 # E501 - line length, because we use Black for that
@@ -43,7 +44,7 @@ select = ["E", "F", "D", "SIM", "TID"]
 # N999 - lowercase variable naming, we use camel case
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
-ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM101", "SIM102", "SIM105", "SIM108", "SIM110", "SIM114", "SIM115", "SIM117", "SIM118"]
+ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM102", "SIM105", "SIM108", "SIM110", "SIM114", "SIM115", "SIM117", "SIM118"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,9 +6,10 @@ required-version = "0.0.272"
 
 # Enable pycodestyle (E) and Pyflakes (F) codes by default.
 # D - NumPy docstring rules
+# N801 - Class name should use CapWords convention
 # SIM - code simplification rules
 # TID - tidy imports
-select = ["E", "F", "D", "SIM", "TID"]
+select = ["E", "F", "D", "N801", "SIM", "TID"]
 
 # Ruff rules we ignore (for now) because they are not 100% automatable
 #
@@ -36,7 +37,7 @@ select = ["E", "F", "D", "SIM", "TID"]
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
 #
-ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E501", "E731", "N", "RUF100", "SIM102", "SIM105", "SIM108", "SIM114", "SIM115", "SIM117", "SIM118"]
+ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E501", "E731", "RUF100", "SIM102", "SIM105", "SIM108", "SIM114", "SIM115", "SIM117", "SIM118"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -73,8 +74,9 @@ line-length = 88
 [per-file-ignores]
 # D1XX - enforces writing docstrings
 # E741 - ambiguous variable name
+# N - We have our own naming conventions for unit tests.
 # SLF001 - private member access
-"*/tests/*" = ["D1", "E741", "SLF001"]
+"*/tests/*" = ["D1", "E741", "N", "SLF001"]
 
 [pydocstyle]
 # Use numpy-style docstrings.

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,7 +17,6 @@ select = ["E", "F", "D", "SIM", "TID"]
 # D102 - Missing docstring in public method
 # D103 - Missing docstring in public function
 # D106 - Missing docstring in public nested class
-# D400 - First line should end with a period
 # D401 - First line of docstring should be in imperative mood
 # D403 - First word of the first line should be capitalized
 # D404 - First word of the docstring should not be "This"
@@ -45,7 +44,7 @@ select = ["E", "F", "D", "SIM", "TID"]
 # N999 - lowercase variable naming, we use camel case
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
-ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D400", "D401", "D403", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM101", "SIM102", "SIM105", "SIM108", "SIM110", "SIM114", "SIM115", "SIM117", "SIM118"]
+ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D403", "D404", "E501", "E731", "N802", "N803", "N806", "N815", "N816", "N999", "RUF100", "SIM101", "SIM102", "SIM105", "SIM108", "SIM110", "SIM114", "SIM115", "SIM117", "SIM118"]
 
 # Exclude a variety of commonly ignored directories.
 exclude = [


### PR DESCRIPTION
## What is the change?

This is my attempt to finalize our ruff settings.  In particular, look at the `ruff.toml` file to see what I changed. The biggest changes I made were to, by default, support all rules under: `D` (numpy docstrings), `SIM` (simplify code), and `TID` (tidy imports).  But then I added a bunch of ruff rules we're going to ignore (for now) because they just aren't automatable:

```python
# D100 - Missing docstring in public module
# D101 - Missing docstring in public class
# D102 - Missing docstring in public method
# D103 - Missing docstring in public function
# D106 - Missing docstring in public nested class
# D401 - First line of docstring should be in imperative mood
# D404 - First word of the docstring should not be "This"
# SIM102 - Use a single if statement instead of nested if statements
# SIM105 - Use contextlib.suppress({exception}) instead of try-except-pass
# SIM108 - Use ternary operator {contents} instead of if-else-block
# SIM114 - Combine if branches using logical or operator
# SIM115 - Use context handler for opening files
# SIM117 - Use a single with statement with multiple contexts instead of nested with statements
```

Though a couple of these (like missing docstrings) ARE important.  But there are ~608 missing docstrings and that would take me days.

## Why is the change being made?

I am hoping this (or something like this, after the review) will be the final PR that gets us to a `ruff.toml` file that we:

1. like
2. can support going forward
3. doesn't cause us a ton of headaches

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
