### PR TITLE
Removing long value of static member in class of test_composities fro…

### DIFF
--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -39,7 +39,9 @@ from armi.tests import ISOAA_PATH
 
 class MockBP:
     allNuclidesInProblem = set(nuclideBases.byName.keys())
+    """:meta hide-value:"""
     activeNuclides = allNuclidesInProblem
+    """:meta hide-value:"""
     inactiveNuclides = set()
     elementsToExpand = set()
     customIsotopics = {}


### PR DESCRIPTION
## What is the change?

This PR adds a doco meta field in `reactor.tests.test_composities.MockBP` that tells sphinx to not display the value of a couple static members.

## Why is the change being made?

These members were essentially listing every nuclide in our library, which isn't very useful from a documentation point of view. It was also preventing a PDF build of the documentation.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
