### PR TITLE
Improving ParamLocations of certain TH Parameters

### DIFF
--- a/armi/physics/thermalHydraulics/parameters.py
+++ b/armi/physics/thermalHydraulics/parameters.py
@@ -209,14 +209,14 @@ def _getBlockParams():
             "THcoolantInletT",
             units=units.DEGC,
             description="The nominal average bulk coolant inlet temperature into the block.",
-            location=ParamLocation.AVERAGE,
+            location=ParamLocation.BOTTOM,
         )
 
         pb.defParam(
             "THcoolantOutletT",
             units=units.DEGC,
             description="Coolant temperature at the outlet of this block",
-            location=ParamLocation.AVERAGE,
+            location=ParamLocation.TOP,
         )
 
         pb.defParam(
@@ -237,7 +237,7 @@ def _getBlockParams():
             "THhotChannelOutletT",
             units=units.DEGC,
             description="Nominal hot channel outlet temperature",
-            location=ParamLocation.AVERAGE,
+            location=ParamLocation.TOP,
         )
 
         pb.defParam(

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -86,7 +86,7 @@ class Category:
 
 
 class ParamLocation(enum.Flag):
-    """Represents point which a parameter is physically meaningful."""
+    """Represents the point on which a parameter is physically meaningful."""
 
     TOP = 1
     CENTROID = 2
@@ -100,14 +100,14 @@ class ParamLocation(enum.Flag):
 
 
 class NoDefault:
-    r"""Class used to allow distinction between not setting a default and setting a default of ``None``."""
+    """Class used to allow distinction between not setting a default and setting a default of ``None``."""
 
     def __init__(self):
         raise NotImplementedError("You cannot create an instance of NoDefault")
 
 
 class _Undefined:
-    r"""Class used to identify a parameter property as being in the undefined state."""
+    """Class used to identify a parameter property as being in the undefined state."""
 
     def __init__(self):
         raise NotImplementedError("You cannot create an instance of _Undefined.")
@@ -399,7 +399,7 @@ class Parameter:
 
 
 class ParameterDefinitionCollection:
-    r"""
+    """
     A very specialized container for managing parameter definitions.
 
     Notes
@@ -483,7 +483,7 @@ class ParameterDefinitionCollection:
             self.add(pd)
 
     def inCategory(self, categoryName):
-        r"""
+        """
         Create a :py:class:`ParameterDefinitionCollection` that contains definitions that are in a
         specific category.
         """


### PR DESCRIPTION
## What is the change?

Close #1233, which points out some more realistic `ParamLocation`s for a few Parameters.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
