### PR TITLE
move setOptionsFromCs to Core.processLoading

### DIFF
--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -139,12 +139,6 @@ class SystemBlueprint(yamlize.Object):
 
         system = self._resolveSystemType(self.typ)(self.name)
 
-        # TODO: This could be somewhere better. If system blueprints could be
-        # subclassed, this could live in the CoreBlueprint. setOptionsFromCS() also isnt
-        # great to begin with, so ideally it could be removed entirely.
-        if isinstance(system, reactors.Core):
-            system.setOptionsFromCs(cs)
-
         # Some systems may not require a prescribed grid design. Only try to use one if
         # it was provided
         if gridDesign is not None:

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2349,6 +2349,7 @@ class Core(composites.Composite):
         --------
         updateAxialMesh : Perturbs the axial mesh originally set up here.
         """
+        self.setOptionsFromCs(cs)
         runLog.header(
             "=========== Initializing Mesh, Assembly Zones, and Nuclide Categories =========== "
         )


### PR DESCRIPTION
## What is the change?
While doing some QA work for a downstream application, found a home for this TODO. We can safely move `setOptionsFromCs` for `reactor.Core` objects onto `Core.processLoading`.

## Why is the change being made?
To clean out a TODO and try and make the code a little easier to understand.

Note, I have run this on a downstream application and reactor loading runs to completion.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- ~Tests have been added/updated to verify that the new/changed code works.~

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- ~The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.~
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `setup.py`.
