### PR TITLE
Remove stale info from `flags` docstring

### DIFF
--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -23,9 +23,6 @@ support extension. We also considered the ``aenum`` package, which permits exten
 ``Enum`` classes, but unfortunately does not support extension of ``Flags``. So, we had to
 make our own. This is a much simplified version of what comes with ``aenum``, but still
 provides most of the safety and functionality.
-
-There is an `issue <https://bitbucket.org/stoneleaf/aenum/issues/27/>`_ on the ``aenum``
-bitbucket site to track ``Flag`` extension.
 """
 import math
 


### PR DESCRIPTION
## What is the change?

<!-- MANDATORY: Describe the change -->

The linked bitbucket site no longer appears to exist. It has been migrated to Github, but the associated ticket appears to have been lost without any apparent resolution.

https://github.com/ethanfurman/aenum

## Why is the change being made?

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

Removing stale info.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here:
    https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The documentation is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
