### PR TITLE
Details for `nuclearDataIO` impl tags

### DIFF
--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -274,7 +274,8 @@ class IORecord:
 
 
 class BinaryRecordReader(IORecord):
-    """Writes a single CCCC record in binary format.
+    """
+    Writes a single CCCC record in binary format.
 
     Notes
     -----
@@ -345,7 +346,8 @@ class BinaryRecordReader(IORecord):
 
 
 class BinaryRecordWriter(IORecord):
-    r"""a single record from a CCCC file.
+    r"""
+    Reads a single CCCC record in binary format.
 
     Reads binary information sequentially.
     """
@@ -406,7 +408,8 @@ class BinaryRecordWriter(IORecord):
 
 
 class AsciiRecordReader(BinaryRecordReader):
-    """Reads a single CCCC record in ASCII format.
+    """
+    Reads a single CCCC record in ASCII format.
 
     See Also
     --------
@@ -441,7 +444,8 @@ class AsciiRecordReader(BinaryRecordReader):
 
 
 class AsciiRecordWriter(IORecord):
-    r"""Writes a single CCCC record in ASCII format.
+    r"""
+    Writes a single CCCC record in ASCII format.
 
     Since there is no specific format of an ASCII CCCC record, the format is roughly the same as
     the :py:class:`BinaryRecordWriter`, except that the :class:`AsciiRecordReader` puts a space in

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -25,9 +25,57 @@ for reactor physics codes.
                  R_ARMI_NUCDATA_PMATRX,
                  R_ARMI_NUCDATA_DLAYXS
 
-    This module provides a number of base classes that implement general capabilities for binary and ascii file I/O. The :py:class:`IORecord` serves as an abstract base class that instantiates a number of methods which the binary and ascii children classes are meant to implement. These methods, prefixed with ``rw``, are meant to convert literal data types, e.g. float or int, to either binary or ascii. This base class does its own conversion for container data types, e.g. list or matrix, relying on the child implementation of the literal types that the container possesses. The binary conversion is implemented in :py:class:`BinaryRecordReader` and :py:class`BinaryRecordWriter`. The ascii conversion is implemented in :py:class:`AsciiRecordReader` and :py:class:`AsciiRecordWriter`.
+    This module provides a number of base classes that implement general
+    capabilities for binary and ascii file I/O. The :py:class:`IORecord` serves
+    as an abstract base class that instantiates a number of methods which the
+    binary and ascii children classes are meant to implement. These methods,
+    prefixed with ``rw``, are meant to convert literal data types, e.g. float or
+    int, to either binary or ascii. This base class does its own conversion for
+    container data types, e.g. list or matrix, relying on the child
+    implementation of the literal types that the container possesses. The binary
+    conversion is implemented in :py:class:`BinaryRecordReader` and
+    :py:class`BinaryRecordWriter`. The ascii conversion is implemented in
+    :py:class:`AsciiRecordReader` and :py:class:`AsciiRecordWriter`.
 
-    These :py:class`IORecord` classes are used within :py:class`Stream` objects for the data conversion.
+    These :py:class`IORecord` classes are used within :py:class:`Stream` objects
+    for the data conversion. :py:class:`Stream` is a context manager that opens
+    a file for reading or writing on the ``__enter__`` and closes that file upon
+    ``__exit__``. :py:class:`Stream` is an abstract base class that is
+    subclassed for each CCCC file. It is subclassed directly for the CCCC files
+    that contain XS data:
+
+      * :py:class:`ISOTXS <armi.nuclearDataIO.cccc.isotxs.IsotxsIO>`,
+      * :py:mod:`GAMISO <armi.nuclearDataIO.cccc.gamiso>`,
+      * :py:class:`PMATRX <armi.nuclearDataIO.cccc.pmatrx.PmatrxIO>`.
+      * :py:class:`DALYXS <armi.nuclearDataIO.cccc.dlayxs.DlayxsIO>`.
+      * :py:mod:`COMPXS <armi.nuclearDataIO.cccc.compxs>`.
+
+    For the CCCC file types that are outputs from a flux solver such as DIF3D
+    (e.g., GEODST, DIF3D, NHFLUX) the streams are subclassed from
+    :py:class:`StreamWithDataContainer`, which is a special abstract subclass of
+    :py:class:`Stream` that implements a common pattern used for these file
+    types. In a :py:class:`StreamWithDataContainer`, the data is directly read
+    to or written from a specialized data container.
+
+    The data container structure for each type of CCCC file is implemented in
+    the module for that file, as a subclass of :py:class:`DataContainer`. The
+    subclasses for each CCCC file type define standard attribute names for the
+    data that will be read from or written to the CCCC file. CCCC file types
+    that follow this pattern include:
+
+      * :py:class:`GEODST <armi.nuclearDataIO.cccc.geodst.GeodstData>`
+      * :py:class:`DIF3D <armi.nuclearDataIO.cccc.dif3d.Dif3dData>`
+      * :py:class:`NHFLUX <armi.nuclearDataIO.cccc.nhflux.NHFLUX>`
+        (and multiple sub-classes thereof)
+      * :py:class:`LABELS <armi.nuclearDataIO.cccc.labels.LabelsData>`
+      * :py:class:`PWDINT <armi.nuclearDataIO.cccc.pwdint.PwdintData>`
+      * :py:class:`RTFLUX <armi.nuclearDataIO.cccc.rtflux.RtfluxData>`
+      * :py:class:`RZFLUX <armi.nuclearDataIO.cccc.rzflux.RzfluxData>`
+      * :py:class:`RTFLUX <armi.nuclearDataIO.cccc.rtflux.RtfluxData>`
+
+    The logic to parse or write each specific file format is contained within
+    the :py:meth:`Stream.readWrite` implementations of the respective
+    subclasses.
 """
 import io
 import itertools

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -47,7 +47,7 @@ for reactor physics codes.
       * :py:class:`ISOTXS <armi.nuclearDataIO.cccc.isotxs.IsotxsIO>`,
       * :py:mod:`GAMISO <armi.nuclearDataIO.cccc.gamiso>`,
       * :py:class:`PMATRX <armi.nuclearDataIO.cccc.pmatrx.PmatrxIO>`.
-      * :py:class:`DALYXS <armi.nuclearDataIO.cccc.dlayxs.DlayxsIO>`.
+      * :py:class:`DLAYXS <armi.nuclearDataIO.cccc.dlayxs.DlayxsIO>`.
       * :py:mod:`COMPXS <armi.nuclearDataIO.cccc.compxs>`.
 
     For the CCCC file types that are outputs from a flux solver such as DIF3D

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -16,7 +16,7 @@
 Defines containers for the reading and writing standard interface files
 for reactor physics codes.
 
-.. impl:: Generic tool for reading and writing CCCC format files for reactor physics codes
+.. impl:: Generic tool for reading and writing Committee on Computer Code Coordination (CCCC) format files for reactor physics codes
     :id: I_ARMI_NUCDATA
     :implements: R_ARMI_NUCDATA_ISOTXS,
                  R_ARMI_NUCDATA_GAMISO,
@@ -26,15 +26,15 @@ for reactor physics codes.
                  R_ARMI_NUCDATA_DLAYXS
 
     This module provides a number of base classes that implement general
-    capabilities for binary and ascii file I/O. The :py:class:`IORecord` serves
-    as an abstract base class that instantiates a number of methods which the
-    binary and ascii children classes are meant to implement. These methods,
+    capabilities for binary and ASCII file I/O. The :py:class:`IORecord` serves
+    as an abstract base class that instantiates a number of methods that the
+    binary and ASCII children classes are meant to implement. These methods,
     prefixed with ``rw``, are meant to convert literal data types, e.g. float or
-    int, to either binary or ascii. This base class does its own conversion for
+    int, to either binary or ASCII. This base class does its own conversion for
     container data types, e.g. list or matrix, relying on the child
     implementation of the literal types that the container possesses. The binary
     conversion is implemented in :py:class:`BinaryRecordReader` and
-    :py:class`BinaryRecordWriter`. The ascii conversion is implemented in
+    :py:class`BinaryRecordWriter`. The ASCII conversion is implemented in
     :py:class:`AsciiRecordReader` and :py:class:`AsciiRecordWriter`.
 
     These :py:class`IORecord` classes are used within :py:class:`Stream` objects

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -13,8 +13,21 @@
 # limitations under the License.
 
 """
-Defines containers for the reading and writing standard interface files 
+Defines containers for the reading and writing standard interface files
 for reactor physics codes.
+
+.. impl:: Generic tool for reading and writing CCCC format files for reactor physics codes
+    :id: I_ARMI_NUCDATA
+    :implements: R_ARMI_NUCDATA_ISOTXS,
+                 R_ARMI_NUCDATA_GAMISO,
+                 R_ARMI_NUCDATA_GEODST,
+                 R_ARMI_NUCDATA_DIF3D,
+                 R_ARMI_NUCDATA_PMATRX,
+                 R_ARMI_NUCDATA_DLAYXS
+
+    This module provides a number of base classes that implement general capabilities for binary and ascii file I/O. The :py:class:`IORecord` serves as an abstract base class that instantiates a number of methods which the binary and ascii children classes are meant to implement. These methods, prefixed with ``rw``, are meant to convert literal data types, e.g. float or int, to either binary or ascii. This base class does its own conversion for container data types, e.g. list or matrix, relying on the child implementation of the literal types that the container possesses. The binary conversion is implemented in :py:class:`BinaryRecordReader` and :py:class`BinaryRecordWriter`. The ascii conversion is implemented in :py:class:`AsciiRecordReader` and :py:class:`AsciiRecordWriter`.
+
+    These :py:class`IORecord` classes are used within :py:class`Stream` objects for the data conversion.
 """
 import io
 import itertools

--- a/armi/nuclearDataIO/cccc/dif3d.py
+++ b/armi/nuclearDataIO/cccc/dif3d.py
@@ -199,11 +199,38 @@ class Dif3dStream(cccc.StreamWithDataContainer):
                     )
 
     def readWrite(self):
-        """Reads or writes metadata and data from 5 records.
+        """Reads or writes metadata and data from the five records of the DIF3D binary file.
 
         .. impl:: Tool to read and write DIF3D files.
             :id: I_ARMI_NUCDATA_DIF3D
             :implements: R_ARMI_NUCDATA_DIF3D
+
+            The reading and writing of the DIF3D binary file is performed using
+            :py:class:`StreamWithDataContainer <.cccc.StreamWithDataContainer>` from the
+            `cccc` package. This class allows for the reading and writing of CCCC binary
+            files, processing one record at a time using subclasses of the
+            :py:class:`IORecord <.cccc.IORecord>`. Each record in a CCCC binary file consists
+            of words that represent integers (short or long), floating-point numbers (single or
+            double precision), or strings of data. One or more of these words are parsed one at
+            a time by the reader. Multiple words processed together have meaning, such as
+            such as groupwise overrelaxation factors. While reading, the data is stored
+            in a Python dictionary as an attribute on the object, one for each record. The
+            keys in each dictionary represent the parsed grouping of words in the records;
+            for example, for the 4D record (stored as the attribute `fourD`), each groupwise
+            overrelaxation factor is stored as the key `OMEGA{i}`, where `i` is the group
+            number.
+
+            Each record is also embedded with the record size at the beginning and end
+            of the record (always assumed to be present), which is used for error checking
+            at the end of processing each record.
+
+            The DIF3D reader processes the file identification record (stored as
+            the attribute `_metadata`) and the five data records for the DIF3D file, as
+            defined in the specification for the file distributed with the DIF3D software.
+
+            This class can also read and write an ASCII version of the DIF3D file. While
+            this format is not used by the DIF3D software, it can be a useful representation
+            for users to access the file in a human-readable format.
         """
         msg = f"{'Reading' if 'r' in self._fileMode else 'Writing'} DIF3D binary data {self}"
         runLog.info(msg)

--- a/armi/nuclearDataIO/cccc/dif3d.py
+++ b/armi/nuclearDataIO/cccc/dif3d.py
@@ -220,7 +220,9 @@ class Dif3dStream(cccc.StreamWithDataContainer):
             record. The keys in each dictionary represent the parsed grouping of
             words in the records; for example, for the 4D record (stored as the
             attribute ``fourD``), each groupwise overrelaxation factor is stored
-            as the key ``OMEGA{i}``, where ``i`` is the group number.
+            as the key ``OMEGA{i}``, where ``i`` is the group number. See
+            :need:`I_ARMI_NUCDATA` for more details on the general
+            implementation.
 
             Each record is also embedded with the record size at the beginning
             and end of the record (always assumed to be present), which is used

--- a/armi/nuclearDataIO/cccc/dif3d.py
+++ b/armi/nuclearDataIO/cccc/dif3d.py
@@ -206,31 +206,35 @@ class Dif3dStream(cccc.StreamWithDataContainer):
             :implements: R_ARMI_NUCDATA_DIF3D
 
             The reading and writing of the DIF3D binary file is performed using
-            :py:class:`StreamWithDataContainer <.cccc.StreamWithDataContainer>` from the
-            `cccc` package. This class allows for the reading and writing of CCCC binary
-            files, processing one record at a time using subclasses of the
-            :py:class:`IORecord <.cccc.IORecord>`. Each record in a CCCC binary file consists
-            of words that represent integers (short or long), floating-point numbers (single or
-            double precision), or strings of data. One or more of these words are parsed one at
-            a time by the reader. Multiple words processed together have meaning, such as
-            such as groupwise overrelaxation factors. While reading, the data is stored
-            in a Python dictionary as an attribute on the object, one for each record. The
-            keys in each dictionary represent the parsed grouping of words in the records;
-            for example, for the 4D record (stored as the attribute `fourD`), each groupwise
-            overrelaxation factor is stored as the key `OMEGA{i}`, where `i` is the group
-            number.
+            :py:class:`StreamWithDataContainer <.cccc.StreamWithDataContainer>`
+            from the :py:mod:`~armi.nuclearDataIO.cccc` package. This class
+            allows for the reading and writing of CCCC binary files, processing
+            one record at a time using subclasses of the :py:class:`IORecord
+            <.cccc.IORecord>`. Each record in a CCCC binary file consists of
+            words that represent integers (short or long), floating-point
+            numbers (single or double precision), or strings of data. One or
+            more of these words are parsed one at a time by the reader. Multiple
+            words processed together have meaning, such as such as groupwise
+            overrelaxation factors. While reading, the data is stored in a
+            Python dictionary as an attribute on the object, one for each
+            record. The keys in each dictionary represent the parsed grouping of
+            words in the records; for example, for the 4D record (stored as the
+            attribute ``fourD``), each groupwise overrelaxation factor is stored
+            as the key ``OMEGA{i}``, where ``i`` is the group number.
 
-            Each record is also embedded with the record size at the beginning and end
-            of the record (always assumed to be present), which is used for error checking
-            at the end of processing each record.
+            Each record is also embedded with the record size at the beginning
+            and end of the record (always assumed to be present), which is used
+            for error checking at the end of processing each record.
 
             The DIF3D reader processes the file identification record (stored as
-            the attribute `_metadata`) and the five data records for the DIF3D file, as
-            defined in the specification for the file distributed with the DIF3D software.
+            the attribute ``_metadata``) and the five data records for the DIF3D
+            file, as defined in the specification for the file distributed with
+            the DIF3D software.
 
-            This class can also read and write an ASCII version of the DIF3D file. While
-            this format is not used by the DIF3D software, it can be a useful representation
-            for users to access the file in a human-readable format.
+            This class can also read and write an ASCII version of the DIF3D
+            file. While this format is not used by the DIF3D software, it can be
+            a useful representation for users to access the file in a
+            human-readable format.
         """
         msg = f"{'Reading' if 'r' in self._fileMode else 'Writing'} DIF3D binary data {self}"
         runLog.info(msg)

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -232,8 +232,8 @@ class DlayxsIO(cccc.Stream):
 
             Reading and writing DLAYXS delayed neutron data files is performed
             using the general nuclear data I/O functionalities described in
-            :need:`I_ARMI_NUCDATA`. A DLAYXS file specifically follows the
-            following steps:
+            :need:`I_ARMI_NUCDATA`. Reading/writing a DLAYXS file is performed
+            through the following steps:
 
             #. Read/write the data ``label`` for identification.
 

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -231,7 +231,9 @@ class DlayxsIO(cccc.Stream):
             :implements: R_ARMI_NUCDATA_DLAYXS
 
             Reading and writing DALYXS delayed neutron data files is performed
-            with the following steps:
+            using the general nuclear data I/O functionalities described in
+            :need:`I_ARMI_NUCDATA`. A DALYXS file specifically follows the
+            following steps:
 
             #. Read/write the data ``label`` for identification.
 

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -224,11 +224,37 @@ class DlayxsIO(cccc.Stream):
         self.metadata = dlayxs.metadata
 
     def readWrite(self):
-        """Read and write DLAYXS files.
+        r"""Read and write DLAYXS files.
 
         .. impl:: Tool to read and write DLAYXS files.
             :id: I_ARMI_NUCDATA_DLAYXS
             :implements: R_ARMI_NUCDATA_DLAYXS
+
+            Reading and writing DALYXS delayed neutron data files is performed
+            with the following steps:
+
+            #. Read/write the data ``label`` for identification.
+
+                .. note::
+
+                    MC\ :sup:`2`-3  file does not use the expected number of
+                    characters for the ``label``, so its length needs to be
+                    stored in the :py:class:`~.cccc.IORecord`.
+
+            #. Read/write data length information, i.e. number of energy groups,
+               number of nuclides, and number of precursor families.
+
+            #. Read/write spectral data, including:
+
+                * Nuclide IDs
+                * Decay constants
+                * Emission spectra
+                * Energy group bounds
+                * Number of families to which fission in a given nuclide
+                  contributes delayed neutron precursors
+
+            #. Read/write 3D delayed neutron yield matrix, indexed by nuclide,
+               precursor family, and outgoing neutron energy group.
         """
         runLog.info(
             "{} DLAYXS library {}".format(

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -230,9 +230,9 @@ class DlayxsIO(cccc.Stream):
             :id: I_ARMI_NUCDATA_DLAYXS
             :implements: R_ARMI_NUCDATA_DLAYXS
 
-            Reading and writing DALYXS delayed neutron data files is performed
+            Reading and writing DLAYXS delayed neutron data files is performed
             using the general nuclear data I/O functionalities described in
-            :need:`I_ARMI_NUCDATA`. A DALYXS file specifically follows the
+            :need:`I_ARMI_NUCDATA`. A DLAYXS file specifically follows the
             following steps:
 
             #. Read/write the data ``label`` for identification.
@@ -243,8 +243,11 @@ class DlayxsIO(cccc.Stream):
                     characters for the ``label``, so its length needs to be
                     stored in the :py:class:`~.cccc.IORecord`.
 
-            #. Read/write data length information, i.e. number of energy groups,
-               number of nuclides, and number of precursor families.
+            #. Read/write file control information, i.e. the 1D record, which includes:
+
+                * Number of energy groups
+                * Number of nuclides
+                * Number of precursor families
 
             #. Read/write spectral data, including:
 
@@ -255,8 +258,9 @@ class DlayxsIO(cccc.Stream):
                 * Number of families to which fission in a given nuclide
                   contributes delayed neutron precursors
 
-            #. Read/write 3D delayed neutron yield matrix, indexed by nuclide,
-               precursor family, and outgoing neutron energy group.
+            #. Read/write 3D delayed neutron yield matrix on the 3D record,
+               indexed by nuclide, precursor family, and outgoing neutron energy
+               group.
         """
         runLog.info(
             "{} DLAYXS library {}".format(

--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -25,14 +25,9 @@ contained within a :py:class:`~armi.nuclearDataIO.xsLibraries.XSLibrary`.
     The majority of the functionality in this module is inherited from the
     :py:mod:`~armi.nuclearDataIO.cccc.isotxs` module. See
     :py:class:`~armi.nuclearDataIO.cccc.isotxs.IsotxsIO` and its associated
-    implementation :need:`I_ARMI_NUCDATA_ISOTXS` for more information. The
-    differences from ISOTXS neutron data is data unique to gamma, including:
-
-    * Special treatment for particle velocities, which is done by overriding
-      ``_rwLibraryEnergies``.
-    * Inclusion of "dummy" nuclides into
-      :py:class:`~armi.nuclearDataIO.xsLibraries.XSLibrary` so both neutron and
-      gamma data cover the same nuclide set.
+    implementation :need:`I_ARMI_NUCDATA_ISOTXS` for more information. The only
+    difference from ISOTXS neutron data is a special treatment for gamma
+    velocities, which is done by overriding ``_rwLibraryEnergies``.
 
 See [GAMSOR]_.
 

--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -22,6 +22,17 @@ contained within a :py:class:`~armi.nuclearDataIO.xsLibraries.XSLibrary`.
     :id: I_ARMI_NUCDATA_GAMISO
     :implements: R_ARMI_NUCDATA_GAMISO
 
+    The majority of the functionality in this module is inherited from the
+    :py:mod:`~armi.nuclearDataIO.cccc.isotxs` module. See
+    :py:class:`~armi.nuclearDataIO.cccc.isotxs.IsotxsIO` and its associated
+    implementation :need:`I_ARMI_NUCDATA_ISOTXS` for more information. The
+    differences from ISOTXS neutron data is data unique to gamma, including:
+
+    * Special treatment for particle velocities
+    * Inclusion of "dummy" nuclides into
+      :py:class:`~armi.nuclearDataIO.xsLibraries.XSLibrary` so both neutron and
+      gamma data cover the same nuclide set.
+
 See [GAMSOR]_.
 
 .. [GAMSOR] Smith, M. A., Lee, C. H., and Hill, R. N. GAMSOR: Gamma Source Preparation and DIF3D Flux Solution. United States:

--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -28,7 +28,8 @@ contained within a :py:class:`~armi.nuclearDataIO.xsLibraries.XSLibrary`.
     implementation :need:`I_ARMI_NUCDATA_ISOTXS` for more information. The
     differences from ISOTXS neutron data is data unique to gamma, including:
 
-    * Special treatment for particle velocities
+    * Special treatment for particle velocities, which is done by overriding
+      ``_rwLibraryEnergies``.
     * Inclusion of "dummy" nuclides into
       :py:class:`~armi.nuclearDataIO.xsLibraries.XSLibrary` so both neutron and
       gamma data cover the same nuclide set.

--- a/armi/nuclearDataIO/cccc/geodst.py
+++ b/armi/nuclearDataIO/cccc/geodst.py
@@ -136,6 +136,47 @@ class GeodstStream(cccc.StreamWithDataContainer):
         .. impl:: Tool to read and write GEODST files.
             :id: I_ARMI_NUCDATA_GEODST
             :implements: R_ARMI_NUCDATA_GEODST
+
+            Reading and writing GEODST files is performed with the following
+            steps:
+
+            #. Read/write file ID record
+
+                .. note::
+
+                    The username, version, etc are embedded in this string but
+                    it's usually blank. The number 28 was actually obtained from
+                    a hex editor and may be code specific.
+
+            #. Read/write file specifications on 1D record.
+
+                .. note::
+
+                    This record contains 27 integers.
+
+            #. Based on the geometry type (``IGOM``), one of following records
+               are read/written:
+
+                * Slab (1), cylinder (3), or sphere (3): Read/write 1-D coarse
+                  mesh boundaries and fine mesh intervals.
+                * X-Y (6), R-Z (7), Theta-R (8), uniform triangular (9),
+                  hexagonal (10), or R-Theta (11): Read/write 2-D coarse mesh
+                  boundaries and fine mesh intervals.
+                * R-Theta-Z (12, 15), R-Theta-Alpha (13, 16), X-Y-Z (14),
+                  uniform triangular-Z (17), hexagonal-Z(18): Read/write 3-D
+                  coarse mesh boundaries and fine mesh intervals.
+
+            #. If the geometry is not zero-dimensional (``IGOM`` > 0) and
+               buckling values are specified (``NBS`` > 0): Read/write geometry
+               data from 5D record.
+
+            #. If the geometry is not zero-dimensional (``IGOM`` > 0) and region
+               assignments are coarse-mesh-based (``NRASS`` = 0): Read/write
+               region assignments to coarse mesh interval.
+
+            #. If the geometry is not zero-dimensional (``IGOM`` > 0) and region
+               assignments are fine-mesh-based (``NRASS`` = 1): Read/write
+               region assignments to fine mesh interval.
         """
         self._rwFileID()
         self._rw1DRecord()
@@ -182,7 +223,6 @@ class GeodstStream(cccc.StreamWithDataContainer):
     def _rw2DRecord(self):
         """Read/write 1-D coarse mesh boundaries and fine mesh intervals."""
         with self.createRecord() as record:
-
             self._data.xmesh = record.rwList(
                 self._data.xmesh, "double", self._metadata["NCINTI"] + 1
             )
@@ -193,7 +233,6 @@ class GeodstStream(cccc.StreamWithDataContainer):
     def _rw3DRecord(self):
         """Read/write 2-D coarse mesh boundaries and fine mesh intervals."""
         with self.createRecord() as record:
-
             self._data.xmesh = record.rwList(
                 self._data.xmesh, "double", self._metadata["NCINTI"] + 1
             )
@@ -210,7 +249,6 @@ class GeodstStream(cccc.StreamWithDataContainer):
     def _rw4DRecord(self):
         """Read/write 3-D coarse mesh boundaries and fine mesh intervals."""
         with self.createRecord() as record:
-
             self._data.xmesh = record.rwList(
                 self._data.xmesh, "double", self._metadata["NCINTI"] + 1
             )

--- a/armi/nuclearDataIO/cccc/geodst.py
+++ b/armi/nuclearDataIO/cccc/geodst.py
@@ -139,16 +139,10 @@ class GeodstStream(cccc.StreamWithDataContainer):
 
             Reading and writing GEODST files is performed using the general
             nuclear data I/O functionalities described in
-            :need:`I_ARMI_NUCDATA`. A GEODST file specifically follows the
-            following steps:
+            :need:`I_ARMI_NUCDATA`. Reading/writing a GEODST file is performed
+            through the following steps:
 
             #. Read/write file ID record
-
-                .. note::
-
-                    The username, version, etc are embedded in this string but
-                    it's usually blank. The number 28 was actually obtained from
-                    a hex editor and may be code specific.
 
             #. Read/write file specifications on 1D record.
 
@@ -201,8 +195,7 @@ class GeodstStream(cccc.StreamWithDataContainer):
 
         Notes
         -----
-        The username, version, etc are embedded in this string but it's
-        usually blank. The number 28 was actually obtained from
+        The number 28 was actually obtained from
         a hex editor and may be code specific.
         """
         with self.createRecord() as record:

--- a/armi/nuclearDataIO/cccc/geodst.py
+++ b/armi/nuclearDataIO/cccc/geodst.py
@@ -152,10 +152,6 @@ class GeodstStream(cccc.StreamWithDataContainer):
 
             #. Read/write file specifications on 1D record.
 
-                .. note::
-
-                    This record contains 27 integers.
-
             #. Based on the geometry type (``IGOM``), one of following records
                are read/written:
 

--- a/armi/nuclearDataIO/cccc/geodst.py
+++ b/armi/nuclearDataIO/cccc/geodst.py
@@ -137,8 +137,10 @@ class GeodstStream(cccc.StreamWithDataContainer):
             :id: I_ARMI_NUCDATA_GEODST
             :implements: R_ARMI_NUCDATA_GEODST
 
-            Reading and writing GEODST files is performed with the following
-            steps:
+            Reading and writing GEODST files is performed using the general
+            nuclear data I/O functionalities described in
+            :need:`I_ARMI_NUCDATA`. A GEODST file specifically follows the
+            following steps:
 
             #. Read/write file ID record
 

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -268,6 +268,45 @@ class IsotxsIO(cccc.Stream):
         .. impl:: Tool to read and write ISOTXS files.
             :id: I_ARMI_NUCDATA_ISOTXS
             :implements: R_ARMI_NUCDATA_ISOTXS
+
+            Reading and writing ISOTXS files is performed with the following
+            steps:
+
+            #. Read/write file ID record
+            #. Read/write file 1D record, which includes:
+
+                * Number of energy groups (``NGROUP``)
+                * Maximum number of up-scatter groups (``MAXUP``)
+                * Maximum number of down-scatter groups (``MAXDN``)
+                * Maximum scattering order (``MAXORD``)
+                * File-wide specification on fission spectrum type, i.e. vector
+                  or matrix (``ICHIST``)
+                * Maximum number of blocks of scattering data (``MSCMAX``)
+                * Subblocking control for scatter matrices (``NSBLOK``)
+
+            #. Read/write file 2D record, which includes:
+
+                * Library IDs for each isotope (``HSETID(I)``)
+                * Isotope names (``HISONM(I)``)
+                * Global fission spectrum (``CHI(J)``) if file-wide spectrum is
+                  specified (``ICHIST`` = 1)
+                * Energy group structure (``EMAX(J)`` and ``EMIN``)
+                * Locations of each nuclide record in the file (``LOCA(I)``)
+
+                    .. note::
+
+                        This is not used within ARMI, because it can compute it
+                        arbitrarily. Other codes use this to seek to a specific
+                        position within an ISOTXS file.
+
+            #. Read/write file 4D record for each nuclide, which includes
+               isotope-dependent, group-independent data.
+            #. Read/write file 5D record for each nuclide, which includes
+               principal cross sections.
+            #. Read/write file 6D record for each nuclide, which includes
+               fission spectrum if it is flagged as a matrix (``ICHI`` > 1)
+            #. Read/write file 7D record for each nuclide, which includes the
+               scattering matrices.
         """
         self._rwMessage()
         properties.unlockImmutableProperties(self._lib)

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -271,8 +271,8 @@ class IsotxsIO(cccc.Stream):
 
             Reading and writing ISOTXS files is performed using the general
             nuclear data I/O functionalities described in
-            :need:`I_ARMI_NUCDATA`. A ISOTXS file specifically follows the
-            following steps:
+            :need:`I_ARMI_NUCDATA`. Reading/writing a ISOTXS file is performed
+            through the following steps:
 
             #. Read/write file ID record
             #. Read/write file 1D record, which includes:
@@ -297,9 +297,10 @@ class IsotxsIO(cccc.Stream):
 
                     .. note::
 
-                        This is not used within ARMI, because it can compute it
-                        arbitrarily. Other codes use this to seek to a specific
-                        position within an ISOTXS file.
+                        The offset data is not read from the binary file because
+                        the ISOTXS reader can dynamically calculate the offset
+                        itself. Therefore, during a read operation, this data is
+                        ignored.
 
             #. Read/write file 4D record for each nuclide, which includes
                isotope-dependent, group-independent data.
@@ -410,8 +411,9 @@ class IsotxsIO(cccc.Stream):
 
         Notes
         -----
-        This is not used within ARMI, because it can compute it arbitrarily. Other codes use this to seek to a
-        specific position within an ISOTXS file.
+        The offset data is not read from the binary file because the ISOTXS
+        reader can dynamically calculate the offset itself. Therefore, during a
+        read operation, this data is ignored.
         """
         recordsPerNuclide = [
             self._computeNumIsotxsRecords(nuc) for nuc in self._lib.nuclides

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -306,7 +306,7 @@ class IsotxsIO(cccc.Stream):
             #. Read/write file 5D record for each nuclide, which includes
                principal cross sections.
             #. Read/write file 6D record for each nuclide, which includes
-               fission spectrum if it is flagged as a matrix (``ICHI`` > 1)
+               fission spectrum if it is flagged as a matrix (``ICHI`` > 1).
             #. Read/write file 7D record for each nuclide, which includes the
                scattering matrices.
         """

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -269,8 +269,10 @@ class IsotxsIO(cccc.Stream):
             :id: I_ARMI_NUCDATA_ISOTXS
             :implements: R_ARMI_NUCDATA_ISOTXS
 
-            Reading and writing ISOTXS files is performed with the following
-            steps:
+            Reading and writing ISOTXS files is performed using the general
+            nuclear data I/O functionalities described in
+            :need:`I_ARMI_NUCDATA`. A ISOTXS file specifically follows the
+            following steps:
 
             #. Read/write file ID record
             #. Read/write file 1D record, which includes:

--- a/armi/nuclearDataIO/cccc/pmatrx.py
+++ b/armi/nuclearDataIO/cccc/pmatrx.py
@@ -192,8 +192,8 @@ class PmatrxIO(cccc.Stream):
 
             Reading and writing PMATRX files is performed using the general
             nuclear data I/O functionalities described in
-            :need:`I_ARMI_NUCDATA`. A PMATRX file specifically follows the
-            following steps:
+            :need:`I_ARMI_NUCDATA`. Reading/writing a PMATRX file is performed
+            through the following steps:
 
             #. Read/write global information including:
 

--- a/armi/nuclearDataIO/cccc/pmatrx.py
+++ b/armi/nuclearDataIO/cccc/pmatrx.py
@@ -190,8 +190,10 @@ class PmatrxIO(cccc.Stream):
             :id: I_ARMI_NUCDATA_PMATRX
             :implements: R_ARMI_NUCDATA_PMATRX
 
-            Reading and writing PMATRIX files is performed with the following
-            steps:
+            Reading and writing PMATRX files is performed using the general
+            nuclear data I/O functionalities described in
+            :need:`I_ARMI_NUCDATA`. A PMATRX file specifically follows the
+            following steps:
 
             #. Read/write global information including:
 

--- a/armi/nuclearDataIO/cccc/pmatrx.py
+++ b/armi/nuclearDataIO/cccc/pmatrx.py
@@ -189,6 +189,23 @@ class PmatrxIO(cccc.Stream):
         .. impl:: Tool to read and write PMATRX files.
             :id: I_ARMI_NUCDATA_PMATRX
             :implements: R_ARMI_NUCDATA_PMATRX
+
+            Reading and writing PMATRIX files is performed with the following
+            steps:
+
+            #. Read/write global information including:
+
+                * Number of gamma energy groups
+                * Number of neutron energy groups
+                * Maximum scattering order
+                * Maximum number of compositions
+                * Maximum number of materials
+                * Maximum number of regions
+
+            #. Read/write energy group structure for neutrons and gammas
+            #. Read/write dose conversion factors
+            #. Read/write gamma production matrices for each nuclide, as well as
+               other reaction constants related to neutron-gamma production.
         """
         self._rwMessage()
         properties.unlockImmutableProperties(self._lib)

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -55,7 +55,7 @@ ND = "nd"              # (n, deuteron)
 NT = "nt"              # (n, triton)
 FISSION_XS = "fission" # (n, fission)
 N2N_XS = "n2n"         # (n,2n)
-NUSIGF = "nuSigF"      
+NUSIGF = "nuSigF"
 NU = "neutronsPerFission"
 # fmt: on
 CAPTURE_XS = [NGAMMA, NAPLHA, NP, ND, NT]
@@ -274,7 +274,6 @@ class XSCollection:
         """Compare the cross sections between two XSCollections objects."""
         equal = True
         for xsName in ALL_COLLECTION_DATA:
-
             myXsData = self.__dict__[xsName]
             theirXsData = other.__dict__[xsName]
 
@@ -785,12 +784,43 @@ def computeMacroscopicGroupConstants(
     multConstant=None,
     multLib=None,
 ):
-    """
+    r"""
     Compute any macroscopic group constants given number densities and a microscopic library.
 
     .. impl:: Compute macroscopic cross sections from microscopic cross sections and number densities.
         :id: I_ARMI_NUCDATA_MACRO
         :implements: R_ARMI_NUCDATA_MACRO
+
+        This method computes the macroscopic cross sections of a specified
+        reaction type from inputted microscopic cross sections and number
+        densities. The ``constantName`` parameter specifies what type of
+        reaction is requested. The ``numberDensities`` parameter is dictionary
+        mapping the nuclide to its density. The ``lib`` parameter is a library
+        object like :py:class:`~armi.nuclearDataIO.xsLibraries.IsotxsLibrary` or
+        :py:class:`~armi.nuclearDataIO.xsLibraries.CompxsLibrary` that holds the
+        microscopic cross-section data. The ``microSuffix`` parameter specifies
+        from which part of the library the microscopic cross sections are
+        gathered; this is typically gathered from a components
+        ``getMicroSuffix`` method like :py:meth:`Block.getMicroSuffix
+        <armi.reactor.blocks.Block.getMicroSuffix>`. ``libType`` is an optional
+        parameter specifying whether the reaction is for neutrons or gammas.
+        This method also has the optional parameters ``multConstant`` and
+        ``multLib``, which allows another reaction's cross section to be
+        multiplied to the primary one. The macroscopic cross are then compute
+        as:
+
+        .. math::
+
+            \Sigma_{g} = \sum_{n} N_n \sigma_{n,g} \sigma_{\mathrm{m}, n,
+            g} \quad g=1,...,G
+
+        where :math:`n` is the isotope index, :math:`g` is the energy group
+        index, :math:`\sigma` is the microscopic cross section, and
+        :math:`\sigma_{\mathrm{m}}` is the multiplying microscopic cross
+        section. If the ``constantName`` reaction is missing a cross section for
+        one or more of the nuclides in ``numberDensities`` a error is raised;
+        but if ``multConstant`` is missing that cross section, then those
+        nuclides are printed as a warning.
 
     Parameters
     ----------

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -791,11 +791,11 @@ def computeMacroscopicGroupConstants(
         :id: I_ARMI_NUCDATA_MACRO
         :implements: R_ARMI_NUCDATA_MACRO
 
-        This method computes the macroscopic cross sections of a specified
+        This function computes the macroscopic cross sections of a specified
         reaction type from inputted microscopic cross sections and number
         densities. The ``constantName`` parameter specifies what type of
         reaction is requested. The ``numberDensities`` parameter is dictionary
-        mapping the nuclide to its density. The ``lib`` parameter is a library
+        mapping the nuclide to its number density. The ``lib`` parameter is a library
         object like :py:class:`~armi.nuclearDataIO.xsLibraries.IsotxsLibrary` or
         :py:class:`~armi.nuclearDataIO.xsLibraries.CompxsLibrary` that holds the
         microscopic cross-section data. The ``microSuffix`` parameter specifies
@@ -804,23 +804,23 @@ def computeMacroscopicGroupConstants(
         ``getMicroSuffix`` method like :py:meth:`Block.getMicroSuffix
         <armi.reactor.blocks.Block.getMicroSuffix>`. ``libType`` is an optional
         parameter specifying whether the reaction is for neutrons or gammas.
-        This method also has the optional parameters ``multConstant`` and
-        ``multLib``, which allows another reaction's cross section to be
-        multiplied to the primary one. The macroscopic cross are then compute
-        as:
+        This function also has the optional parameters ``multConstant`` and
+        ``multLib``, which allows another constant from the library, such as
+        neutrons per fission (nu) or energy per fission (kappa), to be
+        multiplied to the primary one. The macroscopic cross sections are then
+        computed as:
 
         .. math::
 
-            \Sigma_{g} = \sum_{n} N_n \sigma_{n,g} \sigma_{\mathrm{m}, n,
-            g} \quad g=1,...,G
+            \Sigma_{g} = \sum_{n} N_n \sigma_{n,g}\nu_n \quad g=1,...,G
 
         where :math:`n` is the isotope index, :math:`g` is the energy group
-        index, :math:`\sigma` is the microscopic cross section, and
-        :math:`\sigma_{\mathrm{m}}` is the multiplying microscopic cross
-        section. If the ``constantName`` reaction is missing a cross section for
-        one or more of the nuclides in ``numberDensities`` a error is raised;
-        but if ``multConstant`` is missing that cross section, then those
-        nuclides are printed as a warning.
+        index, :math:`\sigma` is the microscopic cross section, and :math:`\nu`
+        is the scalar multiplier. If the library (``lib``) with suffix
+        ``microSuffix`` is missing a cross section for the ``constantName``
+        reaction for one or more of the nuclides in ``numberDensities`` an error
+        is raised; but if ``multConstant`` is missing that cross section, then
+        those nuclides are printed as a warning.
 
     Parameters
     ----------


### PR DESCRIPTION
## What is the change?

Adding details for `nuclearDataIO` impl tags. This was pretty difficult for me since I am horridly unfamiliar with the file formats, but I did my best from reading docstrings. `pmatrx.py` is one that I feel especially bad about since there are no docstrings in the module and information online was extremely sparse.

## Why is the change being made?

Ongoing SQA effort.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
