### PR TITLE
Fixing broken impl tag in geom converters

### DIFF
--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -430,14 +430,14 @@ class HexToRZThetaConverter(GeometryConverter):
         """
         Run the conversion to 3 dimensional R-Z-Theta.
 
+        .. impl:: Tool to convert a hex core to an RZTheta core.
+            :id: I_ARMI_CONV_3DHEX_TO_2DRZ
+            :implements: R_ARMI_CONV_3DHEX_TO_2DRZ
+
         Attributes
         ----------
         r : Reactor object
             The reactor to convert.
-
-        .. impl:: Tool to convert a hex core to an RZTheta core.
-            :id: I_ARMI_CONV_3DHEX_TO_2DRZ
-            :implements: R_ARMI_CONV_3DHEX_TO_2DRZ
 
         Notes
         -----


### PR DESCRIPTION
## What is the change?

Fixing broken impl tag in geom converters

## Why is the change being made?

Sphinx thinks anything after the start of the "Parameters" list is still a parameter.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
