### PR TITLE
Removing deprecated Database3.load() param

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -650,7 +650,6 @@ class Database3:
         bp=None,
         statePointName=None,
         allowMissing=False,
-        updateGlobalAssemNum=True,
     ):
         """Load a new reactor from (cycle, node).
 
@@ -676,8 +675,6 @@ class Database3:
         allowMissing : bool, optional
             Whether to emit a warning, rather than crash if reading a database
             with undefined parameters. Default False.
-        updateGlobalAssemNum : bool, optional
-            DeprecationWarning: This is unused.
 
         Returns
         -------
@@ -718,12 +715,6 @@ class Database3:
             parameterCollections.GLOBAL_SERIAL_NUM, layout.serialNum.max()
         )
         root = comps[0][0]
-
-        if updateGlobalAssemNum:
-            runLog.warning(
-                "The method input `updateGlobalAssemNum` is no longer used.",
-                single=True,
-            )
 
         # return a Reactor object
         if cs[CONF_SORT_REACTOR]:

--- a/armi/bookkeeping/db/databaseInterface.py
+++ b/armi/bookkeeping/db/databaseInterface.py
@@ -302,9 +302,7 @@ class DatabaseInterface(interfaces.Interface):
             if os.path.exists(self.cs["reloadDBName"]):
                 yield Database3(self.cs["reloadDBName"], "r")
 
-    def loadState(
-        self, cycle, timeNode, timeStepName="", fileName=None, updateGlobalAssemNum=True
-    ):
+    def loadState(self, cycle, timeNode, timeStepName="", fileName=None):
         """
         Loads a fresh reactor and applies it to the Operator.
 
@@ -329,7 +327,6 @@ class DatabaseInterface(interfaces.Interface):
                         statePointName=timeStepName,
                         cs=self.cs,
                         allowMissing=True,
-                        updateGlobalAssemNum=updateGlobalAssemNum,
                     )
                     self.o.reattach(newR, self.cs)
                     break


### PR DESCRIPTION
## What is the change?

Removed unused `updateGlobalAssemNum` param from `Database3.load()`.

## Why is the change being made?

This parameter has been unused (and explicitly deprecated) in ARMI for over a year now. And I recently succeeded in removing all downstream references to it in other projects.

It's finally time to remove this thing.

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
