### PR TITLE
Adding req crumbs for runLog and settings

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -118,6 +118,10 @@ def init(choice=None, fName=None, cs=None):
     """
     Scan a directory for armi inputs and load one to interact with.
 
+    .. impl:: Settings are used to define an ARMI run.
+        :id: I_ARMI_SETTING1
+        :implements: R_ARMI_SETTING
+
     Parameters
     ----------
     choice : int, optional
@@ -133,7 +137,6 @@ def init(choice=None, fName=None, cs=None):
     Examples
     --------
     >>> o = armi.init()
-
     """
     from armi import cases
     from armi import settings

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -120,7 +120,13 @@ class App:
         return self._pm
 
     def getSettings(self) -> Dict[str, Setting]:
-        """Return a dictionary containing all Settings defined by the framework and all plugins."""
+        """
+        Return a dictionary containing all Settings defined by the framework and all plugins.
+
+        .. impl:: Applications will not allow duplicate settings.
+            :id: I_ARMI_SETTINGS_UNIQUE
+            :implements: R_ARMI_SETTINGS_UNIQUE
+        """
         # Start with framework settings
         settingDefs = {
             setting.name: setting for setting in fwSettings.getFrameworkSettings()

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -451,6 +451,7 @@ class TestPluginForCopyInterfacesMultipleFiles(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineSettings():
+        """Define settings for the plugin."""
         return [
             settings.setting.Setting(
                 "multipleFilesSetting",
@@ -463,6 +464,7 @@ class TestPluginForCopyInterfacesMultipleFiles(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def exposeInterfaces(cs):
+        """A plugin is mostly just a vehicle to add Interfaces to an Appliation."""
         return [
             interfaces.InterfaceInfo(
                 interfaces.STACK_ORDER.PREPROCESSING,

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -447,6 +447,21 @@ class MultiFilesInterfaces(interfaces.Interface):
         return {settingName: cs[settingName]}
 
 
+class TestPluginWithDupicateSetting(plugins.ArmiPlugin):
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineSettings():
+        """Define a duplicate setting."""
+        return [
+            settings.setting.Setting(
+                "power",
+                default=123,
+                label="power",
+                description="duplicate power",
+            )
+        ]
+
+
 class TestPluginForCopyInterfacesMultipleFiles(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
@@ -550,6 +565,21 @@ class TestCopyInterfaceInputs(unittest.TestCase):
             )
             self.assertFalse(os.path.exists(newSettings[testSetting]))
             self.assertEqual(newSettings[testSetting], fakeShuffle)
+
+    def test_failOnDuplicateSetting(self):
+        """
+        That that if a plugin attempts to add a duplicate setting, it raises an error.
+
+        .. test:: Plugins cannot register duplicate settings.
+            :id: T_ARMI_SETTINGS_UNIQUE
+            :tests: R_ARMI_SETTINGS_UNIQUE
+        """
+        # register the new Plugin
+        app = getApp()
+        app.pluginManager.register(TestPluginWithDupicateSetting)
+
+        with self.assertRaises(ValueError):
+            cs = settings.Settings(ARMI_RUN_PATH)
 
     def test_copyInterfaceInputs_multipleFiles(self):
         # register the new Plugin

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -42,7 +42,13 @@ from armi.utils.mathematics import expandRepeatedFloats
 
 
 class Query:
-    """An individual query."""
+    """
+    An individual setting validator.
+
+    .. impl:: Rules to validate and customize a setting's behavior.
+        :id: I_ARMI_SETTINGS_RULES
+        :implements: R_ARMI_SETTINGS_RULES
+    """
 
     def __init__(self, condition, statement, question, correction):
         """

--- a/armi/operators/tests/test_inspectors.py
+++ b/armi/operators/tests/test_inspectors.py
@@ -66,6 +66,10 @@ class TestInspector(unittest.TestCase):
         """
         Tests the case where a corrective query is resolved.
         Checks to make sure the settings file is overwritten with the resolved setting.
+
+        .. test:: Settings have validation and correction tools.
+            :id: T_ARMI_SETTINGS_RULES0
+            :tests: R_ARMI_SETTINGS_RULES
         """
         # load settings from test settings file
         self.cs["cycleLength"] = 300.0

--- a/armi/physics/fuelCycle/__init__.py
+++ b/armi/physics/fuelCycle/__init__.py
@@ -71,6 +71,7 @@ class FuelHandlerPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineSettings():
+        """Define settings for the plugin."""
         return settings.getFuelCycleSettings()
 
     @staticmethod

--- a/armi/physics/fuelPerformance/plugin.py
+++ b/armi/physics/fuelPerformance/plugin.py
@@ -46,6 +46,7 @@ class FuelPerformancePlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineParameters():
+        """Define parameters for the plugin."""
         from armi.physics.fuelPerformance import parameters
 
         return parameters.getFuelPerformanceParameterDefinitions()

--- a/armi/physics/neutronics/__init__.py
+++ b/armi/physics/neutronics/__init__.py
@@ -60,6 +60,7 @@ class NeutronicsPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineParameters():
+        """Define parameters for the plugin."""
         from armi.physics.neutronics import parameters as neutronicsParameters
 
         return neutronicsParameters.getNeutronicsParameterDefinitions()
@@ -67,6 +68,7 @@ class NeutronicsPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineEntryPoints():
+        """Define entry points for the plugin."""
         from armi.physics.neutronics import diffIsotxs
 
         entryPoints = [diffIsotxs.CompareIsotxsLibraries]
@@ -76,6 +78,7 @@ class NeutronicsPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineSettings():
+        """Define settings for the plugin."""
         from armi.physics.neutronics import settings as neutronicsSettings
         from armi.physics.neutronics import crossSectionSettings
         from armi.physics.neutronics.fissionProductModel import (
@@ -108,6 +111,7 @@ class NeutronicsPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def onProcessCoreLoading(core, cs, dbLoad):
+        """Called whenever a Core object is newly built."""
         applyEffectiveDelayedNeutronFractionToCore(core, cs)
 
     @staticmethod

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModelSettings.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModelSettings.py
@@ -24,6 +24,7 @@ CONF_FISSION_PRODUCT_LIBRARY_NAME = "fpModelLibrary"
 
 
 def defineSettings():
+    """Define settings for the plugin."""
     settings = [
         setting.Setting(
             CONF_FP_MODEL,

--- a/armi/physics/safety/__init__.py
+++ b/armi/physics/safety/__init__.py
@@ -20,4 +20,5 @@ class SafetyPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineSettings():
+        """Define settings for the plugin."""
         return []

--- a/armi/physics/thermalHydraulics/plugin.py
+++ b/armi/physics/thermalHydraulics/plugin.py
@@ -52,6 +52,7 @@ class ThermalHydraulicsPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineParameters():
+        """Define additional parameters for the reactor data model."""
         from armi.physics.thermalHydraulics import parameters
 
         return parameters.getParameterDefinitions()

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -167,7 +167,7 @@ class ArmiPlugin:
     @HOOKSPEC
     def defineParameters() -> Dict:
         """
-        Function for defining additional parameters.
+        Define additional parameters for the reactor data model.
 
         .. impl:: Plugins can add parameters to the reactor data model.
             :id: I_ARMI_PLUGIN_PARAMS

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -263,6 +263,10 @@ class HexReactorTests(ReactorTests):
         .. test:: Parameters accessible throughout the armi tree
             :id: T_ARMI_PARAM_PART
             :tests: R_ARMI_PARAM_PART
+
+        .. impl:: Prove there is a setting for total core power.
+            :id: T_ARMI_SETTINGS_POWER
+            :implements: R_ARMI_SETTINGS_POWER
         """
         # Test at core level
         core = self.r.core

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -322,6 +322,10 @@ def concatenateLogs(logDir=None):
     Concatenate the armi run logs and delete them.
 
     Should only ever be called by parent.
+
+    .. impl:: Log files from different processes are combined.
+        :id: I_ARMI_LOG_MPI
+        :implements: R_ARMI_LOG_MPI
     """
     if logDir is None:
         logDir = LOG_DIR
@@ -494,6 +498,14 @@ class RunLogger(logging.Logger):
 
     1. Giving users the option to de-duplicate warnings
     2. Piping stderr to a log file
+
+    .. impl:: A simulation-wide log, with user-specified verbosity.
+        :id: I_ARMI_LOG
+        :implements: R_ARMI_LOG
+
+    .. impl:: Logging is done to the screen and to file.
+        :id: I_ARMI_LOG_IO
+        :implements: R_ARMI_LOG_IO
     """
 
     FMT = "%(levelname)s%(message)s"

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -54,6 +54,10 @@ class Settings:
     The Settings object has a 1-to-1 correspondence with the ARMI settings input file.
     This file may be created by hand or by the GUI in submitter.py.
 
+    .. impl:: Settings are used to define an ARMI run.
+        :id: I_ARMI_SETTING0
+        :implements: R_ARMI_SETTING
+
     Notes
     -----
     The actual settings in any instance of this class are immutable.

--- a/armi/settings/fwSettings/databaseSettings.py
+++ b/armi/settings/fwSettings/databaseSettings.py
@@ -30,6 +30,7 @@ CONF_FORCE_DB_PARAMS = "forceDbParams"
 
 
 def defineSettings():
+    """Define settings for the interface."""
     settings = [
         setting.Setting(
             CONF_DB,

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -119,7 +119,13 @@ CONF_ZONE_DEFINITIONS = "zoneDefinitions"
 
 
 def defineSettings() -> List[setting.Setting]:
-    """Return a list of global framework settings."""
+    """
+    Return a list of global framework settings.
+
+    .. impl:: There is a setting for total core power.
+        :id: I_ARMI_SETTINGS_POWER
+        :implements: R_ARMI_SETTINGS_POWER
+    """
     settings = [
         setting.Setting(
             CONF_NUM_PROCESSORS,

--- a/armi/settings/fwSettings/reportSettings.py
+++ b/armi/settings/fwSettings/reportSettings.py
@@ -26,6 +26,7 @@ CONF_TIMELINE_INCLUSION_CUTOFF = "timelineInclusionCutoff"
 
 
 def defineSettings():
+    """Define settings for the interface."""
     settings = [
         setting.Setting(
             CONF_GEN_REPORTS,

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -59,6 +59,9 @@ class Setting:
     the custom object and when you call ``dump``, it will be serialized.
     Just accessing the value will return the actual object in this case.
 
+    .. impl:: The setting default is mandatory.
+        :id: I_ARMI_SETTINGS_DEFAULTS
+        :implements: R_ARMI_SETTINGS_DEFAULTS
     """
 
     def __init__(

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -141,6 +141,10 @@ class SettingRenamer:
 class SettingsReader:
     """Abstract class for processing settings files.
 
+    .. impl:: The setting use a human-readable, plain text file as input.
+        :id: I_ARMI_SETTINGS_IO_TXT
+        :implements: R_ARMI_SETTINGS_IO_TXT
+
     Parameters
     ----------
     cs : CaseSettings

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -264,7 +264,13 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         self.assertEqual(cs["extendableOption"], "PLUGIN")
 
     def test_default(self):
-        """Make sure default updating mechanism works."""
+        """
+        Make sure default updating mechanism works.
+
+        .. test:: The setting default is mandatory.
+            :id: T_ARMI_SETTINGS_DEFAULTS
+            :tests: R_ARMI_SETTINGS_DEFAULTS
+        """
         a = setting.Setting("testsetting", 0)
         newDefault = setting.Default(5, "testsetting")
         a.changeDefault(newDefault)

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -45,6 +45,7 @@ class DummyPlugin1(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineSettings():
+        """Define settings for the plugin."""
         return [
             setting.Setting(
                 "extendableOption",
@@ -61,6 +62,7 @@ class DummyPlugin2(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineSettings():
+        """Define settings for the plugin."""
         return [
             setting.Option("PLUGIN", "extendableOption"),
             setting.Default("PLUGIN", "extendableOption"),
@@ -71,6 +73,7 @@ class PluginAddsOptions(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineSettings():
+        """Define settings for the plugin."""
         return [
             setting.Option("MCNP", CONF_NEUTRONICS_KERNEL),
             setting.Option("MCNP_Slab", CONF_NEUTRONICS_KERNEL),

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -70,6 +70,12 @@ class SettingsReaderTests(unittest.TestCase):
         self.assertEqual(getattr(reader, "path"), "")
 
     def test_readFromFile(self):
+        """Read settings from a (human-readable) YAML file.
+
+        .. test:: The setting file is in a human-readable plain text file.
+            :id: T_ARMI_SETTINGS_IO_TXT
+            :tests: R_ARMI_SETTINGS_IO_TXT
+        """
         with directoryChangers.TemporaryDirectoryChanger():
             inPath = os.path.join(TEST_ROOT, "armiRun.yaml")
             outPath = "test_readFromFile.yaml"

--- a/armi/tests/Godiva-blueprints.yaml
+++ b/armi/tests/Godiva-blueprints.yaml
@@ -1,180 +1,48 @@
 nuclide flags:
-  PU237:
-    burn: false
-    xs: true
-    expandTo: []
-  PU240:
-    burn: false
-    xs: true
-    expandTo: []
-  PU241:
-    burn: false
-    xs: true
-    expandTo: []
-  AR:
-    burn: false
-    xs: true
-    expandTo: []
-  PA233:
-    burn: false
-    xs: true
-    expandTo: []
-  NP238:
-    burn: false
-    xs: true
-    expandTo: []
-  AR36:
-    burn: false
-    xs: true
-    expandTo: []
-  TH230:
-    burn: false
-    xs: true
-    expandTo: []
-  AR38:
-    burn: false
-    xs: true
-    expandTo: []
-  U238:
-    burn: false
-    xs: true
-    expandTo: []
-  U239:
-    burn: false
-    xs: true
-    expandTo: []
-  C:
-    burn: false
-    xs: true
-    expandTo: []
-  LFP35:
-    burn: false
-    xs: true
-    expandTo: []
-  U233:
-    burn: false
-    xs: true
-    expandTo: []
-  U234:
-    burn: false
-    xs: true
-    expandTo: []
-  U235:
-    burn: false
-    xs: true
-    expandTo: []
-  U236:
-    burn: false
-    xs: true
-    expandTo: []
-  U237:
-    burn: false
-    xs: true
-    expandTo: []
-  PU239:
-    burn: false
-    xs: true
-    expandTo: []
-  PU238:
-    burn: false
-    xs: true
-    expandTo: []
-  TH234:
-    burn: false
-    xs: true
-    expandTo: []
-  TH232:
-    burn: false
-    xs: true
-    expandTo: []
-  AR40:
-    burn: false
-    xs: true
-    expandTo: []
-  LFP39:
-    burn: false
-    xs: true
-    expandTo: []
-  DUMP2:
-    burn: false
-    xs: true
-    expandTo: []
-  LFP41:
-    burn: false
-    xs: true
-    expandTo: []
-  LFP40:
-    burn: false
-    xs: true
-    expandTo: []
-  PU242:
-    burn: false
-    xs: true
-    expandTo: []
-  PU236:
-    burn: false
-    xs: true
-    expandTo: []
-  U232:
-    burn: false
-    xs: true
-    expandTo: []
-  DUMP1:
-    burn: false
-    xs: true
-    expandTo: []
-  LFP38:
-    burn: false
-    xs: true
-    expandTo: []
-  AM243:
-    burn: false
-    xs: true
-    expandTo: []
-  PA231:
-    burn: false
-    xs: true
-    expandTo: []
-  CM244:
-    burn: false
-    xs: true
-    expandTo: []
-  CM242:
-    burn: false
-    xs: true
-    expandTo: []
-  AM242:
-    burn: false
-    xs: true
-    expandTo: []
-  CM245:
-    burn: false
-    xs: true
-    expandTo: []
-  CM243:
-    burn: false
-    xs: true
-    expandTo: []
-  CM246:
-    burn: false
-    xs: true
-    expandTo: []
-  CM247:
-    burn: false
-    xs: true
-    expandTo: []
-  O:
-    burn: false
-    xs: true
-    expandTo: [O16]
-  N:
-    burn: false
-    xs: true
-    expandTo: [N14]
-  ZR:
-    burn: false
-    xs: true
-    expandTo: []
+  PU237: {burn: false,  xs: true, expandTo: []}
+  PU240: {burn: false,  xs: true, expandTo: []}
+  PU241: {burn: false,  xs: true, expandTo: []}
+  AR: {burn: false,  xs: true, expandTo: []}
+  PA233: {burn: false,  xs: true, expandTo: []}
+  NP238: {burn: false,  xs: true, expandTo: []}
+  AR36: {burn: false,  xs: true, expandTo: []}
+  TH230: {burn: false,  xs: true, expandTo: []}
+  AR38: {burn: false,  xs: true, expandTo: []}
+  U238: {burn: false,  xs: true, expandTo: []}
+  U239: {burn: false,  xs: true, expandTo: []}
+  C: {burn: false,  xs: true, expandTo: []}
+  LFP35: {burn: false,  xs: true, expandTo: []}
+  U233: {burn: false,  xs: true, expandTo: []}
+  U234: {burn: false,  xs: true, expandTo: []}
+  U235: {burn: false,  xs: true, expandTo: []}
+  U236: {burn: false,  xs: true, expandTo: []}
+  U237: {burn: false,  xs: true, expandTo: []}
+  PU239: {burn: false,  xs: true, expandTo: []}
+  PU238: {burn: false,  xs: true, expandTo: []}
+  TH234: {burn: false,  xs: true, expandTo: []}
+  TH232: {burn: false,  xs: true, expandTo: []}
+  AR40: {burn: false,  xs: true, expandTo: []}
+  LFP39: {burn: false,  xs: true, expandTo: []}
+  DUMP2: {burn: false,  xs: true, expandTo: []}
+  LFP41: {burn: false,  xs: true, expandTo: []}
+  LFP40: {burn: false,  xs: true, expandTo: []}
+  PU242: {burn: false,  xs: true, expandTo: []}
+  PU236: {burn: false,  xs: true, expandTo: []}
+  U232: {burn: false,  xs: true, expandTo: []}
+  DUMP1: {burn: false,  xs: true, expandTo: []}
+  LFP38: {burn: false,  xs: true, expandTo: []}
+  AM243: {burn: false,  xs: true, expandTo: []}
+  PA231: {burn: false,  xs: true, expandTo: []}
+  CM244: {burn: false,  xs: true, expandTo: []}
+  CM242: {burn: false,  xs: true, expandTo: []}
+  AM242: {burn: false,  xs: true, expandTo: []}
+  CM245: {burn: false,  xs: true, expandTo: []}
+  CM243: {burn: false,  xs: true, expandTo: []}
+  CM246: {burn: false,  xs: true, expandTo: []}
+  CM247: {burn: false,  xs: true, expandTo: []}
+  O: {burn: false, xs: true, expandTo: [O16]}
+  N: {burn: false, xs: true, expandTo: [N14]}
+  ZR: {burn: false,  xs: true, expandTo: []}
 custom isotopics: {}
 blocks: {}
 assemblies:

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -34,7 +34,13 @@ class TestRunLog(unittest.TestCase):
         self.assertEqual(verbosityRank, logging.DEBUG)
 
     def test_setVerbosityFromString(self):
-        """Test that the log verbosity can be set with a string."""
+        """
+        Test that the log verbosity can be set with a string.
+
+        .. test:: The run log has configurable verbosity.
+            :id: T_ARMI_LOG0
+            :tests: R_ARMI_LOG
+        """
         log = runLog._RunLog(1)
         expectedStrVerbosity = "error"
         verbosityRank = log.getLogVerbosityRank(expectedStrVerbosity)
@@ -79,6 +85,7 @@ class TestRunLog(unittest.TestCase):
         log.log("debug", "You shouldn't see this.", single=False, label=None)
         log.log("warning", "Hello, ", single=False, label=None)
         log.log("error", "world!", single=False, label=None)
+
         log.logger.flush()
         log.logger.close()
         runLog.close(99)
@@ -206,7 +213,16 @@ class TestRunLog(unittest.TestCase):
         runLog.close(0)
 
     def test_setVerbosity(self):
-        """Let's test the setVerbosity() method carefully."""
+        """Let's test the setVerbosity() method carefully.
+
+        .. test:: The run log has configurable verbosity.
+            :id: T_ARMI_LOG1
+            :tests: R_ARMI_LOG
+
+        .. test:: The run log can log to stream.
+            :id: T_ARMI_LOG_IO0
+            :tests: R_ARMI_LOG_IO
+        """
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
             self.assertEqual("", mock.getStdout())
@@ -307,7 +323,17 @@ class TestRunLog(unittest.TestCase):
             mock.emptyStdout()
 
     def test_concatenateLogs(self):
-        """Simple test of the concat logs function."""
+        """
+        Simple test of the concat logs function.
+
+        .. test:: The run log combines logs from different processes.
+            :id: T_ARMI_LOG_MPI
+            :tests: R_ARMI_LOG_MPI
+
+        .. test:: The run log can log to file.
+            :id: T_ARMI_LOG_IO1
+            :tests: R_ARMI_LOG_IO
+        """
         with TemporaryDirectoryChanger():
             # create the log dir
             logDir = "test_concatenateLogs"

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -34,6 +34,7 @@ class UserPluginFlags(plugins.UserPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineFlags():
+        """Function to provide new Flags definitions."""
         return {"SPECIAL": utils.flags.auto()}
 
 
@@ -43,6 +44,7 @@ class UserPluginFlags2(plugins.UserPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineFlags():
+        """Function to provide new Flags definitions."""
         return {"FLAG2": utils.flags.auto()}
 
 
@@ -52,6 +54,7 @@ class UserPluginFlags3(plugins.UserPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineFlags():
+        """Function to provide new Flags definitions."""
         return {"FLAG3": utils.flags.auto()}
 
 
@@ -74,6 +77,7 @@ class UserPluginBadDefinesSettings(plugins.UserPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineSettings():
+        """Define settings for the plugin."""
         return [1, 2, 3]
 
 
@@ -83,6 +87,7 @@ class UserPluginBadDefineParameterRenames(plugins.UserPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def defineParameterRenames():
+        """Return a mapping from old parameter names to new parameter names."""
         return {"oldType": "type"}
 
 
@@ -96,6 +101,7 @@ class UserPluginOnProcessCoreLoading(plugins.UserPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def onProcessCoreLoading(core, cs, dbLoad):
+        """Function to call whenever a Core object is newly built."""
         blocks = core.getBlocks(Flags.FUEL)
         for b in blocks:
             b.p.height += 1.0
@@ -110,6 +116,7 @@ class UpInterface(interfaces.Interface):
     name = "UpInterface"
 
     def interactEveryNode(self, cycle, node):
+        """Logic to be caried out at every time node in the simulation."""
         self.r.core.p.power += 100
 
 
@@ -119,6 +126,7 @@ class UserPluginWithInterface(plugins.UserPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def exposeInterfaces(cs):
+        """Function for exposing interface(s) to other code."""
         return [
             interfaces.InterfaceInfo(
                 interfaces.STACK_ORDER.PREPROCESSING, UpInterface, {"enabled": True}

--- a/armi/utils/densityTools.py
+++ b/armi/utils/densityTools.py
@@ -196,6 +196,7 @@ def formatMaterialCard(
         mCard = ["m{matNum}\n".format(matNum=matNum)]
     else:
         mCard = ["m{}\n"]
+
     for nuc, dens in sorted(densities.items()):
         # skip LFPs and Dummies.
         if isinstance(nuc, (nuclideBases.LumpNuclideBase)):
@@ -214,6 +215,7 @@ def formatMaterialCard(
 
     if mcnp6Compatible:
         mCard.append("      nlib={lib}c\n".format(lib=mcnpLibrary))
+
     return mCard
 
 
@@ -250,7 +252,7 @@ def filterNuclideList(nuclideVector, nuclides):
 
 def normalizeNuclideList(nuclideVector, normalization=1.0):
     """
-    normalize the nuclide vector.
+    Normalize the nuclide vector.
 
     Parameters
     ----------

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -29,7 +29,13 @@ SQRT3 = math.sqrt(3.0)
 
 
 def area(pitch):
-    """Area of a hex given the flat-to-flat pitch."""
+    """
+    Area of a hex given the flat-to-flat pitch.
+
+    Notes
+    -----
+    The pitch is the distance between the center of the hexagaons, in the lattice.
+    """
     return SQRT3 / 2.0 * pitch**2
 
 
@@ -44,6 +50,10 @@ def side(pitch):
         \frac{s}{2}^2 + \frac{p}{2}^2 = s^2
 
     which you can solve to find p = sqrt(3)*s
+
+    Notes
+    -----
+    The pitch is the distance between the center of the hexagaons, in the lattice.
     """
     return pitch / SQRT3
 
@@ -78,6 +88,13 @@ def corners(rotation=0):
 
 
 def pitch(side):
+    """
+    Calculate the pitch from the length of a hexagon side.
+
+    Notes
+    -----
+    The pitch is the distance between the center of the hexagaons, in the lattice.
+    """
     return side * SQRT3
 
 


### PR DESCRIPTION
## What is the change?

In this PR I am doing three things:

* adding req crumbs for the run log
* adding req crumbs for the settings
* added missing docstrings (fairly random, sorry)

## Why is the change being made?

This is part of the on-going QA work.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
