### PR TITLE
Create method to retrieve active interfaces

### DIFF
--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -590,10 +590,10 @@ class Operator:
 
     def interactAllBOC(self, cycle):
         """Interact at beginning of cycle of all enabled interfaces."""
-        activeInterfaces = self.getActiveInterfaces("BOC", cycle)
+        activeInterfaces = self.getActiveInterfaces("BOC", cycle=cycle)
         return self._interactAll("BOC", activeInterfaces, cycle)
 
-    def interactAllEveryNode(self, cycle, tn, excludedInterfaceNames=None):
+    def interactAllEveryNode(self, cycle, tn, excludedInterfaceNames=()):
         """
         Call the interactEveryNode hook for all enabled interfaces.
 
@@ -608,12 +608,12 @@ class Operator:
         excludedInterfaceNames : list, optional
             Names of interface names that will not be interacted with.
         """
-        activeInterfaces = self.getActiveInterfaces("EveryNode")
+        activeInterfaces = self.getActiveInterfaces("EveryNode", excludedInterfaceNames)
         self._interactAll("EveryNode", activeInterfaces, cycle, tn)
 
     def interactAllEOC(self, cycle, excludedInterfaceNames=None):
         """Interact end of cycle for all enabled interfaces."""
-        activeInterfaces = self.getActiveInterfaces("EOC")
+        activeInterfaces = self.getActiveInterfaces("EOC", excludedInterfaceNames)
         self._interactAll("EOC", activeInterfaces, cycle)
 
     def interactAllEOL(self):

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -27,7 +27,7 @@ import os
 import re
 import shutil
 import time
-from typing import Union
+from typing import Tuple
 
 from armi import context
 from armi import interfaces
@@ -927,8 +927,8 @@ class Operator:
     def getActiveInterfaces(
         self,
         interactState: str,
-        excludedInterfaceNames: tuple(str) = (),
-        cycle: int = Union[int, None],
+        excludedInterfaceNames: Tuple[str] = (),
+        cycle: int = 0,
     ):
         """Retrieve the interfaces which are active for a given interaction state.
 
@@ -936,10 +936,10 @@ class Operator:
         ----------
         interactState: str
             A string dictating which interaction state the interfaces should be pulled for.
-        excludedInterfaceNames: tuple(str)
+        excludedInterfaceNames: Tuple[str]
             A tuple of strings dictating which interfaces should be manually skipped.
         cycle: int
-            The given cycle. None by default.
+            The given cycle. 0 by default.
 
         Returns
         -------

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -953,6 +953,9 @@ class Operator:
             The interfaces deemed active for the given interactState.
         """
         # Validate the inputs
+        if excludedInterfaceNames is None:
+            excludedInterfaceNames = ()
+
         if interactState not in ("BOL", "BOC", "EveryNode", "EOC", "EOL", "Coupled"):
             raise ValueError(f"{interactState} is an unknown interaction state!")
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -611,7 +611,7 @@ class Operator:
         activeInterfaces = self.getActiveInterfaces("EveryNode", excludedInterfaceNames)
         self._interactAll("EveryNode", activeInterfaces, cycle, tn)
 
-    def interactAllEOC(self, cycle, excludedInterfaceNames=None):
+    def interactAllEOC(self, cycle, excludedInterfaceNames=()):
         """Interact end of cycle for all enabled interfaces."""
         activeInterfaces = self.getActiveInterfaces("EOC", excludedInterfaceNames)
         self._interactAll("EOC", activeInterfaces, cycle)

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -906,7 +906,13 @@ class Operator:
         return candidateI
 
     def interfaceIsActive(self, name):
-        """True if named interface exists and is active."""
+        """True if named interface exists and is enabled.
+
+        Notes
+        -----
+        This logic is significantly simpler that getActiveInterfaces. This logic only
+        touches the enabled() flag, but doesn't take into account the case settings.
+        """
         i = self.getInterface(name)
         return i and i.enabled()
 

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -175,16 +175,19 @@ class OperatorTests(unittest.TestCase):
 
     def test_getInterfaces(self):
         """Ensure that the right interfaces are returned for a given interaction state."""
+        self.o.cs[CONF_DEFERRED_INTERFACES_CYCLE] = 1
+        self.o.cs[CONF_DEFERRED_INTERFACE_NAMES] = ["history"]
         # test assertion
         with self.assertRaises(ValueError):
             self.o.getActiveInterfaces("notAnInterface")
         # test BOL
-        interfaces = self.o.getActiveInterfaces("BOL")
-        for test, ref in zip(interfaces, self.activeInterfaces):
-            self.assertEqual(test.name, ref.name)
+        interfaces = self.o.getActiveInterfaces(
+            "BOL", excludedInterfaceNames="xsGroups"
+        )
+        interfaceNames = [interface.name for interface in interfaces]
+        self.assertNotIn("xsGroups", interfaceNames)
+        self.assertNotIn("history", interfaceNames)
         # test BOC
-        self.o.cs[CONF_DEFERRED_INTERFACES_CYCLE] = 1
-        self.o.cs[CONF_DEFERRED_INTERFACE_NAMES] = ["history"]
         interfaces = self.o.getActiveInterfaces("BOC", cycle=0)
         interfaceNames = [interface.name for interface in interfaces]
         self.assertNotIn("history", interfaceNames)

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -35,6 +35,8 @@ from armi.settings.fwSettings.globalSettings import (
     CONF_TIGHT_COUPLING,
     CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION,
     CONF_TIGHT_COUPLING_SETTINGS,
+    CONF_DEFERRED_INTERFACE_NAMES,
+    CONF_DEFERRED_INTERFACES_CYCLE,
 )
 from armi.tests import mockRunLogs
 from armi.utils import directoryChangers
@@ -170,6 +172,36 @@ class OperatorTests(unittest.TestCase):
         self.o, _r = test_reactors.loadTestReactor()
         self.assertTrue(self.o.interfaceIsActive("main"))
         self.assertFalse(self.o.interfaceIsActive("Fake-o"))
+
+    def test_getInterfaces(self):
+        """Ensure that the right interfaces are returned for a given interaction state."""
+        # test assertion
+        with self.assertRaises(ValueError):
+            self.o.getActiveInterfaces("notAnInterface")
+        # test BOL
+        interfaces = self.o.getActiveInterfaces("BOL")
+        for test, ref in zip(interfaces, self.activeInterfaces):
+            self.assertEqual(test.name, ref.name)
+        # test BOC
+        self.o.cs[CONF_DEFERRED_INTERFACES_CYCLE] = 1
+        self.o.cs[CONF_DEFERRED_INTERFACE_NAMES] = ["history"]
+        interfaces = self.o.getActiveInterfaces("BOC", cycle=0)
+        interfaceNames = [interface.name for interface in interfaces]
+        self.assertNotIn("history", interfaceNames)
+        # test EveryNode and EOC
+        interfaces = self.o.getActiveInterfaces(
+            "EveryNode", excludedInterfaceNames=("xsGroups")
+        )
+        interfaceNames = [interface.name for interface in interfaces]
+        self.assertIn("history", interfaceNames)
+        self.assertNotIn("xsGroups", interfaceNames)
+        # test EOL
+        interfaces = self.o.getActiveInterfaces("EOL")
+        self.assertEqual(interfaces[-1].name, "main")
+        # test Coupled
+        interfaces = self.o.getActiveInterfaces("Coupled")
+        for test, ref in zip(interfaces, self.activeInterfaces):
+            self.assertEqual(test.name, ref.name)
 
     def test_loadStateError(self):
         """The ``loadTestReactor()`` test tool does not have any history in the DB to load from."""

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -173,35 +173,41 @@ class OperatorTests(unittest.TestCase):
         self.assertTrue(self.o.interfaceIsActive("main"))
         self.assertFalse(self.o.interfaceIsActive("Fake-o"))
 
-    def test_getInterfaces(self):
+    def test_getActiveInterfaces(self):
         """Ensure that the right interfaces are returned for a given interaction state."""
         self.o.cs[CONF_DEFERRED_INTERFACES_CYCLE] = 1
         self.o.cs[CONF_DEFERRED_INTERFACE_NAMES] = ["history"]
-        # test assertion
+
+        # Test invalid inputs.
         with self.assertRaises(ValueError):
             self.o.getActiveInterfaces("notAnInterface")
-        # test BOL
+
+        # Test BOL
         interfaces = self.o.getActiveInterfaces(
-            "BOL", excludedInterfaceNames="xsGroups"
+            "BOL", excludedInterfaceNames=("xsGroups")
         )
         interfaceNames = [interface.name for interface in interfaces]
         self.assertNotIn("xsGroups", interfaceNames)
         self.assertNotIn("history", interfaceNames)
-        # test BOC
+
+        # Test BOC
         interfaces = self.o.getActiveInterfaces("BOC", cycle=0)
         interfaceNames = [interface.name for interface in interfaces]
         self.assertNotIn("history", interfaceNames)
-        # test EveryNode and EOC
+
+        # Test EveryNode and EOC
         interfaces = self.o.getActiveInterfaces(
             "EveryNode", excludedInterfaceNames=("xsGroups")
         )
         interfaceNames = [interface.name for interface in interfaces]
         self.assertIn("history", interfaceNames)
         self.assertNotIn("xsGroups", interfaceNames)
-        # test EOL
+
+        # Test EOL
         interfaces = self.o.getActiveInterfaces("EOL")
         self.assertEqual(interfaces[-1].name, "main")
-        # test Coupled
+
+        # Test Coupled
         interfaces = self.o.getActiveInterfaces("Coupled")
         for test, ref in zip(interfaces, self.activeInterfaces):
             self.assertEqual(test.name, ref.name)


### PR DESCRIPTION
## What is the change?
Adds a method on the Operator to retrieve the active interfaces. Aims to reduce copy and pasted code and improve testing for what interfaces should be active for a given interact state.

## Why is the change being made?
Being able to check which interfaces are active for a given interact state is particularly useful for ARMI Applications.
<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] No [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were altered.
- [x] The dependencies are still up-to-date in `pyproject.toml`.
