### PR TITLE
Adding more implementation detail to our docstrings

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -122,29 +122,27 @@ def init(choice=None, fName=None, cs=None):
         :id: I_ARMI_SETTING1
         :implements: R_ARMI_SETTING
 
-        This method initializes an ARMI run, and if successful returns
-        an Operator. That operator is designed to drive the reactor
-        simulation through time steps to simulate its operator. This
-        method takes in a settings file or object to initialize the
-        operator. Whether a settings file or object is supplied, the
-        operator will be built based on the those settings. Because
-        the total collection of settings can be modified by developers
-        of ARMI applications, providing these settings allow ARMI
-        end-users to define their simulation as granularly as they
-        need to.
+        This method initializes an ARMI run, and if successful returns an Operator.
+        That operator is designed to drive the reactor simulation through time steps to
+        simulate its operation. This method takes in a settings file or object to
+        initialize the operator. Whether a settings file or object is supplied, the
+        operator will be built based on the those settings. Because the total
+        collection of settings can be modified by developers of ARMI applications,
+        providing these settings allow ARMI end-users to define their simulation as
+        granularly as they need.
 
     Parameters
     ----------
     choice : int, optional
-        Automatically run with this item out of the menu
-        that would be produced of existing YAML files.
+        Automatically run with this item out of the menu that would be produced by the
+        existing YAML files.
 
     fName : str, optional
         The path to a settings file to load: my_case.yaml
 
     cs : Settings, optional
-        If supplied, this CS object will supercede the other case
-        input methods and use the object directly
+        If supplied, this CS object will supercede the other case input methods and use
+        the object directly.
 
     Examples
     --------

--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -122,17 +122,29 @@ def init(choice=None, fName=None, cs=None):
         :id: I_ARMI_SETTING1
         :implements: R_ARMI_SETTING
 
+        This method initializes an ARMI run, and if successful returns
+        an Operator. That operator is designed to drive the reactor
+        simulation through time steps to simulate its operator. This
+        method takes in a settings file or object to initialize the
+        operator. Whether a settings file or object is supplied, the
+        operator will be built based on the those settings. Because
+        the total collection of settings can be modified by developers
+        of ARMI applications, providing these settings allow ARMI
+        end-users to define their simulation as granularly as they
+        need to.
+
     Parameters
     ----------
     choice : int, optional
         Automatically run with this item out of the menu
-        that would be produced of existing xml files.
+        that would be produced of existing YAML files.
 
     fName : str, optional
-        An actual case name to load. e.g. ntTwr1.xml
+        The path to a settings file to load: my_case.yaml
 
-    cs : object, optional
-        If supplied, supercede the other case input methods and use the object directly
+    cs : CaseSettings, optional
+        If supplied, this CS object will supercede the other case
+        input methods and use the object directly
 
     Examples
     --------

--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -142,7 +142,7 @@ def init(choice=None, fName=None, cs=None):
     fName : str, optional
         The path to a settings file to load: my_case.yaml
 
-    cs : CaseSettings, optional
+    cs : Settings, optional
         If supplied, this CS object will supercede the other case
         input methods and use the object directly
 

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -42,23 +42,23 @@ from armi.settings import Setting
 
 class App:
     """
-    The main point of customization for the ARMI Framework.
-
-    The App class is intended to be subclassed in order to customize the functionality
-    and look-and-feel of the ARMI Framework for a specific use case. An App contains a
-    plugin manager, which should be populated in ``__init__()`` with a collection of
-    plugins that are deemed suitable for a given application, as well as other methods
-    which provide further customization.
-
-    The base App class is also a good place to expose some more convenient ways to get
-    data out of the Plugin API; calling the ``pluggy`` hooks directly can sometimes be a
-    pain, as the results returned by the individual plugins may need to be merged and/or
-    checked for errors. Adding that logic here reduces boilerplate throughout the rest
-    of the code.
+    The highest-level of abstraction for defining what happens during an ARMI run.
 
     .. impl:: An App has a plugin manager.
         :id: I_ARMI_APP_PLUGINS
         :implements: R_ARMI_APP_PLUGINS
+
+        The App class is intended to be subclassed in order to customize the functionality
+        and look-and-feel of the ARMI Framework for a specific use case. An App contains a
+        plugin manager, which should be populated in ``__init__()`` with a collection of
+        plugins that are deemed suitable for a given application, as well as other methods
+        which provide further customization.
+
+        The base App class is also a good place to expose some more convenient ways to get
+        data out of the Plugin API; calling the ``pluggy`` hooks directly can sometimes be a
+        pain, as the results returned by the individual plugins may need to be merged and/or
+        checked for errors. Adding that logic here reduces boilerplate throughout the rest
+        of the code.
     """
 
     name = "armi"
@@ -130,6 +130,17 @@ class App:
         .. impl:: Applications will not allow duplicate settings.
             :id: I_ARMI_SETTINGS_UNIQUE
             :implements: R_ARMI_SETTINGS_UNIQUE
+
+            Each ARMI application includes a collection of Plugins. Among other
+            things, these plugins can register new settings, that are not amoung
+            the default settings that come with ARMI. This feature provides a
+            lot of utility, so application developers can easily configure
+            their ARMI appliction in customizable ways.
+
+            However, it would get confusing if two different plugins registered
+            a setting with the same name string. Or if a plugin registered a
+            setting with the same name as an ARMI default setting. So this
+            method throws an error if such a situation arises.
         """
         # Start with framework settings
         settingDefs = {

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -132,7 +132,7 @@ class App:
             :implements: R_ARMI_SETTINGS_UNIQUE
 
             Each ARMI application includes a collection of Plugins. Among other
-            things, these plugins can register new settings, that are not amoung
+            things, these plugins can register new settings in addition to
             the default settings that come with ARMI. This feature provides a
             lot of utility, so application developers can easily configure
             their ARMI appliction in customizable ways.

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -52,7 +52,7 @@ class STACK_ORDER:  # noqa: invalid-class-name
         :implements: R_ARMI_OPERATOR_INTERFACES
 
         At each time node during a simulation, an ordered colletion of Interfaces
-        are run (the stack).. But ARMI does not force the order upon the analyst.
+        are run (referred to as the interface stack). But ARMI does not force the order upon the analyst.
         Instead, each Interface registers where in that ordered list it belongs by
         giving itself an order number (which can be an integer or a decimal).
         This class defines a set of constants which can be imported and used
@@ -264,7 +264,7 @@ class Interface:
         The Interface class defines a number methods with names like ``interact***``.
         These methods are called in order at each time node. This allows for an
         individual Plugin defining multiple interfaces to insert code at the start
-        or end of a particular time node or cylce during reactor simulation. In this
+        or end of a particular time node or cycle during reactor simulation. In this
         fashion, the Plugins and thus the Operator control when their code is run.
 
         The end goal of all this work is to allow the Plugins to carefully tune

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -255,17 +255,23 @@ class TightCoupler:
 
 class Interface:
     """
-    The eponymous Interface between the ARMI Reactor model and modules that operate upon it.
-
-    This defines the operator's contract for interacting with the ARMI reactor model.
-    It is expected that interact* methods are defined as appropriate for the physics modeling.
-
-    Interface instances are gathered into an interface stack in
-    :py:meth:`armi.operators.operator.Operator.createInterfaces`.
+    The eponymous Interface between the ARMI reactor data model and the Plugins.
 
     .. impl:: The interface shall allow code execution at important operational points in time.
         :id: I_ARMI_INTERFACE
         :implements: R_ARMI_INTERFACE
+
+        The Interface class defines a number methods with names like ``interact***``.
+        These methods are called in order at each time node. This allows for an
+        individual Plugin defining multiple interfaces to insert code at the start
+        or end of a particular time node or cylce during reactor simulation. In this
+        fashion, the Plugins and thus the Operator control when their code is run.
+
+        The end goal of all this work is to allow the Plugins to carefully tune
+        when and how they interact with the reactor data model.
+
+        Interface instances are gathered into an interface stack in
+        :py:meth:`armi.operators.operator.Operator.createInterfaces`.
     """
 
     # list containing interfaceClass
@@ -284,7 +290,7 @@ class Interface:
     overridden by any concrete class that extends this one.
     """
 
-    # TODO: This is a terrible variable name.
+    # TODO: This is a terrible name.
     function = None
     """
     The function performed by an Interface. This is not required be be defined

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -44,24 +44,23 @@ class STACK_ORDER:  # noqa: invalid-class-name
     """
     Constants that help determine the order of modules in the interface stack.
 
-    Each module specifies an ``ORDER`` constant that specifies where in this order it
+    Each module defines an ``ORDER`` constant that specifies where in this order it
     should be placed in the Interface Stack.
 
     .. impl:: Define an ordered list of interfaces.
         :id: I_ARMI_OPERATOR_INTERFACES0
         :implements: R_ARMI_OPERATOR_INTERFACES
 
-    Notes
-    -----
-    Originally, the ordering was accomplished with a very large if/else construct in ``createInterfaces``.
-    This made more modular by moving the add/activate logic into each module and replacing the if/else with
-    just a large hard-coded list of modules in order that could possibly be added. That hard-coded
-    list presented ``ImportError`` problems when building various subset distributions of ARMI so this ordering
-    mechanism was created to replace it, allowing the modules to define their required order internally.
+        At each time node during a simulation, an ordered colletion of Interfaces
+        are run (the stack).. But ARMI does not force the order upon the analyst.
+        Instead, each Interface registers where in that ordered list it belongs by
+        giving itself an order number (which can be an integer or a decimal).
+        This class defines a set of constants which can be imported and used
+        by Interface developers to define that Interface's position in the stack.
 
-    Future improvements may include simply defining what information is required to perform a calculation
-    and figuring out the ordering from that. It's complex because in coupled simulations, everything
-    depends on everything.
+        The constants defined are given names, based on common stack orderings
+        in the ARMI ecosystem. But in the end, these are just constant values,
+        and the names they are given are merely suggestions.
 
     See Also
     --------
@@ -93,6 +92,21 @@ class TightCoupler:
     .. impl:: The TightCoupler defines the convergence criteria for physics coupling.
         :id: I_ARMI_OPERATOR_PHYSICS0
         :implements: R_ARMI_OPERATOR_PHYSICS
+
+        During a simulation, the developers of an ARMI application frequently
+        want to iterate on some physical calculation until that calculation has
+        converged to within some small tolerance. This is typically done to solve
+        the nonlinear dependence of different physical properties of the
+        reactor, like fuel performance. However, what parameter is being
+        tightly coupled is configurable by the developer.
+
+        This class provides an easy, basic way to calculate if a single parameter
+        has converged, based on some convergence tolerance. If not, the number
+        of iterations the convergence has been tested is incremented, and
+        this class will wait, presuming another iteration is forthcoming. But
+        the general idea is that we need only provide a paramter, a tolerance,
+        and a number of iterations to define a basic convergence calculation,
+        which this class carries out in the ``isConverged`` method.
 
     Parameters
     ----------

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -93,20 +93,19 @@ class TightCoupler:
         :id: I_ARMI_OPERATOR_PHYSICS0
         :implements: R_ARMI_OPERATOR_PHYSICS
 
-        During a simulation, the developers of an ARMI application frequently
-        want to iterate on some physical calculation until that calculation has
-        converged to within some small tolerance. This is typically done to solve
-        the nonlinear dependence of different physical properties of the
-        reactor, like fuel performance. However, what parameter is being
-        tightly coupled is configurable by the developer.
+        During a simulation, the developers of an ARMI application frequently want to
+        iterate on some physical calculation until that calculation has converged to
+        within some small tolerance. This is typically done to solve the nonlinear
+        dependence of different physical properties of the reactor, like fuel
+        performance. However, what parameter is being tightly coupled is configurable
+        by the developer.
 
-        This class provides an easy, basic way to calculate if a single parameter
-        has converged, based on some convergence tolerance. If not, the number
-        of iterations the convergence has been tested is incremented, and
-        this class will wait, presuming another iteration is forthcoming. But
-        the general idea is that we need only provide a paramter, a tolerance,
-        and a number of iterations to define a basic convergence calculation,
-        which this class carries out in the ``isConverged`` method.
+        This class provides a way to calculate if a single parameter has converged
+        based on some convergence tolerance. The user provides the parameter,
+        tolerance, and a maximum number of iterations to define a basic convergence
+        calculation. If in the ``isConverged`` method the parameter has not converged,
+        the number of iterations is incremented, and this class will wait, presuming
+        another iteration is forthcoming.
 
     Parameters
     ----------
@@ -114,9 +113,8 @@ class TightCoupler:
         The name of a parameter defined in the ARMI Reactor model.
 
     tolerance : float
-        Defines the allowable error, epsilon, between the current previous
-        parameter value(s) to determine if the selected coupling parameter has
-        been converged.
+        Defines the allowable error between the current and previous parameter values
+        to determine if the selected coupling parameter has converged.
 
     maxIters : int
         Maximum number of tight coupling iterations allowed

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -95,14 +95,14 @@ class Operator:
         :implements: R_ARMI_OPERATOR_SETTINGS
 
         A major design feature of ARMI is that a run is built from user settings.
-        in code, this means that a CaseSettings object is passed into this
+        In code, this means that a case ``Settings`` object is passed into this
         class to intialize an Operator. Conceptually, this means that the
         Operator that controls a reactor simulation is defined by user settings.
         Because developers can create their own settings, the user can
         control an ARMI simulation with arbitrary granularity in this way. In
         practice, settings common control things like: how many cycles a
         reactor is being modeled for, how many timesteps are to be modeled
-        per time node, the vervosity of the logging during the run, and
+        per time node, the verbosity of the logging during the run, and
         which modeling steps (such as economics) will be run.
 
     Attributes
@@ -208,10 +208,10 @@ class Operator:
             necessary to break time into discrete chunks. In reactor
             modeling, it is common to first break the time a reactor
             is simulated for into the practical cycles the reactor
-            runs. And then those cycles are broke down into smaller
+            runs. And then those cycles are broken down into smaller
             chunks called burn steps. The final step lengths this
             method returns is a two-tiered list, where primary indices
-            correspond to cycle and secondary indices correspond to
+            correspond to the cycle and secondary indices correspond to
             the length of each intra-cycle step (in days).
         """
         if not self._stepLengths:
@@ -677,10 +677,10 @@ class Operator:
             between two or more physics solvers at the same solution point
             in simulated time. For example, a flux solution might be
             computed, then a temperature solution, and then another flux
-            solution based on updated temperatures (which updated
+            solution based on updated temperatures (which updates
             densities, dimensions, and Doppler).
 
-            This is distinct from loose coupling, which would simply uses
+            This is distinct from loose coupling, which simply uses
             the temperature values from the previous timestep in the
             current flux solution. It's also distinct from full coupling
             where all fields are solved simultaneously. ARMI supports

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -62,9 +62,10 @@ from armi.utils import (
 
 class Operator:
     """
-    Orchestrates an ARMI run, building all the pieces, looping through the interfaces, and manipulating the reactor.
+    Orchestrate an ARMI run, building all the pieces, looping through the interfaces,
+    and manipulating the reactor.
 
-    This Standard Operator loops over a user-input number of cycles, each with a
+    This Operator loops over a user-input number of cycles, each with a
     user-input number of subcycles (called time nodes). It calls a series of
     interaction hooks on each of the
     :py:class:`~armi.interfaces.Interface` in the Interface Stack.
@@ -80,9 +81,29 @@ class Operator:
         :id: I_ARMI_OPERATOR_COMM
         :implements: R_ARMI_OPERATOR_COMM
 
+        A major design feature of ARMI is that the Operator orchestrates the
+        simulation, and as part of that, the Operator has access to the
+        Reactor data model. In code, this just means the reactor object is
+        a mandatory attribute of an instance of the Operator. But conceptually,
+        this means that while the Operator drives the simulation of the
+        reactor, all code has access to the same copy of the reactor data
+        model. This is a crucial idea that allows disparate external nuclear
+        models to interact; they interact with the ARMI reactor data model.
+
     .. impl:: An operator is built from user settings.
         :id: I_ARMI_OPERATOR_SETTINGS
         :implements: R_ARMI_OPERATOR_SETTINGS
+
+        A major design feature of ARMI is that a run is built from user settings.
+        in code, this means that a CaseSettings object is passed into this
+        class to intialize an Operator. Conceptually, this means that the
+        Operator that controls a reactor simulation is defined by user settings.
+        Because developers can create their own settings, the user can
+        control an ARMI simulation with arbitrary granularity in this way. In
+        practice, settings common control things like: how many cycles a
+        reactor is being modeled for, how many timesteps are to be modeled
+        per time node, the vervosity of the logging during the run, and
+        which modeling steps (such as economics) will be run.
 
     Attributes
     ----------
@@ -182,6 +203,16 @@ class Operator:
         .. impl:: Calculate step lengths from cycles and burn steps.
             :id: I_ARMI_FW_HISTORY
             :implements: R_ARMI_FW_HISTORY
+
+            In all computational modeling of physical systems, it is
+            necessary to break time into discrete chunks. In reactor
+            modeling, it is common to first break the time a reactor
+            is simulated for into the practical cycles the reactor
+            runs. And then those cycles are broke down into smaller
+            chunks called burn steps. The final step lengths this
+            method returns is a two-tiered list, where primary indices
+            correspond to cycle and secondary indices correspond to
+            the length of each intra-cycle step (in days).
         """
         if not self._stepLengths:
             self._stepLengths = getStepLengths(self.cs)
@@ -622,27 +653,38 @@ class Operator:
 
         Notes
         -----
-        If the interfaces are flagged to be reversed at EOL, they are separated from the main stack and appended
-        at the end in reverse order. This allows, for example, an interface that must run first to also run last.
+        If the interfaces are flagged to be reversed at EOL, they are
+        separated from the main stack and appended at the end in reverse
+        order. This allows, for example, an interface that must run
+        first to also run last.
         """
         activeInterfaces = self.getActiveInterfaces("EOL")
         self._interactAll("EOL", activeInterfaces)
 
     def interactAllCoupled(self, coupledIteration):
         """
-        Interact for tight physics coupling over all enabled interfaces.
-
-        Tight coupling implies operator-split iterations between two or more physics solvers at the same solution
-        point in time. For example, a flux solution might be computed, then a temperature solution, and then
-        another flux solution based on updated temperatures (which updated densities, dimensions, and Doppler).
-
-        This is distinct from loose coupling, which would simply uses the temperature values from the previous timestep
-        in the current flux solution. It's also distinct from full coupling where all fields are solved simultaneously.
-        ARMI supports tight and loose coupling.
+        Run all interfaces that are involved in tight physics coupling.
 
         .. impl:: Physics coupling is driven from Operator.
             :id: I_ARMI_OPERATOR_PHYSICS1
             :implements: R_ARMI_OPERATOR_PHYSICS
+
+            This method runs all the interfaces that are defined as part
+            of the tight physics coupling of the reactor. Then it returns
+            if the coupling has converged or not.
+
+            Tight coupling implies the operator has split iterations
+            between two or more physics solvers at the same solution point
+            in simulated time. For example, a flux solution might be
+            computed, then a temperature solution, and then another flux
+            solution based on updated temperatures (which updated
+            densities, dimensions, and Doppler).
+
+            This is distinct from loose coupling, which would simply uses
+            the temperature values from the previous timestep in the
+            current flux solution. It's also distinct from full coupling
+            where all fields are solved simultaneously. ARMI supports
+            tight and loose coupling.
         """
         activeInterfaces = self.getActiveInterfaces("Coupled")
         # Store the previous iteration values before calling interactAllCoupled
@@ -923,6 +965,15 @@ class Operator:
         .. impl:: An operator will expose an ordered list of interfaces.
             :id: I_ARMI_OPERATOR_INTERFACES
             :implements: R_ARMI_OPERATOR_INTERFACES
+
+            This method returns an ordered list of instances of the Interface
+            class. This list is useful because at any time node in the
+            reactor simulation, these interfaces will be called in
+            sequence to perform various types of calculations. It is
+            important to note that this Operator instance has a list of
+            Plugins, and each of those Plugins potentially defines
+            multiple Interfaces. And these Interfaces define their own
+            order, separate from the ordering of the Plugins.
 
         Notes
         -----

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -16,7 +16,7 @@
 The MPI-aware variant of the standard ARMI operator.
 
 .. impl:: There is an MPI-aware variant of the ARMI Operator.
-    :id: I_ARMI_OPERATOR_MP
+    :id: I_ARMI_OPERATOR_MPI
     :implements: R_ARMI_OPERATOR_MPI
 
     This sets up the main Operator on the primary MPI node and initializes

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -15,20 +15,24 @@
 """
 The MPI-aware variant of the standard ARMI operator.
 
-See :py:class:`~armi.operators.operator.Operator` for the parent class.
+.. impl:: There is an MPI-aware variant of the ARMI Operator.
+    :id: I_ARMI_OPERATOR_MP
+    :implements: R_ARMI_OPERATOR_MPI
 
-This sets up the main Operator on the primary MPI node and initializes worker
-processes on all other MPI nodes. At certain points in the run, particular interfaces
-might call into action all the workers. For example, a depletion or
-subchannel T/H module may ask the MPI pool to perform a few hundred
-independent physics calculations in parallel. In many cases, this can
-speed up the overall execution of an analysis manyfold, if a big enough
-computer or computer cluster is available. 
+    This sets up the main Operator on the primary MPI node and initializes
+    worker processes on all other MPI nodes. At certain points in the run,
+    particular interfaces might call into action all the workers. For
+    example, a depletion or subchannel T/H module may ask the MPI pool to
+    perform a few hundred independent physics calculations in parallel. In
+    many cases, this can speed up the overall execution of an analysis,
+    if a big enough computer or computing cluster is available.
+
+    See :py:class:`~armi.operators.operator.Operator` for the parent class.
 
 Notes
 -----
 This is not *yet* smart enough to use shared memory when the MPI
-tasks are on the same machine. Everything goes through MPI. This can 
+tasks are on the same machine. Everything goes through MPI. This can
 be optimized as needed.
 """
 import gc
@@ -46,13 +50,7 @@ from armi.reactor import reactors
 
 
 class OperatorMPI(Operator):
-    """
-    MPI-aware Operator.
-
-    .. impl:: There is an MPI-aware operator.
-        :id: I_ARMI_OPERATOR_MPI
-        :implements: R_ARMI_OPERATOR_MPI
-    """
+    """MPI-aware Operator."""
 
     def __init__(self, cs):
         try:
@@ -191,6 +189,7 @@ class OperatorMPI(Operator):
                             cmd
                         )
                     )
+
             pm = getPluginManager()
             resetFlags = pm.hook.mpiActionRequiresReset(cmd=cmd)
             # only reset if all the plugins agree to reset

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 """
-A system to check user settings for validity and provide users with meaningful suggestions to fix.
+A system to check user settings for validity and provide users with meaningful
+suggestions to fix.
 
-This allows developers to specify a rich set of rules and suggestions for user settings.
+This allows developers to define a rich set of rules and suggestions for user settings.
 These then pop up during initialization of a run, either on the command line or as
 dialogues in the GUI. They say things like: "Your ___ setting has the value ___, which
 is impossible. Would you like to switch to ___?"
@@ -49,14 +50,13 @@ class Query:
         :id: I_ARMI_SETTINGS_RULES
         :implements: R_ARMI_SETTINGS_RULES
 
-        This class is meant to represent a generic validation test
-        against a setting. The goal is clear: developers create new
-        settings and they want to make sure those settings are used
-        correctly. As an implementation, there is a ``condition``
-        attribute in this class that is a function that returns
-        ``True`` or ``False`` based on the setting name and value.
-        Optionally, this class also contains a ``correction``
-        function that allows users to automatically correct a bad
+        This class is meant to represent a generic validation test against a setting.
+        The goal is: developers create new settings and they want to make sure those
+        settings are used correctly. As an implementation, users pass in a
+        ``condition`` function to this class that returns ``True`` or ``False`` based
+        on the setting name and value. And then this class has a ``resolve`` method
+        which tests if the condition is met. Optionally, this class also contains a
+        ``correction`` function that allows users to automatically correct a bad
         setting, if the developers can find a clear path forward.
     """
 
@@ -67,8 +67,8 @@ class Query:
         Parameters
         ----------
         condition : callable
-            A callable that returns True or False. If True,
-            then the query activates its question and potential correction.
+            A callable that returns True or False. If True, then the query activates
+            its question and potential correction.
         statement : str
             A statement of the problem indicated by a True condition
         question : str

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -48,6 +48,16 @@ class Query:
     .. impl:: Rules to validate and customize a setting's behavior.
         :id: I_ARMI_SETTINGS_RULES
         :implements: R_ARMI_SETTINGS_RULES
+
+        This class is meant to represent a generic validateion test
+        against a setting. The goal is clear: developers create new
+        settings and they want to make sure those settings are used
+        correctly. As an implementation, there is a ``condition``
+        attribute in this class that is a function that returns
+        ``True`` or ``False`` based on the setting name and value.
+        Optionally, this class also contains a ``correction``
+        function that allows users to automatically correct a bad
+        setting, if the developers can find a clear path forward.
     """
 
     def __init__(self, condition, statement, question, correction):

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -49,7 +49,7 @@ class Query:
         :id: I_ARMI_SETTINGS_RULES
         :implements: R_ARMI_SETTINGS_RULES
 
-        This class is meant to represent a generic validateion test
+        This class is meant to represent a generic validation test
         against a setting. The goal is clear: developers create new
         settings and they want to make sure those settings are used
         correctly. As an implementation, there is a ``condition``

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -146,14 +146,13 @@ class ArmiPlugin:
         :id: I_ARMI_PLUGIN
         :implements: R_ARMI_PLUGIN
 
-        Each plugin has the option of implementing the ``exposeInterfaces``
-        method, and this will be used as a plugin hook to add one or more
-        Interfaces to the ARMI Application. Interfaces can wrap external
-        executables with nuclear modeling codes in them, or directly
-        implement their logic in Python. But because Interfaces are Python
-        code, they have direct access to read and write from ARMI's reactor
-        data model. This Plugin to multiple Interfaces to reactor data model
-        connection is the primary way that developers add code to an ARMI
+        Each plugin has the option of implementing the ``exposeInterfaces`` method, and
+        this will be used as a plugin hook to add one or more Interfaces to the ARMI
+        Application. Interfaces can wrap external executables with nuclear modeling
+        codes in them, or directly implement their logic in Python. But because
+        Interfaces are Python code, they have direct access to read and write from
+        ARMI's reactor data model. This Plugin to multiple Interfaces to reactor data
+        model connection is the primary way that developers add code to an ARMI
         application and simulation.
     """
 
@@ -167,14 +166,10 @@ class ArmiPlugin:
             :id: I_ARMI_PLUGIN_INTERFACES
             :implements: R_ARMI_PLUGIN_INTERFACES
 
-            This method takes in a Settings object and returns a list of
-            Interfaces, the position of each Interface in the Interface stack,
-            and a list of arguments to pass to the Interface when initializing
-            it later. But all of that is just what is necessary so this Plugin
-            can add a list of well-defined Interfaces to the interface stack,
-            in the correct order.
-
-            These Interfaces can then be used to add code to a simulation.
+            This method takes in a Settings object and returns a list of Interfaces,
+            the position of each Interface in the Interface stack, and a list of
+            arguments to pass to the Interface when initializing it later. These
+            Interfaces can then be used to add code to a simulation.
 
         Returns
         -------
@@ -200,32 +195,30 @@ class ArmiPlugin:
             :id: I_ARMI_PLUGIN_PARAMS
             :implements: R_ARMI_PLUGIN_PARAMS
 
-            Through this method, plugin developers can create new Parameters.
-            A parameter can represent any physical property an analyst
-            might want to track. And they can be added at any level of the
-            reactor data model. Through this, the developers can extend
-            ARMI and what physical properties of the reactor they want to
-            calculate, track, and store to the database.
+            Through this method, plugin developers can create new Parameters. A
+            parameter can represent any physical property an analyst might want to
+            track. And they can be added at any level of the reactor data model.
+            Through this, the developers can extend ARMI and what physical properties
+            of the reactor they want to calculate, track, and store to the database.
 
         .. impl:: Define an arbitrary physical parameter.
             :id: I_ARMI_PARAM
             :implements: R_ARMI_PARAM
 
-            Through this method, plugin developers can create new Parameters.
-            A parameter can represent any physical property an analyst
-            might want to track. For example, through this method, a plugin
-            developer can add a new thermodynamic property that adds a
-            thermodynamic parameter to every block in the reactor. Or they
-            could add a neutronics parameter to every fuel assembly. A
-            parameter is quite generic. But these parameters will be tracked
-            in the reactor data model, extend what developers can do with ARMI,
+            Through this method, plugin developers can create new Parameters. A
+            parameter can represent any physical property an analyst might want to
+            track. For example, through this method, a plugin developer can add a new
+            thermodynamic property that adds a thermodynamic parameter to every block
+            in the reactor. Or they could add a neutronics parameter to every fuel
+            assembly. A parameter is quite generic. But these parameters will be
+            tracked in the reactor data model, extend what developers can do with ARMI,
             and will be saved to the output database.
 
         Returns
         -------
         dict
             Keys should be subclasses of ArmiObject, values being a
-            ParameterDefinitionCollection should be added to the key's perameter
+            ParameterDefinitionCollection should be added to the key's parameter
             definitions.
 
         Example
@@ -290,15 +283,8 @@ class ArmiPlugin:
             the Flags system. This method returns a dictionary mapping flag names
             to their desired numerical values. In most cases, no specific value
             is needed, one can be automatically generated using
-            :py:class:`armi.utils.flags.auto`.
-
-            Flags should be added to the ARMI system with great care; flag values
-            are potentially added to every object in the reactor data model and
-            stored in a bitfield. Thus, each additional flag increases the width of
-            the data needed to store them. Also remember, when adding new flags,
-            that flags are generally interpreted to define what something is. So
-            we don't expect to change "what something is" very often
-            (see :py:mod:`armi.reactor.flags`).
+            :py:class:`armi.utils.flags.auto`. (For more information, see
+            :py:mod:`armi.reactor.flags`.)
 
         See Also
         --------

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -167,7 +167,7 @@ class ArmiPlugin:
             :id: I_ARMI_PLUGIN_INTERFACES
             :implements: R_ARMI_PLUGIN_INTERFACES
 
-            This method takes in a CaseSettings object and returns a list of
+            This method takes in a Settings object and returns a list of
             Interfaces, the position of each Interface in the Interface stack,
             and a list of arguments to pass to the Interface when initializing
             it later. But all of that is just what is necessary so this Plugin
@@ -214,7 +214,7 @@ class ArmiPlugin:
             Through this method, plugin developers can create new Parameters.
             A parameter can represent any physical property an analyst
             might want to track. For example, through this method, a plugin
-            developer can add a new thermodynmic property that add a
+            developer can add a new thermodynamic property that adds a
             thermodynamic parameter to every block in the reactor. Or they
             could add a neutronics parameter to every fuel assembly. A
             parameter is quite generic. But these parameters will be tracked
@@ -296,7 +296,7 @@ class ArmiPlugin:
             are potentially added to every object in the reactor data model and
             stored in a bitfield. Thus, each additional flag increases the width of
             the data needed to store them. Also remember, when adding new flags,
-            that flags are generally interpretted to define what something is. So
+            that flags are generally interpreted to define what something is. So
             we don't expect to change "what something is" very often
             (see :py:mod:`armi.reactor.flags`).
 
@@ -426,7 +426,7 @@ class ArmiPlugin:
 
             This hook allows plugin developers to provide their own configuration
             settings, which can participate in the
-            :py:class:`armi.settings.caseSettings.CaseSettings`. Plugins may provide
+            :py:class:`armi.settings.caseSettings.Settings`. Plugins may provide
             entirely new settings to what are already provided by ARMI, as well as
             new options or default values for existing settings. For instance, the
             framework provides a ``neutronicsKernel`` setting for selecting which

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -138,12 +138,23 @@ HOOKIMPL = pluggy.HookimplMarker("armi")
 
 class ArmiPlugin:
     """
-    An ArmiPlugin provides a namespace to collect hook implementations provided by a
-    single "plugin". This API is incomplete, unstable, and expected to change.
+    An ArmiPlugin exposes a collection of hooks that allow users to add a
+    variety of things to their ARMI application: Interfaces, parameters,
+    settings, flags, and much more.
 
-    .. impl:: Plugins have interfaces to add code to the application.
+    .. impl:: Plugins add code to the application through interfaces.
         :id: I_ARMI_PLUGIN
         :implements: R_ARMI_PLUGIN
+
+        Each plugin has the option of implementing the ``exposeInterfaces``
+        method, and this will be used as a plugin hook to add one or more
+        Interfaces to the ARMI Application. Interfaces can wrap external
+        executables with nuclear modeling codes in them, or directly
+        implement their logic in Python. But because Interfaces are Python
+        code, they have direct access to read and write from ARMI's reactor
+        data model. This Plugin to multiple Interfaces to reactor data model
+        connection is the primary way that developers add code to an ARMI
+        application and simulation.
     """
 
     @staticmethod
@@ -152,9 +163,18 @@ class ArmiPlugin:
         """
         Function for exposing interface(s) to other code.
 
-        .. impl:: Plugins have interfaces to the operator.
+        .. impl:: Plugins can add interfaces to the operator.
             :id: I_ARMI_PLUGIN_INTERFACES
             :implements: R_ARMI_PLUGIN_INTERFACES
+
+            This method takes in a CaseSettings object and returns a list of
+            Interfaces, the position of each Interface in the Interface stack,
+            and a list of arguments to pass to the Interface when initializing
+            it later. But all of that is just what is necessary so this Plugin
+            can add a list of well-defined Interfaces to the interface stack,
+            in the correct order.
+
+            These Interfaces can then be used to add code to a simulation.
 
         Returns
         -------
@@ -180,9 +200,26 @@ class ArmiPlugin:
             :id: I_ARMI_PLUGIN_PARAMS
             :implements: R_ARMI_PLUGIN_PARAMS
 
+            Through this method, plugin developers can create new Parameters.
+            A parameter can represent any physical property an analyst
+            might want to track. And they can be added at any level of the
+            reactor data model. Through this, the developers can extend
+            ARMI and what physical properties of the reactor they want to
+            calculate, track, and store to the database.
+
         .. impl:: Define an arbitrary physical parameter.
             :id: I_ARMI_PARAM
             :implements: R_ARMI_PARAM
+
+            Through this method, plugin developers can create new Parameters.
+            A parameter can represent any physical property an analyst
+            might want to track. For example, through this method, a plugin
+            developer can add a new thermodynmic property that add a
+            thermodynamic parameter to every block in the reactor. Or they
+            could add a neutronics parameter to every fuel assembly. A
+            parameter is quite generic. But these parameters will be tracked
+            in the reactor data model, extend what developers can do with ARMI,
+            and will be saved to the output database.
 
         Returns
         -------
@@ -243,22 +280,25 @@ class ArmiPlugin:
     @HOOKSPEC
     def defineFlags() -> Dict[str, Union[int, flags.auto]]:
         """
-        Function to provide new Flags definitions.
-
-        This allows a plugin to provide novel values for the Flags system.
-        Implementations should return a dictionary mapping flag names to their desired
-        numerical values. In most cases, no specific value is needed, in which case
-        :py:class:`armi.utils.flags.auto` should be used.
-
-        Flags should be added to the ARMI system with great care; flag values for each
-        object are stored in a bitfield, so each additional flag increases the width of
-        the data needed to store them. Also, due to the `what things are` interpretation
-        of flags (see :py:mod:`armi.reactor.flags`), new flags should probably refer to
-        novel design elements, rather than novel behaviors.
+        Add new flags to the reactor data model, and the simulation.
 
         .. impl:: Plugins can define new, unique flags to the system.
             :id: I_ARMI_FLAG_EXTEND1
             :implements: R_ARMI_FLAG_EXTEND
+
+            This method allows a plugin developers to provide novel values for
+            the Flags system. This method returns a dictionary mapping flag names
+            to their desired numerical values. In most cases, no specific value
+            is needed, one can be automatically generated using
+            :py:class:`armi.utils.flags.auto`.
+
+            Flags should be added to the ARMI system with great care; flag values
+            are potentially added to every object in the reactor data model and
+            stored in a bitfield. Thus, each additional flag increases the width of
+            the data needed to store them. Also remember, when adding new flags,
+            that flags are generally interpretted to define what something is. So
+            we don't expect to change "what something is" very often
+            (see :py:mod:`armi.reactor.flags`).
 
         See Also
         --------
@@ -380,20 +420,22 @@ class ArmiPlugin:
         """
         Define configuration settings for this plugin.
 
-        This hook allows plugins to provide their own configuration settings, which can
-        participate in the :py:class:`armi.settings.caseSettings.CaseSettings`. Plugins
-        may provide entirely new settings to what are already provided by ARMI, as well
-        as new options or default values for existing settings. For instance, the
-        framework provides a ``neutronicsKernel`` setting for selecting which global
-        physics solver to use. Since we wish to enforce that the user specify a valid
-        kernel, the settings validator will check to make sure that the user's requested
-        kernel is among the available options. If a plugin were to provide a new
-        neutronics kernel (let's say MCNP), it should also define a new option to tell
-        the settings system that ``"MCNP"`` is a valid option.
-
         .. impl:: Plugins can add settings to the run.
             :id: I_ARMI_PLUGIN_SETTINGS
             :implements: R_ARMI_PLUGIN_SETTINGS
+
+            This hook allows plugin developers to provide their own configuration
+            settings, which can participate in the
+            :py:class:`armi.settings.caseSettings.CaseSettings`. Plugins may provide
+            entirely new settings to what are already provided by ARMI, as well as
+            new options or default values for existing settings. For instance, the
+            framework provides a ``neutronicsKernel`` setting for selecting which
+            global physics solver to use. Since we wish to enforce that the user
+            specify a valid kernel, the settings validator will check to make sure
+            that the user's requested kernel is among the available options. If a
+            plugin were to provide a new neutronics kernel (let's say MCNP), it
+            should also define a new option to tell the settings system that
+            ``"MCNP"`` is a valid option.
 
         Returns
         -------

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -48,15 +48,16 @@ class Settings:
     """
     A container for run settings, such as case title, power level, and many more.
 
-    It is accessible to most ARMI objects through self.cs (for 'Case Settings').
-    It acts largely as a dictionary, and setting values are accessed by keys.
-
-    The Settings object has a 1-to-1 correspondence with the ARMI settings input file.
-    This file may be created by hand or by the GUI in submitter.py.
-
     .. impl:: Settings are used to define an ARMI run.
         :id: I_ARMI_SETTING0
         :implements: R_ARMI_SETTING
+
+        The Settings object is accessible to most ARMI objects through self.cs
+        (for 'case settings'). It acts largely as a dictionary, and setting values
+        are accessed by keys.
+
+        The Settings object has a 1-to-1 correspondence with the ARMI settings
+        input file. This file may be created by hand or by a GUI.
 
     Notes
     -----
@@ -112,6 +113,15 @@ class Settings:
         .. impl:: Define a case title to go with the settings.
             :id: I_ARMI_SETTINGS_META0
             :implements: R_ARMI_SETTINGS_META
+
+            Every Settings object has a "case title"; a string for users to
+            help identify their run. This case title is used in log file
+            names, it is printed during a run, it is frequently used to
+            name the settings file. It is designed to be an easy-to-use
+            and easy-to-understand way to keep track of simulations. The
+            general idea here is that the average analyst that is using
+            ARMI will run many ARMI-based simulations, and there needs
+            to be an easy to identify them all.
         """
         if not self.path:
             return self.defaultCaseTitle

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -421,7 +421,7 @@ class Settings:
 
         Returns
         -------
-        writer : SettingsWriter object
+        writer : SettingsWriter
         """
         writer = settingsIO.SettingsWriter(
             self, style=style, settingsSetByUser=settingsSetByUser
@@ -435,7 +435,7 @@ class Settings:
 
         Parameters
         ----------
-        otherCs : Settings object
+        otherCs : Settings
             A cs object that environment settings will be inherited from.
 
         This enables users to run tests with their environment rather than the reference environment

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -15,8 +15,9 @@
 """
 Framework-wide settings definitions and constants.
 
-This should contain Settings definitions for general-purpose "framework" settings. These
-should only include settings that are not related to any particular physics or plugins.
+This should contain Settings definitions for general-purpose "framework"
+settings. These should only include settings that are not related to any
+particular physics or plugins.
 """
 import os
 from typing import List
@@ -126,9 +127,32 @@ def defineSettings() -> List[setting.Setting]:
         :id: I_ARMI_SETTINGS_POWER
         :implements: R_ARMI_SETTINGS_POWER
 
+        ARMI defines a collection of settings by default to be associated
+        with all runs, and one such setting is ``power``. This is the
+        total thermal power of the reactor. This is designed to be the
+        standard power of the reactor core, to be easily set by the user.
+        There is frequently the need to adjust the power of the reactor
+        at different cycles. That is done by setting the ``powerFractions``
+        setting to a list of fractions of this power.
+
     .. impl:: Define a comment and a versions list to go with the settings.
         :id: I_ARMI_SETTINGS_META1
         :implements: R_ARMI_SETTINGS_META
+
+        Because nuclear analysts have a lot to keep track of when doing
+        various simulations of a reactor, ARMI provides a ``comment``
+        setting that takes an arbitrary string and stores it. This string
+        will be preserved in the settings file and thus in the database,
+        and can provide helpful notes for analysts in the future.
+
+        Likewise, it is helpful to know what versions of software were
+        used in an ARMI application. There is a dictionary-like setting
+        called ``versions`` that allows users to track the versions of:
+        ARMI, their ARMI application, and the versions of all the plugins
+        in their simulation. While it is always helpful to know what
+        versions of software you run, it is particularly needed in nuclear
+        engineering where demands will be made to track the exact
+        versions of code used in simulations.
     """
     settings = [
         setting.Setting(

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -50,9 +50,10 @@ class Setting:
         :id: I_ARMI_SETTINGS_DEFAULTS
         :implements: R_ARMI_SETTINGS_DEFAULTS
 
-        A Setting object holds all associated information of a setting in ARMI
+        Setting objects hold all associated information of a setting in ARMI
         and should typically be accessed through the Settings class methods
-        rather than directly.
+        rather than directly. The exception being the SettingAdapter class
+        designed for additional GUI related functionality.
 
         Setting subclasses can implement custom ``load`` and ``dump`` methods
         that can enable serialization (to/from dicts) of custom objects. When

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -17,13 +17,11 @@ System to handle basic configuration settings.
 
 Notes
 -----
-Rather than having subclases for each setting type, we simply derive
-the type based on the type of the default, and we enforce it with
-schema validation. This also allows for more complex schema validation
-for settings that are more complex dictionaries (e.g. XS, rx coeffs, etc.).
-
-One reason for complexity of the previous settings implementation was
-good interoperability with the GUI widgets.
+The type of each setting is derived from the type of the default
+value. When users set values to their settings, ARMI enforces
+these types with schema validation. This also allows for more
+complex schema validation for settings that are more complex
+dictionaries (e.g. XS, rx coeffs).
 """
 from collections import namedtuple
 from typing import List, Optional, Tuple
@@ -48,20 +46,19 @@ class Setting:
     """
     A particular setting.
 
-    Setting objects hold all associated information of a setting in ARMI and should
-    typically be accessed through the Settings class methods rather than directly. The
-    exception being the SettingAdapter class designed for additional GUI related
-    functionality.
-
-    Setting subclasses can implement custom ``load`` and ``dump`` methods
-    that can enable serialization (to/from dicts) of custom objects. When
-    you set a setting's value, the value will be unserialized into
-    the custom object and when you call ``dump``, it will be serialized.
-    Just accessing the value will return the actual object in this case.
-
     .. impl:: The setting default is mandatory.
         :id: I_ARMI_SETTINGS_DEFAULTS
         :implements: R_ARMI_SETTINGS_DEFAULTS
+
+        A Setting object holds all associated information of a setting in ARMI
+        and should typically be accessed through the Settings class methods
+        rather than directly.
+
+        Setting subclasses can implement custom ``load`` and ``dump`` methods
+        that can enable serialization (to/from dicts) of custom objects. When
+        you set a setting's value, the value will be unserialized into
+        the custom object and when you call ``dump``, it will be serialized.
+        Just accessing the value will return the actual object in this case.
     """
 
     def __init__(

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -50,16 +50,15 @@ class Setting:
         :id: I_ARMI_SETTINGS_DEFAULTS
         :implements: R_ARMI_SETTINGS_DEFAULTS
 
-        Setting objects hold all associated information of a setting in ARMI
-        and should typically be accessed through the Settings class methods
-        rather than directly. The exception being the SettingAdapter class
-        designed for additional GUI related functionality.
+        Setting objects hold all associated information of a setting in ARMI and should
+        typically be accessed through the Settings class methods rather than directly.
+        Settings require a mandatory default value.
 
-        Setting subclasses can implement custom ``load`` and ``dump`` methods
-        that can enable serialization (to/from dicts) of custom objects. When
-        you set a setting's value, the value will be unserialized into
-        the custom object and when you call ``dump``, it will be serialized.
-        Just accessing the value will return the actual object in this case.
+        Setting subclasses can implement custom ``load`` and ``dump`` methods that can
+        enable serialization (to/from dicts) of custom objects. When you set a
+        setting's value, the value will be unserialized into the custom object and when
+        you call ``dump``, it will be serialized. Just accessing the value will return
+        the actual object in this case.
     """
 
     def __init__(

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -147,7 +147,7 @@ class SettingsReader:
 
     Parameters
     ----------
-    cs : CaseSettings
+    cs : Settings
         The settings object to read into
     """
 


### PR DESCRIPTION
## What is the change?

I am adding more detail to the requirement implementation stubs in the code.

## Why is the change being made?

This is part of on-going QA work.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
