### PR TITLE
Reconnect logger after disconnecting in test.

### DIFF
--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -135,8 +135,9 @@ class TestRunLog(unittest.TestCase):
         self.assertEqual(streamVal.count("test_warningReport"), 2, msg=streamVal)
 
         # bonus check: edge case in duplicates filter
-        log.logger = None
+        backupLog, log.logger = log.logger, None
         self.assertIsNone(log.getDuplicatesFilter())
+        log.logger = backupLog
 
     def test_warningReportInvalid(self):
         """A test of warningReport in an invalid situation."""


### PR DESCRIPTION
## What is the change?
Reconnect logger after disconnecting in test.

Prevents test failures in parallel.

<!-- MANDATORY: Describe the change -->

## Why is the change being made?

Fixes #1380.

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->



---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
