### PR TITLE
FluxFiles Deserve Hashes Too!

### DIFF
--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -138,20 +138,21 @@ def writeWelcomeHeaders(o, cs):
             inputInfo.append((label, fName, shaHash))
 
         # bonus: grab the files stored in the crossSectionControl section
-        for fluxSection, fluxData in cs["crossSectionControl"].items():
+        for xsID, xsSetting in cs["crossSectionControl"].items():
             fNames = []
             # Users shouldn't ever have both of these defined, but this is not the place
             # for code to fail if they do. Allow for both to not be None.
-            if fluxData.xsFileLocation is not None:
-                # list of files
-                fNames.extend(fluxData.xsFileLocation)
-            if fluxData.fluxFileLocation is not None:
+            if xsSetting.xsFileLocation is not None:
+                # possibly a list of files
+                if isinstance(xsSetting.xsFileLocation, list):
+                    fNames.extend(xsSetting.xsFileLocation)
+                else:
+                    fNames.append(xsSetting.xsFileLocation)
+            if xsSetting.fluxFileLocation is not None:
                 # single file
-                fNames.append(fluxData.fluxFileLocation)
+                fNames.append(xsSetting.fluxFileLocation)
             for fName in fNames:
-                label = f"crossSectionControl-{fluxSection}"
-                if isinstance(fName, list):
-                    fName = fName[0]
+                label = f"crossSectionControl-{xsID}"
                 if fName and os.path.exists(fName):
                     shaHash = getFileSHA1Hash(os.path.abspath(fName), digits=10)
                     inputInfo.append((label, fName, shaHash))

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -143,9 +143,11 @@ def writeWelcomeHeaders(o, cs):
             # Users shouldn't ever have both of these defined, but this is not the place
             # for code to fail if they do. Allow for both to not be None.
             if fluxData.xsFileLocation is not None:
+                # list of files
                 fNames.extend(fluxData.xsFileLocation)
             if fluxData.fluxFileLocation is not None:
-                fNames.extend(fluxData.fluxFileLocation)
+                # single file
+                fNames.append(fluxData.fluxFileLocation)
             for fName in fNames:
                 label = f"crossSectionControl-{fluxSection}"
                 if isinstance(fName, list):

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -139,13 +139,19 @@ def writeWelcomeHeaders(o, cs):
 
         # bonus: grab the files stored in the crossSectionControl section
         for fluxSection, fluxData in cs["crossSectionControl"].items():
+            fNames = []
+            # Users shouldn't ever have both of these defined, but this is not the place
+            # for code to fail if they do. Allow for both to not be None.
             if fluxData.xsFileLocation is not None:
+                fNames.extend(fluxData.xsFileLocation)
+            if fluxData.fluxFileLocation is not None:
+                fNames.extend(fluxData.fluxFileLocation)
+            for fName in fNames:
                 label = f"crossSectionControl-{fluxSection}"
-                fName = fluxData.xsFileLocation
                 if isinstance(fName, list):
                     fName = fName[0]
                 if fName and os.path.exists(fName):
-                    shaHash = getFileSHA1Hash(fName, digits=10)
+                    shaHash = getFileSHA1Hash(os.path.abspath(fName), digits=10)
                     inputInfo.append((label, fName, shaHash))
 
         return inputInfo

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -142,6 +142,7 @@ class TestReport(unittest.TestCase):
 
         # pass that random file into the settings
         o.cs["crossSectionControl"]["DA"].xsFileLocation = randoFile
+        o.cs["crossSectionControl"]["DA"].fluxFileLocation = randoFile
 
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate


### PR DESCRIPTION
## What is the change?

Adding fluxFiles to one of the crossSectionControl items that is gifted with a SHA. 

## Why is the change being made?

We want to be able to trace inputs such as these internally.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html). 😈

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
