### PR TITLE
Activate sphinx-needs extension in doc config.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,6 +136,7 @@ extensions = [
     "sphinxcontrib.plantuml",
     "sphinx_rtd_theme",  # needed here for loading jquery in sphinx 6
     "sphinxcontrib.jquery",  # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1452
+    "sphinx_needs",
 ]
 
 # Our API should make sense without documenting private/special members.


### PR DESCRIPTION
The docs have lots of sphinx needs directives in them, including implementation (.. impl::) and tests (.. test::). These are defined by the sphinx-needs extension, which is in our requirements but not actually activated in our docs config. This activates it in the docs. The net result is that hundreds of errors in the doc build process are resolved.


<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
