### PR TITLE
Add sys info printout for all nodes

### DIFF
--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -21,6 +21,7 @@ import collections
 import os
 import pathlib
 import re
+import subprocess
 import sys
 import tabulate
 import textwrap
@@ -170,6 +171,7 @@ def writeWelcomeHeaders(o, cs):
             processorNames = context.MPI_NODENAMES
             uniqueNames = set(processorNames)
             nodeMappingData = []
+            sysInfo = ""
             for uniqueName in uniqueNames:
                 matchingProcs = [
                     str(rank)
@@ -180,6 +182,11 @@ def writeWelcomeHeaders(o, cs):
                 nodeMappingData.append(
                     (uniqueName, numProcessors, ", ".join(matchingProcs))
                 )
+                # Run sys info on each unique node too
+                if "win" in sys.platform:
+                    sysInfoCmd = 'systeminfo | findstr /B /C:"OS Name" /B /C:"OS Version" /B /C:"Processor" && systeminfo | findstr /E /C:"Mhz"'
+                    out = subprocess.run(sysInfoCmd, capture_output=True, shell=True)
+                    sysInfo += out.stdout.decode("utf-8")
             runLog.header("=========== Machine Information ===========")
             runLog.info(
                 tabulate.tabulate(
@@ -188,6 +195,8 @@ def writeWelcomeHeaders(o, cs):
                     tablefmt="armi",
                 )
             )
+            runLog.header("=========== System Information ===========")
+            runLog.info(sysInfo)
 
     def _writeReactorCycleInformation(o, cs):
         """Verify that all the operating parameters are defined for the same number of cycles."""

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -182,11 +182,13 @@ def writeWelcomeHeaders(o, cs):
                 nodeMappingData.append(
                     (uniqueName, numProcessors, ", ".join(matchingProcs))
                 )
-                # Run sys info on each unique node too
+                # If this is on Windows: run sys info on each unique node too
                 if "win" in sys.platform:
                     sysInfoCmd = 'systeminfo | findstr /B /C:"OS Name" /B /C:"OS Version" /B /C:"Processor" && systeminfo | findstr /E /C:"Mhz"'
-                    out = subprocess.run(sysInfoCmd, capture_output=True, shell=True)
-                    sysInfo += out.stdout.decode("utf-8")
+                    out = subprocess.run(
+                        sysInfoCmd, capture_output=True, text=True, shell=True
+                    )
+                    sysInfo += out.stdout
             runLog.header("=========== Machine Information ===========")
             runLog.info(
                 tabulate.tabulate(
@@ -195,8 +197,9 @@ def writeWelcomeHeaders(o, cs):
                     tablefmt="armi",
                 )
             )
-            runLog.header("=========== System Information ===========")
-            runLog.info(sysInfo)
+            if sysInfo:
+                runLog.header("=========== System Information ===========")
+                runLog.info(sysInfo)
 
     def _writeReactorCycleInformation(o, cs):
         """Verify that all the operating parameters are defined for the same number of cycles."""


### PR DESCRIPTION
## What is the change?

This adds a little extra info to the runLog for cases. In addition to the machine information, there's a `systeminfo` printout included for each node to show the processor type and OS info.

### For the reviewer:

I do not think this is an important enough update to include in the release notes, but will add it if the you feel otherwise. Additionally, I am not able to add a test for this unless I can add this to an MPI test file.

## Why is the change being made?

This helps prove that a case was run on a particular system. This is motivated by downstream analysis needs.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
