### PR TITLE
Cleaning up RST formatting in docs

### DIFF
--- a/doc/developer/guide.rst
+++ b/doc/developer/guide.rst
@@ -15,14 +15,14 @@ package's code during runtime.
 
 An approximation of `Composite Design Pattern
 <http://en.wikipedia.org/wiki/Composite_pattern>`_ is used to represent the **Reactor**
-in ARMI. In this hierarchy the **Reactor** object has a child **Core** object, and 
-potentially many generic **Composite** child objects representing ex-core structures. 
-The **Core** is made of **Assembly** objects, which are in turn made up as a collection 
-of **Block** objects. :term:`State <reactor state>` variables may be stored at any level 
-of this hierarchy using the :py:mod:`armi.reactor.parameters` system to contain results 
+in ARMI. In this hierarchy the **Reactor** object has a child **Core** object, and
+potentially many generic **Composite** child objects representing ex-core structures.
+The **Core** is made of **Assembly** objects, which are in turn made up as a collection
+of **Block** objects. :term:`State <reactor state>` variables may be stored at any level
+of this hierarchy using the :py:mod:`armi.reactor.parameters` system to contain results
 (e.g., ``keff``, ``flow rates``, ``power``, ``flux``, etc.). Within each block are
- **Components** that define the pin-level geometry.  Associated with each Component are 
-**Material** objects that contain material properties (``density``, ``conductivity``, 
+**Components** that define the pin-level geometry.  Associated with each Component are
+**Material** objects that contain material properties (``density``, ``conductivity``,
 ``heat capacity``, etc.) and isotopic mass fractions.
 
 .. note:: Non-core structures (spent fuel pools, core restraint, heat exchangers, etc.)

--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -164,6 +164,7 @@ Every release should follow this process:
   - Or from another commit: ``git tag <commit-hash> 1.0.0 -m "Release v1.0.0"``
   - Pushing to the repo: ``git push origin 1.0.0``
   - **NOTE** - The ONLY tags in the ARMI repo are for official version releases.
+
 5. Also add the release notes on `the GitHub UI <https://github.com/terrapower/armi/releases>`__.
 6. Follow the instructions `here <https://github.com/terrapower/terrapower.github.io>`_ to
    archive the new documentation.


### PR DESCRIPTION
## What is the change?

Cleaning up RST formatting in docs

## Why is the change being made?

There were some of those subtle RST errors that Sphinx was complaining about, so I fixed them.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
