### PR TITLE
Adding 3 test crumbs for requirements

### DIFF
--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -166,9 +166,7 @@ class MaterialFindingTests(unittest.TestCase):
         # let's do a quick test of getting a material from the default namespace
         setMaterialNamespaceOrder(["armi.materials"])
         uo2 = materials.resolveMaterialClassByName(
-            # "Hafnium", namespaceOrder=["armi.materials"]
-            "UO2",
-            namespaceOrder=["armi.materials"],
+            "UO2", namespaceOrder=["armi.materials"]
         )
         self.assertGreater(uo2().density(500), 0)
 
@@ -187,13 +185,6 @@ class MaterialFindingTests(unittest.TestCase):
         for t in range(200, 600):
             self.assertEqual(testMatIgnoreFake().density(t), 0)
             self.assertEqual(testMatIgnoreFake().pseudoDensity(t), 0)
-
-        # show the ordering of the material namespaces works
-        # (The second material namespace would set the density of UO2 to zero.)
-        uo2 = materials.resolveMaterialClassByName(
-            "UO2", namespaceOrder=["armi.materials", newMats]
-        )
-        self.assertGreater(uo2().density(500), 0)
 
         # for safety, reset the material namespace list and order
         setMaterialNamespaceOrder(["armi.materials"])

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -163,10 +163,12 @@ class MaterialFindingTests(unittest.TestCase):
             :id: T_ARMI_MAT_ORDER
             :tests: R_ARMI_MAT_ORDER
         """
-        newMats = "armi.utils.tests.test_densityTools"
         # let's do a quick test of getting a material from the default namespace
+        setMaterialNamespaceOrder(["armi.materials"])
         uo2 = materials.resolveMaterialClassByName(
-            "UO2", namespaceOrder=["armi.materials"]
+            # "Hafnium", namespaceOrder=["armi.materials"]
+            "UO2",
+            namespaceOrder=["armi.materials"],
         )
         self.assertGreater(uo2().density(500), 0)
 
@@ -174,8 +176,8 @@ class MaterialFindingTests(unittest.TestCase):
         self.__validateMaterialNamespace()
 
         # show you can add a material namespace
-        originalOrder = _MATERIAL_NAMESPACE_ORDER.copy()
-        setMaterialNamespaceOrder(originalOrder + [newMats])
+        newMats = "armi.utils.tests.test_densityTools"
+        setMaterialNamespaceOrder(["armi.materials", newMats])
         self.__validateMaterialNamespace()
 
         # show that adding a name material namespace provides access to new materials
@@ -191,10 +193,10 @@ class MaterialFindingTests(unittest.TestCase):
         uo2 = materials.resolveMaterialClassByName(
             "UO2", namespaceOrder=["armi.materials", newMats]
         )
-        self.assertEqual(uo2().density(500), 0)
+        self.assertGreater(uo2().density(500), 0)
 
         # for safety, reset the material namespace list and order
-        setMaterialNamespaceOrder(originalOrder)
+        setMaterialNamespaceOrder(["armi.materials"])
 
 
 class Californium_TestCase(_Material_Test, unittest.TestCase):

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -415,7 +415,6 @@ class MacroscopicCrossSectionCreator:
         -------
         macros : xsCollection.XSCollection
             A new XSCollection full of macroscopic cross sections
-
         """
         runLog.debug("Building macroscopic cross sections for {0}".format(block))
         if nucNames is None:

--- a/armi/nuclearDataIO/xsNuclides.py
+++ b/armi/nuclearDataIO/xsNuclides.py
@@ -95,7 +95,7 @@ class XSNuclide(nuclideBases.NuclideWrapper):
         self._base = nuclideBase
 
     def getMicroXS(self, interaction, group):
-        r"""Returns the microscopic xs as the ISOTXS value if it exists or a 0 since it doesn't."""
+        """Returns the microscopic xs as the ISOTXS value if it exists or a 0 since it doesn't."""
         if interaction in self.micros.__dict__:
             try:
                 return self.micros[interaction][group]
@@ -109,7 +109,7 @@ class XSNuclide(nuclideBases.NuclideWrapper):
             return 0
 
     def getXS(self, interaction):
-        r"""Get the cross section of a particular interaction.
+        """Get the cross section of a particular interaction.
 
         See Also
         --------

--- a/armi/physics/neutronics/macroXSGenerationInterface.py
+++ b/armi/physics/neutronics/macroXSGenerationInterface.py
@@ -67,7 +67,6 @@ class MacroXSGenerator(mpiActions.MpiAction):
         )
 
     def invokeHook(self):
-
         # logic here gets messy due to all the default arguments in the calling
         # method. There exists a large number of permutations to be handled.
 
@@ -169,7 +168,6 @@ class MacroXSGenerationInterface(interfaces.Interface):
         libType : str, optional
             The block attribute containing the desired microscopic XS for this block:
             either "micros" for neutron XS or "gammaXS" for gamma XS.
-
         """
         cycle = self.r.p.cycle
         self.macrosLastBuiltAt = (

--- a/armi/physics/neutronics/tests/test_macroXSGenerationInterface.py
+++ b/armi/physics/neutronics/tests/test_macroXSGenerationInterface.py
@@ -37,7 +37,7 @@ class TestMacroXSGenerationInterface(unittest.TestCase):
         _o, r = loadTestReactor()
         reduceTestReactorRings(r, cs, 2)
 
-        # Before: verify there are no macro XS in the reactor
+        # Before: verify there are no macro XS on each block
         for b in r.core.getBlocks():
             self.assertIsNone(b.macros)
 
@@ -46,7 +46,7 @@ class TestMacroXSGenerationInterface(unittest.TestCase):
         self.assertEqual(i.minimumNuclideDensity, 1e-15)
         self.assertEqual(i.name, "macroXsGen")
 
-        # Moock up a nuclide library
+        # Mock up a nuclide library
         mockLib = isotxs.readBinary(ISOAA_PATH)
         mockLib.__dict__["_nuclides"] = defaultdict(
             lambda: mockLib.__dict__["_nuclides"]["CAA"], mockLib.__dict__["_nuclides"]
@@ -57,7 +57,7 @@ class TestMacroXSGenerationInterface(unittest.TestCase):
         i.buildMacros(mockLib, buildScatterMatrix=False)
         self.assertEqual(i.macrosLastBuiltAt, 0)
 
-        # After: verify there are no macro XS in the reactor
+        # After: verify there are macro XS on each block
         for b in r.core.getBlocks():
             self.assertIsNotNone(b.macros)
             self.assertTrue(isinstance(b.macros, XSCollection))

--- a/armi/physics/tests/test_executers.py
+++ b/armi/physics/tests/test_executers.py
@@ -14,21 +14,18 @@
 
 """This module provides tests for the generic Executers."""
 import os
+import subprocess
 import unittest
 
+from armi.physics import executers
 from armi.reactor import geometry
 from armi.utils import directoryChangers
-from armi.physics import executers
 
 
-class MockReactorParams:
+class MockParams:
     def __init__(self):
         self.cycle = 1
         self.timeNode = 2
-
-
-class MockCoreParams:
-    pass
 
 
 class MockCore:
@@ -36,14 +33,14 @@ class MockCore:
         # just pick a random geomType
         self.geomType = geometry.GeomType.CARTESIAN
         self.symmetry = "full"
-        self.p = MockCoreParams()
+        self.p = MockParams()
 
 
 class MockReactor:
     def __init__(self):
         self.core = MockCore()
         self.o = None
-        self.p = MockReactorParams()
+        self.p = MockParams()
 
 
 class TestExecutionOptions(unittest.TestCase):
@@ -106,3 +103,58 @@ class TestExecuters(unittest.TestCase):
         self.executer.dcType = directoryChangers.ForcedCreationDirectoryChanger
         self.executer._updateRunDir("notThisString")
         self.assertEqual(self.executer.options.runDir, "runDir")
+
+    def test_runExternalExecutable(self):
+        """Run an external executable with an Executer.
+
+        .. test:: Run an external executable with an Executer.
+            :id: T_ARMI_EX
+            :tests: R_ARMI_EX
+        """
+        filePath = "test_runExternalExecutable.py"
+        outFile = "tmp.txt"
+
+        class TestSillyExecuter(executers.Executer):
+            def run(self, args):
+                subprocess.run(["python", filePath, args])
+
+        with directoryChangers.TemporaryDirectoryChanger():
+            # build a mock external program (a little Python script)
+            self.__makeALittleTestProgram(filePath, outFile)
+
+            # make sure the output file doesn't exist yet
+            self.assertFalse(os.path.exists(outFile))
+
+            # set up an executer for our little test program
+            exe = TestSillyExecuter(None, None)
+            exe.run("")
+
+            # make sure the output file exists now
+            self.assertTrue(os.path.exists(outFile))
+
+            # run the executer with options
+            testString = "some options"
+            exe.run(testString)
+
+            # make sure the output file exists now
+            self.assertTrue(os.path.exists(outFile))
+            newTxt = open(outFile, "r").read()
+            self.assertIn(testString, newTxt)
+
+    @staticmethod
+    def __makeALittleTestProgram(filePath, outFile):
+        """Helper method to write a tiny Python script.
+
+        We need "an external program" for testing.
+        """
+        txt = f"""import sys
+
+def main():
+    with open("{outFile}", "w") as f:
+        f.write(str(sys.argv))
+
+if __name__ == "__main__":
+    main()
+"""
+        with open(filePath, "w") as f:
+            f.write(txt)

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -16,7 +16,6 @@
 import copy
 import unittest
 
-from armi import cli
 from armi import configure
 from armi import context
 from armi import getApp

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -18,16 +18,11 @@ from typing import Optional
 
 import yamlize
 
-from armi import getPluginManagerOrFail
 from armi import interfaces
 from armi import plugins
 from armi import settings
 from armi.physics.neutronics import NeutronicsPlugin
-from armi.reactor import parameters
-from armi.reactor.blocks import Block, HexBlock
-from armi.reactor.parameters import ParamLocation
-from armi.reactor.parameters.parameterCollections import collectPluginParameters
-from armi.utils import units
+from armi.reactor.blocks import Block
 
 
 class TestPluginBasics(unittest.TestCase):

--- a/armi/utils/tests/test_densityTools.py
+++ b/armi/utils/tests/test_densityTools.py
@@ -14,21 +14,23 @@
 """Test densityTools."""
 import unittest
 
+from armi.materials.material import Material
 from armi.materials.uraniumOxide import UO2
 from armi.nucDirectory import elements, nuclideBases
 from armi.utils import densityTools
 
 
-# A test material that needs to be stored in a different namespace, for tests in:
-#     armi.materials.tests.test_materials.py
-def testFakeDensity(self, Tk=None, Tc=None):
-    return 0.0
+class TestMaterialIgnoreFake(Material):
+    """A test material that needs to be stored in a different namespace.
 
+    For tests in: armi.materials.tests.test_materials.py
+    """
 
-TestMaterialIgnoreFake = UO2
-TestMaterialIgnoreFake.density = testFakeDensity
-TestMaterialIgnoreFake.pseudoDensity = testFakeDensity
-TestMaterialIgnoreFake._name = "TestMaterialIgnoreFake"
+    def pseudoDensity(self, Tk=None, Tc=None):
+        return 0.0
+
+    def density(self, Tk=None, Tc=None):
+        return 0.0
 
 
 class TestDensityTools(unittest.TestCase):

--- a/armi/utils/tests/test_densityTools.py
+++ b/armi/utils/tests/test_densityTools.py
@@ -19,6 +19,18 @@ from armi.nucDirectory import elements, nuclideBases
 from armi.utils import densityTools
 
 
+# A test material that needs to be stored in a different namespace, for tests in:
+#     armi.materials.tests.test_materials.py
+def testFakeDensity(self, Tk=None, Tc=None):
+    return 0.0
+
+
+TestMaterialIgnoreFake = UO2
+TestMaterialIgnoreFake.density = testFakeDensity
+TestMaterialIgnoreFake.pseudoDensity = testFakeDensity
+TestMaterialIgnoreFake._name = "TestMaterialIgnoreFake"
+
+
 class TestDensityTools(unittest.TestCase):
     def test_expandElementalMassFracsToNuclides(self):
         """
@@ -50,7 +62,6 @@ class TestDensityTools(unittest.TestCase):
         self.assertAlmostEqual(sum(mass.values()), 1.0)
 
     def test_getChemicals(self):
-
         u235 = nuclideBases.byName["U235"]
         u238 = nuclideBases.byName["U238"]
         o16 = nuclideBases.byName["O16"]


### PR DESCRIPTION
## What is the change?

Adding 3 test crumbs for requirements.

## Why is the change being made?

This is part of on-going requirement work.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
