### PR TITLE
Hiding attribute values that are not useful

### DIFF
--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -36,7 +36,7 @@ framework and applications.
     The :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
     provides a data structure for information about a single nuclide, including
     the atom number, atomic weight, element, isomeric state, half-life, and
-    name. 
+    name.
 
     The :py:mod:`nuclideBases <armi.nucDirectory.nuclideBases>` module provides
     a factory and associated functions for instantiating the
@@ -91,44 +91,45 @@ Retrieve U-235 by the AAAZZZS ID:
 >>> nuclideBases.byAAAZZZSId['2350920']
 <NuclideBase U235:  Z:92, A:235, S:0, W:2.350439e+02, Label:U235>, HL:2.22160758861e+16, Abund:7.204000e-03>
 
-.. _nuclide-bases-table:
+.. only:: html
 
-.. exec::
-    import numpy
-    from tabulate import tabulate
-    from armi.nucDirectory import nuclideBases
-    
-    attributes = ['name',
-                  'type',
-                  'a',
-                  'z',
-                  'state',
-                  'abundance',
-                  'weight',
-                  'halflife']
-    
-    def getAttributes(nuc):
-        if nuc.halflife == numpy.inf:
-            halflife = "inf"
-        else:
-            halflife = f'{nuc.halflife:<12.6e}'
-        return [
-            f'``{nuc.name}``',
-            f':py:class:`~armi.nucDirectory.nuclideBases.{nuc.__class__.__name__}`',
-            f'``{nuc.a}``',
-            f'``{nuc.z}``',
-            f'``{nuc.state}``',
-            f'``{nuc.abundance:<12.6e}``',
-            f'``{nuc.weight:<12.6e}``',
-            f'``{halflife}``',
-        ]
-    
-    sortedNucs = sorted(nuclideBases.instances)
-    return create_table(tabulate(tabular_data=[getAttributes(nuc) for nuc in sortedNucs],
-                                    headers=attributes,
-                                    tablefmt='rst'),
-                                    caption='List of nuclides')
+    .. _nuclide-bases-table:
 
+    .. exec::
+        import numpy
+        from tabulate import tabulate
+        from armi.nucDirectory import nuclideBases
+
+        attributes = ['name',
+                    'type',
+                    'a',
+                    'z',
+                    'state',
+                    'abundance',
+                    'weight',
+                    'halflife']
+
+        def getAttributes(nuc):
+            if nuc.halflife == numpy.inf:
+                halflife = "inf"
+            else:
+                halflife = f'{nuc.halflife:<12.6e}'
+            return [
+                f'``{nuc.name}``',
+                f':py:class:`~armi.nucDirectory.nuclideBases.{nuc.__class__.__name__}`',
+                f'``{nuc.a}``',
+                f'``{nuc.z}``',
+                f'``{nuc.state}``',
+                f'``{nuc.abundance:<12.6e}``',
+                f'``{nuc.weight:<12.6e}``',
+                f'``{halflife}``',
+            ]
+
+        sortedNucs = sorted(nuclideBases.instances)
+        return create_table(tabulate(tabular_data=[getAttributes(nuc) for nuc in sortedNucs],
+                                        headers=attributes,
+                                        tablefmt='rst'),
+                                        caption='List of nuclides')
 """
 
 import os

--- a/armi/physics/constants.py
+++ b/armi/physics/constants.py
@@ -22,6 +22,8 @@ Displacements per atom are correlated to material damage.
 Notes
 -----
 This data structure can be updated by plugins with design-specific dpa data.
+
+:meta hide-value:
 """
 
 # The following are multigroup DPA XS for EBR II. They were generated using an ultra hard MCC spectrum

--- a/armi/physics/neutronics/energyGroups.py
+++ b/armi/physics/neutronics/energyGroups.py
@@ -131,6 +131,8 @@ Energy groups for use in multigroup neutronics.
 
 Values are the upper bound of each energy in eV from highest energy to lowest
 (because neutrons typically downscatter...)
+
+:meta hide-value:
 """
 
 GROUP_STRUCTURE["2"] = [HIGH_ENERGY_EV, 6.25e-01]
@@ -313,6 +315,7 @@ GROUP_STRUCTURE["ANL1041"] = _create_anl_energies_with_group_lethargies(
 GROUP_STRUCTURE["ANL2082"] = _create_anl_energies_with_group_lethargies(
     itertools.repeat(1, 2082)
 )
+
 
 # fmt: on
 def _create_multigroup_structures_on_finegroup_energies(

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -25,7 +25,6 @@ from armi.reactor.flags import Flags
 
 
 class TestCustomIsotopics(unittest.TestCase):
-
     yamlString = r"""
 nuclide flags:
     U238: {burn: true, xs: true}
@@ -185,6 +184,7 @@ assemblies:
         axial mesh points: [1, 1, 1, 1, 1, 1,1]
         xs types: [A, A, A, A, A, A,A]
 """
+    """:meta hide-value:"""
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## What is the change?

In the PDF build of the docs, there are some instances of overly verbose and extremely long content that was automatically generated. These are a few of them that I found:

- List of Nuclides table. Now this is only built with the PDF
- energyGroups.GROUP_STRUCTURE
- constant.DPA_CROSS_SECTIONS
- test_customIsotopics.TestCustomIsotopics.yamlString

The last three are removed using `:meta hide-value:` which tells sphinx to not display the value of the attribute.

## Why is the change being made?

Ongoing SQA effort

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
