### PR TITLE
Fixing ruff formatting of doc gallery examples

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -76,6 +76,7 @@ line-length = 88
 # N - We have our own naming conventions for unit tests.
 # SLF001 - private member access
 "*/tests/*" = ["D1", "E741", "N", "SLF001"]
+"doc/gallery-src/*" = ["D400"]
 
 [pydocstyle]
 # Use numpy-style docstrings.


### PR DESCRIPTION
## What is the change?

Fixing some ruff errors.

## Why is the change being made?

A recent PR changed all these lines, to make the docs look prettier when they render in HTML. Fine. So I am going through and fixing the new ruff errors.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
