### PR TITLE
Removing units.NOT_APPLICABLE in favor of UNITLESS

### DIFF
--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -167,7 +167,7 @@ def getAssemblyParameterDefinitions():
 
         pb.defParam(
             "notes",
-            units=units.NOT_APPLICABLE,
+            units=units.UNITLESS,
             description="A string with notes about the assembly, limited to 1000 characters."
             " This parameter is not meant to store data. Needlessly storing large strings"
             " on this parameter for every assembly is potentially unwise from a memory"

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -216,7 +216,7 @@ def getBlockParameterDefinitions():
 
         pb.defParam(
             "buGroup",
-            units=units.NOT_APPLICABLE,
+            units=units.UNITLESS,
             description="The burnup group letter of this block",
             default="A",
             setter=buGroup,
@@ -236,7 +236,7 @@ def getBlockParameterDefinitions():
 
         pb.defParam(
             "buGroupNum",
-            units=units.NOT_APPLICABLE,
+            units=units.UNITLESS,
             description="An integer representation of the burnup group, linked to buGroup.",
             default=0,
             setter=buGroupNum,
@@ -401,7 +401,7 @@ def getBlockParameterDefinitions():
 
         pb.defParam(
             "xsType",
-            units=units.NOT_APPLICABLE,
+            units=units.UNITLESS,
             description="The xs group letter of this block",
             default="A",
             setter=xsType,
@@ -415,7 +415,7 @@ def getBlockParameterDefinitions():
 
         pb.defParam(
             "xsTypeNum",
-            units=units.NOT_APPLICABLE,
+            units=units.UNITLESS,
             description="An integer representation of the cross section type, linked to xsType.",
             default=65,  # NOTE: buGroupNum actually starts at 0
             setter=xsTypeNum,

--- a/armi/utils/tests/test_textProcessors.py
+++ b/armi/utils/tests/test_textProcessors.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for functions in textProcessors.py."""
-from io import StringIO, TextIOWrapper, TextIOBase
+from io import StringIO
 import os
 import pathlib
 import ruamel
@@ -61,7 +61,7 @@ class YamlIncludeTest(unittest.TestCase):
         self.assertTrue(anchorFound)
 
     def test_resolveIncludes_StringIO(self):
-        """Tests that resolveMarkupInclusions handles StringIO input"""
+        """Tests that resolveMarkupInclusions handles StringIO input."""
         yaml = ruamel.yaml.YAML()
         with open(os.path.join(RES_DIR, "root.yaml")) as f:
             loadedYaml = yaml.load(f)

--- a/armi/utils/textProcessors.py
+++ b/armi/utils/textProcessors.py
@@ -90,7 +90,7 @@ def _processIncludes(
     indentSpace = " " * indentation
     if hasattr(src, "getvalue"):
         # assume stringIO
-        lines = [l + "\n" for l in src.getvalue().split("\n")]
+        lines = [ln + "\n" for ln in src.getvalue().split("\n")]
     else:
         # assume file stream or TextIOBase, and it has a readlines attr
         lines = src.readlines()

--- a/armi/utils/units.py
+++ b/armi/utils/units.py
@@ -29,7 +29,6 @@ GRAMS = "g"
 KG = "kg"
 METERS = "m"
 MICRONS = chr(181) + "m"
-NOT_APPLICABLE = "N/A"  # prefer UNITLESS
 PASCALS = "Pa"
 PERCENT = "%"
 SECONDS = "s"


### PR DESCRIPTION
## What is the change?

This PR removes the unit `NOT_APPLICABLE`, in favor of just using `UNITLESS`.

(Also, it fixes some `ruff` errors.)

## Why is the change being made?

I marked the `NOT_APPLICABLE` unit as "prefer UNITLESS" in a recent PR. But after looking in all downstream repos, I couldn't find a single instance of `NOT_APPLICABLE` being used. So I think it's less confusing to just have one of them.  This should be easier for developers to understand moving forward.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
