### PR TITLE
Adding a Component Parameter table to the docs

### DIFF
--- a/doc/user/assembly_parameters_report.rst
+++ b/doc/user/assembly_parameters_report.rst
@@ -1,7 +1,6 @@
 Assembly Parameters
 ===================
-This document lists all of the Assembly Parameters that are provided by the ARMI
-Framework and included plugins.
+This document lists all of the Assembly Parameters that are provided by the ARMI Framework.
 
 .. exec::
    from armi.reactor import assemblies

--- a/doc/user/block_parameters_report.rst
+++ b/doc/user/block_parameters_report.rst
@@ -1,7 +1,6 @@
 Block Parameters
 ================
-This document lists all of the Block Parameters that are provided by the ARMI
-Framework and included plugins.
+This document lists all of the Block Parameters that are provided by the ARMI Framework.
 
 .. exec::
    from armi.reactor import blocks

--- a/doc/user/component_parameters_report.rst
+++ b/doc/user/component_parameters_report.rst
@@ -1,0 +1,10 @@
+Component Parameters
+====================
+This document lists all of the Component Parameters that are provided by the ARMI Framework.
+
+.. exec::
+   from armi.reactor.components import Component
+   from armi.reactor.components.componentParameters import getComponentParameterDefinitions
+   from armi.utils.dochelpers import generateParamTable
+
+   return generateParamTable(Component, getComponentParameterDefinitions())

--- a/doc/user/core_parameters_report.rst
+++ b/doc/user/core_parameters_report.rst
@@ -1,7 +1,6 @@
 Core Parameters
 ===============
-This document lists all of the Core Parameters that are provided by the ARMI
-Framework and included plugins.
+This document lists all of the Core Parameters that are provided by the ARMI Framework.
 
 .. exec::
    from armi.reactor import reactors

--- a/doc/user/index.rst
+++ b/doc/user/index.rst
@@ -18,6 +18,7 @@ analyzing ARMI output files, etc.
    manual_data_access
    reactor_parameters_report
    core_parameters_report
+   component_parameters_report
    assembly_parameters_report
    block_parameters_report
    physics_coupling

--- a/doc/user/manual_data_access.rst
+++ b/doc/user/manual_data_access.rst
@@ -2,7 +2,7 @@
 Accessing Data in ARMI
 **********************
 
-A basic user only needs to know the GUI and can perform basic
+A basic user only needs to know the CLI or GUI and can perform basic
 analysis and design with just that. But a power user will be more interested
 in programmatically building and manipulating inputs and gathering detailed information
 out of ARMI results. Let's now go into a bit more detail for the power user.
@@ -15,9 +15,9 @@ and state parameters in use across ARMI.
 * :doc:`Table of all global settings </user/inputs/settings_report>`
 * :doc:`Reactor Parameters </user/reactor_parameters_report>`
 * :doc:`Core Parameters </user/core_parameters_report>`
+* :doc:`Component Parameters </user/component_parameters_report>`
 * :doc:`Assembly Parameters </user/assembly_parameters_report>`
 * :doc:`Block Parameters </user/block_parameters_report>`
-* :ref:`Component Parameters <componentTypes>`
 
 
 Accessing Some Interesting Info

--- a/doc/user/reactor_parameters_report.rst
+++ b/doc/user/reactor_parameters_report.rst
@@ -1,7 +1,6 @@
 Reactor Parameters
 ==================
-This document lists all of the Reactor Parameters that are provided by the ARMI
-Framework and included plugins.
+This document lists all of the Reactor Parameters that are provided by the ARMI Framework.
 
 .. exec::
    from armi.reactor import reactors


### PR DESCRIPTION
## What is the change?

I added a new table/page to the docs, that displays the `Parameter`s of `Component`s.

**NOTE**: I have tested this locally, and the docs built find and look correct.

## Why is the change being made?

To close #354 , because we have similar pages for `Parameter`s of assemblies, blocks, the core, and the reactor. But the current link to component parameters is broken and strange.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
