### PR TITLE
fix indenting on deleted code block

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2023,7 +2023,7 @@ class HexBlock(Block):
         pinOuterFlatToFlat = (
             pinCenterFlatToFlat
             + clad.getDimension("od", cold=cold)
-            + wire.getDimension("od", cold=cold)
+            + 2.0 * wire.getDimension("od", cold=cold)
         )
         ductMarginToContact = duct.getDimension("ip", cold=cold) - pinOuterFlatToFlat
         pinToDuctGap = ductMarginToContact / 2.0

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1958,21 +1958,12 @@ class HexBlock(Block):
                 )
         # check gap between pins and duct
         pinToDuctGap = self.getPinToDuctGap(cold=True)
-        if pinToDuctGap is not None:
-            # Allow for some tolerance; user input precision may lead to slight negative gaps
-            if pinToDuctGap < -0.005:
-                raise ValueError(
-                    "Gap between pins and duct is {0:.4f} cm in {1}. Make more room.".format(
-                        pinToDuctGap, self
-                    )
+        if pinToDuctGap is not None and pinToDuctGap < 0.0:
+            raise ValueError(
+                "Gap between pins and duct is {0:.4f} cm in {1}. Make more room.".format(
+                    pinToDuctGap, self
                 )
-            # make sure there's room for the pins in the duct
-            wireThicknesses = wireComp.getDimension("od", cold=False)
-            if pinToDuctGap < wireThicknesses:
-                raise ValueError(
-                    f"Gap between pins and duct is {pinToDuctGap:.4f} cm in {self} which does not allow room for the wire "
-                    f"with diameter {wireThicknesses}"
-                )
+            )
         else:
             # only produce a warning if pin or clad are found, but not all of pin, clad and duct. We
             # may need to tune this logic a bit

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -289,7 +289,7 @@ class Block(composites.Composite):
         # Compute component areas
         cladID = numpy.mean([clad.getDimension("id", cold=cold) for clad in clads])
         innerCladdingArea = (
-            math.pi * (cladID ** 2) / 4.0 * self.getNumComponents(Flags.FUEL)
+            math.pi * (cladID**2) / 4.0 * self.getNumComponents(Flags.FUEL)
         )
         fuelComponentArea = 0.0
         unmovableComponentArea = 0.0
@@ -734,7 +734,6 @@ class Block(composites.Composite):
         numDensities = self.getNuclideNumberDensities(adjustList)
 
         for nuclideName, dens in zip(adjustList, numDensities):
-
             if not dens:
                 # don't modify zeros.
                 continue
@@ -1577,7 +1576,6 @@ class Block(composites.Composite):
 
 
 class HexBlock(Block):
-
     PITCH_COMPONENT_TYPE: ClassVar[_PitchDefiningComponent] = (components.Hexagon,)
 
     def __init__(self, name, height=1.0):
@@ -2079,14 +2077,10 @@ class HexBlock(Block):
                 # seeing the first one is the easiest way to detect them.
                 # Check it last in the and statement so we don't waste time doing it.
                 upperEdgeLoc = self.core.spatialGrid[-1, 2, 0]
-                if (
-                    symmetryLine
-                    in [
-                        grids.BOUNDARY_0_DEGREES,
-                        grids.BOUNDARY_120_DEGREES,
-                    ]
-                    and bool(self.core.childrenByLocator.get(upperEdgeLoc))
-                ):
+                if symmetryLine in [
+                    grids.BOUNDARY_0_DEGREES,
+                    grids.BOUNDARY_120_DEGREES,
+                ] and bool(self.core.childrenByLocator.get(upperEdgeLoc)):
                     return 2.0
         return 1.0
 
@@ -2301,7 +2295,6 @@ class HexBlock(Block):
 
 
 class CartesianBlock(Block):
-
     PITCH_DIMENSION = "widthOuter"
     PITCH_COMPONENT_TYPE = components.Rectangle
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2023,7 +2023,7 @@ class HexBlock(Block):
         pinOuterFlatToFlat = (
             pinCenterFlatToFlat
             + clad.getDimension("od", cold=cold)
-            + 2.0 * wire.getDimension("od", cold=cold)
+            + wire.getDimension("od", cold=cold)
         )
         ductMarginToContact = duct.getDimension("ip", cold=cold) - pinOuterFlatToFlat
         pinToDuctGap = ductMarginToContact / 2.0

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -939,13 +939,13 @@ class HexReactorTests(ReactorTests):
 
     def test_getAvgTemp(self):
         t0 = self.r.core.getAvgTemp([Flags.CLAD, Flags.WIRE, Flags.DUCT])
-        self.assertAlmostEqual(t0, 459.267, delta=0.01)
+        self.assertAlmostEqual(t0, 459.512, delta=0.01)
 
         t1 = self.r.core.getAvgTemp([Flags.CLAD, Flags.FUEL])
         self.assertAlmostEqual(t1, 545.043, delta=0.01)
 
         t2 = self.r.core.getAvgTemp([Flags.CLAD, Flags.WIRE, Flags.DUCT, Flags.FUEL])
-        self.assertAlmostEqual(t2, 521.95269, delta=0.01)
+        self.assertAlmostEqual(t2, 522.994, delta=0.01)
 
     def test_getScalarEvolution(self):
         self.r.core.scalarVals["fake"] = 123

--- a/armi/tests/refSmallReactorBase.yaml
+++ b/armi/tests/refSmallReactorBase.yaml
@@ -87,7 +87,7 @@ blocks:
             material: HT9
             Tinput: 450.0
             Thot: 450.0
-            ip: 14.268
+            ip: 14.5
             mult: 1.0
             op: 14.582
         duct: &component_control_duct
@@ -184,7 +184,7 @@ blocks:
             id: shield.od
             mult: shield.mult
             od: clad.id
-        duct: *component_control_duct
+        duct: *component_fuel_duct
         intercoolant: *component_fuel_intercoolant
         coolant: *component_fuel_coolant
         wire:


### PR DESCRIPTION
## What is the change?
@mgjarrett brought up a decent point in #1354 after the fact. Though it hasn't been hit recently doesn't mean that it can't get hit. It seems reasonable enough to bring back.

## Why is the change being made?
I think it might be useful in case a user defines a pin design that won't fit in a duct. 

Edit: Turns out, the armi test reactor in armi/tests actually hit this ValueError! The blueprints had to be slightly modified. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.
    - test_blocks.py could use some tidying... This is low priority so I'll leave this for now....

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
