### PR TITLE
Adding even more test crumbs

### DIFF
--- a/armi/bookkeeping/db/__init__.py
+++ b/armi/bookkeeping/db/__init__.py
@@ -249,6 +249,10 @@ def _getH5File(db):
 
     All this being said, we are probably violating this already with genAuxiliaryData,
     but we have to start somewhere.
+
+    .. impl:: The ARMI output file has a language-agnostic format.
+        :id: I_ARMI_DB_H5
+        :implements: R_ARMI_DB_H5
     """
     if isinstance(db, Database3):
         return db.h5db

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -109,10 +109,6 @@ class Database3:
     handles the packing and unpacking of the structure of the objects, their
     relationships, and their non-parameter attributes.
 
-    .. impl:: The ARMI output file has a language-agnostic format.
-        :id: I_ARMI_DB_H5
-        :implements: R_ARMI_DB_H5
-
     See Also
     --------
     `doc/user/outputs/database` for more details.

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -109,6 +109,10 @@ class Database3:
     handles the packing and unpacking of the structure of the objects, their
     relationships, and their non-parameter attributes.
 
+    .. impl:: The ARMI output file has a language-agnostic format.
+        :id: I_ARMI_DB_H5
+        :implements: R_ARMI_DB_H5
+
     See Also
     --------
     `doc/user/outputs/database` for more details.
@@ -1458,7 +1462,6 @@ def packSpecialData(
       ``None`` with a magical value that shouldn't be encountered in realistic
       scenarios.
 
-
     Parameters
     ----------
     data
@@ -1609,7 +1612,6 @@ def unpackSpecialData(data: numpy.ndarray, attrs, paramName: str) -> numpy.ndarr
     numpy.ndarray
         An ndarray containing the closest possible representation of the data that was
         originally written to the database.
-
 
     See Also
     --------

--- a/armi/bookkeeping/db/databaseInterface.py
+++ b/armi/bookkeeping/db/databaseInterface.py
@@ -222,6 +222,10 @@ class DatabaseInterface(interfaces.Interface):
         `startCycle` and `startNode`, having loaded the state from all cycles prior
         to that in the requested database.
 
+        .. impl:: Runs at a particular timenode can be re-instantiated for a snapshot.
+            :id: I_ARMI_SNAPSHOT_RESTART
+            :implements: R_ARMI_SNAPSHOT_RESTART
+
         Notes
         -----
         Mixing the use of simple vs detailed cycles settings is allowed, provided

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -95,6 +95,13 @@ class TestDatabase3(unittest.TestCase):
         )
 
     def test_getH5File(self):
+        """
+        Get the h5 file for the database, because that file format is language-agnostic.
+
+        .. test:: Show the database is H5-formatted.
+            :id: T_ARMI_DB_H5
+            :tests: R_ARMI_DB_H5
+        """
         with self.assertRaises(TypeError):
             _getH5File(None)
 
@@ -185,6 +192,10 @@ class TestDatabase3(unittest.TestCase):
         above. In that cs, `reloadDBName` is set to 'reloadingDB.h5', `startCycle` = 1,
         and `startNode` = 2. The nonexistent 'reloadingDB.h5' must first be
         created here for this test.
+
+        .. test:: Runs can be restarted from a snapshot.
+            :id: T_ARMI_SNAPSHOT_RESTART
+            :tests: R_ARMI_SNAPSHOT_RESTART
         """
         # first successfully call to prepRestartRun
         o, r = loadTestReactor(

--- a/armi/bookkeeping/snapshotInterface.py
+++ b/armi/bookkeeping/snapshotInterface.py
@@ -42,7 +42,13 @@ def describeInterfaces(cs):
 
 
 class SnapshotInterface(interfaces.Interface):
-    """Snapshot managerial interface."""
+    """
+    Snapshot managerial interface.
+
+    .. impl:: Save extra data to be saved from a run, at specified time nodes.
+        :id: I_ARMI_SNAPSHOT0
+        :implements: R_ARMI_SNAPSHOT
+    """
 
     name = "snapshot"
 

--- a/armi/bookkeeping/tests/test_snapshot.py
+++ b/armi/bookkeeping/tests/test_snapshot.py
@@ -59,6 +59,13 @@ class TestSnapshotInterface(unittest.TestCase):
         self.assertTrue(mockSnapshotRequest.called)
 
     def test_activeateDefaultSnapshots_30cycles2BurnSteps(self):
+        """
+        Test snapshots for 30 cycles and 2 burnsteps, checking the dumpSnapshot setting.
+
+        .. test:: Allow extra data to be saved from a run, at specified time nodes.
+            :id: T_ARMI_SNAPSHOT0
+            :tests: R_ARMI_SNAPSHOT
+        """
         self.assertEqual([], self.cs["dumpSnapshot"])
 
         newSettings = {}
@@ -72,6 +79,13 @@ class TestSnapshotInterface(unittest.TestCase):
         self.assertEqual(["000000", "014000", "029002"], self.si.cs["dumpSnapshot"])
 
     def test_activeateDefaultSnapshots_17cycles5BurnSteps(self):
+        """
+        Test snapshots for 17 cycles and 5 burnsteps, checking the dumpSnapshot setting.
+
+        .. test:: Allow extra data to be saved from a run, at specified time nodes.
+            :id: T_ARMI_SNAPSHOT1
+            :tests: R_ARMI_SNAPSHOT
+        """
         self.assertEqual([], self.cs["dumpSnapshot"])
 
         newSettings = {}

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -336,6 +336,10 @@ class Case:
         It also activates supervisory things like code coverage checking, profiling,
         or tracing, if requested by users during debugging.
 
+        .. impl:: The case class allows for a generic ARMI simulation.
+            :id: T_ARMI_CASE
+            :implements: R_ARMI_CASE
+
         Notes
         -----
         Room for improvement: The coverage, profiling, etc. stuff can probably be moved
@@ -555,6 +559,10 @@ class Case:
     def checkInputs(self):
         """
         Checks ARMI inputs for consistency.
+
+        .. impl:: Perform validity checks on case inputs.
+            :id: T_ARMI_CASE_CHECK
+            :implements: R_ARMI_CASE_CHECK
 
         Returns
         -------

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -337,7 +337,7 @@ class Case:
         or tracing, if requested by users during debugging.
 
         .. impl:: The case class allows for a generic ARMI simulation.
-            :id: T_ARMI_CASE
+            :id: I_ARMI_CASE
             :implements: R_ARMI_CASE
 
         Notes
@@ -561,7 +561,7 @@ class Case:
         Checks ARMI inputs for consistency.
 
         .. impl:: Perform validity checks on case inputs.
-            :id: T_ARMI_CASE_CHECK
+            :id: I_ARMI_CASE_CHECK
             :implements: R_ARMI_CASE_CHECK
 
         Returns

--- a/armi/cases/inputModifiers/inputModifiers.py
+++ b/armi/cases/inputModifiers/inputModifiers.py
@@ -32,7 +32,7 @@ class InputModifier:
     modifiers in most cases.
 
     .. impl:: A generic tool to modify user inputs on multiple cases.
-        :id: T_ARMI_CASE_MOD1
+        :id: I_ARMI_CASE_MOD1
         :implements: R_ARMI_CASE_MOD
     """
 

--- a/armi/cases/inputModifiers/inputModifiers.py
+++ b/armi/cases/inputModifiers/inputModifiers.py
@@ -30,6 +30,10 @@ class InputModifier:
 
     Some subclasses are provided, but you are expected to make your own design-specific
     modifiers in most cases.
+
+    .. impl:: A generic tool to modify user inputs on multiple cases.
+        :id: T_ARMI_CASE_MOD1
+        :implements: R_ARMI_CASE_MOD
     """
 
     FAIL_IF_AFTER = ()

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -45,6 +45,10 @@ class SuiteBuilder:
     """
     Class for constructing a CaseSuite from combinations of modifications on base inputs.
 
+    .. impl:: A generic tool to modify user inputs on multiple cases.
+        :id: T_ARMI_CASE_MOD0
+        :implements: R_ARMI_CASE_MOD
+
     Attributes
     ----------
     baseCase : armi.cases.case.Case

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -46,7 +46,7 @@ class SuiteBuilder:
     Class for constructing a CaseSuite from combinations of modifications on base inputs.
 
     .. impl:: A generic tool to modify user inputs on multiple cases.
-        :id: T_ARMI_CASE_MOD0
+        :id: I_ARMI_CASE_MOD0
         :implements: R_ARMI_CASE_MOD
 
     Attributes

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -262,7 +262,12 @@ class TestArmiCase(unittest.TestCase):
 
 
 class TestCaseSuiteDependencies(unittest.TestCase):
-    """CaseSuite tests."""
+    """CaseSuite tests.
+
+    .. test:: Dependence allows for one case to start after the completion of another.
+        :id: T_ARMI_CASE_SUITE0
+        :tests: R_ARMI_CASE_SUITE
+    """
 
     def setUp(self):
         self.suite = cases.CaseSuite(settings.Settings())
@@ -283,6 +288,17 @@ class TestCaseSuiteDependencies(unittest.TestCase):
         """If you pass an invalid path, the clone can't happen, but it won't do any damage either."""
         with self.assertRaises(RuntimeError):
             _clone = self.suite.clone("test_clone")
+
+    def test_checkInputs(self):
+        """
+        Test the checkInputs() method on a couple of cases.
+
+        .. test:: Test the checkInputs method.
+            :id: T_ARMI_CASE_CHECK
+            :tests: R_ARMI_CASE_CHECK
+        """
+        self.c1.checkInputs()
+        self.c2.checkInputs()
 
     def test_dependenciesWithObscurePaths(self):
         """

--- a/armi/cases/tests/test_suiteBuilder.py
+++ b/armi/cases/tests/test_suiteBuilder.py
@@ -49,7 +49,7 @@ class TestLatinHyperCubeSuiteBuilder(unittest.TestCase):
     """
     Class to test LatinHyperCubeSuiteBuilder.
 
-    .. test:: The run log has configurable verbosity.
+    .. test:: A generic mechanism to allow users to modify user inputs in cases.
         :id: T_ARMI_CASE_MOD0
         :tests: R_ARMI_CASE_MOD
     """

--- a/armi/cases/tests/test_suiteBuilder.py
+++ b/armi/cases/tests/test_suiteBuilder.py
@@ -46,7 +46,13 @@ class LatinHyperCubeModifier(SamplingInputModifier):
 
 
 class TestLatinHyperCubeSuiteBuilder(unittest.TestCase):
-    """Class to test LatinHyperCubeSuiteBuilder."""
+    """
+    Class to test LatinHyperCubeSuiteBuilder.
+
+    .. test:: The run log has configurable verbosity.
+        :id: T_ARMI_CASE_MOD0
+        :tests: R_ARMI_CASE_MOD
+    """
 
     def test_initialize(self):
         builder = LatinHyperCubeSuiteBuilder(case, size=20)

--- a/armi/materials/tests/test_air.py
+++ b/armi/materials/tests/test_air.py
@@ -178,7 +178,12 @@ REFERENCE_THERMAL_CONDUCTIVITY_mJ_PER_M_K = [
 
 
 class Test_Air(unittest.TestCase):
-    """unit tests for air materials."""
+    """unit tests for air materials.
+
+    .. test:: There is a base class for fluid materials.
+        :id: T_ARMI_MAT_FLUID1
+        :tests: R_ARMI_MAT_FLUID
+    """
 
     def test_pseudoDensity(self):
         """

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -108,7 +108,7 @@ class _Material_Test:
         self.assertEqual(val, "Noether")
 
     def test_densityKgM3(self):
-        """Test the density for gk/m^3.
+        """Test the density for kg/m^3.
 
         .. test:: Test the material base class.
             :id: T_ARMI_MAT_PROPERTIES5
@@ -119,7 +119,7 @@ class _Material_Test:
         self.assertEqual(dens * 1000.0, densKgM3)
 
     def test_pseudoDensityKgM3(self):
-        """Test the pseudo density for gk/m^3.
+        """Test the pseudo density for kg/m^3.
 
         .. test:: Test the material base class.
             :id: T_ARMI_MAT_PROPERTIES6

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -784,7 +784,7 @@ class Thorium_TestCase(_Material_Test, unittest.TestCase):
 
     def test_setDefaultMassFracs(self):
         """
-        Test test default mass fracitons.
+        Test default mass fractions.
 
         .. test:: The materials generate nuclide mass fractions.
             :id: T_ARMI_MAT_FRACS0
@@ -887,7 +887,7 @@ class Void_TestCase(_Material_Test, unittest.TestCase):
         self.assertEqual(cur, 0.0)
 
     def test_linearExpansion(self):
-        """This material does not expand linerally.
+        """This material does not expand linearly.
 
         .. test:: There is a void material.
             :id: T_ARMI_MAT_VOID2
@@ -916,7 +916,7 @@ class Mixture_TestCase(_Material_Test, unittest.TestCase):
 
     def test_setDefaultMassFracs(self):
         """
-        Test test default mass fracitons.
+        Test default mass fractions.
 
         .. test:: The materials generate nuclide mass fractions.
             :id: T_ARMI_MAT_FRACS1
@@ -969,7 +969,7 @@ class Lead_TestCase(_Material_Test, unittest.TestCase):
 
     def test_setDefaultMassFracs(self):
         """
-        Test test default mass fracitons.
+        Test default mass fractions.
 
         .. test:: The materials generate nuclide mass fractions.
             :id: T_ARMI_MAT_FRACS2

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -35,7 +35,12 @@ class _Material_Test:
         self.mat = self.MAT_CLASS()
 
     def test_isPicklable(self):
-        """Test that all materials are picklable so we can do MPI communication of state."""
+        """Test that all materials are picklable so we can do MPI communication of state.
+
+        .. test:: Test the material base class.
+            :id: T_ARMI_MAT_PROPERTIES0
+            :tests: R_ARMI_MAT_PROPERTIES
+        """
         stream = pickle.dumps(self.mat)
         mat = pickle.loads(stream)
 
@@ -45,10 +50,21 @@ class _Material_Test:
         )
 
     def test_density(self):
-        """Test that all materials produce a zero density from density."""
+        """Test that all materials produce a zero density from density.
+
+        .. test:: Test the material base class.
+            :id: T_ARMI_MAT_PROPERTIES1
+            :tests: R_ARMI_MAT_PROPERTIES
+        """
         self.assertNotEqual(self.mat.density(500), 0)
 
     def test_TD(self):
+        """Test the material density.
+
+        .. test:: Test the material base class.
+            :id: T_ARMI_MAT_PROPERTIES2
+            :tests: R_ARMI_MAT_PROPERTIES
+        """
         self.assertEqual(self.mat.getTD(), self.mat.theoreticalDensityFrac)
 
         self.mat.clearCache()
@@ -59,6 +75,12 @@ class _Material_Test:
         self.assertEqual(self.mat.cached, {})
 
     def test_duplicate(self):
+        """Test the material duplication.
+
+        .. test:: Test the material base class.
+            :id: T_ARMI_MAT_PROPERTIES3
+            :tests: R_ARMI_MAT_PROPERTIES
+        """
         mat = self.mat.duplicate()
 
         self.assertEqual(len(mat.massFrac), len(self.mat.massFrac))
@@ -70,6 +92,12 @@ class _Material_Test:
         self.assertEqual(mat.theoreticalDensityFrac, self.mat.theoreticalDensityFrac)
 
     def test_cache(self):
+        """Test the material cache.
+
+        .. test:: Test the material base class.
+            :id: T_ARMI_MAT_PROPERTIES4
+            :tests: R_ARMI_MAT_PROPERTIES
+        """
         self.mat.clearCache()
         self.assertEqual(len(self.mat.cached), 0)
 
@@ -80,11 +108,23 @@ class _Material_Test:
         self.assertEqual(val, "Noether")
 
     def test_densityKgM3(self):
+        """Test the density for gk/m^3.
+
+        .. test:: Test the material base class.
+            :id: T_ARMI_MAT_PROPERTIES5
+            :tests: R_ARMI_MAT_PROPERTIES
+        """
         dens = self.mat.density(500)
         densKgM3 = self.mat.densityKgM3(500)
         self.assertEqual(dens * 1000.0, densKgM3)
 
     def test_pseudoDensityKgM3(self):
+        """Test the pseudo density for gk/m^3.
+
+        .. test:: Test the material base class.
+            :id: T_ARMI_MAT_PROPERTIES6
+            :tests: R_ARMI_MAT_PROPERTIES
+        """
         dens = self.mat.pseudoDensity(500)
         densKgM3 = self.mat.pseudoDensityKgM3(500)
         self.assertEqual(dens * 1000.0, densKgM3)
@@ -101,6 +141,12 @@ class MaterialFindingTests(unittest.TestCase):
     """Make sure materials are discoverable as designed."""
 
     def test_findMaterial(self):
+        """Test resolveMaterialClassByName() function.
+
+        .. test:: You can find a meterial by name.
+            :id: T_ARMI_MAT_NAME
+            :tests: R_ARMI_MAT_NAME
+        """
         self.assertIs(
             materials.resolveMaterialClassByName(
                 "Void", namespaceOrder=["armi.materials"]
@@ -737,6 +783,13 @@ class Thorium_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Thorium
 
     def test_setDefaultMassFracs(self):
+        """
+        Test test default mass fracitons.
+
+        .. test:: The materials generate nuclide mass fractions.
+            :id: T_ARMI_MAT_FRACS0
+            :tests: R_ARMI_LOG
+        """
         self.mat.setDefaultMassFracs()
         cur = self.mat.massFrac
         ref = {"TH232": 1.0}
@@ -810,12 +863,23 @@ class Void_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.Void
 
     def test_pseudoDensity(self):
+        """This material has a no pseudo-density.
+
+        .. test:: There is a void material.
+            :id: T_ARMI_MAT_VOID0
+            :tests: R_ARMI_MAT_VOID
+        """
         self.mat.setDefaultMassFracs()
         cur = self.mat.pseudoDensity()
         self.assertEqual(cur, 0.0)
 
     def test_density(self):
-        """This material has no density function."""
+        """This material has no density.
+
+        .. test:: There is a void material.
+            :id: T_ARMI_MAT_VOID1
+            :tests: R_ARMI_MAT_VOID
+        """
         self.assertEqual(self.mat.density(500), 0)
 
         self.mat.setDefaultMassFracs()
@@ -823,11 +887,23 @@ class Void_TestCase(_Material_Test, unittest.TestCase):
         self.assertEqual(cur, 0.0)
 
     def test_linearExpansion(self):
+        """This material does not expand linerally.
+
+        .. test:: There is a void material.
+            :id: T_ARMI_MAT_VOID2
+            :tests: R_ARMI_MAT_VOID
+        """
         cur = self.mat.linearExpansion(400)
         ref = 0.0
         self.assertEqual(cur, ref)
 
     def test_propertyValidTemperature(self):
+        """This material has no valid temperatures.
+
+        .. test:: There is a void material.
+            :id: T_ARMI_MAT_VOID3
+            :tests: R_ARMI_MAT_VOID
+        """
         self.assertEqual(len(self.mat.propertyValidTemperature), 0)
 
 
@@ -839,6 +915,13 @@ class Mixture_TestCase(_Material_Test, unittest.TestCase):
         self.assertEqual(self.mat.density(500), 0)
 
     def test_setDefaultMassFracs(self):
+        """
+        Test test default mass fracitons.
+
+        .. test:: The materials generate nuclide mass fractions.
+            :id: T_ARMI_MAT_FRACS1
+            :tests: R_ARMI_LOG
+        """
         self.mat.setDefaultMassFracs()
         cur = self.mat.pseudoDensity(500)
         self.assertEqual(cur, 0.0)
@@ -852,6 +935,13 @@ class Mixture_TestCase(_Material_Test, unittest.TestCase):
 
 
 class Lead_TestCase(_Material_Test, unittest.TestCase):
+    """Unit tests for lead materials.
+
+    .. test:: There is a base class for fluid materials.
+        :id: T_ARMI_MAT_FLUID2
+        :tests: R_ARMI_MAT_FLUID
+    """
+
     MAT_CLASS = materials.Lead
 
     def test_volumetricExpansion(self):
@@ -878,6 +968,13 @@ class Lead_TestCase(_Material_Test, unittest.TestCase):
         self.assertEqual(cur, ref)
 
     def test_setDefaultMassFracs(self):
+        """
+        Test test default mass fracitons.
+
+        .. test:: The materials generate nuclide mass fractions.
+            :id: T_ARMI_MAT_FRACS2
+            :tests: R_ARMI_LOG
+        """
         self.mat.setDefaultMassFracs()
         cur = self.mat.massFrac
         ref = {"PB": 1}
@@ -908,6 +1005,13 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.LeadBismuth
 
     def test_setDefaultMassFracs(self):
+        """
+        Test test default mass fracitons.
+
+        .. test:: The materials generate nuclide mass fractions.
+            :id: T_ARMI_MAT_FRACS3
+            :tests: R_ARMI_LOG
+        """
         self.mat.setDefaultMassFracs()
         cur = self.mat.massFrac
         ref = {"BI209": 0.555, "PB": 0.445}

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -1006,7 +1006,7 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
 
     def test_setDefaultMassFracs(self):
         """
-        Test test default mass fracitons.
+        Test default mass fractions.
 
         .. test:: The materials generate nuclide mass fractions.
             :id: T_ARMI_MAT_FRACS3

--- a/armi/materials/tests/test_water.py
+++ b/armi/materials/tests/test_water.py
@@ -19,7 +19,12 @@ from armi.materials.water import SaturatedWater, SaturatedSteam, Water
 
 
 class Test_Water(unittest.TestCase):
-    """Unit tests for water materials."""
+    """Unit tests for water materials.
+
+    .. test:: There is a base class for fluid materials.
+        :id: T_ARMI_MAT_FLUID0
+        :tests: R_ARMI_MAT_FLUID
+    """
 
     def test_water_at_freezing(self):
         """

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -24,6 +24,10 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
 
     These may add CR worth curves, rx coefficients, transient runs etc at these snapshots.
     This operator can be run as a restart, adding new physics to a previous run.
+
+    .. impl:: Save extra data to be saved from a run, at specified time nodes.
+        :id: I_ARMI_SNAPSHOT1
+        :implements: R_ARMI_SNAPSHOT
     """
 
     def __init__(self, cs):

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -24,10 +24,6 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
 
     These may add CR worth curves, rx coefficients, transient runs etc at these snapshots.
     This operator can be run as a restart, adding new physics to a previous run.
-
-    .. impl:: Save extra data to be saved from a run, at specified time nodes.
-        :id: I_ARMI_SNAPSHOT1
-        :implements: R_ARMI_SNAPSHOT
     """
 
     def __init__(self, cs):

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -146,10 +146,6 @@ class AxialExpansionChanger:
             :id: I_ARMI_AXIAL_EXP_PRESC
             :implements: R_ARMI_AXIAL_EXP_PRESC
 
-        .. impl:: Perform thermal expansion/contraction, given an axial temp distribution over an assembly.
-            :id: I_ARMI_AXIAL_EXP_THERM
-            :implements: R_ARMI_AXIAL_EXP_THERM
-
         Parameters
         ----------
         a : :py:class:`Assembly <armi.reactor.assemblies.Assembly>`
@@ -179,6 +175,10 @@ class AxialExpansionChanger:
         expandFromTinputToThot: bool = False,
     ):
         """Perform thermal expansion for an assembly given an axial temperature grid and field.
+
+        .. impl:: Perform thermal expansion/contraction, given an axial temp distribution over an assembly.
+            :id: I_ARMI_AXIAL_EXP_THERM
+            :implements: R_ARMI_AXIAL_EXP_THERM
 
         Parameters
         ----------

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -65,6 +65,10 @@ def expandColdDimsToHot(
     """
     Expand BOL assemblies, resolve disjoint axial mesh (if needed), and update block BOL heights.
 
+    .. impl:: Perform expansion during core construction based on block heights at a specified temperature.
+        :id: I_ARMI_INP_COLD_HEIGHT
+        :implements: R_ARMI_INP_COLD_HEIGHT
+
     Parameters
     ----------
     assems: list[:py:class:`Assembly <armi.reactor.assemblies.Assembly>`]
@@ -137,6 +141,14 @@ class AxialExpansionChanger:
         self, a, componentLst: list, percents: list, setFuel=True
     ):
         """Perform axial expansion of an assembly given prescribed expansion percentages.
+
+        .. impl:: Perform expansion/contraction, given a list of components and expansion coefficients.
+            :id: I_ARMI_AXIAL_EXP_PRESC
+            :implements: R_ARMI_AXIAL_EXP_PRESC
+
+        .. impl:: Perform thermal expansion/contraction, given an axial temp distribution over an assembly.
+            :id: I_ARMI_AXIAL_EXP_THERM
+            :implements: R_ARMI_AXIAL_EXP_THERM
 
         Parameters
         ----------

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -775,7 +775,13 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
             self.assertEqual(the_exception.error_code, 3)
 
     def test_manuallySetTargetComponent(self):
-        """Ensures that target components can be manually set (is done in practice via blueprints)."""
+        """
+        Ensures that target components can be manually set (is done in practice via blueprints).
+
+        .. test:: Allow user-specified target axial expansion components on a given block.
+            :id: T_ARMI_MANUAL_TARG_COMP
+            :tests: R_ARMI_MANUAL_TARG_COMP
+        """
         b = HexBlock("dummy", height=10.0)
         ductDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
         duct = Hexagon("duct", "FakeMat", **ductDims)
@@ -833,6 +839,10 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
 
     def test_coldAssemblyExpansion(self):
         """Block heights are cold and should be expanded.
+
+        .. test:: Preserve the total height of a compatible ARMI assembly.
+            :id: T_ARMI_ASSEM_HEIGHT_PRES
+            :tests: R_ARMI_ASSEM_HEIGHT_PRES
 
         Notes
         -----

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -251,7 +251,13 @@ class TestUniformMeshGenerator(unittest.TestCase):
         self.assertNotEqual(refMesh[4], avgMesh[4], "Not equal above the fuel.")
 
     def test_filterMesh(self):
-        """Test that the mesh can be correctly filtered."""
+        """
+        Test that the mesh can be correctly filtered.
+
+        .. test:: Try to preserve the boundaries of fuel and control material.
+            :id: T_ARMI_UMC_NON_UNIFORM1
+            :tests: R_ARMI_UMC_NON_UNIFORM
+        """
         meshList = [1.0, 3.0, 4.0, 7.0, 9.0, 12.0, 16.0, 19.0, 20.0]
         anchorPoints = [4.0, 16.0]
         combinedMesh = self.generator._filterMesh(
@@ -295,7 +301,17 @@ class TestUniformMeshGenerator(unittest.TestCase):
         self.assertListEqual(ctrlAndFuelTops, [75.0, 101.25, 105.0])
 
     def test_generateCommonMesh(self):
-        """Covers generateCommonmesh() and _decuspAxialMesh()."""
+        """
+        Covers generateCommonmesh() and _decuspAxialMesh().
+
+        .. test:: Produce a uniform mesh with a size no smaller than a user-specified value.
+            :id: T_ARMI_UMC_MIN_MESH
+            :tests: R_ARMI_UMC_MIN_MESH
+
+        .. test:: Try to preserve the boundaries of fuel and control material.
+            :id: T_ARMI_UMC_NON_UNIFORM0
+            :tests: R_ARMI_UMC_NON_UNIFORM
+        """
         self.generator.generateCommonMesh()
         expectedMesh = [
             25.0,
@@ -346,7 +362,7 @@ class TestUniformMeshComponents(unittest.TestCase):
             "allNuclidesInProblem",
             "elementsToExpand",
             "inertNuclides",
-        ]  # note, items within toCompare must be list or "list-like", like an ordered set
+        ]  # Note: items within toCompare must be list or "list-like", like an ordered set
         for attr in toCompare:
             for c, o in zip(getattr(converted, attr), getattr(original, attr)):
                 self.assertEqual(c, o)
@@ -394,6 +410,13 @@ class TestUniformMesh(unittest.TestCase):
         )
 
     def test_convertNumberDensities(self):
+        """
+        Test the reactor mass before and after conversion.
+
+        .. test:: Make a copy of the reactor where the new reactor core has a uniform axial mesh.
+            :id: T_ARMI_UMC
+            :tests: R_ARMI_UMC
+        """
         refMass = self.r.core.getMass("U235")
         applyNonUniformHeightDistribution(
             self.r
@@ -413,6 +436,13 @@ class TestUniformMesh(unittest.TestCase):
         )  # conversion didn't change source reactor mass
 
     def test_applyStateToOriginal(self):
+        """
+        Test applyStateToOriginal() to revert mesh conversion.
+
+        .. test:: Map select parameters from composites on the new mesh to the original mesh.
+            :id: T_ARMI_UMC_PARAM_BACKWARD0
+            :tests: R_ARMI_UMC_PARAM_BACKWARD
+        """
         applyNonUniformHeightDistribution(self.r)  # note: this perturbs the ref mass
 
         self.converter.convert(self.r)
@@ -505,6 +535,13 @@ class TestGammaUniformMesh(unittest.TestCase):
         )  # conversion didn't change source reactor mass
 
     def test_applyStateToOriginal(self):
+        """
+        Test applyStateToOriginal() to revert mesh conversion.
+
+        .. test:: Map select parameters from composites on the new mesh to the original mesh.
+            :id: T_ARMI_UMC_PARAM_BACKWARD1
+            :tests: R_ARMI_UMC_PARAM_BACKWARD
+        """
         applyNonUniformHeightDistribution(self.r)  # note: this perturbs the ref. mass
 
         # set original parameters on pre-mapped core with non-uniform assemblies
@@ -612,6 +649,10 @@ class TestParamConversion(unittest.TestCase):
         Test that state is translated correctly from source to dest assems.
 
         Here we set flux and pdens to 3 on the source blocks.
+
+        .. test:: Map select parameters from composites on the original mesh to the new mesh.
+            :id: T_ARMI_UMC_PARAM_FORWARD
+            :tests: R_ARMI_UMC_PARAM_FORWARD
         """
         paramList = ["flux", "pdens"]
         for pName in paramList:

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -118,6 +118,14 @@ class UniformMeshGenerator:
         """
         Generate a common axial mesh to use.
 
+        .. impl:: Try to preserve the boundaries of fuel and control material.
+            :id: I_ARMI_UMC_NON_UNIFORM
+            :implements: R_ARMI_UMC_NON_UNIFORM
+
+        .. impl:: Produce a mesh with a size no smaller than a user-specified value.
+            :id: I_ARMI_UMC_MIN_MESH
+            :implements: R_ARMI_UMC_MIN_MESH
+
         Notes
         -----
         Attempts to reduce the effect of fuel and control rod absorber smearing
@@ -407,7 +415,17 @@ class UniformMeshGeometryConverter(GeometryConverter):
             self._minimumMeshSize = cs[CONF_UNIFORM_MESH_MINIMUM_SIZE]
 
     def convert(self, r=None):
-        """Create a new reactor core with a uniform mesh."""
+        """
+        Create a new reactor core with a uniform mesh.
+
+        .. impl:: Make a copy of the reactor where the new core has a uniform axial mesh.
+            :id: I_ARMI_UMC
+            :implements: R_ARMI_UMC
+
+        .. impl:: Map select parameters from composites on the original mesh to the new mesh.
+            :id: I_ARMI_UMC_PARAM_FORWARD
+            :implements: R_ARMI_UMC_PARAM_FORWARD
+        """
         if r is None:
             raise ValueError(f"No reactor provided in {self}")
 
@@ -519,7 +537,14 @@ class UniformMeshGeometryConverter(GeometryConverter):
         return newReactor
 
     def applyStateToOriginal(self):
-        """Apply the state of the converted reactor back to the original reactor, mapping number densities and block parameters."""
+        """
+        Apply the state of the converted reactor back to the original reactor,
+        mapping number densities and block parameters.
+
+        .. impl:: Map select parameters from composites on the new mesh to the original mesh.
+            :id: I_ARMI_UMC_PARAM_BACKWARD
+            :implements: R_ARMI_UMC_PARAM_BACKWARD
+        """
         runLog.extra(
             f"Applying uniform neutronics results from {self.convReactor} to {self._sourceReactor}"
         )


### PR DESCRIPTION
## What is the change?

Added test crumbs for:

* cases
* materials

And added impl and test crumbs for:

* database3
* snapshots
* uniform mesh converter
* axial expansion changer

## Why is the change being made?

This is part of the on-going requirements work.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
