### PR TITLE
Update docstring of `getAssemblyWithStringLocation`

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -1653,7 +1653,7 @@ class Core(composites.Composite):
         return self.getAssembly(assemNum=assemNum)
 
     def getAssemblyWithStringLocation(self, locationString):
-        """Returns an assembly or none if given a location string like 'B0014'.
+        """Returns an assembly or none if given a location string like '001-001'.
 
         .. impl:: Get assembly by location.
             :id: I_ARMI_R_GET_ASSEM_LOC


### PR DESCRIPTION
## What is the change?

A docstring provided incorrect input format. I fixed it.

See usage example at, for instance, https://github.com/terrapower/armi/blob/7e1e16736b7082c2ce4892bb36243fb080c63a48/armi/reactor/converters/geometryConverters.py#L1358

## Why is the change being made?

So that our docstrings provided correct instructions to users.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
