### PR TITLE
Fixing docs - sphinx needs reqs to be 5 chars min

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,8 +2,8 @@ name: Documentation
 
 on:
   push:
-#    branches:
-#      - main
+    branches:
+      - main
 
 jobs:
   build:
@@ -28,11 +28,11 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v1
       - name: Make HTML Docs
         run: tox -e doc
-#      - name: deploy
-#        uses: JamesIves/github-pages-deploy-action@4.1.5
-#        with:
-#          token: ${{ secrets.ACCESS_TOKEN }}
-#          repository-name: ${{ github.repository_owner }}/terrapower.github.io
-#          branch: main
-#          folder: doc/_build/html
-#          target-folder: armi
+      - name: deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          repository-name: ${{ github.repository_owner }}/terrapower.github.io
+          branch: main
+          folder: doc/_build/html
+          target-folder: armi

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,8 +2,8 @@ name: Documentation
 
 on:
   push:
-    branches:
-      - main
+#    branches:
+#      - main
 
 jobs:
   build:
@@ -28,11 +28,11 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v1
       - name: Make HTML Docs
         run: tox -e doc
-      - name: deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
-        with:
-          token: ${{ secrets.ACCESS_TOKEN }}
-          repository-name: ${{ github.repository_owner }}/terrapower.github.io
-          branch: main
-          folder: doc/_build/html
-          target-folder: armi
+#      - name: deploy
+#        uses: JamesIves/github-pages-deploy-action@4.1.5
+#        with:
+#          token: ${{ secrets.ACCESS_TOKEN }}
+#          repository-name: ${{ github.repository_owner }}/terrapower.github.io
+#          branch: main
+#          folder: doc/_build/html
+#          target-folder: armi

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -113,9 +113,6 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # -- General configuration -----------------------------------------------------
 
-# If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.4.0"
-
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
@@ -137,7 +134,6 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinx.ext.imgconverter",  # to convert GH Actions badge SVGs to PNG for LaTeX
     "sphinxcontrib.plantuml",
-    "sphinx_needs",
     "sphinx_rtd_theme",  # needed here for loading jquery in sphinx 6
     "sphinxcontrib.jquery",  # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1452
 ]

--- a/doc/requirements/srsd.rst
+++ b/doc/requirements/srsd.rst
@@ -444,7 +444,7 @@ Software Attributes
 -------------------
 
 .. req:: ARMI shall generally support at least one modern Windows and one modern CentOS operating system version.
-    :id: R_OS
+    :id: R_OSS
     :status: needs implementation, needs test
 
 .. req:: The database produced shall be easily accessible in a variety of programming environments beyond Python.


### PR DESCRIPTION
## What is the change?

I am changing the `id` of a Sphinx-Needs-like requirement from `R_OS` to `R_OSS`.

## Why is the change being made?

The documentation in ARMI is currently broken:

https://github.com/terrapower/armi/actions/runs/6382574343/job/17332368734

They break with the error:

```bash
Sphinx error:
Given ID 'R_OS' does not match configured regex '^[A-Z0-9_]{5,}'
```

It turns out `sphinx` demands that any requirement ID be at least 5 characters long.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
