### PR TITLE
Improving the formatting of some broken See Also's

### DIFF
--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -58,82 +58,81 @@ FILE_SPEC_1D_KEYS_VARIANT11 = (
 
 class NHFLUX(cccc.DataContainer):
     """
-    An abstraction of a NHFLUX file. This format is defined in the DIF3D manual. Note
-    that the format for DIF3D-Nodal and DIF3D-VARIANT are not the same. The VARIANT
-    NHFLUX format has recently changed, so this reader is only compatible with files
-    produced by v11.0 of the solver.
-
-    .. warning::
-        DIF3D outputs NHFLUX at every time node, but REBUS outputs NHFLUX only at every cycle.
-
-    See also [VARIANT-95]_ and [VARIANT-2014]_.
-
-    .. [VARIANT-95] G. Palmiotti, E. E. Lewis, and C. B. Carrico, VARIANT: VARIational
-       Anisotropic Nodal Transport for Multidimensional Cartesian and Hexagonal Geometry
-       Calculation, ANL-95/40, Argonne National Laboratory, Argonne, IL (October 1995).
-
-    .. [VARIANT-2014] Smith, M. A., Lewis, E. E., and Shemon, E. R. DIF3D-VARIANT 11.0: A
-       Decade of Updates. United States: N. p., 2014. Web. doi:10.2172/1127298.
-       https://publications.anl.gov/anlpubs/2014/04/78313.pdf
+    An abstraction of a NHFLUX file. This format is defined in the DIF3D manual. Note that the
+    format for DIF3D-Nodal and DIF3D-VARIANT are not the same. The VARIANT NHFLUX format has
+    recently changed, so this reader is only compatible with files produced by v11.0 of the solver.
 
     Attributes
     ----------
     metadata : file control
-        The NHFLUX file control info (sort of global for this library). This is the contents
-        of the 1D data block on the file.
+        The NHFLUX file control info (sort of global for this library). This is the contents of the
+        1D data block on the file.
 
     incomingPointersToAllAssemblies: 2-D list of floats
-        This is an index map for the "internal surfaces" between DIF3D nodal
-        indexing and DIF3D GEODST indexing. It can be used to process incoming partial
-        currents. This uses the same ordering as the geodstCoordMap attribute.
+        This is an index map for the "internal surfaces" between DIF3D nodal indexing and DIF3D
+        GEODST indexing. It can be used to process incoming partial currents. This uses the same
+        ordering as the geodstCoordMap attribute.
 
     externalCurrentPointers : list of ints
-        This is an index map for the "external surfaces" between DIF3D nodal
-        indexing and DIF3D GEODST indexing. "External surfaces" are important because they
-        contain the INCOMING partial currents from the outer reactor boundary. This uses
-        the same ordering as geodstCoordMap, except that each assembly now has multiple
-        subsequent indices. For example, for a hexagonal core, if hex of index n (0 to N-1)
-        has a surface of index k (0 to 5) that lies on the vacuum boundary, then the index
-        of that surface is N*6 + k + 1.
+        This is an index map for the "external surfaces" between DIF3D nodal indexing and DIF3D
+        GEODST indexing. "External surfaces" are important because they contain the INCOMING partial
+        currents from the outer reactor boundary. This uses the same ordering as geodstCoordMap,
+        except that each assembly now has multiple subsequent indices. For example, for a hexagonal
+        core, if hex of index n (0 to N-1) has a surface of index k (0 to 5) that lies on the vacuum
+        boundary, then the index of that surface is N*6 + k + 1.
 
     geodstCoordMap : list of ints
-        This is an index map between DIF3D nodal and DIF3D GEODST. It is
-        necessary for interpreting the ordering of flux and partial current data in the
-        NHFLUX file. Note that this mapping between DIF3D-Nodal and DIF3D-VARIANT is not
-        the same.
+        This is an index map between DIF3D nodal and DIF3D GEODST. It is necessary for interpreting
+        the ordering of flux and partial current data in the NHFLUX file. Note that this mapping
+        between DIF3D-Nodal and DIF3D-VARIANT is not the same.
 
     outgoingPCSymSeCPointers: list of ints
-        This is an index map for the outpgoing partial currents on the symmetric and sector
-        lateral boundary. It is only present for DIF3D-VARIANT for hexagonal cores.
+        This is an index map for the outpgoing partial currents on the symmetric and sector lateral
+        boundary. It is only present for DIF3D-VARIANT for hexagonal cores.
 
     ingoingPCSymSeCPointers: list of ints
-        This is an index map for the ingoing (or incoming) partial currents on the symmetric
-        and sector lateral boundary. It is only present for DIF3D-VARIANT for hexagonal cores.
+        This is an index map for the ingoing (or incoming) partial currents on the symmetric and
+        sector lateral boundary. It is only present for DIF3D-VARIANT for hexagonal cores.
 
     fluxMomentsAll : 4-D list of floats
-        This contains all the flux moments for all core assemblies. The jth planar flux moment
-        of assembly i in group g in axial node k is fluxMoments[i][k][j][g]. The
-        assemblies are ordered according to the geodstCoordMap attribute. For DIF3D-VARIANT,
-        this includes both even and odd parity moments.
+        This contains all the flux moments for all core assemblies. The jth planar flux moment of
+        assembly i in group g in axial node k is fluxMoments[i][k][j][g]. The assemblies are ordered
+        according to the geodstCoordMap attribute. For DIF3D-VARIANT, this includes both even and
+        odd parity moments.
 
     partialCurrentsHexAll : 5-D list of floats
         This contains all the OUTGOING partial currents for all core assemblies. The OUTGOING
         partial current on surface j in assembly i in axial node k in group g is
         partialCurrentsHex[i][k][j][g][m], where m=0. The assemblies are ordered according to the
-        geodstCoordMap attribute. For DIF3D-VARIANT, higher-order data is available for the
-        m axis.
+        geodstCoordMap attribute. For DIF3D-VARIANT, higher-order data is available for the m axis.
 
     partialCurrentsHex_extAll : 4-D list of floats
-        This contains all the INCOMING partial currents on "external surfaces", which are
-        adjacent to the reactor outer boundary (usually vacuum). Internal reflective surfaces
-        are NOT included in this! These "external surfaces" are ordered according to
-        externalCurrentPointers. For DIF3D-VARIANT, higher-order data is available for the
-        last axis.
+        This contains all the INCOMING partial currents on "external surfaces", which are adjacent
+        to the reactor outer boundary (usually vacuum). Internal reflective surfaces are NOT
+        included in this! These "external surfaces" are ordered according to
+        externalCurrentPointers. For DIF3D-VARIANT, higher-order data is available for the last
+        axis.
 
     partialCurrentsZAll : 5-D list of floats
-        This contains all the upward and downward partial currents for all core assemblies
-        The assemblies are ordered according to the geodstCoordMap attribute. For DIF3D-VARIANT,
-        higher-order data is available for the last axis.
+        This contains all the upward and downward partial currents for all core assemblies. The
+        assemblies are ordered according to the geodstCoordMap attribute. For DIF3D-VARIANT, higher-
+        order data is available for the last axis.
+
+    Warning
+    -------
+    DIF3D outputs NHFLUX at every time node, but REBUS outputs NHFLUX only at every cycle.
+
+    See Also
+    --------
+    [VARIANT-95]_ and [VARIANT-2014]_.
+
+    .. [VARIANT-95] G. Palmiotti, E. E. Lewis, and C. B. Carrico, VARIANT: VARIational Anisotropic
+       Nodal Transport for Multidimensional Cartesian and Hexagonal Geometry Calculation, ANL-95/40,
+       Argonne National Laboratory, Argonne, IL (October 1995).
+
+    .. [VARIANT-2014] Smith, M. A., Lewis, E. E., and Shemon, E. R. DIF3D-VARIANT 11.0: A Decade of
+       Updates. United States: N. p., 2014. Web. doi:10.2172/1127298.
+       https://publications.anl.gov/anlpubs/2014/04/78313.pdf
     """
 
     def __init__(self, fName="NHFLUX", variant=False, numDataSetsToRead=1):
@@ -146,8 +145,8 @@ class NHFLUX(cccc.DataContainer):
             Filename of the NHFLUX binary file to be read.
 
         variant : bool, optional
-            Whether or not this NHFLUX/NAFLUX file has the DIF3D-VARIANT output format, which
-            is different than the DIF3D-Nodal format.
+            Whether or not this NHFLUX/NAFLUX file has the DIF3D-VARIANT output format, which is
+            different than the DIF3D-Nodal format.
         """
         cccc.DataContainer.__init__(self)
 
@@ -181,8 +180,8 @@ class NHFLUX(cccc.DataContainer):
     def partialCurrentsHex(self):
         """
         For DIF3D-Nodal, this property is almost always equivalent to the attribute
-        `partialCurrentsHex`. For DIF3D-VARIANT, this property returns the zeroth-order
-        moment of the outgoing radial currents.
+        ``partialCurrentsHex``. For DIF3D-VARIANT, this property returns the zeroth-order moment of
+        the outgoing radial currents.
 
         Read-only property (there is no setter).
         """
@@ -217,11 +216,11 @@ class NhfluxStream(cccc.StreamWithDataContainer):
         return NHFLUX()
 
     def readWrite(self):
-        r"""
+        """
         Read everything from the DIF3D binary file NHFLUX.
 
-        Read all surface-averaged partial currents, all planar moments, and the DIF3D
-        nodal coordinate mapping system.
+        Read all surface-averaged partial currents, all planar moments, and the DIF3D nodal
+        coordinate mapping system.
 
         Notes
         -----
@@ -231,18 +230,17 @@ class NhfluxStream(cccc.StreamWithDataContainer):
         Parameters
         ----------
         numDataSetsToRead : int, optional
-            The number of whole-core flux data sets included in this NHFLUX/NAFLUX file
-            that one wishes to be read. Some NHFLUX/NAFLUX files, such as NAFLUX files
-            written by SASSYS/DIF3D-K, contain more than one flux data set. Each data set
-            overwrites the previous one on the NHFLUX class object, which will contain only the
-            numDataSetsToRead-th data set. The first numDataSetsToRead-1 data sets are essentially
-            skipped over.
+            The number of whole-core flux data sets included in this NHFLUX/NAFLUX file that one
+            wishes to be read. Some NHFLUX/NAFLUX files, such as NAFLUX files written by
+            SASSYS/DIF3D-K, contain more than one flux data set. Each data set overwrites the
+            previous one on the NHFLUX class object, which will contain only the
+            ``numDataSetsToRead-th`` data set. The first numDataSetsToRead-1 data sets are
+            essentially skipped over.
         """
         self._rwFileID()
         self._rwBasicFileData1D()
 
-        # This control info only exists for VARIANT. We can only process entries with 0
-        # or 1.
+        # This control info only exists for VARIANT. We can only process entries with 0 or 1.
         if self._metadata["variantFlag"] and self._metadata["iwnhfl"] == 2:
             msg = (
                 "This reader can only read VARIANT NHFLUX files where 'iwnhfl'=0 (both "
@@ -619,9 +617,9 @@ class NhfluxStream(cccc.StreamWithDataContainer):
         return surfCurrents
 
     def _getEnergyGroupIndex(self, g):
-        r"""
-        Real fluxes stored in NHFLUX have "normal" (or "forward") energy groups.
-        Also see the subclass method NAFLUX.getEnergyGroupIndex().
+        """
+        Real fluxes stored in NHFLUX have "normal" (or "forward") energy groups. Also see the
+        subclass method NAFLUX.getEnergyGroupIndex().
         """
         return g
 
@@ -634,7 +632,7 @@ class NafluxStream(NhfluxStream):
     """
 
     def _getEnergyGroupIndex(self, g):
-        r"""Adjoint fluxes stored in NAFLUX have "reversed" (or "backward") energy groups."""
+        """Adjoint fluxes stored in NAFLUX have "reversed" (or "backward") energy groups."""
         ng = self._metadata["ngroup"]
         return ng - g - 1
 
@@ -645,7 +643,7 @@ class NhfluxStreamVariant(NhfluxStream):
 
     Notes
     -----
-    Can be deleted after have the NHFLUX data container be the public interface
+    Can be deleted after have the NHFLUX data container be the public interface.
     """
 
     @staticmethod
@@ -659,7 +657,7 @@ class NafluxStreamVariant(NafluxStream):
 
     Notes
     -----
-    Can be deleted after have the NHFLUX data container be the public interface
+    Can be deleted after have the NHFLUX data container be the public interface.
     """
 
     @staticmethod
@@ -668,9 +666,9 @@ class NafluxStreamVariant(NafluxStream):
 
 
 def getNhfluxReader(adjointFlag, variantFlag):
-    r"""
-    Returns the appropriate DIF3D nodal flux binary file reader class,
-    either NHFLUX (real) or NAFLUX (adjoint).
+    """
+    Returns the appropriate DIF3D nodal flux binary file reader class, either NHFLUX (real) or
+    NAFLUX (adjoint).
     """
     if adjointFlag:
         reader = NafluxStreamVariant if variantFlag else NafluxStream

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -16,18 +16,21 @@
 This module contains the basic composite pattern underlying the reactor package.
 
 This follows the principles of the `Composite Design Pattern
-<https://en.wikipedia.org/wiki/Composite_pattern>`_ to allow the construction of a
-part/whole hierarchy representing a physical nuclear reactor. The composite objects act
-somewhat like lists: they can be indexed, iterated over, appended, extended, inserted,
-etc. Each member of the hierarchy knows its children and its parent, so full access to
-the hierarchy is available from everywhere. This design was chosen because of the close
-analogy of the model to the physical nature of nuclear reactors.
+<https://en.wikipedia.org/wiki/Composite_pattern>`_ to allow the construction of a part/whole
+hierarchy representing a physical nuclear reactor. The composite objects act somewhat like lists:
+they can be indexed, iterated over, appended, extended, inserted, etc. Each member of the hierarchy
+knows its children and its parent, so full access to the hierarchy is available from everywhere.
+This design was chosen because of the close analogy of the model to the physical nature of nuclear
+reactors.
 
-.. warning:: Because each member of the hierarchy is linked to the entire tree,
-    it is often unsafe to save references to individual members; it can cause
-    large and unexpected memory inefficiencies.
+Warning
+-------
+Because each member of the hierarchy is linked to the entire tree, it is often unsafe to save
+references to individual members; it can cause large and unexpected memory inefficiencies.
 
-See Also: :doc:`/developer/index`.
+See Also
+--------
+:doc:`/developer/index`.
 """
 import collections
 import itertools
@@ -566,7 +569,6 @@ class ArmiObject(metaclass=CompositeModelType):
         ----------
         typeSpec : TypeSpec
             Requested type of the child
-
         """
         for c in self.getChildren(deep):
             if c.hasFlags(typeSpec, exact=False):
@@ -587,7 +589,6 @@ class ArmiObject(metaclass=CompositeModelType):
         --------
         self.doChildrenHaveFlags
         self.containsOnlyChildrenWithFlags
-
         """
         return any(self.doChildrenHaveFlags(typeSpec))
 
@@ -604,7 +605,6 @@ class ArmiObject(metaclass=CompositeModelType):
         --------
         self.doChildrenHaveFlags
         self.containsAtLeastOneChildWithFlags
-
         """
         return all(self.doChildrenHaveFlags(typeSpec))
 

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -443,18 +443,17 @@ class AssemblyAxialLinkage:
         reference to original assembly; is directly modified/changed during expansion.
 
     linkedBlocks : dict
-        keys   --> :py:class:`Block <armi.reactor.blocks.Block>`
-
-        values --> list of axially linked blocks; index 0 = lower linked block; index 1: upper linked block.
-
-        see also: self._getLinkedBlocks()
+        - keys = :py:class:`Block <armi.reactor.blocks.Block>`
+        - values = list of axially linked blocks; index 0 = lower linked block; index 1: upper linked block.
 
     linkedComponents : dict
-        keys -->   :py:class:`Component <armi.reactor.components.component.Component>`
+        - keys = :py:class:`Component <armi.reactor.components.component.Component>`
+        - values = list of axially linked components; index 0 = lower linked component; index 1: upper linked component.
 
-        values --> list of axially linked components; index 0 = lower linked component; index 1: upper linked component.
-
-        see also: self._getLinkedComponents
+    See Also
+    --------
+    - self._getLinkedComponents
+    - self._getLinkedBlocks()
     """
 
     def __init__(self, StdAssem):

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -197,19 +197,22 @@ class AxialExpansionChanger:
         setFuel: bool = True,
         expandFromTinputToThot: bool = False,
     ):
-        """Perform thermal expansion/contraction for an assembly given an axial temperature grid and field.
+        """Perform thermal expansion/contraction for an assembly given an axial temperature grid and
+        field.
 
-        .. impl:: Perform thermal expansion/contraction, given an axial temperature distribution over an assembly.
+        .. impl:: Perform thermal expansion/contraction, given an axial temperature distribution
+            over an assembly.
             :id: I_ARMI_AXIAL_EXP_THERM
             :implements: R_ARMI_AXIAL_EXP_THERM
 
-            This method performs component-wise thermal expansion for an assembly given a discrete temperature
-            distribution over the axial length of the Assembly. In ``setAssembly``, the Assembly is prepared
-            for axial expansion by determining Component-wise axial linkage and checking to see if a dummy Block
-            is in place (necessary for ensuring conservation properties). The discrete temperature distribution
-            is then leveraged to update Component temperatures and compute thermal expansion factors
-            (via ``updateComponentTempsBy1DTempField`` and ``computeThermalExpansionFactors``, respectively).
-            Finally, the axial expansion is performed in ``axiallyExpandAssembly``.
+            This method performs component-wise thermal expansion for an assembly given a discrete
+            temperature distribution over the axial length of the Assembly. In ``setAssembly``, the
+            Assembly is prepared for axial expansion by determining Component-wise axial linkage and
+            checking to see if a dummy Block is in place (necessary for ensuring conservation
+            properties). The discrete temperature distribution is then leveraged to update Component
+            temperatures and compute thermal expansion factors (via
+            ``updateComponentTempsBy1DTempField`` and ``computeThermalExpansionFactors``,
+            respectively). Finally, the axial expansion is performed in ``axiallyExpandAssembly``.
 
         Parameters
         ----------
@@ -251,10 +254,11 @@ class AxialExpansionChanger:
 
         Notes
         -----
-        When considering thermal expansion, if there is an axial temperature distribution on the assembly,
-        the axial expansion methodology will NOT perfectly preseve mass. The magnitude of the gradient of
-        the temperature distribution is the primary factor in determining the cumulative loss of mass conservation.
-        Additional details will be documented in :ref:`axialExpansion` of the documentation.
+        When considering thermal expansion, if there is an axial temperature distribution on the
+        assembly, the axial expansion methodology will NOT perfectly preseve mass. The magnitude of
+        the gradient of the temperature distribution is the primary factor in determining the
+        cumulative loss of mass conservation. Additional details will be documented in
+        :ref:`axialExpansion` of the documentation.
         """
         self.linked = AssemblyAxialLinkage(a)
         self.expansionData = ExpansionData(
@@ -360,7 +364,8 @@ class AxialExpansionChanger:
             b.p.z = b.p.zbottom + b.getHeight() / 2.0
 
             _checkBlockHeight(b)
-            # call component.clearCache to update the component volume, and therefore the masses, of all solid components.
+            # Call Component.clearCache to update the Component volume, and therefore the masses,
+            # of all solid components.
             for c in getSolidComponents(b):
                 c.clearCache()
             # redo mesh -- functionality based on assembly.calculateZCoords()
@@ -444,11 +449,13 @@ class AssemblyAxialLinkage:
 
     linkedBlocks : dict
         - keys = :py:class:`Block <armi.reactor.blocks.Block>`
-        - values = list of axially linked blocks; index 0 = lower linked block; index 1: upper linked block.
+        - values = list of axially linked blocks; index 0 = lower linked block; index 1: upper
+          linked block.
 
     linkedComponents : dict
         - keys = :py:class:`Component <armi.reactor.components.component.Component>`
-        - values = list of axially linked components; index 0 = lower linked component; index 1: upper linked component.
+        - values = list of axially linked components; index 0 = lower linked component;
+          index 1: upper linked component.
 
     See Also
     --------
@@ -549,8 +556,8 @@ class AssemblyAxialLinkage:
                             errMsg = (
                                 "Multiple component axial linkages have been found for "
                                 f"Component {c}; Block {b}; Assembly {b.parent}."
-                                " This is indicative of an error in the blueprints! Linked components found are"
-                                f"{lstLinkedC[ib]} and {otherC}"
+                                " This is indicative of an error in the blueprints! Linked "
+                                f"components found are {lstLinkedC[ib]} and {otherC}"
                             )
                             runLog.error(msg=errMsg)
                             raise RuntimeError(errMsg)
@@ -582,9 +589,10 @@ def _determineLinked(componentA, componentB):
 
     Notes
     -----
-    - Requires that shapes have the getCircleInnerDiameter and getBoundingCircleOuterDiameter defined
-    - For axial linkage to be True, components MUST be solids, the same Component Class, multiplicity, and meet inner
-      and outer diameter requirements.
+    - Requires that shapes have the getCircleInnerDiameter and getBoundingCircleOuterDiameter
+      defined
+    - For axial linkage to be True, components MUST be solids, the same Component Class,
+      multiplicity, and meet inner and outer diameter requirements.
     - When component dimensions are retrieved, cold=True to ensure that dimensions are evaluated
       at cold/input temperatures. At temperature, solid-solid interfaces in ARMI may produce
       slight overlaps due to thermal expansion. Handling these potential overlaps are out of scope.
@@ -602,8 +610,8 @@ def _determineLinked(componentA, componentB):
         if isinstance(componentA, UnshapedComponent):
             runLog.warning(
                 f"Components {componentA} and {componentB} are UnshapedComponents "
-                "and do not have 'getCircleInnerDiameter' or getBoundingCircleOuterDiameter methods; "
-                "nor is it physical to do so. Instead of crashing and raising an error, "
+                "and do not have 'getCircleInnerDiameter' or getBoundingCircleOuterDiameter "
+                "methods; nor is it physical to do so. Instead of crashing and raising an error, "
                 "they are going to be assumed to not be linked.",
                 single=True,
             )
@@ -680,12 +688,18 @@ class ExpansionData:
             )
             raise RuntimeError
         if 0.0 in expFrac:
-            msg = "An expansion fraction, L1/L0, equal to 0.0, is not physical. Expansion fractions should be greater than 0.0."
+            msg = (
+                "An expansion fraction, L1/L0, equal to 0.0, is not physical. Expansion fractions "
+                "should be greater than 0.0."
+            )
             runLog.error(msg)
             raise RuntimeError(msg)
         for exp in expFrac:
             if exp < 0.0:
-                msg = "A negative expansion fraction, L1/L0, is not physical. Expansion fractions should be greater than 0.0."
+                msg = (
+                    "A negative expansion fraction, L1/L0, is not physical. Expansion fractions "
+                    "should be greater than 0.0."
+                )
                 runLog.error(msg)
                 raise RuntimeError(msg)
         for c, p in zip(componentLst, expFrac):
@@ -761,7 +775,7 @@ class ExpansionData:
         for b in self._a:
             for c in getSolidComponents(b):
                 if self.expandFromTinputToThot:
-                    # get thermal expansion factor between c.inputTemperatureInC and c.temperatureInC
+                    # get thermal expansion factor between c.inputTemperatureInC & c.temperatureInC
                     self._expansionFactors[c] = c.getThermalExpansionFactor()
                 elif c in self.componentReferenceTemperature:
                     growFrac = c.getThermalExpansionFactor(
@@ -769,9 +783,9 @@ class ExpansionData:
                     )
                     self._expansionFactors[c] = growFrac
                 else:
-                    # we want expansion factors relative to componentReferenceTemperature not Tinput.
-                    # But for this component there isn't a componentReferenceTemperature,
-                    # so we'll assume that the expansion factor is 1.0.
+                    # We want expansion factors relative to componentReferenceTemperature not
+                    # Tinput. But for this component there isn't a componentReferenceTemperature, so
+                    # we'll assume that the expansion factor is 1.0.
                     self._expansionFactors[c] = 1.0
 
     def getExpansionFactor(self, c):
@@ -809,7 +823,8 @@ class ExpansionData:
                 self.determineTargetComponent(b)
 
     def determineTargetComponent(self, b, flagOfInterest=None):
-        """Determines target component, stores it on the block, and appends it to self._componentDeterminesBlockHeight.
+        """Determines target component, stores it on the block, and appends it to
+        self._componentDeterminesBlockHeight.
 
         Parameters
         ----------
@@ -832,7 +847,7 @@ class ExpansionData:
             multiple target components found
         """
         if flagOfInterest is None:
-            # Follow expansion of most neutronically important component, fuel first then control/poison
+            # Follow expansion of most neutronically important component, fuel then control/poison
             for targetFlag in TARGET_FLAGS_IN_PREFERRED_ORDER:
                 componentWFlag = [c for c in b.getChildren() if c.hasFlags(targetFlag)]
                 if componentWFlag != []:


### PR DESCRIPTION
## What is the change?

Improving the formatting of some broken See Also statements in our docstrings.

## Why is the change being made?

Some of these "See Also" statements were just broken and not being rendered the way they should.

Also, I appologise, I shortened some of the lines to be <=100 characters, because some of our docstrings were >120 characters.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).  **cough**
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
