### PR TITLE
Removing global variable from runLog.py

### DIFF
--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -88,6 +88,15 @@ class TestRunLog(unittest.TestCase):
         self.assertIn("Hello", streamVal, msg=streamVal)
         self.assertIn("world", streamVal, msg=streamVal)
 
+    def test_getWhiteSpace(self):
+        log = runLog._RunLog(0)
+        space0 = len(log.getWhiteSpace(0))
+        space1 = len(log.getWhiteSpace(1))
+        space9 = len(log.getWhiteSpace(9))
+
+        self.assertGreater(space1, space0)
+        self.assertEqual(space1, space9)
+
     def test_warningReport(self):
         """A simple test of the warning tracking and reporting logic."""
         # create the logger and do some logging
@@ -124,6 +133,10 @@ class TestRunLog(unittest.TestCase):
         self.assertIn("Final Warning Count", streamVal, msg=streamVal)
         self.assertNotIn("invisible", streamVal, msg=streamVal)
         self.assertEqual(streamVal.count("test_warningReport"), 2, msg=streamVal)
+
+        # bonus check: edge case in duplicates filter
+        log.logger = None
+        self.assertIsNone(log.getDuplicatesFilter())
 
     def test_warningReportInvalid(self):
         """A test of warningReport in an invalid situation."""


### PR DESCRIPTION
## What is the change?

I removed the global `_WHITE_SPACE` variable from `runLog.py`.

## Why is the change being made?

Other than getting rid of an ugly global variable, I was responding to [this dicussion](https://github.com/terrapower/armi/discussions/1360), started by Arrielle. Good call!

---

## Checklist

- [X] This PR has only one purpose or idea. (For real this time.)
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
