### PR TITLE
Update to black v22.6

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -13,6 +13,6 @@ jobs:
               with:
                 python-version: '3.11'
             - name: Install Black
-              run: pip install 'black==20.8b1' 'click==8.0.1'
+              run: pip install 'black==22.6' 'click'
             - name: Run black --check .
               run: black --check .

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -220,10 +220,10 @@ class MemoryProfiler(interfaces.Interface):
                 "UNIQUE_INSTANCE_COUNT: {:60s} {:10d}     {:10.1f} MB".format(
                     counter.classType.__name__,
                     counter.count,
-                    counter.memSize / (1024 ** 2.0),
+                    counter.memSize / (1024**2.0),
                 )
             )
-            if printReferrers and counter.memSize / (1024 ** 2.0) > 100:
+            if printReferrers and counter.memSize / (1024**2.0) > 100:
                 referrers = gc.get_referrers(counter.first)
                 runLog.info("          Referrers of first one: ")
                 for referrer in referrers:
@@ -342,7 +342,7 @@ class SystemAndProcessMemoryUsage:
         self.processMemoryInMB: Optional[float] = None
         if _havePsutil:
             self.percentNodeRamUsed = psutil.virtual_memory().percent
-            self.processMemoryInMB = psutil.Process().memory_info().rss / (1012.0 ** 2)
+            self.processMemoryInMB = psutil.Process().memory_info().rss / (1012.0**2)
 
     def __isub__(self, other):
         if self.percentNodeRamUsed is not None and other.percentNodeRamUsed is not None:

--- a/armi/materials/air.py
+++ b/armi/materials/air.py
@@ -85,7 +85,7 @@ class Air(material.Fluid):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("pseudoDensity", Tk)
         inv_Tk = 1.0 / getTk(Tc, Tk)
-        rho_kgPerM3 = 1.15675e03 * inv_Tk ** 2 + 3.43413e02 * inv_Tk + 2.99731e-03
+        rho_kgPerM3 = 1.15675e03 * inv_Tk**2 + 3.43413e02 * inv_Tk + 2.99731e-03
         return rho_kgPerM3 / G_PER_CM3_TO_KG_PER_M3
 
     def specificVolumeLiquid(self, Tk=None, Tc=None):
@@ -114,8 +114,8 @@ class Air(material.Fluid):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tk)
         thermalConductivity = (
-            2.13014e-08 * Tk ** 3
-            - 6.31916e-05 * Tk ** 2
+            2.13014e-08 * Tk**3
+            - 6.31916e-05 * Tk**2
             + 1.11629e-01 * Tk
             - 2.00043e00
         )
@@ -145,9 +145,9 @@ class Air(material.Fluid):
         return (
             sum(
                 [
-                    +1.38642e-13 * Tk ** 4,
-                    -6.47481e-10 * Tk ** 3,
-                    +1.02345e-06 * Tk ** 2,
+                    +1.38642e-13 * Tk**4,
+                    -6.47481e-10 * Tk**3,
+                    +1.02345e-06 * Tk**2,
                     -4.32829e-04 * Tk,
                     +1.06133e00,
                 ]

--- a/armi/materials/be9.py
+++ b/armi/materials/be9.py
@@ -43,4 +43,4 @@ class Be9(Material):
         """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tk)
-        return 1e-4 * (8.4305 + 1.1464e-2 * Tk - 2.9752e-6 * Tk ** 2)
+        return 1e-4 * (8.4305 + 1.1464e-2 * Tk - 2.9752e-6 * Tk**2)

--- a/armi/materials/copper.py
+++ b/armi/materials/copper.py
@@ -41,4 +41,4 @@ class Cu(Material):
         """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tk)
-        return 5.0298e-07 * Tk ** 2 + 1.3042e-03 * Tk - 4.3097e-01
+        return 5.0298e-07 * Tk**2 + 1.3042e-03 * Tk - 4.3097e-01

--- a/armi/materials/graphite.py
+++ b/armi/materials/graphite.py
@@ -47,4 +47,4 @@ class Graphite(Material):
         From  [INL-EXT-16-38241]_, page 4.
         """
         Tc = units.getTc(Tc, Tk)
-        return 100 * (-1.454e-4 + 4.812e-6 * Tc + 1.145e-9 * Tc ** 2)
+        return 100 * (-1.454e-4 + 4.812e-6 * Tc + 1.145e-9 * Tc**2)

--- a/armi/materials/hastelloyN.py
+++ b/armi/materials/hastelloyN.py
@@ -87,7 +87,7 @@ class HastelloyN(Material):
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc=Tc)
         self.checkPropertyTempRange("thermal conductivity", Tk)
-        return 1.92857e-05 * Tc ** 2 + 3.12857e-03 * Tc + 1.17743e01  # W/m-K
+        return 1.92857e-05 * Tc**2 + 3.12857e-03 * Tc + 1.17743e01  # W/m-K
 
     def heatCapacity(self, Tk=None, Tc=None):
         r"""
@@ -112,11 +112,11 @@ class HastelloyN(Material):
         return (
             +3.19981e02
             + 2.47421e00 * Tc
-            - 2.49306e-02 * Tc ** 2
-            + 1.32517e-04 * Tc ** 3
-            - 3.58872e-07 * Tc ** 4
-            + 4.69003e-10 * Tc ** 5
-            - 2.32692e-13 * Tc ** 6
+            - 2.49306e-02 * Tc**2
+            + 1.32517e-04 * Tc**3
+            - 3.58872e-07 * Tc**4
+            + 4.69003e-10 * Tc**5
+            - 2.32692e-13 * Tc**6
         )
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
@@ -157,4 +157,4 @@ class HastelloyN(Material):
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc=Tc)
         self.checkPropertyTempRange("thermal expansion", Tk)
-        return 2.60282e-12 * Tc ** 2 + 7.69859e-10 * Tc + 1.21036e-05
+        return 2.60282e-12 * Tc**2 + 7.69859e-10 * Tc + 1.21036e-05

--- a/armi/materials/ht9.py
+++ b/armi/materials/ht9.py
@@ -66,7 +66,7 @@ class HT9(materials.Material):
         """
         tk = units.getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion", tk)
-        return -0.16256 + 1.62307e-4 * tk + 1.42357e-6 * tk ** 2 - 5.50344e-10 * tk ** 3
+        return -0.16256 + 1.62307e-4 * tk + 1.42357e-6 * tk**2 - 5.50344e-10 * tk**3
 
     def thermalConductivity(self, Tk=None, Tc=None):
         """
@@ -80,7 +80,7 @@ class HT9(materials.Material):
         return (
             29.65
             - 6.668e-2 * Tk
-            + 2.184e-4 * Tk ** 2
-            - 2.527e-7 * Tk ** 3
-            + 9.621e-11 * Tk ** 4
+            + 2.184e-4 * Tk**2
+            - 2.527e-7 * Tk**3
+            + 9.621e-11 * Tk**4
         )

--- a/armi/materials/inconel600.py
+++ b/armi/materials/inconel600.py
@@ -93,7 +93,7 @@ class Inconel600(Material):
         """
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tc)
-        thermalCond = 3.4938e-6 * Tc ** 2 + 1.3403e-2 * Tc + 14.572
+        thermalCond = 3.4938e-6 * Tc**2 + 1.3403e-2 * Tc + 14.572
         return thermalCond  # W/m-C
 
     def polyfitHeatCapacity(self, power=2):
@@ -133,7 +133,7 @@ class Inconel600(Material):
         """
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tc)
-        heatCapacity = 7.4021e-6 * Tc ** 2 + 0.20573 * Tc + 441.3
+        heatCapacity = 7.4021e-6 * Tc**2 + 0.20573 * Tc + 441.3
         return heatCapacity  # J/kg-C
 
     def polyfitLinearExpansionPercent(self, power=2):
@@ -195,7 +195,7 @@ class Inconel600(Material):
         """
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tc)
-        linExpPercent = 3.722e-7 * Tc ** 2 + 1.303e-3 * Tc - 2.863e-2
+        linExpPercent = 3.722e-7 * Tc**2 + 1.303e-3 * Tc - 2.863e-2
         return linExpPercent
 
     def linearExpansion(self, Tk=None, Tc=None):

--- a/armi/materials/inconel625.py
+++ b/armi/materials/inconel625.py
@@ -98,7 +98,7 @@ class Inconel625(Material):
         """
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tc)
-        thermalCond = 2.7474e-6 * Tc ** 2 + 0.012907 * Tc + 9.62532
+        thermalCond = 2.7474e-6 * Tc**2 + 0.012907 * Tc + 9.62532
         return thermalCond  # W/m-C
 
     def polyfitHeatCapacity(self, power=2):
@@ -162,7 +162,7 @@ class Inconel625(Material):
         """
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tc)
-        heatCapacity = -5.3777e-6 * Tc ** 2 + 0.25 * Tc + 404.26
+        heatCapacity = -5.3777e-6 * Tc**2 + 0.25 * Tc + 404.26
         return heatCapacity  # J/kg-C
 
     def polyfitLinearExpansionPercent(self, power=2):
@@ -224,7 +224,7 @@ class Inconel625(Material):
         """
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tc)
-        linExpPercent = 5.083e-7 * Tc ** 2 + 1.125e-3 * Tc - 1.804e-2
+        linExpPercent = 5.083e-7 * Tc**2 + 1.125e-3 * Tc - 1.804e-2
         return linExpPercent
 
     def linearExpansion(self, Tk=None, Tc=None):

--- a/armi/materials/inconel800.py
+++ b/armi/materials/inconel800.py
@@ -86,8 +86,8 @@ class Inconel800(Material):
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("thermal expansion", Tc)
         return (
-            2.52525e-14 * Tc ** 3
-            - 3.77814e-11 * Tc ** 2
+            2.52525e-14 * Tc**3
+            - 3.77814e-11 * Tc**2
             + 2.06360e-08 * Tc
             + 1.28071e-05
         )

--- a/armi/materials/inconelX750.py
+++ b/armi/materials/inconelX750.py
@@ -123,7 +123,7 @@ class InconelX750(Material):
         """
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tc)
-        thermalCond = 1.4835e-6 * Tc ** 2 + 1.2668e-2 * Tc + 11.632
+        thermalCond = 1.4835e-6 * Tc**2 + 1.2668e-2 * Tc + 11.632
         return thermalCond  # W/m-C
 
     def polyfitHeatCapacity(self, power=3):
@@ -164,7 +164,7 @@ class InconelX750(Material):
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tc)
         heatCapacity = (
-            9.2261e-7 * Tc ** 3 - 9.6368e-4 * Tc ** 2 + 4.7778e-1 * Tc + 420.55
+            9.2261e-7 * Tc**3 - 9.6368e-4 * Tc**2 + 4.7778e-1 * Tc + 420.55
         )
         return heatCapacity  # J/kg-C
 
@@ -227,7 +227,7 @@ class InconelX750(Material):
         """
         Tc = getTc(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tc)
-        linExpPercent = 6.8378e-7 * Tc ** 2 + 1.056e-3 * Tc - 1.3161e-2
+        linExpPercent = 6.8378e-7 * Tc**2 + 1.056e-3 * Tc - 1.3161e-2
         return linExpPercent
 
     def linearExpansion(self, Tk=None, Tc=None):

--- a/armi/materials/lead.py
+++ b/armi/materials/lead.py
@@ -54,4 +54,4 @@ class Lead(material.Fluid):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 
-        return 162.9 - 3.022e-2 * Tk + 8.341e-6 * Tk ** 2
+        return 162.9 - 3.022e-2 * Tk + 8.341e-6 * Tk**2

--- a/armi/materials/leadBismuth.py
+++ b/armi/materials/leadBismuth.py
@@ -63,7 +63,7 @@ class LeadBismuth(material.Fluid):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("heat capacity", Tk)
 
-        return 159 - 2.72e-2 * Tk + 7.12e-6 * Tk ** 2
+        return 159 - 2.72e-2 * Tk + 7.12e-6 * Tk**2
 
     def thermalConductivity(self, Tk=None, Tc=None):
         r"""Thermal conductivity in W/m/K from Sobolev.

--- a/armi/materials/mgO.py
+++ b/armi/materials/mgO.py
@@ -49,4 +49,4 @@ class MgO(Material):
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc=Tc)
         self.checkPropertyTempRange("linear expansion percent", Tk)
-        return 1.0489e-5 * Tc + 6.0458e-9 * Tc ** 2 - 2.6875e-12 * Tc ** 3
+        return 1.0489e-5 * Tc + 6.0458e-9 * Tc**2 - 2.6875e-12 * Tc**3

--- a/armi/materials/mox.py
+++ b/armi/materials/mox.py
@@ -179,6 +179,6 @@ class MOX(UraniumOxide):
         return (
             3120.0
             - 655.3 * molFracPuO2
-            + 336.4 * molFracPuO2 ** 2
-            - 99.9 * molFracPuO2 ** 3
+            + 336.4 * molFracPuO2**2
+            - 99.9 * molFracPuO2**3
         )

--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -41,4 +41,4 @@ class Potassium(material.Fluid):
         Tc = getTc(Tc, Tk)
         Tk = getTk(Tc=Tc)
         self.checkPropertyTempRange("density", Tc)
-        return 0.8415 - 2.172e-4 * Tc - 2.70e-8 * Tc ** 2 + 4.77e-12 * Tc ** 3
+        return 0.8415 - 2.172e-4 * Tc - 2.70e-8 * Tc**2 + 4.77e-12 * Tc**3

--- a/armi/materials/scandiumOxide.py
+++ b/armi/materials/scandiumOxide.py
@@ -43,4 +43,4 @@ class Sc2O3(Material):
         """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tk)
-        return 2.6045e-07 * Tk ** 2 + 4.6374e-04 * Tk - 1.4696e-01
+        return 2.6045e-07 * Tk**2 + 4.6374e-04 * Tk - 1.4696e-01

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -98,8 +98,8 @@ class Sodium(material.Fluid):
         enthalpy = (
             -365.77
             + 1.6582 * Tk
-            - 4.2395e-4 * Tk ** 2
-            + 1.4847e-7 * Tk ** 3
+            - 4.2395e-4 * Tk**2
+            + 1.4847e-7 * Tk**3
             + 2992.6 / Tk
         )
         enthalpy = enthalpy * 1000  # convert from kJ/kg to kJ/kg
@@ -126,6 +126,6 @@ class Sodium(material.Fluid):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tk)
         thermalConductivity = (
-            124.67 - 0.11381 * Tk + 5.5226e-5 * Tk ** 2 - 1.1842e-8 * Tk ** 3
+            124.67 - 0.11381 * Tk + 5.5226e-5 * Tk**2 - 1.1842e-8 * Tk**3
         )
         return thermalConductivity

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -222,7 +222,7 @@ class Uranium(FuelMaterial):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tk)
 
-        kU = 21.73 + (0.01591 * Tk) + (0.000005907 * Tk ** 2)
+        kU = 21.73 + (0.01591 * Tk) + (0.000005907 * Tk**2)
         return kU
 
     def heatCapacity(self, Tk: float = None, Tc: float = None) -> float:

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -165,7 +165,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("density", Tk)
 
-        return (-1.01147e-7 * Tk ** 2 - 1.29933e-4 * Tk + 1.09805e1) * self.getTD()
+        return (-1.01147e-7 * Tk**2 - 1.29933e-4 * Tk + 1.09805e1) * self.getTD()
 
     def heatCapacity(self, Tk: float = None, Tc: float = None) -> float:
         """
@@ -184,7 +184,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
             * math.exp(hcc.theta / Tk)
             / (math.exp(hcc.theta / Tk) - 1.0) ** 2
             + 2 * hcc.c2 * Tk
-            + hcc.c3 * hcc.Ea * math.exp(-hcc.Ea / Tk) / Tk ** 2
+            + hcc.c3 * hcc.Ea * math.exp(-hcc.Ea / Tk) / Tk**2
         )
         return specificHeatCapacity
 
@@ -197,7 +197,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion", Tk)
 
-        return 1.06817e-12 * Tk ** 2 - 1.37322e-9 * Tk + 1.02863e-5
+        return 1.06817e-12 * Tk**2 - 1.37322e-9 * Tk + 1.02863e-5
 
     def linearExpansionPercent(self, Tk: float = None, Tc: float = None) -> float:
         """
@@ -210,11 +210,11 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
 
         if Tk >= 273.0 and Tk < 923.0:
             return (
-                -2.66e-03 + 9.802e-06 * Tk - 2.705e-10 * Tk ** 2 + 4.391e-13 * Tk ** 3
+                -2.66e-03 + 9.802e-06 * Tk - 2.705e-10 * Tk**2 + 4.391e-13 * Tk**3
             ) * 100.0
         else:
             return (
-                -3.28e-03 + 1.179e-05 * Tk - 2.429e-09 * Tk ** 2 + 1.219e-12 * Tk ** 3
+                -3.28e-03 + 1.179e-05 * Tk - 2.429e-09 * Tk**2 + 1.219e-12 * Tk**3
             ) * 100.0
 
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:

--- a/armi/materials/water.py
+++ b/armi/materials/water.py
@@ -130,11 +130,11 @@ class Water(Fluid):
 
         sum_coefficients = (
             a1 * tau
-            + a2 * tau ** 1.5
-            + a3 * tau ** 3
-            + a4 * tau ** 3.5
-            + a5 * tau ** 4
-            + a6 * tau ** 7.5
+            + a2 * tau**1.5
+            + a3 * tau**3
+            + a4 * tau**3.5
+            + a5 * tau**4
+            + a6 * tau**7.5
         )
         log_vapor_pressure = T_ratio * sum_coefficients
         vapor_pressure = self.VAPOR_PRESSURE_CRITICAL_PA * math.e ** (
@@ -198,11 +198,11 @@ class Water(Fluid):
 
         normalized_alpha = (
             self.d["alpha"]
-            + self.d[1] * theta ** -19
+            + self.d[1] * theta**-19
             + self.d[2] * theta
-            + self.d[3] * theta ** 4.5
-            + self.d[4] * theta ** 5.0
-            + self.d[5] * theta ** 54.5
+            + self.d[3] * theta**4.5
+            + self.d[4] * theta**5.0
+            + self.d[5] * theta**54.5
         )
 
         # past the supercritical point tau's raised to .5 cause complex #'s
@@ -240,11 +240,11 @@ class Water(Fluid):
 
         normalized_phi = (
             self.d["phi"]
-            + 19.0 / 20.0 * self.d[1] * theta ** -20.0
+            + 19.0 / 20.0 * self.d[1] * theta**-20.0
             + self.d[2] * math.log(theta)
-            + 9.0 / 7.0 * self.d[3] * theta ** 3.5
-            + 5.0 / 4.0 * self.d[4] * theta ** 4.0
-            + 109.0 / 107.0 * self.d[5] * theta ** 53.5
+            + 9.0 / 7.0 * self.d[3] * theta**3.5
+            + 5.0 / 4.0 * self.d[4] * theta**4.0
+            + 109.0 / 107.0 * self.d[5] * theta**53.5
         )
 
         # past the supercritical point tau's raised to .5 cause complex #'s
@@ -435,6 +435,6 @@ class SaturatedSteam(Water):
 
         # past the supercritical point tau's raised to .5 cause complex #'s
         return (
-            math.e ** log_normalized_rho.real
+            math.e**log_normalized_rho.real
             * self.DENSITY_CRITICAL_GPERCUBICCENTIMETER
         )

--- a/armi/materials/yttriumOxide.py
+++ b/armi/materials/yttriumOxide.py
@@ -40,4 +40,4 @@ class Y2O3(Material):
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("linear expansion percent", Tk)
 
-        return 1.4922e-07 * Tk ** 2 + 6.2448e-04 * Tk - 1.8414e-01
+        return 1.4922e-07 * Tk**2 + 6.2448e-04 * Tk - 1.8414e-01

--- a/armi/materials/zincOxide.py
+++ b/armi/materials/zincOxide.py
@@ -42,5 +42,5 @@ class ZnO(Material):
         self.checkPropertyTempRange("linear expansion percent", Tk)
 
         return (
-            -1.9183e-10 * Tk ** 3 + 6.5944e-07 * Tk ** 2 + 5.2992e-05 * Tk - 5.2631e-02
+            -1.9183e-10 * Tk**3 + 6.5944e-07 * Tk**2 + 5.2992e-05 * Tk - 5.2631e-02
         )

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -88,9 +88,9 @@ class Zr(Material):
         self.checkPropertyTempRange("density", Tk)
 
         if Tk < 1135:
-            return -3.29256e-8 * Tk ** 2 - 9.67145e-5 * Tk + 6.60176
+            return -3.29256e-8 * Tk**2 - 9.67145e-5 * Tk + 6.60176
         else:
-            return -2.61683e-8 * Tk ** 2 - 1.11331e-4 * Tk + 6.63616
+            return -2.61683e-8 * Tk**2 - 1.11331e-4 * Tk + 6.63616
 
     def thermalConductivity(self, Tk=None, Tc=None):
         """
@@ -100,7 +100,7 @@ class Zr(Material):
         """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("thermal conductivity", Tk)
-        return 8.853 + (0.007082 * Tk) + (0.000002533 * Tk ** 2) + (2992.0 / Tk)
+        return 8.853 + (0.007082 * Tk) + (0.000002533 * Tk**2) + (2992.0 / Tk)
 
     def linearExpansion(self, Tk=None, Tc=None):
         r"""Linear expansion in m/mK.
@@ -128,9 +128,9 @@ class Zr(Material):
         # NOTE: checkPropertyTempRange takes care of lower/upper limits
         if Tk < 1137:
             return (
-                -0.111 + (2.325e-4 * Tk) + (5.595e-7 * Tk ** 2) - (1.768e-10 * Tk ** 3)
+                -0.111 + (2.325e-4 * Tk) + (5.595e-7 * Tk**2) - (1.768e-10 * Tk**3)
             )
         else:
             return (
-                -0.759 + (1.474e-3 * Tk) - (5.140e-7 * Tk ** 2) + (1.559e-10 * Tk ** 3)
+                -0.759 + (1.474e-3 * Tk) - (5.140e-7 * Tk**2) + (1.559e-10 * Tk**3)
             )

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -59,7 +59,7 @@ class IORecord:
     _intSize = struct.calcsize("i")
     _longSize = struct.calcsize("q")
     maxsize = len(
-        str(2 ** 31 - 1)
+        str(2**31 - 1)
     )  # limit to max short even though Python3 can go bigger.
     _intFormat = " {{:>+{}}}".format(maxsize)
     _intLength = maxsize + 1

--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -159,7 +159,7 @@ class _GamisoNuclideIO(isotxs._IsotxsNuclideIO):
     The GAMISO file format is identical to ISOTXS.
     """
 
-    _FILE_LABEL = u"GAMISO"
+    _FILE_LABEL = "GAMISO"
 
     def _getFileMetadata(self):
         return self._lib.gamisoMetadata

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -200,7 +200,7 @@ class _IsotxsIO(cccc.Stream):
     specified in http://t2.lanl.gov/codes/transx-hyper/isotxs.html.
     """
 
-    _FILE_LABEL = u"ISOTXS"
+    _FILE_LABEL = "ISOTXS"
 
     def __init__(self, fileName, lib, fileMode, getNuclideFunc):
         cccc.Stream.__init__(self, fileName, fileMode)

--- a/armi/physics/fuelPerformance/utils.py
+++ b/armi/physics/fuelPerformance/utils.py
@@ -43,7 +43,7 @@ def applyFuelDisplacement(block, displacementInCm):
     newHotODInCm = min(cladID * 0.995, originalHotODInCm + displacementInCm * 2)
     fuel.setDimension("od", newHotODInCm, retainLink=True, cold=False)
     # reduce number density of fuel to conserve number of atoms (and mass)
-    fuel.changeNDensByFactor(originalHotODInCm ** 2 / newHotODInCm ** 2)
+    fuel.changeNDensByFactor(originalHotODInCm**2 / newHotODInCm**2)
 
 
 def gasConductivityCorrection(tempInC: float, porosity: float, morphology: int = 2):

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -289,7 +289,7 @@ class Block(composites.Composite):
         # Compute component areas
         cladID = numpy.mean([clad.getDimension("id", cold=cold) for clad in clads])
         innerCladdingArea = (
-            math.pi * (cladID ** 2) / 4.0 * self.getNumComponents(Flags.FUEL)
+            math.pi * (cladID**2) / 4.0 * self.getNumComponents(Flags.FUEL)
         )
         fuelComponentArea = 0.0
         unmovableComponentArea = 0.0
@@ -2072,14 +2072,10 @@ class HexBlock(Block):
                 # seeing the first one is the easiest way to detect them.
                 # Check it last in the and statement so we don't waste time doing it.
                 upperEdgeLoc = self.core.spatialGrid[-1, 2, 0]
-                if (
-                    symmetryLine
-                    in [
-                        grids.BOUNDARY_0_DEGREES,
-                        grids.BOUNDARY_120_DEGREES,
-                    ]
-                    and bool(self.core.childrenByLocator.get(upperEdgeLoc))
-                ):
+                if symmetryLine in [
+                    grids.BOUNDARY_0_DEGREES,
+                    grids.BOUNDARY_120_DEGREES,
+                ] and bool(self.core.childrenByLocator.get(upperEdgeLoc)):
                     return 2.0
         return 1.0
 

--- a/armi/reactor/components/basicShapes.py
+++ b/armi/reactor/components/basicShapes.py
@@ -79,7 +79,7 @@ class Circle(ShapedComponent):
         idiam = self.getDimension("id", cold=cold)
         od = self.getDimension("od", cold=cold)
         mult = self.getDimension("mult", cold=cold)
-        area = math.pi * (od ** 2 - idiam ** 2) / 4.0
+        area = math.pi * (od**2 - idiam**2) / 4.0
         area *= mult
         return area
 
@@ -146,7 +146,7 @@ class Hexagon(ShapedComponent):
         op = self.getDimension("op", cold=cold)
         ip = self.getDimension("ip", cold=cold)
         mult = self.getDimension("mult")
-        area = math.sqrt(3.0) / 2.0 * (op ** 2 - ip ** 2)
+        area = math.sqrt(3.0) / 2.0 * (op**2 - ip**2)
         area *= mult
         return area
 
@@ -218,12 +218,12 @@ class Rectangle(ShapedComponent):
     def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
         lengthO = self.getDimension("lengthOuter", Tc, cold=cold)
         widthO = self.getDimension("widthOuter", Tc, cold=cold)
-        return math.sqrt(widthO ** 2 + lengthO ** 2)
+        return math.sqrt(widthO**2 + lengthO**2)
 
     def getCircleInnerDiameter(self, Tc=None, cold=False):
         lengthI = self.getDimension("lengthInner", Tc, cold=cold)
         widthI = self.getDimension("widthInner", Tc, cold=cold)
-        return math.sqrt(widthI ** 2 + lengthI ** 2)
+        return math.sqrt(widthI**2 + lengthI**2)
 
     def getComponentArea(self, cold=False):
         """Computes the area of the rectangle in cm^2."""
@@ -359,11 +359,11 @@ class Square(Rectangle):
 
     def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):
         widthO = self.getDimension("widthOuter", Tc, cold=cold)
-        return math.sqrt(widthO ** 2 + widthO ** 2)
+        return math.sqrt(widthO**2 + widthO**2)
 
     def getCircleInnerDiameter(self, Tc=None, cold=False):
         widthI = self.getDimension("widthInner", Tc, cold=cold)
-        return math.sqrt(widthI ** 2 + widthI ** 2)
+        return math.sqrt(widthI**2 + widthI**2)
 
     def getPitchData(self):
         """

--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -72,7 +72,7 @@ class HoledHexagon(basicShapes.Hexagon):
         holeOD = self.getDimension("holeOD", cold=cold)
         nHoles = self.getDimension("nHoles", cold=cold)
         mult = self.getDimension("mult")
-        hexArea = math.sqrt(3.0) / 2.0 * (op ** 2)
+        hexArea = math.sqrt(3.0) / 2.0 * (op**2)
         circularArea = nHoles * math.pi * ((holeOD / 2.0) ** 2)
         area = mult * (hexArea - circularArea)
         return area
@@ -131,7 +131,7 @@ class HexHoledCircle(basicShapes.Circle):
         od = self.getDimension("od", cold=cold)
         holeOP = self.getDimension("holeOP", cold=cold)
         mult = self.getDimension("mult")
-        hexArea = math.sqrt(3.0) / 2.0 * (holeOP ** 2)
+        hexArea = math.sqrt(3.0) / 2.0 * (holeOP**2)
         circularArea = math.pi * ((od / 2.0) ** 2)
         area = mult * (circularArea - hexArea)
         return area
@@ -236,7 +236,7 @@ class HoledSquare(basicShapes.Square):
     def getComponentArea(self, cold=False):
         r"""Computes the area (in cm^2) for the the square with one hole in it."""
         width = self.getDimension("widthOuter", cold=cold)
-        rectangleArea = width ** 2
+        rectangleArea = width**2
         holeOD = self.getDimension("holeOD", cold=cold)
         circularArea = math.pi * ((holeOD / 2.0) ** 2)
         mult = self.getDimension("mult")
@@ -331,6 +331,6 @@ class Helix(ShapedComponent):
         od = self.getDimension("od", cold=cold)
         mult = self.getDimension("mult")
         c = ap / (2.0 * math.pi)
-        helixFactor = math.sqrt((hd / 2.0) ** 2 + c ** 2) / c
+        helixFactor = math.sqrt((hd / 2.0) ** 2 + c**2) / c
         area = mult * math.pi * ((od / 2.0) ** 2 - (id / 2.0) ** 2) * helixFactor
         return area

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -251,7 +251,7 @@ class RadialSegment(ShapedComponent):
         outerTheta = self.getDimension("outer_theta")
         innerTheta = self.getDimension("inner_theta")
         height = self.getDimension("height")
-        radialArea = math.pi * (outerRad ** 2 - innerRad ** 2)
+        radialArea = math.pi * (outerRad**2 - innerRad**2)
         aziFraction = (outerTheta - innerTheta) / (math.pi * 2.0)
         vol = mult * radialArea * aziFraction * height
         return vol

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -701,7 +701,7 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
 
 def getOuterDiamFromIDAndArea(ID, area):
     """Return the outer diameter of an annulus with given inner diameter (ID) and area."""
-    return math.sqrt(ID ** 2.0 + 4.0 * area / math.pi)  # from A = pi *(d ** 2)/4.0
+    return math.sqrt(ID**2.0 + 4.0 * area / math.pi)  # from A = pi *(d ** 2)/4.0
 
 
 def radiiFromHexPitches(pitches):
@@ -761,7 +761,7 @@ def radiiFromRingOfRods(distToRodCenter, numRods, rodRadii, layout="hexagon"):
     radiiFromRodCenter = []
     rLast = bigRLast = 0.0
     for rodRadius in rodRadii:
-        area = math.pi * (rodRadius ** 2.0 - rLast ** 2.0) * float(numRods)
+        area = math.pi * (rodRadius**2.0 - rLast**2.0) * float(numRods)
         thicknessOnEachSide = area / (4 * math.pi * radToRodCenter)
         distFromCenterComp = bigRLast + thicknessOnEachSide
         radiiFromRodCenter.append(radToRodCenter + distFromCenterComp)

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -880,11 +880,14 @@ class HexToRZThetaConverter(GeometryConverter):
                 self.blockVolFracs[homBlock][b] = blockVolumeHere
         # Notify if blocks with different xs types are being homogenized. May be undesired behavior.
         if len(homBlockXsTypes) > 1:
-            msg = "Blocks {} with dissimilar XS IDs are being homogenized in {} between axial heights {} " "cm and {} cm. ".format(
-                self.blockMap[homBlock],
-                self.convReactor.core,
-                lowerAxialZ,
-                upperAxialZ,
+            msg = (
+                "Blocks {} with dissimilar XS IDs are being homogenized in {} between axial heights {} "
+                "cm and {} cm. ".format(
+                    self.blockMap[homBlock],
+                    self.convReactor.core,
+                    lowerAxialZ,
+                    upperAxialZ,
+                )
             )
             if self._strictHomogenization:
                 raise ValueError(

--- a/armi/reactor/converters/pinTypeBlockConverters.py
+++ b/armi/reactor/converters/pinTypeBlockConverters.py
@@ -76,7 +76,7 @@ def adjustSmearDensity(obj, value, bolBlock=None):
         newID = fuelOD * math.sqrt(1.0 - value)
         fuel.setDimension("id", newID)
     else:  # Slug fuel (Adjust fuel OD to get new smear density)
-        newOD = math.sqrt(value * cladID ** 2)
+        newOD = math.sqrt(value * cladID**2)
         fuel.setDimension("od", newOD)
 
     # update things like hm at BOC and smear density parameters.

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -244,7 +244,7 @@ class TestHexGrid(unittest.TestCase):
         jDirection = tuple(direction[1] for direction in unitSteps)
         for directionVector in (iDirection, jDirection):
             self.assertAlmostEqual(
-                (sum(val ** 2 for val in directionVector)) ** 0.5,
+                (sum(val**2 for val in directionVector)) ** 0.5,
                 1.0,
                 msg=f"Direction vector {directionVector} should have "
                 "magnitude 1 for pitch 1.",

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2177,7 +2177,7 @@ class Core(composites.Composite):
 
         for b in blockList:
             if flux2Weight:
-                weight = b.p.flux ** 2.0
+                weight = b.p.flux**2.0
             else:
                 weight = 1.0
             for c in b.iterComponents(typeSpec):

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1362,6 +1362,6 @@ assemblies:
         intercoolant = fuelBlock.getComponent(Flags.INTERCOOLANT)
 
         bpAssemblyArea = assembly.getArea()
-        actualAssemblyArea = math.sqrt(3) / 2.0 * intercoolant.p.op ** 2
+        actualAssemblyArea = math.sqrt(3) / 2.0 * intercoolant.p.op**2
 
         self.assertAlmostEqual(bpAssemblyArea, actualAssemblyArea)

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1583,7 +1583,7 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(
             blockPitch, self.block.getComponent(Flags.INTERCOOLANT).getDimension("op")
         )
-        totalHexArea = blockPitch ** 2 * math.sqrt(3) / 2.0
+        totalHexArea = blockPitch**2 * math.sqrt(3) / 2.0
 
         clad = self.block.getComponent(Flags.CLAD)
         pinArea = (
@@ -1760,7 +1760,7 @@ class HexBlock_TestCase(unittest.TestCase):
 
     def test_getArea(self):
         cur = self.HexBlock.getArea()
-        ref = math.sqrt(3) / 2.0 * 70.6 ** 2
+        ref = math.sqrt(3) / 2.0 * 70.6**2
         places = 6
         self.assertAlmostEqual(cur, ref, places=places)
 
@@ -1839,7 +1839,7 @@ class HexBlock_TestCase(unittest.TestCase):
         self.assertGreater(min(x), -side)
 
         # center pin should be at 0
-        mags = [(xi ** 2 + yi ** 2, (xi, yi)) for xi, yi, zi in xyz]
+        mags = [(xi**2 + yi**2, (xi, yi)) for xi, yi, zi in xyz]
         _centerMag, (cx, cy) = min(mags)
         self.assertAlmostEqual(cx, 0.0)
         self.assertAlmostEqual(cy, 0.0)

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -986,7 +986,7 @@ class TestHexagon(TestShapedComponent):
         mult = self.component.getDimension("mult")
         op = self.component.getDimension("op")
         ip = self.component.getDimension("ip")
-        ref = math.sqrt(3.0) / 2.0 * (op ** 2 - ip ** 2) * mult
+        ref = math.sqrt(3.0) / 2.0 * (op**2 - ip**2) * mult
         self.assertAlmostEqual(cur, ref)
 
     def test_thermallyExpands(self):
@@ -1047,7 +1047,7 @@ class TestHoledHexagon(TestShapedComponent):
         odHole = self.component.getDimension("holeOD")
         nHoles = self.component.getDimension("nHoles")
         mult = self.component.getDimension("mult")
-        hexarea = math.sqrt(3.0) / 2.0 * (op ** 2)
+        hexarea = math.sqrt(3.0) / 2.0 * (op**2)
         holeArea = nHoles * math.pi * ((odHole / 2.0) ** 2)
         ref = mult * (hexarea - holeArea)
         cur = self.component.getArea()
@@ -1098,7 +1098,7 @@ class TestHexHoledCircle(TestShapedComponent):
         od = self.component.getDimension("od")
         holeOP = self.component.getDimension("holeOP")
         mult = self.component.getDimension("mult")
-        hexarea = math.sqrt(3.0) / 2.0 * (holeOP ** 2)
+        hexarea = math.sqrt(3.0) / 2.0 * (holeOP**2)
         holeArea = math.pi * ((od / 2.0) ** 2)
         ref = mult * (holeArea - hexarea)
         cur = self.component.getArea()
@@ -1147,7 +1147,7 @@ class TestHoledRectangle(TestShapedComponent):
 
     def test_getBoundingCircleOuterDiameter(self):
         # hypotenuse
-        ref = (self.length ** 2 + self.width ** 2) ** 0.5
+        ref = (self.length**2 + self.width**2) ** 0.5
         cur = self.component.getBoundingCircleOuterDiameter()
         self.assertAlmostEqual(ref, cur)
 
@@ -1233,11 +1233,11 @@ class TestHelix(TestShapedComponent):
         outerDiameter = self.component.getDimension("od")
         mult = self.component.getDimension("mult")
         c = axialPitch / (2.0 * math.pi)
-        helixFactor = math.sqrt((helixDiameter / 2.0) ** 2 + c ** 2) / c
+        helixFactor = math.sqrt((helixDiameter / 2.0) ** 2 + c**2) / c
         ref = (
             mult
             * math.pi
-            * (outerDiameter ** 2 / 4.0 - innerDiameter ** 2 / 4.0)
+            * (outerDiameter**2 / 4.0 - innerDiameter**2 / 4.0)
             * helixFactor
         )
         self.assertAlmostEqual(cur, ref)
@@ -1334,7 +1334,7 @@ class TestRadialSegment(TestShapedComponent):
         outerTheta = self.component.getDimension("outer_theta")
         innerTheta = self.component.getDimension("inner_theta")
         height = self.component.getDimension("height")
-        radialArea = math.pi * (outerRad ** 2 - innerRad ** 2)
+        radialArea = math.pi * (outerRad**2 - innerRad**2)
         aziFraction = (outerTheta - innerTheta) / (math.pi * 2.0)
         ref = mult * radialArea * aziFraction * height
         cur = self.component.getVolume()
@@ -1367,7 +1367,7 @@ class TestDifferentialRadialSegment(TestShapedComponent):
         outerTheta = self.component.getDimension("outer_theta")
         innerTheta = self.component.getDimension("inner_theta")
         height = self.component.getDimension("height")
-        radialArea = math.pi * (outerRad ** 2 - innerRad ** 2)
+        radialArea = math.pi * (outerRad**2 - innerRad**2)
         aziFraction = (outerTheta - innerTheta) / (math.pi * 2.0)
         ref = mult * radialArea * aziFraction * height
         cur = self.component.getVolume()

--- a/armi/reactor/tests/test_rz_reactors.py
+++ b/armi/reactor/tests/test_rz_reactors.py
@@ -60,7 +60,7 @@ class Test_RZT_Reactor_modern(unittest.TestCase):
         reactorRadius = 9
         reactorHeight = 17.5
 
-        refReactorVolume = math.pi * reactorRadius ** 2 * reactorHeight / 8
+        refReactorVolume = math.pi * reactorRadius**2 * reactorHeight / 8
         refFuelVolume = 4.0 / 3.0 * math.pi * (godivaRadius) ** 3 / 8
 
         reactorVolumes = []

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -31,7 +31,7 @@ SQRT3 = math.sqrt(3.0)
 
 def area(pitch):
     """Area of a hex given the flat-to-flat pitch."""
-    return SQRT3 / 2.0 * pitch ** 2
+    return SQRT3 / 2.0 * pitch**2
 
 
 def side(pitch):

--- a/armi/utils/tests/test_parsing.py
+++ b/armi/utils/tests/test_parsing.py
@@ -43,8 +43,8 @@ class LiteralEvalTest(unittest.TestCase):
         )
         self.assertEqual(parsing.tryLiteralEval("(1,2)"), (1, 2))
         self.assertEqual(parsing.tryLiteralEval((1, 2)), (1, 2))
-        self.assertEqual(parsing.tryLiteralEval("u'apple'"), u"apple")
-        self.assertEqual(parsing.tryLiteralEval(u"apple"), u"apple")
+        self.assertEqual(parsing.tryLiteralEval("u'apple'"), "apple")
+        self.assertEqual(parsing.tryLiteralEval("apple"), "apple")
         self.assertEqual(parsing.tryLiteralEval("apple"), "apple")
         self.assertEqual(parsing.tryLiteralEval(tuple), tuple)
 

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -45,7 +45,7 @@ o, reactor = test_reactors.loadTestReactor(inputFileName="refTestCartesian.yaml"
 # Apply a dummy burnup distribution roughly in a cosine
 for b in reactor.core.getBlocks(Flags.FUEL):
     x, y, z = b.spatialLocator.getGlobalCoordinates()
-    d = math.sqrt(x ** 2 + y ** 2)
+    d = math.sqrt(x**2 + y**2)
     b.p.percentBu = 5 * math.cos(d * math.pi / 2 / 90)
 
 # show the initial burnup distribution

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -30,7 +30,7 @@ reactor.core.growToFullCore(None)
 # set dummy power
 for b in reactor.core.getBlocks():
     x, y, z = b.spatialLocator.getGlobalCoordinates()
-    b.p.pdens = x ** 2 + y ** 2 + z ** 2
+    b.p.pdens = x**2 + y**2 + z**2
 
 plotting.plotFaceMap(reactor.core, param="pdens", labelFmt="{0:.1e}")
 plotting.close()

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,8 @@ setup(
         "grids": ["wxpython==4.2.1"],
         "memprof": ["psutil"],
         "dev": [
-            "black==20.8b1",
-            "click==8.0.1",  # fixing click problem in black
+            "black==22.6",
+            "click",
             "docutils",
             "ipykernel",
             "jupyter-contrib-nbextensions",


### PR DESCRIPTION
## What is the change?

Updating to a more modern, but not totally modern, version of black for autoformatting expectations

## Why is the change being made?

We are using a pre-release quite old version of black, v20.8b1. This has led to the need to version pin click as well. So updating to v22.6 brings us closer to the present while also allowing us to un-pin click. This is 100% whitespace updates so it should be a quick review. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [ ] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [ ] The documentation is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `setup.py`.
