### PR TITLE
Fix assemNum parameter for uniform mesh reactor.

### DIFF
--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -434,7 +434,6 @@ class UniformMeshGeometryConverter(GeometryConverter):
                     includePinCoordinates=self.includePinCoordinates,
                 )
                 homogAssem.spatialLocator = assem.spatialLocator
-                homogAssem.p.assemNum = assem.p.assemNum
 
                 # Remove this assembly from the core and add it to the temporary storage
                 # so that it can be replaced with the homogenized assembly. Note that we
@@ -505,6 +504,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         coreDesign.construct(cs, bp, newReactor, loadAssems=False)
         newReactor.p.cycle = sourceReactor.p.cycle
         newReactor.p.timeNode = sourceReactor.p.timeNode
+        newReactor.p.maxAssemNum = sourceReactor.p.maxAssemNum
         newReactor.core.p.coupledIteration = sourceReactor.core.p.coupledIteration
         newReactor.core.lib = sourceReactor.core.lib
         newReactor.core.setPitchUniform(sourceReactor.core.getAssemblyPitch())
@@ -628,6 +628,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
             between two assemblies.
         """
         newAssem = UniformMeshGeometryConverter._createNewAssembly(sourceAssem)
+        newAssem.p.assemNum = sourceAssem.p.assemNum
         runLog.debug(f"Creating a uniform mesh of {newAssem}")
         bottom = 0.0
 


### PR DESCRIPTION
## What is the change?

When creating a new uniform mesh assembly from a `sourceAssem`, copy the `assemNum` parameter over as the first operation.

## Why is the change being made?

Previously, the `assemNum` was copied over much later in the process of creating a homogenized assembly, which resulted in the individual blocks within the homogenized assembly having a bad `assemNum` parameter and `name`.



---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
