### PR TITLE
Cleaning up material modification table

### DIFF
--- a/doc/user/inputs/blueprints.rst
+++ b/doc/user/inputs/blueprints.rst
@@ -395,22 +395,35 @@ material modifications
       from tabulate import tabulate
 
       data = []
-
       for m in Material.__subclasses__():
           numArgs = m.applyInputParams.__code__.co_argcount
           if numArgs > 1:
               modNames = m.applyInputParams.__code__.co_varnames[1:numArgs]
-              data.append((m.__name__, ', '.join(modNames)))
+              data.append((m.__name__, ", ".join(modNames)))
 
           for subM in m.__subclasses__():
               num = subM.applyInputParams.__code__.co_argcount
               if num > 1:
                   mods = subM.applyInputParams.__code__.co_varnames[1:num]
-                  data.append((subM.__name__, ', '.join(mods)))
+                  if numArgs > 1:
+                      mods += modNames
+                  data.append((subM.__name__, ", ".join(mods)))
 
+      d = {}
+      for k, v in data:
+          if k not in d:
+              d[k] = v
+          else:
+              d[k] = d[k].split(",") + v.split(",")
+              d[k] = sorted(set([vv.strip() for vv in d[k]]))
+              d[k] = ", ".join(d[k])
+      data = [(k, v) for k, v in d.items()]
       data.sort(key=lambda t: t[0])
-      return tabulate(headers=('Material Name', 'Available Modifications'),
-                      tabular_data=data, tablefmt='rst')
+      return tabulate(
+          headers=("Material Name", "Available Modifications"),
+          tabular_data=data,
+          tablefmt="rst",
+      )
 
   The class 1/class 2 modifications in fuel materials are used to identify mixtures of
   custom isotopics labels for input scenarios where a varying blend of a high-reactivity


### PR DESCRIPTION
## What is the change?

I improved the "materials modification" table in the blueprints docs:

* I removed duplicate entries.
* I added any modifications from the superclasses.

The contents of the table are now:

```python
('B4C', 'B10_wt_frac, theoretical_density, TD_frac')
('FuelMaterial', 'class1_custom_isotopics, class2_custom_isotopics, class1_wt_frac, customIsotopics')
('Lithium', 'LI_wt_frac, LI6_wt_frac')
('Sulfur', 'sulfur_density_frac, TD_frac')
('ThU', 'U233_wt_frac, class1_custom_isotopics, class2_custom_isotopics, class1_wt_frac, customIsotopics')
('Thorium', 'class1_custom_isotopics, class2_custom_isotopics, class1_wt_frac, customIsotopics, class1_custom_isotopics, class2_custom_isotopics, class1_wt_frac, customIsotopics')
('ThoriumOxide', 'TD_frac, class1_custom_isotopics, class1_wt_frac, class2_custom_isotopics, customIsotopics')
('UThZr', 'U235_wt_frac, ZR_wt_frac, class1_custom_isotopics, class2_custom_isotopics, class1_wt_frac, customIsotopics')
('UZr', 'U235_wt_frac, ZR_wt_frac, class1_custom_isotopics, class2_custom_isotopics, class1_wt_frac, customIsotopics')
('Uranium', 'U235_wt_frac, TD_frac, class1_custom_isotopics, class2_custom_isotopics, class1_wt_frac, customIsotopics')
('UraniumOxide', 'TD_frac, U235_wt_frac, class1_custom_isotopics, class1_wt_frac, class2_custom_isotopics, customIsotopics')
```

## Why is the change being made?

To close #1437

---

## Checklist

- [X] This PR has only one purpose or idea.
- [X] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The documentation is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
