### PR TITLE
[CDSD-274] Adding back b.p.avgFuelTemp

### DIFF
--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -797,6 +797,13 @@ def getBlockParameterDefinitions():
     with pDefs.createBuilder(default=0.0) as pb:
 
         pb.defParam(
+            "avgFuelTemp",
+            units=units.DEGC,
+            description="Average fuel temperature.",
+            location=ParamLocation.AVERAGE,
+        )
+
+        pb.defParam(
             "assemNum",
             units=units.UNITLESS,
             description="Index that refers, nominally, to the assemNum parameter of "

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -12,6 +12,7 @@ What's new in ARMI
 #. Broad cleanup of ``Parameters``: filled in all empty units and descriptions, removed unused params. (`PR#1345 <https://github.com/terrapower/armi/pull/1345>`_)
 #. Removed redundant ``Material.name`` variable. (`PR#1335 <https://github.com/terrapower/armi/pull/1335>`_)
 #. Added SHA1 hashes of XS control files to the welcome text. (`PR#1334 <https://github.com/terrapower/armi/pull/1334>`_)
+#. Put back ``avgFuelTemp`` block parameter. (`PR#1362 <https://github.com/terrapower/armi/pull/1362>`_)
 #. TBD
 
 Bug fixes


### PR DESCRIPTION
## What is the change?
The block parameter, avgFuelTemp, was erroneously removed in #1345. This PR puts it back for use in a downstream application. 
<!-- MANDATORY: Describe the change -->

## Why is the change being made?
Though only used in a downstream application, it was decided that this is general enough of a parameter that it can live on ARMI. 

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->
---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- ~Tests have been added/updated to verify that the new/changed code works.~ N/A

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
