### PR TITLE
Cleaning out defunct shuffle logic validator

### DIFF
--- a/armi/physics/fuelCycle/settings.py
+++ b/armi/physics/fuelCycle/settings.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Settings for generic fuel cycle code."""
-import re
-import os
-
-from armi.settings import setting
 from armi.operators import settingsValidation
+from armi.settings import setting
 
 CONF_ASSEM_ROTATION_STATIONARY = "assemblyRotationStationary"
 CONF_ASSEMBLY_ROTATION_ALG = "assemblyRotationAlgorithm"
@@ -131,66 +128,6 @@ def getFuelCycleSettingValidators(inspector):
         )
     )
 
-    # Check for code fixes for input code on the fuel shuffling outside the version control of ARMI
-    # These are basically auto-migrations for untracked code using
-    # the ARMI API. (This may make sense at a higher level)
-    regex_solutions = [
-        (
-            r"(#{0,20}?)[^\s#]*output\s*?\((.*?)(,\s*[1-3]{1}\s*)\)",
-            r"\1runLog.important(\2)",
-        ),
-        (
-            r"(#{0,20}?)[^\s#]*output\s*?\((.*?)(,\s*[4-5]{1,2}\s*)\)",
-            r"\1runLog.info(\2)",
-        ),
-        (
-            r"(#{0,20}?)[^\s#]*output\s*?\((.*?)(,\s*[6-8]{1,2}\s*)\)",
-            r"\1runLog.extra(\2)",
-        ),
-        (
-            r"(#{0,20}?)[^\s#]*output\s*?\((.*?)(,\s*\d{1,2}\s*)\)",
-            r"\1runLog.debug(\2)",
-        ),
-        (r"(#{0,20}?)[^\s#]*output\s*?\((.*?)\)", r"\1runLog.important(\2)"),
-        (r"output = self.cs.output", r""),
-        (r"cs\.getSetting\(\s*([^\)]+)\s*\)", r"cs[\1]"),
-        (r"cs\.setSetting\(\s*([^\)]+)\s*,\s*([^\)]+)\s*\)", r"cs[\1] = \2"),
-        (
-            r"import\s*armi\.components\s*as\s*components",
-            r"from armi.reactor import components",
-        ),
-        (r"\[['\"]caseTitle['\"]\]", r".caseTitle"),
-        (
-            r"self.r.core.bolAssems\['(.*?)'\]",
-            r"self.r.blueprints.assemblies['\1']",
-        ),
-        (r"copyAssembly", r"duplicate"),
-    ]
-
-    def _locateRegexOccurences():
-        with open(inspector._csRelativePath(inspector.cs[CONF_SHUFFLE_LOGIC])) as src:
-            src = src.read()
-            matches = []
-            for pattern, _sub in regex_solutions:
-                matches += re.findall(pattern, src)
-            return matches
-
-    def _applyRegexSolutions():
-        srcFile = inspector._csRelativePath(inspector.cs[CONF_SHUFFLE_LOGIC])
-        destFile = os.path.splitext(srcFile)[0] + "migrated.py"
-        with open(srcFile) as src, open(destFile, "w") as dest:
-            srcContent = src.read()  # get the buffer content
-            regexContent = srcContent  # keep the before and after changes separate
-
-            for pattern, sub in regex_solutions:
-                regexContent = re.sub(pattern, sub, regexContent)
-
-            if regexContent != srcContent:
-                dest.write("from armi import runLog\n")
-            dest.write(regexContent)
-
-        inspector.cs = inspector.cs.modified(newSettings={CONF_SHUFFLE_LOGIC: destFile})
-
     queries.append(
         settingsValidation.Query(
             lambda: " " in inspector.cs[CONF_SHUFFLE_LOGIC],
@@ -216,17 +153,4 @@ def getFuelCycleSettingValidators(inspector):
         )
     )
 
-    queries.append(
-        settingsValidation.Query(
-            lambda: inspector.cs[CONF_SHUFFLE_LOGIC]
-            and inspector._csRelativePathExists(inspector.cs[CONF_SHUFFLE_LOGIC])
-            and _locateRegexOccurences(),
-            "The shuffle logic file {} uses deprecated code."
-            " It will not work unless you permit some automated changes to occur."
-            " The logic file will be backed up to the current directory under a timestamped name"
-            "".format(inspector.cs[CONF_SHUFFLE_LOGIC]),
-            "Proceed?",
-            _applyRegexSolutions,
-        )
-    )
     return queries


### PR DESCRIPTION
## What is the change?

I am removing some defunct regex from ARMI.

## Why is the change being made?

* This code was only temporarily useful as a band-aid, and is no longer used.
* 100 lines of regex is very hard to test.
* This code was never tested.

**NOTE**: I am currently hunting for log files that might have this log line in it, to prove this code is still used. So far, no such log file has been found.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
