### PR TITLE
Move max assembly number out of global scope

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include armi/bookkeeping/tests/armiRun-A0039-aHist-ref.txt
+include armi/bookkeeping/tests/armiRun-A0032-aHist-ref.txt
 include armi/nuclearDataIO/cccc/tests/fixtures/labels.ascii
 include armi/nuclearDataIO/cccc/tests/fixtures/labels.binary
 include armi/nuclearDataIO/cccc/tests/fixtures/mc2v3.dlayxs

--- a/armi/bookkeeping/db/__init__.py
+++ b/armi/bookkeeping/db/__init__.py
@@ -67,7 +67,7 @@ from armi import runLog
 
 # re-export package components for easier import
 from .permissions import Permissions
-from .database3 import Database3, updateGlobalAssemblyNum
+from .database3 import Database3
 from .databaseInterface import DatabaseInterface
 from .compareDB3 import compareDatabases
 from .factory import databaseFactory
@@ -143,12 +143,6 @@ def loadOperator(pathToDb, loadCycle, loadNode, allowMissing=False):
         r = db.load(loadCycle, loadNode, allowMissing=allowMissing)
 
     settings.setMasterCs(cs)
-
-    # Update the global assembly number because, if the user is loading a reactor from
-    # blueprints and does not have access to an operator, it is unlikely that there is
-    # another reactor that has alter the global assem num. Fresh cases typically want
-    # this updated.
-    updateGlobalAssemblyNum(r)
 
     o = thisCase.initializeOperator(r=r)
     runLog.important(

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -727,6 +727,11 @@ class Database3:
         )
         root = comps[0][0]
 
+        if updateGlobalAssemNum:
+            raise DeprecationWarning(
+                "The method input `updateGlobalAssemNum` is no longer used."
+            )
+
         # return a Reactor object
         if cs[CONF_SORT_REACTOR]:
             root.sort()

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -101,18 +101,6 @@ def getH5GroupName(cycle: int, timeNode: int, statePointName: str = None) -> str
     return "c{:0>2}n{:0>2}{}".format(cycle, timeNode, statePointName or "")
 
 
-def updateGlobalAssemblyNum(r) -> None:
-    """
-    Updated the global assembly number counter in ARMI, using the assemblies
-    read from a database.
-    """
-    assemNum = r.core.p.maxAssemNum
-    if assemNum is not None:
-        assemblies.setAssemNumCounter(int(assemNum + 1))
-    else:
-        raise ValueError("Could not load maxAssemNum from the database")
-
-
 class Database3:
     """
     Version 3 of the ARMI Database, handling serialization and loading of Reactor states.
@@ -691,8 +679,7 @@ class Database3:
             Whether to emit a warning, rather than crash if reading a database
             with undefined parameters. Default False.
         updateGlobalAssemNum : bool, optional
-            Whether to update the global assembly number to the value stored in
-            r.core.p.maxAssemNum. Default True.
+            DeprecationWarning: This is unused.
         updateMasterCs : bool, optional
             Whether to apply the cs (whether provided as an argument or read from
             the database) as the primary for the case. Default True. Can be useful
@@ -740,10 +727,6 @@ class Database3:
             parameterCollections.GLOBAL_SERIAL_NUM, layout.serialNum.max()
         )
         root = comps[0][0]
-
-        # ensure the max assembly number is correct, unless the user says no
-        if updateGlobalAssemNum:
-            updateGlobalAssemblyNum(root)
 
         # return a Reactor object
         if cs[CONF_SORT_REACTOR]:

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -728,8 +728,9 @@ class Database3:
         root = comps[0][0]
 
         if updateGlobalAssemNum:
-            raise DeprecationWarning(
-                "The method input `updateGlobalAssemNum` is no longer used."
+            raise runLog.warning(
+                "The method input `updateGlobalAssemNum` is no longer used.",
+                single=True,
             )
 
         # return a Reactor object

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -70,7 +70,6 @@ from armi.bookkeeping.db.layout import (
 from armi.bookkeeping.db.typedefs import History, Histories
 from armi.nucDirectory import nuclideBases
 from armi.physics.neutronics.settings import CONF_LOADING_FILE
-from armi.reactor import assemblies
 from armi.reactor import grids
 from armi.reactor import parameters
 from armi.reactor import systemLayoutInput

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -728,7 +728,7 @@ class Database3:
         root = comps[0][0]
 
         if updateGlobalAssemNum:
-            raise runLog.warning(
+            runLog.warning(
                 "The method input `updateGlobalAssemNum` is no longer used.",
                 single=True,
             )

--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -125,7 +125,7 @@ class TestCompareDB3(unittest.TestCase):
         self.assertEqual(diffs.nDiffs(), 0)
 
     def test_compareDatabaseSim(self):
-        """end-to-end test of compareDatabases() on very simlar databases."""
+        """End-to-end test of compareDatabases() on very simlar databases."""
         # build two super-simple H5 files for testing
         o, r = test_reactors.loadTestReactor(
             TEST_ROOT, customSettings={"reloadDBName": "reloadingDB.h5"}
@@ -177,7 +177,7 @@ class TestCompareDB3(unittest.TestCase):
             dbs[1]._fullPath,
             timestepCompare=[(0, 0), (0, 1)],
         )
-        self.assertEqual(len(diffs.diffs), 465)
+        self.assertEqual(len(diffs.diffs), 468)
         # Cycle length is only diff (x3)
         self.assertEqual(diffs.nDiffs(), 3)
 

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -81,7 +81,7 @@ class TestDatabase3(unittest.TestCase):
         self.assertEqual(sorted(self.db.h5db["c00n00"].keys()), sorted(keys))
 
         # validate availabilityFactor did not make it into the H5 file
-        rKeys = ["assemNum", "cycle", "cycleLength", "flags", "serialNum", "timeNode"]
+        rKeys = ["maxAssemNum", "cycle", "cycleLength", "flags", "serialNum", "timeNode"]
         self.assertEqual(
             sorted(self.db.h5db["c00n00"]["Reactor"].keys()), sorted(rKeys)
         )

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -81,7 +81,14 @@ class TestDatabase3(unittest.TestCase):
         self.assertEqual(sorted(self.db.h5db["c00n00"].keys()), sorted(keys))
 
         # validate availabilityFactor did not make it into the H5 file
-        rKeys = ["maxAssemNum", "cycle", "cycleLength", "flags", "serialNum", "timeNode"]
+        rKeys = [
+            "maxAssemNum",
+            "cycle",
+            "cycleLength",
+            "flags",
+            "serialNum",
+            "timeNode",
+        ]
         self.assertEqual(
             sorted(self.db.h5db["c00n00"]["Reactor"].keys()), sorted(rKeys)
         )

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -81,7 +81,7 @@ class TestDatabase3(unittest.TestCase):
         self.assertEqual(sorted(self.db.h5db["c00n00"].keys()), sorted(keys))
 
         # validate availabilityFactor did not make it into the H5 file
-        rKeys = ["cycle", "cycleLength", "flags", "serialNum", "timeNode"]
+        rKeys = ["assemNum", "cycle", "cycleLength", "flags", "serialNum", "timeNode"]
         self.assertEqual(
             sorted(self.db.h5db["c00n00"]["Reactor"].keys()), sorted(rKeys)
         )
@@ -109,8 +109,7 @@ class TestDatabase3(unittest.TestCase):
         # Serial numbers *are not stable* (i.e., they can be different between test runs
         # due to parallelism and test run order). However, they are the simplest way to
         # check correctness of location-based history tracking. So we stash the serial
-        # numbers at the location of interest so that we can use them later to check our
-        # work.
+        # numbers at the location of interest so we can use them later to check our work.
         self.centralAssemSerialNums = []
         self.centralTopBlockSerialNums = []
 
@@ -364,39 +363,6 @@ class TestDatabase3(unittest.TestCase):
         # the reactor / core should be the same size
         self.assertEqual(len(r0), len(r1))
         self.assertEqual(len(r0.core), len(r1.core))
-
-    def test_load_updateGlobalAssemNum(self):
-        from armi.reactor import assemblies
-        from armi.reactor.assemblies import resetAssemNumCounter
-
-        self.makeHistory()
-
-        resetAssemNumCounter()
-        self.assertEqual(assemblies._assemNum, 0)
-
-        r = self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=False)
-        #  len(r.sfp) is zero but these nums are still reserved
-        numSFPBlueprints = 4
-        expectedNum = len(r.core) + numSFPBlueprints
-        self.assertEqual(assemblies._assemNum, expectedNum)
-
-        # now do the same call again and show that the global _assemNum keeps going up.
-        # in db.load, rector objects are built in layout._initComps() so the global assem num
-        # will continue to grow (in this case, double).
-        self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=False)
-        self.assertEqual(assemblies._assemNum, expectedNum * 2)
-
-        # now load but set updateGlobalAssemNum=True and show that the global assem num
-        # is updated and equal to self.r.p.maxAssemNum + 1 which is equal to the number of
-        # assemblies in blueprints/core.
-        r = self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=True)
-        expected = len(self.r.core) + len(self.r.blueprints.assemblies.values())
-        self.assertEqual(15, expected)
-
-        # repeat the test above to show that subsequent db loads (with updateGlobalAssemNum=True)
-        # do not continue to increase the global assem num.
-        self.db.load(0, 0, allowMissing=True, updateGlobalAssemNum=True)
-        self.assertEqual(15, expected)
 
     def test_history(self):
         self.makeShuffleHistory()

--- a/armi/bookkeeping/tests/armiRun-A0032-aHist-ref.txt
+++ b/armi/bookkeeping/tests/armiRun-A0032-aHist-ref.txt
@@ -47,7 +47,7 @@ EOL        bottom         top      center
 
 
 Assembly info
-A0039 outer core fuel
+A0032 outer core fuel
 "reflector" C A
 "fuel" C A
 "fuel" C A

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -68,7 +68,6 @@ from armi import runLog
 from armi import settings
 from armi import utils
 from armi.reactor import reactors
-from armi.reactor import assemblies
 from armi.reactor.parameters import parameterDefinitions
 from armi.utils import iterables
 

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -610,8 +610,6 @@ class DistributeStateAction(MpiAction):
         runLog.debug(
             "The reactor has {} assemblies".format(len(self.r.core.getAssemblies()))
         )
-        numAssemblies = self.broadcast(assemblies.getAssemNum())
-        assemblies.setAssemNumCounter(numAssemblies)
         # attach here so any interface actions use a properly-setup reactor.
         self.o.reattach(self.r, cs)  # sets r and cs
 

--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -105,6 +105,7 @@ class FuelHandlerInterface(interfaces.Interface):
         self.r.core.locateAllAssemblies()
         shuffleFactors, _ = fh.getFactorList(cycle)
         fh.outage(shuffleFactors)  # move the assemblies around
+
         if self.cs[CONF_PLOT_SHUFFLE_ARROWS]:
             arrows = fh.makeShuffleArrows()
             plotting.plotFaceMap(

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -90,7 +90,7 @@ class FuelHandler:
         return self.o.r
 
     def outage(self, factor=1.0):
-        r"""
+        """
         Simulates a reactor reload outage. Moves and tracks fuel.
 
         This sets the moveList structure.

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -398,7 +398,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         for a in self.r.sfp.getChildren():
             self.assertEqual(a.getLocation(), "SFP")
 
-        # do some shuffles.
+        # do some shuffles
         fh = self.r.o.getInterface("fuelHandler")
         self.runShuffling(fh)  # changes caseTitle
 
@@ -455,7 +455,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         sfpMove = moves[2][-2]
         self.assertEqual(sfpMove[0], "SFP")
         self.assertEqual(sfpMove[1], "005-003")
-        self.assertEqual(sfpMove[4], "A0085")  # name of assem in SFP
+        self.assertEqual(sfpMove[4], "A0077")  # name of assem in SFP
 
     def test_processMoveList(self):
         fh = fuelHandlers.FuelHandler(self.o)
@@ -468,7 +468,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
             loadNames,
             _,
         ) = fh.processMoveList(moves[2])
-        self.assertIn("A0085", loadNames)
+        self.assertIn("A0077", loadNames)
         self.assertIn(None, loadNames)
         self.assertNotIn("SFP", loadChains)
         self.assertNotIn("LoadQueue", loadChains)

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -68,10 +68,11 @@ class Assembly(composites.Composite):
             Name of assembly design (e.g. the name from the blueprints input file).
 
         assemNum : int, optional
-            The unique ID number of this assembly. If none is passed, the class-level
-            value will be taken and then incremented.
+            The unique ID number of this assembly. If None is provided, we generate a
+            random int. This makes it clear that it is a placeholder. When an assembly with
+            a negative ID is placed into a Reactor, it will be given a new, positive ID.
         """
-        # TODO: Make it negative... JOHN... words
+        # If no assembly number is provided, generate a random number as a placeholder.
         if assemNum is None:
             assemNum = randint(-9e12, -1)
         name = self.makeNameFromAssemNum(assemNum)

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -20,6 +20,7 @@ Generally, blocks are stacked from bottom to top.
 import copy
 import math
 import pickle
+from random import randint
 
 import numpy
 from scipy import interpolate
@@ -32,31 +33,6 @@ from armi.reactor import composites
 from armi.reactor import grids
 from armi.reactor.flags import Flags
 from armi.reactor.parameters import ParamLocation
-
-# to count the blocks that we create and generate a block number
-_assemNum = 0
-
-
-def incrementAssemNum():
-    global _assemNum  # tracked on a  module level
-    val = _assemNum  # return value before incrementing.
-    _assemNum += 1
-    return val
-
-
-def getAssemNum():
-    global _assemNum
-    return _assemNum
-
-
-def resetAssemNumCounter():
-    setAssemNumCounter(0)
-
-
-def setAssemNumCounter(val):
-    runLog.extra("Resetting global assembly number to {0}".format(val))
-    global _assemNum
-    _assemNum = val
 
 
 class Assembly(composites.Composite):
@@ -80,8 +56,7 @@ class Assembly(composites.Composite):
     SPENT_FUEL_POOL = "SFP"
     # For assemblies coming in from the database, waiting to be loaded to their old
     # position. This is a necessary distinction, since we need to make sure that a bunch
-    # of fuel management stuff doesn't treat its re-placement into the core as a new
-    # move
+    # of fuel management stuff doesn't treat its re-placement into the core as a new move
     DATABASE = "database"
     NOT_IN_CORE = [LOAD_QUEUE, SPENT_FUEL_POOL]
 
@@ -96,8 +71,9 @@ class Assembly(composites.Composite):
             The unique ID number of this assembly. If none is passed, the class-level
             value will be taken and then incremented.
         """
+        # TODO: Make it negative... JOHN... words
         if assemNum is None:
-            assemNum = incrementAssemNum()
+            assemNum = randint(-9e12, -1)
         name = self.makeNameFromAssemNum(assemNum)
         composites.Composite.__init__(self, name)
         self.p.assemNum = assemNum
@@ -145,7 +121,8 @@ class Assembly(composites.Composite):
         ``deepcopy`` to get a unique ``assemNum`` since a deepcopy implies it would
         otherwise have been the same object.
         """
-        self.p.assemNum = incrementAssemNum()
+        # TODO: JOHN, explain it
+        self.p.assemNum = randint(-9e12, -1)
         self.name = self.makeNameFromAssemNum(self.p.assemNum)
         for bi, b in enumerate(self):
             b.setName(b.makeName(self.p.assemNum, bi))
@@ -157,8 +134,7 @@ class Assembly(composites.Composite):
 
         AssemNums are like serial numbers for assemblies.
         """
-        name = "A{0:04d}".format(int(assemNum))
-        return name
+        return "A{0:04d}".format(int(assemNum))
 
     def add(self, obj):
         """

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -125,8 +125,7 @@ class Assembly(composites.Composite):
         # TODO: JOHN, explain it
         self.p.assemNum = randint(-9e12, -1)
         self.name = self.makeNameFromAssemNum(self.p.assemNum)
-        for bi, b in enumerate(self):
-            b.setName(b.makeName(self.p.assemNum, bi))
+        self.renameBlocksAccordingToAssemblyNum()
 
     @staticmethod
     def makeNameFromAssemNum(assemNum):
@@ -146,8 +145,7 @@ class Assembly(composites.Composite):
         """
         composites.Composite.add(self, obj)
         obj.spatialLocator = self.spatialGrid[0, 0, len(self) - 1]
-        # assemblies have bounds-based 1-D spatial grids. Adjust it to have the right
-        # value.
+        # assemblies have bounds-based 1-D spatial grids. Adjust it to the right value.
         if len(self.spatialGrid._bounds[2]) < len(self):
             self.spatialGrid._bounds[2][len(self)] = (
                 self.spatialGrid._bounds[2][len(self) - 1] + obj.getHeight()

--- a/armi/reactor/assemblyLists.py
+++ b/armi/reactor/assemblyLists.py
@@ -129,15 +129,12 @@ class AssemblyList(composites.Composite):
             The Assembly to add to the list
 
         loc : LocationBase, optional
-            If provided, the assembly is inserted at that location, similarly to how a
-            Core would function. If it is not provided, the locator on the Assembly
-            object will be used. If the Assembly's locator belongs to
-            ``self.spatialGrid``, the Assembly's existing locator will not be used.
-            This is unlike the Core, which would try to use the same indices, but move
-            the locator to the Core's grid. If no locator is passed, or if the
-            Assembly's locator is not in the AssemblyList's grid, then the Assembly will
-            be automatically located in the grid using the associated ``AutoFiller``
-            object.
+            If provided, the assembly is inserted at that location. If it is not
+            provided, the locator on the Assembly object will be used. If the
+            Assembly's locator belongs to ``self.spatialGrid``, the Assembly's
+            existing locator will not be used. This is unlike the Core, which would try
+            to use the same indices, but move the locator to the Core's grid. With a
+            locator, the associated ``AutoFiller`` will be used.
         """
         if loc is not None and loc.grid is not self.spatialGrid:
             raise ValueError(
@@ -170,6 +167,7 @@ class AssemblyList(composites.Composite):
     def count(self):
         if not self.getChildren():
             return
+
         runLog.important("Count:")
         totCount = 0
         thisTimeCount = 0
@@ -193,6 +191,30 @@ class AssemblyList(composites.Composite):
 
 class SpentFuelPool(AssemblyList):
     """A place to put assemblies when they've been discharged. Can tell you inventory stats, etc."""
+
+    def add(self, assem, loc=None):  # TODO: JOHN EXPLAIN IT
+        """
+        Add an Assembly to the list.
+
+        Parameters
+        ----------
+        assem : Assembly
+            The Assembly to add to the list
+
+        loc : LocationBase, optional
+            If provided, the assembly is inserted at that location. If it is not
+            provided, the locator on the Assembly object will be used. If the
+            Assembly's locator belongs to ``self.spatialGrid``, the Assembly's
+            existing locator will not be used. This is unlike the Core, which would try
+            to use the same indices, but move the locator to the Core's grid. With a
+            locator, the associated ``AutoFiller`` will be used.
+        """
+        # TODO: JOHN, explain
+        if assem.p.assemNum < 0:
+            assem.p.assemNum = self.r.incrementAssemNum()
+            assem.setName(assem.makeNameFromAssemNum(assem.p.assemNum))
+
+        super().add(assem, loc)
 
     def report(self):
         title = "{0} Report".format(self.name)

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -266,7 +266,6 @@ class Block(composites.Composite):
         -------
         smearDensity : float
             The smear density as a fraction
-
         """
         fuels = self.getComponents(Flags.FUEL)
         if not fuels:

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
+"""
 Blueprints describe the geometric and composition details of the objects in the reactor
 (e.g. fuel assemblies, control rods, etc.).
 
@@ -305,23 +305,11 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             self._assembliesBySpecifier.clear()
             self.assemblies.clear()
 
-            # retrieve current count of assemblies to restore after
-            # creating blueprints assemblies. This is particularly useful for
-            # doing snapshot based runs and multiple database loads, and ensures
-            # that each database load/snapshot to not cumulative increase the assembly
-            # count during creation of blueprints assemblies. During initial
-            # constructions the first N numbers are reserved for blueprints, so this
-            # ensures consistency.
-            currentCount = assemblies.getAssemNum()
-            # reset the assembly counter so that blueprints assemblies are always
-            # numbered 0 to len(self.assemDesigns)
-            assemblies.resetAssemNumCounter()
             for aDesign in self.assemDesigns:
                 a = aDesign.construct(cs, self)
                 self._assembliesBySpecifier[aDesign.specifier] = a
                 self.assemblies[aDesign.name] = a
-            if currentCount != 0:
-                assemblies.setAssemNumCounter(currentCount)
+
             runLog.header("=========== Verifying Assembly Configurations ===========")
             self._checkAssemblyAreaConsistency(cs)
 

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -96,10 +96,6 @@ class GeometryChanger:
         runLog.info(
             f"Resetting the state of the converted reactor core model in {self}"
         )
-        currentAssemCounter = assemblies.getAssemNum()
-        assemblies.setAssemNumCounter(
-            currentAssemCounter - len(self._newAssembliesAdded)
-        )
         self._newAssembliesAdded = []
 
 
@@ -253,7 +249,7 @@ class FuelAssemNumModifier(GeometryChanger):
         )
 
     def addRing(self, assemType="big shield"):
-        r"""
+        """
         Add a ring of fuel assemblies around the outside of an existing core.
 
         Works by first finding the assembly furthest from the center, then filling in

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -1424,8 +1424,8 @@ class EdgeAssemblyChanger(GeometryChanger):
         )
 
     def removeEdgeAssemblies(self, core):
-        r"""
-        remove the edge assemblies in preparation for the nodal diffusion approximation.
+        """
+        Remove the edge assemblies in preparation for the nodal diffusion approximation.
 
         This makes use of the assemblies knowledge of if it is in a region that it
         needs to be removed.
@@ -1460,7 +1460,8 @@ class EdgeAssemblyChanger(GeometryChanger):
             pDefs = parameters.ALL_DEFINITIONS.unchanged_since(NEVER)
             pDefs.setAssignmentFlag(SINCE_LAST_GEOMETRY_TRANSFORMATION)
         else:
-            runLog.extra("No edge assemblies to remove")
+            runLog.debug("No edge assemblies to remove.")
+
         self.reset()
 
     @staticmethod

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -366,7 +366,7 @@ def applyNonUniformHeightDistribution(reactor):
         a[-1].setHeight(a[-1].getHeight() - delta)
         a.calculateZCoords()
 
-    reactor.core.normalizeAssemblyNames()  # TODO: JOHN! WAS I SUPPOSED TO REMOVE THIS???
+    reactor.core.normalizeAssemblyNames()
 
 
 class TestUniformMesh(unittest.TestCase):
@@ -668,9 +668,6 @@ class TestUniformMeshNonUniformAssemFlags(unittest.TestCase):
         self.converter = uniformMesh.NeutronicsUniformMeshConverter(
             cs=self.o.cs, calcReactionRates=True
         )
-        # self.r.core.normalizeAssemblyNames()  # TODO: JOHN!!!!!!!!!!! TESTING
-        # self.converter._sourceReactor.core.normalizeAssemblyNames()  # TODO: JOHN!!!!!!!!!!! TESTING
-        # self.converter.convReactor.core.normalizeAssemblyNames()  # TODO: JOHN!!!!!!!!!!! TESTING
 
     def test_reactorConversion(self):
         """Tests the reactor conversion to and from the original reactor."""

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -366,7 +366,7 @@ def applyNonUniformHeightDistribution(reactor):
         a[-1].setHeight(a[-1].getHeight() - delta)
         a.calculateZCoords()
 
-    reactor.core.normalizeAssemblyNames()
+    reactor.normalizeNames()
 
 
 class TestUniformMesh(unittest.TestCase):

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -366,6 +366,8 @@ def applyNonUniformHeightDistribution(reactor):
         a[-1].setHeight(a[-1].getHeight() - delta)
         a.calculateZCoords()
 
+    reactor.core.normalizeAssemblyNames()  # TODO: JOHN! WAS I SUPPOSED TO REMOVE THIS???
+
 
 class TestUniformMesh(unittest.TestCase):
     """
@@ -411,7 +413,7 @@ class TestUniformMesh(unittest.TestCase):
         )  # conversion didn't change source reactor mass
 
     def test_applyStateToOriginal(self):
-        applyNonUniformHeightDistribution(self.r)  # note: this perturbs the ref. mass
+        applyNonUniformHeightDistribution(self.r)  # note: this perturbs the ref mass
 
         self.converter.convert(self.r)
         for ib, b in enumerate(self.converter.convReactor.core.getBlocks()):
@@ -666,6 +668,9 @@ class TestUniformMeshNonUniformAssemFlags(unittest.TestCase):
         self.converter = uniformMesh.NeutronicsUniformMeshConverter(
             cs=self.o.cs, calcReactionRates=True
         )
+        # self.r.core.normalizeAssemblyNames()  # TODO: JOHN!!!!!!!!!!! TESTING
+        # self.converter._sourceReactor.core.normalizeAssemblyNames()  # TODO: JOHN!!!!!!!!!!! TESTING
+        # self.converter.convReactor.core.normalizeAssemblyNames()  # TODO: JOHN!!!!!!!!!!! TESTING
 
     def test_reactorConversion(self):
         """Tests the reactor conversion to and from the original reactor."""
@@ -685,7 +690,6 @@ class TestUniformMeshNonUniformAssemFlags(unittest.TestCase):
                 self.assertFalse(b.p.rateAbs)
 
         self.converter.convert(self.r)
-
         self.assertEqual(
             len(controlAssems),
             len(self.converter._nonUniformAssemStorage),

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -425,7 +425,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 f"the core's reference assembly mesh: {r.core.refAssem.getAxialMesh()}"
             )
             self.convReactor = self._sourceReactor
-            # self.convReactor.core.normalizeAssemblyNames()  # TODO: JOHN!!!!!!!!!!! TESTING
             self.convReactor.core.updateAxialMesh()
             for assem in self.convReactor.core.getAssemblies(self._nonUniformMeshFlags):
                 homogAssem = self.makeAssemWithUniformMesh(
@@ -468,8 +467,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
         runLog.extra(
             f"Reactor core conversion time: {completeEndTime-completeStartTime} seconds"
         )
-        # self._sourceReactor.core.normalizeAssemblyNames()  # TODO: JOHN!!!!!!!!!!! TESTING
-        # self.convReactor.core.normalizeAssemblyNames()  # TODO: JOHN!!!!!!!!!!! TESTING
 
     def _generateUniformMesh(self, minimumMeshSize):
         """
@@ -528,9 +525,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
             f"Applying uniform neutronics results from {self.convReactor} to {self._sourceReactor}"
         )
         completeStartTime = timer()
-
-        # self._sourceReactor.core.normalizeAssemblyNames()  # TODO: JOHN TESTING
-        # self.convReactor.core.normalizeAssemblyNames()  # TODO: JOHN TESTING
 
         # map the block parameters back to the non-uniform assembly
         self._setParamsToUpdate("out")

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -453,7 +453,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
         else:
             runLog.extra(f"Building copy of {r} with a uniform axial mesh.")
             self.convReactor = self.initNewReactor(r, self._cs)
-            # TODO: Update JOHN normalize reactor-level assem numbers
             self._generateUniformMesh(minimumMeshSize=self._minimumMeshSize)
             self._buildAllUniformAssemblies()
             self._mapStateFromReactorToOther(
@@ -536,7 +535,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
             for assem in self._sourceReactor.core.getAssemblies(
                 self._nonUniformMeshFlags
             ):
-                # TODO: JOHN: This doesn't need to be a loop......
                 for storedAssem in self._nonUniformAssemStorage:
                     if (
                         storedAssem.getName()

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -86,6 +86,13 @@ def defineReactorParameters():
             "timeNode", units=units.UNITLESS, description="Integer timeNode", default=0
         )
 
+        pb.defParam(
+            "assemNum",
+            units=units.UNITLESS,
+            description="Number of assemblies created so far in the simulation (integer)",
+            default=0,
+        )
+
     with pDefs.createBuilder(
         location=ParamLocation.AVERAGE, default=0.0, categories=["economics"]
     ) as pb:

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -87,9 +87,9 @@ def defineReactorParameters():
         )
 
         pb.defParam(
-            "assemNum",
+            "maxAssemNum",
             units=units.UNITLESS,
-            description="Number of assemblies created so far in the simulation (integer)",
+            description="Max number of assemblies created so far in the Reactor (integer)",
             default=0,
         )
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -113,7 +113,14 @@ class Reactor(composites.Composite):
 
     def incrementAssemNum(self):
         """
-        Increase the max assembly number by one and return the current value.
+        Increase the max assembly number by one and returns the current value.
+
+        Notes
+        -----
+        The "max assembly number" is not currently used in the Reactor. So the idea
+        is that we return the current number, then iterate it for the next assembly.
+
+        Obviously, this method will be unused for non-assembly-based reactors.
 
         Returns
         -------
@@ -600,15 +607,18 @@ class Core(composites.Composite):
 
             ind += 1
 
-        # Update some bookkeeping dictionaries of assembly and block names in this Core.
+        self.normalizeInternalBookeeping()
+
+        return ind
+
+    def normalizeInternalBookeeping(self):
+        """Update some bookkeeping dictionaries of assembly and block names in this Core."""
         self.assembliesByName = {}
         self.blocksByName = {}
         for assem in self:
             self.assembliesByName[assem.getName()] = assem
             for b in assem:
                 self.blocksByName[b.getName()] = b
-
-        return ind
 
     def add(self, a, spatialLocator=None):
         """

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -74,7 +74,7 @@ class Reactor(composites.Composite):
         self.o = None
         self.spatialGrid = None
         self.spatialLocator = None
-        self.p.assemNum = 0
+        self.p.maxAssemNum = 0
         self.p.cycle = 0
         self.p.flags |= Flags.REACTOR
         self.core = None
@@ -113,8 +113,8 @@ class Reactor(composites.Composite):
 
     # TODO: This might be unnecessary.
     def incrementAssemNum(self):
-        val = int(self.p.assemNum)
-        self.p.assemNum += 1
+        val = int(self.p.maxAssemNum)
+        self.p.maxAssemNum += 1
         return val
 
 
@@ -539,7 +539,7 @@ class Core(composites.Composite):
         self.blocksByName = {}
         self.assembliesByName = {}
 
-        self.parent.p.assemNum = 0
+        self.parent.p.maxAssemNum = 0
 
     def normalizeAssemblyNames(self):
         """TODO: JOHN."""
@@ -644,7 +644,7 @@ class Core(composites.Composite):
             runLog.error(
                 "The assembly {1} in the reactor already has the name {0}.\nCannot add {2}. "
                 "Current assemNum is {3}"
-                "".format(aName, self.assembliesByName[aName], a, self.r.p.assemNum)
+                "".format(aName, self.assembliesByName[aName], a, self.r.p.maxAssemNum)
             )
             raise RuntimeError("Core already contains an assembly with the same name.")
         self.assembliesByName[aName] = a

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -630,14 +630,9 @@ class Core(composites.Composite):
         --------
         removeAssembly : removes an assembly
         """
-        # TODO: JOHN, explain
-        # TODO: JOHN, perhaps create a method: Assembly.recursivelyRename(assemNum)
+        # Negative assembly IDs are placeholders, and we need to renumber the assembly
         if a.p.assemNum < 0:
             a.renumber(self.r.incrementAssemNum())
-            # a.setName(a.makeNameFromAssemNum(a.p.assemNum))
-            # for b in a:
-            #    axialIndex = int(b.name.split("-")[-1])  # TODO: is THIS unnecessary? JOHN?
-            #    b.name = b.makeName(int(a.p.assemNum), axialIndex)
 
         # resetting .assigned forces database to be rewritten for shuffled core
         paramDefs = set(parameters.ALL_DEFINITIONS)

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -40,7 +40,6 @@ import tabulate
 from armi import getPluginManagerOrFail, materials, nuclearDataIO
 from armi import runLog
 from armi.nuclearDataIO import xsLibraries
-from armi.reactor import assemblies
 from armi.reactor import assemblyLists
 from armi.reactor import composites
 from armi.reactor import geometry
@@ -1284,7 +1283,6 @@ class Core(composites.Composite):
 
         structureNuclides : set
             set of nuclide names
-
         """
         if not self._nuclideCategories:
             coolantNuclides = set()
@@ -1522,8 +1520,6 @@ class Core(composites.Composite):
         -------
         foundAssembly : Assembly object or None
             The assembly found, or None
-
-
         """
         return self.getAssembly(assemNum=assemNum)
 
@@ -1619,7 +1615,6 @@ class Core(composites.Composite):
         See Also
         --------
         grids.Grid.getSymmetricEquivalents
-
         """
         neighborIndices = self.spatialGrid.getNeighboringCellIndices(
             *a.spatialLocator.getCompleteIndices()
@@ -1662,6 +1657,7 @@ class Core(composites.Composite):
             duplicateAssem = self.childrenByLocator.get(neighborLocation2)
             if duplicateAssem is not None:
                 duplicates.append(duplicateAssem)
+
         # should always be 0 or 1
         nDuplicates = len(duplicates)
         if nDuplicates == 1:
@@ -1961,7 +1957,7 @@ class Core(composites.Composite):
         return meshList, True
 
     def findAllAziMeshPoints(self, extraAssems=None, applySubMesh=True):
-        r"""
+        """
         Returns a list of all azimuthal (theta)-mesh positions in the core.
 
         Parameters
@@ -1972,7 +1968,6 @@ class Core(composites.Composite):
 
         applySubMesh : bool
             generates submesh points to further discretize the theta reactor mesh
-
         """
         i, _, _ = self.findAllMeshPoints(extraAssems, applySubMesh)
         return i
@@ -1980,7 +1975,6 @@ class Core(composites.Composite):
     def findAllRadMeshPoints(self, extraAssems=None, applySubMesh=True):
         """
         Return a list of all radial-mesh positions in the core.
-
 
         Parameters
         ----------
@@ -1991,7 +1985,6 @@ class Core(composites.Composite):
         applySubMesh : bool
             (not implemented) generates submesh points to further discretize the radial
             reactor mesh
-
         """
         _, j, _ = self.findAllMeshPoints(extraAssems, applySubMesh)
         return j
@@ -2019,7 +2012,7 @@ class Core(composites.Composite):
         return max(b.getNumPins() for b in self.getBlocks())
 
     def getMinimumPercentFluxInFuel(self, target=0.005):
-        r"""
+        """
         Goes through the entire reactor to determine what percentage of flux occures at
         each ring.  Starting with the outer ring, this function helps determine the effective
         size of the core where additional assemblies will not help the breeding in the TWR.

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -41,8 +41,6 @@ from armi.tests import TEST_ROOT, mockRunLogs
 from armi.utils import directoryChangers
 from armi.utils import textProcessors
 from armi.reactor.tests import test_reactors
-from armi.reactor.assemblies import getAssemNum
-from armi.reactor.assemblies import resetAssemNumCounter
 from armi.physics.neutronics.settings import (
     CONF_LOADING_FILE,
     CONF_XS_KERNEL,
@@ -287,12 +285,6 @@ class Assembly_TestCase(unittest.TestCase):
 
         self.assembly.p.notes = tooLongNote
         self.assertEqual(self.assembly.p.notes, tooLongNote[0:1000])
-
-    def test_resetAssemNumCounter(self):
-        resetAssemNumCounter()
-        cur = 0
-        ref = getAssemNum()
-        self.assertEqual(cur, ref)
 
     def test_iter(self):
         cur = []

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -319,7 +319,7 @@ class HexReactorTests(ReactorTests):
         indices = [(1, 1, 1), (3, 2, 2)]
         actualBlocks = self.r.core.getBlocksByIndices(indices)
         actualNames = [b.getName() for b in actualBlocks]
-        expectedNames = ["B0022-001", "B0043-002"]
+        expectedNames = ["B0014-001", "B0035-002"]
         self.assertListEqual(expectedNames, actualNames)
 
     def test_getAllXsSuffixes(self):
@@ -632,10 +632,11 @@ class HexReactorTests(ReactorTests):
 
     def test_getAssembly(self):
         a1 = self.r.core.getAssemblyWithAssemNum(assemNum=10)
-        a2 = self.r.core.getAssembly(locationString="005-023")
+        a2 = self.r.core.getAssembly(locationString="003-001")
         a3 = self.r.core.getAssembly(assemblyName="A0010")
-        self.assertEqual(a1, a2)
+
         self.assertEqual(a1, a3)
+        self.assertEqual(a1, a2)
 
     def test_restoreReactor(self):
         aListLength = len(self.r.core.getAssemblies())

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -208,7 +208,7 @@ def loadTestReactor(
     if isPickeledReactor:
         # cache it for fast load for other future tests
         # protocol=2 allows for classes with __slots__ but not __getstate__ to be pickled
-        TEST_REACTOR = cPickle.dumps((o, o.r, o.r.p.assemNum), protocol=2)
+        TEST_REACTOR = cPickle.dumps((o, o.r, o.r.p.maxAssemNum), protocol=2)
 
     return o, o.r
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -172,12 +172,10 @@ def loadTestReactor(
     fName = os.path.join(inputFilePath, inputFileName)
     customSettings = customSettings or {}
     isPickeledReactor = fName == ARMI_RUN_PATH and customSettings == {}
-    assemblies.resetAssemNumCounter()
 
     if isPickeledReactor and TEST_REACTOR:
         # return test reactor only if no custom settings are needed.
         o, r, assemNum = cPickle.loads(TEST_REACTOR)
-        assemblies.setAssemNumCounter(assemNum)
         settings.setMasterCs(o.cs)
         o.reattach(r, o.cs)
         return o, r
@@ -210,7 +208,7 @@ def loadTestReactor(
     if isPickeledReactor:
         # cache it for fast load for other future tests
         # protocol=2 allows for classes with __slots__ but not __getstate__ to be pickled
-        TEST_REACTOR = cPickle.dumps((o, o.r, assemblies.getAssemNum()), protocol=2)
+        TEST_REACTOR = cPickle.dumps((o, o.r, o.r.p.assemNum), protocol=2)
 
     return o, o.r
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -337,6 +337,28 @@ class HexReactorTests(ReactorTests):
         )
         self.assertEqual(numControlBlocks, 3)
 
+    def test_normalizeNames(self):
+        # these are the correct, normalized names
+        numAssems = 73
+        a = self.r.core.getFirstAssembly()
+        correctNames = [a.makeNameFromAssemNum(n) for n in range(numAssems)]
+
+        # validate the reactor is what we think now
+        self.assertEqual(len(self.r.core), numAssems)
+        currentNames = [a.getName() for a in self.r.core]
+        self.assertNotEqual(correctNames, currentNames)
+
+        # validate that we can normalize the names correctly once
+        self.r.normalizeNames()
+        currentNames = [a.getName() for a in self.r.core]
+        self.assertEqual(correctNames, currentNames)
+
+        # validate that repeated applications of this method are stable
+        for _ in range(3):
+            self.r.normalizeNames()
+            currentNames = [a.getName() for a in self.r.core]
+            self.assertEqual(correctNames, currentNames)
+
     def test_setB10VolOnCreation(self):
         """Test the setting of b.p.initialB10ComponentVol."""
         for controlBlock in self.r.core.getBlocks(Flags.CONTROL):

--- a/armi/tests/armiRun-SHUFFLES.txt
+++ b/armi/tests/armiRun-SHUFFLES.txt
@@ -13,7 +13,7 @@ Before cycle 2:
 005-004 moved to 004-001 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 006-004 moved to 005-004 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 LoadQueue moved to 006-004 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-SFP moved to 005-003 with assembly type feed fuel ANAME=A0085 with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+SFP moved to 005-003 with assembly type feed fuel ANAME=A0077 with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 005-003 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 
 Before cycle 3:
@@ -23,6 +23,6 @@ Before cycle 3:
 005-002 moved to 004-003 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 006-007 moved to 005-002 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 LoadQueue moved to 006-007 with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
-SFP moved to 005-004 with assembly type feed fuel ANAME=A0086 with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
+SFP moved to 005-004 with assembly type feed fuel ANAME=A0078 with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 005-004 moved to SFP with assembly type igniter fuel with enrich list: 0.00000000 0.11000000 0.11000000 0.11000000 0.00000000
 

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -11,7 +11,7 @@ What's new in ARMI
 #. The Spent Fuel Pool (``sfp``) was moved from the ``Core`` out to the ``Reactor``. (`PR#1336 <https://github.com/terrapower/armi/pull/1336>`_)
 #. Broad cleanup of ``Parameters``: filled in all empty units and descriptions, removed unused params. (`PR#1345 <https://github.com/terrapower/armi/pull/1345>`_)
 #. Removed redundant ``Material.name`` variable. (`PR#1335 <https://github.com/terrapower/armi/pull/1335>`_)
-#. Moved the ``Reactor`` assembly number from the global scope to a ``Parameter``.
+#. Moved the ``Reactor`` assembly number from the global scope to a ``Parameter``. (`PR#1383 <https://github.com/terrapower/armi/pull/1383>`_)
 #. Added SHA1 hashes of XS control files to the welcome text. (`PR#1334 <https://github.com/terrapower/armi/pull/1334>`_)
 #. Add python 3.11 to ARMI's CI testing GH actions! (`PR#1341 <https://github.com/terrapower/armi/pull/1341>`_)
 #. Put back ``avgFuelTemp`` block parameter. (`PR#1362 <https://github.com/terrapower/armi/pull/1362>`_)

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -11,6 +11,7 @@ What's new in ARMI
 #. The Spent Fuel Pool (``sfp``) was moved from the ``Core`` out to the ``Reactor``. (`PR#1336 <https://github.com/terrapower/armi/pull/1336>`_)
 #. Broad cleanup of ``Parameters``: filled in all empty units and descriptions, removed unused params. (`PR#1345 <https://github.com/terrapower/armi/pull/1345>`_)
 #. Removed redundant ``Material.name`` variable. (`PR#1335 <https://github.com/terrapower/armi/pull/1335>`_)
+#. Moved the ``Reactor`` assembly number from the global scope to a ``Parameter``.
 #. Added SHA1 hashes of XS control files to the welcome text. (`PR#1334 <https://github.com/terrapower/armi/pull/1334>`_)
 #. Put back ``avgFuelTemp`` block parameter. (`PR#1362 <https://github.com/terrapower/armi/pull/1362>`_)
 #. Make cylindrical component block collection less strict about pre-homogenization checks. (`PR#1347 <https://github.com/terrapower/armi/pull/1347>`_)

--- a/ruff.toml
+++ b/ruff.toml
@@ -11,6 +11,8 @@ required-version = "0.0.272"
 # TID - tidy imports
 select = ["E", "F", "D", "N801", "SIM", "TID"]
 
+# TODO: We want to support PLW0603 - don't use the global keyword
+
 # Ruff rules we ignore (for now) because they are not 100% automatable
 #
 # D100 - Missing docstring in public module


### PR DESCRIPTION
## What is the change?

This PR moves the "maximum assembly number" out of the global scope and into a `Reactor` `Parameter`.  (The reason it's a `Parameter` and not just a class attribute is so we can store it in the Database.)

## Why is the change being made?

We have far too many global variables in ARMI.  Such a mess.  This particular change was spurred by a [discussion](https://github.com/terrapower/armi/discussions/1360) @opotowsky stared.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
