### PR TITLE
Adding list-table powers to the docs

### DIFF
--- a/armi/utils/dochelpers.py
+++ b/armi/utils/dochelpers.py
@@ -78,9 +78,9 @@ def createListTable(
     rows: list
         List of input data (first row is the header).
     align: str
-        “left”, “center”, or “right”
+        "left", "center", or "right"
     widths: str
-        “auto”, “grid”, or a list of integers
+        "auto", "grid", or a list of integers
     width: str
         `length`_ or `percentage`_ of the current line width
     klass: str

--- a/armi/utils/dochelpers.py
+++ b/armi/utils/dochelpers.py
@@ -89,8 +89,8 @@ def createListTable(rows, caption=None, align=None, widths=None, width=None):
     # we need valid input data
     assert len(rows) > 1, "Not enough input data."
     len0 = len(rows[0])
-    for row in rows[1]:
-        assert len(row) == len0, "Rows aren't all the same length"
+    for row in rows[1:]:
+        assert len(row) == len0, "Rows aren't all the same length."
 
     # build the list-table header block
     rst = [".. list-table:: {}".format(caption or "")]

--- a/armi/utils/dochelpers.py
+++ b/armi/utils/dochelpers.py
@@ -68,6 +68,49 @@ def create_table(rst_table, caption=None, align=None, widths=None, width=None):
     return "\n".join(rst)
 
 
+def createListTable(rows, caption=None, align=None, widths=None, width=None):
+    """Take a list of data, and produce an RST-type string for a list-table.
+
+    Parameters
+    ----------
+    rows: list
+        List of input data (first row is the header).
+    align: str
+        “left”, “center”, or “right”
+    widths: str
+        “auto”, “grid”, or a list of integers
+    width: str
+        `length`_ or `percentage`_ of the current line width
+
+    Returns
+    -------
+        str: RST list-table string
+    """
+    # we need valid input data
+    assert len(rows) > 1, "Not enough input data."
+    len0 = len(rows[0])
+    for row in rows[1]:
+        assert len(row) == len0, "Rows aren't all the same length"
+
+    # build the list-table header block
+    rst = [".. list-table:: {}".format(caption or "")]
+    rst += ["    :header-rows: 1"]
+    if align:
+        rst += ["    :align: {}".format(align)]
+    if width:
+        rst += ["    :width: {}".format(width)]
+    if widths:
+        rst += ["    :widths: " + " ".join([str(w) for w in widths])]
+    rst += [""]
+
+    # build the list-table data
+    for row in rows:
+        rst += [f"    * - {row[0]}"]
+        rst += [f"      - {word}" for word in row[1:]]
+
+    return "\n".join(rst)
+
+
 class ExecDirective(Directive):
     """
     Execute the specified python code and insert the output into the document.

--- a/armi/utils/dochelpers.py
+++ b/armi/utils/dochelpers.py
@@ -68,7 +68,9 @@ def create_table(rst_table, caption=None, align=None, widths=None, width=None):
     return "\n".join(rst)
 
 
-def createListTable(rows, caption=None, align=None, widths=None, width=None):
+def createListTable(
+    rows, caption=None, align=None, widths=None, width=None, klass=None
+):
     """Take a list of data, and produce an RST-type string for a list-table.
 
     Parameters
@@ -81,6 +83,9 @@ def createListTable(rows, caption=None, align=None, widths=None, width=None):
         “auto”, “grid”, or a list of integers
     width: str
         `length`_ or `percentage`_ of the current line width
+    klass: str
+        Should be "class", but that is a reserved keyword.
+        "longtable", "special", or something custom
 
     Returns
     -------
@@ -95,6 +100,8 @@ def createListTable(rows, caption=None, align=None, widths=None, width=None):
     # build the list-table header block
     rst = [".. list-table:: {}".format(caption or "")]
     rst += ["    :header-rows: 1"]
+    if klass:
+        rst += ["    :class: {}".format(klass)]
     if align:
         rst += ["    :align: {}".format(align)]
     if width:

--- a/armi/utils/tests/test_dochelpers.py
+++ b/armi/utils/tests/test_dochelpers.py
@@ -19,6 +19,7 @@ from armi.reactor import reactorParameters
 from armi.utils.dochelpers import (
     create_figure,
     create_table,
+    createListTable,
     generateParamTable,
     generatePluginSettingsTable,
 )
@@ -73,3 +74,24 @@ class TestDocHelpers(unittest.TestCase):
         self.assertIn("width: 250", table)
         self.assertIn("widths: [200, 300]", table)
         self.assertIn("thing", table)
+
+    def test_createListTable(self):
+        rows = [["h1", "h2"], ["a1", "a2"], ["b1", "b2"]]
+        table = createListTable(
+            rows, caption="awesomeTable", align="left", widths=[10, 30], width=100
+        )
+
+        self.assertEqual(len(table), 167)
+        self.assertIn("awesomeTable", table)
+        self.assertIn("list-table", table)
+        self.assertIn("width: 100", table)
+        self.assertIn("widths: 10 30", table)
+
+        with self.assertRaises(AssertionError):
+            createListTable([])
+
+        with self.assertRaises(AssertionError):
+            createListTable([["h1", "h2"]])
+
+        with self.assertRaises(AssertionError):
+            createListTable([["h1", "h2"], ["a1", "b2", "c3"]])

--- a/armi/utils/tests/test_dochelpers.py
+++ b/armi/utils/tests/test_dochelpers.py
@@ -86,7 +86,7 @@ class TestDocHelpers(unittest.TestCase):
             klass="longtable",
         )
 
-        self.assertEqual(len(table), 167)
+        self.assertEqual(len(table), 189)
         self.assertIn("awesomeTable", table)
         self.assertIn("list-table", table)
         self.assertIn("longtable", table)

--- a/armi/utils/tests/test_dochelpers.py
+++ b/armi/utils/tests/test_dochelpers.py
@@ -78,12 +78,18 @@ class TestDocHelpers(unittest.TestCase):
     def test_createListTable(self):
         rows = [["h1", "h2"], ["a1", "a2"], ["b1", "b2"]]
         table = createListTable(
-            rows, caption="awesomeTable", align="left", widths=[10, 30], width=100
+            rows,
+            caption="awesomeTable",
+            align="left",
+            widths=[10, 30],
+            width=100,
+            klass="longtable",
         )
 
         self.assertEqual(len(table), 167)
         self.assertIn("awesomeTable", table)
         self.assertIn("list-table", table)
+        self.assertIn("longtable", table)
         self.assertIn("width: 100", table)
         self.assertIn("widths: 10 30", table)
 

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -586,14 +586,14 @@ in cm.  The following is a list of included component shapes and their dimension
 additional/custom components with arbitrary dimensions may be provided by the user via plugins.
 
 .. exec::
-from armi.reactor.components import ComponentType
-from armi.utils.dochelpers import createListTable
+    from armi.reactor.components import ComponentType
+    from armi.utils.dochelpers import createListTable
 
-rows = [['Component Name', 'Dimensions']]
-for c in ComponentType.TYPES.values():
-    rows.append([c.__name__, ', '.join(c.DIMENSION_NAMES)])
+    rows = [['Component Name', 'Dimensions']]
+    for c in ComponentType.TYPES.values():
+        rows.append([c.__name__, ', '.join(c.DIMENSION_NAMES)])
 
-return createListTable(rows, widths=[25, 65])
+    return createListTable(rows, widths=[25, 65])
 
 When a ``DerivedShape`` is specified as the final component in a block, its area is inferred from
 the difference between the area of the block and the sum of the areas

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -593,7 +593,7 @@ additional/custom components with arbitrary dimensions may be provided by the us
     for c in ComponentType.TYPES.values():
         rows.append([c.__name__, ', '.join(c.DIMENSION_NAMES)])
 
-    return createListTable(rows, widths=[25, 65])
+    return createListTable(rows, widths=[25, 65], klass="longtable")
 
 When a ``DerivedShape`` is specified as the final component in a block, its area is inferred from
 the difference between the area of the block and the sum of the areas

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -586,15 +586,14 @@ in cm.  The following is a list of included component shapes and their dimension
 additional/custom components with arbitrary dimensions may be provided by the user via plugins.
 
 .. exec::
-    from tabulate import tabulate
-    from armi.reactor.components import ComponentType
-    from armi.utils.dochelpers import createListTable
+from armi.reactor.components import ComponentType
+from armi.utils.dochelpers import createListTable
 
-    rows = [['Component Name', 'Dimensions']]
-    for c in ComponentType.TYPES.values():
-        rows.append([c.__name__, ', '.join(c.DIMENSION_NAMES)])
+rows = [['Component Name', 'Dimensions']]
+for c in ComponentType.TYPES.values():
+    rows.append([c.__name__, ', '.join(c.DIMENSION_NAMES)])
 
-    return createListTable(rows, widths=[25, 65])
+return createListTable(rows, widths=[25, 65])
 
 When a ``DerivedShape`` is specified as the final component in a block, its area is inferred from
 the difference between the area of the block and the sum of the areas

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -585,27 +585,16 @@ Each component has a variety of dimensions to define the shape and composition. 
 in cm.  The following is a list of included component shapes and their dimension inputs. Again,
 additional/custom components with arbitrary dimensions may be provided by the user via plugins.
 
-.. only:: html
+.. exec::
+    from tabulate import tabulate
+    from armi.reactor.components import ComponentType
+    from armi.utils.dochelpers import createListTable
 
-    .. exec::
-        from tabulate import tabulate
-        from armi.reactor.components import ComponentType
+    rows = [['Component Name', 'Dimensions']]
+    for c in ComponentType.TYPES.values():
+        rows.append([c.__name__, ', '.join(c.DIMENSION_NAMES)])
 
-        return create_table(tabulate(headers=('Component Name', 'Dimensions'),
-                       tabular_data=[(c.__name__, ', '.join(c.DIMENSION_NAMES)) for c in ComponentType.TYPES.values()],
-                       tablefmt='rst'), caption="Component list")
-
-.. only:: latex
-
-    .. raw:: latex
-
-        .. exec::
-            from tabulate import tabulate
-            from armi.reactor.components import ComponentType
-
-            return tabulate(headers=('Component Name', 'Dimensions'),
-                   tabular_data=[(c.__name__, ', '.join(c.DIMENSION_NAMES)) for c in ComponentType.TYPES.values()],
-                   tablefmt='latex_longtable')
+    return createListTable(rows, widths=[25, 65])
 
 When a ``DerivedShape`` is specified as the final component in a block, its area is inferred from
 the difference between the area of the block and the sum of the areas

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -585,13 +585,27 @@ Each component has a variety of dimensions to define the shape and composition. 
 in cm.  The following is a list of included component shapes and their dimension inputs. Again,
 additional/custom components with arbitrary dimensions may be provided by the user via plugins.
 
-.. exec::
-    from tabulate import tabulate
-    from armi.reactor.components import ComponentType
+.. only:: html
 
-    return create_table(tabulate(headers=('Component Name', 'Dimensions'),
+    .. exec::
+        from tabulate import tabulate
+        from armi.reactor.components import ComponentType
+
+        return create_table(tabulate(headers=('Component Name', 'Dimensions'),
+                       tabular_data=[(c.__name__, ', '.join(c.DIMENSION_NAMES)) for c in ComponentType.TYPES.values()],
+                       tablefmt='rst'), caption="Component list")
+
+.. only:: latex
+
+    .. raw:: latex
+
+        .. exec::
+            from tabulate import tabulate
+            from armi.reactor.components import ComponentType
+
+            return tabulate(headers=('Component Name', 'Dimensions'),
                    tabular_data=[(c.__name__, ', '.join(c.DIMENSION_NAMES)) for c in ComponentType.TYPES.values()],
-                   tablefmt='rst'), caption="Component list")
+                   tablefmt='latex_longtable')
 
 When a ``DerivedShape`` is specified as the final component in a block, its area is inferred from
 the difference between the area of the block and the sum of the areas


### PR DESCRIPTION
## What is the change?

Adding list-table powers to the docs.

## Why is the change being made?

We wanted to improve the PDF version of our docs.

---

Here is an example of the function working correctly in the PDF docs;

![image](https://github.com/terrapower/armi/assets/1831479/fcd40439-f33a-4376-b3aa-9230d0644465)

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
