### PR TITLE
Fixing docstring example formatting

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -19,13 +19,14 @@ This module defines the :py:class:`App` class, which is used to configure the AR
 Framework for a specific application. An ``App`` implements a simple interface for
 customizing much of the Framework's behavior.
 
-.. admonition:: Historical Fun Fact
+Notes
+-----
+Historical Fun Fact
 
-    This pattern is used by many frameworks as a way of encapsulating what would
-    otherwise be global state. The ARMI Framework has historically made heavy use of
-    global state (e.g., :py:mod:`armi.nucDirectory.nuclideBases`), and it will take
-    quite a bit of effort to refactor the code to access such things through an App
-    object.
+This pattern is used by many frameworks as a way of encapsulating what would otherwise be global
+state. The ARMI Framework has historically made heavy use of global state (e.g.,
+:py:mod:`armi.nucDirectory.nuclideBases`), and it will take quite a bit of effort to refactor the
+code to access such things through an App object.
 """
 # ruff: noqa: E402
 from typing import Dict, Optional, Tuple, List

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -21,9 +21,7 @@ Learn all about interfaces in :doc:`/developer/guide`
 See Also
 --------
 armi.operators : Schedule calls to various interfaces
-
 armi.plugins : Register various interfaces
-
 """
 import copy
 from typing import Union
@@ -362,7 +360,7 @@ class Interface:
 
         Examples
         --------
-        return {'neutronsPerFission',self.neutronsPerFission}
+        >>> return {'neutronsPerFission',self.neutronsPerFission}
         """
         return {}
 

--- a/armi/nuclearDataIO/cccc/compxs.py
+++ b/armi/nuclearDataIO/cccc/compxs.py
@@ -46,7 +46,6 @@ See Also
 
 Examples
 --------
-::
     >>> from armi.nuclearDataIO import compxs
     >>> lib = compxs.readBinary('COMPXS')
     >>> r0 = lib.regions[0]

--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -413,7 +413,7 @@ class NhfluxStream(cccc.StreamWithDataContainer):
 
         Examples
         --------
-        geodstCoordMap[NodalIndex] = geodstIndex
+            geodstCoordMap[NodalIndex] = geodstIndex
 
         See Also
         --------

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -27,14 +27,14 @@ armi.nuclearDataIO.xsCollection.XSCollection : object that gets created.
 
 Examples
 --------
-# creating a MicroscopicXSCollection by loading one from ISOTXS.
-microLib = armi.nuclearDataIO.ISOTXS('ISOTXS')
-micros = myLib.nuclides['U235AA'].micros
+    # creating a MicroscopicXSCollection by loading one from ISOTXS.
+    microLib = armi.nuclearDataIO.ISOTXS('ISOTXS')
+    micros = myLib.nuclides['U235AA'].micros
 
-# creating macroscopic XS:
-mc = MacroscopicCrossSectionCreator()
-macroCollection = mc.createMacrosFromMicros(microLib, block)
-blocksWithMacros = mc.createMacrosOnBlocklist(microLib, blocks)
+    # creating macroscopic XS:
+    mc = MacroscopicCrossSectionCreator()
+    macroCollection = mc.createMacrosFromMicros(microLib, block)
+    blocksWithMacros = mc.createMacrosOnBlocklist(microLib, blocks)
 
 """
 import numpy

--- a/armi/nuclearDataIO/xsNuclides.py
+++ b/armi/nuclearDataIO/xsNuclides.py
@@ -14,11 +14,11 @@
 
 r"""
 This module contains cross section nuclides, which are a wrapper around the
-:py:class:`~armi.nucDirectory.nuclideBases.INuclide` objects. The cross section nuclide objects contain
-cross section information from a specific calculation (e.g. neutron, or gamma cross sections).
+:py:class:`~armi.nucDirectory.nuclideBases.INuclide` objects. The cross section nuclide objects
+contain cross section information from a specific calculation (e.g. neutron, or gamma cross sections).
 
-:py:class:`XSNuclide` objects also contain meta data from the original file, so that another file can be
-reconstructed.
+:py:class:`XSNuclide` objects also contain meta data from the original file, so that another file
+can be reconstructed.
 
 .. warning::
     :py:class:`XSNuclide` objects should only be created by reading data into

--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -87,8 +87,8 @@ class XSGeometryTypes(Enum):
 
         Examples
         --------
-        XSGeometryTypes.getStr(XSGeometryTypes.ZERO_DIMENSIONAL) == "0D"
-        XSGeometryTypes.getStr(XSGeometryTypes.TWO_DIMENSIONAL_HEX) == "2D hex"
+            XSGeometryTypes.getStr(XSGeometryTypes.ZERO_DIMENSIONAL) == "0D"
+            XSGeometryTypes.getStr(XSGeometryTypes.TWO_DIMENSIONAL_HEX) == "2D hex"
         """
         geometryTypes = list(cls)
         if typeSpec not in geometryTypes:

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -864,8 +864,8 @@ class Assembly(composites.Composite):
 
         Examples
         --------
-        for block, bottomZ in a.getBlocksAndZ(returnBottomZ=True):
-            print({0}'s bottom mesh point is {1}'.format(block, bottomZ))
+            for block, bottomZ in a.getBlocksAndZ(returnBottomZ=True):
+                print({0}'s bottom mesh point is {1}'.format(block, bottomZ))
         """
         if returnBottomZ and returnTopZ:
             raise ValueError("Both returnTopZ and returnBottomZ are set to `True`")
@@ -982,9 +982,9 @@ class Assembly(composites.Composite):
         Examples
         --------
         If the block structure looks like:
-         50.0 to 100.0 Block3
-         25.0 to 50.0  Block2
-         0.0 to 25.0   Block1
+        50.0 to 100.0 Block3
+        25.0 to 50.0  Block2
+        0.0 to 25.0   Block1
 
         Then,
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2049,7 +2049,7 @@ class HexBlock(Block):
 
         Examples
         --------
-        rotateIndexLookup[i_after_rotation-1] = i_before_rotation-1
+            rotateIndexLookup[i_after_rotation-1] = i_before_rotation-1
         """
         if not 0 <= rotNum <= 5:
             raise ValueError(

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -1399,8 +1399,8 @@ class EdgeAssemblyChanger(GeometryChanger):
 
     Examples
     --------
-    edgeChanger = EdgeAssemblyChanger()
-    edgeChanger.removeEdgeAssemblies(reactor.core)
+        edgeChanger = EdgeAssemblyChanger()
+        edgeChanger.removeEdgeAssemblies(reactor.core)
     """
 
     def addEdgeAssemblies(self, core):

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -41,11 +41,11 @@ Requirements
 
 Examples
 --------
-converter = uniformMesh.NeutronicsUniformMeshConverter()
-converter.convert(reactor)
-uniformReactor = converter.convReactor
-# do calcs, then:
-converter.applyStateToOriginal()
+    converter = uniformMesh.NeutronicsUniformMeshConverter()
+    converter.convert(reactor)
+    uniformReactor = converter.convReactor
+    # do calcs, then:
+    converter.applyStateToOriginal()
 
 The mesh mapping happens as described in the figure:
 

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2585,10 +2585,10 @@ class Core(composites.Composite):
         --------
         Manual zones will be defined in a special string format, e.g.:
 
-        zoneDefinitions:
-            - ring-1: 001-001
-            - ring-2: 002-001, 002-002
-            - ring-3: 003-001, 003-002, 003-003
+        >>> zoneDefinitions:
+        >>>     - ring-1: 001-001
+        >>>     - ring-2: 002-001, 002-002
+        >>>     - ring-3: 003-001, 003-002, 003-003
 
         Notes
         -----

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -446,10 +446,10 @@ class Zones:
 
         Examples
         --------
-        zoneDefinitions:
-        - ring-1: 001-001
-        - ring-2: 002-001, 002-002
-        - ring-3: 003-001, 003-002, 003-003
+            zoneDefinitions:
+            - ring-1: 001-001
+            - ring-2: 002-001, 002-002
+            - ring-3: 003-001, 003-002, 003-003
         """
         # log a quick header
         runLog.info("zoneDefinitions:")

--- a/armi/settings/fwSettings/tightCouplingSettings.py
+++ b/armi/settings/fwSettings/tightCouplingSettings.py
@@ -49,7 +49,7 @@ class TightCouplingSettings(dict):
 
     Examples
     --------
-    couplingSettings = TightCouplingSettings({'globalFlux': {'parameter': 'keff', 'convergence': 1e-05}})
+        couplingSettings = TightCouplingSettings({'globalFlux': {'parameter': 'keff', 'convergence': 1e-05}})
     """
 
     def __repr__(self):

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -84,7 +84,7 @@ def convertToSlice(x, increment=False):
 
     Examples
     --------
-    a = np.array([10, 11, 12, 13])
+    >>> a = np.array([10, 11, 12, 13])
 
     >>> convertToSlice(2)
     slice(2, 3, None)


### PR DESCRIPTION
## What is the change?

Fixing the "Examples" section in many docstrings.

## Why is the change being made?

They were improperly formatted, and not working correctly.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
