### PR TITLE
Cleaning up bootstrap warning

### DIFF
--- a/armi/_bootstrap.py
+++ b/armi/_bootstrap.py
@@ -12,25 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Collection of code that needs to be executed before most ARMI components are safe to
-import.
-"""
+"""Code that needs to be executed before most ARMI components are safe to import."""
 
 import sys
 import tabulate
 
-# This needs to happen pretty darn early, as one of it's purposes is to provide a better
-# python version warning than "invalid syntax". Maybe this is enough of a crutch that we
-# should get rid of it...
+# This is a courtesy, to help people who accidently run ARMI with an old version of Python.
 if (
     sys.version_info.major < 3
     or sys.version_info.major == 3
-    and sys.version_info.minor < 6
+    and sys.version_info.minor < 7
 ):
     raise RuntimeError(
-        "ARMI highly recommends using Python 3.7. Are you sure you are using the correct "
-        "interpreter?\nUsing: {}".format(sys.executable)
+        "ARMI highly recommends using Python 3.9 or 3.11. Are you sure you are using the "
+        f"correct interpreter?\nYou are using: {sys.executable}"
     )
 
 


### PR DESCRIPTION
## What is the change?

The Python version warning in `_bootstrap.py` needed updating.

## Why is the change being made?

We really don't WANT people to use Python 3.7 any more.

**NOTE**: I feel like this file's existence is a red flag.  Other than this version thing, this file does two things:

* Hand-configure `tabulate` at a global level. So, I officially hate that library now.
* Build our global `nuclideBases`.

I don't like:

1. That those two things are global.
2. That we have to run so much code when someone does `import armi`. Do you think NumPy runs a ton of code at import time? Hell no.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
