### PR TITLE
Fix units on various block params

### DIFF
--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -449,7 +449,7 @@ def getBlockParameterDefinitions():
 
         pb.defParam(
             "fuelWorth",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Reactivity worth of fuel material per unit mass",
         )
 
@@ -491,13 +491,13 @@ def getBlockParameterDefinitions():
 
         pb.defParam(
             "coolantWorth",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Reactivity worth of coolant material per unit mass",
         )
 
         pb.defParam(
             "cladWorth",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Reactivity worth of clad material per unit mass",
         )
 
@@ -623,7 +623,7 @@ def getBlockParameterDefinitions():
         # FUEL COEFFICIENTS
         pb.defParam(
             "rxFuelDensityCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Fuel Density Coefficient",
         )
 
@@ -641,20 +641,20 @@ def getBlockParameterDefinitions():
 
         pb.defParam(
             "rxFuelTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Fuel Temperature Coefficient",
         )
 
         pb.defParam(
             "rxFuelVoidedTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Fuel Voided-Coolant Temperature Coefficient",
         )
 
         # CLAD COEFFICIENTS
         pb.defParam(
             "rxCladDensityCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Clad Density Coefficient",
         )
 
@@ -666,14 +666,14 @@ def getBlockParameterDefinitions():
 
         pb.defParam(
             "rxCladTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Clad Temperature Coefficient",
         )
 
         # STRUCTURE COEFFICIENTS
         pb.defParam(
             "rxStructureDensityCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Structure Density Coefficient",
         )
 
@@ -685,20 +685,20 @@ def getBlockParameterDefinitions():
 
         pb.defParam(
             "rxStructureTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Structure Temperature Coefficient",
         )
 
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Coolant Density Coefficient",
         )
 
         pb.defParam(
             "rxCoolantTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG})",
+            units=f"{units.REACTIVITY}/{units.KG}",
             description="Coolant Temperature Coefficient",
         )
 


### PR DESCRIPTION
## What is the change?

Tiny change to fix a typo in the printed units of various block parameters.

## Why is the change being made?

Quality.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
