### PR TITLE
Updating runLog requirement crumbs

### DIFF
--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -813,7 +813,7 @@ class Thorium_TestCase(_Material_Test, unittest.TestCase):
 
         .. test:: The materials generate nuclide mass fractions.
             :id: T_ARMI_MAT_FRACS0
-            :tests: R_ARMI_LOG
+            :tests: R_ARMI_MAT_FRACS
         """
         self.mat.setDefaultMassFracs()
         cur = self.mat.massFrac
@@ -945,7 +945,7 @@ class Mixture_TestCase(_Material_Test, unittest.TestCase):
 
         .. test:: The materials generate nuclide mass fractions.
             :id: T_ARMI_MAT_FRACS1
-            :tests: R_ARMI_LOG
+            :tests: R_ARMI_MAT_FRACS
         """
         self.mat.setDefaultMassFracs()
         cur = self.mat.pseudoDensity(500)
@@ -998,7 +998,7 @@ class Lead_TestCase(_Material_Test, unittest.TestCase):
 
         .. test:: The materials generate nuclide mass fractions.
             :id: T_ARMI_MAT_FRACS2
-            :tests: R_ARMI_LOG
+            :tests: R_ARMI_MAT_FRACS
         """
         self.mat.setDefaultMassFracs()
         cur = self.mat.massFrac
@@ -1035,7 +1035,7 @@ class LeadBismuth_TestCase(_Material_Test, unittest.TestCase):
 
         .. test:: The materials generate nuclide mass fractions.
             :id: T_ARMI_MAT_FRACS3
-            :tests: R_ARMI_LOG
+            :tests: R_ARMI_MAT_FRACS
         """
         self.mat.setDefaultMassFracs()
         cur = self.mat.massFrac

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -25,7 +25,12 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 class TestRunLog(unittest.TestCase):
     def test_setVerbosityFromInteger(self):
-        """Test that the log verbosity can be set with an integer."""
+        """Test that the log verbosity can be set with an integer.
+
+        .. test:: The run log verbosity can be configured with an integer.
+            :id: T_ARMI_LOG0
+            :tests: R_ARMI_LOG
+        """
         log = runLog._RunLog(1)
         expectedStrVerbosity = "debug"
         verbosityRank = log.getLogVerbosityRank(expectedStrVerbosity)
@@ -37,8 +42,8 @@ class TestRunLog(unittest.TestCase):
         """
         Test that the log verbosity can be set with a string.
 
-        .. test:: The run log has configurable verbosity.
-            :id: T_ARMI_LOG0
+        .. test:: The run log verbosity can be configured with a string.
+            :id: T_ARMI_LOG1
             :tests: R_ARMI_LOG
         """
         log = runLog._RunLog(1)
@@ -105,7 +110,12 @@ class TestRunLog(unittest.TestCase):
         self.assertEqual(space1, space9)
 
     def test_warningReport(self):
-        """A simple test of the warning tracking and reporting logic."""
+        """A simple test of the warning tracking and reporting logic.
+
+        .. test:: Generate a warning report after a simulation is complete.
+            :id: T_ARMI_LOG2
+            :tests: R_ARMI_LOG
+        """
         # create the logger and do some logging
         log = runLog.LOG = runLog._RunLog(321)
         log.startLog("test_warningReport")
@@ -147,7 +157,12 @@ class TestRunLog(unittest.TestCase):
         log.logger = backupLog
 
     def test_warningReportInvalid(self):
-        """A test of warningReport in an invalid situation."""
+        """A test of warningReport in an invalid situation.
+
+        .. test:: Test an important edge case for a warning report.
+            :id: T_ARMI_LOG3
+            :tests: R_ARMI_LOG
+        """
         # create the logger and do some logging
         testName = "test_warningReportInvalid"
         log = runLog.LOG = runLog._RunLog(323)
@@ -216,7 +231,7 @@ class TestRunLog(unittest.TestCase):
         """Let's test the setVerbosity() method carefully.
 
         .. test:: The run log has configurable verbosity.
-            :id: T_ARMI_LOG1
+            :id: T_ARMI_LOG4
             :tests: R_ARMI_LOG
 
         .. test:: The run log can log to stream.
@@ -265,9 +280,15 @@ class TestRunLog(unittest.TestCase):
             self.assertEqual(runLog.LOG.getVerbosity(), logging.WARNING)
 
     def test_setVerbosityBeforeStartLog(self):
-        """The user/dev may accidentally call ``setVerbosity()`` before ``startLog()``, this should be mostly supportable."""
+        """The user/dev may accidentally call ``setVerbosity()`` before ``startLog()``,
+        this should be mostly supportable. This is just an edge case.
+
+        .. test:: Test that we support the user setting log verbosity BEFORE the logging starts.
+            :id: T_ARMI_LOG5
+            :tests: R_ARMI_LOG
+        """
         with mockRunLogs.BufferLog() as mock:
-            # we should start with a clean slate
+            # we should start with a clean slate, before debug logging
             self.assertEqual("", mock.getStdout())
             runLog.LOG.setVerbosity(logging.DEBUG)
             runLog.LOG.startLog("test_setVerbosityBeforeStartLog")
@@ -276,6 +297,19 @@ class TestRunLog(unittest.TestCase):
             self.assertEqual(runLog.LOG.getVerbosity(), logging.DEBUG)
             runLog.debug("hi")
             self.assertIn("hi", mock.getStdout())
+            mock.emptyStdout()
+
+            # we should start with a clean slate, before info loggin
+            self.assertEqual("", mock.getStdout())
+            runLog.LOG.setVerbosity(logging.INFO)
+            runLog.LOG.startLog("test_setVerbosityBeforeStartLog2")
+
+            # we should start at info level, and that should be working correctly
+            self.assertEqual(runLog.LOG.getVerbosity(), logging.INFO)
+            runLog.debug("nope")
+            runLog.info("hi")
+            self.assertIn("hi", mock.getStdout())
+            self.assertNotIn("nope", mock.getStdout())
             mock.emptyStdout()
 
     def test_callingStartLogMultipleTimes(self):
@@ -377,7 +411,12 @@ class TestRunLog(unittest.TestCase):
             self.assertFalse(os.path.exists(stderrFile))
 
     def test_createLogDir(self):
-        """Test the createLogDir() method."""
+        """Test the createLogDir() method.
+
+        .. test:: Test that log directories can be created for logging output files.
+            :id: T_ARMI_LOG6
+            :tests: R_ARMI_LOG
+        """
         with TemporaryDirectoryChanger():
             logDir = "test_createLogDir"
             self.assertFalse(os.path.exists(logDir))
@@ -410,6 +449,12 @@ class TestRunLogger(unittest.TestCase):
         self.assertEqual(len(self.rl.filters), 1)
 
     def test_write(self):
+        """Test that we can write text to the logger output stream.
+
+        .. test:: Write logging text to the logging stream and/or file.
+            :id: T_ARMI_LOG7
+            :tests: R_ARMI_LOG
+        """
         # divert the logging to a stream, to make testing easier
         stream = StringIO()
         handler = logging.StreamHandler(stream)


### PR DESCRIPTION
## What is the change?

Here I make some updates to runLog requirement crumbs:

* remove some faulty req crumbs from the material package (typos?)
* Add more req crumbs 
* Beef up some runLog tests

## Why is the change being made?

This is in response to requirement review by @jakehader 

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
