### PR TITLE
Adding impl and test tags for requirements

### DIFF
--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -47,6 +47,10 @@ class STACK_ORDER:  # noqa: invalid-class-name
     Each module specifies an ``ORDER`` constant that specifies where in this order it
     should be placed in the Interface Stack.
 
+    .. impl:: Define an ordered list of interfaces.
+        :id: I_ARMI_OPERATOR_INTERFACES0
+        :implements: R_ARMI_OPERATOR_INTERFACES
+
     Notes
     -----
     Originally, the ordering was accomplished with a very large if/else construct in ``createInterfaces``.
@@ -84,7 +88,11 @@ class STACK_ORDER:  # noqa: invalid-class-name
 class TightCoupler:
     """
     Data structure that defines tight coupling attributes that are implemented
-    within an Interface and called upon when ``interactCoupled`` is called.
+    within an Interface and called upon when ``interactAllCoupled`` is called.
+
+    .. impl:: The TightCoupler defines the convergence criteria for physics coupling.
+        :id: I_ARMI_OPERATOR_PHYSICS0
+        :implements: R_ARMI_OPERATOR_PHYSICS
 
     Parameters
     ----------
@@ -240,6 +248,10 @@ class Interface:
 
     Interface instances are gathered into an interface stack in
     :py:meth:`armi.operators.operator.Operator.createInterfaces`.
+
+    .. impl:: The interface shall allow code execution at important operational points in time.
+        :id: I_ARMI_INTERFACE
+        :implements: R_ARMI_INTERFACE
     """
 
     # list containing interfaceClass

--- a/armi/materials/__init__.py
+++ b/armi/materials/__init__.py
@@ -46,6 +46,13 @@ _MATERIAL_NAMESPACE_ORDER = ["armi.materials"]
 
 
 def setMaterialNamespaceOrder(order):
+    """
+    Set the material namespace order at the Python interpretter, global level.
+
+    .. impl:: Materials can be searched across packages in a defined namespace.
+        :id: I_ARMI_MAT_NAMESPACE
+        :implements: R_ARMI_MAT_NAMESPACE
+    """
     global _MATERIAL_NAMESPACE_ORDER
     _MATERIAL_NAMESPACE_ORDER = order
 
@@ -120,6 +127,10 @@ def resolveMaterialClassByName(name: str, namespaceOrder: List[str] = None):
     Input files usually specify a material like UO2. Which particular implementation
     gets used (Framework's UO2 vs. a user plugins UO2 vs. the Kentucky Transportation
     Cabinet's UO2) is up to the user at runtime.
+
+    .. impl:: Material collections are defined with an order of precedence in the case of duplicates.
+        :id: I_ARMI_MAT_ORDER
+        :implements: R_ARMI_MAT_ORDER
 
     Parameters
     ----------

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -36,6 +36,14 @@ class Material:
     """
     A material is made up of elements or isotopes. It has bulk properties like mass density.
 
+    .. impl:: The abstract material class.
+        :id: I_ARMI_MAT_PROPERTIES
+        :implements: R_ARMI_MAT_PROPERTIES
+
+    .. impl:: Materials generate nuclide mass fractions at instantiation.
+        :id: I_ARMI_MAT_FRACS
+        :implements: R_ARMI_MAT_FRACS
+
     Attributes
     ----------
     parent : Component
@@ -94,7 +102,13 @@ class Material:
 
     @property
     def name(self):
-        """Getter for the private name attribute of this Material."""
+        """
+        Getter for the private name attribute of this Material.
+
+        .. impl:: The name of a material is accessible.
+            :id: I_ARMI_MAT_NAME
+            :implements: R_ARMI_MAT_NAME
+        """
         return self._name
 
     @name.setter
@@ -707,6 +721,10 @@ class Fluid(Material):
     def linearExpansion(self, Tk=None, Tc=None):
         """For void, lets just not allow temperature changes to change dimensions
         since it is a liquid it will fill its space.
+
+        .. impl:: Fluid materials are not thermally expandable.
+            :id: I_ARMI_MAT_FLUID
+            :implements: R_ARMI_MAT_FLUID
         """
         return 0.0
 

--- a/armi/materials/void.py
+++ b/armi/materials/void.py
@@ -21,6 +21,13 @@ from armi.materials import material
 
 
 class Void(material.Fluid):
+    """A Void material is a bookkeeping material with zero density.
+
+    .. impl:: Define a void material with zero density.
+        :id: I_ARMI_MAT_VOID
+        :implements: R_ARMI_MAT_VOID
+    """
+
     def pseudoDensity(self, Tk: float = None, Tc: float = None) -> float:
         return 0.0
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -74,7 +74,7 @@ class Operator:
     .. note:: The :doc:`/developer/guide` has some additional narrative on this topic.
 
     .. impl:: The operator package shall expose an ordered list of interfaces, and loop over them in order.
-        :id: I_ARMI_OPERATOR_INTERFACES2
+        :id: I_ARMI_OPERATOR_INTERFACES1
         :implements: R_ARMI_OPERATOR_INTERFACES
 
     Attributes
@@ -656,7 +656,7 @@ class Operator:
         ARMI supports tight and loose coupling.
 
         .. impl:: Physics coupling is driven from Operator.
-            :id: I_ARMI_OPERATOR_PHYSICS2
+            :id: I_ARMI_OPERATOR_PHYSICS1
             :implements: R_ARMI_OPERATOR_PHYSICS
         """
         activeInterfaces = [ii for ii in self.interfaces if ii.enabled()]

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -73,6 +73,10 @@ class Operator:
 
     .. note:: The :doc:`/developer/guide` has some additional narrative on this topic.
 
+    .. impl:: The operator package shall expose an ordered list of interfaces, and loop over them in order.
+        :id: I_ARMI_OPERATOR_INTERFACES2
+        :implements: R_ARMI_OPERATOR_INTERFACES
+
     Attributes
     ----------
     cs : CaseSettings object
@@ -650,6 +654,10 @@ class Operator:
         This is distinct from loose coupling, which would simply uses the temperature values from the previous timestep
         in the current flux solution. It's also distinct from full coupling where all fields are solved simultaneously.
         ARMI supports tight and loose coupling.
+
+        .. impl:: Physics coupling is driven from Operator.
+            :id: I_ARMI_OPERATOR_PHYSICS2
+            :implements: R_ARMI_OPERATOR_PHYSICS
         """
         activeInterfaces = [ii for ii in self.interfaces if ii.enabled()]
 

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -334,6 +334,10 @@ class GlobalFluxInterfaceUsingExecuters(GlobalFluxInterface):
 class GlobalFluxOptions(executers.ExecutionOptions):
     """Data structure representing common options in Global Flux Solvers.
 
+    .. impl:: Options for neutronics solvers.
+        :id: I_ARMI_FLUX_OPTIONS
+        :implements: R_ARMI_FLUX_OPTIONS
+
     Attributes
     ----------
     adjoint : bool
@@ -527,6 +531,10 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
 
         In both cases, we need to undo the modifications between reading the output
         and applying the result to the data model.
+
+        .. impl:: Ensure the mesh in the reactor model is appropriate for neutronics solver execution.
+            :id: I_ARMI_FLUX_RX_RATES
+            :implements: R_ARMI_FLUX_RX_RATES
 
         See Also
         --------
@@ -1243,6 +1251,10 @@ def computeDpaRate(mgFlux, dpaXs):
 def calcReactionRates(obj, keff, lib):
     r"""
     Compute 1-group reaction rates for this object (usually a block).
+
+    .. impl:: Return the reaction rates for a given ArmiObject.
+        :id: I_ARMI_FLUX_RX_RATES
+        :implements: R_ARMI_FLUX_RX_RATES
 
     Parameters
     ----------

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -104,6 +104,14 @@ class MockGlobalFluxExecuter(globalFluxInterface.GlobalFluxExecuter):
 
 
 class TestGlobalFluxOptions(unittest.TestCase):
+    """
+    Tests for GlobalFluxOptions.
+
+    .. test:: Tests GlobalFluxOptions
+        :id: T_ARMI_FLUX_OPTIONS
+        :tests: R_ARMI_FLUX_OPTIONS
+    """
+
     def test_readFromSettings(self):
         cs = settings.Settings()
         opts = globalFluxInterface.GlobalFluxOptions("neutronics-run")

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -169,6 +169,10 @@ class ArmiPlugin:
         """
         Function for defining additional parameters.
 
+        .. impl:: Plugins can add parameters to the reactor data model.
+            :id: I_ARMI_PLUGIN_PARAMS
+            :implements: R_ARMI_PLUGIN_PARAMS
+
         Returns
         -------
         dict
@@ -371,6 +375,10 @@ class ArmiPlugin:
         kernel is among the available options. If a plugin were to provide a new
         neutronics kernel (let's say MCNP), it should also define a new option to tell
         the settings system that ``"MCNP"`` is a valid option.
+
+        .. impl:: Plugins can add settings to the run.
+            :id: I_ARMI_PLUGIN_SETTINGS
+            :implements: R_ARMI_PLUGIN_SETTINGS
 
         Returns
         -------


### PR DESCRIPTION
## What is the change?

This PR adds a smattering of `impl` and `test` tags for requirements in:

* interfaces
* materials
* plugins
* globalFluxInterface

## Why is the change being made?

This is part of the on-going work on ARMI requirements.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
