### PR TITLE
Fix CLI description printout

### DIFF
--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -103,7 +103,7 @@ class ArmiCLI:
     ARMI CLI -- The main entry point into ARMI. There are various commands
     available. To get help for the individual commands, run again with
     `<command> --help`. Typically, the CLI implements functions that already
-    exists within ARMI.
+    exist within ARMI.
 
     .. impl:: The basic ARMI CLI, for running a simulation.
         :id: I_ARMI_CLI_CS

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -101,8 +101,8 @@ class ArmiParser(argparse.ArgumentParser):
 class ArmiCLI:
     """
     ARMI CLI -- The main entry point into ARMI. There are various commands
-    available, to get help for the individual commands, run again with
-    `<command> --help`. Generically, the CLI implements functions that already
+    available. To get help for the individual commands, run again with
+    `<command> --help`. Typically, the CLI implements functions that already
     exists within ARMI.
 
     .. impl:: The basic ARMI CLI, for running a simulation.
@@ -128,7 +128,7 @@ class ArmiCLI:
 
         parser = ArmiParser(
             prog=context.APP_NAME,
-            description=self.__doc__,
+            description=self.__doc__.split(".. impl")[0],
             usage="%(prog)s [-h] [-l | command [args]]",
         )
 


### PR DESCRIPTION
## What is the change?

Splits what prints of the description for the ARMI CLI at the impl tag.

## Why is the change being made?

Because the full docstring was being used, the impl tag was being printed when you run `armi -h`:

![image](https://github.com/terrapower/armi/assets/5347433/27784752-ff79-4017-8117-825b91163a4e)

This PR fixes that to:

![image](https://github.com/terrapower/armi/assets/5347433/462c2ba9-bbd4-487f-9d39-0854a1fa6b3a)

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
