### PR TITLE
Adding interactCoupled to dev docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -405,7 +405,7 @@ The ARMI system is licensed as follows:
 
 .. code-block:: none
 
-	Copyright 2009-2023 TerraPower, LLC
+	Copyright 2009-2024 TerraPower, LLC
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.

--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2009-2019 TerraPower, LLC
+# Copyright 2019 TerraPower, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/armi/bookkeeping/db/tests/__init__.py
+++ b/armi/bookkeeping/db/tests/__init__.py
@@ -13,16 +13,3 @@
 # limitations under the License.
 
 """Database tests."""
-# Copyright 2009-2019 TerraPower, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.

--- a/doc/developer/guide.rst
+++ b/doc/developer/guide.rst
@@ -221,8 +221,8 @@ hooks include:
 * :py:meth:`interactBOC <armi.interfaces.Interface.interactBOC>` -- Beginning of cycle.
   Happens once per cycle.
 
-* :py:meth:`interactEveryNode <armi.interfaces.Interface.interactEveryNode>` -- happens
-  after every node step/flux calculation
+* :py:meth:`interactEveryNode <armi.interfaces.Interface.interactEveryNode>` -- Happens
+  after every node step/flux calculation.
 
 * :py:meth:`interactEOC <armi.interfaces.Interface.interactEOC>` -- End of cycle.
 
@@ -230,6 +230,9 @@ hooks include:
 
 * :py:meth:`interactError <armi.interfaces.Interface.interactError>` -- When an error
   occurs, this can run to clean up or print debugging info.
+
+* :py:meth:`interactCoupled <armi.interfaces.Interface.interactCoupled>` -- Happens
+  after every node step/flux calculation, if tight physics coupling is active.
 
 These interaction points are optional in every interface, and you may override one or
 more of them to suit your needs.  You should not change the arguments to the hooks,


### PR DESCRIPTION
## What is the change?

Adding interactCoupled to dev docs

## Why is the change being made?

It was missing.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
