### PR TITLE
Adding test crumb finder to CI

### DIFF
--- a/.github/workflows/find_test_crumbs.py
+++ b/.github/workflows/find_test_crumbs.py
@@ -1,0 +1,52 @@
+# Copyright 2024 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This script exists so we can determine if new tests in CI are leaving crumbs."""
+
+import subprocess
+
+# A list of objects we expect during a run, and don't mind (like pycache dirs).
+IGNORED_OBJECTS = [
+    ".pytest_cache",
+    ".tox",
+    "__pycache__",
+    "armi/logs/ARMI.armiRun.",
+    "armi/logs/armiRun.mpi.log",
+    "armi/tests/tutorials/case-suite/",
+    "armi/tests/tutorials/logs/",
+]
+
+
+def main():
+    # use "git clean" to find all non-tracked files
+    proc = subprocess.Popen(["git", "clean", "-xnd"], stdout=subprocess.PIPE)
+    lines = proc.communicate()[0].decode("utf-8").split("\n")
+
+    # clean up the whitespace
+    lines = [l.strip() for l in lines if len(l.strip())]
+
+    # ignore certain untracked object, like __pycache__ dirs
+    for ignore in IGNORED_OBJECTS:
+        lines = [l for l in lines if ignore not in l]
+
+    # fail hard if there are still untracked files
+    if len(lines):
+        for line in lines:
+            print(line)
+
+        raise ValueError("The workspace is dirty; the tests are leaving crumbs!")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/find_test_crumbs.py
+++ b/.github/workflows/find_test_crumbs.py
@@ -21,6 +21,7 @@ IGNORED_OBJECTS = [
     ".pytest_cache",
     ".tox",
     "__pycache__",
+    "armi.egg-info",
     "armi/logs/ARMI.armiRun.",
     "armi/logs/armiRun.mpi.log",
     "armi/tests/tutorials/case-suite/",

--- a/.github/workflows/find_test_crumbs.py
+++ b/.github/workflows/find_test_crumbs.py
@@ -34,11 +34,11 @@ def main():
     lines = proc.communicate()[0].decode("utf-8").split("\n")
 
     # clean up the whitespace
-    lines = [l.strip() for l in lines if len(l.strip())]
+    lines = [ln.strip() for ln in lines if len(ln.strip())]
 
     # ignore certain untracked object, like __pycache__ dirs
     for ignore in IGNORED_OBJECTS:
-        lines = [l for l in lines if ignore not in l]
+        lines = [ln for ln in lines if ignore not in ln]
 
     # fail hard if there are still untracked files
     if len(lines):

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -25,3 +25,5 @@ jobs:
         run: python -m pip install tox tox-gh-actions
       - name: Run Tox
         run: tox -e test
+      - name: Find Test Crumbs
+        run: python .github/workflows/find_test_crumbs.py


### PR DESCRIPTION
## What is the change?

I added a script to our GH CI that checks if the basic unit tests are leaving crumbs.  If they are, the build fails.

## Why is the change being made?

@opotowsky recently had to make a PR to remove a ton of test crumbs.  And I have to do this once every few months as well.  This is a constant source of annoying work, because we had no way to track when people added crumby tests to the repo.

This PR aims to solve this issue.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
