### PR TITLE
Formatting fixes in some tags

### DIFF
--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -1230,11 +1230,11 @@ def addNuclideBases():
         :id: I_ARMI_ND_DATA0
         :implements: R_ARMI_ND_DATA
 
-        This function reads the `nuclides.dat` file from the ARMI resources
+        This function reads the ``nuclides.dat`` file from the ARMI resources
         folder. This file contains metadata for 4,614 nuclides, including
         number of protons, number of neutrons, atomic number, excited
         state, element symbol, atomic mass, natural abundance, half-life,
-        and spontaneous fission yield. The data in `nuclides.dat` have been
+        and spontaneous fission yield. The data in ``nuclides.dat`` have been
         collected from multiple different sources; the references are given
         in comments at the top of that file.
     """

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -745,7 +745,7 @@ class FuelHandler:
             and same height of stationary blocks. If not, return an error.
 
             If all checks pass, the :py:meth:`~armi.reactor.assemblies.Assembly.remove`
-            and :py:meth:`~armi.reactor.assemblies.Assembly.insert``
+            and :py:meth:`~armi.reactor.assemblies.Assembly.insert`
             methods are used to swap the stationary blocks between the two assemblies.
 
             Once this process is complete, the actual assembly movement can take

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -324,7 +324,7 @@ class AverageBlockCollection(BlockCollection):
         volume-weighted average. Inheriting functionality from the abstract
         :py:class:`Reactor <armi.physics.neutronics.crossSectionGroupManager.BlockCollection>` object, this class
         will construct representative blocks using averaged parameters of all blocks in the given collection.
-        Number density averages can be computed at a component level through `self._performAverageByComponent`,
+        Number density averages can be computed at a component level through ``self._performAverageByComponent``,
         or at a block level by default. Average nuclide temperatures and burnup are also included when constructing a representative block.
 
     """

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -187,8 +187,8 @@ class Component(composites.Composite, metaclass=ComponentType):
         :implements: R_ARMI_COMP_ORDER
 
         Determining Component order by outermost diameters is implemented via
-        the __lt__() method, which is used to control sort() as the
-        standard approach in Python. However, __lt__() does not show up in the API.
+        the ``__lt__()`` method, which is used to control ``sort()`` as the
+        standard approach in Python. However, ``__lt__()`` does not show up in the API.
 
     Attributes
     ----------
@@ -977,7 +977,7 @@ class Component(composites.Composite, metaclass=ComponentType):
 
             This method enables the calculation of the thermal expansion factor
             for a given material. If the material is solid, the difference
-            between T0 and Tc is used to calculate the thermal expansion
+            between ``T0`` and ``Tc`` is used to calculate the thermal expansion
             factor. If a solid material does not have a linear expansion factor
             defined and the temperature difference is greater than
             :py:attr:`armi.reactor.components.component.Component._TOLERANCE`, an

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -830,7 +830,7 @@ class Core(composites.Composite):
             :implements: R_ARMI_R_NUM_RINGS
 
             This method determines the number of rings in the reactor. If the
-            setting `circularRingMode` is enabled (by default it is false), the
+            setting ``circularRingMode`` is enabled (by default it is false), the
             assemblies will be grouped into roughly circular rings based on
             their positions and the number of circular rings is reteurned.
             Otherwise, the number of hex rings is returned. This parameter is
@@ -1196,8 +1196,8 @@ class Core(composites.Composite):
 
             This method returns the :py:class:`assembly
             <armi.reactor.core.assemblies.Assembly>` with a name matching the
-            value provided as an input parameter to this function. The `name` of
-            an assembly is based on the `assemNum` parameter.
+            value provided as an input parameter to this function. The ``name`` of
+            an assembly is based on the ``assemNum`` parameter.
 
         Parameters
         ----------
@@ -1719,10 +1719,10 @@ class Core(composites.Composite):
             This method returns the :py:class:`assembly
             <armi.reactor.core.assemblies.Assembly>` located in the requested
             location. The location is provided to this method as an input
-            parameter in a string with the format "001-001". For a `HexGrid
+            parameter in a string with the format "001-001". For a :py:class:`HexGrid
             <armi.reactor.grids.hexagonal.HexGrid>`, the first number indicates
             the hexagonal ring and the second number indicates the position
-            within that ring. For a `CartesianGrid
+            within that ring. For a :py:class:`CartesianGrid
             <armi.reactor.grids.cartesian.CartesianGrid>`, the first number
             represents the x index and the second number represents the y index.
             If there is no assembly in the grid at the requested location, this
@@ -1775,15 +1775,15 @@ class Core(composites.Composite):
             :py:meth:`getNeighboringCellIndices
             <armi.reactor.grids.StructuredGrid.getNeighboringCellIndices>`. For
             a hexagonal grid, the (i, j) indices are converted to (ring,
-            position) indexing using the core.spatialGrid instance attribute.
+            position) indexing using the ``core.spatialGrid`` instance attribute.
 
-            The `showBlanks` option determines whether non-existing assemblies
-            will be indicated with a `None` in the list or just excluded from
+            The ``showBlanks`` option determines whether non-existing assemblies
+            will be indicated with a ``None`` in the list or just excluded from
             the list altogether.
 
-            The `duplicateAssembliesOnReflectiveBoundary` setting only works for
+            The ``duplicateAssembliesOnReflectiveBoundary`` setting only works for
             1/3 core symmetry with periodic boundary conditions. For these types
-            of geometries, if this setting is `True`, neighbor lists for
+            of geometries, if this setting is ``True``, neighbor lists for
             assemblies along a periodic boundary will include the assemblies
             along the opposite periodic boundary that are effectively neighbors.
 
@@ -2046,9 +2046,9 @@ class Core(composites.Composite):
             :implements: R_ARMI_R_MESH
 
             This method iterates through all of the assemblies provided, or all
-            assemblies in the core if no list of `assems` is provided, and
+            assemblies in the core if no list of ``assems`` is provided, and
             constructs a tuple of three lists which contain the unique i, j, and
-            k mesh coordinates, respectively. The `applySubMesh` setting
+            k mesh coordinates, respectively. The ``applySubMesh`` setting
             controls whether the mesh will include the submesh coordinates. For
             a standard assembly-based reactor geometry with a hexagonal or
             Cartesian assembly grid, this method is only used to produce axial

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -261,9 +261,9 @@ class Core(composites.Composite):
         A :py:class:`Core <armi.reactor.reactors.Core>` object is typically a
         child of a :py:class:`Reactor <armi.reactor.reactors.Reactor>` object.
         A Reactor can contain multiple objects of the Core type. The instance
-        attribute name `r.core` is reserved for the object representating the
+        attribute name ``r.core`` is reserved for the object representating the
         active core. A reactor may also have a spent fuel pool instance
-        attribute, `r.sfp`, which is also of type
+        attribute, ``r.sfp``, which is also of type
         :py:class:`core <armi.reactor.reactors.Core>`.
 
         Most of the operations to retrieve information from the ARMI reactor

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -545,8 +545,8 @@ class RunLogger(logging.Logger):
         At any place in the ARMI application, developers can interject a plain text
         logging message, and when that code is hit during an ARMI simulation, the text
         will be piped to screen and a log file. By default, the ``logging`` module only
-        logs to screen, but ARMI adds a ``FileHandler` in the ``RunLog`` constructor
-        and in py:meth:`armi.runLog._RunLog.startLog`.
+        logs to screen, but ARMI adds a ``FileHandler`` in the ``RunLog`` constructor
+        and in ``_RunLog.startLog``.
     """
 
     FMT = "%(levelname)s%(message)s"


### PR DESCRIPTION
## What is the change?

I perused a recent HTML build of some docs, and found some missing backticks, mostly. 

## Why is the change being made?

Formatting to perfection !

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
