### PR TITLE
Global flux review

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -1183,7 +1183,7 @@ def computeDpaRate(mgFlux, dpaXs):
     r"""
     Compute the DPA rate incurred by exposure of a certain flux spectrum.
 
-    .. impl:: Compute DPA and DPA rates.
+    .. impl:: Compute DPA rates.
         :id: I_ARMI_FLUX_DPA
         :implements: R_ARMI_FLUX_DPA
 

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -243,7 +243,7 @@ class TestGlobalFluxInterfaceWithExecuters(unittest.TestCase):
             mockGeometryTransform
         )
         mockExecute.side_effect = lambda *a, **kw: call_order.append(mockExecute)
-        gfi, r = self.gfi, self.r
+        gfi = self.gfi
         gfi.interactBOC()
         gfi.interactEveryNode(0, 0)
         self.assertEqual([mockGeometryTransform, mockExecute], call_order)
@@ -323,7 +323,7 @@ class TestGlobalFluxInterfaceWithExecutersNonUniform(unittest.TestCase):
             converter is shown to have been called when a nonuniform flag is
             used.
         """
-        gfi, r = self.gfi, self.r
+        gfi = self.gfi
         gfi.interactBOC()
         gfi.interactEveryNode(0, 0)
         self.assertTrue(gfi.getExecuterOptions().hasNonUniformAssems)

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -326,6 +326,7 @@ class TestGlobalFluxInterfaceWithExecutersNonUniform(unittest.TestCase):
         gfi, r = self.gfi, self.r
         gfi.interactBOC()
         gfi.interactEveryNode(0, 0)
+        self.assertTrue(gfi.getExecuterOptions().hasNonUniformAssems)
         mockConverterFactory.assert_called()
 
     def test_calculateKeff(self):


### PR DESCRIPTION
## What is the change?

The implementation crumb for one implementation was updated to not mention something it didn't need to.

Several tests/test tags have been modified to either change wording, split into multiple tests, or better accomplish the task they purported to do.

## Why is the change being made?

This change is in response to comments on the requirements for the global flux interface.
<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
