### PR TITLE
Cleanup allowing xml file as a settings file

### DIFF
--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -103,7 +103,7 @@ class CaseSuite:
         """
         csFiles = settings.recursivelyLoadSettingsFiles(
             rootDir or os.path.abspath(os.getcwd()),
-            patterns or ["*.yaml", "*.xml"],  # xml temporary to transistion
+            patterns or ["*.yaml"],
             recursive=recursive,
             ignorePatterns=ignorePatterns,
             handleInvalids=False,


### PR DESCRIPTION
## What is the change?

Removing `xml` as an allowable file for settings file discovery

## Why is the change being made?

The comment that xml files were there for a transition is 4 years old. @mgjarrett noticed this while troubleshooting an issue so I'm just making the PR to do the cleanup.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [ ] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [ ] The documentation is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
