### PR TITLE
ARMI does not officially support Python 3.6

### DIFF
--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -12,7 +12,7 @@ particular, we assume familiarity with `Python <https://www.python.org/>`__,
 
 You must have the following installed before proceeding:
 
-* `Python <https://www.python.org/downloads/>`__ version 3.6 or later (preferably 64-bit)
+* `Python <https://www.python.org/downloads/>`__ version 3.7 or newer (preferably 64-bit).
 
   .. admonition:: The right Python command
 


### PR DESCRIPTION
## What is the change?

A one line fix to the ARMI docs.

## Why is the change being made?

ARMI does not (officially) support Python 3.6.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
