### PR TITLE
Fixing unform mesh issue

### DIFF
--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -413,6 +413,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         completeStartTime = timer()
         self._sourceReactor = r
+        self._sourceReactor.normalizeNames()
         self._setParamsToUpdate("in")
 
         # Here we are taking a short cut to homogenizing the core by only focusing on the
@@ -461,7 +462,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
             self._newAssembliesAdded = self.convReactor.core.getAssemblies()
 
         self.convReactor.core.updateAxialMesh()
-        self.convReactor.normalizeNames()
         self._checkConversion()
         completeEndTime = timer()
         runLog.extra(

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -506,6 +506,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         coreDesign.construct(cs, bp, newReactor, loadAssems=False)
         newReactor.p.cycle = sourceReactor.p.cycle
         newReactor.p.timeNode = sourceReactor.p.timeNode
+        newReactor.p.maxAssemNum = sourceReactor.p.maxAssemNum
         newReactor.core.p.coupledIteration = sourceReactor.core.p.coupledIteration
         newReactor.core.lib = sourceReactor.core.lib
         newReactor.core.setPitchUniform(sourceReactor.core.getAssemblyPitch())
@@ -629,6 +630,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
             between two assemblies.
         """
         newAssem = UniformMeshGeometryConverter._createNewAssembly(sourceAssem)
+        newAssem.p.assemNum = sourceAssem.p.assemNum
         runLog.debug(f"Creating a uniform mesh of {newAssem}")
         bottom = 0.0
 

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -461,6 +461,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
             self._newAssembliesAdded = self.convReactor.core.getAssemblies()
 
         self.convReactor.core.updateAxialMesh()
+        self.convReactor.normalizeNames()
         self._checkConversion()
         completeEndTime = timer()
         runLog.extra(

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -600,7 +600,6 @@ class Core(composites.Composite):
             newName = a.makeNameFromAssemNum(ind)
             if oldName == newName:
                 ind += 1
-                continue
 
             a.p.assemNum = ind
             a.setName(newName)

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -149,8 +149,9 @@ class Reactor(composites.Composite):
         ind = self.core.normalizeNames(self.p.maxAssemNum)
         self.p.maxAssemNum = ind
 
-        ind = self.sfp.normalizeNames(self.p.maxAssemNum)
-        self.p.maxAssemNum = ind
+        if self.sfp:
+            ind = self.sfp.normalizeNames(self.p.maxAssemNum)
+            self.p.maxAssemNum = ind
 
         return ind
 


### PR DESCRIPTION
## What is the change?

Fixing up the Assembly/Block names in a Reactor after the `UniformMeshConverter.convert()`.

## Why is the change being made?

A but was found downstream. We are attempting to fix it.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
