### PR TITLE
Replace some cs["string"] with cs[CONF]

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -51,11 +51,17 @@ from armi.reactor.flags import Flags
 from armi.reactor.systemLayoutInput import SystemLayoutInput
 from armi.settings.fwSettings.globalSettings import (
     CONF_MATERIAL_NAMESPACE_ORDER,
+    CONF_FRESH_FEED_TYPE,
     CONF_SORT_REACTOR,
     CONF_GEOM_FILE,
     CONF_NON_UNIFORM_ASSEM_FLAGS,
     CONF_STATIONARY_BLOCK_FLAGS,
     CONF_ZONE_DEFINITIONS,
+    CONF_TRACK_ASSEMS,
+    CONF_CIRCULAR_RING_PITCH,
+    CONF_AUTOMATIC_VARIABLE_MESH,
+    CONF_MIN_MESH_SIZE_RATIO,
+    CONF_DETAILED_AXIAL_EXPANSION,
 )
 from armi.utils import createFormattedStrWithDelimiter, units
 from armi.utils import directoryChangers
@@ -283,13 +289,7 @@ class Core(composites.Composite):
     def setOptionsFromCs(self, cs):
         from armi.physics.fuelCycle.settings import (
             CONF_JUMP_RING_NUM,
-            CONF_FRESH_FEED_TYPE,
-            CONF_TRACK_ASSEMS,
             CONF_CIRCULAR_RING_MODE,
-            CONF_CIRCULAR_RING_PITCH,
-            CONF_AUTOMATIC_VARIABLE_MESH,
-            CONF_MIN_MESH_SIZE_RATIO,
-            CONF_DETAILED_AXIAL_EXPANSION,
         )
 
         # these are really "user modifiable modeling constants"

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -49,8 +49,20 @@ from armi.reactor import zones
 from armi.reactor.assemblyLists import SpentFuelPool
 from armi.reactor.flags import Flags
 from armi.reactor.systemLayoutInput import SystemLayoutInput
-from armi.settings.fwSettings.globalSettings import CONF_MATERIAL_NAMESPACE_ORDER
-from armi.settings.fwSettings.globalSettings import CONF_SORT_REACTOR
+from armi.settings.fwSettings.globalSettings import (
+    CONF_MATERIAL_NAMESPACE_ORDER,
+    CONF_SORT_REACTOR,
+    CONF_FRESH_FEED_TYPE,
+    CONF_TRACK_ASSEMS,
+    CONF_CIRCULAR_RING_PITCH,
+    CONF_AUTOMATIC_VARIABLE_MESH,
+    CONF_MIN_MESH_SIZE_RATIO,
+    CONF_DETAILED_AXIAL_EXPANSION,
+    CONF_GEOM_FILE,
+    CONF_NON_UNIFORM_ASSEM_FLAGS,
+    CONF_STATIONARY_BLOCK_FLAGS,
+    CONF_ZONE_DEFINITIONS,
+)
 from armi.utils import createFormattedStrWithDelimiter, units
 from armi.utils import directoryChangers
 from armi.utils.iterables import Sequence
@@ -186,7 +198,7 @@ def factory(cs, bp, geom: Optional[SystemLayoutInput] = None) -> Reactor:
         materials.setMaterialNamespaceOrder(cs[CONF_MATERIAL_NAMESPACE_ORDER])
     r = Reactor(cs.caseTitle, bp)
 
-    if cs["geomFile"]:
+    if cs[CONF_GEOM_FILE]:
         blueprints.migrate(bp, cs)
 
     if not any(structure.typ == "sfp" for structure in bp.systemDesigns.values()):
@@ -280,13 +292,13 @@ class Core(composites.Composite):
 
         # these are really "user modifiable modeling constants"
         self.p.jumpRing = cs[CONF_JUMP_RING_NUM]
-        self._freshFeedType = cs["freshFeedType"]
-        self._trackAssems = cs["trackAssems"]
+        self._freshFeedType = cs[CONF_FRESH_FEED_TYPE]
+        self._trackAssems = cs[CONF_TRACK_ASSEMS]
         self._circularRingMode = cs[CONF_CIRCULAR_RING_MODE]
-        self._circularRingPitch = cs["circularRingPitch"]
-        self._automaticVariableMesh = cs["automaticVariableMesh"]
-        self._minMeshSizeRatio = cs["minMeshSizeRatio"]
-        self._detailedAxialExpansion = cs["detailedAxialExpansion"]
+        self._circularRingPitch = cs[CONF_CIRCULAR_RING_PITCH]
+        self._automaticVariableMesh = cs[CONF_AUTOMATIC_VARIABLE_MESH]
+        self._minMeshSizeRatio = cs[CONF_MIN_MESH_SIZE_RATIO]
+        self._detailedAxialExpansion = cs[CONF_DETAILED_AXIAL_EXPANSION]
 
     def __getstate__(self):
         """Applies a settings and parent to the core and components."""
@@ -2372,7 +2384,8 @@ class Core(composites.Composite):
         else:
             # set reactor level meshing params
             nonUniformAssems = [
-                Flags.fromStringIgnoreErrors(t) for t in cs["nonUniformAssemFlags"]
+                Flags.fromStringIgnoreErrors(t)
+                for t in cs[CONF_NON_UNIFORM_ASSEM_FLAGS]
             ]
             # some assemblies, like control assemblies, have a non-conforming mesh
             # and should not be included in self.p.referenceBlockAxialMesh and self.p.axialMesh
@@ -2397,7 +2410,7 @@ class Core(composites.Composite):
         # Generate list of flags that are to be stationary during assembly shuffling
         stationaryBlockFlags = []
 
-        for stationaryBlockFlagString in cs["stationaryBlockFlags"]:
+        for stationaryBlockFlagString in cs[CONF_STATIONARY_BLOCK_FLAGS]:
             stationaryBlockFlags.append(Flags.fromString(stationaryBlockFlagString))
 
         self.stationaryBlockFlagsList = stationaryBlockFlags
@@ -2442,7 +2455,7 @@ class Core(composites.Composite):
         self.zones = zones.Zones()
 
         # parse the special input string for zone definitions
-        for zoneString in cs["zoneDefinitions"]:
+        for zoneString in cs[CONF_ZONE_DEFINITIONS]:
             zoneName, zoneLocs = zoneString.split(":")
             zoneLocs = zoneLocs.split(",")
             zone = zones.Zone(zoneName.strip())

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -52,12 +52,6 @@ from armi.reactor.systemLayoutInput import SystemLayoutInput
 from armi.settings.fwSettings.globalSettings import (
     CONF_MATERIAL_NAMESPACE_ORDER,
     CONF_SORT_REACTOR,
-    CONF_FRESH_FEED_TYPE,
-    CONF_TRACK_ASSEMS,
-    CONF_CIRCULAR_RING_PITCH,
-    CONF_AUTOMATIC_VARIABLE_MESH,
-    CONF_MIN_MESH_SIZE_RATIO,
-    CONF_DETAILED_AXIAL_EXPANSION,
     CONF_GEOM_FILE,
     CONF_NON_UNIFORM_ASSEM_FLAGS,
     CONF_STATIONARY_BLOCK_FLAGS,
@@ -287,8 +281,16 @@ class Core(composites.Composite):
         self._detailedAxialExpansion = False
 
     def setOptionsFromCs(self, cs):
-        from armi.physics.fuelCycle.settings import CONF_CIRCULAR_RING_MODE
-        from armi.physics.fuelCycle.settings import CONF_JUMP_RING_NUM
+        from armi.physics.fuelCycle.settings import (
+            CONF_JUMP_RING_NUM,
+            CONF_FRESH_FEED_TYPE,
+            CONF_TRACK_ASSEMS,
+            CONF_CIRCULAR_RING_MODE,
+            CONF_CIRCULAR_RING_PITCH,
+            CONF_AUTOMATIC_VARIABLE_MESH,
+            CONF_MIN_MESH_SIZE_RATIO,
+            CONF_DETAILED_AXIAL_EXPANSION,
+        )
 
         # these are really "user modifiable modeling constants"
         self.p.jumpRing = cs[CONF_JUMP_RING_NUM]
@@ -2204,7 +2206,7 @@ class Core(composites.Composite):
 
         for b in blockList:
             if flux2Weight:
-                weight = b.p.flux**2.0
+                weight = b.p.flux ** 2.0
             else:
                 weight = 1.0
             for c in b.iterComponents(typeSpec):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2206,7 +2206,7 @@ class Core(composites.Composite):
 
         for b in blockList:
             if flux2Weight:
-                weight = b.p.flux ** 2.0
+                weight = b.p.flux**2.0
             else:
                 weight = 1.0
             for c in b.iterComponents(typeSpec):


### PR DESCRIPTION
## What is the change?
Swapping out some (low priority) cs["string"] usages for cs[CONF_SETTING].

## Why is the change being made?
Consistency! Plus I'm tired of having to grep for the string when you can just alt-click on the CONF setting in vscode and jump straight to it. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- ~Tests have been added/updated to verify that the new/changed code works.~

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html). _well, the last commit, maybe not, but that's ok, right? lol_

<!-- Check the project-level cruft -->

-  ~The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.~
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
