### PR TITLE
Be smarter about debug messages in the axial expansion changer

### DIFF
--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -454,22 +454,14 @@ class AssemblyAxialLinkage:
 
         if lowerLinkedBlock is None:
             runLog.debug(
-                "Assembly {0:22s} at location {1:22s}, Block {2:22s}"
-                "is not linked to a block below!".format(
-                    str(self.a.getName()),
-                    str(self.a.getLocation()),
-                    str(b.p.flags),
-                ),
+                f"Assembly {self.a.getName()} at location {self.a.getLocation()}, Block {b}"
+                "is not linked to a block below!",
                 single=True,
             )
         if upperLinkedBlock is None:
             runLog.debug(
-                "Assembly {0:22s} at location {1:22s}, Block {2:22s}"
-                "is not linked to a block above!".format(
-                    str(self.a.getName()),
-                    str(self.a.getLocation()),
-                    str(b.p.flags),
-                ),
+                f"Assembly {self.a.getName()} at location {self.a.getLocation()}, Block {b}"
+                "is not linked to a block above!",
                 single=True,
             )
 

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -443,22 +443,26 @@ class AssemblyAxialLinkage:
         lowerLinkedBlock = None
         upperLinkedBlock = None
         block_list = self.a.getChildren()
-        for otherBlk in block_list:
+        for idx, otherBlk in enumerate(block_list):
             if b.name != otherBlk.name:
                 if b.p.zbottom == otherBlk.p.ztop:
                     lowerLinkedBlock = otherBlk
                 elif b.p.ztop == otherBlk.p.zbottom:
                     upperLinkedBlock = otherBlk
+            else:
+                bIdx = idx
 
         self.linkedBlocks[b] = [lowerLinkedBlock, upperLinkedBlock]
 
-        if lowerLinkedBlock is None:
+        if lowerLinkedBlock is None and bIdx != 0:
+            # only print if this isn't the bottom block
             runLog.debug(
                 f"Assembly {self.a.getName()} at location {self.a.getLocation()}, Block {b}"
                 "is not linked to a block below!",
                 single=True,
             )
-        if upperLinkedBlock is None:
+        if upperLinkedBlock is None and bIdx != idx:
+            # only print if this isn't the topmost block
             runLog.debug(
                 f"Assembly {self.a.getName()} at location {self.a.getLocation()}, Block {b}"
                 "is not linked to a block above!",

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -503,11 +503,18 @@ class AssemblyAxialLinkage:
         self.linkedComponents[c] = lstLinkedC
 
         if lstLinkedC[0] is None and self.linkedBlocks[b][0] is not None:
+            # only print debug if there is a linked block below in the first place
             runLog.debug(
                 f"Assembly {self.a}, Block {b}, Component {c} has nothing linked below it!",
                 single=True,
             )
-        if lstLinkedC[1] is None and self.linkedBlocks[b][1] is not None:
+        if (
+            lstLinkedC[1] is None
+            and self.linkedBlocks[b][1] is not None
+            and not self.linkedBlocks[b][1].hasFlags(Flags.DUMMY)
+        ):
+            # only print debug is there is a linked block above in the first place,
+            # and if that linked block is not the DUMMY block
             runLog.debug(
                 f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
                 single=True,

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -502,12 +502,12 @@ class AssemblyAxialLinkage:
 
         self.linkedComponents[c] = lstLinkedC
 
-        if lstLinkedC[0] is None:
+        if lstLinkedC[0] is None and self.linkedBlocks[b][0] is not None:
             runLog.debug(
                 f"Assembly {self.a}, Block {b}, Component {c} has nothing linked below it!",
                 single=True,
             )
-        if lstLinkedC[1] is None:
+        if lstLinkedC[1] is None and self.linkedBlocks[b][1] is not None:
             runLog.debug(
                 f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
                 single=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ authors = [
 dependencies = [
     "configparser",
     "coverage",
-    "h5py>=3.0",
+    "h5py>=3.0,<=3.9.0",
     "htmltree",
     "matplotlib",
     "numpy>=1.21,<=1.23.5",


### PR DESCRIPTION
## What is the change?

<!-- MANDATORY: Describe the change -->

This simply adds some logic to only print certain debug messages when they make sense. The scenarios that have been changed:
- Don't print debugs about unlinked blocks below (above) the bottom-most (upper-most) block in an assembly, because there is nothing to link by definition
- Don't print debugs about unlinked components below (above) the bottom-most (upper-most) block in an assembly, because there is nothing to link by definition

This is a teeny bit related to #1338 .

## Why is the change being made?

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

This will reduce the size of a debug stdout by `n * (number of assembly designs)` lines, where `n` is at least 4 and often more like ~8, and allow the user to focus on error messages that actually indicate a problem with their run.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
