### PR TITLE
Adding implementation description to runLog impl crumbs

### DIFF
--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -327,17 +327,15 @@ def concatenateLogs(logDir=None):
         :id: I_ARMI_LOG_MPI
         :implements: R_ARMI_LOG_MPI
 
-        The log files are plain text files. Since ARMI is
-        frequently run in parallel, the situation arises where
-        each ARMI process generates its own plain text log file.
-        This function combines the separate log files, per
-        process, into one log file.
+        The log files are plain text files. Since ARMI is frequently run in parallel,
+        the situation arises where each ARMI process generates its own plain text log
+        file. This function combines the separate log files, per process, into one log
+        file.
 
-        The files are written in numerical order, with the lead
-        process stdout first then the lead process stderr. Then
-        each other process is written to the combined file, in
-        order, stdout then stderr. Finally, the original stdout
-        and stderr files are deleted.
+        The files are written in numerical order, with the lead process stdout first
+        then the lead process stderr. Then each other process is written to the
+        combined file, in order, stdout then stderr. Finally, the original stdout and
+        stderr files are deleted.
     """
     if logDir is None:
         logDir = LOG_DIR
@@ -515,41 +513,40 @@ class RunLogger(logging.Logger):
         :id: I_ARMI_LOG
         :implements: R_ARMI_LOG
 
-        This logger makes it easy for users to add log statements to
-        and ARMI application, and ARMI will control the flow of
-        those log statements. In particular, ARMI overrides the normal
-        Python logging tooling, to allow developers to pipe their log
-        statements to both screen and file. This works for stdout and
-        stderr.
+        Log statements can be any text a user wants to record during a run. For
+        instance, basic notifications of what is happening in the run, basic warnings,
+        or full errors. These are easily identified by specifying the "verbosity" of
+        the log statement in the code where you do the logging. The most important
+        verbosities are: error, warning, info (the default), and debug. In the ARMI
+        codebase, you will see many examples of logging:
 
-        The log statements themselves can be any text a user wants to
-        record during a run. For instance, basic notifications of what
-        is happening in the run, or basic warnings about something that
-        could be an issue, so you want people to know about. Likewise,
-        full errors can be recorded with this tool. These different
-        types of log statements are easily identified by specifying the
-        "verbosity" of the log statement, in the code where you do the
-        logging. The most important verbosities are: error, warning,
-        info (which is just to add information to the log), and debug
-        (which is meant to be extremely detailed and not always
-        desired).
+        .. code-block:: python
 
-        At the end of the ARMI-based simulation, the analyst doing
-        the simulation will have a full record of potentially interesting
-        information they can use to understand their run.
+            runLog.error("This sort of error might usually terminate the run.")
+            runLog.warning("The run will not terminate, but users might want to know.")
+            runLog.info("This is the usual verbosity.")
+            runLog.debug("This is only logged during a debug run.")
+
+        At the end of the ARMI-based simulation, the analyst will have a full record of
+        potentially interesting information they can use to understand their run.
 
     .. impl:: Logging is done to the screen and to file.
         :id: I_ARMI_LOG_IO
         :implements: R_ARMI_LOG_IO
 
-        By default, this logger prints all log messages during an ARMI
-        simulation to screen and to a plain text file. That is, at any
-        place in the ARMI application, developers can interject a plain
-        text logging message, and when that code is hit during an ARMI
-        simulation, the text will be piped to screen and to a log file.
-        This helpful for analysts who want to watch their simulation in
-        real time, and for everyone that want a record of anything
-        interesting that happened during the run.
+        This logger makes it easy for users to add log statements to and ARMI
+        application, and ARMI will control the flow of those log statements. In
+        particular, ARMI overrides the normal Python logging tooling, to allow
+        developers to pipe their log statements to both screen and file. This works for
+        stdout and stderr.
+
+        By default, this logger prints all log messages during an ARMI simulation to
+        screen and to a plain text file. That is, at any place in the ARMI application,
+        developers can interject a plain text logging message, and when that code is
+        hit during an ARMI simulation, the text will be piped to screen and to a log
+        file. This helpful for analysts who want to watch their simulation in real
+        time, and for everyone that want a record of anything interesting that happened
+        during the run.
     """
 
     FMT = "%(levelname)s%(message)s"

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -326,6 +326,18 @@ def concatenateLogs(logDir=None):
     .. impl:: Log files from different processes are combined.
         :id: I_ARMI_LOG_MPI
         :implements: R_ARMI_LOG_MPI
+
+        The log files are plain text files. Since ARMI is
+        frequently run in parallel, the situation arises where
+        each ARMI process generates its own plain text log file.
+        This function combines the separate log files, per
+        process into one log file.
+
+        The files are written in numerical order, with the lead
+        process stdout first then the lead process stderr. Then
+        each other process is written to the combined file, in
+        order, stdout then stderr. Finally, the original stdout
+        and stderr files are deleted.
     """
     if logDir is None:
         logDir = LOG_DIR
@@ -503,9 +515,41 @@ class RunLogger(logging.Logger):
         :id: I_ARMI_LOG
         :implements: R_ARMI_LOG
 
+        This logger makes it easy for users to add log statements to
+        and ARMI application, and ARMI will control the flow of
+        those log statements. In particular, ARMI overrides the normal
+        Python logging tooling, to allow developers to pipe their log
+        statements to both screen and file. This works for stdout and
+        stderr.
+
+        The log statements themselves can be any text a user wants to
+        record during a run. For instance, basic notifications of what
+        is happening in the run, or basic warnings about something that
+        could be an issue, so you want people to know about. Likewise,
+        full errors can be recorded with this tool. These different
+        types of log statements are easily identified by specifying the
+        "verbosity" of the log statement, in the code where you do the
+        logging. The most important verbosities are: error, warning,
+        info (which is just to add information to the log), and debug
+        (which is meant to be extremely detailed and not always
+        desired).
+
+        And at the end of the ARMI-based simulation, the analyst doing
+        the simulation will have a full record of potentially intersting
+        information they can use to understand their run.
+
     .. impl:: Logging is done to the screen and to file.
         :id: I_ARMI_LOG_IO
         :implements: R_ARMI_LOG_IO
+
+        By default, this logger prints all log messages during an ARMI
+        simulation to screen and to a plain text file. That is, at any
+        place in the ARMI application, developers can interject a plain
+        text logging message, and when that code is hit during an ARMI
+        simulation, the text will be piped to screen and to a log file.
+        This helpful for analysts who want to watch their simulation in
+        real time, and for everyone that want a record of anything
+        interesting that happened during the run.
     """
 
     FMT = "%(levelname)s%(message)s"

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -513,19 +513,21 @@ class RunLogger(logging.Logger):
         :id: I_ARMI_LOG
         :implements: R_ARMI_LOG
 
-        Log statements can be any text a user wants to record during a run. For
-        instance, basic notifications of what is happening in the run, basic warnings,
-        or full errors. These are easily identified by specifying the "verbosity" of
-        the log statement in the code where you do the logging. The most important
-        verbosities are: error, warning, info (the default), and debug. In the ARMI
-        codebase, you will see many examples of logging:
+        Log statements are any text a user wants to record during a run. For instance,
+        basic notifications of what is happening in the run, simple warnings, or hard
+        errors. Every log message has an associated log level, controlled by the
+        "verbosity" of the logging statement in the code. In the ARMI codebase, you
+        can see many examples of logging:
 
         .. code-block:: python
 
             runLog.error("This sort of error might usually terminate the run.")
-            runLog.warning("The run will not terminate, but users might want to know.")
+            runLog.warning("Users probably want to know.")
             runLog.info("This is the usual verbosity.")
             runLog.debug("This is only logged during a debug run.")
+
+        The full list of logging levels is defined in ``_RunLog.getLogLevels()``, and
+        the developer specifies the verbosity of a run via ``_RunLog.setVerbosity()``.
 
         At the end of the ARMI-based simulation, the analyst will have a full record of
         potentially interesting information they can use to understand their run.
@@ -540,10 +542,11 @@ class RunLogger(logging.Logger):
         developers to pipe their log statements to both screen and file. This works for
         stdout and stderr.
 
-        By default, this logger prints all log messages during an ARMI simulation to
-        screen and to a plain text file. That is, at any place in the ARMI application,
-        developers can interject a plain text logging message, and when that code is
-        hit during an ARMI simulation, the text will be piped to screen and a log file.
+        At any place in the ARMI application, developers can interject a plain text
+        logging message, and when that code is hit during an ARMI simulation, the text
+        will be piped to screen and a log file. By default, the ``logging`` module only
+        logs to screen, but ARMI adds a ``FileHandler` in the ``RunLog`` constructor
+        and in py:meth:`armi.runLog._RunLog.startLog`.
     """
 
     FMT = "%(levelname)s%(message)s"

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -543,10 +543,7 @@ class RunLogger(logging.Logger):
         By default, this logger prints all log messages during an ARMI simulation to
         screen and to a plain text file. That is, at any place in the ARMI application,
         developers can interject a plain text logging message, and when that code is
-        hit during an ARMI simulation, the text will be piped to screen and to a log
-        file. This helpful for analysts who want to watch their simulation in real
-        time, and for everyone that want a record of anything interesting that happened
-        during the run.
+        hit during an ARMI simulation, the text will be piped to screen and a log file.
     """
 
     FMT = "%(levelname)s%(message)s"

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -331,7 +331,7 @@ def concatenateLogs(logDir=None):
         frequently run in parallel, the situation arises where
         each ARMI process generates its own plain text log file.
         This function combines the separate log files, per
-        process into one log file.
+        process, into one log file.
 
         The files are written in numerical order, with the lead
         process stdout first then the lead process stderr. Then
@@ -534,8 +534,8 @@ class RunLogger(logging.Logger):
         (which is meant to be extremely detailed and not always
         desired).
 
-        And at the end of the ARMI-based simulation, the analyst doing
-        the simulation will have a full record of potentially intersting
+        At the end of the ARMI-based simulation, the analyst doing
+        the simulation will have a full record of potentially interesting
         information they can use to understand their run.
 
     .. impl:: Logging is done to the screen and to file.


### PR DESCRIPTION
## What is the change?

Adding information to some `impl` crumbs in `runLog`.

## Why is the change being made?

Adding more information about the runLog system.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
