### PR TITLE
Removing unfinished requirements from docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,7 +15,6 @@ ARMI
    developer/index
    release/index
    glossary
-   requirements/index
    API Docs <.apidocs/modules>
 
 


### PR DESCRIPTION
## What is the change?

I have removed the "Requirements" section from the ARMI docs. All the data still exists, we just aren't showing it in the built docs.

## Why is the change being made?

The requirements section of the ARMI docs is just a starting place, and an outline of what ARMI's requirements might be.  It's really nothing more.

As such, everyone just ignores this section of the docs.  And if they didn't, they wouldn't find anything of interest.

So I am just _hiding_ the requirements until we have something more finalized.  (We can still work on requirements as time goes on, and wait to render them in the docs until they are more flushed out.)

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
