### PR TITLE
Fixing broken impl tag

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -841,33 +841,31 @@ class FuelHandler:
     def dischargeSwap(self, incoming, outgoing):
         """Removes one assembly from the core and replace it with another assembly.
 
+        .. impl:: User-specified blocks can be left in place for the discharge swap.
+            :id: I_ARMI_SHUFFLE_STATIONARY1
+            :implements: R_ARMI_SHUFFLE_STATIONARY
+
+            Before assemblies are moved, the ``_transferStationaryBlocks`` class method is called to
+            check if there are any block types specified by the user as stationary via the
+            ``stationaryBlockFlags`` case setting. Using these flags, blocks are gathered from each
+            assembly which should remain stationary and checked to make sure that both assemblies
+            have the same number and same height of stationary blocks. If not, return an error.
+
+            If all checks pass, the :py:meth:`~armi.reactor.assemblies.Assembly.remove` and
+            :py:meth:`~armi.reactor.assemblies.Assembly.insert`` methods are used to swap the
+            stationary blocks between the two assemblies.
+
+            Once this process is complete, the actual assembly movement can take place. Through this
+            process, the stationary blocks from the outgoing assembly remain in the original core
+            position, while the stationary blocks from the incoming assembly are discharged with the
+            outgoing assembly.
+
         Parameters
         ----------
         incoming : :py:class:`Assembly <armi.reactor.assemblies.Assembly>`
             The assembly getting swapped into the core.
         outgoing : :py:class:`Assembly <armi.reactor.assemblies.Assembly>`
             The assembly getting discharged out the core.
-
-        .. impl:: User-specified blocks can be left in place for the discharge swap.
-            :id: I_ARMI_SHUFFLE_STATIONARY1
-            :implements: R_ARMI_SHUFFLE_STATIONARY
-
-            Before assemblies are moved,
-            the ``_transferStationaryBlocks`` class method is called to
-            check if there are any block types specified by the user as stationary
-            via the ``stationaryBlockFlags`` case setting. Using these flags, blocks
-            are gathered from each assembly which should remain stationary and
-            checked to make sure that both assemblies have the same number
-            and same height of stationary blocks. If not, return an error.
-
-            If all checks pass, the :py:meth:`~armi.reactor.assemblies.Assembly.remove`
-            and :py:meth:`~armi.reactor.assemblies.Assembly.insert``
-            methods are used to swap the stationary blocks between the two assemblies.
-
-            Once this process is complete, the actual assembly movement can take
-            place. Through this process, the stationary blocks from the outgoing
-            assembly remain in the original core position, while the stationary
-            blocks from the incoming assembly are discharged with the outgoing assembly.
 
         See Also
         --------


### PR DESCRIPTION
## What is the change?

Fixed broken `impl` tag.

## Why is the change being made?

The `.. impl` tag was underneath the `Parameters` heading, and thus not rendering properly, as it was considered by Sphinx to be a note on the parameter.

(Also, I aligned the text to be 100 characters wide instead of 82, as it was.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [X] The dependencies are still up-to-date in `pyproject.toml`.
