### PR TITLE
Adding crumbs for CLI

### DIFF
--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -104,6 +104,10 @@ class ArmiCLI:
     available, to get help for the individual commands, run again with
     `<command> --help`. Generically, the CLI implements functions that already
     exists within ARMI.
+
+    .. impl:: The basic ARMI CLI, for running a simulation.
+        :id: I_ARMI_CLI_CS
+        :implements: R_ARMI_CLI_CS
     """
 
     def __init__(self):
@@ -198,7 +202,7 @@ class ArmiCLI:
         return self.executeCommand(args.command, args.args)
 
     def executeCommand(self, command, args) -> Optional[int]:
-        r"""Execute `command` with arguments `args`, return optional exit code."""
+        """Execute `command` with arguments `args`, return optional exit code."""
         command = command.lower()
         if command not in self._entryPoints:
             print(

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -53,6 +53,10 @@ class EntryPoint:
 
     A valid subclass must provide at least a ``name`` class attribute, and may also
     specify the other class attributes described below.
+
+    .. impl:: Generic CLI base class for developers to use.
+        :id: I_ARMI_CLI_GEN
+        :implements: R_ARMI_CLI_GEN
     """
 
     #: The <command-name> that is used to call the command from the command line

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -37,7 +37,12 @@ from armi.utils.dynamicImporter import getEntireFamilyTree
 
 class TestInitializationEntryPoints(unittest.TestCase):
     def test_entryPointInitialization(self):
-        """Tests the initialization of all subclasses of `EntryPoint`."""
+        """Tests the initialization of all subclasses of `EntryPoint`.
+
+        .. test:: Test initialization of many basic CLIs.
+            :id: T_ARMI_CLI_GEN0
+            :tests: R_ARMI_CLI_GEN
+        """
         entryPoints = getEntireFamilyTree(EntryPoint)
 
         # Comparing to a minimum number of entry points, in case more are added.
@@ -74,6 +79,12 @@ class TestCheckInputEntryPoint(unittest.TestCase):
         self.assertEqual(ci.args.generate_design_summary, False)
 
     def test_checkInputEntryPointInvoke(self):
+        """Test the "check inputs" entry point.
+
+        .. test:: A working CLI child class, to validate inputs.
+            :id: T_ARMI_CLI_GEN1
+            :tests: R_ARMI_CLI_GEN
+        """
         ci = CheckInputEntryPoint()
         ci.addOptions()
         ci.parse_args([ARMI_RUN_PATH])
@@ -124,6 +135,12 @@ class TestCloneArmiRunCommandBatch(unittest.TestCase):
             self.assertNotIn("availabilityFactor", txt)
 
     def test_cloneArmiRunCommandBatchInvokeMedium(self):
+        """Test the "clone armi run" batch entry point, on medium detail.
+
+        .. test:: A working CLI child class, to clone a run.
+            :id: T_ARMI_CLI_GEN2
+            :tests: R_ARMI_CLI_GEN
+        """
         # Test medium write style
         ca = CloneArmiRunCommandBatch()
         ca.addOptions()

--- a/armi/cli/tests/test_runSuite.py
+++ b/armi/cli/tests/test_runSuite.py
@@ -67,10 +67,17 @@ class TestRunSuiteSuite(unittest.TestCase):
             :id: T_ARMI_CLI_CS2
             :tests: R_ARMI_CLI_CS
         """
-        correct = 777
+        correct = 0
         acli = ArmiCLI()
 
         mockExeCmd.return_value = correct
 
-        ret = acli.run()
+        origout = sys.stdout
+        try:
+            out = io.StringIO()
+            sys.stdout = out
+            ret = acli.run()
+        finally:
+            sys.stdout = origout
+
         self.assertEqual(ret, correct)

--- a/armi/cli/tests/test_runSuite.py
+++ b/armi/cli/tests/test_runSuite.py
@@ -69,15 +69,6 @@ class TestRunSuiteSuite(unittest.TestCase):
         """
         correct = 0
         acli = ArmiCLI()
-
         mockExeCmd.return_value = correct
-
-        origout = sys.stdout
-        try:
-            out = io.StringIO()
-            sys.stdout = out
-            ret = acli.run()
-        finally:
-            sys.stdout = origout
-
+        ret = acli.run()
         self.assertEqual(ret, correct)

--- a/armi/cli/tests/test_runSuite.py
+++ b/armi/cli/tests/test_runSuite.py
@@ -15,6 +15,7 @@
 import io
 import sys
 import unittest
+from unittest.mock import patch
 
 from armi import meta
 from armi.cli import ArmiCLI
@@ -22,7 +23,12 @@ from armi.cli import ArmiCLI
 
 class TestRunSuiteSuite(unittest.TestCase):
     def test_listCommand(self):
-        """Ensure run-suite entry point is registered."""
+        """Ensure run-suite entry point is registered.
+
+        .. test:: The ARMI CLI can be correctly initialized.
+            :id: T_ARMI_CLI_CS0
+            :tests: R_ARMI_CLI_CS
+        """
         acli = ArmiCLI()
 
         origout = sys.stdout
@@ -36,7 +42,12 @@ class TestRunSuiteSuite(unittest.TestCase):
         self.assertIn("run-suite", out.getvalue())
 
     def test_showVersion(self):
-        """Test the ArmiCLI.showVersion method."""
+        """Test the ArmiCLI.showVersion method.
+
+        .. test:: The ARMI CLI's basic "--version" functionality works.
+            :id: T_ARMI_CLI_CS1
+            :tests: R_ARMI_CLI_CS
+        """
         origout = sys.stdout
         try:
             out = io.StringIO()
@@ -47,3 +58,19 @@ class TestRunSuiteSuite(unittest.TestCase):
 
         self.assertIn("armi", out.getvalue())
         self.assertIn(meta.__version__, out.getvalue())
+
+    @patch("armi.cli.ArmiCLI.executeCommand")
+    def test_run(self, mockExeCmd):
+        """Test the ArmiCLI.run method.
+
+        .. test:: The ARMI CLI's import run() method works.
+            :id: T_ARMI_CLI_CS2
+            :tests: R_ARMI_CLI_CS
+        """
+        correct = 777
+        acli = ArmiCLI()
+
+        mockExeCmd.return_value = correct
+
+        ret = acli.run()
+        self.assertEqual(ret, correct)


### PR DESCRIPTION
## What is the change?

Adding crumbs for CLI.

## Why is the change being made?

This is part of the on-going requirements work.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
