### PR TITLE
Fixing gallery example for new working Grids

### DIFF
--- a/doc/gallery-src/framework/run_grids2_cartesian.py
+++ b/doc/gallery-src/framework/run_grids2_cartesian.py
@@ -31,7 +31,7 @@ configure(permissive=True)
 
 fig = plt.figure()
 zCoords = [1, 4, 8]
-cartesian_grid = grids.Grid(
+cartesian_grid = grids.CartesianGrid(
     unitSteps=((1, 0), (0, 1)),
     bounds=(None, None, zCoords),
     offset=(10, 5, 5),


### PR DESCRIPTION
## What is the change?

Fixing a line with broken syntax in the docs.

## Why is the change being made?

A [recent PR](https://github.com/terrapower/armi/pull/1373) made the `Grid` class abstract, which leads to [a failure](https://github.com/terrapower/armi/actions/runs/5978350890/job/16220251937) in building our docs, because our docs have a working example that uses the grids.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
