### PR TITLE
More converters testing updates

### DIFF
--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -863,6 +863,9 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
 
         Notes
         -----
+        For R_ARMI_INP_COLD_HEIGHT, the action of axial expansion occurs in setUp() during core
+        construction, specifically in :py:meth:`constructAssem <armi.reactor.blueprints.Blueprints.constructAssem>`
+
         Two assertions here:
             1. total assembly height should be preserved (through use of top dummy block)
             2. in armi.tests.detailedAxialExpansion.refSmallReactorBase.yaml,

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -116,14 +116,10 @@ class TestBlockConverter(unittest.TestCase):
             .core.getAssemblies(Flags.FUEL)[2]
             .getFirstBlock(Flags.FUEL)
         )
-
         block.spatialGrid = grids.HexGrid.fromPitch(1.0)
 
-        area = block.getArea()
         converter = blockConverters.HexComponentsToCylConverter(block)
         converter.convert()
-        self.assertAlmostEqual(area, converter.convertedBlock.getArea())
-        self.assertAlmostEqual(area, block.getArea())
 
         for compType in [Flags.FUEL, Flags.CLAD, Flags.DUCT]:
             self.assertAlmostEqual(
@@ -136,7 +132,12 @@ class TestBlockConverter(unittest.TestCase):
                     ]
                 ),
             )
+            for c in converter.convertedBlock.getComponents(compType):
+                self.assertEqual(
+                    block.getComponent(compType).temperatureInC, c.temperatureInC
+                )
 
+        self.assertEqual(block.getHeight(), converter.convertedBlock.getHeight())
         self._checkAreaAndComposition(block, converter.convertedBlock)
         self._checkCiclesAreInContact(converter.convertedBlock)
 

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -254,6 +254,10 @@ class TestUniformMeshGenerator(unittest.TestCase):
         """
         Test that the mesh can be correctly filtered.
 
+        .. test:: Produce a uniform mesh with a size no smaller than a user-specified value.
+            :id: T_ARMI_UMC_MIN_MESH1
+            :tests: R_ARMI_UMC_MIN_MESH
+
         .. test:: Preserve the boundaries of fuel and control material.
             :id: T_ARMI_UMC_NON_UNIFORM1
             :tests: R_ARMI_UMC_NON_UNIFORM
@@ -305,7 +309,7 @@ class TestUniformMeshGenerator(unittest.TestCase):
         Covers generateCommonmesh() and _decuspAxialMesh().
 
         .. test:: Produce a uniform mesh with a size no smaller than a user-specified value.
-            :id: T_ARMI_UMC_MIN_MESH
+            :id: T_ARMI_UMC_MIN_MESH0
             :tests: R_ARMI_UMC_MIN_MESH
 
         .. test:: Preserve the boundaries of fuel and control material.

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -418,9 +418,8 @@ class TestUniformMesh(unittest.TestCase):
             :tests: R_ARMI_UMC
         """
         refMass = self.r.core.getMass("U235")
-        applyNonUniformHeightDistribution(
-            self.r
-        )  # this changes the mass of everything in the core
+        # perturb the heights of the assemblies -> changes the mass of everything in the core
+        applyNonUniformHeightDistribution(self.r)
         perturbedCoreMass = self.r.core.getMass("U235")
         self.assertNotEqual(refMass, perturbedCoreMass)
         self.converter.convert(self.r)
@@ -428,12 +427,16 @@ class TestUniformMesh(unittest.TestCase):
         uniformReactor = self.converter.convReactor
         uniformMass = uniformReactor.core.getMass("U235")
 
-        self.assertAlmostEqual(
-            perturbedCoreMass, uniformMass
-        )  # conversion conserved mass
-        self.assertAlmostEqual(
-            self.r.core.getMass("U235"), perturbedCoreMass
-        )  # conversion didn't change source reactor mass
+        # conversion conserved mass
+        self.assertAlmostEqual(perturbedCoreMass, uniformMass)
+        # conversion didn't change source reactor mass
+        self.assertAlmostEqual(self.r.core.getMass("U235"), perturbedCoreMass)
+        # conversion results in uniform axial mesh
+        refAssemMesh = self.converter.convReactor.core.refAssem.getAxialMesh()
+        for a in self.converter.convReactor.core:
+            mesh = a.getAxialMesh()
+            for ref, check in zip(refAssemMesh, mesh):
+                self.assertEqual(ref, check)
 
     def test_applyStateToOriginal(self):
         """

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -257,10 +257,6 @@ class TestUniformMeshGenerator(unittest.TestCase):
         .. test:: Produce a uniform mesh with a size no smaller than a user-specified value.
             :id: T_ARMI_UMC_MIN_MESH1
             :tests: R_ARMI_UMC_MIN_MESH
-
-        .. test:: Preserve the boundaries of fuel and control material.
-            :id: T_ARMI_UMC_NON_UNIFORM1
-            :tests: R_ARMI_UMC_NON_UNIFORM
         """
         meshList = [1.0, 3.0, 4.0, 7.0, 9.0, 12.0, 16.0, 19.0, 20.0]
         anchorPoints = [4.0, 16.0]


### PR DESCRIPTION
## What is the change?
Some more updates to the converters as part of a review for requirements. 
<!-- MANDATORY: Describe the change -->

## Why is the change being made?
Reviewers are people too. 
<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
