### PR TITLE
Improve logic for computing thermal expansion factors

### DIFF
--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -629,7 +629,9 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
         This is implemented by creating a fuel block that contains no fuel component
         and passing it to ExpansionData::_isFuelLocked.
         """
-        expdata = ExpansionData(HexAssembly("testAssemblyType"), setFuel=True)
+        expdata = ExpansionData(
+            HexAssembly("testAssemblyType"), setFuel=True, coldHeightsToHot=False
+        )
         b_NoFuel = HexBlock("fuel", height=10.0)
         shieldDims = {
             "Tinput": 25.0,
@@ -666,7 +668,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
 
     def setUp(self):
         AxialExpansionTestBase.setUp(self)
-        self.expData = ExpansionData([], None)
+        self.expData = ExpansionData([], True, True)
         coolDims = {"Tinput": 25.0, "Thot": 25.0}
         self.coolant = DerivedShape("coolant", "Sodium", **coolDims)
 


### PR DESCRIPTION
## What is the change?
The logic within axialExpansionChanger.py::ExpansionData::computeThermalExpansionFactors was prone to computing the wrong thermal expansion factors for some corner cases. This PR aims to address these use cases by adding an optional parameter that specifically calls out if the temperature change for computing the thermal expansion factors should use c.inputTemperatureInC and c.temperatureInC (i.e., if `coldHeightsToHot` is True) or between the "component reference temperature" and c.temperatureInC (i.e., if `coldHeightsToHot` is False). 

<!-- MANDATORY: Describe the change -->

## Why is the change being made?
The logic for computing thermal expansion factors was error prone and could be misinterpreted. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
