### PR TITLE
Moving missing file warning to debug

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
+"""
 The ``Case`` object is responsible for running, and executing a set of user inputs.  Many
 entry points redirect into ``Case`` methods, such as ``clone``, ``compare``, and ``run``.
 
@@ -939,7 +939,7 @@ def copyInterfaceInputs(
                 except NonexistentSetting(key):
                     raise ValueError(
                         f"{key} is not a valid setting. Ensure the relevant specifyInputs "
-                        f"method uses a correct setting name."
+                        "method uses a correct setting name."
                     )
             label = key.name
 
@@ -961,6 +961,7 @@ def copyInterfaceInputs(
                             continue
                     except OSError:
                         pass
+
                 # Attempt to construct an absolute file path
                 sourceFullPath = os.path.join(sourceDirPath, f)
                 if WILDCARD:
@@ -982,11 +983,11 @@ def copyInterfaceInputs(
                         label, sourceFullPath, destination, f
                     )
                     newFiles.append(str(destFilePath))
+
                 if destFilePath == f:
-                    runLog.info(
+                    runLog.debug(
                         f"No input files for `{label}` setting could be resolved with "
-                        f"the following path: `{sourceFullPath}`. Will not update "
-                        f"`{label}`."
+                        f"the following path: `{sourceFullPath}`. Will not update `{label}`."
                     )
 
             # Some settings are a single filename. Others are lists of files. Make
@@ -995,4 +996,5 @@ def copyInterfaceInputs(
                 newSettings[label] = newFiles[0]
             else:
                 newSettings[label] = newFiles
+
     return newSettings

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -338,7 +338,7 @@ class Inspector:
         against the default, if the user specifies all the simple cycle settings
         _exactly_ as the defaults, this won't be caught. But, it would be very
         coincidental for the user to _specify_ all the default values when
-        performing any real analysis, so whatever.
+        performing any real analysis.
 
         Also, we must bypass the `Settings` getter and reach directly
         into the underlying `__settings` dict to avoid triggering an error
@@ -711,7 +711,7 @@ class Inspector:
 
 
 def createQueryRevertBadPathToDefault(inspector, settingName, initialLambda=None):
-    r"""
+    """
     Return a query to revert a bad path to its default.
 
     Parameters

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -822,7 +822,6 @@ class HexReactorTests(ReactorTests):
             runLog.LOG.setVerbosity(logging.INFO)
 
             a = self.r.core[-1]  # last assembly
-            b = a[-1]  # use the last block in case we ever figure out stationary blocks
             aLoc = a.spatialLocator
             self.assertIsNotNone(aLoc.grid)
             core = self.r.core


### PR DESCRIPTION
## What is the change?

This moves a "missing file" warning from `INFO` to `DEBUG` when cloning a case.

> The only problem I have here, is I don't know how to test this with all the different workflows, to make sure it doesn't cause anyone problems.  Ideas?

## Why is the change being made?

This is to close #1304 .

It is a request, because users don't like seeing the extra warning on the command line.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
