### PR TITLE
Updating Framework Concept tests and crumbs

### DIFF
--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -846,6 +846,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
             :id: T_ARMI_XSGM_FREQ0
             :tests: R_ARMI_XSGM_FREQ
         """
+        self.assertFalse(self.csm.representativeBlocks)
         self.blockList[0].r.p.timeNode = 0
         self.csm.cs[CONF_LATTICE_PHYSICS_FREQUENCY] = "BOL"
         self.csm.interactBOL()
@@ -858,6 +859,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
             :id: T_ARMI_XSGM_FREQ1
             :tests: R_ARMI_XSGM_FREQ
         """
+        self.assertFalse(self.csm.representativeBlocks)
         self.blockList[0].r.p.timeNode = 0
         self.csm.cs[CONF_LATTICE_PHYSICS_FREQUENCY] = "BOC"
         self.csm.interactBOL()

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -161,8 +161,6 @@ def loadTestReactor(
     o : Operator
     r : Reactor
     """
-    # TODO: it would be nice to have this be more stream-oriented. Juggling files is
-    # devilishly difficult.
     global TEST_REACTOR
     fName = os.path.join(inputFilePath, inputFileName)
     customSettings = customSettings or {}

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -137,6 +137,7 @@ class TestTightCoupler(unittest.TestCase):
         Ragged lists are easier to manage with lists as opposed to numpy.arrays,
         namely, their dimension is preserved.
         """
+        # show a situation where it doesn't converge
         previousValues = {
             "float": 1.0,
             "list1D": [1.0, 2.0],
@@ -150,6 +151,12 @@ class TestTightCoupler(unittest.TestCase):
         for previous, current in zip(previousValues.values(), updatedValues.values()):
             self.interface.coupler.storePreviousIterationValue(previous)
             self.assertFalse(self.interface.coupler.isConverged(current))
+
+        # show a situation where it DOES converge
+        previousValues = updatedValues
+        for previous, current in zip(previousValues.values(), updatedValues.values()):
+            self.interface.coupler.storePreviousIterationValue(previous)
+            self.assertTrue(self.interface.coupler.isConverged(current))
 
     def test_isConvergedRuntimeError(self):
         """Test to ensure 3D arrays do not work."""

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -18,11 +18,13 @@ from typing import Optional
 
 import yamlize
 
+from armi import getPluginManagerOrFail
 from armi import interfaces
 from armi import plugins
 from armi import settings
 from armi.physics.neutronics import NeutronicsPlugin
 from armi.reactor.blocks import Block
+from armi.reactor.tests.test_reactors import loadTestReactor, TEST_ROOT
 
 
 class TestPluginBasics(unittest.TestCase):
@@ -54,7 +56,7 @@ class TestPluginBasics(unittest.TestCase):
         """Make sure that the exposeInterfaces hook is properly implemented.
 
         .. test:: Plugins can add interfaces to the interface stack.
-            :id: T_ARMI_PLUGIN_INTERFACES
+            :id: T_ARMI_PLUGIN_INTERFACES0
             :tests: R_ARMI_PLUGIN_INTERFACES
         """
         plugin = NeutronicsPlugin()
@@ -75,6 +77,46 @@ class TestPluginBasics(unittest.TestCase):
             self.assertIsInstance(order, (int, float))
             self.assertTrue(issubclass(interface, interfaces.Interface))
             self.assertIsInstance(kwargs, dict)
+
+    def test_pluginsExposeInterfaces(self):
+        """Make sure that plugins properly expose their interfaces, by checking some
+        known examples.
+
+        .. test:: Check that some known plugins correctly add interfaces to the stack.
+            :id: T_ARMI_PLUGIN_INTERFACES1
+            :tests: R_ARMI_PLUGIN_INTERFACES
+        """
+        # generate a test operator, with a full set of interfaces from plugsin
+        o = loadTestReactor(TEST_ROOT)[0]
+        pm = getPluginManagerOrFail()
+
+        # test the plugins were generated
+        plugins = pm.get_plugins()
+        self.assertGreater(len(plugins), 0)
+
+        # test interfaces were generated from those plugins
+        ints = o.interfaces
+        self.assertGreater(len(ints), 0)
+
+        # test that certain plugins exist and correctly registered their interfaces
+        pluginStrings = " ".join([str(p) for p in plugins])
+        interfaceStrings = " ".join([str(i) for i in ints])
+
+        # Test that the BookkeepingPlugin registered the DatabaseInterface
+        self.assertIn("BookkeepingPlugin", pluginStrings)
+        self.assertIn("DatabaseInterface", interfaceStrings)
+
+        # Test that the BookkeepingPlugin registered the history interface
+        self.assertIn("BookkeepingPlugin", pluginStrings)
+        self.assertIn("history", interfaceStrings)
+
+        # Test that the EntryPointsPlugin registered the main interface
+        self.assertIn("EntryPointsPlugin", pluginStrings)
+        self.assertIn("main", interfaceStrings)
+
+        # Test that the FuelHandlerPlugin registered the fuelHandler interface
+        self.assertIn("FuelHandlerPlugin", pluginStrings)
+        self.assertIn("fuelHandler", interfaceStrings)
 
 
 class TestPlugin(unittest.TestCase):


### PR DESCRIPTION
## What is the change?

Updating Framework Concept tests and crumbs.

## Why is the change being made?

This is in response to requirement review by @jakehader

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
