### PR TITLE
Removing mako from dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
             "ipykernel",
             "jupyter-contrib-nbextensions",
             "jupyter_client",
-            "mako",
             "nbsphinx",
             "nbsphinx-link",
             "pytest",


### PR DESCRIPTION
## What is the change?

I can find no use of the `mako` library in ARMI.  

## Why is the change being made?

Either it is unused and can be deleted, or it is a secondary dependency and can be deleted.

Either way, less is more.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `setup.py`.
