### PR TITLE
Update NHFLUX reader to read VARSRC files

### DIFF
--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -323,7 +323,7 @@ class NhfluxStream(cccc.StreamWithDataContainer):
                         self._data.fluxMomentsAll[:, z, :, gEff]
                     )
 
-                # Process currents, but only if iwnhfl is not equal to 1.
+                # Process currents, but only if iwnhfl is not equal to 1
                 if self._metadata["iwnhfl"] != 1:
                     # Loop through axial nodes
                     for z in range(nz):

--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -253,8 +253,9 @@ class NhfluxStream(cccc.StreamWithDataContainer):
         # Read the hex ordering map between DIF3D nodal and DIF3D GEODST. Also read index
         # pointers to incoming partial currents on outer reactor surface (these don't
         # belong to any assembly). Incoming partial currents are non-zero due to flux
-        # extrapolation. This record is only required when nSurf is greater than 1 (it
-        # is equal to one for VARSRC files, which are a subset of NHFLUX files).
+        # extrapolation. This record is only required when nSurf is greater than 1. It
+        # is equal to 1 for VARSRC files, which are a subset of NHFLUX files; VARSRC files
+        # do not have a 2D record (or 4D or 5D records).
         if self._metadata["nSurf"] > 1:
             self._rwGeodstCoordMap2D()
 

--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -253,8 +253,10 @@ class NhfluxStream(cccc.StreamWithDataContainer):
         # Read the hex ordering map between DIF3D nodal and DIF3D GEODST. Also read index
         # pointers to incoming partial currents on outer reactor surface (these don't
         # belong to any assembly). Incoming partial currents are non-zero due to flux
-        # extrapolation
-        self._rwGeodstCoordMap2D()
+        # extrapolation. This record is only required when nSurf is greater than 1 (it
+        # is equal to one for VARSRC files, which are a subset of NHFLUX files).
+        if self._metadata["nSurf"] > 1:
+            self._rwGeodstCoordMap2D()
 
         # Number of energy groups
         ng = self._metadata["ngroup"]
@@ -320,7 +322,7 @@ class NhfluxStream(cccc.StreamWithDataContainer):
                         self._data.fluxMomentsAll[:, z, :, gEff]
                     )
 
-                # Process currents
+                # Process currents, but only if iwnhfl is not equal to 1.
                 if self._metadata["iwnhfl"] != 1:
                     # Loop through axial nodes
                     for z in range(nz):

--- a/armi/nuclearDataIO/cccc/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_nhflux.py
@@ -235,9 +235,9 @@ class TestNhfluxVariantVarsrc(unittest.TestCase):
 
         # Make sure that the flux moments match identically
         self.assertTrue(
-            np.isclose(
+            np.allclose(
                 writtenVarsrc.fluxMoments, self.nhf.fluxMoments, rtol=0.0, atol=0.0
-            ).all()
+            )
         )
 
         # Make sure all other datasets are empty, since the reader should not be trying

--- a/armi/nuclearDataIO/cccc/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_nhflux.py
@@ -222,8 +222,8 @@ class TestNhfluxVariantVarsrc(unittest.TestCase):
 
     def test_writeRead(self):
         """
-        Write out the data structure to file. Then read it back in and make sure it matches
-        the data currently in memory.
+        Write out the modified data structure to file. Then, we read it back in and make
+        sure it matches the data currently in memory.
         """
         filename = "VARSRC"
         with TemporaryDirectoryChanger():

--- a/armi/nuclearDataIO/cccc/tests/test_nhflux.py
+++ b/armi/nuclearDataIO/cccc/tests/test_nhflux.py
@@ -181,9 +181,7 @@ class TestNhfluxVariant(unittest.TestCase):
         )
 
     def test_write(self):
-        """
-        Verify binary equivalence of written binary file.
-        """
+        """Verify binary equivalence of written binary file."""
         with TemporaryDirectoryChanger():
             nhflux.NhfluxStreamVariant.writeBinary(self.nhf, "NHFLUX2")
             with open(SIMPLE_HEXZ_NHFLUX_VARIANT, "rb") as f1, open(


### PR DESCRIPTION
## What is the change?

This PR adds a conditional processing of the 2D record in the NHFLUX binary file based on the value of the IWNHFL flag.

## Why is the change being made?

The VARSRC binary file format is a subset of the NHFLUX binary file format. The reader currently has a minor bug in it that doesn't allow it to read a VARSRC file because it always assumes that the 2D record is present, which is not true for VARSRC files. This PR addresses the bug.

A new test has also been added to ensure that the VARSRC file format is considered as part of future code changes.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    (If a checkbox requires no action for this PR, put an `x` in the box.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) (location `doc/release/0.X.rst`) are up-to-date with any important changes.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] If any [requirements](https://terrapower.github.io/armi/developer/tooling.html#watch-for-requirements) were affected, mention it in the [release notes](https://terrapower.github.io/armi/release/index.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
