### PR TITLE
Cleaning up various docstring errors

### DIFF
--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -49,12 +49,11 @@ class CaseSuite:
         :implements: R_ARMI_CASE_SUITE
 
         The CaseSuite object allows multiple, often related,
-        :py:class:`~armi.cases.case.Case` objects to be run sequentially. A
-        CaseSuite is intended to be both a pre-processing and post-processing
-        tool to facilitate case generation and analysis. Under most
-        circumstances one may wish to subclass a CaseSuite to meet the needs of
-        a specific calculation. A CaseSuite is a collection that is keyed off
-        Case titles.
+        :py:class:`~armi.cases.case.Case` objects to be run sequentially. A CaseSuite
+        is intended to be both a pre-processing or a post-processing tool to facilitate
+        case generation and analysis. Under most circumstances one may wish to subclass
+        a CaseSuite to meet the needs of a specific calculation. A CaseSuite is a
+        collection that is keyed off Case titles.
     """
 
     def __init__(self, cs):
@@ -92,7 +91,8 @@ class CaseSuite:
         self, rootDir=None, patterns=None, ignorePatterns=None, recursive=True
     ):
         """
-        Finds case objects by searching for a pattern of inputs, and adds them to the suite.
+        Finds case objects by searching for a pattern of file paths, and adds them to
+        the suite.
 
         This searches for Settings input files and loads them to create Case objects.
 
@@ -126,8 +126,8 @@ class CaseSuite:
 
         Notes
         -----
-        Some of these printouts won't make sense for all users, and may
-        make sense to be delegated to the plugins/app.
+        Some of these printouts won't make sense for all users, and may make sense to
+        be delegated to the plugins/app.
         """
         for setting in self.cs.environmentSettings:
             runLog.important(
@@ -158,8 +158,8 @@ class CaseSuite:
 
         Creates a clone for each case within a CaseSuite. If ``oldRoot`` is not
         specified, then each case clone is made in a directory with the title of the
-        case. If ``oldRoot`` is specified, then a relative path from ``oldRoot`` will be
-        used to determine a new relative path to the current directory ``oldRoot``.
+        case. If ``oldRoot`` is specified, then a relative path from ``oldRoot`` will
+        be used to determine a new relative path to the current directory ``oldRoot``.
 
         Parameters
         ----------

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -371,14 +371,15 @@ class FuelHandler:
 
         Examples
         --------
-        feed = self.findAssembly(targetRing=4,
-                                 width=(0,0),
-                                 param='maxPercentBu',
-                                 compareTo=100,
-                                 typeSpec=Flags.FEED | Flags.FUEL)
+        This returns the feed fuel assembly in ring 4 that has a burnup closest to 100%
+        (the highest burnup assembly)::
 
-        returns the feed fuel assembly in ring 4 that has a burnup closest to 100% (the highest
-        burnup assembly)
+            feed = self.findAssembly(targetRing=4,
+                                     width=(0,0),
+                                     param='maxPercentBu',
+                                     compareTo=100,
+                                     typeSpec=Flags.FEED | Flags.FUEL)
+
         """
 
         def compareAssem(candidate, current):

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1246,11 +1246,17 @@ class Assembly(composites.Composite):
     def rotate(self, rad):
         """Rotates the spatial variables on an assembly by the specified angle.
 
-        Each block on the assembly is rotated in turn.
+        Each Block on the Assembly is rotated in turn.
 
         .. impl:: An assembly can be rotated about its z-axis.
             :id: I_ARMI_SHUFFLE_ROTATE
             :implements: R_ARMI_SHUFFLE_ROTATE
+
+            This method loops through every ``Block`` in this ``Assembly`` and rotates
+            it by a given angle (in radians). The rotation angle is positive in the
+            counter-clockwise direction, and must be divisible by increments of PI/6
+            (60 degrees). To actually perform the ``Block`` rotation, the
+            :py:meth:`armi.reactor.blocks.Block.rotate` method is called.
 
         Parameters
         ----------
@@ -1259,14 +1265,14 @@ class Assembly(composites.Composite):
 
         Warning
         -------
-        rad must be in 60-degree increments! (i.e., PI/6, PI/3, PI, 2 * PI/3, 5 * PI/6, etc)
+        rad must be in 60-degree increments! (i.e., PI/6, PI/3, PI, 2 * PI/3, etc)
         """
         for b in self.getBlocks():
             b.rotate(rad)
 
 
 class HexAssembly(Assembly):
-    """Placeholder, so users can explicitly define a hex-based assembly."""
+    """Placeholder, so users can explicitly define a hex-based Assembly."""
 
     pass
 
@@ -1281,7 +1287,9 @@ class RZAssembly(Assembly):
     HexAssembly because they use different locations and need to have Radial Meshes in
     their setting.
 
-    note ThRZAssemblies should be a subclass of Assemblies (similar to Hex-Z) because
+    Notes
+    -----
+    ThRZAssemblies should be a subclass of Assemblies (similar to Hex-Z) because
     they should have a common place to put information about subdividing the global mesh
     for transport - this is similar to how blocks have 'AxialMesh' in their blocks.
     """
@@ -1292,7 +1300,7 @@ class RZAssembly(Assembly):
 
     def radialOuter(self):
         """
-        returns the outer radial boundary of this assembly.
+        Returns the outer radial boundary of this assembly.
 
         See Also
         --------
@@ -1339,8 +1347,8 @@ class ThRZAssembly(RZAssembly):
 
     Notes
     -----
-    This is a subclass of RZAssemblies, which is its a subclass of the Generics Assembly
-    Object
+    This is a subclass of RZAssemblies, which is itself a subclass of the generic
+    Assembly class.
     """
 
     def __init__(self, assemType, assemNum=None):

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -145,6 +145,10 @@ class SettingsReader:
         :id: I_ARMI_SETTINGS_IO_TXT
         :implements: R_ARMI_SETTINGS_IO_TXT
 
+        ARMI uses the YAML standard for settings files. ARMI uses industry-standard
+        ``ruamel.yaml`` Python libraray to read these files. ARMI does not bend or
+        change the YAML file format standard in any way.
+
     Parameters
     ----------
     cs : Settings
@@ -171,9 +175,9 @@ class SettingsReader:
 
         self._renamer = SettingRenamer(dict(self.cs.items()))
 
-        # the input version will be overwritten if explicitly stated in input file.
+        # The input version will be overwritten if explicitly stated in input file.
         # otherwise, it's assumed to precede the version inclusion change and should be
-        # treated as alright
+        # treated as alright.
 
     def __getitem__(self, key):
         return self.cs[key]


### PR DESCRIPTION
## What is the change?

Cleaning up various docstring errors

## Why is the change being made?

This is part of on-going QA work.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
