### PR TITLE
Improving isDepletable test

### DIFF
--- a/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
@@ -138,12 +138,34 @@ class TestFissionProductModelExplicitMC2Library(unittest.TestCase):
         self.assertGreater(len(fuelBlocks), 0)
         self.assertGreater(len(controlBlocks), 0)
 
+        # prove that the control blocks are not depletable
+        for b in controlBlocks:
+            self.assertFalse(isDepletable(b))
+
+        # as a corrolary of the above, prove that no components in the control blocks are depletable
+        for b in controlBlocks:
+            for c in b.getComponents():
+                self.assertFalse(isDepletable(c))
+
         # Force the the first component in the control blocks
         # to be labeled as depletable for checking that explicit
         # fission products can be assigned.
         for b in controlBlocks:
             c = b.getComponents()[0]
             c.p.flags |= Flags.DEPLETABLE
+
+        # now each control block should be depletable
+        for b in controlBlocks:
+            self.assertTrue(isDepletable(b))
+
+        # as a corrolary of the above, prove that only the first component in each control block is depletable
+        for b in controlBlocks:
+            comps = list(b.getComponents())
+            for i, c in enumerate(comps):
+                if i == 0:
+                    self.assertTrue(isDepletable(c))
+                else:
+                    self.assertFalse(isDepletable(c))
 
         # Run the ``interactBOL`` here to trigger setting up the fission
         # products in the reactor data model.


### PR DESCRIPTION
## What is the change?

Improving isDepletable test

## Why is the change being made?

We are now testing if the components in these blocks are depletable, not just the blocks themselves.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
