### PR TITLE
Update testing for geometry converters reqs

### DIFF
--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -435,8 +435,16 @@ class HexToRZThetaConverter(GeometryConverter):
         r : Reactor object
             The reactor to convert.
 
+        .. impl:: Tool to convert a hex core to an RZTheta core.
+            :id: I_ARMI_CONV_3DHEX_TO_2DRZ
+            :implements: R_ARMI_CONV_3DHEX_TO_2DRZ
+
         Notes
         -----
+        The linked requirement technically points to a child class of this class,
+        HexToRZConverter. However, this is the method where the conversion actually happens
+        and thus the implementation tag is noted here.
+
         As a part of the RZT mesh converters it is possible to obtain a radial mesh that
         has repeated ring numbers.  For instance, if there are fuel assemblies and control
         assemblies within the same radial hex ring then it's possible that a radial mesh
@@ -1199,10 +1207,6 @@ class HexToRZConverter(HexToRZThetaConverter):
 
     This is a subclass of the HexToRZThetaConverter. See the HexToRZThetaConverter for
     explanation and setup of the converterSettings.
-
-    .. impl:: Tool to convert a hex core to an RZTheta core.
-        :id: I_ARMI_CONV_3DHEX_TO_2DRZ
-        :implements: R_ARMI_CONV_3DHEX_TO_2DRZ
     """
 
     _GEOMETRY_TYPE = geometry.GeomType.RZ

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -312,7 +312,7 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
 class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(TEST_ROOT)
-        reduceTestReactorRings(self.r, self.o.cs, 2)
+        reduceTestReactorRings(self.r, self.o.cs, 3)
 
         # initialize the block powers to a uniform power profile, accounting for
         # the loaded reactor being 1/3 core
@@ -344,6 +344,14 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
             :id: T_ARMI_THIRD_TO_FULL_CORE0
             :tests: R_ARMI_THIRD_TO_FULL_CORE
         """
+
+        def getLTAAssems():
+            aList = []
+            for a in self.r.core.getAssemblies():
+                if a.getType == "lta fuel":
+                    aList.append(a)
+            return aList
+
         # Check the initialization of the third core model
         self.assertFalse(self.r.core.isFullCore)
         self.assertEqual(
@@ -353,7 +361,10 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
             ),
         )
         initialNumBlocks = len(self.r.core.getBlocks())
-
+        assems = getLTAAssems()
+        expectedLoc = [(3, 2)]
+        for i, a in enumerate(assems):
+            self.assertEqual(a.spatialLocator.getRingPos(), expectedLoc[i])
         self.assertAlmostEqual(
             self.r.core.getTotalBlockParam("power"), self.o.cs["power"] / 3, places=5
         )
@@ -370,6 +381,10 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
         self.assertTrue(self.r.core.isFullCore)
         self.assertGreater(len(self.r.core.getBlocks()), initialNumBlocks)
         self.assertEqual(self.r.core.symmetry.domain, geometry.DomainType.FULL_CORE)
+        assems = getLTAAssems()
+        expectedLoc = [(3, 2), (3, 6), (3, 10)]
+        for i, a in enumerate(assems):
+            self.assertEqual(a.spatialLocator.getRingPos(), expectedLoc[i])
 
         # ensure that block power is handled correctly
         self.assertAlmostEqual(
@@ -394,6 +409,10 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
         self.assertAlmostEqual(
             self.r.core.getTotalBlockParam("power"), self.o.cs["power"] / 3, places=5
         )
+        assems = getLTAAssems()
+        expectedLoc = [(3, 2)]
+        for i, a in enumerate(assems):
+            self.assertEqual(a.spatialLocator.getRingPos(), expectedLoc[i])
 
     def test_initNewFullReactor(self):
         """Test that initNewReactor will growToFullCore if necessary."""

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -410,7 +410,13 @@ class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):
         self.assertEqual(newR.core.symmetry.domain, geometry.DomainType.FULL_CORE)
 
     def test_skipGrowToFullCoreWhenAlreadyFullCore(self):
-        """Test that hex core is not modified when third core to full core changer is called on an already full core geometry."""
+        """Test that hex core is not modified when third core to full core changer is called on an already full core geometry.
+
+        .. test: Convert a one-third core to full core and restore back to one-third core.
+            :id: T_ARMI_THIRD_TO_FULL_CORE2
+            :tests: R_ARMI_THIRD_TO_FULL_CORE
+
+        """
         # Check the initialization of the third core model and convert to a full core
         self.assertFalse(self.r.core.isFullCore)
         self.assertEqual(

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -141,7 +141,14 @@ class TestHexToRZConverter(unittest.TestCase):
         del self.r
 
     def test_convert(self):
-        """Test the HexToRZConverter.
+        """Test HexToRZConverter.convert().
+
+        Notes
+        -----
+        Ensure the converted reactor has 1) nuclides and nuclide masses that match the
+        original reactor, 2) for a given (r,z,theta) location the expected block type exists,
+        3) the converted reactor has the right (r,z,theta) coordinates, and 4) the converted
+        reactor blocks all have a single (homogenized) component.
 
         .. test:: Convert a 3D hex reactor core to an RZ-Theta core.
             :id: T_ARMI_CONV_3DHEX_TO_2DRZ

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -755,10 +755,36 @@ class HexReactorTests(ReactorTests):
             :id: T_ARMI_THIRD_TO_FULL_CORE1
             :tests: R_ARMI_THIRD_TO_FULL_CORE
         """
-        aListLength = len(self.r.core.getAssemblies())
+        numOfAssembliesOneThird = len(self.r.core.getAssemblies())
+        self.assertFalse(self.r.core.isFullCore)
+        self.assertEqual(
+            self.r.core.symmetry,
+            geometry.SymmetryType(
+                geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC
+            ),
+        )
+        # grow to full core
         converter = self.r.core.growToFullCore(self.o.cs)
+        self.assertTrue(self.r.core.isFullCore)
+        self.assertGreater(len(self.r.core.getAssemblies()), numOfAssembliesOneThird)
+        self.assertEqual(self.r.core.symmetry.domain, geometry.DomainType.FULL_CORE)
+        # restore back to 1/3 core
         converter.restorePreviousGeometry(self.r)
-        self.assertEqual(aListLength, len(self.r.core.getAssemblies()))
+        self.assertEqual(numOfAssembliesOneThird, len(self.r.core.getAssemblies()))
+        self.assertEqual(
+            self.r.core.symmetry,
+            geometry.SymmetryType(
+                geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC
+            ),
+        )
+        self.assertFalse(self.r.core.isFullCore)
+        self.assertEqual(numOfAssembliesOneThird, len(self.r.core.getAssemblies()))
+        self.assertEqual(
+            self.r.core.symmetry,
+            geometry.SymmetryType(
+                geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC
+            ),
+        )
 
     def test_differentNuclideModels(self):
         self.assertEqual(self.o.cs[CONF_XS_KERNEL], "MC2v3")


### PR DESCRIPTION
## What is the change?
Providing updates to the geometry converters testing as part of requirements review. 
<!-- MANDATORY: Describe the change -->

## Why is the change being made?
It's good to not ignore reviewers! 
<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
