### PR TITLE
Removing unused settings

### DIFF
--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -74,6 +74,7 @@ CONF_EXPLICIT_REPEAT_SHUFFLES = "explicitRepeatShuffles"
 CONF_FLUX_RECON = "fluxRecon"  # strange coupling in fuel handlers
 CONF_FRESH_FEED_TYPE = "freshFeedType"
 CONF_GEOM_FILE = "geomFile"
+CONF_GROW_TO_FULL_CORE_AFTER_LOAD = "growToFullCoreAfterLoad"
 CONF_INDEPENDENT_VARIABLES = "independentVariables"
 CONF_INITIALIZE_BURN_CHAIN = "initializeBurnChain"
 CONF_INPUT_HEIGHTS_HOT = "inputHeightsConsideredHot"
@@ -96,6 +97,7 @@ CONF_POWER = "power"
 CONF_POWER_FRACTIONS = "powerFractions"
 CONF_PROFILE = "profile"
 CONF_REALLY_SMALL_RUN = "reallySmallRun"
+CONF_REMOVE_PER_CYCLE = "removePerCycle"
 CONF_RUN_TYPE = "runType"
 CONF_SKIP_CYCLES = "skipCycles"
 CONF_SMALL_RUN = "smallRun"
@@ -116,14 +118,6 @@ CONF_USER_PLUGINS = "userPlugins"
 CONF_VERBOSITY = "verbosity"
 CONF_VERSIONS = "versions"
 CONF_ZONE_DEFINITIONS = "zoneDefinitions"
-
-# TODO: Unused by ARMI, slated for removal
-CONF_CONDITIONAL_MODULE_NAME = "conditionalModuleName"  # mcfr
-CONF_GROW_TO_FULL_CORE_AFTER_LOAD = "growToFullCoreAfterLoad"  # mcnp & gui
-CONF_MEM_PER_NODE = "memPerNode"  # unused
-CONF_NUM_CONTROL_BLOCKS = "numControlBlocks"  # unused
-CONF_REMOVE_PER_CYCLE = "removePerCycle"  # crucible, equilibrium, gui
-CONF_USE_INPUT_TEMPERATURES_ON_DBLOAD = "useInputTemperaturesOnDBLoad"  # unused
 
 
 def defineSettings() -> List[setting.Setting]:
@@ -199,14 +193,6 @@ def defineSettings() -> List[setting.Setting]:
                 "This is a flag to determine if block heights, as provided in blueprints, are at hot dimensions. "
                 "If false, block heights are at cold/as-built dimensions and will be thermally expanded as appropriate."
             ),
-        ),
-        setting.Setting(
-            CONF_CONDITIONAL_MODULE_NAME,
-            default="",
-            label="Burn End Conditional",
-            description="File name (directory not included) of the Python "
-            "module that contains a conditional function to determine the end of burn "
-            "cycles",
         ),
         setting.Setting(
             CONF_AUTOMATIC_VARIABLE_MESH,
@@ -575,12 +561,6 @@ def defineSettings() -> List[setting.Setting]:
             schema=vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
         ),
         setting.Setting(
-            CONF_MEM_PER_NODE,
-            default=2000,
-            label="Memory per Node",
-            description="Memory requested per cluster node",
-        ),
-        setting.Setting(
             CONF_MPI_TASKS_PER_NODE,
             default=0,
             label="MPI Tasks per Node",
@@ -598,12 +578,6 @@ def defineSettings() -> List[setting.Setting]:
             "this value should include both cycles from the restart plus any additional "
             "cycles to be run after `startCycle`.",
             schema=vol.All(vol.Coerce(int), vol.Range(min=1)),
-        ),
-        setting.Setting(
-            CONF_NUM_CONTROL_BLOCKS,
-            default=6,
-            label="Number of Control Blocks",
-            description="Number of blocks with control for a REBUS poison search",
         ),
         setting.Setting(
             CONF_TIGHT_COUPLING,
@@ -779,14 +753,6 @@ def defineSettings() -> List[setting.Setting]:
             label="Outlet Temperature",
             description="The outlet temperature of the reactor in C",
             schema=vol.All(vol.Coerce(float), vol.Range(min=-273.15)),
-        ),
-        setting.Setting(
-            CONF_USE_INPUT_TEMPERATURES_ON_DBLOAD,
-            default=False,
-            label="Temperatures From Input on DB Load",
-            description="When loading from a database, first set all component "
-            "temperatures to the input temperatures. Required when a coupled TH "
-            "case is being derived from a case without any coupled TH.",
         ),
         setting.Setting(
             CONF_DEFERRED_INTERFACES_CYCLE,

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -24,7 +24,6 @@ from armi import getDefaultPluginManager
 from armi import isStableReleaseVersion
 from armi import meta
 from armi import plugins
-from armi import utils
 from armi.reactor.flags import Flags
 from armi.__main__ import main
 


### PR DESCRIPTION
## What is the change?

I removed the settings:

- `CONF_CONDITIONAL_MODULE_NAME`
- `CONF_MEM_PER_NODE`
- `CONF_NUM_CONTROL_BLOCKS`
- `CONF_USE_INPUT_TEMPERATURES_ON_DBLOAD`

Two of the settings marked under the `TODO` before I found were actually used in multiple downstream repos. so I determined to leave them in ARMI.

## Why is the change being made?

I am just solving an existing `TODO` in the repo.  One of these is only used in a single downstream repo, so I have opened a PR there for that. But the other three I determined are entirely unused anywhere.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
