### PR TITLE
Remove undefined acronyms from requirements + fix broken links

### DIFF
--- a/armi/materials/mixture.py
+++ b/armi/materials/mixture.py
@@ -21,6 +21,8 @@ class _Mixture(materials.Material):
     """
     Homogenized mixture of materials.
 
+    :meta public:
+
     .. warning:: This class is meant to be used for homogenized block models for neutronics and other
        physics solvers.
 

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -42,7 +42,7 @@ for reactor physics codes.
     a file for reading or writing on the ``__enter__`` and closes that file upon
     ``__exit__``. :py:class:`Stream` is an abstract base class that is
     subclassed for each CCCC file. It is subclassed directly for the CCCC files
-    that contain XS data:
+    that contain cross-section data:
 
       * :py:class:`ISOTXS <armi.nuclearDataIO.cccc.isotxs.IsotxsIO>`,
       * :py:mod:`GAMISO <armi.nuclearDataIO.cccc.gamiso>`,

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -324,7 +324,7 @@ class AverageBlockCollection(BlockCollection):
         volume-weighted average. Inheriting functionality from the abstract
         :py:class:`Reactor <armi.physics.neutronics.crossSectionGroupManager.BlockCollection>` object, this class
         will construct representative blocks using averaged parameters of all blocks in the given collection.
-        Number density averages can be computed at a component level through ``self._performAverageByComponent``,
+        Number density averages can be computed at a component level
         or at a block level by default. Average nuclide temperatures and burnup are also included when constructing a representative block.
 
     """

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -855,7 +855,7 @@ class CrossSectionGroupManager(interfaces.Interface):
     def interactBOL(self):
         """Called at the Beginning-of-Life of a run, before any cycles start.
 
-        .. impl:: The lattice physics interface and XSGM are connected at BOL.
+        .. impl:: The lattice physics interface and cross-section group manager are connected at BOL.
             :id: I_ARMI_XSGM_FREQ0
             :implements: R_ARMI_XSGM_FREQ
 
@@ -885,7 +885,7 @@ class CrossSectionGroupManager(interfaces.Interface):
         """
         Update representative blocks and block burnup groups.
 
-        .. impl:: The lattice physics interface and XSGM are connected at BOC.
+        .. impl:: The lattice physics interface and cross-section group manager are connected at BOC.
             :id: I_ARMI_XSGM_FREQ1
             :implements: R_ARMI_XSGM_FREQ
 
@@ -910,7 +910,7 @@ class CrossSectionGroupManager(interfaces.Interface):
     def interactEveryNode(self, cycle=None, tn=None):
         """Interaction at every time node.
 
-        .. impl:: The lattice physics interface and XSGM are connected at every time node.
+        .. impl:: The lattice physics interface and cross-section group manager are connected at every time node.
             :id: I_ARMI_XSGM_FREQ2
             :implements: R_ARMI_XSGM_FREQ
 
@@ -923,19 +923,19 @@ class CrossSectionGroupManager(interfaces.Interface):
             self.createRepresentativeBlocks()
 
     def interactCoupled(self, iteration):
-        """Update XS groups on each physics coupling iteration to get latest temperatures.
+        """Update cross-section groups on each physics coupling iteration to get latest temperatures.
 
-        .. impl:: The lattice physics interface and XSGM are connected during coupling.
+        .. impl:: The lattice physics interface and cross-section group manager are connected during coupling.
             :id: I_ARMI_XSGM_FREQ3
             :implements: R_ARMI_XSGM_FREQ
 
             This method updates representative blocks and block burnups at every node and the first coupled iteration for each cross-section ID
-            if the control logic for lattices physics frequency updates is set for the first coupled iteration (`firstCoupledIteration`) through the :py:class:`LatticePhysicsInterface <armi.physics.neutronics.latticePhysics>`.
+            if the control logic for lattices physics frequency updates is set for the first coupled iteration (``firstCoupledIteration``) through the :py:class:`LatticePhysicsInterface <armi.physics.neutronics.latticePhysics>`.
             The cross-section group manager will construct representative blocks for each cross-section ID at the first iteration of every time node.
 
         Notes
         -----
-        Updating the XS on only the first (i.e., iteration == 0) timenode can be a reasonable approximation to
+        Updating the cross-section on only the first (i.e., iteration == 0) timenode can be a reasonable approximation to
         get new cross sections with some temperature updates but not have to run lattice physics on each
         coupled iteration. If the user desires to have the cross sections updated with every coupling iteration,
         the ``latticePhysicsFrequency: all`` option.
@@ -1112,7 +1112,7 @@ class CrossSectionGroupManager(interfaces.Interface):
     def createRepresentativeBlocks(self):
         """Get a representative block from each cross-section ID managed here.
 
-        .. impl:: Create collections of blocks based on XS type and burn-up group.
+        .. impl:: Create collections of blocks based on cross-section type and burn-up group.
             :id: I_ARMI_XSGM_CREATE_XS_GROUPS
             :implements: R_ARMI_XSGM_CREATE_XS_GROUPS
 

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -1245,7 +1245,7 @@ def computeDpaRate(mgFlux, dpaXs):
         :implements: R_ARMI_FLUX_DPA
 
         This method calculates DPA rates using the inputted multigroup flux and DPA cross sections.
-        Displacements calculated by displacement XS:
+        Displacements calculated by displacement cross-section:
 
         .. math::
             :nowrap:
@@ -1269,8 +1269,8 @@ def computeDpaRate(mgFlux, dpaXs):
 
             \frac{\text{dpa}}{s}  = \frac{\phi N \sigma}{N} = \phi * \sigma
 
-        the Number density of the structural material cancels out. It's in the macroscopic
-        XS and in the original number of atoms.
+        the number density of the structural material cancels out. It's in the macroscopic
+        cross-section and in the original number of atoms.
 
     Raises
     ------

--- a/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
+++ b/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
@@ -187,7 +187,7 @@ def makeReactionRateTable(obj, nuclides: List = None):
         that is stored there. If ``obj`` does not belong to a ``Core``, a warning
         is printed.
 
-        For each child of ``obj``, use the ISOTXS library and the xsID for the associated block
+        For each child of ``obj``, use the ISOTXS library and the cross-section ID for the associated block
         to produce a reaction rate dictionary in units of inverse seconds for
         the nuclide specified in the original call to ``obj.getReactionRates()``.
         Because ``nDensity`` was originally specified as

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -485,7 +485,7 @@ class TestBlockCollectionComponentAverage1DCylinder(unittest.TestCase):
         ]
 
     def test_ComponentAverage1DCylinder(self):
-        """Tests that the XS group manager calculates the expected component atom density
+        """Tests that the cross-section group manager calculates the expected component atom density
         and component area correctly.
 
         Order of components is also checked since in 1D cases the order of the components matters.
@@ -852,7 +852,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
     def test_interactBOL(self):
         """Test `BOL` lattice physics update frequency.
 
-        .. test:: The XSGM frequency depends on the LPI frequency at BOL.
+        .. test:: The cross-section group manager frequency depends on the LPI frequency at BOL.
             :id: T_ARMI_XSGM_FREQ0
             :tests: R_ARMI_XSGM_FREQ
         """
@@ -865,7 +865,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
     def test_interactBOC(self):
         """Test `BOC` lattice physics update frequency.
 
-        .. test:: The XSGM frequency depends on the LPI frequency at BOC.
+        .. test:: The cross-section group manager frequency depends on the LPI frequency at BOC.
             :id: T_ARMI_XSGM_FREQ1
             :tests: R_ARMI_XSGM_FREQ
         """
@@ -879,7 +879,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
     def test_interactEveryNode(self):
         """Test `everyNode` lattice physics update frequency.
 
-        .. test:: The XSGM frequency depends on the LPI frequency at every time node.
+        .. test:: The cross-section group manager frequency depends on the LPI frequency at every time node.
             :id: T_ARMI_XSGM_FREQ2
             :tests: R_ARMI_XSGM_FREQ
         """
@@ -895,7 +895,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
     def test_interactFirstCoupledIteration(self):
         """Test `firstCoupledIteration` lattice physics update frequency.
 
-        .. test:: The XSGM frequency depends on the LPI frequency during first coupled iteration.
+        .. test:: The cross-section group manager frequency depends on the LPI frequency during first coupled iteration.
             :id: T_ARMI_XSGM_FREQ3
             :tests: R_ARMI_XSGM_FREQ
         """
@@ -911,7 +911,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
     def test_interactAllCoupled(self):
         """Test `all` lattice physics update frequency.
 
-        .. test:: The XSGM frequency depends on the LPI frequency during coupling.
+        .. test:: The cross-section group manager frequency depends on the LPI frequency during coupling.
             :id: T_ARMI_XSGM_FREQ4
             :tests: R_ARMI_XSGM_FREQ
         """
@@ -927,7 +927,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
     def test_xsgmIsRunBeforeXS(self):
         """Test that the XSGM is run before the cross sections are calculated.
 
-        .. test:: Test that the XSGM is run before the cross sections are calculated.
+        .. test:: Test that the cross-section group manager is run before the cross sections are calculated.
             :id: T_ARMI_XSGM_FREQ5
             :tests: R_ARMI_XSGM_FREQ
         """

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1223,7 +1223,7 @@ class Assembly(composites.Composite):
             ``dimName``. There is a hard-coded preference for Components
             to be within fuel Blocks. If there are no Blocks, then ``None``
             is returned. If ``typeSpec`` is not within the first Block, an
-            error is raised within :py:meth:`armi.reactor.blocksBlock.getDim`.
+            error is raised within :py:meth:`~armi.reactor.blocks.Block.getDim`.
         """
         # prefer fuel blocks.
         bList = self.getBlocks(Flags.FUEL)

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1812,8 +1812,8 @@ class HexBlock(Block):
             :implements: R_ARMI_BLOCK_DIMS
 
             This method first retrieves the pitch of the hexagonal Block
-            (:need:I_ARMI_UTIL_HEXAGON0) and then leverages the
-            area calculation via :need:I_ARMI_UTIL_HEXAGON0.
+            (:need:`I_ARMI_UTIL_HEXAGON0`) and then leverages the
+            area calculation via :need:`I_ARMI_UTIL_HEXAGON0`.
 
         """
         pitch = self.getPitch()
@@ -2495,7 +2495,7 @@ class HexBlock(Block):
             :implements: R_ARMI_BLOCK_DIMS
 
             Retrieving the flow area requires that there be a single coolant Component.
-            If available, the area is calculated (:need:I_ARMI_COMP_VOL0).
+            If available, the area is calculated (:need:`I_ARMI_COMP_VOL0`).
         """
         return self.getComponent(Flags.COOLANT, exact=True).getArea()
 
@@ -2518,8 +2518,8 @@ class HexBlock(Block):
 
                 4\frac{A}{P},
 
-            where :math:`A` is the flow area (:need:I_ARMI_BLOCK_DIMS8) and :math:`P` is the
-            wetted perimeter (:need:I_ARMI_BLOCK_DIMS7).
+            where :math:`A` is the flow area (:need:`I_ARMI_BLOCK_DIMS8`) and :math:`P` is the
+            wetted perimeter (:need:`I_ARMI_BLOCK_DIMS7`).
         """
         return 4.0 * self.getFlowArea() / self.getWettedPerimeter()
 

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -980,7 +980,7 @@ class Component(composites.Composite, metaclass=ComponentType):
             between ``T0`` and ``Tc`` is used to calculate the thermal expansion
             factor. If a solid material does not have a linear expansion factor
             defined and the temperature difference is greater than
-            :py:attr:`armi.reactor.components.component.Component._TOLERANCE`, an
+            a predetermined tolerance, an
             error is raised. Thermal expansion of fluids or custom materials is
             neglected, currently.
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -396,9 +396,9 @@ class Core(composites.Composite):
             <armi.reactor.grids.grid.Grid>` type, :py:class:`DomainType
             <armi.reactor.geometry.DomainType>`, and :py:class:`BoundaryType
             <armi.reactor.geometry.BoundaryType>` are valid. The validity of a
-            user-specified geometry and symmetry is verified by a settings:
-            :py:meth:`Inspector
-            <armi.operators.settingsValidation.Inspector._inspectSettings`.
+            user-specified geometry and symmetry is verified by a settings
+            :py:class:`Inspector
+            <armi.operators.settingsValidation.Inspector`.
         """
         if not self.spatialGrid:
             raise ValueError("Cannot access symmetry before a spatialGrid is attached.")


### PR DESCRIPTION
## What is the change?
When SQA documentation is generated, these acronyms (though commonly known internally and by SMEs) are technically undefined. We shouldn't have that. 

Also sneaking in a couple of broken links.

## Why is the change being made?
SQA efforts. 

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- ~This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).~ It did at one point. See above.
- ~[Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.~

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
