### PR TITLE
Adding code coverage to FuelHandlers and Core

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -544,17 +544,9 @@ class FuelHandler:
                         # this assembly is in the excluded location list. skip it.
                         continue
 
-                # only continue of the Assembly is in a Zone
-                if zoneList:
-                    found = False  # guilty until proven innocent
-                    for zone in zoneList:
-                        if a.getLocation() in zone:
-                            # great! it's in there, so we'll accept this assembly
-                            found = True  # innocent
-                            break
-                    if not found:
-                        # this assembly is not in any of the zones in the zone list. skip it.
-                        continue
+                # only process of the Assembly is in a Zone
+                if not self.isAssemblyInAZone(zoneList, a):
+                    continue
 
                 # Now find the assembly with the param closest to the target val.
                 if param:
@@ -621,6 +613,21 @@ class FuelHandler:
         else:
             return minDiff[1]
 
+    @staticmethod
+    def isAssemblyInAZone(zoneList, a):
+        """Does the given assembly in one of these zones."""
+        if zoneList:
+            # ruff: noqa: SIM110
+            for zone in zoneList:
+                if a.getLocation() in zone:
+                    # Success!
+                    return True
+
+            return False
+        else:
+            # A little counter-intuitively, if there are no zones, we return True.
+            return True
+
     def _getAssembliesInRings(
         self,
         ringList,
@@ -629,7 +636,7 @@ class FuelHandler:
         exclusions=None,
         circularRingFlag=False,
     ):
-        r"""
+        """
         find assemblies in particular rings.
 
         Parameters

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -124,7 +124,10 @@ class FuelHandler:
             # The user can choose the algorithm method name directly in the settings
             if hasattr(rotAlgos, self.cs[CONF_ASSEMBLY_ROTATION_ALG]):
                 rotationMethod = getattr(rotAlgos, self.cs[CONF_ASSEMBLY_ROTATION_ALG])
-                rotationMethod()
+                try:
+                    rotationMethod()
+                except TypeError:
+                    rotationMethod(self)
             else:
                 raise RuntimeError(
                     "FuelHandler {0} does not have a rotation algorithm called {1}.\n"

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -38,6 +38,7 @@ from armi.physics.neutronics.latticePhysics.latticePhysicsInterface import (
 from armi.reactor import assemblies, blocks, components, grids
 from armi.reactor.flags import Flags
 from armi.reactor.tests import test_reactors
+from armi.reactor.zones import Zone
 from armi.settings import caseSettings
 from armi.tests import ArmiTestHelper
 from armi.tests import mockRunLogs
@@ -209,6 +210,22 @@ class TestFuelHandler(FuelHandlerTestHelper):
         )
         fh.outage(factor=1.0)
         self.assertEqual(len(fh.moved), 0)
+
+    def test_isAssemblyInAZone(self):
+        # build a fuel handler
+        fh = fuelHandlers.FuelHandler(self.o)
+
+        # test the default value if there are no zones
+        a = self.r.core.getFirstAssembly()
+        self.assertTrue(fh.isAssemblyInAZone(None, a))
+
+        # If our assembly isn't in one of the supplied zones
+        z = Zone("test_isAssemblyInAZone")
+        self.assertFalse(fh.isAssemblyInAZone([z], a))
+
+        # If our assembly IS in one of the supplied zones
+        z.addLoc(a.getLocation())
+        self.assertTrue(fh.isAssemblyInAZone([z], a))
 
     def test_width(self):
         """Tests the width capability of findAssembly."""

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -515,6 +515,10 @@ class TestFuelHandler(FuelHandlerTestHelper):
         self.assertEqual(sfpMove[1], "005-003")
         self.assertEqual(sfpMove[4], "A0073")  # name of assem in SFP
 
+        # make sure we fail hard if the file doesn't exist
+        with self.assertRaises(RuntimeError):
+            fh.readMoves("totall_fictional_file.txt")
+
     def test_processMoveList(self):
         fh = fuelHandlers.FuelHandler(self.o)
         moves = fh.readMoves("armiRun-SHUFFLES.txt")

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -1037,6 +1037,15 @@ class HexReactorTests(ReactorTests):
         self.assertEqual(self.r.core.getNumRings(indexBased=True), 9)
         self.assertEqual(self.r.core.getNumRings(indexBased=False), 3)
 
+    @patch("armi.reactor.reactors.Core.getAssemblies")
+    def test_whenNoAssemblies(self, mockGetAssemblies):
+        """Test various edge cases when there are no assemblies."""
+        mockGetAssemblies.return_value = []
+
+        self.assertEqual(self.r.core.countBlocksWithFlags(Flags.FUEL), 0)
+        self.assertEqual(self.r.core.countFuelAxialBlocks(), 0)
+        self.assertGreater(self.r.core.getFirstFuelBlockAxialNode(), 9e9)
+
     def test_removeAssembliesInRingHex(self):
         """
         Since the test reactor is hex, we need to use the overrideCircularRingMode option

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -467,6 +467,13 @@ class HexReactorTests(ReactorTests):
         with self.assertRaises(RuntimeError):
             self.r.add(self.r.core)
 
+    def test_getReactor(self):
+        """The Core object can return its Reactor parent; test that getter."""
+        self.assertTrue(isinstance(self.r.core.r, reactors.Reactor))
+
+        self.r.core.parent = None
+        self.assertIsNone(self.r.core.r)
+
     def test_addMoreNodes(self):
         originalMesh = self.r.core.p.axialMesh
         bigMesh = list(originalMesh)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -462,6 +462,11 @@ class HexReactorTests(ReactorTests):
         numPins = self.r.core.getMaxNumPins()
         self.assertEqual(169, numPins)
 
+    def test_addMultipleCores(self):
+        """Test the catch that a reactor can only have one core."""
+        with self.assertRaises(RuntimeError):
+            self.r.add(self.r.core)
+
     def test_addMoreNodes(self):
         originalMesh = self.r.core.p.axialMesh
         bigMesh = list(originalMesh)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -1027,6 +1027,16 @@ class HexReactorTests(ReactorTests):
         self.r.core.removeAssembliesInRing(9, self.o.cs)
         self.assertEqual(self.r.core.getNumRings(), 8)
 
+    def test_getNumRings(self):
+        self.assertEqual(len(self.r.core.circularRingList), 0)
+        self.assertEqual(self.r.core.getNumRings(indexBased=True), 9)
+        self.assertEqual(self.r.core.getNumRings(indexBased=False), 9)
+
+        self.r.core.circularRingList = {1, 2, 3}
+        self.assertEqual(len(self.r.core.circularRingList), 3)
+        self.assertEqual(self.r.core.getNumRings(indexBased=True), 9)
+        self.assertEqual(self.r.core.getNumRings(indexBased=False), 3)
+
     def test_removeAssembliesInRingHex(self):
         """
         Since the test reactor is hex, we need to use the overrideCircularRingMode option


### PR DESCRIPTION
## What is the change?

Adding a little code coverage to `FuelHandlers` and `Core`.

## Why is the change being made?

Just trying to improve code coverage.  It's not much, but these things add up.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [X] The dependencies are still up-to-date in `pyproject.toml`.
