### PR TITLE
Cleanup on Aisle 5! Dirty Testing

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,9 @@
 name: Documentation
 
-on: [push, pull_request]
-  # push:
-  #   branches:
-  #     - main
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,9 @@
 name: Documentation
 
-on:
-  push:
-    branches:
-      - main
+on: [push, pull request]
+  # push:
+  #   branches:
+  #     - main
 
 jobs:
   build:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,6 @@
 name: Documentation
 
-on: [push, pull request]
+on: [push, pull_request]
   # push:
   #   branches:
   #     - main

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -93,9 +93,11 @@ class TestDatabaseInterface(unittest.TestCase):
         self.db.close()
         self.stateRetainer.__exit__()
         self.td.__exit__(None, None, None)
-        # interactBOL leaves behind some dirt (accessible after db close) that the
+        # test_interactBOL leaves behind some dirt (accessible after db close) that the
         # TempDirChanger is not catching
-        os.remove(os.path.join(PROJECT_ROOT, "armiRun.h5"))
+        bolDirt = os.path.join(PROJECT_ROOT, "armiRun.h5")
+        if os.path.exists(bolDirt):
+            os.remove(bolDirt)
 
     def test_interactEveryNodeReturn(self):
         """Test that the DB is NOT written to if cs["tightCoupling"] = True."""

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -27,6 +27,7 @@ from armi import settings
 from armi.bookkeeping.db.database3 import Database3
 from armi.bookkeeping.db.databaseInterface import DatabaseInterface
 from armi.cases import case
+from armi.context import PROJECT_ROOT
 from armi.physics.neutronics.settings import CONF_LOADING_FILE
 from armi.reactor import grids
 from armi.reactor.flags import Flags
@@ -92,6 +93,9 @@ class TestDatabaseInterface(unittest.TestCase):
         self.db.close()
         self.stateRetainer.__exit__()
         self.td.__exit__(None, None, None)
+        # interactBOL leaves behind some dirt (accessible after db close) that the
+        # TempDirChanger is not catching
+        os.remove(os.path.join(PROJECT_ROOT, "armiRun.h5"))
 
     def test_interactEveryNodeReturn(self):
         """Test that the DB is NOT written to if cs["tightCoupling"] = True."""

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -32,6 +32,7 @@ from armi.bookkeeping.report.reportingUtils import (
 )
 from armi.reactor.tests.test_reactors import loadTestReactor
 from armi.tests import mockRunLogs
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestReport(unittest.TestCase):
@@ -158,6 +159,15 @@ class TestReport(unittest.TestCase):
 
 
 class TestReportInterface(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.td = TemporaryDirectoryChanger()
+        cls.td.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.__exit__(None, None, None)
+
     def test_printReports(self):
         """Testing printReports method."""
         repInt = reportInterface.ReportInterface(None, None)

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -311,7 +311,7 @@ class TestXSlibraryMerging(TempFileMixin):
         del cls.libLumped
 
     def setUp(self):
-        super().setUp()
+        TempFileMixin.setUp(self)
         # load a library that is in the ARMI tree. This should
         # be a small library with LFPs, Actinides, structure, and coolant
         for attrName, path in [

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -54,7 +54,7 @@ DLAYXS_MCC3 = os.path.join(FIXTURE_DIR_CCCC, "mc2v3.dlayxs")
 UFG_FLUX_EDIT = os.path.join(FIXTURE_DIR, "mc2v3-AA.flux_ufg")
 
 
-class TempFileMixin:
+class TempFileMixin(unittest.TestCase):
     """really a test case."""
 
     def setUp(self):
@@ -67,12 +67,12 @@ class TempFileMixin:
     @property
     def testFileName(self):
         return os.path.join(
-            THIS_DIR,
+            self.td.destination,
             "{}-{}.nucdata".format(self.__class__.__name__, self._testMethodName),
         )
 
 
-class TestXSLibrary(unittest.TestCase, TempFileMixin):
+class TestXSLibrary(TempFileMixin):
     @classmethod
     def setUpClass(cls):
         cls.isotxsAA = isotxs.readBinary(ISOTXS_AA)
@@ -233,9 +233,6 @@ class TestXSLibrary(unittest.TestCase, TempFileMixin):
         # check to make sure they labels overlap... or are actually the same
         writer.writeBinary(self.xsLib, self.testFileName)
         self.assertTrue(filecmp.cmp(refFile, self.testFileName))
-        # These files get around the TempDirChanger for some reason,
-        # and the bug is not obvious
-        os.remove(self.testFileName)
 
 
 class TestGetISOTXSFilesInWorkingDirectory(unittest.TestCase):
@@ -292,7 +289,7 @@ class TestGetISOTXSFilesInWorkingDirectory(unittest.TestCase):
 
 
 # NOTE: This is just a base class, so it isn't run directly.
-class TestXSlibraryMerging(unittest.TestCase, TempFileMixin):
+class TestXSlibraryMerging(TempFileMixin):
     """A shared class that defines tests that should be true for all IsotxsLibrary merging."""
 
     @classmethod
@@ -314,6 +311,7 @@ class TestXSlibraryMerging(unittest.TestCase, TempFileMixin):
         del cls.libLumped
 
     def setUp(self):
+        super().setUp()
         # load a library that is in the ARMI tree. This should
         # be a small library with LFPs, Actinides, structure, and coolant
         for attrName, path in [
@@ -369,9 +367,6 @@ class TestXSlibraryMerging(unittest.TestCase, TempFileMixin):
         self.__class__.libAA = None
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibAAPath(), self.testFileName))
-        # These files get around the TempDirChanger for some reason,
-        # and the bug is not obvious
-        os.remove(self.testFileName)
 
     def test_mergeTwoXSLibFiles(self):
         emptyXSLib = xsLibraries.IsotxsLibrary()
@@ -385,9 +380,6 @@ class TestXSlibraryMerging(unittest.TestCase, TempFileMixin):
         self.assertTrue(xsLibraries.compare(emptyXSLib, self.libCombined))
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibAA_ABPath(), self.testFileName))
-        # These files get around the TempDirChanger for some reason,
-        # and the bug is not obvious
-        os.remove(self.testFileName)
 
     def test_canRemoveIsotopes(self):
         emptyXSLib = xsLibraries.IsotxsLibrary()
@@ -416,9 +408,6 @@ class TestXSlibraryMerging(unittest.TestCase, TempFileMixin):
         )
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
-        # These files get around the TempDirChanger for some reason,
-        # and the bug is not obvious
-        os.remove(self.testFileName)
 
 
 class Pmatrx_merge_Tests(TestXSlibraryMerging):

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -233,6 +233,9 @@ class TestXSLibrary(unittest.TestCase, TempFileMixin):
         # check to make sure they labels overlap... or are actually the same
         writer.writeBinary(self.xsLib, self.testFileName)
         self.assertTrue(filecmp.cmp(refFile, self.testFileName))
+        # These files get around the TempDirChanger for some reason,
+        # and the bug is not obvious
+        os.remove(self.testFileName)
 
 
 class TestGetISOTXSFilesInWorkingDirectory(unittest.TestCase):
@@ -366,6 +369,9 @@ class TestXSlibraryMerging(unittest.TestCase, TempFileMixin):
         self.__class__.libAA = None
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibAAPath(), self.testFileName))
+        # These files get around the TempDirChanger for some reason,
+        # and the bug is not obvious
+        os.remove(self.testFileName)
 
     def test_mergeTwoXSLibFiles(self):
         emptyXSLib = xsLibraries.IsotxsLibrary()
@@ -379,6 +385,9 @@ class TestXSlibraryMerging(unittest.TestCase, TempFileMixin):
         self.assertTrue(xsLibraries.compare(emptyXSLib, self.libCombined))
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibAA_ABPath(), self.testFileName))
+        # These files get around the TempDirChanger for some reason,
+        # and the bug is not obvious
+        os.remove(self.testFileName)
 
     def test_canRemoveIsotopes(self):
         emptyXSLib = xsLibraries.IsotxsLibrary()
@@ -407,6 +416,9 @@ class TestXSlibraryMerging(unittest.TestCase, TempFileMixin):
         )
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
+        # These files get around the TempDirChanger for some reason,
+        # and the bug is not obvious
+        os.remove(self.testFileName)
 
 
 class Pmatrx_merge_Tests(TestXSlibraryMerging):

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -19,6 +19,7 @@ are called armiRun.yaml which is located in armi.tests
 """
 import collections
 import copy
+import os
 import unittest
 from unittest.mock import patch
 
@@ -489,6 +490,13 @@ class TestFuelHandler(FuelHandlerTestHelper):
             self.assertEqual(a.getName(), firstPassResults[a.getLocation()])
         for a in self.r.sfp.getChildren():
             self.assertEqual(a.getLocation(), "SFP")
+
+        # Do some cleanup, since the fuelHandler Interface has code that gets
+        # around the TempDirectoryChanger
+        os.remove("armiRun2-SHUFFLES.txt")
+        os.remove("armiRun2.shuffles_0.png")
+        os.remove("armiRun2.shuffles_1.png")
+        os.remove("armiRun2.shuffles_2.png")
 
     def test_readMoves(self):
         """

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -44,6 +44,7 @@ from armi.settings.fwSettings.globalSettings import CONF_SORT_REACTOR
 from armi.tests import ARMI_RUN_PATH, mockRunLogs, TEST_ROOT
 from armi.utils import directoryChangers
 
+THIS_DIR = os.path.dirname(__file__)
 TEST_REACTOR = None  # pickled string of test reactor (for fast caching)
 
 
@@ -862,7 +863,8 @@ class HexReactorTests(ReactorTests):
         for b in self.r.core.getBlocks():
             b.p.mgFlux = range(5)
             b.p.adjMgFlux = range(5)
-        self.r.core.saveAllFlux()
+        with directoryChangers.TemporaryDirectoryChanger(root=THIS_DIR):
+            self.r.core.saveAllFlux()
 
     def test_getFluxVector(self):
         class MockLib:

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -90,8 +90,9 @@ class C5G7ReactorTests(unittest.TestCase):
         o = armi_init(fName=TEST_INPUT_TITLE + ".yaml")
         locsInput, locsDB = {}, {}
         loadLocs(o, locsInput)
-        o.operate()
-        o2 = db.loadOperator(TEST_INPUT_TITLE + ".h5", 0, 0)
+        with directoryChangers.TemporaryDirectoryChanger():
+            o.operate()
+            o2 = db.loadOperator(TEST_INPUT_TITLE + ".h5", 0, 0)
         loadLocs(o2, locsDB)
 
         for indices, coordsInput in sorted(locsInput.items()):

--- a/armi/tests/test_notebooks.py
+++ b/armi/tests/test_notebooks.py
@@ -36,6 +36,9 @@ class NotebookTests(unittest.TestCase):
 
     def test_runDataModel(self):
         runNotebook(os.path.join(TUTORIALS, "data_model.ipynb"))
+        # Do some cleanup because some code run in the notebook doesn't honor the
+        # TempDirectoryChanger
+        os.remove(os.path.join(TUTORIALS, "anl-afci-177.h5"))
 
 
 def runNotebook(filename):

--- a/armi/utils/tests/test_directoryChangers.py
+++ b/armi/utils/tests/test_directoryChangers.py
@@ -143,8 +143,7 @@ class TestDirectoryChangers(unittest.TestCase):
 
         self.assertTrue(os.path.exists(os.path.join("temp", f("file1.txt"))))
         self.assertTrue(os.path.exists(os.path.join("temp", f("file2.txt"))))
-        os.remove(os.path.join("temp", f("file1.txt")))
-        os.remove(os.path.join("temp", f("file2.txt")))
+        shutil.rmtree("temp")
 
     def test_file_retrieval_missing_file(self):
         """Tests that the directory changer still returns a subset of files even if all do not exist."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ test = [
     "black==22.6.0",
     "docutils",
     "ipykernel",
-    "jupyter-contrib-nbextensions",
     "jupyter_client",
     "nbconvert",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,9 @@ docs = [
     "ipykernel==6.25.1", # iPython kernel to run Jupyter notebooks
     "pylint==2.17.5", # Generates UML diagrams
     "Jinja2==3.0.3", # Used in numpydoc and nbconvert
-    "sphinxcontrib-jquery==4.1", # Handle missing jquery errors 
+    "sphinxcontrib-jquery==4.1", # Handle missing jquery errors
+    "jupyter-contrib-nbextensions",
+    "lxml<5.0.0", # Needed because the dep above is no longer an active project
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ test = [
     "black==22.6.0",
     "docutils",
     "ipykernel",
+    "jupyter-contrib-nbextensions",
     "jupyter_client",
     "nbconvert",
     "pytest",


### PR DESCRIPTION
## What is the change?

This PR cleans up a number of tests that leave dust behind.

## Why is the change being made?

I noticed some tests were a little bit dirty, so I added `TemporaryDirectoryChanger` where possible and manually delete files from tests that call code that "get around" the dir changer. (The code itself, in some places, has file paths that are not relative.)

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
