### PR TITLE
Add longer descriptions to `blueprints` impls

### DIFF
--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -123,7 +123,7 @@ class AssemblyBlueprint(yamlize.Object):
         assembly from within their blueprints file, including a name, flags, specifier
         for use in defining a core map, a list of blocks, a list of block heights,
         a list of axial mesh points in each block, a list of cross section identifiers
-        for each block, and material options (see :need:I_ARMI_MAT_USER_INPUT0).
+        for each block, and material options (see :need:`I_ARMI_MAT_USER_INPUT0`).
 
         Relies on the underlying infrastrature from the ``yamlize`` package for
         reading from text files, serialization, and internal storage of the data.

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -125,7 +125,7 @@ class AssemblyBlueprint(yamlize.Object):
         a list of axial mesh points in each block, a list of cross section identifiers
         for each block, and material options (see :need:`I_ARMI_MAT_USER_INPUT0`).
 
-        Relies on the underlying infrastrature from the ``yamlize`` package for
+        Relies on the underlying infrastructure from the ``yamlize`` package for
         reading from text files, serialization, and internal storage of the data.
 
         Is implemented as part of a blueprints file by being imported and used

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -79,6 +79,24 @@ class MaterialModifications(yamlize.Map):
     .. impl:: User-impact on material definitions.
         :id: I_ARMI_MAT_USER_INPUT0
         :implements: R_ARMI_MAT_USER_INPUT
+
+        Defines a yaml map attribute for the assembly portion of the blueprints
+        (see :py:class:`~armi.blueprints.assemblyBlueprint.AssemblyBlueprint`) that
+        allows users to specify material attributes as lists corresponding to
+        each axial block in the assembly. Two types of specifications can be made:
+
+            1. Key-value pairs can be specified directly, where the key is the
+            name of the modification and the value is the list of block values.
+
+            2. The "by component" attribute can be used, in which case the user
+            can specify material attributes that are specific to individual components
+            in each block. This is enabled through the :py:class:`~armi.reactor.blueprints.assemblyBlueprint.ByComponentModifications`
+            class, which basically just allows for one additional layer of attributes
+            corresponding to the component names.
+
+        These material attributes can be used during the resolution of material
+        classes during core instantiation (see :py:meth:`~armi.reactor.blueprints.blockBlueprint.BlockBlueprint.construct`
+        and :py:meth:`~armi.reactor.blueprints.componentBlueprint.ComponentBlueprint.construct`).
     """
 
     key_type = yamlize.Typed(str)
@@ -100,6 +118,23 @@ class AssemblyBlueprint(yamlize.Object):
     .. impl:: Create assembly from blueprint file.
         :id: I_ARMI_BP_ASSEM
         :implements: R_ARMI_BP_ASSEM
+
+        Defines a yaml construct that allows the user to specify attributes of an
+        assembly from within their blueprints file, including a name, flags, specifier
+        for use in defining a core map, a list of blocks, a list of block heights,
+        a list of axial mesh points in each block, a list of cross section identifiers
+        for each block, and material options (see :need:I_ARMI_MAT_USER_INPUT0).
+
+        Relies on the underlying infrastrature from the ``yamlize`` package for
+        reading from text files, serialization, and internal storage of the data.
+
+        Is implemented as part of a blueprints file by being imported and used
+        as an attribute within the larger :py:class:`~armi.reactor.blueprints.Blueprints`
+        class.
+
+        Includes a ``construct`` method, which instantiates an instance of
+        :py:class:`~armi.reactor.assemblies.Assembly` with the characteristics
+        as specified in the blueprints.
     """
 
     name = yamlize.Attribute(type=str)

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -47,6 +47,26 @@ class BlockBlueprint(yamlize.KeyedList):
     .. impl:: Create a Block from blueprint file.
         :id: I_ARMI_BP_BLOCK
         :implements: R_ARMI_BP_BLOCK
+
+        Defines a yaml construct that allows the user to specify attributes of a
+        block from within their blueprints file, including a name, flags, a radial
+        grid to specify locations of pins, and the name of a component which
+        drives the axial expansion of the block (see :py:mod:`~armi.reactor.converters.axialExpansionChanger`).
+
+        In addition, the user may specify key-value pairs to specify the components
+        contained within the block, where the keys are component names and the
+        values are component blueprints (see :py:class:`~armi.reactor.blueprints.ComponentBlueprint.ComponentBlueprint`).
+
+        Relies on the underlying infrastrature from the ``yamlize`` package for
+        reading from text files, serialization, and internal storage of the data.
+
+        Is implemented into a blueprints file by being imported and used
+        as an attribute within the larger :py:class:`~armi.reactor.blueprints.Blueprints`
+        class.
+
+        Includes a ``construct`` method, which instantiates an instance of
+        :py:class:`~armi.reactor.blocks.Block` with the characteristics
+        as specified in the blueprints.
     """
 
     item_type = componentBlueprint.ComponentBlueprint

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -57,7 +57,7 @@ class BlockBlueprint(yamlize.KeyedList):
         contained within the block, where the keys are component names and the
         values are component blueprints (see :py:class:`~armi.reactor.blueprints.ComponentBlueprint.ComponentBlueprint`).
 
-        Relies on the underlying infrastrature from the ``yamlize`` package for
+        Relies on the underlying infrastructure from the ``yamlize`` package for
         reading from text files, serialization, and internal storage of the data.
 
         Is implemented into a blueprints file by being imported and used

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -193,11 +193,11 @@ class ComponentBlueprint(yamlize.Object):
             :implements: R_ARMI_MAT_USER_INPUT
 
             Allows for user input to impact a component's materials by applying
-            the ``material modifications`` section of a blueprints file (see :need:`I_ARMI_MAT_USER_INPUT0`)
-            to the material during constructions. This takes place during lower
+            the "material modifications" section of a blueprints file (see :need:`I_ARMI_MAT_USER_INPUT0`)
+            to the material during construction. This takes place during lower
             calls to ``_conformKwargs()`` and subsequently ``_constructMaterial()``,
-            which is passed in the component blueprint and the associated material
-            modifications for the block that the component belongs to.
+            which operate using the component blueprint and associated material
+            modifications from the component's block.
 
             Within ``_constructMaterial()``, the material class is resolved into a material
             object by calling :py:func:`~armi.materials.resolveMaterialClassByName`.
@@ -337,7 +337,7 @@ def insertDepletableNuclideKeys(c, blueprint):
         :id: I_ARMI_BP_NUC_FLAGS0
         :implements: R_ARMI_BP_NUC_FLAGS
 
-        This called during the component construction process for each component from within
+        This is called during the component construction process for each component from within
         :py:meth:`~armi.reactor.blueprints.componentBlueprint.ComponentBlueprint.construct`.
 
         For a given initialized component, check its flags to determine if it

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -123,6 +123,30 @@ class ComponentBlueprint(yamlize.Object):
     .. impl:: Construct component from blueprint file.
         :id: I_ARMI_BP_COMP
         :implements: R_ARMI_BP_COMP
+
+        Defines a yaml construct that allows the user to specify attributes of a
+        component from within their blueprints file, including a name, flags, shape,
+        material and/or isotopic vector, input temperature, corresponding component dimensions,
+        and ID for placement in a block lattice (see :py:class:`~armi.reactor.blueprints.blockBlueprint.BlockBlueprint`).
+        Component dimensions that can be defined for a given component are dependent
+        on the component's ``shape`` attribute, and the dimensions defining each
+        shape can be found in the :py:mod:`~armi.reactor.components` module.
+
+        Limited validation on the inputs is performed to ensure that the component
+        shape corresponds to a valid shape defined by the ARMI application.
+
+        Relies on the underlying infrastrature from the ``yamlize`` package for
+        reading from text files, serialization, and internal storage of the data.
+
+        Is implemented as part of a blueprints file by being imported and used
+        as an attribute within the larger :py:class:`~armi.reactor.blueprints.Blueprints`
+        class. Is also be used within the :py:class:`~armi.reactor.blueprints.blockBlueprint.BlockBlueprint`
+        class to enable specification of components directly within the ``blocks``
+        portion of the blueprint file.
+
+        Includes a ``construct`` method, which instantiates an instance of
+        :py:class:`~armi.reactor.components.component.Component` with the characteristics
+        specified in the blueprints (see :need:`I_ARMI_MAT_USER_INPUT1`).
     """
 
     name = yamlize.Attribute(type=str)
@@ -167,6 +191,19 @@ class ComponentBlueprint(yamlize.Object):
         .. impl:: User-defined on material alterations are applied here.
             :id: I_ARMI_MAT_USER_INPUT1
             :implements: R_ARMI_MAT_USER_INPUT
+
+            Allows for user input to impact a component's materials by applying
+            the ``material modifications`` section of a blueprints file (see :need:`I_ARMI_MAT_USER_INPUT0`)
+            to the material during constructions. This takes place during lower
+            calls to ``_conformKwargs()`` and subsequently ``_constructMaterial()``,
+            which is passed in the component blueprint and the associated material
+            modifications for the block that the component belongs to.
+
+            Within ``_constructMaterial()``, the material class is resolved into a material
+            object by calling :py:func:`~armi.materials.resolveMaterialClassByName`.
+            The ``applyInputParams()`` method of that material class is then called,
+            passing in the associated material modifications data, which the material
+            class can then use to modify the isotopics as necessary.
         """
         runLog.debug("Constructing component {}".format(self.name))
         kwargs = self._conformKwargs(blueprint, matMods)
@@ -299,6 +336,20 @@ def insertDepletableNuclideKeys(c, blueprint):
     .. impl:: Insert any depletable blueprint flags onto this component.
         :id: I_ARMI_BP_NUC_FLAGS0
         :implements: R_ARMI_BP_NUC_FLAGS
+
+        This called during the component construction process for each component from within
+        :py:meth:`~armi.reactor.blueprints.componentBlueprint.ComponentBlueprint.construct`.
+
+        For a given initialized component, check its flags to determine if it
+        has been marked as depletable. If it is, use :py:func:`~armi.nucDirectory.nuclideBases.initReachableActiveNuclidesThroughBurnChain`
+        to apply the user-specifications in the "nuclide flags" section of the blueprints
+        to the component such that all active isotopes and derivatives of those
+        isotopes in the burn chain are initialized to have an entry in the component's
+        ``numberDensities`` dictionary.
+
+        Note that certain case settings, including ``fpModel`` and ``fpModelLibrary``,
+        may trigger modifications to the active nuclides specified by the user
+        in the "nuclide flags" section of the blueprints.
 
     Notes
     -----

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -135,7 +135,7 @@ class ComponentBlueprint(yamlize.Object):
         Limited validation on the inputs is performed to ensure that the component
         shape corresponds to a valid shape defined by the ARMI application.
 
-        Relies on the underlying infrastrature from the ``yamlize`` package for
+        Relies on the underlying infrastructure from the ``yamlize`` package for
         reading from text files, serialization, and internal storage of the data.
 
         Is implemented as part of a blueprints file by being imported and used

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -141,7 +141,7 @@ class ComponentBlueprint(yamlize.Object):
         Is implemented as part of a blueprints file by being imported and used
         as an attribute within the larger :py:class:`~armi.reactor.blueprints.Blueprints`
         class. Can also be used within the :py:class:`~armi.reactor.blueprints.blockBlueprint.BlockBlueprint`
-        class to enable specification of components directly within the ``blocks``
+        class to enable specification of components directly within the "blocks"
         portion of the blueprint file.
 
         Includes a ``construct`` method, which instantiates an instance of

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -140,7 +140,7 @@ class ComponentBlueprint(yamlize.Object):
 
         Is implemented as part of a blueprints file by being imported and used
         as an attribute within the larger :py:class:`~armi.reactor.blueprints.Blueprints`
-        class. Is also be used within the :py:class:`~armi.reactor.blueprints.blockBlueprint.BlockBlueprint`
+        class. Can also be used within the :py:class:`~armi.reactor.blueprints.blockBlueprint.BlockBlueprint`
         class to enable specification of components directly within the ``blocks``
         portion of the blueprint file.
 

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -148,7 +148,7 @@ class GridBlueprint(yamlize.Object):
         :id: I_ARMI_BP_GRID
         :implements: R_ARMI_BP_GRID
 
-        Defines a yaml construct that allows the user to a grid
+        Defines a yaml construct that allows the user to define a grid
         from within their blueprints file, including a name, geometry, dimensions,
         symmetry, and a map specifying the relative locations of components within that grid.
 

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -148,15 +148,15 @@ class GridBlueprint(yamlize.Object):
         :id: I_ARMI_BP_GRID
         :implements: R_ARMI_BP_GRID
 
-        Defines a yaml construct that allows the user to define a grid
+        Defines a yaml construct that allows the user to specify a grid
         from within their blueprints file, including a name, geometry, dimensions,
-        symmetry, and a map specifying the relative locations of components within that grid.
+        symmetry, and a map with the relative locations of components within that grid.
 
         Relies on the underlying infrastrature from the ``yamlize`` package for
         reading from text files, serialization, and internal storage of the data.
 
         Is implemented as part of a blueprints file by being used in key-value pairs
-        within the :py:class:~`armi.reactor.blueprints.gridBlueprint.Grid` class,
+        within the :py:class:`~armi.reactor.blueprints.gridBlueprint.Grid` class,
         which is imported and used as an attribute within the larger :py:class:`~armi.reactor.blueprints.Blueprints`
         class.
 

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -544,21 +544,34 @@ def _filterOutsideDomain(gridBp):
 
 
 def saveToStream(stream, bluep, full=False, tryMap=False):
-    """Save the blueprints to the passed stream.
+    """
+    Save the blueprints to the passed stream.
 
     This can save either the entire blueprints, or just the `grids:` section of the
     blueprints, based on the passed ``full`` argument. Saving just the grid
     blueprints can be useful when cobbling blueprints together with !include flags.
 
-    stream: file output stream of some kind
-    bluep: armi.reactor.blueprints.Blueprints, or Grids
-    full: bool ~ Is this a full output file, or just a partial/grids?
-    tryMap: regardless of input form, attempt to output as a lattice map. let's face it;
-    they're prettier.
-
     .. impl:: Write a blueprint file from a blueprint object.
         :id: I_ARMI_BP_TO_DB
         :implements: R_ARMI_BP_TO_DB
+
+        First makes a copy of the blueprints that are passed in. Then modifies
+        any grids specified in the blueprints into a canonical lattice map style,
+        if needed. Then uses the ``dump`` method that is inherent to all ``yamlize``
+        subclasses to write the blueprints to the given ``stream`` object.
+
+        If called with the ``full`` argument, the entire blueprints is dumped.
+        If not, only the grids portion is dumped.
+
+    Parameters
+    ----------
+    stream :
+        file output stream of some kind
+    bluep : armi.reactor.blueprints.Blueprints, or Grids
+    full : bool
+        Is this a full output file, or just a partial/grids?
+    tryMap : bool
+        regardless of input form, attempt to output as a lattice map
     """
     # To save, we want to try our best to output our grid blueprints in the lattice
     # map style. However, we do not want to wreck the state that the current

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -148,6 +148,24 @@ class GridBlueprint(yamlize.Object):
         :id: I_ARMI_BP_GRID
         :implements: R_ARMI_BP_GRID
 
+        Defines a yaml construct that allows the user to a grid
+        from within their blueprints file, including a name, geometry, dimensions,
+        symmetry, and a map specifying the relative locations of components within that grid.
+
+        Relies on the underlying infrastrature from the ``yamlize`` package for
+        reading from text files, serialization, and internal storage of the data.
+
+        Is implemented as part of a blueprints file by being used in key-value pairs
+        within the :py:class:~`armi.reactor.blueprints.gridBlueprint.Grid` class,
+        which is imported and used as an attribute within the larger :py:class:`~armi.reactor.blueprints.Blueprints`
+        class.
+
+        Includes a ``construct`` method, which instantiates an instance of one
+        of the subclasses of :py:class:`~armi.reactor.grids.structuredgrid.StructuredGrid`.
+        This is typically called from within :py:meth:`~armi.reactor.blueprints.blockBlueprint.BlockBlueprint.construct`,
+        which then also associates the individual components in the block with
+        locations specifed in the grid.
+
     Attributes
     ----------
     name : str

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -152,7 +152,7 @@ class GridBlueprint(yamlize.Object):
         from within their blueprints file, including a name, geometry, dimensions,
         symmetry, and a map with the relative locations of components within that grid.
 
-        Relies on the underlying infrastrature from the ``yamlize`` package for
+        Relies on the underlying infrastructure from the ``yamlize`` package for
         reading from text files, serialization, and internal storage of the data.
 
         Is implemented as part of a blueprints file by being used in key-value pairs

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -65,6 +65,24 @@ class NuclideFlag(yamlize.Object):
         :id: I_ARMI_BP_NUC_FLAGS1
         :implements: R_ARMI_BP_NUC_FLAGS
 
+        This class creates a yaml interface for the user to specify in their blueprints
+        which isotopes should be depleted. It is incorporated into the "nuclide flags"
+        section of a blueprints file by being included as key-value pairs within
+        the :py:class:`~armi.reactor.blueprints.isotopicOptions.NuclideFlags` class,
+        which is in turn included into the overall blueprints within
+        :py:class:`~armi.reactor.blueprints.Blueprints`.
+
+        This class includes a boolean ``burn`` attribute which can be specified
+        for any nuclide. This attribute is examined by the :py:meth:`~armi.reactor.blueprints.isotopicOptions.NuclideFlag.fileAsActiveOrInert`
+        method to sort the nuclides into sets of depletable or not, which is typically
+        called during construction of assemblies in :py:meth:`~armi.reactor.blueprints.Blueprints.constructAssem`.
+
+        Note that while the ``burn`` attribute can be set by the user in the blueprints,
+        other methods may also set it based on case settings (see, for instance,
+        :py:func:`~armi.reactor.blueprints.isotopicOptions.genDefaultNucFlags`,
+        :py:func:`~armi.reactor.blueprints.isotopicOptions.autoUpdateNuclideFlags`, and
+        :py:func:`~armi.reactor.blueprints.isotopicOptions.getAllNuclideBasesByLibrary`).
+
     Attributes
     ----------
     nuclideName : str
@@ -154,6 +172,26 @@ class CustomIsotopic(yamlize.Map):
     .. impl:: Certain material modifications will be applied using this code.
         :id: I_ARMI_MAT_USER_INPUT2
         :implements: R_ARMI_MAT_USER_INPUT
+
+        Defines a yaml construct that allows the user to define a custom isotopic vector
+        from within their blueprints file, including a name and key-value pairs
+        corresponding to nuclide names and their concentrations.
+
+        Relies on the underlying infrastrature from the ``yamlize`` package for
+        reading from text files, serialization, and internal storage of the data.
+
+        Is implemented as part of a blueprints file by being used in key-value pairs
+        within the :py:class:~`armi.reactor.blueprints.isotopicOptions.CustomIsotopics` class,
+        which is imported and used as an attribute within the larger :py:class:`~armi.reactor.blueprints.Blueprints`
+        class.
+
+        These isotopics are linked to a component during calls to :py:meth:`~armi.reactor.blueprints.componentBlueprint.ComponentBlueprint.apply`,
+        where the name specified in the ``isotopics`` attribute of the component blueprint
+        is searched against the available ``CustomIsotopics`` defined in the
+        "custom isotopics" section of the blueprints.
+        Once linked, the :py:meth:`~armi.reactor.blueprints.isotopicOptions.CustomIsotopic.apply`
+        method is called, which adjusts the ``massFrac`` attribute of the component's
+        material class.
     """
 
     key_type = yamlize.Typed(str)

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -181,11 +181,11 @@ class CustomIsotopic(yamlize.Map):
         reading from text files, serialization, and internal storage of the data.
 
         Is implemented as part of a blueprints file by being used in key-value pairs
-        within the :py:class:~`armi.reactor.blueprints.isotopicOptions.CustomIsotopics` class,
+        within the :py:class:`~armi.reactor.blueprints.isotopicOptions.CustomIsotopics` class,
         which is imported and used as an attribute within the larger :py:class:`~armi.reactor.blueprints.Blueprints`
         class.
 
-        These isotopics are linked to a component during calls to :py:meth:`~armi.reactor.blueprints.componentBlueprint.ComponentBlueprint.apply`,
+        These isotopics are linked to a component during calls to :py:meth:`~armi.reactor.blueprints.componentBlueprint.ComponentBlueprint.construct`,
         where the name specified in the ``isotopics`` attribute of the component blueprint
         is searched against the available ``CustomIsotopics`` defined in the
         "custom isotopics" section of the blueprints.

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -177,7 +177,7 @@ class CustomIsotopic(yamlize.Map):
         from within their blueprints file, including a name and key-value pairs
         corresponding to nuclide names and their concentrations.
 
-        Relies on the underlying infrastrature from the ``yamlize`` package for
+        Relies on the underlying infrastructure from the ``yamlize`` package for
         reading from text files, serialization, and internal storage of the data.
 
         Is implemented as part of a blueprints file by being used in key-value pairs

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -49,6 +49,26 @@ class SystemBlueprint(yamlize.Object):
     """
     The reactor-level structure input blueprint.
 
+    .. impl:: Build core and spent fuel pool from blueprint
+        :id: I_ARMI_BP_SYSTEMS
+        :implements: R_ARMI_BP_SYSTEMS, R_ARMI_BP_CORE
+
+        This class creates a yaml interface for the user to define systems with
+        grids, such as cores or spent fuel pools, each having their own name,
+        type, grid, and position in space. It is incorporated into the "systems"
+        section of a blueprints file by being included as key-value pairs within
+        the :py:class:`~armi.reactor.blueprints.reactorBlueprint.Systems` class,
+        which is in turn included into the overall blueprints within
+        :py:class:`~armi.reactor.blueprints.Blueprints`.
+
+        This class includes an :py:meth:`~armi.reactor.blueprints.reactorBlueprint.SystemBlueprint.construct`
+        method, which is typically called from within :py:func:`~armi.reactor.reactors.factory`
+        during the initialization of the reactor object to instantiate the core
+        and/or spent fuel pool objects. During that process, a spatial grid is
+        constructed based on the grid blueprints specified in the "grids" section
+        of the blueprints (see :need:`I_ARMI_BP_GRID`) and the assemblies needed
+        to fill that lattice are built from blueprints using :py:meth:`~armi.reactor.blueprints.Blueprints.constructAssem`.
+
     .. note:: We use string keys to link grids to objects that use them. This differs
         from how blocks/assembies are specified, which use YAML anchors. YAML anchors
         have proven to be problematic and difficult to work with
@@ -100,14 +120,6 @@ class SystemBlueprint(yamlize.Object):
 
     def construct(self, cs, bp, reactor, geom=None, loadAssems=True):
         """Build a core/IVS/EVST/whatever and fill it with children.
-
-        .. impl:: Build core and spent fuel pool from blueprint
-            :id: I_ARMI_BP_SYSTEMS
-            :implements: R_ARMI_BP_SYSTEMS
-
-        .. impl:: Create core object from blueprint.
-            :id: I_ARMI_BP_CORE
-            :implements: R_ARMI_BP_CORE
 
         Parameters
         ----------

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -49,7 +49,7 @@ class SystemBlueprint(yamlize.Object):
     """
     The reactor-level structure input blueprint.
 
-    .. impl:: Build core and spent fuel pool from blueprint
+    .. impl:: Build core and spent fuel pool from blueprints
         :id: I_ARMI_BP_SYSTEMS
         :implements: R_ARMI_BP_SYSTEMS, R_ARMI_BP_CORE
 
@@ -61,13 +61,13 @@ class SystemBlueprint(yamlize.Object):
         which is in turn included into the overall blueprints within
         :py:class:`~armi.reactor.blueprints.Blueprints`.
 
-        This class includes an :py:meth:`~armi.reactor.blueprints.reactorBlueprint.SystemBlueprint.construct`
+        This class includes a :py:meth:`~armi.reactor.blueprints.reactorBlueprint.SystemBlueprint.construct`
         method, which is typically called from within :py:func:`~armi.reactor.reactors.factory`
         during the initialization of the reactor object to instantiate the core
         and/or spent fuel pool objects. During that process, a spatial grid is
         constructed based on the grid blueprints specified in the "grids" section
         of the blueprints (see :need:`I_ARMI_BP_GRID`) and the assemblies needed
-        to fill that lattice are built from blueprints using :py:meth:`~armi.reactor.blueprints.Blueprints.constructAssem`.
+        to fill the lattice are built from blueprints using :py:meth:`~armi.reactor.blueprints.Blueprints.constructAssem`.
 
     .. note:: We use string keys to link grids to objects that use them. This differs
         from how blocks/assembies are specified, which use YAML anchors. YAML anchors


### PR DESCRIPTION
## What is the change?

Just adding long-form descriptions to the impl tags in the `blueprints` package.

## Why is the change being made?

Quality

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
