### PR TITLE
Removing the non-Python term class method

### DIFF
--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -698,7 +698,7 @@ class UserPlugin(ArmiPlugin):
             assert (
                 len(self.__class__.defineSettings()) == 0
             ), "UserPlugins cannot define new Settings, consider using an ArmiPlugin."
-            # NOTE: These are the class methods that we are staunchly _not_ allowing people
+            # NOTE: These are the methods that we are staunchly _not_ allowing people
             # to change in this class. If you need these, please use a regular ArmiPlugin.
             self.defineParameterRenames = lambda: {}
             self.defineSettings = lambda: []

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -546,7 +546,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
     @classmethod
     def load(cls, stream, roundTrip=False):
-        """This class method is a wrapper around the `yamlize.Object.load()` method.
+        """This method is a wrapper around the `yamlize.Object.load()` method.
 
         The reason for the wrapper is to allow us to default to `Cloader`. Essentially,
         the `CLoader` class is 10x faster, but doesn't allow for "round trip" (read-

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -251,7 +251,7 @@ class BlockBlueprint(yamlize.KeyedList):
                             materialParentClass.applyInputParams
                         ).parameters.keys()
                     )
-        # self is a parameter to class methods, so it gets picked up here
+        # self is a parameter to methods, so it gets picked up here
         # but that's obviously not a real material modifier
         perChildModifiers.discard("self")
         return perChildModifiers

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -121,7 +121,7 @@ class SystemBlueprint(yamlize.Object):
         loadAssems : bool, optional
             whether to fill reactor with assemblies, as defined in blueprints, or not. Is False in
             :py:class:`UniformMeshGeometryConverter <armi.reactor.converters.uniformMesh.UniformMeshGeometryConverter>`
-            within the initNewReactor() class method.
+            within the initNewReactor() method.
 
         Raises
         ------

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -617,7 +617,7 @@ class ArmiObject(metaclass=CompositeModelType):
         Return a new instance of the specific ParameterCollection type associated with this object.
 
         This has the same effect as ``obj.paramCollectionType()``. Getting a new
-        instance through a method like this is useful in situations where the
+        instance through a class method like this is useful in situations where the
         ``paramCollectionType`` is not a top-level object and therefore cannot be
         trivially pickled. Since we know that by the time we want to make any instances
         of/unpickle a given ``ArmiObject``, such a class attribute will have been

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -617,11 +617,11 @@ class ArmiObject(metaclass=CompositeModelType):
         Return a new instance of the specific ParameterCollection type associated with this object.
 
         This has the same effect as ``obj.paramCollectionType()``. Getting a new
-        instance through a class method like this is useful in situations where the
+        instance through a method like this is useful in situations where the
         ``paramCollectionType`` is not a top-level object and therefore cannot be
         trivially pickled. Since we know that by the time we want to make any instances
         of/unpickle a given ``ArmiObject``, such a class attribute will have been
-        created and associated. So, we use this top-level class method to dig
+        created and associated. So, we use this top-level method to dig
         dynamically down to the underlying parameter collection type.
 
         .. impl:: Composites (and all ARMI objects) have parameter collections.

--- a/armi/reactor/parameters/__init__.py
+++ b/armi/reactor/parameters/__init__.py
@@ -179,7 +179,7 @@ Design Considerations
     * - Parameters are just fancy properties with meta data.
       - Implementing the descriptor interface on a :py:class:`Parameter` removes the
         need to construct a :py:class:`Parameter` without a name, then come back through
-        with the ``applyParameters()`` class method to apply the
+        with the ``applyParameters()`` method to apply the
         :py:class:`Parameter` as a descriptor.
 
 .. _thefreedictionary: http://www.thefreedictionary.com/parameter

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -767,6 +767,6 @@ class ParameterBuilder:
 
 
 # Container for all parameter definition collections that have been bound to an
-# ArmiObject or subclass. These are added from the applyParameters() class method on
+# ArmiObject or subclass. These are added from the applyParameters() method on
 # the ParameterCollection class.
 ALL_DEFINITIONS = ParameterDefinitionCollection()

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -51,7 +51,7 @@ class Setting:
         :implements: R_ARMI_SETTINGS_DEFAULTS
 
         Setting objects hold all associated information of a setting in ARMI and should
-        typically be accessed through the Settings class methods rather than directly.
+        typically be accessed through the Settings methods rather than directly.
         Settings require a mandatory default value.
 
         Setting subclasses can implement custom ``load`` and ``dump`` methods that can

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -233,7 +233,7 @@ class Flag(metaclass=_FlagMeta):
             :id: I_ARMI_FLAG_EXTEND0
             :implements: R_ARMI_FLAG_EXTEND
 
-            A class method to extend a ``Flag`` with a vector of provided additional ``fields``,
+            A method to extend a ``Flag`` with a vector of provided additional ``fields``,
             with field names as keys, without loss of uniqueness. Values for the additional
             ``fields`` can be explicitly specified, or an instance of ``auto`` can be supplied.
 

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -233,7 +233,7 @@ class Flag(metaclass=_FlagMeta):
             :id: I_ARMI_FLAG_EXTEND0
             :implements: R_ARMI_FLAG_EXTEND
 
-            A method to extend a ``Flag`` with a vector of provided additional ``fields``,
+            A class method to extend a ``Flag`` with a vector of provided additional ``fields``,
             with field names as keys, without loss of uniqueness. Values for the additional
             ``fields`` can be explicitly specified, or an instance of ``auto`` can be supplied.
 


### PR DESCRIPTION
## What is the change?

Removing the non-Python term class method

## Why is the change being made?

In Python, a "method" is a "function" that is part of a class.  That is how those two terms are defined in Python. In other languages, those words mean slightly different things, sometimes.

In Python, the only time you say "class method", is if you use the [@classmethod](https://docs.python.org/3/library/functions.html#classmethod) decorator. So, this PR cleans up the language in a few places.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
