### PR TITLE
Test crumbs

### DIFF
--- a/armi/physics/neutronics/tests/test_energyGroups.py
+++ b/armi/physics/neutronics/tests/test_energyGroups.py
@@ -53,3 +53,14 @@ class TestEnergyGroups(unittest.TestCase):
                     energyGroups.getGroupStructure(groupStructureType)
                 ),
             )
+
+    def test_getFastFluxGroupCutoff(self):
+        """Test ability to get the ARMI energy group index contained in energy threshold.
+
+        .. test:: Return the energy group index which contains a given energy threshold.
+            :id: T_ARMI_EG_FE
+            :tests: R_ARMI_EG_FE
+        """
+        group, frac = energyGroups.getFastFluxGroupCutoff([100002, 100001, 100000, 99999, 0])
+
+        self.assertListEqual([group, frac], [2, 0])

--- a/armi/physics/neutronics/tests/test_energyGroups.py
+++ b/armi/physics/neutronics/tests/test_energyGroups.py
@@ -61,6 +61,8 @@ class TestEnergyGroups(unittest.TestCase):
             :id: T_ARMI_EG_FE
             :tests: R_ARMI_EG_FE
         """
-        group, frac = energyGroups.getFastFluxGroupCutoff([100002, 100001, 100000, 99999, 0])
+        group, frac = energyGroups.getFastFluxGroupCutoff(
+            [100002, 100001, 100000, 99999, 0]
+        )
 
         self.assertListEqual([group, frac], [2, 0])

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -320,6 +320,28 @@ class TestUnshapedComponent(TestGeneralComponents):
             * self.component.getThermalExpansionFactor(self.component.temperatureInC),
         )
 
+    def test_component_less_than(self):
+        """Ensure that comparisons between components properly reference bounding circle outer diameter.
+
+        .. test:: Order components by their outermost diameter
+            :id: T_ARMI_COMP_ORDER
+            :tests: R_ARMI_COMP_ORDER
+        """
+        componentCls = UnshapedComponent
+        componentMaterial = "HT9"
+
+        smallDims = {"Tinput": 25.0, "Thot": 430.0, "area": 0.5 * math.pi}
+        sameDims = {"Tinput": 25.0, "Thot": 430.0, "area": 1.0 * math.pi}
+        bigDims = {"Tinput": 25.0, "Thot": 430.0, "area": 2.0 * math.pi}
+
+        smallComponent = componentCls("TestComponent", componentMaterial, **smallDims)
+        sameComponent = componentCls("TestComponent", componentMaterial, **sameDims)
+        bigComponent = componentCls("TestComponent", componentMaterial, **bigDims)
+
+        self.assertTrue(smallComponent < self.component)
+        self.assertFalse(bigComponent < self.component)
+        self.assertFalse(sameComponent < self.component)
+
     def test_fromComponent(self):
         circle = components.Circle("testCircle", "HT9", 25, 500, 1.0)
         unshaped = components.UnshapedComponent.fromComponent(circle)


### PR DESCRIPTION
## What is the change?

This PR adds two additional test crumbs for energyGroups and components.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
