### PR TITLE
Fixing release notes for 0.3.0

### DIFF
--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -3,7 +3,7 @@ ARMI v0.3 Release Notes
 ***********************
 
 ARMI v0.3.1
-============
+===========
 Release Date: TBD
 
 What's new in ARMI?
@@ -12,17 +12,16 @@ What's new in ARMI?
 
 Bug Fixes
 ---------
-#. ``StructuredGrid.getNeighboringCellIndices()`` was incorrectly implemented for the second neighbor. (`PR#1614 <https://github.com/terrapower/armi/pull/1614>`_)
+#. TBD
 
 Changes that Affect Requirements
 --------------------------------
-
 #. TBD
 
 
 ARMI v0.3.0
-============
-Release Date: 2023-12-21
+===========
+Release Date: 2024-01-26
 
 What's new in ARMI?
 -------------------
@@ -30,6 +29,10 @@ What's new in ARMI?
 #. Attempt to set representative block number densities by component if possible. (`PR#1412 <https://github.com/terrapower/armi/pull/1412>`_)
 #. Use ``functools`` to preserve function attributes when wrapping with ``codeTiming.timed`` (`PR#1466 <https://github.com/terrapower/armi/pull/1466>`_)
 #. Remove a number of deprecated block, assembly, and core parameters related to a defunct internal plugin.
+
+Bug Fixes
+---------
+#. ``StructuredGrid.getNeighboringCellIndices()`` was incorrectly implemented for the second neighbor. (`PR#1614 <https://github.com/terrapower/armi/pull/1614>`_)
 
 Quality Work
 ------------


### PR DESCRIPTION
## What is the change?

Fixing release notes for `0.3.0`.

## Why is the change being made?

We have been "waiting to release v0.3.0" for like a month now. So the fact that someone didn't know where to put their bug fix release note is understandable. But we haven't tagged `0.3.0` yet, and when we do that bug fix will be part of `0.3.0`. So I am just moving it to a new release section.

Also: I maintain the exact "date" listed on the release notes is not hyper important.  But I updated it to be _more_ correct.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
