### PR TITLE
Test Parameter interaction with DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ pytestdebug.log
 dump-temp-*
 dump-tests*
 .vim-bookmarks
+armi-venv/*
 venv*/
 .mypy_cache/
 **/__pycache__

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -20,9 +20,6 @@ import h5py
 import numpy
 from numpy.testing import assert_allclose, assert_equal
 
-import armi
-armi.configure()
-
 from armi import __version__ as version
 from armi import interfaces
 from armi import runLog

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -20,6 +20,9 @@ import h5py
 import numpy
 from numpy.testing import assert_allclose, assert_equal
 
+import armi
+armi.configure()
+
 from armi import __version__ as version
 from armi import interfaces
 from armi import runLog

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -147,8 +147,8 @@ class Serializer:
         Defining a Serializer for a Parameter in part defines the underlying
         representation of the data within a database file; the data stored in a database
         are sensitive to the code that wrote them. Changing the method that a Serializer
-        uses to pack or unpack data may break compatibility with old databse files.
-        Therefore, Serializers should be dilligent about signalling changes by updating
+        uses to pack or unpack data may break compatibility with old database files.
+        Therefore, Serializers should be diligent about signalling changes by updating
         their version. It is also good practice, whenever possible, to support reading
         old versions so that database files written by old versions can still be read.
 

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -576,8 +576,8 @@ class ParameterDefinitionCollection:
         Get a list of acceptable parameters to store to the database for a level of the data model.
 
         .. impl:: Implementation for restricting some parameters from being written to the database.
-            :id: I_ARMI_RESTRICT_DATABASE_WRITE
-            :links: R_ARMI_RESTRICT_DATABASE_WRITE
+            :id: I_ARMI_RESTRICT_DB_WRITE
+            :links: R_ARMI_RESTRICT_DB_WRITE
 
         Parameters
         ----------

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -575,6 +575,10 @@ class ParameterDefinitionCollection:
         """
         Get a list of acceptable parameters to store to the database for a level of the data model.
 
+        .. impl:: Implementation for restricting some parameters from being written to the database.
+            :id: I_ARMI_RESTRICT_DATABASE_WRITE
+            :links: R_ARMI_RESTRICT_DATABASE_WRITE
+
         Parameters
         ----------
         assignedMask : int

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -170,7 +170,7 @@ class Serializer:
         Given unpacked data, return packed data and a dictionary of attributes needed to
         unpack it.
 
-        The should perform the fundamental packing operation, returning the packed data
+        This should perform the fundamental packing operation, returning the packed data
         and any metadata ("attributes") that would be necessary to unpack the data. The
         class's version is always stored, so no need to provide it as an attribute.
 

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -575,10 +575,6 @@ class ParameterDefinitionCollection:
         """
         Get a list of acceptable parameters to store to the database for a level of the data model.
 
-        .. impl:: Implementation for restricting some parameters from being written to the database.
-            :id: I_ARMI_RESTRICT_DB_WRITE
-            :links: R_ARMI_RESTRICT_DB_WRITE
-
         Parameters
         ----------
         assignedMask : int

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -66,6 +66,29 @@ class ParameterTests(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 fail = pDefs.createBuilder(default={})
 
+    def test_writeSomeParamsToDB(self):
+        """
+        This test tests the ability to specify which parameters should be
+        written to the database. It assumes that the list returned by
+        ParameterDefinitionCollection.toWriteToDB() is used to filter for which
+        parameters to include in the database.
+        """
+
+        class Mock(parameters.ParameterCollection):
+            pDefs = parameters.ParameterDefinitionCollection()
+            with pDefs.createBuilder() as pb:
+                pb.defParam(
+                    "write_me", "units", "description", "location", default=42)
+                pb.defParam(
+                    "and_me", "units", "description", "location", default=42)
+                pb.defParam(
+                    "dont_write_me", "units", "description", "location", default=42,
+                    saveToDB=False)
+            db_params = pDefs.toWriteToDB(32)
+        mock = Mock()
+        self.assertListEqual(['write_me', 'and_me'], [p.name for p in mock.db_params])
+
+
     def test_paramPropertyDoesNotConflict(self):
         class Mock(parameters.ParameterCollection):
             pDefs = parameters.ParameterDefinitionCollection()

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -74,8 +74,8 @@ class ParameterTests(unittest.TestCase):
         parameters to include in the database.
 
         .. test:: Test to restrict some parameters from being written to the database.
-            :id: T_ARMI_RESTRICT_DATABASE_WRITE
-            :links: R_ARMI_RESTRICT_DATABASE_WRITE
+            :id: T_ARMI_RESTRICT_DB_WRITE
+            :links: R_ARMI_RESTRICT_DB_WRITE
         """
 
         pDefs = parameters.ParameterDefinitionCollection()
@@ -99,7 +99,7 @@ class ParameterTests(unittest.TestCase):
 
         .. test:: Tests for ability to serialize data to database in a custom manner.
             :id: T_ARMI_PARAM_SERIALIZE
-            :links: R_ARMI_PARAM_SERIALIZE
+            :links: R_ARMI_PARAM_SERIALIZER
         """
 
         class TestSerializer(parameters.Serializer):

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -72,6 +72,10 @@ class ParameterTests(unittest.TestCase):
         written to the database. It assumes that the list returned by
         ParameterDefinitionCollection.toWriteToDB() is used to filter for which
         parameters to include in the database.
+
+        .. test:: Test to restrict some parameters from being written to the database.
+            :id: T_ARMI_RESTRICT_DATABASE_WRITE
+            :links: R_ARMI_RESTRICT_DATABASE_WRITE
         """
 
         class Mock(parameters.ParameterCollection):
@@ -87,7 +91,6 @@ class ParameterTests(unittest.TestCase):
             db_params = pDefs.toWriteToDB(32)
         mock = Mock()
         self.assertListEqual(['write_me', 'and_me'], [p.name for p in mock.db_params])
-
 
     def test_paramPropertyDoesNotConflict(self):
         class Mock(parameters.ParameterCollection):

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -80,15 +80,18 @@ class ParameterTests(unittest.TestCase):
 
         pDefs = parameters.ParameterDefinitionCollection()
         with pDefs.createBuilder() as pb:
+            pb.defParam("write_me", "units", "description", "location", default=42)
+            pb.defParam("and_me", "units", "description", "location", default=42)
             pb.defParam(
-                "write_me", "units", "description", "location", default=42)
-            pb.defParam(
-                "and_me", "units", "description", "location", default=42)
-            pb.defParam(
-                "dont_write_me", "units", "description", "location", default=42,
-                saveToDB=False)
+                "dont_write_me",
+                "units",
+                "description",
+                "location",
+                default=42,
+                saveToDB=False,
+            )
         db_params = pDefs.toWriteToDB(32)
-        self.assertListEqual(['write_me', 'and_me'], [p.name for p in db_params])
+        self.assertListEqual(["write_me", "and_me"], [p.name for p in db_params])
 
     def test_serializer_pack_unpack(self):
         """
@@ -114,15 +117,16 @@ class ParameterTests(unittest.TestCase):
                 return array
 
         param = parameters.Parameter(
-            name='myparam',
-            units='kg',
-            description='a param',
+            name="myparam",
+            units="kg",
+            description="a param",
             location=None,
             saveToDB=True,
             default=[1],
             setter=None,
             categories=None,
-            serializer=TestSerializer())
+            serializer=TestSerializer(),
+        )
         param.assigned = [1]
 
         packed = param.serializer.pack(param.assigned)

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -78,19 +78,17 @@ class ParameterTests(unittest.TestCase):
             :links: R_ARMI_RESTRICT_DATABASE_WRITE
         """
 
-        class Mock(parameters.ParameterCollection):
-            pDefs = parameters.ParameterDefinitionCollection()
-            with pDefs.createBuilder() as pb:
-                pb.defParam(
-                    "write_me", "units", "description", "location", default=42)
-                pb.defParam(
-                    "and_me", "units", "description", "location", default=42)
-                pb.defParam(
-                    "dont_write_me", "units", "description", "location", default=42,
-                    saveToDB=False)
-            db_params = pDefs.toWriteToDB(32)
-        mock = Mock()
-        self.assertListEqual(['write_me', 'and_me'], [p.name for p in mock.db_params])
+        pDefs = parameters.ParameterDefinitionCollection()
+        with pDefs.createBuilder() as pb:
+            pb.defParam(
+                "write_me", "units", "description", "location", default=42)
+            pb.defParam(
+                "and_me", "units", "description", "location", default=42)
+            pb.defParam(
+                "dont_write_me", "units", "description", "location", default=42,
+                saveToDB=False)
+        db_params = pDefs.toWriteToDB(32)
+        self.assertListEqual(['write_me', 'and_me'], [p.name for p in db_params])
 
     def test_paramPropertyDoesNotConflict(self):
         class Mock(parameters.ParameterCollection):


### PR DESCRIPTION
## What is the change?

This PR adds tests for two Parameters related requirements. Specifically it tests the following:
- Allowing a Parameter to not be written with the saveToDB attribute (R_ARMI_RESTRICT_DB_WRITE)
- Allowing a Parameter to define its own serializer for writing to a DB file (R_ARMI_PARAM_SERIALISER)

Additionally, this PR fixes a few stray typos, and includes "armi-venv" as an ignored folder, consistent with the [installation instructions](https://terrapower.github.io/armi/installation.html).

## Why is the change being made?

The Parameters requirements must be tested to ensure requirements are met.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
