### PR TITLE
Cleaning up docstrings and formatting

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -25,8 +25,7 @@ customizing much of the Framework's behavior.
     otherwise be global state. The ARMI Framework has historically made heavy use of
     global state (e.g., :py:mod:`armi.nucDirectory.nuclideBases`), and it will take
     quite a bit of effort to refactor the code to access such things through an App
-    object. We are planning to do this, but for now this App class is somewhat
-    rudimentary.
+    object.
 """
 # ruff: noqa: E402
 from typing import Dict, Optional, Tuple, List

--- a/armi/bookkeeping/snapshotInterface.py
+++ b/armi/bookkeeping/snapshotInterface.py
@@ -28,8 +28,8 @@ What in particular is done is dependent on the case settings and the collection 
 Snapshots can be requested through the settings: ``dumpSnapshot`` and/or ``defaultSnapshots``.
 """
 from armi import interfaces
-from armi import runLog
 from armi import operators
+from armi import runLog
 from armi.utils import getStepLengths
 
 

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -22,7 +22,7 @@ and submit them to a cluster for execution. Furthermore, a ``CaseSuite`` can be 
 executed cases for post-analysis.
 
 ``CaseSuite``\ s should allow ``Cases`` to be added from totally separate directories.
-This is useful for plugin-informed in-use testing as well as other things.
+This is useful for plugin-informed testing as well as other things.
 
 See Also
 --------

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -246,7 +246,6 @@ class FullFactorialSuiteBuilderNoisy(FullFactorialSuiteBuilder):
         self.noiseFraction = noiseFraction
 
     def addDegreeOfFreedom(self, inputModifiers):
-
         new = []
         for newMod in inputModifiers:
             for existingModSet in self.modifierSets:

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -605,7 +605,6 @@ class Operator:
             The time node that is currently being run (0 for BOC, etc.)
         excludedInterfaceNames : list, optional
             Names of interface names that will not be interacted with.
-
         """
         excludedInterfaceNames = excludedInterfaceNames or ()
         activeInterfaces = [

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -17,13 +17,12 @@ Executors are useful for having a standard way to run physics calculations.
 They may involve external codes (with inputs/execution/output) or in-memory
 data pathways.
 """
-
-import os
 import hashlib
+import os
 
-from armi.utils import directoryChangers, pathTools
 from armi import runLog
 from armi.context import getFastPath, MPI_RANK
+from armi.utils import directoryChangers, pathTools
 
 
 class ExecutionOptions:

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -59,7 +59,6 @@ Some things you may want to bring in via a plugin includes:
 
 Warning
 -------
-
 The plugin system was developed to support improved collaboration.  It is new and should
 be considered under development. The API is subject to change as the version of the ARMI
 framework approaches 1.0.

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -785,7 +785,6 @@ class Assembly(composites.Composite):
         -------
         blocks : list
             List of blocks.
-
         """
         if typeSpec is None:
             return self.getChildren()

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -719,10 +719,9 @@ class Block(composites.Composite):
 
         Returns
         -------
-             mass : float
+        mass : float
             Mass difference in grams. If you subtract mass, mass will be negative.
             If returnMass is False (default), this will always be zero.
-
         """
         self._updateDetailedNdens(frac, adjustList)
 

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -81,25 +81,10 @@ from armi import migration
 from armi import plugins
 from armi import runLog
 from armi.nucDirectory import nuclideBases
+from armi.physics.neutronics.settings import CONF_LOADING_FILE
 from armi.reactor import assemblies
 from armi.reactor import geometry
 from armi.reactor import systemLayoutInput
-from armi.reactor.flags import Flags
-from armi.utils.customExceptions import InputError
-from armi.utils import textProcessors
-from armi.settings.fwSettings.globalSettings import (
-    CONF_DETAILED_AXIAL_EXPANSION,
-    CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP,
-    CONF_INPUT_HEIGHTS_HOT,
-    CONF_NON_UNIFORM_ASSEM_FLAGS,
-    CONF_ACCEPTABLE_BLOCK_AREA_ERROR,
-    CONF_GEOM_FILE,
-)
-from armi.physics.neutronics.settings import CONF_LOADING_FILE
-
-# NOTE: using non-ARMI-standard imports because these are all a part of this package,
-# and using the module imports would make the attribute definitions extremely long
-# without adding detail
 from armi.reactor.blueprints import isotopicOptions
 from armi.reactor.blueprints.assemblyBlueprint import AssemblyKeyedList
 from armi.reactor.blueprints.blockBlueprint import BlockKeyedList
@@ -108,13 +93,24 @@ from armi.reactor.blueprints.componentBlueprint import ComponentKeyedList
 from armi.reactor.blueprints.gridBlueprint import Grids, Triplet
 from armi.reactor.blueprints.reactorBlueprint import Systems, SystemBlueprint
 from armi.reactor.converters import axialExpansionChanger
+from armi.reactor.flags import Flags
+from armi.settings.fwSettings.globalSettings import (
+    CONF_DETAILED_AXIAL_EXPANSION,
+    CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP,
+    CONF_INPUT_HEIGHTS_HOT,
+    CONF_NON_UNIFORM_ASSEM_FLAGS,
+    CONF_ACCEPTABLE_BLOCK_AREA_ERROR,
+    CONF_GEOM_FILE,
+)
+from armi.utils import textProcessors
+from armi.utils.customExceptions import InputError
 
 context.BLUEPRINTS_IMPORTED = True
 context.BLUEPRINTS_IMPORT_CONTEXT = "".join(traceback.format_stack())
 
 
 def loadFromCs(cs, roundTrip=False):
-    r"""Function to load Blueprints based on supplied ``CaseSettings``."""
+    """Function to load Blueprints based on supplied ``CaseSettings``."""
     from armi.utils import directoryChangers
 
     with directoryChangers.DirectoryChanger(cs.inputDirectory, dumpOnException=False):

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -63,7 +63,6 @@ class FlagSerializer(parameters.Serializer):
     sequence of enough uint8 elements to represent all flags. These constitute a
     dimension of a 2-D numpy array containing all Flags for all objects provided to the
     ``pack()`` function.
-
     """
 
     version = "1"
@@ -437,11 +436,8 @@ class ArmiObject(metaclass=CompositeModelType):
         to be considered non-zero even if they don't have any blocks. This is important
         for parent resolution, etc. If one of these objects exists, it is non-zero,
         regardless of its contents.
-
         """
         return True
-
-    __nonzero__ = __bool__  # Python 2 compatibility
 
     def __add__(self, other):
         """Return a list of all children in this and another object."""

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -14,7 +14,7 @@
 
 """
 This defines a Settings object that acts mostly like a dictionary. It
-is meant so that each ARMI run has one-and-only-one Settings object. It global
+is meant so that each ARMI run has one-and-only-one Settings object. It records
 user settings like the core power level, the input file names, the number of cycles to
 run, the run type, the environment setup, and hundreds of other things.
 

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -14,15 +14,12 @@
 
 """
 This defines a Settings object that acts mostly like a dictionary. It
-is meant to be treated mostly like a singleton, where each custom ARMI
-object has access to it. It contains global user settings like the core
-power level, the input file names, the number of cycles to run, the run type,
-the environment setup, and hundreds of other things.
+is meant so that each ARMI run has one-and-only-one Settings object. It global
+user settings like the core power level, the input file names, the number of cycles to
+run, the run type, the environment setup, and hundreds of other things.
 
-A settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to
+A Settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to
 create this settings file, which is then loaded by an ARMI process on the cluster.
-
-A primary case settings is created as ``masterCs``.
 """
 import io
 import logging
@@ -37,8 +34,6 @@ from armi.settings.setting import Setting
 from armi.utils import pathTools
 from armi.utils.customExceptions import NonexistentSetting
 
-DEP_WARNING = "Deprecation Warning: Settings will not be mutable mid-run: {}"
-
 SIMPLE_CYCLES_INPUTS = {
     "availabilityFactor",
     "availabilityFactors",
@@ -51,12 +46,12 @@ SIMPLE_CYCLES_INPUTS = {
 
 class Settings:
     """
-    A container for global settings, such as case title, power level, and many run options.
+    A container for run settings, such as case title, power level, and many more.
 
     It is accessible to most ARMI objects through self.cs (for 'Case Settings').
     It acts largely as a dictionary, and setting values are accessed by keys.
 
-    The settings object has a 1-to-1 correspondence with the ARMI settings input file.
+    The Settings object has a 1-to-1 correspondence with the ARMI settings input file.
     This file may be created by hand or by the GUI in submitter.py.
 
     Notes
@@ -68,7 +63,7 @@ class Settings:
 
     def __init__(self, fName=None):
         """
-        Instantiate a settings object.
+        Instantiate a Settings object.
 
         Parameters
         ----------
@@ -426,7 +421,7 @@ class Settings:
         return writer
 
     def updateEnvironmentSettingsFrom(self, otherCs):
-        r"""Updates the environment settings in this object based on some other cs
+        """Updates the environment settings in this object based on some other cs
         (from the GUI, most likely).
 
         Parameters

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -19,7 +19,6 @@ Hexagons are fundamental to advanced reactors.
 
 .. image:: /.static/hexagon.png
     :width: 100%
-
 """
 
 import math
@@ -83,7 +82,7 @@ def pitch(side):
 
 
 def numRingsToHoldNumCells(numCells):
-    r"""
+    """
     Determine the number of rings in a hexagonal grid with this many hex cells.
     If the number of pins don't fit exactly into any ring, returns the ring just large
     enough to fit them.

--- a/armi/utils/textProcessors.py
+++ b/armi/utils/textProcessors.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utility classes and functions for manipulating text files."""
+import io
 import os
 import re
-import io
 import pathlib
 from typing import List, Tuple, Union, Optional, TextIO
 
@@ -554,7 +554,7 @@ class TextProcessor:
             self.f = SmartList(f)
 
     def reset(self):
-        r"""Rewinds the file so you can search through it again."""
+        """Rewinds the file so you can search through it again."""
         self.f.seek(0)
 
     def __repr__(self):
@@ -567,7 +567,7 @@ class TextProcessor:
         pass
 
     def fsearch(self, pattern, msg=None, killOn=None, textFlag=False):
-        r"""
+        """
         Searches file f for pattern and displays msg when found. Returns line in which
         pattern is found or FALSE if no pattern is found.
         Stops searching if finds killOn first.
@@ -619,7 +619,7 @@ class TextProcessor:
 
 
 class SmartList:
-    r"""A list that does stuff like files do i.e. remembers where it was, can seek, etc.
+    """A list that does stuff like files do i.e. remembers where it was, can seek, etc.
     Actually this is pretty slow. so much for being smart. nice idea though.
     """
 

--- a/armi/utils/units.py
+++ b/armi/utils/units.py
@@ -316,7 +316,7 @@ def sanitizeAngle(theta):
 
 def getXYLineParameters(theta, x=0, y=0):
     """
-    returns parameters A B C D for a plane in the XY direction.
+    Returns parameters A B C D for a plane in the XY direction.
 
     Parameters
     ----------

--- a/doc/developer/parallel_coding.rst
+++ b/doc/developer/parallel_coding.rst
@@ -61,9 +61,11 @@ CPUs, you can either pass the first 10 values out of the list and keep sending g
 are all sent (multiple sets of transmitions) or you can split the data up into 10 evenly-populated groups (single
 transmition to each CPU). This is called *load balancing*. 
 
-ARMI has utilities that can help called :py:func:`armi.utils.chunks` and :py:func:`armi.iterables.flatten`. 
-Given an arbitrary list, ``chunks`` breaks it up into a certain number of chunks and ``unchunk`` does the 
+ARMI has utilities that can help called :py:func:`armi.utils.iterables.chunk` and :py:func:`armi.utils.iterables.flatten`.
+Given an arbitrary list, ``chunk`` breaks it up into a certain number of chunks and ``unchunk`` does the
 opposite to reassemble the original list after processing. Check it out::
+
+    from armi.utils import iterables
 
     if rank == 0:
         # primary. Make data and send it.
@@ -130,7 +132,7 @@ MPI transmit the results, they will not survive on the primary node. For instanc
 a block parameter (e.g. ``b.p.paramName = 10.0)``, these **will not** be set on the primary! There are a few
 mechanisms that can help you get the data back to the primary reactor.
 
-.. note:: If you want similar capabilities for objects that are not blocks, take another look at :py:func:`armi.utils.chunks`.
+.. note:: If you want similar capabilities for objects that are not blocks, take another look at :py:func:`armi.utils.iterables.chunk`.
 
 
 Example using ``bcast``


### PR DESCRIPTION
## What is the change?

I made some cleanup improvements throughout the repo:

* Fixed broken imports in parallelization docs
* Fixed language in docstrings
* Removed unnecessary blank lines
* Alphabetized imports
* Changed r-strings to regular strings, if I could.

## Why is the change being made?

As part of a big project, I have been looking through the repo quite broadly lately.  While doing so I found and absent-mindedly fixed a bunch of little things.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
