### PR TITLE
Version-pinning the h5py library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ authors = [
 dependencies = [
     "configparser",
     "coverage",
-    "h5py>=3.0",
+    "h5py>=3.0,<=3.9",
     "htmltree",
     "matplotlib",
     "numpy>=1.21,<=1.23.5",


### PR DESCRIPTION
## What is the change?

This PR just version-pins the `h5py` library.

## Why is the change being made?

To close #1428.

A recent change to that library broke it for us. So we don't want `h5py=3.10.0`.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
