### PR TITLE
Removing reference to CaseSettings class.

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -448,7 +448,7 @@ class Database3:
 
     def writeInputsToDB(self, cs, csString=None, geomString=None, bpString=None):
         """
-        Write inputs into the database based the CaseSettings.
+        Write inputs into the database based the Settings.
 
         This is not DRY on purpose. The goal is that any particular Database
         implementation should be very stable, so we dont want it to be easy to change

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 """
-The ``Case`` object is responsible for running, and executing a set of user inputs.  Many
-entry points redirect into ``Case`` methods, such as ``clone``, ``compare``, and ``run``.
+The ``Case`` object is responsible for running, and executing a set of
+user inputs.  Many entry points redirect into ``Case`` methods, such as
+``clone``, ``compare``, and ``run``.
 
-The ``Case`` object provides an abstraction around ARMI inputs to allow for manipulation and
-collection of cases.
+The ``Case`` object provides an abstraction around ARMI inputs to allow
+for manipulation and collection of cases.
 
 See Also
 --------
@@ -81,8 +82,8 @@ class Case:
 
         Parameters
         ----------
-        cs : CaseSettings
-            CaseSettings for this Case
+        cs : Settings
+            Settings for this Case
 
         caseSuite : CaseSuite, optional
             CaseSuite this particular case belongs. Passing this in allows dependency
@@ -96,8 +97,8 @@ class Case:
             ``cs`` as needed.
 
         geom : SystemLayoutInput, optional
-            SystemLayoutInput for this case. If not supplied, it will be loaded from the ``cs`` as
-            needed.
+            SystemLayoutInput for this case. If not supplied, it will be loaded from the
+            ``cs`` as needed.
         """
         self._startTime = time.time()
         self._caseSuite = caseSuite
@@ -374,7 +375,7 @@ class Case:
 
     def _startCoverage(self):
         """Helper to the Case.run(): spin up the code coverage tooling,
-        if the CaseSettings file says to.
+        if the Settings file says to.
 
         Returns
         -------
@@ -402,7 +403,7 @@ class Case:
     @staticmethod
     def _endCoverage(userCovFile, cov=None):
         """Helper to the Case.run(): stop and report code coverage,
-        if the CaseSettings file says to.
+        if the Settings file says to.
 
         Parameters
         ----------
@@ -468,7 +469,7 @@ class Case:
 
     def _startProfiling(self):
         """Helper to the Case.run(): start the Python profiling,
-        if the CaseSettings file says to.
+        if the Settings file says to.
 
         Returns
         -------
@@ -485,7 +486,7 @@ class Case:
     @staticmethod
     def _endProfiling(profiler=None):
         """Helper to the Case.run(): stop and report python profiling,
-        if the CaseSettings file says to.
+        if the Settings file says to.
 
         Parameters
         ----------
@@ -912,7 +913,7 @@ def copyInterfaceInputs(
 
     Parameters
     ----------
-    cs : CaseSettings
+    cs : Settings
         The source case settings to find input files
     destination : str
         The target directory to copy input files to

--- a/armi/cases/inputModifiers/inputModifiers.py
+++ b/armi/cases/inputModifiers/inputModifiers.py
@@ -20,7 +20,7 @@ class InputModifier:
 
     (This class is abstract.)
 
-    Subclasses must implement a ``__call__`` method accepting a ``CaseSettings``,
+    Subclasses must implement a ``__call__`` method accepting a ``Settings``,
     ``Blueprints``, and ``SystemLayoutInput``.
 
     The class attribute ``FAIL_IF_AFTER`` should be a tuple defining what, if any,
@@ -64,7 +64,7 @@ class SamplingInputModifier(InputModifier):
 
     (This class is abstract.)
 
-    Subclasses must implement a ``__call__`` method accepting a ``CaseSettings``,
+    Subclasses must implement a ``__call__`` method accepting a ``Settings``,
     ``Blueprints``, and ``SystemLayoutInput``.
 
     This is a modified version of the InputModifier abstract class that imposes
@@ -110,7 +110,7 @@ class FullCoreModifier(InputModifier):
 
     Notes
     -----
-    Besides the core, other grids may also be of interest for expansion, like
+    Besides the Core, other grids may also be of interest for expansion, like
     a grid that defines fuel management. However, the expansion of a fuel
     management schedule to full core is less trivial than just expanding
     the core itself. Thus, this modifier currently does not attempt

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -92,7 +92,7 @@ class CaseSuite:
         """
         Finds case objects by searching for a pattern of inputs, and adds them to the suite.
 
-        This searches for CaseSettings input files and loads them to create Case objects.
+        This searches for Settings input files and loads them to create Case objects.
 
         Parameters
         ----------

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -90,9 +90,9 @@ class SuiteBuilder:
 
         Parameters
         ----------
-        inputModifiers : list(callable(CaseSettings, Blueprints, SystemLayoutInput))
+        inputModifiers : list(callable(Settings, Blueprints, SystemLayoutInput))
             A list of callable objects with the signature
-            ``(CaseSettings, Blueprints, SystemLayoutInput)``. When these objects are called
+            ``(Settings, Blueprints, SystemLayoutInput)``. When these objects are called
             they should perturb the settings, blueprints, and/or geometry by some amount determined
             by their construction.
         """
@@ -121,7 +121,7 @@ class SuiteBuilder:
             and a tuple of InputModifiers used to edit the case. This should be enough information
             for someone to derive a meaningful name.
 
-            The function should return a string specifying the path of the ``CaseSettings``, this
+            The function should return a string specifying the path of the ``Settings``, this
             allows the user to specify the directories where each case will be run.
 
             If not supplied the path will be ``./case-suite/<0000>/<title>-<0000>``, where
@@ -396,7 +396,7 @@ class LatinHyperCubeSuiteBuilder(SuiteBuilder):
             and a tuple of InputModifiers used to edit the case. This should be enough information
             for someone to derive a meaningful name.
 
-            The function should return a string specifying the path of the ``CaseSettings``, this
+            The function should return a string specifying the path of the ``Settings``, this
             allows the user to specify the directories where each case will be run.
 
             If not supplied the path will be ``./case-suite/<0000>/<title>-<0000>``, where

--- a/armi/cli/modify.py
+++ b/armi/cli/modify.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
+"""
 Search through a directory tree and modify ARMI settings in existing input
 file(s). All valid settings may be used as keyword arguments.
 """

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -601,7 +601,7 @@ class Interface:
         relative to the input directory. Absolute paths will not be copied anywhere.
 
 
-        The returned dictionary will enable the source CaseSettings object to
+        The returned dictionary will enable the source Settings object to
         be updated to the new file location. While the dictionary keys are
         recommended to be Setting objects, the name of the setting as a string,
         e.g., "shuffleLogic", is still interpreted. If the string name does not
@@ -618,7 +618,7 @@ class Interface:
 
         Parameters
         ----------
-        cs : CaseSettings
+        cs : Settings
             The case settings for a particular Case
         """
         return {}
@@ -740,7 +740,7 @@ def getActiveInterfaceInfo(cs):
 
     Parameters
     ----------
-    cs : CaseSettings
+    cs : Settings
         The case settings that activate relevant Interfaces
     """
     interfaceInfo = []

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -86,7 +86,7 @@ class Operator:
 
     Attributes
     ----------
-    cs : CaseSettings object
+    cs : Settings
             Global settings that define the run.
 
     cycleNames : list of str
@@ -127,7 +127,7 @@ class Operator:
 
         Parameters
         ----------
-        cs : CaseSettings object
+        cs : Settings
             Global settings that define the run.
 
         Raises

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -89,7 +89,7 @@ class ExecutionOptions:
         return f"<{self.__class__.__name__}: {self.label}>"
 
     def fromUserSettings(self, cs):
-        """Set options from a particular CaseSettings object."""
+        """Set options from a particular Settings object."""
         raise NotImplementedError()
 
     def fromReactor(self, reactor):

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -381,7 +381,7 @@ class ArmiPlugin:
         Define configuration settings for this plugin.
 
         This hook allows plugins to provide their own configuration settings, which can
-        participate in the :py:class:`armi.settings.caseSettings.CaseSettings`. Plugins
+        participate in the :py:class:`armi.settings.caseSettings.Settings`. Plugins
         may provide entirely new settings to what are already provided by ARMI, as well
         as new options or default values for existing settings. For instance, the
         framework provides a ``neutronicsKernel`` setting for selecting which global

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -110,7 +110,7 @@ context.BLUEPRINTS_IMPORT_CONTEXT = "".join(traceback.format_stack())
 
 
 def loadFromCs(cs, roundTrip=False):
-    """Function to load Blueprints based on supplied ``CaseSettings``."""
+    """Function to load Blueprints based on supplied ``Settings``."""
     from armi.utils import directoryChangers
 
     with directoryChangers.DirectoryChanger(cs.inputDirectory, dumpOnException=False):
@@ -231,7 +231,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
         Parameters
         ----------
-        cs : CaseSettings object
+        cs : Settings
             Used to apply various modeling options when constructing an assembly.
 
         name : str (optional, and should be exclusive with specifier)

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -148,8 +148,8 @@ class AssemblyBlueprint(yamlize.Object):
 
         Parameters
         ----------
-        cs : CaseSettings
-            CaseSettings object which containing relevant modeling options.
+        cs : Settings
+            Settings object which containing relevant modeling options.
         blueprint : Blueprint
             Root blueprint object containing relevant modeling options.
         """

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -86,8 +86,8 @@ class BlockBlueprint(yamlize.KeyedList):
 
         Parameters
         ----------
-        cs : CaseSettings
-            CaseSettings object for the appropriate simulation.
+        cs : Settings
+            Settings object for the appropriate simulation.
 
         blueprint : Blueprints
             Blueprints object containing various detailed information, such as nuclides to model

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -508,7 +508,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         ----------
         sourceReactor : :py:class:`Reactor <armi.reactor.reactors.Reactor>` object.
             original reactor to be copied
-        cs: CaseSetting object
+        cs: Setting
             Complete settings object
         """
         # developer note: deepcopy on the blueprint object ensures that all relevant blueprints

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 """
-Reactor objects represent the highest level in the hierarchy of structures that compose the system
-to be modeled. Core objects represent collections of assemblies.
+Reactor objects represent the highest level in the hierarchy of
+structures that compose the system to be modeled. Core objects
+represent collections of assemblies.
 
-Core is a high-level object in the data model in ARMI. They contain assemblies which in turn contain
-more refinement in representing the physical reactor. The reactor is the owner of many of the
-plant-wide state variables such as keff, cycle, and node.
+Core is a high-level object in the data model in ARMI. They
+contain assemblies which in turn contain more refinement in
+representing the physical reactor. The reactor is the owner of
+many of the plant-wide state variables such as keff, cycle,
+and node.
 """
 from typing import Optional
 import collections
@@ -170,7 +173,7 @@ def loadFromCs(cs) -> Reactor:
 
     Parameters
     ----------
-    cs: CaseSettings
+    cs: Settings
         A relevant settings object
 
     Returns
@@ -559,7 +562,7 @@ class Core(composites.Composite):
         ----------
         ringNum : int
             The ring to remove
-        cs: CaseSettings
+        cs: Settings
             A relevant settings object
         overrideCircularRingMode : bool, optional
             False ~ default: use circular/square/hex rings, just as the reactor defines them
@@ -1810,7 +1813,7 @@ class Core(composites.Composite):
 
         Parameters
         ----------
-        cs : CaseSettings object
+        cs : Settings
             Global settings for the case
 
         See Also
@@ -1829,7 +1832,7 @@ class Core(composites.Composite):
             The assembly type to create
         enrichList : list
             weight percent enrichments of each block
-        cs : CaseSettings object
+        cs : Settings
             Global settings for the case
 
         Returns
@@ -2449,12 +2452,12 @@ class Core(composites.Composite):
 
     def buildManualZones(self, cs):
         """
-        Build the Zones that are defined manually in the given CaseSettings file,
+        Build the Zones that are defined manually in the given Settings file,
         in the `zoneDefinitions` setting.
 
         Parameters
         ----------
-        cs : CaseSettings
+        cs : Settings
             The standard ARMI settings object
 
         Examples

--- a/armi/reactor/systemLayoutInput.py
+++ b/armi/reactor/systemLayoutInput.py
@@ -551,7 +551,7 @@ class SystemLayoutInput:
 
     @classmethod
     def loadFromCs(cls, cs):
-        """Function to load Geoemtry based on supplied ``CaseSettings``."""
+        """Function to load Geoemtry based on supplied ``Settings``."""
         if not cs["geomFile"]:
             return None
 

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -147,7 +147,7 @@ class SettingsReader:
 
     Parameters
     ----------
-    cs : CaseSettings
+    cs : Settings
         The settings object to read into
     """
 

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -86,7 +86,7 @@ class PluginAddsOptions(plugins.ArmiPlugin):
         ]
 
 
-class TestCaseSettings(unittest.TestCase):
+class TestSettings(unittest.TestCase):
     def setUp(self):
         self.cs = caseSettings.Settings()
 

--- a/armi/tests/tutorials/data_model.ipynb
+++ b/armi/tests/tutorials/data_model.ipynb
@@ -516,7 +516,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With this `CaseSettings` object, we could create a brand new `Case` and `Operator` and do all sorts of magic. This way of interacting with ARMI is rather advanced, and beyond the scope of this tutorial."
+    "With this `Settings` object, we could create a brand new `Case` and `Operator` and do all sorts of magic. This way of interacting with ARMI is rather advanced, and beyond the scope of this tutorial."
    ]
   },
   {

--- a/doc/developer/guide.rst
+++ b/doc/developer/guide.rst
@@ -281,7 +281,7 @@ cases, launch the GUI, and perform various testing and utility operations. When 
 invoke ARMI with ``python -m armi run``, the ``__main__.py`` file is loaded and all
 valid Entry Points are dynamically loaded. The proper entry point (in this case,
 :py:class:`armi.cli.run.RunEntryPoint`) is invoked. As ARMI initializes itself, settings
-are loaded into a :py:class:`CaseSettings <armi.settings.caseSettings.CaseSettings>`
+are loaded into a :py:class:`Settings <armi.settings.caseSettings.Settings>`
 object.  From those settings, an :py:class:`Operator <armi.operators.operator.Operator>`
 subclass is built by a factory and its ``operate`` method is called. This fires up the
 main ARMI analysis loop and its interface stack is looped over as indicated by user

--- a/doc/release/0.2.rst
+++ b/doc/release/0.2.rst
@@ -9,7 +9,7 @@ Release Date: 2023-09-27
 What's new in ARMI
 ------------------
 #. Moved the ``Reactor`` assembly number from the global scope to a ``Parameter``. (`PR#1383 <https://github.com/terrapower/armi/pull/1383>`_)
-#. Removed the global ``CaseSettings`` object, ``getMasterCs()``, and ``setMasterCs()``. (`PR#1399 <https://github.com/terrapower/armi/pull/1399>`_)
+#. Removed the global ``Settings`` object, ``getMasterCs()``, and ``setMasterCs()``. (`PR#1399 <https://github.com/terrapower/armi/pull/1399>`_)
 #. Moved the Spent Fuel Pool (``sfp``) from the ``Core`` to the ``Reactor``. (`PR#1336 <https://github.com/terrapower/armi/pull/1336>`_)
 #. Made the ``sfp`` a child of the ``Reactor`` so it is stored in the database. (`PR#1349 <https://github.com/terrapower/armi/pull/1349>`_)
 #. Broad cleanup of ``Parameters``: filled in all empty units and descriptions, removed unused params. (`PR#1345 <https://github.com/terrapower/armi/pull/1345>`_)


### PR DESCRIPTION
## What is the change?

In this PR, I remove all reference to the `CaseSettings` class in the docstrings.

## Why is the change being made?

There is no `CaseSettings` class, but a `Settings` class instead. I think the confusion is that the FILE the `Settings` class is defined in is called `caseSettings.py`.

This is part of on-going QA work.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
