### PR TITLE
Fix getNeighboringCellIndices

### DIFF
--- a/armi/reactor/grids/structuredgrid.py
+++ b/armi/reactor/grids/structuredgrid.py
@@ -368,7 +368,7 @@ class StructuredGrid(Grid):
     @staticmethod
     def getNeighboringCellIndices(i, j=0, k=0):
         """Return the indices of the immediate neighbors of a mesh point in the plane."""
-        return ((i + 1, j, k), (1, j + 1, k), (i - 1, j, k), (i, j - 1, k))
+        return ((i + 1, j, k), (i, j + 1, k), (i - 1, j, k), (i, j - 1, k))
 
     @staticmethod
     def getAboveAndBelowCellIndices(indices):

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -1383,13 +1383,7 @@ class CartesianReactorNeighborTests(ReactorTests):
         self.r = loadTestReactor(TEST_ROOT, inputFileName="zpprTest.yaml")[1]
 
     def test_findNeighborsCartesian(self):
-        """
-        Find neighbors of a given assembly in Cartesian grid.
-
-        .. test:: Retrieve neighboring assemblies of a given assembly in a Cartesian grid.
-            :id: T_ARMI_R_FIND_NEIGHBORS_CART
-            :tests: R_ARMI_R_FIND_NEIGHBORS
-        """
+        """Find neighbors of a given assembly in a Cartesian grid."""
         loc = self.r.core.spatialGrid[1, 1, 0]
         a = self.r.core.childrenByLocator[loc]
         neighbs = self.r.core.findNeighbors(a)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -1376,3 +1376,36 @@ class CartesianReactorTests(ReactorTests):
 
         self.assertIn("Nuclide categorization", messages)
         self.assertIn("Structure", messages)
+
+
+class CartesianReactorNeighborTests(ReactorTests):
+    def setUp(self):
+        self.r = loadTestReactor(TEST_ROOT, inputFileName="zpprTest.yaml")[1]
+
+    def test_findNeighborsCartesian(self):
+        """
+        Find neighbors of a given assembly in Cartesian grid.
+
+        .. test:: Retrieve neighboring assemblies of a given assembly in a Cartesian grid.
+            :id: T_ARMI_R_FIND_NEIGHBORS_CART
+            :tests: R_ARMI_R_FIND_NEIGHBORS
+        """
+        loc = self.r.core.spatialGrid[1, 1, 0]
+        a = self.r.core.childrenByLocator[loc]
+        neighbs = self.r.core.findNeighbors(a)
+        locs = [tuple(a.spatialLocator.indices[:2]) for a in neighbs]
+        self.assertEqual(len(neighbs), 4)
+        self.assertIn((2, 1), locs)
+        self.assertIn((1, 2), locs)
+        self.assertIn((0, 1), locs)
+        self.assertIn((1, 0), locs)
+
+        # try with edge assembly
+        loc = self.r.core.spatialGrid[0, 0, 0]
+        a = self.r.core.childrenByLocator[loc]
+        neighbs = self.r.core.findNeighbors(a, showBlanks=False)
+        locs = [tuple(a.spatialLocator.indices[:2]) for a in neighbs]
+        self.assertEqual(len(neighbs), 2)
+        # in this case no locations that aren't actually in the core should be returned
+        self.assertIn((1, 0), locs)
+        self.assertIn((0, 1), locs)

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -12,7 +12,7 @@ What's new in ARMI?
 
 Bug Fixes
 ---------
-#. TBD
+#. ``StructuredGrid.getNeighboringCellIndices()`` was incorrectly implemented for the second neighbor. (`PR#1614 <https://github.com/terrapower/armi/pull/1614>`_)
 
 Changes that Affect Requirements
 --------------------------------


### PR DESCRIPTION
## What is the change?

The staticmethod to get neighboring cell indices in a `StructuredGrid` is implemented incorrectly:

https://github.com/terrapower/armi/blob/14c951a05214154a1e6bfb43c728aa714084cea7/armi/reactor/grids/structuredgrid.py#L379-L382

It looks like a typo; there is a `1` where there should be an `i`.

Also, a unit test is added to cover this function.

## Why is the change being made?

The previous implementation is incorrect.

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
