### PR TITLE
Removing the Ring and Pos parameters

### DIFF
--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -302,10 +302,6 @@ def getAssemblyParameterDefinitions():
 
     with pDefs.createBuilder(default=0.0) as pb:
 
-        pb.defParam("Pos", units="?", description="?", location="?")
-
-        pb.defParam("Ring", units="?", description="?", location="?")
-
         pb.defParam("THcoolantInletT", units="?", description="?", location="?")
 
         pb.defParam("assemNum", units="?", description="?", location="?")


### PR DESCRIPTION
## What is the change?

This PR removed the `Ring` and `Pos` assembly Parameters.

## Why is the change being made?

It turns out these Parameters are defunct, and were replaced long ago by the `spatialLocator` class.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
