### PR TITLE
Moving Spent Fuel pool off Core and onto Reactor

### DIFF
--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -375,7 +375,7 @@ class TestDatabase3(unittest.TestCase):
         self.assertEqual(assemblies._assemNum, 0)
 
         r = self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=False)
-        #  len(r.core.sfp) is zero but these nums are still reserved
+        #  len(r.sfp) is zero but these nums are still reserved
         numSFPBlueprints = 4
         expectedNum = len(r.core) + numSFPBlueprints
         self.assertEqual(assemblies._assemNum, expectedNum)

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -141,7 +141,7 @@ class MemoryProfiler(interfaces.Interface):
                     "Dict {:30s} has {:4d} ArmiObjects".format(attrName, len(attrObj))
                 )
 
-        runLog.important("SFP has {:4d} ArmiObjects".format(len(self.r.core.sfp)))
+        runLog.important("SFP has {:4d} ArmiObjects".format(len(self.r.sfp)))
 
     def checkForDuplicateObjectsOnArmiModel(self, attrName, refObject):
         """Scans thorugh ARMI model for duplicate objects."""

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
-This interface serves the reporting needs of ARMI. If there is any information that a user desires
-to show in PDF form to others this is the place to do it.
+"""
+This interface serves the reporting needs of ARMI.
+
+If there is any information that a user desires to show in PDF form to
+others this is the place to do it.
 """
 import re
 
@@ -169,5 +171,5 @@ class ReportInterface(interfaces.Interface):
     def writeRunSummary(self):
         """Make a summary of the run."""
         # spent fuel pool report
-        self.r.core.sfp.report()
-        self.r.core.sfp.count()
+        self.r.sfp.report()
+        self.r.sfp.count()

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -226,7 +226,7 @@ class Material:
         return 1.0 / (1 + dLL) ** 2
 
     def setDefaultMassFracs(self):
-        r"""Mass fractions."""
+        """Mass fractions."""
         pass
 
     def setMassFrac(self, nucName: str, massFrac: float) -> None:
@@ -520,7 +520,7 @@ class Material:
         return self.massFrac.get(nucName, 0.0)
 
     def clearMassFrac(self) -> None:
-        r"""Zero out all nuclide mass fractions."""
+        """Zero out all nuclide mass fractions."""
         self.massFrac.clear()
 
     def removeNucMassFrac(self, nuc: str) -> None:
@@ -535,7 +535,7 @@ class Material:
         return copy.deepcopy(self.massFrac)
 
     def checkPropertyTempRange(self, label, val):
-        r"""Checks if the given property / value combination fall between the min and max valid
+        """Checks if the given property / value combination fall between the min and max valid
         temperatures provided in the propertyValidTemperature object.
 
         Parameters
@@ -554,7 +554,7 @@ class Material:
         self.checkTempRange(minT, maxT, val, label)
 
     def checkTempRange(self, minT, maxT, val, label=""):
-        r"""
+        """
         Checks if the given temperature (val) is between the minT and maxT temperature limits supplied.
         Label identifies what material type or element is being evaluated in the check.
 
@@ -584,14 +584,15 @@ class Material:
                 )
 
     def densityTimesHeatCapacity(self, Tk: float = None, Tc: float = None) -> float:
-        r"""
-        Return heat capacity * density at a temperature
+        """
+        Return heat capacity * density at a temperature.
+
         Parameters
         ----------
         Tk : float, optional
             Temperature in Kelvin.
         Tc : float, optional
-            Temperature in degrees Celsius.
+            Temperature in degrees Celsius
 
         Returns
         -------
@@ -840,7 +841,7 @@ class FuelMaterial(Material):
         densityTools.applyIsotopicsMix(self, class1Isotopics, class2Isotopics)
 
     def duplicate(self):
-        r"""Copy without needing a deepcopy."""
+        """Copy without needing a deepcopy."""
         m = self.__class__()
 
         m.massFrac = {}

--- a/armi/materials/tests/test_water.py
+++ b/armi/materials/tests/test_water.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""unit tests for water materials."""
+"""Unit tests for water materials."""
 import unittest
 
 from armi.materials.water import SaturatedWater, SaturatedSteam

--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -89,9 +89,7 @@ class FuelHandlerInterface(interfaces.Interface):
         timeYears = self.r.p.time
         # keep track of the EOC time in years.
         self.cycleTime[cycle] = timeYears
-        runLog.extra(
-            "There are {} assemblies in the Spent Fuel Pool".format(len(self.r.sfp))
-        )
+        runLog.extra(f"There are {len(self.r.sfp)} assemblies in the Spent Fuel Pool")
 
     def interactEOL(self):
         """Make reports at EOL."""

--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -90,9 +90,7 @@ class FuelHandlerInterface(interfaces.Interface):
         # keep track of the EOC time in years.
         self.cycleTime[cycle] = timeYears
         runLog.extra(
-            "There are {} assemblies in the Spent Fuel Pool".format(
-                len(self.r.core.sfp)
-            )
+            "There are {} assemblies in the Spent Fuel Pool".format(len(self.r.sfp))
         )
 
     def interactEOL(self):

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -662,7 +662,7 @@ class FuelHandler:
             assemListTmp2 = []
             if ringList[0] == "SFP":
                 # kind of a hack for now. Need the capability.
-                assemblyList = self.r.core.sfp.getChildren()
+                assemblyList = self.r.sfp.getChildren()
             else:
                 for i, ringNumber in enumerate(ringList):
                     assemListTmp = self.r.core.getAssembliesInCircularRing(
@@ -680,7 +680,7 @@ class FuelHandler:
         else:
             if ringList[0] == "SFP":
                 # kind of a hack for now. Need the capability.
-                assemList = self.r.core.sfp.getChildren()
+                assemList = self.r.sfp.getChildren()
             else:
                 assemList = self.r.core.getAssemblies()
 
@@ -826,10 +826,10 @@ class FuelHandler:
         # future, this mechanism may be used to handle symmetry in general.
         outgoing.p.multiplicity = len(loc.getSymmetricEquivalents()) + 1
 
-        if incoming in self.r.core.sfp.getChildren():
+        if incoming in self.r.sfp.getChildren():
             # pull it out of the sfp if it's in there.
             runLog.extra("removing {0} from the sfp".format(incoming))
-            self.r.core.sfp.remove(incoming)
+            self.r.sfp.remove(incoming)
 
         incoming.p.multiplicity = 1
         self.r.core.add(incoming, loc)
@@ -1279,11 +1279,11 @@ class FuelHandler:
             # not only use the proper assembly type but also adjust the enrichment.
             if assemblyName:
                 # get this assembly from the SFP
-                loadAssembly = self.r.core.sfp.getAssembly(assemblyName)
+                loadAssembly = self.r.sfp.getAssembly(assemblyName)
                 if not loadAssembly:
                     runLog.error(
                         "the required assembly {0} is not found in the SFP. It contains: {1}"
-                        "".format(assemblyName, self.r.core.sfp.getChildren())
+                        "".format(assemblyName, self.r.sfp.getChildren())
                     )
                     raise RuntimeError(
                         "the required assembly {0} is not found in the SFP.".format(

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -75,7 +75,7 @@ class FuelHandlerTestHelper(ArmiTestHelper):
                 b.p.percentBu = 30.0 * bi / len(blockList)
         self.nfeed = len(self.r.core.getAssemblies(Flags.FEED))
         self.nigniter = len(self.r.core.getAssemblies(Flags.IGNITER))
-        self.nSfp = len(self.r.core.sfp)
+        self.nSfp = len(self.r.sfp)
 
         # generate a reactor with assemblies
         # generate components with materials
@@ -376,7 +376,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
             self.r.p.cycle = cycle
             fh.cycle = cycle
             fh.manageFuel(cycle)
-            for a in self.r.core.sfp.getChildren():
+            for a in self.r.sfp.getChildren():
                 self.assertEqual(a.getLocation(), "SFP")
             for b in self.r.core.getBlocks(Flags.FUEL):
                 self.assertGreater(b.p.kgHM, 0.0, "b.p.kgHM not populated!")
@@ -395,7 +395,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         runShuffling : creates the shuffling file to be read in.
         """
         # check labels before shuffling:
-        for a in self.r.core.sfp.getChildren():
+        for a in self.r.sfp.getChildren():
             self.assertEqual(a.getLocation(), "SFP")
 
         # do some shuffles.
@@ -429,7 +429,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         # make sure the shuffle was repeated perfectly.
         for a in self.r.core.getAssemblies():
             self.assertEqual(a.getName(), firstPassResults[a.getLocation()])
-        for a in self.r.core.sfp.getChildren():
+        for a in self.r.sfp.getChildren():
             self.assertEqual(a.getLocation(), "SFP")
 
     def test_readMoves(self):
@@ -685,7 +685,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
 
         # grab an arbitrary fuel assembly from the core and from the SFP
         a1 = self.r.core.getAssemblies(Flags.FUEL)[0]
-        a2 = self.r.core.sfp.getChildren(Flags.FUEL)[0]
+        a2 = self.r.sfp.getChildren(Flags.FUEL)[0]
 
         # grab the stationary blocks pre swap
         a1PreSwapStationaryBlocks = [
@@ -734,7 +734,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
 
         # grab an arbitrary fuel assembly from the core and from the SFP
         a1 = self.r.core.getAssemblies(Flags.FUEL)[0]
-        a2 = self.r.core.sfp.getChildren(Flags.FUEL)[0]
+        a2 = self.r.sfp.getChildren(Flags.FUEL)[0]
 
         # change a block in assembly 1 to be flagged as a stationary block
         for block in a1:
@@ -753,7 +753,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         # re-initialize assemblies
         self.setUp()
         a1 = self.r.core.getAssemblies(Flags.FUEL)[0]
-        a2 = self.r.core.sfp.getChildren(Flags.FUEL)[0]
+        a2 = self.r.sfp.getChildren(Flags.FUEL)[0]
 
         # move location of a stationary flag in assembly 1
         for block in a1:

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -78,6 +78,7 @@ class Reactor(composites.Composite):
         self.p.cycle = 0
         self.p.flags |= Flags.REACTOR
         self.core = None
+        self.sfp = assemblyLists.SpentFuelPool("Spent Fuel Pool", self)
         self.blueprints = blueprints
 
     def __getstate__(self):
@@ -88,6 +89,7 @@ class Reactor(composites.Composite):
 
     def __setstate__(self, state):
         composites.Composite.__setstate__(self, state)
+        self.sfp.parent = self
 
     def __deepcopy__(self, memo):
         memo[id(self)] = newR = self.__class__.__new__(self.__class__)
@@ -207,10 +209,6 @@ class Core(composites.Composite):
         self.spatialGrid = None
         self.xsIndex = {}
         self.p.numMoves = 0
-
-        # build a spent fuel pool for this reactor
-        runLog.debug("Building spent fuel pools")
-        self.sfp = assemblyLists.SpentFuelPool("Spent Fuel Pool", self)
         self._lib = None  # placeholder for ISOTXS object
         self.locParams = {}  # location-based parameters
         # overridden in case.py to include pre-reactor time.
@@ -252,7 +250,6 @@ class Core(composites.Composite):
 
     def __setstate__(self, state):
         composites.Composite.__setstate__(self, state)
-        self.sfp.parent = self
         self.regenAssemblyLists()
 
     def __deepcopy__(self, memo):
@@ -466,7 +463,8 @@ class Core(composites.Composite):
         self.remove(a1)
 
         if discharge and self._trackAssems:
-            self.sfp.add(a1)
+            if hasattr(self.parent, "sfp"):
+                self.parent.sfp.add(a1)
         else:
             self._removeListFromAuxiliaries(a1)
 
@@ -527,7 +525,8 @@ class Core(composites.Composite):
         assems = set(self)
         for a in assems:
             self.removeAssembly(a, discharge)
-        self.sfp.removeAll()
+        if hasattr(self.parent, "sfp"):
+            self.parent.sfp.removeAll()
         self.blocksByName = {}
         self.assembliesByName = {}
 
@@ -1069,8 +1068,8 @@ class Core(composites.Composite):
 
         assems.extend(a for a in sorted(self, key=sortKey))
 
-        if includeSFP:
-            assems.extend(self.sfp.getChildren())
+        if includeSFP and hasattr(self.parent, "sfp"):
+            assems.extend(self.parent.sfp.getChildren())
 
         if typeSpec:
             assems = [a for a in assems if a.hasFlags(typeSpec, exact=exact)]

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -465,6 +465,8 @@ class Core(composites.Composite):
         if discharge and self._trackAssems:
             if hasattr(self.parent, "sfp"):
                 self.parent.sfp.add(a1)
+            else:
+                runLog.info("No Spent Fuel Pool is found, can't track assemblies.")
         else:
             self._removeListFromAuxiliaries(a1)
 
@@ -950,7 +952,6 @@ class Core(composites.Composite):
         ----------
         ringPitch : float, optional
             The relative pitch that should be used to define the spacing between each ring.
-
         """
         runLog.extra(
             "Building a circular ring dictionary with ring pitch {}".format(ringPitch)
@@ -1010,7 +1011,6 @@ class Core(composites.Composite):
         See Also
         --------
         getAssembly : more general version of this method
-
         """
         return self.assembliesByName[name]
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -202,7 +202,7 @@ def loadTestReactor(
     # put some stuff in the SFP too.
     for a in range(10):
         a = o.r.blueprints.constructAssem(o.cs, name="feed fuel")
-        o.r.core.sfp.add(a)
+        o.r.sfp.add(a)
 
     o.r.core.regenAssemblyLists()
 
@@ -806,7 +806,7 @@ class HexReactorTests(ReactorTests):
         bLoc = b.spatialLocator
         self.r.core.removeAssembly(a)
         self.assertNotEqual(aLoc, a.spatialLocator)
-        self.assertEqual(a.spatialLocator.grid, self.r.core.sfp.spatialGrid)
+        self.assertEqual(a.spatialLocator.grid, self.r.sfp.spatialGrid)
 
         # confirm only attached to removed assem
         self.assertIs(bLoc, b.spatialLocator)  # block location does not change
@@ -826,7 +826,7 @@ class HexReactorTests(ReactorTests):
         self.r.core.removeAssembliesInRing(3, self.o.cs)
         for i, a in assems.items():
             self.assertNotEqual(aLoc[i], a.spatialLocator)
-            self.assertEqual(a.spatialLocator.grid, self.r.core.sfp.spatialGrid)
+            self.assertEqual(a.spatialLocator.grid, self.r.sfp.spatialGrid)
 
     def test_removeAssembliesInRingByCount(self):
         self.assertEqual(self.r.core.getNumRings(), 9)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Testing for reactors.py."""
 import copy
+import logging
 import os
 import unittest
 
@@ -144,7 +145,7 @@ def loadTestReactor(
     customSettings=None,
     inputFileName="armiRun.yaml",
 ):
-    r"""
+    """
     Loads a test reactor. Can be used in other test modules.
 
     Parameters
@@ -812,6 +813,24 @@ class HexReactorTests(ReactorTests):
         self.assertIs(bLoc, b.spatialLocator)  # block location does not change
         self.assertIs(a, b.parent)
         self.assertIs(a, b.spatialLocator.grid.armiObject)
+
+    def test_removeAssemblyNoSfp(self):
+        with mockRunLogs.BufferLog() as mock:
+            # we should start with a clean slate
+            self.assertEqual("", mock.getStdout())
+            runLog.LOG.startLog("test_removeAssemblyNoSfp")
+            runLog.LOG.setVerbosity(logging.INFO)
+
+            a = self.r.core[-1]  # last assembly
+            b = a[-1]  # use the last block in case we ever figure out stationary blocks
+            aLoc = a.spatialLocator
+            self.assertIsNotNone(aLoc.grid)
+            bLoc = b.spatialLocator
+            core = self.r.core
+            del core.parent.sfp
+            core.removeAssembly(a)
+
+            self.assertIn("No Spent Fuel Pool", mock.getStdout())
 
     def test_removeAssembliesInRing(self):
         aLoc = [

--- a/armi/tests/refSmallReactorShuffleLogic.py
+++ b/armi/tests/refSmallReactorShuffleLogic.py
@@ -16,7 +16,7 @@ from armi.physics.fuelCycle.fuelHandlers import FuelHandler
 
 
 class EquilibriumShuffler(FuelHandler):
-    r"""Convergent divergent equilibrium shuffler."""
+    """Convergent divergent equilibrium shuffler."""
 
     def chooseSwaps(self, factorList):
         cycleMoves = [
@@ -36,10 +36,10 @@ class EquilibriumShuffler(FuelHandler):
         self.dischargeSwap(fresh, cascade[0])
         if self.cycle > 0:
             # do a swap where the assembly comes from the sfp
-            incoming = self.r.core.sfp.getChildren().pop(0)
+            incoming = self.r.sfp.getChildren().pop(0)
             if not incoming:
                 raise RuntimeError(
-                    "No assembly in SFP {0}".format(self.r.core.sfp.getChildren())
+                    "No assembly in SFP {0}".format(self.r.sfp.getChildren())
                 )
             outLoc = self.r.core.spatialGrid.getLocatorFromRingAndPos(5, 2 + self.cycle)
             self.dischargeSwap(incoming, self.r.core.childrenByLocator[outLoc])

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -8,6 +8,7 @@ Release Date: TBD
 
 What's new in ARMI
 ------------------
+#. The Spent Fuel Pool (``sfp``) was moved from the ``Core`` out to the ``Reactor``. (`PR#1336 <https://github.com/terrapower/armi/pull/1336>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## What is the change?

I moved the Spent Fuel Pool (SFP) object was on the `Core` instead of the `Reactor`.

I wanted to make the shift more cleanly than I did, but when you call `Core.removeAssembly()`, it wants to put the assembly in the SFP.  Which means the `Core` needs to at _least_ know the SFP is on the `Reactor`.  But fine.

For some reason the 

## Why is the change being made?

The SPF is, objectively, not inside the Core.  This was just wrong.  And more importantly, counterintuitive for the users.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
