### PR TITLE
Responding to review of assembly requirements

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1227,12 +1227,7 @@ class Assembly(composites.Composite):
 
 
 class HexAssembly(Assembly):
-    """Placeholder, so users can explicitly define a hex-based assembly.
-
-    .. impl:: Assembly of hex blocks.
-        :id: I_ARMI_ASSEM_HEX
-        :implements: R_ARMI_ASSEM_HEX
-    """
+    """Placeholder, so users can explicitly define a hex-based assembly."""
 
     pass
 

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -216,16 +216,16 @@ class Assembly(composites.Composite):
         """
         Get string label representing this object's location.
 
+        .. impl:: Assembly location is retrievable.
+            :id: I_ARMI_ASSEM_POSI0
+            :implements: R_ARMI_ASSEM_POSI
+
         Notes
         -----
         This function (and its friends) were created before the advent of both the
         grid/spatialLocator system and the ability to represent things like the SFP as
         siblings of a Core. In future, this will likely be re-implemented in terms of
         just spatialLocator objects.
-
-        .. impl:: Assembly location is retrievable.
-            :id: I_ARMI_ASSEM_POSI0
-            :implements: R_ARMI_ASSEM_POSI
         """
         # just use ring and position, not axial (which is 0)
         if not self.parent:

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1123,12 +1123,7 @@ class Assembly_TestCase(unittest.TestCase):
             self.assertGreater(zCoords[i], zCoords[i - 1])
 
     def test_assem_hex_type(self):
-        """Test that all children of a hex assembly are hexagons.
-
-        .. test:: Validate child types of assembly are Hex type.
-            :id: T_ARMI_ASSEM_HEX
-            :tests: R_ARMI_ASSEM_HEX
-        """
+        """Test that all children of a hex assembly are hexagons."""
         for b in self.assembly.getBlocks():
 
             # For a hex assem, confirm they are of type "Hexagon"

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1101,16 +1101,26 @@ class Assembly_TestCase(unittest.TestCase):
             self.assertIn("No rotation method defined", mock.getStdout())
 
     def test_assem_block_types(self):
-        """Test that all children of an assembly are blocks.
+        """Test that all children of an assembly are blocks, ordered from top to bottom.
 
-        .. test:: Validate child types of assembly are blocks.
+        .. test:: Validate child types of assembly are blocks, ordered from top to bottom.
             :id: T_ARMI_ASSEM_BLOCKS
             :tests: R_ARMI_ASSEM_BLOCKS
         """
+        coords = []
         for b in self.assembly.getBlocks():
-
             # Confirm children are blocks
             self.assertIsInstance(b, blocks.Block)
+
+            # get coords from the child blocks
+            coords.append(b.getLocation())
+
+        # get the Z-coords for each block
+        zCoords = [int(c.split("-")[-1]) for c in coords]
+
+        # verify the blocks are ordered top-to-bottom, vertically
+        for i in range(1, len(zCoords)):
+            self.assertGreater(zCoords[i], zCoords[i - 1])
 
     def test_assem_hex_type(self):
         """Test that all children of a hex assembly are hexagons.


### PR DESCRIPTION
## What is the change?

Responding to review of assembly requirements.

## Why is the change being made?

This is response to a review by @keckler

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
