### PR TITLE
Removing unused Database3.load() argument

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -651,7 +651,6 @@ class Database3:
         statePointName=None,
         allowMissing=False,
         updateGlobalAssemNum=True,
-        updateMasterCs=True,
     ):
         """Load a new reactor from (cycle, node).
 
@@ -679,8 +678,6 @@ class Database3:
             with undefined parameters. Default False.
         updateGlobalAssemNum : bool, optional
             DeprecationWarning: This is unused.
-        updateMasterCs : bool, optional
-            TODO: Deprecated. Slated for removal.
 
         Returns
         -------


### PR DESCRIPTION
## What is the change?

Removing an unused argument to `Database3.load()`.

## Why is the change being made?

It is confusing for people when there are unused inputs to major/import methods.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
