### PR TITLE
Fixing broken docstring

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -778,6 +778,8 @@ class Core(composites.Composite):
         """
         Returns the number of rings in this reactor. Based on location so indexing will start at 1.
 
+        Circular ring shuffling changes the interpretation of this result.
+
         .. impl:: Retrieve number of rings in core.
             :id: I_ARMI_R_NUM_RINGS
             :implements: R_ARMI_R_NUM_RINGS
@@ -790,9 +792,6 @@ class Core(composites.Composite):
         ----------
         indexBased : bool, optional
             If true, will force location-index interpretation, even if "circular shuffling" is enabled.
-
-        When circular ring shuffling is activated, this changes interpretation.
-        Developers plan on making this another method for the secondary interpretation.
         """
         if self.circularRingList and not indexBased:
             return max(self.circularRingList)


### PR DESCRIPTION
## What is the change?

Fixing a broken docstring in `getNumRings()`.

## Why is the change being made?

#1531 - Someone tried to put more text AFTER the `Parameters` section of the docstring.  But this is contrary to the NumPy docstring format and the RST renders the result strangely.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
