### PR TITLE
Automating the Material names

### DIFF
--- a/armi/materials/air.py
+++ b/armi/materials/air.py
@@ -28,8 +28,6 @@ class Air(material.Fluid):
             https://www.pnnl.gov/main/publications/external/technical_reports/PNNL-15870Rev1.pdf
     """
 
-    name = "Air"
-
     """
     temperature ranges based on where values are more than 1% off of reference
     """

--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -21,7 +21,6 @@ from armi.utils.units import getTk
 
 class Alloy200(Material):
 
-    name = "Alloy200"
     references = {
         "linearExpansion": [
             "Alloy 200/201 Data Sheet http://www.jacquet.biz/JACQUET/USA/files/JCQusa-alloy-200-201.pdf"

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -29,7 +29,6 @@ DEFAULT_MASS_DENSITY = 2.52
 
 
 class B4C(material.Material):
-    name = "B4C"
     enrichedNuclide = "B10"
     propertyValidTemperature = {"linear expansion percent": ((25, 500), "C")}
 

--- a/armi/materials/be9.py
+++ b/armi/materials/be9.py
@@ -27,7 +27,6 @@ from armi.nucDirectory import nuclideBases as nb
 class Be9(Material):
     """Beryllium."""
 
-    name = "Be9"
     thermalScatteringLaws = (tsl.byNbAndCompound[nb.byName["BE"], tsl.BE_METAL],)
     propertyValidTemperature = {"linear expansion percent": ((50, 1560.0), "K")}
 

--- a/armi/materials/caH2.py
+++ b/armi/materials/caH2.py
@@ -20,8 +20,6 @@ from armi.materials.material import SimpleSolid
 class CaH2(SimpleSolid):
     """CalciumHydride."""
 
-    name = "CaH2"
-
     def setDefaultMassFracs(self):
         """Default mass fractions.
 

--- a/armi/materials/californium.py
+++ b/armi/materials/californium.py
@@ -23,9 +23,6 @@ from armi.materials.material import SimpleSolid
 
 
 class Californium(SimpleSolid):
-
-    name = "Californium"
-
     def setDefaultMassFracs(self):
         self.setMassFrac("CF252", 1.0)
 

--- a/armi/materials/concrete.py
+++ b/armi/materials/concrete.py
@@ -24,8 +24,10 @@ from armi.materials.material import Material
 
 
 class Concrete(Material):
-    name = "Concrete"
-    """ http://jolissrch-inter.tokai-sc.jaea.go.jp/pdfdata/JAERI-Data-Code-98-004.pdf """
+    """Simple concreate material.
+
+    http://jolissrch-inter.tokai-sc.jaea.go.jp/pdfdata/JAERI-Data-Code-98-004.pdf
+    """
 
     def setDefaultMassFracs(self):
         self.setMassFrac("H", 0.023 / 2.302)

--- a/armi/materials/copper.py
+++ b/armi/materials/copper.py
@@ -19,7 +19,6 @@ from armi.materials.material import Material
 
 
 class Cu(Material):
-    name = "Cu"
 
     propertyValidTemperature = {"linear expansion percent": ((40.43, 788.83), "K")}
 

--- a/armi/materials/cs.py
+++ b/armi/materials/cs.py
@@ -21,8 +21,6 @@ from armi.utils.units import getTk
 class Cs(Fluid):
     """Cesium."""
 
-    name = "Cs"
-
     def setDefaultMassFracs(self):
         self.setMassFrac("CS133", 1.0)
 

--- a/armi/materials/custom.py
+++ b/armi/materials/custom.py
@@ -40,7 +40,7 @@ class Custom(Material):
         self.customDensity = 1.0
 
     def pseudoDensity(self, Tk=None, Tc=None):
-        r"""
+        """
         The density value is set in the loading input.
 
         In some cases it needs to be set after full core assemblies are populated (e.g. for

--- a/armi/materials/custom.py
+++ b/armi/materials/custom.py
@@ -27,7 +27,6 @@ from armi.materials.material import Material
 class Custom(Material):
     """Custom Materials have user input properties."""
 
-    name = "Custom"
     enrichedNuclide = "U235"
 
     def __init__(self):

--- a/armi/materials/graphite.py
+++ b/armi/materials/graphite.py
@@ -29,7 +29,6 @@ class Graphite(Material):
         https://www.osti.gov/biblio/1330693
     """
 
-    name = "Graphite"
     thermalScatteringLaws = (tsl.byNbAndCompound[nb.byName["C"], tsl.GRAPHITE_10P],)
 
     def setDefaultMassFracs(self):

--- a/armi/materials/hafnium.py
+++ b/armi/materials/hafnium.py
@@ -19,8 +19,6 @@ from armi.materials.material import SimpleSolid
 
 
 class Hafnium(SimpleSolid):
-    name = "Hafnium"
-
     def setDefaultMassFracs(self):
         for a, abund in nucDir.getNaturalMassIsotopics("HF"):
             self.setMassFrac("HF{0}".format(a), abund)

--- a/armi/materials/hastelloyN.py
+++ b/armi/materials/hastelloyN.py
@@ -31,8 +31,6 @@ class HastelloyN(Material):
 
     """
 
-    name = "HastelloyN"
-
     materialIntro = (
         "Hastelloy N alloy is a nickel-base alloy that was invented at Oak RIdge National Laboratories "
         "as a container material for molten fluoride salts. It has good oxidation resistance to hot fluoride "
@@ -48,7 +46,7 @@ class HastelloyN(Material):
     refTempK = 293.15
 
     def setDefaultMassFracs(self):
-        r"""
+        """
         Hastelloy N mass fractions.
 
         From [Haynes]_.

--- a/armi/materials/ht9.py
+++ b/armi/materials/ht9.py
@@ -37,8 +37,6 @@ class HT9(materials.Material):
             https://www.osti.gov/biblio/1506477-metallic-fuels-handbook
     """
 
-    name = "HT9"
-
     propertyValidTemperature = {"linear expansion": ((293, 1050), "K")}
 
     def setDefaultMassFracs(self):

--- a/armi/materials/inconel.py
+++ b/armi/materials/inconel.py
@@ -18,7 +18,6 @@ from armi.materials.material import SimpleSolid
 
 
 class Inconel(SimpleSolid):
-    name = "Inconel"
     references = {
         "mass fractions": "https://www.specialmetals.com/documents/technical-bulletins/inconel/inconel-alloy-617.pdf",
         "density": "https://www.specialmetals.com/documents/technical-bulletins/inconel/inconel-alloy-617.pdf",
@@ -49,5 +48,3 @@ class Inconel617(Inconel):
     Inconel 617. This material enables the user to know with certainty that
     this material represents Inconel 617 and doesn't break any older models.
     """
-
-    name = "Inconel617"

--- a/armi/materials/inconel600.py
+++ b/armi/materials/inconel600.py
@@ -20,7 +20,6 @@ from armi.utils.units import getTc
 
 
 class Inconel600(Material):
-    name = "Inconel600"
     propertyValidTemperature = {
         "heat capacity": ((20, 900), "C"),
         "linear expansion": ((21.0, 900.0), "C"),

--- a/armi/materials/inconel625.py
+++ b/armi/materials/inconel625.py
@@ -20,7 +20,6 @@ from armi.utils.units import getTc
 
 
 class Inconel625(Material):
-    name = "Inconel625"
     propertyValidTemperature = {
         "heat capacity": ((221.0, 1093.0), "C"),
         "linear expansion": ((21.0, 927.0), "C"),
@@ -146,7 +145,7 @@ class Inconel625(Material):
         return numpy.polyfit(numpy.array(Tc), numpy.array(cp), power).tolist()
 
     def heatCapacity(self, Tk=None, Tc=None):
-        r"""
+        """
         Returns the specific heat capacity of Inconel625.
 
         Parameters
@@ -209,7 +208,7 @@ class Inconel625(Material):
         ).tolist()
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
-        r"""
+        """
         Returns percent linear expansion of Inconel625.
 
         Parameters

--- a/armi/materials/inconel800.py
+++ b/armi/materials/inconel800.py
@@ -26,12 +26,11 @@ class Inconel800(Material):
         (https://www.specialmetals.com/assets/smc/documents/alloys/incoloy/incoloy-alloy-800.pdf)
     """
 
-    name = "Inconel800"
     propertyValidTemperature = {"thermal expansion": ((20.0, 800.0), "C")}
     refTempK = 294.15
 
     def setDefaultMassFracs(self):
-        r"""
+        """
         Incoloy 800H mass fractions.
 
         From [SM]_.
@@ -50,7 +49,7 @@ class Inconel800(Material):
         self.refDens = 7.94
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
-        r"""
+        """
         average thermal expansion dL/L. Used for computing hot dimensions.
 
         Parameters
@@ -69,7 +68,7 @@ class Inconel800(Material):
         return 100.0 * self.meanCoefficientThermalExpansion(Tc=Tc) * (Tc - refTempC)
 
     def meanCoefficientThermalExpansion(self, Tk=None, Tc=None):
-        r"""
+        """
         Mean coefficient of thermal expansion for Incoloy 800.
         Third order polynomial fit of table 5 from [SM]_.
 

--- a/armi/materials/inconelPE16.py
+++ b/armi/materials/inconelPE16.py
@@ -20,7 +20,6 @@ from armi.nucDirectory import nuclideBases
 
 
 class InconelPE16(SimpleSolid):
-    name = "InconelPE16"
     references = {
         "mass fractions": r"http://www.specialmetals.com/assets/documents/alloys/nimonic/nimonic-alloy-pe16.pdf",
         "density": r"http://www.specialmetals.com/assets/documents/alloys/nimonic/nimonic-alloy-pe16.pdf",

--- a/armi/materials/inconelX750.py
+++ b/armi/materials/inconelX750.py
@@ -20,7 +20,6 @@ from armi.materials.material import Material
 
 
 class InconelX750(Material):
-    name = "InconelX750"
     propertyValidTemperature = {
         "heat capacity": ((-18.0, 1093.0), "C"),
         "linear expansion": ((21.1, 982.2), "C"),

--- a/armi/materials/lead.py
+++ b/armi/materials/lead.py
@@ -19,9 +19,8 @@ from armi.utils.units import getTk
 
 
 class Lead(material.Fluid):
-    r"""Natural lead."""
+    """Natural lead."""
 
-    name = "Lead"
     propertyValidTemperature = {
         "density": ((600, 1700), "K"),
         "heat capacity": ((600, 1500), "K"),
@@ -40,18 +39,18 @@ class Lead(material.Fluid):
         return 1.0 / (9516.9 - Tk)
 
     def setDefaultMassFracs(self):
-        r"""Mass fractions."""
+        """Mass fractions."""
         self.setMassFrac("PB", 1)
 
     def pseudoDensity(self, Tk=None, Tc=None):
-        r"""Density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
+        """Density in g/cc from V. sobolev/ J Nucl Mat 362 (2007) 235-247."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 
         return 11.367 - 0.0011944 * Tk  # pre-converted from kg/m^3 to g/cc
 
     def heatCapacity(self, Tk=None, Tc=None):
-        r"""Heat capacity in J/kg/K from Sobolev."""
+        """Heat capacity in J/kg/K from Sobolev."""
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 

--- a/armi/materials/leadBismuth.py
+++ b/armi/materials/leadBismuth.py
@@ -27,7 +27,6 @@ from armi.utils.units import getTk
 class LeadBismuth(material.Fluid):
     """Lead bismuth eutectic."""
 
-    name = "LeadBismuth"
     propertyValidTemperature = {
         "density": ((400, 1300), "K"),
         "dynamic visc": ((400, 1100), "K"),

--- a/armi/materials/lithium.py
+++ b/armi/materials/lithium.py
@@ -25,7 +25,6 @@ from armi.utils.mathematics import getFloat
 
 
 class Lithium(material.Fluid):
-    name = "Lithium"
     references = {"density": "Wikipedia"}
     enrichedNuclide = "LI6"
 

--- a/armi/materials/magnesium.py
+++ b/armi/materials/magnesium.py
@@ -19,14 +19,13 @@ from armi.utils.units import getTk
 
 
 class Magnesium(material.Fluid):
-    name = "Magnesium"
     propertyValidTemperature = {"density": ((923, 1390), "K")}
 
     def setDefaultMassFracs(self):
         self.setMassFrac("MG", 1.0)
 
     def pseudoDensity(self, Tk=None, Tc=None):
-        r"""Returns mass density of magnesium in g/cm3.
+        """Returns mass density of magnesium in g/cm3.
 
         The Liquid Temperature Range, Density and Constants of Magnesium. P.J. McGonigal. Temple University 1961.
 

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -669,8 +669,6 @@ class Material:
 class Fluid(Material):
     """A material that fills its container. Could also be a gas."""
 
-    name = "Fluid"
-
     def getThermalExpansionDensityReduction(self, prevTempInC, newTempInC):
         """Return the factor required to update thermal expansion going from temperatureInC to temperatureInCNew."""
         rho0 = self.pseudoDensity(Tc=prevTempInC)

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -599,7 +599,7 @@ class Material:
         Tk : float, optional
             Temperature in Kelvin.
         Tc : float, optional
-            Temperature in degrees Celsius
+            Temperature in degrees Celsius.
 
         Returns
         -------

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -95,10 +95,22 @@ class Material:
 
     @property
     def name(self):
+        """Getter for the private name attribute of this Material."""
         return self._name
 
     @name.setter
     def name(self, nomen):
+        """Setter for the private name attribute of this Material.
+
+        Warning
+        -------
+        Some code in ARMI expects the "name" of a meterial matches its
+        class name. So you use this method at your own risk.
+
+        See Also
+        --------
+        armi.materials.resolveMaterialClassByName
+        """
         self._name = nomen
 
     def getName(self):

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -61,9 +61,6 @@ class Material:
     DATA_SOURCE = "ARMI"
     """Indication of where the material is loaded from (may be plugin name)"""
 
-    name = "Material"
-    """String identifying the material"""
-
     references = {}
     """The literature references {property : citation}"""
 
@@ -88,15 +85,25 @@ class Material:
         self.theoreticalDensityFrac = 1.0
         self.cached = {}
         self._backupCache = None
+        self._name = self.__class__.__name__
 
         # call subclass implementations
         self.setDefaultMassFracs()
 
     def __repr__(self):
-        return "<Material: {0}>".format(self.getName())
+        return f"<Material: {self._name}>"
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, nomen):
+        self._name = nomen
 
     def getName(self):
-        return self.name
+        """Duplicate of name property, kept for backwards compatibility."""
+        return self._name
 
     def getChildren(
         self, deep=False, generationNum=1, includeMaterials=False, predicate=None
@@ -226,7 +233,7 @@ class Material:
         return 1.0 / (1 + dLL) ** 2
 
     def setDefaultMassFracs(self):
-        r"""Mass fractions."""
+        """Mass fractions."""
         pass
 
     def setMassFrac(self, nucName: str, massFrac: float) -> None:
@@ -520,7 +527,7 @@ class Material:
         return self.massFrac.get(nucName, 0.0)
 
     def clearMassFrac(self) -> None:
-        r"""Zero out all nuclide mass fractions."""
+        """Zero out all nuclide mass fractions."""
         self.massFrac.clear()
 
     def removeNucMassFrac(self, nuc: str) -> None:
@@ -535,7 +542,7 @@ class Material:
         return copy.deepcopy(self.massFrac)
 
     def checkPropertyTempRange(self, label, val):
-        r"""Checks if the given property / value combination fall between the min and max valid
+        """Checks if the given property / value combination fall between the min and max valid
         temperatures provided in the propertyValidTemperature object.
 
         Parameters
@@ -554,7 +561,7 @@ class Material:
         self.checkTempRange(minT, maxT, val, label)
 
     def checkTempRange(self, minT, maxT, val, label=""):
-        r"""
+        """
         Checks if the given temperature (val) is between the minT and maxT temperature limits supplied.
         Label identifies what material type or element is being evaluated in the check.
 
@@ -584,14 +591,15 @@ class Material:
                 )
 
     def densityTimesHeatCapacity(self, Tk: float = None, Tc: float = None) -> float:
-        r"""
-        Return heat capacity * density at a temperature
+        """
+        Return heat capacity * density at a temperature.
+
         Parameters
         ----------
         Tk : float, optional
             Temperature in Kelvin.
         Tc : float, optional
-            Temperature in degrees Celsius.
+            Temperature in degrees Celsius
 
         Returns
         -------
@@ -840,7 +848,7 @@ class FuelMaterial(Material):
         densityTools.applyIsotopicsMix(self, class1Isotopics, class2Isotopics)
 
     def duplicate(self):
-        r"""Copy without needing a deepcopy."""
+        """Copy without needing a deepcopy."""
         m = self.__class__()
 
         m.massFrac = {}

--- a/armi/materials/mgO.py
+++ b/armi/materials/mgO.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 """Magnesium Oxide."""
-from armi.utils.units import getTc, getTk
 from armi.materials.material import Material
+from armi.utils.units import getTc, getTk
 
 
 class MgO(Material):
-    r"""MagnesiumOxide."""
+    """MagnesiumOxide."""
 
-    name = "MgO"
     propertyValidTemperature = {
         "density": ((273, 1273), "K"),
         "linear expansion percent": ((273.15, 1273.15), "K"),
@@ -35,7 +34,7 @@ class MgO(Material):
         self.refDens = 3.58
 
     def setDefaultMassFracs(self):
-        r"""Mass fractions."""
+        """Mass fractions."""
         self.setMassFrac("MG", 0.603035897)
         self.setMassFrac("O16", 0.396964103)
 

--- a/armi/materials/mixture.py
+++ b/armi/materials/mixture.py
@@ -35,5 +35,3 @@ class _Mixture(materials.Material):
     --------
     armi.reactor.blocks.HexBlock._createHomogenizedCopy
     """
-
-    name = "Mixture"

--- a/armi/materials/molybdenum.py
+++ b/armi/materials/molybdenum.py
@@ -18,8 +18,6 @@ from armi.materials.material import SimpleSolid
 
 
 class Molybdenum(SimpleSolid):
-    name = "Molybdenum"
-
     def setDefaultMassFracs(self):
         """Moly mass fractions."""
         self.setMassFrac("MO", 1.0)

--- a/armi/materials/mox.py
+++ b/armi/materials/mox.py
@@ -37,8 +37,6 @@ class MOX(UraniumOxide):
     Specific MOX mixtures may be defined in blueprints under custom isotopics.
     """
 
-    name = "MOX"
-
     enrichedNuclide = "U235"
 
     def __init__(self):

--- a/armi/materials/nZ.py
+++ b/armi/materials/nZ.py
@@ -18,8 +18,6 @@ from armi.materials.material import SimpleSolid
 
 
 class NZ(SimpleSolid):
-    name = "NZ"
-
     def setDefaultMassFracs(self):
         self.setMassFrac("NB93", 0.99)
         self.setMassFrac("ZR", 0.01)

--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -25,7 +25,6 @@ class Potassium(material.Fluid):
     From Foust, O.J. Sodium-NaK Engineering Handbook Vol. 1. New York: Gordon and Breach, 1972.
     """
 
-    name = "Potassium"
     propertyValidTemperature = {"density": ((63.2, 1250), "C")}
 
     def pseudoDensity(self, Tk=None, Tc=None):

--- a/armi/materials/scandiumOxide.py
+++ b/armi/materials/scandiumOxide.py
@@ -19,7 +19,6 @@ from armi.utils.units import getTk
 
 
 class Sc2O3(Material):
-    name = "Sc2O3"
 
     propertyValidTemperature = {"linear expansion percent": ((273.15, 1573.15), "K")}
 

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -23,9 +23,8 @@ from armi.utils.units import getTc
 
 
 class SiC(Material):
-    r"""Silicon Carbide."""
+    """Silicon Carbide."""
 
-    name = "SiC"
     thermalScatteringLaws = (
         tsl.byNbAndCompound[nb.byName["C"], tsl.SIC],
         tsl.byNbAndCompound[nb.byName["SI"], tsl.SIC],

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -33,8 +33,6 @@ class Sodium(material.Fluid):
         https://www.osti.gov/biblio/94649-gXNdLI/webviewable/
     """
 
-    name = "Sodium"
-
     propertyValidTemperature = {
         "density": ((97.85, 2230.55), "C"),
         "enthalpy": ((371.0, 2000.0), "K"),

--- a/armi/materials/sodiumChloride.py
+++ b/armi/materials/sodiumChloride.py
@@ -15,15 +15,15 @@
 """
 Sodium Chloride salt.
 
-.. note:: This is a very simple description of this material.
+Notes
+-----
+This is a very simple description of this material.
 """
 from armi.materials.material import SimpleSolid
 from armi.utils.units import getTk
 
 
 class NaCl(SimpleSolid):
-    name = "NaCl"
-
     def setDefaultMassFracs(self):
         self.setMassFrac("NA23", 0.3934)
         self.setMassFrac("CL35", 0.4596)

--- a/armi/materials/sulfur.py
+++ b/armi/materials/sulfur.py
@@ -21,7 +21,6 @@ from armi.utils.units import getTk
 
 
 class Sulfur(material.Fluid):
-    name = "Sulfur"
 
     propertyValidTemperature = {
         "density": ((334, 430), "K"),
@@ -57,7 +56,7 @@ class Sulfur(material.Fluid):
         self.setMassFrac("S36", 0.002)
 
     def pseudoDensity(self, Tk=None, Tc=None):
-        r"""Density of Liquid Sulfur.
+        """Density of Liquid Sulfur.
 
         Ref: P. Espeau, R. Ceolin "density of molten sulfur in the 334-508K range"
 
@@ -71,8 +70,10 @@ class Sulfur(material.Fluid):
         return (2.18835 - 0.00098187 * Tk) * (self.fullDensFrac)
 
     def volumetricExpansion(self, Tk=None, Tc=None):
-        r"""P. Espeau, R. Ceolin "density of molten sulfur in the 334-508K range"
+        """
         This is just a two-point interpolation.
+
+        P. Espeau, R. Ceolin "density of molten sulfur in the 334-508K range"
         """
         Tk = getTk(Tc, Tk)
         (Tmin, Tmax) = self.propertyValidTemperature["volumetric expansion"][0]

--- a/armi/materials/tZM.py
+++ b/armi/materials/tZM.py
@@ -20,7 +20,6 @@ from armi.utils.units import getTc
 
 
 class TZM(Material):
-    name = "TZM"
     propertyValidTemperature = {"linear expansion percent": ((21.11, 1382.22), "C")}
     references = {
         "linear expansion percent": "Report on the Mechanical and Thermal Properties of Tungsten and TZM Sheet Produced \

--- a/armi/materials/tantalum.py
+++ b/armi/materials/tantalum.py
@@ -18,8 +18,6 @@ from armi.materials.material import SimpleSolid
 
 
 class Tantalum(SimpleSolid):
-    name = "Tantalum"
-
     def setDefaultMassFracs(self):
         self.setMassFrac("TA181", 1)
 

--- a/armi/materials/tests/test_water.py
+++ b/armi/materials/tests/test_water.py
@@ -15,7 +15,7 @@
 """unit tests for water materials."""
 import unittest
 
-from armi.materials.water import SaturatedWater, SaturatedSteam
+from armi.materials.water import SaturatedWater, SaturatedSteam, Water
 
 
 class Test_Water(unittest.TestCase):
@@ -206,3 +206,13 @@ class Test_Water(unittest.TestCase):
 
         steam = SaturatedSteam()
         self.assertEqual(len(steam.propertyValidTemperature), 0)
+
+    def test_validateNames(self):
+        water = Water()
+        self.assertEqual(water.name, "Water")
+
+        sat = SaturatedWater()
+        self.assertEqual(sat.name, "SaturatedWater")
+
+        steam = SaturatedSteam()
+        self.assertEqual(steam.name, "SaturatedSteam")

--- a/armi/materials/thU.py
+++ b/armi/materials/thU.py
@@ -27,7 +27,6 @@ from armi.utils.units import getTk
 
 
 class ThU(FuelMaterial):
-    name = "ThU"
     enrichedNuclide = "U233"
     propertyValidTemperature = {"linear expansion": ((30, 600), "K")}
 

--- a/armi/materials/thorium.py
+++ b/armi/materials/thorium.py
@@ -25,7 +25,6 @@ from armi.utils.units import getTk
 
 
 class Thorium(FuelMaterial):
-    name = "Thorium"
     propertyValidTemperature = {"linear expansion": ((30, 600), "K")}
 
     def __init__(self):
@@ -47,5 +46,5 @@ class Thorium(FuelMaterial):
         return 43.1
 
     def meltingPoint(self):
-        r"""Melting point in K from IAEA TE 1450."""
+        """Melting point in K from IAEA TE 1450."""
         return 2025.0

--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -26,7 +26,6 @@ from armi.materials.material import Material, FuelMaterial, SimpleSolid
 
 
 class ThoriumOxide(FuelMaterial, SimpleSolid):
-    name = "ThoriumOxide"
     propertyValidTemperature = {"linear expansion": ((298, 1223), "K")}
 
     def __init__(self):

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -25,7 +25,6 @@ class UThZr(FuelMaterial):
     This gives the combined fuel cycle of U-235, U-238, U-233, Pu-239 etc.
     """
 
-    name = "UThZr"
     enrichedNuclide = "U235"
 
     def applyInputParams(self, U235_wt_frac=None, ZR_wt_frac=None, *args, **kwargs):
@@ -37,7 +36,7 @@ class UThZr(FuelMaterial):
         FuelMaterial.applyInputParams(self, *args, **kwargs)
 
     def setDefaultMassFracs(self):
-        r"""U-ZR mass fractions."""
+        """U-ZR mass fractions."""
         self.setMassFrac("U238", 0.8)
         self.setMassFrac("U235", 0.1)
         self.setMassFrac("ZR", 0.09999)

--- a/armi/materials/uZr.py
+++ b/armi/materials/uZr.py
@@ -41,7 +41,6 @@ class UZr(material.FuelMaterial):
         https://doi.org/10.1016/j.jallcom.2009.02.077.
     """
 
-    name = "UZr"
     enrichedNuclide = "U235"
     zrFracDefault = 0.10
     uFracDefault = 1.0 - zrFracDefault
@@ -50,7 +49,7 @@ class UZr(material.FuelMaterial):
         material.Material.__init__(self)
 
     def setDefaultMassFracs(self):
-        r"""U-Pu-Zr mass fractions."""
+        """U-Pu-Zr mass fractions."""
         u235Enrichment = 0.1
         self.uFrac = self.uFracDefault
         self.zrFrac = self.zrFracDefault

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -29,7 +29,6 @@ from armi.utils.units import getTk
 
 
 class Uranium(FuelMaterial):
-    name = "Uranium"
 
     enrichedNuclide = "U235"
 

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -39,7 +39,6 @@ HeatCapacityConstants = collections.namedtuple(
 
 
 class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
-    name = "UraniumOxide"
 
     enrichedNuclide = "U235"
 
@@ -131,7 +130,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
         material.FuelMaterial.applyInputParams(self, *args, **kwargs)
 
     def setDefaultMassFracs(self) -> None:
-        r"""UO2 mass fractions. Using Natural Uranium without U234."""
+        """UO2 mass fractions. Using Natural Uranium without U234."""
         u235 = nb.byName["U235"]
         u238 = nb.byName["U238"]
         oxygen = nb.byName["O"]
@@ -232,6 +231,8 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
 
 
 class UO2(UraniumOxide):
-    r"""Another name for UraniumOxide."""
+    """Another name for UraniumOxide."""
 
-    pass
+    def __init__(self):
+        UraniumOxide.__init__(self)
+        self._name = "UraniumOxide"

--- a/armi/materials/void.py
+++ b/armi/materials/void.py
@@ -21,8 +21,6 @@ from armi.materials import material
 
 
 class Void(material.Fluid):
-    name = "Void"
-
     def pseudoDensity(self, Tk: float = None, Tc: float = None) -> float:
         return 0.0
 

--- a/armi/materials/water.py
+++ b/armi/materials/water.py
@@ -39,7 +39,6 @@ class Water(Fluid):
     power industry
     """
 
-    name = "Water"
     thermalScatteringLaws = (tsl.byNbAndCompound[nb.byName["H"], tsl.H2O],)
     references = {
         "vapor pressure": "IAPWS SR1-86 Revised Supplementary Release on Saturation Properties of Ordinary Water and Steam",
@@ -335,8 +334,6 @@ class SaturatedWater(Water):
     Saturated  Steam Material Class.
     """
 
-    name = "SaturatedWater"
-
     def pseudoDensity(self, Tk: float = None, Tc: float = None) -> float:
         """
         Returns density in g/cc.
@@ -394,8 +391,6 @@ class SaturatedSteam(Water):
     This is the Saturated Liquid Water Material Class. For steam look to the
     Saturated  Steam Material Class.
     """
-
-    name = "SaturatedSteam"
 
     def pseudoDensity(self, Tk: float = None, Tc: float = None) -> float:
         """

--- a/armi/materials/yttriumOxide.py
+++ b/armi/materials/yttriumOxide.py
@@ -19,8 +19,6 @@ from armi.utils.units import getTk
 
 
 class Y2O3(Material):
-    name = "Y2O3"
-
     propertyValidTemperature = {"linear expansion percent": ((273.15, 1573.15), "K")}
 
     def __init__(self):

--- a/armi/materials/zincOxide.py
+++ b/armi/materials/zincOxide.py
@@ -19,7 +19,6 @@ from armi.utils.units import getTk
 
 
 class ZnO(Material):
-    name = "ZnO"
 
     propertyValidTemperature = {"linear expansion percent": ((10.12, 1491.28), "K")}
 

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -23,8 +23,6 @@ from armi.utils.units import getTk
 class Zr(Material):
     """Metallic zirconium."""
 
-    name = "Zr"
-
     propertyValidTemperature = {
         "density": ((293, 1800), "K"),
         "linear expansion": ((293, 1800), "K"),

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -797,7 +797,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
 
 
 class TestGetSolidComponents(unittest.TestCase):
-    """verify that getSolidComponents returns just solid components"""
+    """Verify that getSolidComponents returns just solid components."""
 
     def setUp(self):
         self.a = buildTestAssemblyWithFakeMaterial(name="HT9")

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -9,6 +9,7 @@ Release Date: TBD
 What's new in ARMI
 ------------------
 #. The Spent Fuel Pool (``sfp``) was moved from the ``Core`` out to the ``Reactor``. (`PR#1336 <https://github.com/terrapower/armi/pull/1336>`_)
+#. Removed redundant ``Material.name`` variable. (`PR#1335 <https://github.com/terrapower/armi/pull/1335>`_)
 #. Added SHA1 hashes of XS control files to the welcome text. (`PR#1334 <https://github.com/terrapower/armi/pull/1334>`_)
 #. TBD
 


### PR DESCRIPTION
## What is the change?

All materials in ARMI (or ARMI plugins) used to need a class attribute that defined their name.  But that name HAD to exactly match the name of the class.

That led to all kinds of silly problem, because of course it did.

So this PR automates that process.

BUT it also still allows developers to manually set the name of the material, if they want. So everyone's use cases should be covered.

## Why is the change being made?

We have run up against the problem of ARMI materials having the wrong `.name` attribute several times lately.  And we have had to go through various repos and manually fix things.  But this is a problem that can be solved by automation.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
