### PR TITLE
Removing global plugin flags

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -307,7 +307,7 @@ def configure(app: Optional[apps.App] = None, permissive=False):
     pm = app.pluginManager
     parameters.collectPluginParameters(pm)
     parameters.applyAllParameters()
-    flags.registerPluginFlags(pm)
+    pm.registerPluginFlags()
 
 
 def applyAsyncioWindowsWorkaround() -> None:

--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -307,7 +307,7 @@ def configure(app: Optional[apps.App] = None, permissive=False):
     pm = app.pluginManager
     parameters.collectPluginParameters(pm)
     parameters.applyAllParameters()
-    pm.registerPluginFlags()
+    _app.registerPluginFlags()
 
 
 def applyAsyncioWindowsWorkaround() -> None:

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -75,6 +75,7 @@ class App:
         For a description of the things that an ARMI plugin can do, see the
         :py:mod:`armi.plugins` module.
         """
+        self._pluginFlagsRegistered: bool = False
         self._pm: Optional[pluginManager.ArmiPluginManager] = None
         self._paramRenames: Optional[Tuple[Dict[str, str], int]] = None
         self.__initNewPlugins()
@@ -227,6 +228,24 @@ class App:
                 renames.update(pluginRenames)
             self._paramRenames = renames, self._pm.counter
         return renames
+
+    def registerPluginFlags(self):
+        """
+        Apply flags specified in the passed ``PluginManager`` to the ``Flags`` class.
+
+        See Also
+        --------
+        armi.plugins.ArmiPlugin.defineFlags
+        """
+        if self._pluginFlagsRegistered:
+            raise RuntimeError(
+                "Plugin flags have already been registered. Cannot do it twice!"
+            )
+
+        for pluginFlags in self._pm.hook.defineFlags():
+            Flags.extend(pluginFlags)
+
+        self._pluginFlagsRegistered = True
 
     def registerUserPlugins(self, pluginPaths):
         r"""

--- a/armi/pluginManager.py
+++ b/armi/pluginManager.py
@@ -15,8 +15,6 @@
 
 import pluggy
 
-from armi.reactor.flags import Flags
-
 
 class ArmiPluginManager(pluggy.PluginManager):
     """
@@ -34,7 +32,6 @@ class ArmiPluginManager(pluggy.PluginManager):
         pluggy.PluginManager.__init__(self, *args, **kwargs)
 
         self._counter = 0
-        self._pluginFlagsRegistered = False
 
     @property
     def counter(self):
@@ -47,22 +44,3 @@ class ArmiPluginManager(pluggy.PluginManager):
     def unregister(self, *args, **kwargs):
         self._counter += 1
         pluggy.PluginManager.unregister(self, *args, **kwargs)
-
-    def registerPluginFlags(self):
-        """
-        Apply flags specified in the passed ``PluginManager`` to the ``Flags`` class.
-
-        See Also
-        --------
-        armi.plugins.ArmiPlugin.defineFlags
-        """
-        if self._pluginFlagsRegistered:
-            raise RuntimeError(
-                "Plugin flags have already been registered. Cannot do it twice!"
-            )
-
-        for pluginFlags in self.hook.defineFlags():
-            Flags.extend(pluginFlags)
-
-        self._pluginFlagsRegistered = True
-

--- a/armi/pluginManager.py
+++ b/armi/pluginManager.py
@@ -15,6 +15,8 @@
 
 import pluggy
 
+from armi.reactor.flags import Flags
+
 
 class ArmiPluginManager(pluggy.PluginManager):
     """
@@ -32,6 +34,7 @@ class ArmiPluginManager(pluggy.PluginManager):
         pluggy.PluginManager.__init__(self, *args, **kwargs)
 
         self._counter = 0
+        self._pluginFlagsRegistered = False
 
     @property
     def counter(self):
@@ -44,3 +47,22 @@ class ArmiPluginManager(pluggy.PluginManager):
     def unregister(self, *args, **kwargs):
         self._counter += 1
         pluggy.PluginManager.unregister(self, *args, **kwargs)
+
+    def registerPluginFlags(self):
+        """
+        Apply flags specified in the passed ``PluginManager`` to the ``Flags`` class.
+
+        See Also
+        --------
+        armi.plugins.ArmiPlugin.defineFlags
+        """
+        if self._pluginFlagsRegistered:
+            raise RuntimeError(
+                "Plugin flags have already been registered. Cannot do it twice!"
+            )
+
+        for pluginFlags in self.hook.defineFlags():
+            Flags.extend(pluginFlags)
+
+        self._pluginFlagsRegistered = True
+

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -151,7 +151,6 @@ def _fromStringIgnoreErrors(cls, typeSpec):
     a. multiple-word flags are used such as *grid plate* or
        *inlet nozzle* so we use lookups.
     b. Some flags have digits in them. We just strip those off.
-
     """
 
     def updateMethodIgnoreErrors(typeSpec):
@@ -296,28 +295,6 @@ class InvalidFlagsError(KeyError):
     """Raised when code attempts to look for an undefined flag."""
 
     pass
-
-
-_PLUGIN_FLAGS_REGISTERED = False
-
-
-def registerPluginFlags(pm):
-    """
-    Apply flags specified in the passed ``PluginManager`` to the ``Flags`` class.
-
-    See Also
-    --------
-    armi.plugins.ArmiPlugin.defineFlags
-    """
-    global _PLUGIN_FLAGS_REGISTERED
-    if _PLUGIN_FLAGS_REGISTERED:
-        raise RuntimeError(
-            "Plugin flags have already been registered. Cannot do it twice!"
-        )
-
-    for pluginFlags in pm.hook.defineFlags():
-        Flags.extend(pluginFlags)
-    _PLUGIN_FLAGS_REGISTERED = True
 
 
 # string conversions for multiple-word flags

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -24,6 +24,8 @@ from armi import getDefaultPluginManager
 from armi import isStableReleaseVersion
 from armi import meta
 from armi import plugins
+from armi import utils
+from armi.reactor.flags import Flags
 from armi.__main__ import main
 
 
@@ -35,6 +37,11 @@ class TestPlugin1(plugins.ArmiPlugin):
     def defineParameterRenames():
         return {"oldType": "type"}
 
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineFlags():
+        return {"FLAG1": utils.flags.auto()}
+
 
 class TestPlugin2(plugins.ArmiPlugin):
     """This should lead to an error if it coexists with Plugin1."""
@@ -43,6 +50,11 @@ class TestPlugin2(plugins.ArmiPlugin):
     @plugins.HOOKIMPL
     def defineParameterRenames():
         return {"oldType": "type"}
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineFlags():
+        return {"FLAG2": utils.flags.auto()}
 
 
 class TestPlugin3(plugins.ArmiPlugin):
@@ -118,6 +130,25 @@ class TestApps(unittest.TestCase):
             plugins.PluginError, ".*currently-defined parameters.*"
         ):
             app.getParamRenames()
+
+    def test_registerPluginFlags(self):
+        # set up the app, pm, and register some plugins
+        app = getApp()
+        app.pluginManager.register(TestPlugin1)
+        app.pluginManager.register(TestPlugin2)
+        app.pluginManager.register(TestPlugin3)  # Test a plugin with no flags.
+
+        # call the method we want to test
+        app.pluginManager.registerPluginFlags()
+
+        # validate our flags have been registered
+        self.assertEqual(Flags.fromString("FLAG1"), Flags.FLAG1)
+        self.assertEqual(Flags.fromString("FLAG2"), Flags.FLAG2)
+
+        # validate we can only register the flags once
+        for _ in range(3):
+            with self.assertRaises(RuntimeError):
+                app.pluginManager.registerPluginFlags()
 
     def test_getParamRenamesInvalids(self):
         # a basic test of the method

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -37,11 +37,6 @@ class TestPlugin1(plugins.ArmiPlugin):
     def defineParameterRenames():
         return {"oldType": "type"}
 
-    @staticmethod
-    @plugins.HOOKIMPL
-    def defineFlags():
-        return {"FLAG1": utils.flags.auto()}
-
 
 class TestPlugin2(plugins.ArmiPlugin):
     """This should lead to an error if it coexists with Plugin1."""
@@ -50,11 +45,6 @@ class TestPlugin2(plugins.ArmiPlugin):
     @plugins.HOOKIMPL
     def defineParameterRenames():
         return {"oldType": "type"}
-
-    @staticmethod
-    @plugins.HOOKIMPL
-    def defineFlags():
-        return {"FLAG2": utils.flags.auto()}
 
 
 class TestPlugin3(plugins.ArmiPlugin):
@@ -134,21 +124,15 @@ class TestApps(unittest.TestCase):
     def test_registerPluginFlags(self):
         # set up the app, pm, and register some plugins
         app = getApp()
-        app.pluginManager.register(TestPlugin1)
-        app.pluginManager.register(TestPlugin2)
-        app.pluginManager.register(TestPlugin3)  # Test a plugin with no flags.
-
-        # call the method we want to test
-        app.pluginManager.registerPluginFlags()
 
         # validate our flags have been registered
-        self.assertEqual(Flags.fromString("FLAG1"), Flags.FLAG1)
-        self.assertEqual(Flags.fromString("FLAG2"), Flags.FLAG2)
+        self.assertEqual(Flags.fromString("FUEL"), Flags.FUEL)
+        self.assertEqual(Flags.fromString("PRIMARY"), Flags.PRIMARY)
 
         # validate we can only register the flags once
         for _ in range(3):
             with self.assertRaises(RuntimeError):
-                app.pluginManager.registerPluginFlags()
+                app.registerPluginFlags()
 
     def test_getParamRenamesInvalids(self):
         # a basic test of the method


### PR DESCRIPTION
## What is the change?

For some reason, the `Flag`s defined by each `Plugin` were defined in the global scope.  Here I moved that inside the `App`.

## Why is the change being made?

The flag system is not entirely free from the global scope. But I moved the big boolean out of the global scope. As time goes on, we will move more and more things out of the global scope.

This is part of the work from [this discussion](https://github.com/terrapower/armi/discussions/1360).

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
