### PR TITLE
Editorial fixes for various rxcoeff params

### DIFF
--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -443,82 +443,82 @@ def getBlockParameterDefinitions():
         pb.defParam(
             "rxFuelDensityCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
-            description="Fuel Density Coefficient",
+            description="Fuel density coefficient",
         )
 
         pb.defParam(
             "rxFuelDopplerConstant",
             units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
-            description="Fuel Doppler Constant",
+            description="Fuel Doppler constant",
         )
 
         pb.defParam(
             "rxFuelVoidedDopplerConstant",
             units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
-            description="Fuel Voided-Coolant Constant",
+            description="Fuel voided-coolant Doppler constant",
         )
 
         pb.defParam(
             "rxFuelTemperatureCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
-            description="Fuel Temperature Coefficient",
+            description="Fuel temperature coefficient",
         )
 
         pb.defParam(
             "rxFuelVoidedTemperatureCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
-            description="Fuel Voided-Coolant Temperature Coefficient",
+            description="Fuel voided-coolant temperature coefficient",
         )
 
         # CLAD COEFFICIENTS
         pb.defParam(
             "rxCladDensityCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
-            description="Clad Density Coefficient",
+            description="Clad density coefficient",
         )
 
         pb.defParam(
             "rxCladDopplerConstant",
             units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
-            description="Clad Doppler Constant",
+            description="Clad Doppler constant",
         )
 
         pb.defParam(
             "rxCladTemperatureCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
-            description="Clad Temperature Coefficient",
+            description="Clad temperature coefficient",
         )
 
         # STRUCTURE COEFFICIENTS
         pb.defParam(
             "rxStructureDensityCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
-            description="Structure Density Coefficient",
+            description="Structure density coefficient",
         )
 
         pb.defParam(
             "rxStructureDopplerConstant",
             units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
-            description="Structure Doppler Constant",
+            description="Structure Doppler constant",
         )
 
         pb.defParam(
             "rxStructureTemperatureCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
-            description="Structure Temperature Coefficient",
+            description="Structure temperature coefficient",
         )
 
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
-            description="Coolant Density Coefficient",
+            description="Coolant density coefficient",
         )
 
         pb.defParam(
             "rxCoolantTemperatureCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
-            description="Coolant Temperature Coefficient",
+            description="Coolant temperature coefficient",
         )
 
     with pDefs.createBuilder(
@@ -535,82 +535,82 @@ def getBlockParameterDefinitions():
         pb.defParam(
             "rxFuelDensityCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel Density Coefficient",
+            description="Fuel density coefficient",
         )
 
         pb.defParam(
             "rxFuelDopplerCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel Doppler Coefficient",
+            description="Fuel Doppler coefficient",
         )
 
         pb.defParam(
             "rxFuelVoidedDopplerCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel Voided-Coolant Doppler Coefficient",
+            description="Fuel voided-coolant Doppler coefficient",
         )
 
         pb.defParam(
             "rxFuelTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel Temperature Coefficient",
+            description="Fuel temperature coefficient",
         )
 
         pb.defParam(
             "rxFuelVoidedTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel Voided-Coolant Temperature Coefficient",
+            description="Fuel voided-coolant temperature coefficient",
         )
 
         # CLAD COEFFICIENTS
         pb.defParam(
             "rxCladDensityCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Clad Density Coefficient",
+            description="Clad density coefficient",
         )
 
         pb.defParam(
             "rxCladDopplerCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Clad Doppler Coefficient",
+            description="Clad Doppler coefficient",
         )
 
         pb.defParam(
             "rxCladTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Clad Temperature Coefficient",
+            description="Clad temperature coefficient",
         )
 
         # STRUCTURE COEFFICIENTS
         pb.defParam(
             "rxStructureDensityCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Structure Density Coefficient",
+            description="Structure density coefficient",
         )
 
         pb.defParam(
             "rxStructureDopplerCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Structure Doppler Coefficient",
+            description="Structure Doppler coefficient",
         )
 
         pb.defParam(
             "rxStructureTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Structure Temperature Coefficient",
+            description="Structure temperature coefficient",
         )
 
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Coolant Density Coefficient",
+            description="Coolant density coefficient",
         )
 
         pb.defParam(
             "rxCoolantTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Coolant Temperature Coefficient",
+            description="Coolant temperature coefficient",
         )
 
     with pDefs.createBuilder(default=0.0) as pb:

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -534,82 +534,82 @@ def getBlockParameterDefinitions():
         # FUEL COEFFICIENTS
         pb.defParam(
             "rxFuelDensityCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Fuel Density Coefficient",
         )
 
         pb.defParam(
             "rxFuelDopplerCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Fuel Doppler Coefficient",
         )
 
         pb.defParam(
             "rxFuelVoidedDopplerCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Fuel Voided-Coolant Doppler Coefficient",
         )
 
         pb.defParam(
             "rxFuelTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Fuel Temperature Coefficient",
         )
 
         pb.defParam(
             "rxFuelVoidedTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Fuel Voided-Coolant Temperature Coefficient",
         )
 
         # CLAD COEFFICIENTS
         pb.defParam(
             "rxCladDensityCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Clad Density Coefficient",
         )
 
         pb.defParam(
             "rxCladDopplerCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Clad Doppler Coefficient",
         )
 
         pb.defParam(
             "rxCladTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Clad Temperature Coefficient",
         )
 
         # STRUCTURE COEFFICIENTS
         pb.defParam(
             "rxStructureDensityCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Structure Density Coefficient",
         )
 
         pb.defParam(
             "rxStructureDopplerCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Structure Doppler Coefficient",
         )
 
         pb.defParam(
             "rxStructureTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Structure Temperature Coefficient",
         )
 
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Coolant Density Coefficient",
         )
 
         pb.defParam(
             "rxCoolantTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK})",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Coolant Temperature Coefficient",
         )
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -574,7 +574,7 @@ def defineCoreParameters():
 
         pb.defParam(
             "rxFuelAxialExpansionCoeffPerPercent",
-            units="dk/kk'-%",
+            units=f"{units.REACTIVITY}/{units.PERCENT}",
             description="Fuel Axial Expansion Coefficient",
         )
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -537,7 +537,7 @@ def defineCoreParameters():
         pb.defParam(
             "betaComponents",
             units=units.UNITLESS,
-            description="Group-wise delayed neutron fractions.",
+            description="Group-wise delayed neutron fractions",
             default=None,
         )
 


### PR DESCRIPTION
## What is the change?

This is a continuation of https://github.com/terrapower/armi/pull/1498. I wish I had caught everything in that single PR, but alas I did not.

I only do the following:
* change the units strings on a handful of parameters in which there was a stray parenthesis at the end
* Make the capitalization and punctuation consistent across rxcoeff param descriptions (didn't change the param names themselves)

 No physics changes at all.

## Why is the change being made?

Cleanliness.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] ~~[Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.~~

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] ~~The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.~~
- [ ] ~~The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.~~
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
