### PR TITLE
Add requirements, implementation, and test crumbs for the LABELS and NHFLUX data files

### DIFF
--- a/armi/nuclearDataIO/cccc/labels.py
+++ b/armi/nuclearDataIO/cccc/labels.py
@@ -124,7 +124,7 @@ class LabelsStream(cccc.StreamWithDataContainer):
     def readWrite(self):
         """
         Performs a read/write of a LABELS data file.
-        
+
         .. impl:: Tool to read and write LABELS files.
             :id: I_ARMI_NUCDATA_LABELS
             :implements: R_ARMI_NUCDATA_LABELS

--- a/armi/nuclearDataIO/cccc/labels.py
+++ b/armi/nuclearDataIO/cccc/labels.py
@@ -122,6 +122,13 @@ class LabelsStream(cccc.StreamWithDataContainer):
         return LabelsData()
 
     def readWrite(self):
+        """
+        Performs a read/write of a LABELS data file.
+        
+        .. impl:: Tool to read and write LABELS files.
+            :id: I_ARMI_NUCDATA_LABELS
+            :implements: R_ARMI_NUCDATA_LABELS
+        """
         runLog.info(
             "{} LABELS data {}".format(
                 "Reading" if "r" in self._fileMode else "Writing", self

--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -237,6 +237,10 @@ class NhfluxStream(cccc.StreamWithDataContainer):
             overwrites the previous one on the NHFLUX class object, which will contain only the
             numDataSetsToRead-th data set. The first numDataSetsToRead-1 data sets are essentially
             skipped over.
+        
+        .. impl:: Tool to read and write NHFLUX files.
+            :id: I_ARMI_NUCDATA_NHFLUX
+            :implements: R_ARMI_NUCDATA_NHFLUX_VARIANT
         """
         self._rwFileID()
         self._rwBasicFileData1D()

--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -237,7 +237,7 @@ class NhfluxStream(cccc.StreamWithDataContainer):
             overwrites the previous one on the NHFLUX class object, which will contain only the
             numDataSetsToRead-th data set. The first numDataSetsToRead-1 data sets are essentially
             skipped over.
-        
+
         .. impl:: Tool to read and write NHFLUX files.
             :id: I_ARMI_NUCDATA_NHFLUX
             :implements: R_ARMI_NUCDATA_NHFLUX_VARIANT

--- a/armi/nuclearDataIO/cccc/tests/test_labels.py
+++ b/armi/nuclearDataIO/cccc/tests/test_labels.py
@@ -29,6 +29,13 @@ class TestLabels(unittest.TestCase):
     """Tests for labels."""
 
     def test_readLabelsBinary(self):
+        """
+        Tests reading a LABELS binary file and comparing expected metadata results.
+        
+        .. test:: Test reading LABELS files.
+            :id: T_ARMI_NUCDATA_LABELS0
+            :tests: R_ARMI_NUCDATA_LABELS
+        """
         expectedName = "LABELS"
         expectedTrianglesPerHex = 6
         expectedNumZones = 5800
@@ -47,6 +54,13 @@ class TestLabels(unittest.TestCase):
         self.assertEqual(len(labelsData.regionLabels), expectedNumRegions)
 
     def test_writeLabelsAscii(self):
+        """
+        Tests writing a LABELS file in ASCII format.
+        
+        .. test:: Test writing LABELS files.
+            :id: T_ARMI_NUCDATA_LABELS1
+            :tests: R_ARMI_NUCDATA_LABELS
+        """
         with TemporaryDirectoryChanger():
             labelsData = labels.readBinary(LABELS_FILE_BIN)
             labels.writeAscii(labelsData, self._testMethodName + "labels.ascii")

--- a/armi/nuclearDataIO/cccc/tests/test_labels.py
+++ b/armi/nuclearDataIO/cccc/tests/test_labels.py
@@ -31,7 +31,7 @@ class TestLabels(unittest.TestCase):
     def test_readLabelsBinary(self):
         """
         Tests reading a LABELS binary file and comparing expected metadata results.
-        
+
         .. test:: Test reading LABELS files.
             :id: T_ARMI_NUCDATA_LABELS0
             :tests: R_ARMI_NUCDATA_LABELS
@@ -56,7 +56,7 @@ class TestLabels(unittest.TestCase):
     def test_writeLabelsAscii(self):
         """
         Tests writing a LABELS file in ASCII format.
-        
+
         .. test:: Test writing LABELS files.
             :id: T_ARMI_NUCDATA_LABELS1
             :tests: R_ARMI_NUCDATA_LABELS

--- a/armi/nuclearDataIO/cccc/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_nhflux.py
@@ -135,11 +135,22 @@ class TestNhflux(unittest.TestCase):
 class TestNhfluxVariant(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        """Load NHFLUX data from binary file. This file was produced using VARIANT v11.0."""
+        """
+        Load NHFLUX data from binary file. This file was produced using VARIANT v11.0.
+        
+        .. test:: Test reading NHFLUX files from VARIANT transport solver.
+            :id: T_ARMI_NUCDATA_NHFLUX_VARIANT0
+            :tests: R_ARMI_NUCDATA_NHFLUX_VARIANT
+        """
         cls.nhf = nhflux.NhfluxStreamVariant.readBinary(SIMPLE_HEXZ_NHFLUX_VARIANT)
 
     def test_fc(self):
-        """Verify the file control info."""
+        """Verify the file control info.
+        
+        .. test:: Tests expected metadata from the NHFLUX file.
+            :id: T_ARMI_NUCDATA_NHFLUX_VARIANT1
+            :tests: R_ARMI_NUCDATA_NHFLUX_VARIANT
+        """
         # These entries exist for both Nodal and VARIANT, but have different values
         # for the same model
         print(self.nhf.metadata.items())
@@ -154,6 +165,13 @@ class TestNhfluxVariant(unittest.TestCase):
         self.assertEqual(self.nhf.metadata["nMoms"], 0)
 
     def test_fluxMoments(self):
+        """
+        Test the comparison between the expected and loaded flux moments from an NHFLUX binary file.
+        
+        .. test:: Tests expected flux moment data from the NHFLUX file.
+            :id: T_ARMI_NUCDATA_NHFLUX_VARIANT2
+            :tests: R_ARMI_NUCDATA_NHFLUX_VARIANT
+        """
         # node 1 (ring=1, position=1), axial=3, group=2
         i = 0
         self.assertEqual(self.nhf.geodstCoordMap[i], 13)
@@ -181,7 +199,13 @@ class TestNhfluxVariant(unittest.TestCase):
         )
 
     def test_write(self):
-        """Verify binary equivalence of written binary file."""
+        """
+        Verify binary equivalence of written binary file.
+        
+        .. test:: Tests writing the NHFLUX file as a binary data format.
+            :id: T_ARMI_NUCDATA_NHFLUX_VARIANT3
+            :tests: R_ARMI_NUCDATA_NHFLUX_VARIANT
+        """
         with TemporaryDirectoryChanger():
             nhflux.NhfluxStreamVariant.writeBinary(self.nhf, "NHFLUX2")
             with open(SIMPLE_HEXZ_NHFLUX_VARIANT, "rb") as f1, open(

--- a/armi/nuclearDataIO/cccc/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_nhflux.py
@@ -137,7 +137,7 @@ class TestNhfluxVariant(unittest.TestCase):
     def setUpClass(cls):
         """
         Load NHFLUX data from binary file. This file was produced using VARIANT v11.0.
-        
+
         .. test:: Test reading NHFLUX files from VARIANT transport solver.
             :id: T_ARMI_NUCDATA_NHFLUX_VARIANT0
             :tests: R_ARMI_NUCDATA_NHFLUX_VARIANT
@@ -146,7 +146,7 @@ class TestNhfluxVariant(unittest.TestCase):
 
     def test_fc(self):
         """Verify the file control info.
-        
+
         .. test:: Tests expected metadata from the NHFLUX file.
             :id: T_ARMI_NUCDATA_NHFLUX_VARIANT1
             :tests: R_ARMI_NUCDATA_NHFLUX_VARIANT
@@ -167,7 +167,7 @@ class TestNhfluxVariant(unittest.TestCase):
     def test_fluxMoments(self):
         """
         Test the comparison between the expected and loaded flux moments from an NHFLUX binary file.
-        
+
         .. test:: Tests expected flux moment data from the NHFLUX file.
             :id: T_ARMI_NUCDATA_NHFLUX_VARIANT2
             :tests: R_ARMI_NUCDATA_NHFLUX_VARIANT
@@ -201,7 +201,7 @@ class TestNhfluxVariant(unittest.TestCase):
     def test_write(self):
         """
         Verify binary equivalence of written binary file.
-        
+
         .. test:: Tests writing the NHFLUX file as a binary data format.
             :id: T_ARMI_NUCDATA_NHFLUX_VARIANT3
             :tests: R_ARMI_NUCDATA_NHFLUX_VARIANT


### PR DESCRIPTION
## What is the change?

<!-- MANDATORY: Describe the change -->

Adds test crumbs for SQA work in the Nuclear Data IO package.

## Why is the change being made?

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
