### PR TITLE
Making block impl tags unique

### DIFF
--- a/armi/nuclearDataIO/tests/test_xsCollections.py
+++ b/armi/nuclearDataIO/tests/test_xsCollections.py
@@ -138,6 +138,13 @@ class MockBlock(HexBlock):
         self._r = r
 
     def getVolume(self, *args, **kwargs):
+        """
+        Return the volume of a block.
+
+        .. impl:: Volume of block is retrievable
+            :id: I_ARMI_BLOCK_DIMS10
+            :implements: R_ARMI_BLOCK_DIMS
+        """
         return 1.0
 
     def getNuclideNumberDensities(self, nucNames):

--- a/armi/nuclearDataIO/tests/test_xsCollections.py
+++ b/armi/nuclearDataIO/tests/test_xsCollections.py
@@ -138,23 +138,20 @@ class MockBlock(HexBlock):
         self._r = r
 
     def getVolume(self, *args, **kwargs):
-        """
-        Return the volume of a block.
-
-        .. impl:: Volume of block is retrievable
-            :id: I_ARMI_BLOCK_DIMS10
-            :implements: R_ARMI_BLOCK_DIMS
-        """
+        """Return the volume of a block."""
         return 1.0
 
     def getNuclideNumberDensities(self, nucNames):
+        """Return a list of number densities in atoms/barn-cm for the nuc names requested."""
         return [self.density.get(nucName, 0.0) for nucName in nucNames]
 
     def _getNdensHelper(self):
         return {nucName: density for nucName, density in self.density.items()}
 
     def setNumberDensity(self, key, val, *args, **kwargs):
+        """Set the number density of this nuclide to this value."""
         self.density[key] = val
 
     def getNuclides(self):
+        """Determine which nuclides are present in this armi block."""
         return self.density.keys()

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -584,7 +584,7 @@ class Block(composites.Composite):
         """Return a string representation of the location.
 
         .. impl:: Location of a block is retrievable
-            :id: I_ARMI_BLOCK_POSI
+            :id: I_ARMI_BLOCK_POSI0
             :implements: R_ARMI_BLOCK_POSI
         """
         if self.core and self.parent.spatialGrid and self.spatialLocator:
@@ -599,7 +599,7 @@ class Block(composites.Composite):
         Returns the coordinates of the block.
 
         .. impl:: Coordinates of a block are queryable
-            :id: I_ARMI_BLOCK_POSI
+            :id: I_ARMI_BLOCK_POSI1
             :implements: R_ARMI_BLOCK_POSI
         """
         if rotationDegreesCCW:
@@ -607,7 +607,7 @@ class Block(composites.Composite):
         return self.spatialLocator.getGlobalCoordinates()
 
     def setBuLimitInfo(self):
-        r"""Sets burnup limit based on igniter, feed, etc."""
+        """Sets burnup limit based on igniter, feed, etc."""
         if self.p.buRate == 0:
             # might be cycle 1 or a non-burning block
             self.p.timeToLimit = 0.0
@@ -683,7 +683,7 @@ class Block(composites.Composite):
         Return the volume of a block.
 
         .. impl:: Volume of block is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS0
             :implements: R_ARMI_BLOCK_DIMS
 
         Returns
@@ -1248,7 +1248,7 @@ class Block(composites.Composite):
             define the pitch, returns None
 
         .. impl:: Pitch of block is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS1
             :implements: R_ARMI_BLOCK_DIMS
 
         Notes
@@ -1262,7 +1262,6 @@ class Block(composites.Composite):
         See Also
         --------
         setPitch : sets pitch
-
         """
         c, _p = self._pitchDefiningComponent
         if c is None:
@@ -1549,8 +1548,8 @@ class Block(composites.Composite):
 
         Parameters
         ----------
-        rad - float
-            number (in radians) specifying the angle of counter clockwise rotation
+        rad: float
+            Number (in radians) specifying the angle of counter clockwise rotation.
         """
         raise NotImplementedError
 
@@ -1708,7 +1707,7 @@ class HexBlock(Block):
         Compute the max area of this block if it was totally full.
 
         .. impl:: Area of block is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS2
             :implements: R_ARMI_BLOCK_DIMS
         """
         pitch = self.getPitch()
@@ -1721,7 +1720,7 @@ class HexBlock(Block):
         Returns the duct IP dimension.
 
         .. impl:: IP dimension is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS3
             :implements: R_ARMI_BLOCK_DIMS
         """
         duct = self.getComponent(Flags.DUCT, exact=True)
@@ -1732,7 +1731,7 @@ class HexBlock(Block):
         Returns the duct OP dimension.
 
         .. impl:: OP dimension is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS4
             :implements: R_ARMI_BLOCK_DIMS
         """
         duct = self.getComponent(Flags.DUCT, exact=True)
@@ -2035,7 +2034,7 @@ class HexBlock(Block):
         Returns the distance in cm between the outer most pin and the duct in a block.
 
         .. impl:: Pin to duct gap of block is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS5
             :implements: R_ARMI_BLOCK_DIMS
 
         Parameters
@@ -2219,7 +2218,7 @@ class HexBlock(Block):
         and wire wraps. Grid spacers not yet supported.
 
         .. impl:: Pin pitch within block is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS6
             :implements: R_ARMI_BLOCK_DIMS
 
         Parameters
@@ -2256,7 +2255,7 @@ class HexBlock(Block):
         """Return the total wetted perimeter of the block in cm.
 
         .. impl:: Wetted perimeter of block is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS7
             :implements: R_ARMI_BLOCK_DIMS
         """
         # flags pertaining to hexagon components where the interior of the hexagon is wetted
@@ -2334,7 +2333,7 @@ class HexBlock(Block):
         """Return the total flowing coolant area of the block in cm^2.
 
         .. impl:: Flow area of block is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS8
             :implements: R_ARMI_BLOCK_DIMS
         """
         return self.getComponent(Flags.COOLANT, exact=True).getArea()
@@ -2355,7 +2354,7 @@ class HexBlock(Block):
         l = 6*p/sqrt(3)
 
         .. impl:: Hydraulic diameter of block is retrievable
-            :id: I_ARMI_BLOCK_DIMS
+            :id: I_ARMI_BLOCK_DIMS9
             :implements: R_ARMI_BLOCK_DIMS
         """
         return 4.0 * self.getFlowArea() / self.getWettedPerimeter()

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1745,6 +1745,7 @@ class HexBlock(Block):
         return duct.getDimension("op")
 
     def initializePinLocations(self):
+        """Initialize pin locations."""
         nPins = self.getNumPins()
         self.p.pinLocation = list(range(1, nPins + 1))
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1609,6 +1609,13 @@ class HexBlock(Block):
         Block.__init__(self, name, height)
 
     def coords(self, rotationDegreesCCW=0.0):
+        """
+        Returns the coordinates of the block.
+
+        .. impl:: Coordinates of a block are queryable
+            :id: I_ARMI_BLOCK_POSI2
+            :implements: R_ARMI_BLOCK_POSI
+        """
         x, y, _z = self.spatialLocator.getGlobalCoordinates()
         x += self.p.displacementX * 100.0
         y += self.p.displacementY * 100.0


### PR DESCRIPTION
## What is the change?

This PR makes all the sphinx-needs `impl` tags in the repo unique.

## Why is the change being made?

We had some duplicate `impl` tags in `blocks.py`.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
