### PR TITLE
Updating documentation dependencies for Python 3.11

### DIFF
--- a/doc/.static/css/theme_fixes.css
+++ b/doc/.static/css/theme_fixes.css
@@ -1,3 +1,5 @@
+@import 'theme.css';
+
 /* override table width restrictions */
 @media screen and (min-width: 767px) {
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,7 +137,7 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinx.ext.imgconverter",  # to convert GH Actions badge SVGs to PNG for LaTeX
     "sphinxcontrib.plantuml",
-    # "sphinx_needs",
+    "sphinx_needs",
     "sphinx_rtd_theme",  # needed here for loading jquery in sphinx 6
     "sphinxcontrib.jquery",  # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1452
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,7 +137,9 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinx.ext.imgconverter",  # to convert GH Actions badge SVGs to PNG for LaTeX
     "sphinxcontrib.plantuml",
-    "sphinxcontrib.needs",
+    # "sphinx_needs",
+    "sphinx_rtd_theme",  # needed here for loading jquery in sphinx 6
+    "sphinxcontrib.jquery",  # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1452
 ]
 
 # Our API should make sense without documenting private/special members.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -240,16 +240,16 @@ html_logo = os.path.join(".static", "armiicon_24x24.ico")
 html_theme_options = {
     "style_external_links": True,
     "style_nav_header_background": "#233C5B",  # TP blue looks better than green
-    'logo_only': False,
-    'display_version': True,
-    'prev_next_buttons_location': 'bottom',
-    'vcs_pageview_mode': '',
+    "logo_only": False,
+    "display_version": True,
+    "prev_next_buttons_location": "bottom",
+    "vcs_pageview_mode": "",
     # Toc options
-    'collapse_navigation': True,
-    'sticky_navigation': True,
-    'navigation_depth': 4,
-    'includehidden': True,
-    'titles_only': False
+    "collapse_navigation": True,
+    "sticky_navigation": True,
+    "navigation_depth": 4,
+    "includehidden": True,
+    "titles_only": False,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -240,10 +240,23 @@ html_logo = os.path.join(".static", "armiicon_24x24.ico")
 html_theme_options = {
     "style_external_links": True,
     "style_nav_header_background": "#233C5B",  # TP blue looks better than green
+    'logo_only': False,
+    'display_version': True,
+    'prev_next_buttons_location': 'bottom',
+    'vcs_pageview_mode': '',
+    # Toc options
+    'collapse_navigation': True,
+    'sticky_navigation': True,
+    'navigation_depth': 4,
+    'includehidden': True,
+    'titles_only': False
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# as long as this file @import's the theme's main css it won't break anything
+html_style = "css/theme_fixes.css"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
@@ -262,14 +275,7 @@ html_last_updated_fmt = "%Y-%m-%d"
 # Output file base name for HTML help builder.
 htmlhelp_basename = "ARMIdoc"
 
-# Need to manually add gallery css files or else the theme_fixes override them.
 html_context = {
-    "css_files": [
-        "_static/theme_fixes.css",  # overrides for wide tables in RTD theme
-        "_static/gallery.css",  # for the sphinx-gallery plugin
-        "_static/gallery-binder.css",
-        "_static/gallery-dataframe.css",
-    ],
     "display_github": True,  # Integrate GitHub
     "github_user": "terrapower",  # Username
     "github_repo": "armi",  # Repo name

--- a/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
+++ b/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Write MCNP Material Cards.
+Write MCNP Material Cards
+=========================
 
 Here we load a test reactor and write each component of one fuel block out as
 MCNP material cards.

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -14,7 +14,8 @@
 
 # -*- coding: utf-8 -*-
 """
-Computing Component Volume Fractions on a Block with Automatic Thermal Expansion.
+Computing Component Volume Fractions on a Block with Automatic Thermal Expansion
+================================================================================
 
 Given an :py:mod:`Block <armi.reactor.blocks.Block>`, compute
 the component volume fractions. Assess the change in volume

--- a/doc/gallery-src/framework/run_chartOfNuclides.py
+++ b/doc/gallery-src/framework/run_chartOfNuclides.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Plot a chart of the nuclides.
+=============================
 
 Use the nuclide directory of ARMI to plot a chart of the nuclides
 coloring the squares with the natural abundance.

--- a/doc/gallery-src/framework/run_computeReactionRates.py
+++ b/doc/gallery-src/framework/run_computeReactionRates.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Computing Reaction Rates on a Block.
+====================================
 
 In this example, a set of 1-group reaction rates (in #/s) are evaluated
 for a dummy fuel block containing UZr fuel, HT9 structure, and

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Fuel management in a LWR.
+=========================
 
 Demo of locating and swapping assemblies in a core with Cartesian geometry. Given a burnup
 distribution, this swaps high burnup assemblies with low ones.

--- a/doc/gallery-src/framework/run_grids1_hex.py
+++ b/doc/gallery-src/framework/run_grids1_hex.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Make a hex grid.
+================
 
 This uses a grid factory method to build an infinite 2-D grid of hexagons with pitch
 equal to 1.0 cm.

--- a/doc/gallery-src/framework/run_grids2_cartesian.py
+++ b/doc/gallery-src/framework/run_grids2_cartesian.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Make a Cartesian grid.
+======================
 
 This builds a Cartesian grid with squares 1 cm square, with the z-coordinates
 provided explicitly. It is also offset in 3D space to X, Y, Z = 10, 5, 5 cm.

--- a/doc/gallery-src/framework/run_grids3_rzt.py
+++ b/doc/gallery-src/framework/run_grids3_rzt.py
@@ -14,6 +14,7 @@
 
 """
 Make a Theta-R-Z grid.
+======================
 
 This builds a 3-D grid in Theta-R-Z geometry by specifying the theta, r, and z
 dimension bounds explicitly.

--- a/doc/gallery-src/framework/run_isotxs.py
+++ b/doc/gallery-src/framework/run_isotxs.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Plotting Multi-group XS from ISOTXS.
+====================================
 
 In this example, several cross sections are plotted from
 an existing binary cross section library file in :py:mod:`ISOTXS <armi.nuclearDataIO.isotxs>` format.

--- a/doc/gallery-src/framework/run_isotxs2_matrix.py
+++ b/doc/gallery-src/framework/run_isotxs2_matrix.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Plotting a multi-group scatter matrix.
+======================================
 
 Here we plot scatter matrices from an ISOTXS microscopic cross section library.
 We plot the inelastic scatter cross section of U235 as well as the (n,2n) source

--- a/doc/gallery-src/framework/run_materials.py
+++ b/doc/gallery-src/framework/run_materials.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Listing of Material Library.
+============================
 
 This is a listing of all the elements in all the materials that are included in the ARMI
 material library. Many of the materials in this library are academic in quality and

--- a/doc/gallery-src/framework/run_programmaticReactorDefinition.py
+++ b/doc/gallery-src/framework/run_programmaticReactorDefinition.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Build Reactor Inputs Programmatically.
+======================================
 
 Sometimes it's desirable to build input definitions for ARMI using
 code rather than by writing the textual input files directly.

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Plot a reactor facemap.
+=======================
 
 Load a test reactor from the test suite and plot a dummy
 power distribution from it. You can plot any block parameter.

--- a/doc/gallery-src/framework/run_transmutationMatrix.py
+++ b/doc/gallery-src/framework/run_transmutationMatrix.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Transmutation and decay reactions.
+==================================
 
 This plots some of the transmutation and decay pathways for the actinides and some light
 nuclides using the burn chain definition that is included with ARMI. Note that many of

--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -1,7 +1,12 @@
 # these are most specified that usual, because Sphinx docs seem to be quite fragile
 # limited <7 by sphinx-rtd-theme at the moment.
-# sphinx-rtd-theme requires docutils 0.18 but sphinx dropped that support in 6.0.0
+# sphinx-rtd-theme requires docutils <0.19 but sphinx dropped support for 0.18 in 6.0.0
+# so we're stuck at these versions
 Sphinx==5.3.0
+docutils==0.18.1
+
+# Read-The-Docs theme for Sphinx
+sphinx-rtd-theme==1.2.2
 
 # Parses Jupyter notebooks
 nbsphinx==0.9.2
@@ -11,9 +16,6 @@ nbsphinx-link==1.3.0
 
 # builds a HTML version of a Python script and puts it into a gallery
 sphinx-gallery==0.13.0
-
-# Read-The-Docs theme for Sphinx
-sphinx-rtd-theme==1.2.2
 
 # allows us to more easily document our API
 sphinxcontrib-apidoc==0.3.0

--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -1,41 +1,44 @@
 # these are most specified that usual, because Sphinx docs seem to be quite fragile
-Sphinx==4.4.0
+# limited <7 by sphinx-rtd-theme at the moment.
+# sphinx-rtd-theme requires docutils 0.18 but sphinx dropped that support in 6.0.0
+Sphinx==5.3.0
 
 # Parses Jupyter notebooks
-nbsphinx==0.8.8
+nbsphinx==0.9.2
 
 # Includes Jupyter notebooks in Sphinx source root
 nbsphinx-link==1.3.0
 
 # builds a HTML version of a Python script and puts it into a gallery
-sphinx-gallery==0.9.0
+sphinx-gallery==0.13.0
 
 # Read-The-Docs theme for Sphinx
-sphinx-rtd-theme==0.5.2
+sphinx-rtd-theme==1.2.2
 
 # allows us to more easily document our API
 sphinxcontrib-apidoc==0.3.0
 
-# generates OpenGraph metadata?
-sphinxext-opengraph==0.5.1
+# generates OpenGraph metadata to make good-looking cards on social media
+sphinxext-opengraph==0.8.2
 
-# supporting requirement documentation
-sphinxcontrib-needs==0.7.6
-sphinxcontrib-plantuml==0.23
+# supporting requirements traceability matrices for QA
+sphinx-needs==1.2.2
+
+# uml support in sphinx-needs
+sphinxcontrib-plantuml==0.25
 
 # This is not strictly necessary via PIP, but MUST be in the path.
 # Used to convert between file formats.
 pandoc
 
 # iPython kernel to run Jupyter notebooks
-ipykernel==6.7.0
-
-# docutils 0.17 introduced a bug that prevents bullets from rendering
-# see https://github.com/terrapower/armi/issues/274
-docutils <0.17
+ipykernel==6.25.1
 
 # used to generate UML diagrams
-pylint==2.7.4
+pylint==2.17.5
 
-# needed to side step bug: https://github.com/numpy/numpydoc/issues/380
-Jinja2==3.0.1
+# used in numpydoc
+Jinja2==3.1.2
+
+# deal with missing jquery errors 
+sphinxcontrib-jquery==4.1

--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -39,8 +39,8 @@ ipykernel==6.25.1
 # used to generate UML diagrams
 pylint==2.17.5
 
-# used in numpydoc
-Jinja2==3.1.2
+# used in numpydoc and nbconvert
+Jinja2==3.0.3
 
 # deal with missing jquery errors 
 sphinxcontrib-jquery==4.1

--- a/doc/requirements/srsd.rst
+++ b/doc/requirements/srsd.rst
@@ -510,7 +510,7 @@ TODO: This is completed by the :doc:`Settings Report </user/inputs/settings_repo
    :id: REQ_LATTICE_OUTPUTS
    :status: needs implementation, needs test
 
-.. reg:: The reactor package shall check input for basic correctness.
+.. req:: The reactor package shall check input for basic correctness.
    :id: REQ_REACTOR_CORRECTNESS
    :status: needs implementation, needs test
 


### PR DESCRIPTION
## What is the change?

Update documentation dependencies to be Python 3.11 compatible.

## Why is the change being made?

The dependencies as pinned don't work in Python 3.11. The new ones do. 

Fixes #1344

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

(well I built the docs in python 3.11 and 3.9 and confirmed they worked.)

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
