### PR TITLE
Fixing import loop in test blueprints

### DIFF
--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -23,7 +23,6 @@ if not isConfigured():
 from armi.reactor import systemLayoutInput
 from armi.reactor.blueprints import Blueprints
 from armi.reactor.blueprints.gridBlueprint import Grids, saveToStream
-from armi.reactor.blueprints.tests.test_blockBlueprints import FULL_BP, FULL_BP_GRID
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
@@ -401,6 +400,8 @@ class TestGridBlueprintsSection(unittest.TestCase):
             :id: T_ARMI_BP_GRID0
             :tests: R_ARMI_BP_GRID
         """
+        from armi.reactor.blueprints.tests.test_blockBlueprints import FULL_BP
+
         # Cartesian full, even/odd hybrid
         gridDesign4 = self.grids["sfp even"]
         _grid = gridDesign4.construct()
@@ -432,6 +433,8 @@ class TestGridBlueprintsSection(unittest.TestCase):
         self.assertTrue(os.path.exists(filePath))
 
     def test_simpleReadNoLatticeMap(self):
+        from armi.reactor.blueprints.tests.test_blockBlueprints import FULL_BP_GRID
+
         # Cartesian full, even/odd hybrid
         gridDesign4 = self.grids["sfp even"]
         _grid = gridDesign4.construct()


### PR DESCRIPTION
## What is the change?

Fixing an import loop in our tests.

## Why is the change being made?

The goal is to close #1494 , opened by @albeanth .

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
