### PR TITLE
Allow for different file formats in plotBlockDiagram

### DIFF
--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -1372,7 +1372,9 @@ def _makeComponentPatch(component, position, cold):
     return [blockPatch]
 
 
-def plotBlockDiagram(block, fName, cold, cmapName="RdYlBu", materialList=None):
+def plotBlockDiagram(
+    block, fName, cold, cmapName="RdYlBu", materialList=None, fileFormat="svg"
+):
     """Given a Block with a spatial Grid, plot the diagram of
     it with all of its components. (wire, duct, coolant, etc...).
 
@@ -1380,14 +1382,16 @@ def plotBlockDiagram(block, fName, cold, cmapName="RdYlBu", materialList=None):
     ----------
     block : block object
     fName : String
-        name of the file to save to
+        Name of the file to save to
     cold : boolean
-        true is for cold temps, hot is false.
+        True is for cold temps, False is hot
     cmapName : String
         name of a colorMap to use for block colors
-    materialList: List
-        a list of material names across all blocks to be plotted
-        so that same material on all diagrams will have the same color.
+    materialList : List
+        A list of material names across all blocks to be plotted
+        so that same material on all diagrams will have the same color
+    fileFormat : str
+        The format to save the picture as, e.g. svg, png, jpg, etc.
     """
     _, ax = plt.subplots(figsize=(20, 20), dpi=200)
 
@@ -1440,7 +1444,7 @@ def plotBlockDiagram(block, fName, cold, cmapName="RdYlBu", materialList=None):
     ax.spines["left"].set_visible(False)
     ax.spines["bottom"].set_visible(False)
     ax.margins(0)
-    plt.savefig(fName, format="svg", **pltKwargs)
+    plt.savefig(fName, format=fileFormat, **pltKwargs)
     plt.close()
 
     return os.path.abspath(fName)


### PR DESCRIPTION
## What is the change?

<!-- MANDATORY: Describe the change -->

Just allowing for different file formats to be saved when creating block diagrams. The default behavior remains unchanged.

## Why is the change being made?

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

I need to be able to make png or jpg images, but right now this function only allows sgv.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
