### PR TITLE
Remove coveragepy-lcov dependency during CI.

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,17 +31,9 @@ jobs:
         run: tox -e cov1 || true
       - name: Run Coverage Part 2
         run: tox -e cov2
-      - name: Convert Coverage Results
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: |
-          pip install click==8.1.3
-          pip install coverage==6.5.0
-          pip install coveragepy-lcov==0.1.2
-          coveragepy-lcov --data_file_path coverage_results.cov --output_file_path lcov.txt
       - name: Publish to coveralls.io
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: lcov.txt
+          path-to-lcov: coverage.lcov
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,19 +8,16 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-22.04
-
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Update package index
         run: sudo apt-get update
       - name: Install mpi libs
@@ -36,4 +33,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov
-

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ doc/gallery
 doc/gallery-src/framework/*.yaml
 .coverage
 coverage.xml
+coverage.lcov
 coverage_results.*
 htmlcov/
 monkeytype.*

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,7 @@ setup(
     entry_points={"console_scripts": ["armi = armi.__main__:main"]},
     install_requires=[
         "configparser",
-        'coverage; python_version>="3.11"',
-        'coverage<=6.5.0; python_version<"3.11"',
+        "coverage",
         "future",
         "h5py>=3.0",
         "htmltree",

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps=
 allowlist_externals =
     /usr/bin/mpiexec
 commands =
-    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --ignore=venv --cov-fail-under=80 armi/tests/test_mpiFeatures.py
+    mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=.coveragerc -m pytest --cov=armi --cov-config=.coveragerc --cov-report=lcov --ignore=venv --cov-fail-under=80 armi/tests/test_mpiFeatures.py
 
 # Second, run code coverage over the rest of the unit tests, and combine the coverage results together
 [testenv:cov2]
@@ -51,7 +51,7 @@ deps=
 allowlist_externals =
     /usr/bin/mpiexec
 commands =
-    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-append --ignore=venv armi
+    coverage run --rcfile=.coveragerc -m pytest -n 4 --cov=armi --cov-config=.coveragerc --cov-report=lcov --cov-append --ignore=venv armi
     coverage combine --rcfile=.coveragerc --keep -a
 
 # NOTE: This only runs the MPI unit tests.


### PR DESCRIPTION
## What is the change?

coveragepy-lcov is incompatible with coverage 7.0.0 and in fact is totally unnecessary now that pytest can write lcov format files directly. This switches pytest to write lcov directly. Now coverage should work in CI on python 3.11.

Fixes #1377

I have not fully tested this but tested the components. Will need to let CI run to see if it fully works I think.

<!-- MANDATORY: Describe the change -->

## Why is the change being made?

We want coverage on python 3.11


---

## Checklist


- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
