### PR TITLE
Rename reqs using R_, T_, and I_

### DIFF
--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -23,8 +23,8 @@ often from initial startup, through the various cycles, and out to
 the end of plant life.
 
 .. impl:: ARMI controls the time flow of the reactor, by running a sequence of Interfaces at each time step.
-   :id: IMPL_EVOLVING_STATE_0
-   :links: REQ_EVOLVING_STATE
+   :id: I_EVOLVING_STATE_0
+   :links: R_EVOLVING_STATE
 """
 import collections
 import os

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -56,7 +56,7 @@ class InterfaceC(Interface):
     name = "Third"
 
 
-# TODO: Add a test that shows time evolution of Reactor (REQ_EVOLVING_STATE)
+# TODO: Add a test that shows time evolution of Reactor (R_EVOLVING_STATE)
 class OperatorTests(unittest.TestCase):
     def setUp(self):
         self.o, self.r = test_reactors.loadTestReactor()

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -175,8 +175,8 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
     Base Blueprintsobject representing all the subsections in the input file.
 
     .. impl:: ARMI represents a user-specified reactor by providing a "Blueprint" YAML interface.
-        :id: IMPL_REACTOR_0
-        :links: REQ_REACTOR
+        :id: I_REACTOR_0
+        :links: R_REACTOR
     """
 
     nuclideFlags = yamlize.Attribute(

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -68,8 +68,8 @@ class TestBlueprints(unittest.TestCase):
         """Tests the available sets of nuclides work as expected.
 
         .. test:: Tests that users can define their nuclides of interest.
-            :id: TEST_REACTOR_0
-            :links: REQ_REACTOR
+            :id: T_REACTOR_0
+            :links: R_REACTOR
         """
         actives = set(self.blueprints.activeNuclides)
         inerts = set(self.blueprints.inertNuclides)
@@ -95,8 +95,8 @@ class TestBlueprints(unittest.TestCase):
         """Tests that the user can specifiy the dimensions of a component with arbitray fidelity.
 
         .. test:: Tests that the user can specify the dimensions of a component with arbitrary fidelity.
-            :id: TEST_REACTOR_1
-            :links: REQ_REACTOR
+            :id: T_REACTOR_1
+            :links: R_REACTOR
         """
         fuelAssem = self.blueprints.constructAssem(self.cs, name="igniter fuel")
         fuel = fuelAssem.getComponents(Flags.FUEL)[0]

--- a/armi/reactor/components/basicShapes.py
+++ b/armi/reactor/components/basicShapes.py
@@ -19,8 +19,8 @@ Many reactor components can be described in 2D by circles, hexagons, rectangles,
 are defined in this subpackage.
 
 .. impl:: ARMI supports a reasonable set of basic shapes.
-   :id: IMPL_REACTOR_SHAPES_0
-   :links: REQ_REACTOR_SHAPES
+   :id: I_REACTOR_SHAPES_0
+   :links: R_REACTOR_SHAPES
 
    Here ARMI implements its support for: Circles, Hexagons, Rectangles, Solid Rectangles,
    Squares, and Triangles.

--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -16,8 +16,8 @@
 Components represented by complex shapes, and typically less widely used.
 
 .. impl:: ARMI supports a reasonable set of basic shapes.
-   :id: IMPL_REACTOR_SHAPES_1
-   :links: REQ_REACTOR_SHAPES
+   :id: I_REACTOR_SHAPES_1
+   :links: R_REACTOR_SHAPES
 
    Here ARMI implements its support for: Holed Hexagons, Holed Rectangles,
    Holed Squares, and Helixes.

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -181,8 +181,8 @@ class Component(composites.Composite, metaclass=ComponentType):
         The material object that makes up this component and give it its thermo-mechanical properties.
 
     .. impl:: ARMI allows for thermal expansion of all components by user-defined custom curves.
-       :id: IMPL_REACTOR_THERMAL_EXPANSION_0
-       :links: REQ_REACTOR_THERMAL_EXPANSION
+       :id: I_REACTOR_THERMAL_EXPANSION_0
+       :links: R_REACTOR_THERMAL_EXPANSION
     """
 
     DIMENSION_NAMES = tuple()  # will be assigned by ComponentType

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -15,8 +15,8 @@
 """3-dimensional shapes.
 
 .. impl:: ARMI supports a reasonable set of basic shapes.
-   :id: IMPL_REACTOR_SHAPES_2
-   :links: REQ_REACTOR_SHAPES
+   :id: I_REACTOR_SHAPES_2
+   :links: R_REACTOR_SHAPES
 
    Here ARMI implements its support for: Cubes, Spheres, RadialSegments, and more.
 """

--- a/armi/reactor/grids/cartesian.py
+++ b/armi/reactor/grids/cartesian.py
@@ -69,8 +69,8 @@ class CartesianGrid(StructuredGrid):
         location is offset from the origin.
 
     .. impl:: ARMI supports a Cartesian mesh.
-       :id: IMPL_REACTOR_MESH_1
-       :links: REQ_REACTOR_MESH
+       :id: I_REACTOR_MESH_1
+       :links: R_REACTOR_MESH
     """
 
     @classmethod

--- a/armi/reactor/grids/hexagonal.py
+++ b/armi/reactor/grids/hexagonal.py
@@ -69,8 +69,8 @@ class HexGrid(StructuredGrid):
                 (-1, 0) ( 0,-1)
 
     .. impl:: ARMI supports a Hexagonal mesh.
-       :id: IMPL_REACTOR_MESH_2
-       :links: REQ_REACTOR_MESH
+       :id: I_REACTOR_MESH_2
+       :links: R_REACTOR_MESH
     """
 
     @staticmethod

--- a/armi/reactor/grids/structuredgrid.py
+++ b/armi/reactor/grids/structuredgrid.py
@@ -138,8 +138,8 @@ class StructuredGrid(Grid):
       indices. Thus we reduce the size of the unitSteps tuple accordingly.
 
     .. impl:: ARMI supports a number of structured mesh options.
-       :id: IMPL_REACTOR_MESH_0
-       :links: REQ_REACTOR_MESH
+       :id: I_REACTOR_MESH_0
+       :links: R_REACTOR_MESH
     """
 
     def __init__(

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -226,8 +226,8 @@ class TestHexGrid(unittest.TestCase):
     """A set of tests for the Hexagonal Grid.
 
     .. test: Tests of the Hexagonal grid.
-       :id: TEST_REACTOR_MESH_0
-       :link: REQ_REACTOR_MESH
+       :id: T_REACTOR_MESH_0
+       :link: R_REACTOR_MESH
     """
 
     def test_positions(self):
@@ -493,8 +493,8 @@ class TestThetaRZGrid(unittest.TestCase):
     """A set of tests for the RZTheta Grid.
 
     .. test: Tests of the RZTheta grid.
-       :id: TEST_REACTOR_MESH_1
-       :link: REQ_REACTOR_MESH
+       :id: T_REACTOR_MESH_1
+       :link: R_REACTOR_MESH
     """
 
     def test_positions(self):
@@ -516,8 +516,8 @@ class TestCartesianGrid(unittest.TestCase):
     """A set of tests for the Cartesian Grid.
 
     .. test: Tests of the Cartesian grid.
-       :id: TEST_REACTOR_MESH_2
-       :link: REQ_REACTOR_MESH
+       :id: T_REACTOR_MESH_2
+       :link: R_REACTOR_MESH
     """
 
     def test_ringPosNoSplit(self):

--- a/armi/reactor/grids/thetarz.py
+++ b/armi/reactor/grids/thetarz.py
@@ -39,8 +39,8 @@ class ThetaRZGrid(StructuredGrid):
     See Figure 2.2 in Derstine 1984, ANL. [DIF3D]_.
 
     .. impl:: ARMI supports an RZTheta mesh.
-       :id: IMPL_REACTOR_MESH_3
-       :links: REQ_REACTOR_MESH
+       :id: I_REACTOR_MESH_3
+       :links: R_REACTOR_MESH
     """
 
     def getSymmetricEquivalents(self, indices: IJType) -> NoReturn:

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -21,8 +21,8 @@ more refinement in representing the physical reactor. The reactor is the owner o
 plant-wide state variables such as keff, cycle, and node.
 
 .. impl:: ARMI represents the Reactor heirarchically.
-   :id: IMPL_REACTOR_HIERARCHY_0
-   :links: REQ_REACTOR_HIERARCHY
+   :id: I_REACTOR_HIERARCHY_0
+   :links: R_REACTOR_HIERARCHY
 
    The Reactor contains a Core, which contains a heirachical collection of Assemblies, which in turn
    each contain a collection of Blocks.

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -260,8 +260,8 @@ class TestShapedComponent(TestGeneralComponents):
         """Test that when we thermally expand any arbitrary shape, mass is conserved.
 
         .. test:: Test that ARMI can thermally expand any arbitrary shape.
-           :id: TEST_REACTOR_THERMAL_EXPANSION_0
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_0
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         if not self.component.THERMAL_EXPANSION_DIMS:
             return
@@ -373,8 +373,8 @@ class TestCircle(TestShapedComponent):
         """Test that when ARMI thermally expands a circle, mass is conserved.
 
         .. test:: Test that ARMI correctly thermally expands objects with circular shape.
-           :id: TEST_REACTOR_THERMAL_EXPANSION_1
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_1
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         hotTemp = 700.0
         dLL = self.component.material.linearExpansionFactor(
@@ -394,8 +394,8 @@ class TestCircle(TestShapedComponent):
         """Test that ARMI can thermally expands a circle.
 
         .. test:: Test that ARMI can thermally expands a circle
-           :id: TEST_REACTOR_THERMAL_EXPANSION_2
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_2
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
 
@@ -712,8 +712,8 @@ class TestTriangle(TestShapedComponent):
         """Test that ARMI can thermally expands a triangle.
 
         .. test:: Test that ARMI can thermally expands a triangle
-           :id: TEST_REACTOR_THERMAL_EXPANSION_3
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_3
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
 
@@ -780,8 +780,8 @@ class TestRectangle(TestShapedComponent):
         """Test that ARMI can thermally expands a rectangle.
 
         .. test:: Test that ARMI can thermally expands a rectangle
-           :id: TEST_REACTOR_THERMAL_EXPANSION_4
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_4
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
 
@@ -826,8 +826,8 @@ class TestSolidRectangle(TestShapedComponent):
         """Test that ARMI can thermally expands a solid rectangle.
 
         .. test:: Test that ARMI can thermally expands a solid rectangle
-           :id: TEST_REACTOR_THERMAL_EXPANSION_5
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_5
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
 
@@ -889,8 +889,8 @@ class TestSquare(TestShapedComponent):
         """Test that ARMI can thermally expands a square.
 
         .. test:: Test that ARMI can thermally expands a square
-           :id: TEST_REACTOR_THERMAL_EXPANSION_6
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_6
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
 
@@ -954,8 +954,8 @@ class TestCube(TestShapedComponent):
         """Test that ARMI can thermally expands a cube.
 
         .. test:: Test that ARMI can thermally expands a cube
-           :id: TEST_REACTOR_THERMAL_EXPANSION_7
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_7
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         self.assertFalse(self.component.THERMAL_EXPANSION_DIMS)
 
@@ -993,8 +993,8 @@ class TestHexagon(TestShapedComponent):
         """Test that ARMI can thermally expands a hexagon.
 
         .. test:: Test that ARMI can thermally expands a hexagon
-           :id: TEST_REACTOR_THERMAL_EXPANSION_8
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_8
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
 
@@ -1057,8 +1057,8 @@ class TestHoledHexagon(TestShapedComponent):
         """Test that ARMI can thermally expands a holed hexagon.
 
         .. test:: Test that ARMI can thermally expands a holed hexagon
-           :id: TEST_REACTOR_THERMAL_EXPANSION_9
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_9
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
 
@@ -1108,8 +1108,8 @@ class TestHexHoledCircle(TestShapedComponent):
         """Test that ARMI can thermally expands a holed hexagon.
 
         .. test:: Test that ARMI can thermally expands a holed hexagon
-           :id: TEST_REACTOR_THERMAL_EXPANSION_10
-           :links: REQ_REACTOR_THERMAL_EXPANSION
+           :id: T_REACTOR_THERMAL_EXPANSION_10
+           :links: R_REACTOR_THERMAL_EXPANSION
         """
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
 

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -374,8 +374,8 @@ class HexReactorTests(ReactorTests):
         """Tests that the users definition of fuel blocks is preserved.
 
         .. test:: Tests that the users definition of fuel blocks is preserved.
-            :id: TEST_REACTOR_2
-            :links: REQ_REACTOR
+            :id: T_REACTOR_2
+            :links: R_REACTOR
         """
         numFuelBlocks = self.r.core.countFuelAxialBlocks()
         self.assertEqual(numFuelBlocks, 3)

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -140,8 +140,8 @@ class TestGeneralUtils(unittest.TestCase):
         """Tests the classesInHierarchy utility.
 
         .. test:: Tests that the Reactor is stored heirarchically
-           :id: TEST_REACTOR_HIERARCHY_0
-           :links: REQ_REACTOR_HIERARCHY
+           :id: T_REACTOR_HIERARCHY_0
+           :links: R_REACTOR_HIERARCHY
 
            This test shows that the Blocks and Assemblies are stored
            heirarchically inside the Core, which is inside the Reactor object.

--- a/doc/requirements/srsd.rst
+++ b/doc/requirements/srsd.rst
@@ -32,25 +32,25 @@ Functional Requirements
 -----------------------
 
 .. req:: The database shall maintain fidelity of data.
-   :id: REQ_DB_FIDELITY
+   :id: R_DB_FIDELITY
    :status: needs implementation, needs test
 
 The database shall faithfully represent the possessed information and not alter its contents, retrieving the data exactly as input.
 
 .. req:: The database shall allow case restarts.
-   :id: REQ_DB_RESTARTS
+   :id: R_DB_RESTARTS
    :status: needs implementation, needs test
 
 The state information representing as near as possible the entirety of the run when the database write was executed, shall be retrievable to restore the previous case to a particular point in time for further use by analysts.
 
 .. req:: The database shall accept all pythonic primitive data types.
-   :id: REQ_DB_PRIMITIVES
+   :id: R_DB_PRIMITIVES
    :status: needs implementation, needs test
 
 Given the ubiquity of Python's ``None`` the database shall support its inclusion as a valid entry for data. There will be no support for any abstract data type beyond None.
 
 .. req:: The report package shall maintain data fidelity.
-   :id: REQ_REPORT_FIDELITY
+   :id: R_REPORT_FIDELITY
    :status: implemented, needs more tests
 
 The report package shall not modify or subvert data integrity as it reports the information out to the user.
@@ -60,7 +60,7 @@ The report package shall not modify or subvert data integrity as it reports the 
    TODO: blueprints need some interface and I/O reqs
 
 .. req:: The settings package shall not accept ambiguous setting definitions.
-   :id: REQ_SETTINGS_UNAMBIGUOUS
+   :id: R_SETTINGS_UNAMBIGUOUS
    :status: implemented, needs more tests
 
 Settings defined in the system must have both the intended data type and default value defined, or it is considered incomplete and therefore invalid. Additionally the system shall not accept multiple definitions of the same name.
@@ -68,7 +68,7 @@ Settings defined in the system must have both the intended data type and default
 TODO: This may be tested by a unit test loading in duplicate setting definitions or cases where a definition does not provide adequate details.
 
    .. req:: Settings shall have unique, case-insensitive names.
-      :id: REQ_SETTINGS_UNAMBIGUOUS_NAME
+      :id: R_SETTINGS_UNAMBIGUOUS_NAME
       :status: implemented, needs more tests
 
    No two settings may share names.
@@ -76,7 +76,7 @@ TODO: This may be tested by a unit test loading in duplicate setting definitions
    TODO: This may be tested by a unit test loading two similar names
 
    .. req:: Settings shall not allow dynamic typing.
-      :id: REQ_SETTINGS_UNAMBIGUOUS_TYPE
+      :id: R_SETTINGS_UNAMBIGUOUS_TYPE
       :status: implemented, needs more tests
 
    Settings shall exist exclusively as a well-defined data type, as chosen by the setting definition.
@@ -84,7 +84,7 @@ TODO: This may be tested by a unit test loading in duplicate setting definitions
    TODO: This may be tested by unit tests attempting to subvert the contained data type.
 
    .. req:: The settings package shall contain a default state of all settings.
-      :id: REQ_SETTINGS_DEFAULTS
+      :id: R_SETTINGS_DEFAULTS
       :status: implemented, needs more tests
 
    Many of the settings will not be altered by the user of a run, and there will likely be too many for a user to deal with on an individual basis. Therefore, most settings will need to function sensibly with their default value. This default value shall always be accessible throughout the runs life cycle.
@@ -92,7 +92,7 @@ TODO: This may be tested by a unit test loading in duplicate setting definitions
    TODO: This may be tested by unit tests loading and checking values on each setting.
 
 .. req:: Settings shall support more complex rule association to further customize each setting's behavior.
-   :id: REQ_SETTINGS_RULES
+   :id: R_SETTINGS_RULES
    :status: implemented, needs more tests
 
 It shall be possible to support a valid list or range of values for any given setting.
@@ -100,7 +100,7 @@ It shall be possible to support a valid list or range of values for any given se
 TODO: This may be tested by a unit test attempting to set a value outside a given min/max range.
 
 .. req:: Setting addition, renaming, and removal shall be supported.setting's behavior.
-   :id: REQ_SETTINGS_CHANGES
+   :id: R_SETTINGS_CHANGES
    :status: implemented, needs more tests
 
 The setting package shall accomodate the introduction of new settings, renaming of old settings, and support the complex deprecation behaviors of settings.
@@ -108,7 +108,7 @@ The setting package shall accomodate the introduction of new settings, renaming 
 TODO: This may be tested by a unit test containing removed settings references in both input and code references, as well as an additional definition load and use
 
 .. req:: The settings package shall support version tracking.
-   :id: REQ_SETTINGS_VERSION
+   :id: R_SETTINGS_VERSION
    :status: implemented, needs more tests
 
 Each settings file is only genuinely valid with the version of ARMI that generated the file, as settings might change between versions. As a safegaurd of this, the settings system shall alert the user if the version of the settings file does not match the version of ARMI in-memory.
@@ -116,7 +116,7 @@ Each settings file is only genuinely valid with the version of ARMI that generat
 TODO: This may be tested by unit tests with out of date or omitted version information
 
 .. req:: The settings system shall raise an error if the same setting is created twice.
-   :id: REQ_SETTINGS_DUPLICATES
+   :id: R_SETTINGS_DUPLICATES
    :status: implemented, needs more tests
 
 When a user creates a setting twice, it shall be detected as an error which is raised to the user.
@@ -124,63 +124,63 @@ When a user creates a setting twice, it shall be detected as an error which is r
 TODO: This may be tested by unit tests loading and checking settings that have a setting created twice, and failing.
 
 .. req:: ARMI shall be able to represent a user-specified reactor.
-   :id: REQ_REACTOR
+   :id: R_REACTOR
    :status: implemented, needs more tests
 
    Given user input describing a reactor, ARMI shall construct with equivalent fidelity a software model of the reactor. In particular, ARMI shall appropriately represent the shape, arrangement, connectivity, dimensions, materials (including thermo-mechanical properties), isotopic composition, and temperatures of the reactor.
 
    .. req:: ARMI shall represent the reactor hierarchically.
-      :id: REQ_REACTOR_HIERARCHY
+      :id: R_REACTOR_HIERARCHY
       :status: completed
 
       To maintain consistency with the physical reactor being modeled, ARMI shall maintain a hierarchical definition of its components. For example, all the fuel pins in a single fuel assembly in a solid-fuel reactor shall be collected such that they can be queried or modified as a unit as well as individuals.
 
    .. req:: ARMI shall automatically handle thermal expansion.
-      :id: REQ_REACTOR_THERMAL_EXPANSION
+      :id: R_REACTOR_THERMAL_EXPANSION
       :status: completed
 
       ARMI shall automatically compute and applied thermal expansion and contraction
       of materials.
 
    .. req:: ARMI shall support a reasonable set of basic shapes.
-      :id: REQ_REACTOR_SHAPES
+      :id: R_REACTOR_SHAPES
       :status: implemented, needs more tests
 
       ARMI shall support the following basic shapes: Hexagonal prism (ducts in fast reactors), rectangular prism (ducts in thermal reactors), cylindrical prism (fuel pins, cladding, etc.), and helix (wire wrap).
 
    .. req:: ARMI shall support a number of structured mesh options.
-      :id: REQ_REACTOR_MESH
+      :id: R_REACTOR_MESH
       :status: completed
 
       ARMI shall support regular, repeating meshes in hexagonal, radial-zeta-theta (RZT), and Cartesian structures.
 
    .. req:: ARMI shall support the specification of symmetry options and boundary conditions.
-      :id: REQ_REACTOR_4
+      :id: R_REACTOR_4
       :status: implemented, need impl/test
 
       ARMI shall support symmetric models including 1/4, 1/8 core models for Cartesian meshes and 1/3 and full core for Hex meshes. For Cartesian 1/8 core symmetry, the core axial symmetry plane (midplane) will be located at the top of the reactor.
 
    .. req:: ARMI shall check for basic correctness.
-      :id: REQ_REACTOR_5
+      :id: R_REACTOR_5
       :status: implemented, need impl/test
 
       ARMI shall check its input for certain obvious errors including unphysical densities and proper fit.
 
    .. req:: ARMI shall allow for the definition of limited one-dimensional translation paths.
-      :id: REQ_REACTOR_6
+      :id: R_REACTOR_6
       :status: implemented, need impl/test
 
       ARMI shall allow the user specification of translation pathways for certain objects to
       follow, to support moving control mechanisms.
 
    .. req:: ARMI shall allow the definition of fuel management operations (i.e. shuffling)
-      :id: REQ_REACTOR_7
+      :id: R_REACTOR_7
       :status: implemented, need impl/test
 
       ARMI shall allow for the modeling of a reactor over multiple cycles.
 
 .. req:: ARMI shall represent and reflect the evolving state of a reactor.
-   :id: REQ_1
+   :id: R_1
    :status: needs implementation, needs test
 
    The reactor state shale be made available to users and plugins, which may in turn modify the state. ARMI shall fully define how all aspects of state may be accessed and modified and shall reflect any new state after it is applied.
@@ -188,41 +188,41 @@ TODO: This may be tested by unit tests loading and checking settings that have a
    The reactor state shall be represented as evolving either through time (i.e. in a typical cycle-by-cycle analysis) or through a series of control configurations.
 
 .. req:: The operator package shall provide a means by which to communicate inputs and results between analysis plugins.
-   :id: REQ_OPERATOR_IO
+   :id: R_OPERATOR_IO
    :status: needs implementation, needs test
 
 The operator package shall receive output from calculation Plugins and store the results on a well-defined central model. A composite pattern shall be used, with a Reactor containing Assemblies containing Blocks, etc.
 
 .. req:: The operator package shall provide a means to perform computations in parallel on a high performance computer.
-   :id: REQ_OPERATOR_PARALLEL
+   :id: R_OPERATOR_PARALLEL
    :status: needs implementation, needs test
 
 Many analysis tasks require high performance computing (HPC), and the operator package shall contain utilities and routines to communicate with an HPC and to facilitate execution of simulations in parallel.
 
 .. req:: The operator package shall allow physics coupling between analysis plugins.
-   :id: REQ_OPERATOR_COUPLING
+   :id: R_OPERATOR_COUPLING
    :status: implemented, needs more tests
 
 For coupled physics (e.g. neutronics depends on thermal hydraulics depends on neutronics), the operator package shall allow loose and/or tight coupling. Loose coupling is using the values from the previous timestep to update the next timestep. Tight is an operator-splitting iteration until convergence between one or more plugins.
 
 .. req:: The operator package shall allow analysis plugins to be replaced without affecting interfaces in other plugins.
-   :id: REQ_OPERATOR_ANALYSIS
+   :id: R_OPERATOR_ANALYSIS
    :status: needs implementation, needs test
 
 Often, a plugin is replaced with a new plugin fulfilling some new requirement. When this happens, the operator package shall isolate required changes to the new plugin. For example, if a fuel performance plugin needs temperatures but the temperature-computing plugin is replaced, the fuel performance plugin should require no changes to work with the drop-in replacement. This requires modular design and standardization in state names.
 
 .. req:: The operator package shall coordinate calls to the various plugins.
-   :id: REQ_OPERATOR_COORD
+   :id: R_OPERATOR_COORD
    :status: needs implementation, needs test
 
 Based on user settings, the ordering, initialization, and calls to other plugins shall be coordinated by the operator package. The operator package must therefore be aware of dependencies of each plugin.
 
 .. req:: The latticePhysics package will execute the lattice physics code in a parallel or serial fashion depending on the mode.
-   :id: REQ_LATTICE_EXE
+   :id: R_LATTICE_EXE
    :status: needs implementation, needs test
 
 .. req:: The nucDirectory package shall contain basic nuclide information for a wide range of nuclides.
-   :id: REQ_NUCDIR_INFO
+   :id: R_NUCDIR_INFO
    :status: needs implementation, needs test
 
 The nucDirectory package shall contain the following general information for each nuclide:
@@ -236,7 +236,7 @@ The nucDirectory package shall contain the following general information for eac
 - meta stable state
 
 .. req:: The nucDirectory package shall store data separately from code.
-   :id: REQ_NUCDIR_FILES
+   :id: R_NUCDIR_FILES
    :status: needs implementation, needs test
 
 The software shall be made flexible such that the definition of specific nuclides available (i.e. those used in a version of MCC), can be updated without modifying the code.
@@ -244,7 +244,7 @@ The software shall be made flexible such that the definition of specific nuclide
 TODO: This can be tested by inspecting the logic of the code to retrieve data from a resource file, or by modifying the resource file to create an expected outcome.
 
 .. req:: The nucDirectory package shall enforce unique nuclide names.
-   :id: REQ_NUCDIR_UNIQUE
+   :id: R_NUCDIR_UNIQUE
    :status: needs implementation, needs test
 
 The nuclides names shall be unique, and consist of the nuclide's symbol, mass number, and an indication if it is in a meta-stable state. Elemental nuclides shall omit the mass number, since they represent more than a single mass number. Lumped nuclides shall also have unqiue, user-data identified names.
@@ -252,7 +252,7 @@ The nuclides names shall be unique, and consist of the nuclide's symbol, mass nu
 TODO: A unit test can be used to demonstrate that all nuclide names are unique.
 
 .. req:: The nucDirectory package shall be capable of generating unique 4-character labels.
-   :id: REQ_NUCDIR_LABELS
+   :id: R_NUCDIR_LABELS
    :status: needs implementation, needs test
 
 Versions 2 and 3 of MCC allow for unique 6 character labels to be used to reference nuclides. Two characters need to be used to describe the different cross section sets used by the problem. Therefore, every nuclide in ARMI needs to have a unique 4 character representation to use in MCC and the downstream global flux solver.
@@ -260,7 +260,7 @@ Versions 2 and 3 of MCC allow for unique 6 character labels to be used to refere
 TODO: A unit test can be used to demonstrate that all nuclides have unique 4-character labels.
 
 .. req:: The nucDirectory package shall allow for use of lumped nuclides.
-   :id: REQ_NUCDIR_LUMPED
+   :id: R_NUCDIR_LUMPED
    :status: needs implementation, needs test
 
 Lumped nuclides are bulk defined nuclides that are typically used when modeling fission products. Lumping the nuclides during burnup calculations lowers the problem size without having a significant impact on the results. Consequently, they do not always need to be modeled individually, but can be grouped.
@@ -268,19 +268,19 @@ Lumped nuclides are bulk defined nuclides that are typically used when modeling 
 TODO: A unit test can be used to demonstrate that lumped nuclides can be used and created.
 
 .. req:: The nucDirectory package shall allow for elemental nuclides.
-   :id: REQ_NUCDIR_ELEMENTALS
+   :id: R_NUCDIR_ELEMENTALS
    :status: needs implementation, needs test
 
 The nuclear data libraries available in versions 2 and 3 of MCC do not always allow for nuclide input, and some materials are grouped into elemental nuclides. Iron is an example of this in MCC version 2. Consequently, ARMI needs to be able to model elemental nuclides which represent the entire element, as well as the individual nuclides.
 
 .. req:: The nucDirectory package shall allow for dummy nuclides.
-   :id: REQ_NUCDIR_DUMMY
+   :id: R_NUCDIR_DUMMY
    :status: needs implementation, needs test
 
 Dummy nuclides, typically written in all capitals as "DUMMY", are used to truncate the burn chain in order to reduce the problem size without compromising the results.
 
 .. req:: The nucDirectory package shall allow for indexing of nuclide information.
-   :id: REQ_NUCDIR_INDEX
+   :id: R_NUCDIR_INDEX
    :status: needs implementation, needs test
 
 The nuclear data files created by physics codes such as MCC and DIF3D may not necessary correspond to the name used within ARMI, it will be necessary to load nuclide information based on a non-ARMI name. The software shall provide lookup mechanisms for nuclide objects based on:
@@ -290,7 +290,7 @@ The nuclear data files created by physics codes such as MCC and DIF3D may not ne
 - MCC versions 2 and 3 IDs
 
 .. req:: The nucDirectory package shall contain decay chain data.
-   :id: REQ_NUCDIR_DECAY_CHAIN
+   :id: R_NUCDIR_DECAY_CHAIN
    :status: needs implementation, needs test
 
 The decay chain is an important step in performing burn-up calculations. The nucDirectory shall contain necessary decay mechanisms:
@@ -306,7 +306,7 @@ The nucDirectory shall contain the half-life, decay mode(s) with corresponding b
 TODO: A unit test can be generated to test that the correct decay chain is present, and that the data matches other resources.
 
 .. req:: The nucDirectory package shall contain transmutation data.
-   :id: REQ_NUCDIR_TRANSMUTE
+   :id: R_NUCDIR_TRANSMUTE
    :status: needs implementation, needs test
 
 In addition to the decay chain, nuclides may transmute through interactions into other nuclides. The nucDirectory shall contain transmutations including:
@@ -323,7 +323,7 @@ The nucDirectory shall contain the transmutation mechanism, branch ratio, and pr
 TODO: A unit test can be generated to test that the correct transmutations are present, and corresponding data matches other resources.
 
 .. req:: The nucDirectory package shall warn the user if there are potential burn-chain faults.
-   :id: REQ_NUCDIR_BURN_CHAIN
+   :id: R_NUCDIR_BURN_CHAIN
    :status: needs implementation, needs test
 
 The user supplies the nuclides to be modeled in the simulation; therefore, it is possible that the user may inadvertently describe a burn-chain that is not complete. The software shall be capable of detecting erroneous user input and terminate the program.
@@ -331,7 +331,7 @@ The user supplies the nuclides to be modeled in the simulation; therefore, it is
 TODO: A unit test can be generated with faulty decay chains to determine that they do not work.
 
 .. req:: The nuclearDataIO package shall read and write ISOTXS files.
-   :id: REQ_NUCDATA_ISOTXS
+   :id: R_NUCDATA_ISOTXS
    :status: needs implementation, needs test
 
 ISOTXS files contain the multi-group microscopic cross sections, and other nuclear data, for each nuclide being modeled. The multi-group cross sections are used throughout ARMI.
@@ -341,7 +341,7 @@ The software shall be capable of reading an ISOTXS file into memory, and writing
 TODO: A unit test can be created with reads an ISOTXS file generated by MCC, and then writes out the file to another name. The two files can then be compared using a binary file comparison to demonstrate that the contents of the files are identical.
 
 .. req:: The nuclearDataIO package shall read and write GAMISO files.
-   :id: REQ_NUCDATA_GAMISO
+   :id: R_NUCDATA_GAMISO
    :status: needs implementation, needs test
 
 GAMISO files are generated by MCC-v3, and are the same format as an ISOTXS file. The file contains photon interaction cross sections instead of neutron cross sections.
@@ -351,7 +351,7 @@ The software shall be capable of reading a GAMISO file into memory, and writing 
 TODO: This can be covered in a unit test; the unit test can be the same as described for ISOTXS files.
 
 .. req:: The nuclearDataIO package shall read and write PMATRX files.
-   :id: REQ_NUCDATA_PMATRX
+   :id: R_NUCDATA_PMATRX
    :status: needs implementation, needs test
 
 PMATRX files contain the gamma production matrix resulting from fission or capture events. Given a neutron flux distribution, and a PMATRX file, the gamma source can be computed and then used to determine gamma transport and heating.
@@ -368,7 +368,7 @@ The software shall be capable of reading a DLAYXS file into memory, and writing 
 TODO: This can be covered in a unit test; the unit test can be the same as described for ISOTXS files.
 
 .. req:: The nuclearDataIO package shall merge files of the same type.
-   :id: REQ_NUCDATA_MERGE
+   :id: R_NUCDATA_MERGE
    :status: needs implementation, needs test
 
 The software shall be capable merging multiple files of the same type (ISOTXS, PMATRX, etc.) into a single file meeting the specifications. The software shall fail with a descriptive error message if any two nuclides have the same name.
@@ -380,13 +380,13 @@ This can be covered in a unit test which runs 3 MCC-v3 cases.
 The third MCC-v3 case will produce a merged ISOTXS file which can be compared to an ISOTXS file generated by merging the output ISOTXS from cases 1 and 2.
 
 .. req:: The nuclearDataIO package shall make the data programmatically available.
-   :id: REQ_NUCDATA_AVAIL
+   :id: R_NUCDATA_AVAIL
    :status: needs implementation, needs test
 
 The software shall make the nuclear data provided in ISOTXS, GAMISO, PMATRX and DLAYXS available in the form of Python objects, such that it can be used elsewhere in the code, such as in the depletion, nuclear uncertainty quantification, and `\beta` calculations.
 
    .. req:: The nuclearDataIO package shall key nuclear data based on nuclide label and xsID.
-      :id: REQ_NUCDATA_AVAIL_LABEL
+      :id: R_NUCDATA_AVAIL_LABEL
       :status: needs implementation, needs test
 
 When nuclear data files are read, they should be made available in a container object, such as a dictionary, and keyed on the nuclide label (a unique four character nuclide identifier) and the cross section ID, a two character identifier for block type and burnup group.
@@ -394,7 +394,7 @@ When nuclear data files are read, they should be made available in a container o
 TODO: This can be covered by a unit test which reads an ISOTXS into a container object, and then obtaining cross sections by using the nuclide label and xsID.
 
    .. req:: The nuclearDataIO package shall be able to remove nuclides from specifc nuclear data files.
-      :id: REQ_NUCDATA_AVAIL_FILES
+      :id: R_NUCDATA_AVAIL_FILES
       :status: needs implementation, needs test
 
 ARMI has a concept of "lumped fission products" that result in more nuclides being in ISOTXS, GAMISO, and PMATRX files than are needed for subsequent calculations. The software shall be capable of removing the unused nuclides from ISOTXS, GAMISO, and PMATRX files. This generally does not apply to DLAYXS files, because they typically only contain nuclides that fission.
@@ -402,7 +402,7 @@ ARMI has a concept of "lumped fission products" that result in more nuclides bei
 TODO: This can be covered by a unit test where a file is read in, a nuclide removed, and then rewritten and reread. The reread file should not contain the removed nuclides.
 
    .. req:: The nuclearDataIO package shall be able to modify the nuclear data.
-      :id: REQ_NUCDATA_AVAIL_MODIFY
+      :id: R_NUCDATA_AVAIL_MODIFY
       :status: needs implementation, needs test
 
 In order to calculate the uncertainties of our methodology introduced by nuclear data uncertainty, it is necessary to be able to perturb (i.e. modify) specific values within the nuclear data files.
@@ -414,26 +414,26 @@ Performance Requirements
 ------------------------
 
 .. req:: The database representation on disk shall be smaller than the the in-memory Python representation
-   :id: REQ_DB_PERFORMANCE
+   :id: R_DB_PERFORMANCE
    :status: needs implementation, needs test
 
 The database implementation shall use lossless compression to reduce the database size.
 
 .. req:: The report package shall present no burden.
-   :id: REQ_REPORT_PERFORMANCE
+   :id: R_REPORT_PERFORMANCE
    :status: needs implementation, needs test
 
 As the report package is a lightweight interface to write data out to a text based format, and render a few images, the performance costs are entirely negligible and should not burden the run, nor the user's computer in both memory and processor time.
 
 .. req:: The reactor package shall allow rapid synchronization of state across the network to parallel processors.
-   :id: REQ_REACTOR_PARALLEL
+   :id: R_REACTOR_PARALLEL
    :status: needs implementation, needs test
 
 For performance, many physics calculations are done in parallel. The reactor must be able to synchronize
 the state on multiple processors efficiently.
 
 .. req:: The nucDirectory package shall try to prevent data duplication to limit the memory footprint of this information.
-   :id: REQ_NUCDIR_DUPLICATION
+   :id: R_NUCDIR_DUPLICATION
    :status: needs implementation, needs test
 
 TODO: Is this testable?
@@ -444,15 +444,15 @@ Software Attributes
 -------------------
 
 .. req:: ARMI shall generally support at least one modern Windows and one modern CentOS operating system version.
-    :id: REQ_OS
+    :id: R_OS
     :status: needs implementation, needs test
 
 .. req:: The database produced shall be easily accessible in a variety of programming environments beyond Python.
-    :id: REQ_DB_LANGUAGE
+    :id: R_DB_LANGUAGE
     :status: needs implementation, needs test
 
 .. req:: The settings package shall use human-readable, plain-text files as input.
-   :id: REQ_SETTINGS_READABLE
+   :id: R_SETTINGS_READABLE
    :status: implemented, needs more tests
 
 The user must be able to read and edit their settings file as plain text in broadly any typical text editor.
@@ -463,25 +463,25 @@ Software Design Constraints
 ---------------------------
 
 .. req:: The report package shall not burden new developers with grasping a complex system.
-    :id: REQ_REPORT_TECH
+    :id: R_REPORT_TECH
     :status: needs implementation, needs test
 
 Given the functional requirements of the report package, new developers should be able to understand how to contribute to a report nigh instantly. No new technologies should be introduced to the system as HTML and ASCII are both purely text-based.
 
 .. req:: The reactor package shall not exhibit any stochastic behavior.
-    :id: REQ_REACTOR_STOCHASTIC
+    :id: R_REACTOR_STOCHASTIC
     :status: needs implementation, needs test
 
 Any two ARMI runs with the same input file must produce the same results.
 
 .. req:: The nucDirectory package shall use nuclear data that is contained within the ARMI code base.
-    :id: REQ_NUCDIR_DATA
+    :id: R_NUCDIR_DATA
     :status: needs implementation, needs test
 
 The nucDirectory package shall not use data data retrieved from online sources. The intent here is to prevent inadvertent security risks.
 
 .. req:: The nucDirectory package shall follow a particular naming convention.
-    :id: REQ_NUCDIR_NAMING
+    :id: R_NUCDIR_NAMING
     :status: needs implementation, needs test
 
 Other physics codes use the name Am-242 for the metastable state of Am-242, and use Am-242g for the ground state.
@@ -495,7 +495,7 @@ Interface I/O Requirements
    TODO: blueprints need some interface and I/O reqs
 
 .. req:: The setting system shall render a view of every defined setting as well as the key attributes associated with it
-   :id: REQ_SETTINGS_REPORT
+   :id: R_SETTINGS_REPORT
    :status: implemented, needs more tests
 
 Utilizing the documentation of the ARMI project the settings system shall contribute a page containing a table summary of the settings included in the system.
@@ -503,15 +503,15 @@ Utilizing the documentation of the ARMI project the settings system shall contri
 TODO: This is completed by the :doc:`Settings Report </user/inputs/settings_report>`.
 
 .. req:: The latticePhysics package will write input files for the desired code for each representative block to be modeled.
-   :id: REQ_LATTICE_INPUTS
+   :id: R_LATTICE_INPUTS
    :status: needs implementation, needs test
 
 .. req:: The latticePhysics package will use the output(s) to create a reactor library, ``ISOTXS`` or ``COMPXS``, used in the global flux solution.
-   :id: REQ_LATTICE_OUTPUTS
+   :id: R_LATTICE_OUTPUTS
    :status: needs implementation, needs test
 
 .. req:: The reactor package shall check input for basic correctness.
-   :id: REQ_REACTOR_CORRECTNESS
+   :id: R_REACTOR_CORRECTNESS
    :status: needs implementation, needs test
 
 The reactor package shall check its inputs for certain obvious errors including unphysical quantities. At a deep level, the reactor package will not attempt to fully validate subtle engineering aspects of the reactor; that is more generally the reason users will want to fully simulate a reactor and cannot be done at input time.


### PR DESCRIPTION
## What is the change?

Renaming some requirement-documentation things like:

* `REQ_XYZ1` -> `R_XYZ`
* `TEST_XYZ1` -> `T_XYZ`
* `IMPL_XYZ1` -> `I_XYZ`

## Why is the change being made?

This is just an improvement to our naming conventions, that we have discussed lately.

I should note that the ARMI requirements are very preliminary, and still a work-in-progress.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
