### PR TITLE
Removing unused method HexGrid.allPositionsInThird

### DIFF
--- a/armi/reactor/grids/hexagonal.py
+++ b/armi/reactor/grids/hexagonal.py
@@ -25,7 +25,7 @@ from armi.reactor.grids.constants import (
     BOUNDARY_60_DEGREES,
     BOUNDARY_CENTER,
 )
-from armi.reactor.grids.locations import IndexLocation, IJKType, IJType
+from armi.reactor.grids.locations import IJKType, IJType
 from armi.reactor.grids.structuredGrid import StructuredGrid
 
 COS30 = sqrt(3) / 2.0
@@ -469,33 +469,3 @@ class HexGrid(StructuredGrid):
         )
 
         return locList[:nLocs]
-
-    # TODO: this is only used by testing and another method that just needs the count of assemblies
-    #       in a ring, not the actual positions
-    def allPositionsInThird(self, ring, includeEdgeAssems=False):
-        """
-        Returns a list of all the positions in a ring (in the first third).
-
-        Parameters
-        ----------
-        ring : int
-            The ring to check
-        includeEdgeAssems : bool, optional
-            If True, include repeated positions in odd ring numbers. Default: False
-
-        Notes
-        -----
-        Rings start at 1, positions start at 1
-
-        Returns
-        -------
-        positions : int
-        """
-        positions = []
-        for pos in range(1, self.getPositionsInRing(ring) + 1):
-            i, j = self.getIndicesFromRingAndPos(ring, pos)
-            loc = IndexLocation(i, j, 0, None)
-            if self.isInFirstThird(loc, includeEdgeAssems):
-                positions.append(pos)
-
-        return positions

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -14,6 +14,7 @@ API Changes
 -----------
 #. Renaming ``structuredgrid.py`` to camelCase. (`PR#1650 <https://github.com/terrapower/armi/pull/1650>`_)
 #. Removing unused argument from ``Block.coords()``. (`PR#1651 <https://github.com/terrapower/armi/pull/1651>`_)
+#. Removing unused method ``HexGrid.allPositionsInThird()``. (`PR#1655 <https://github.com/terrapower/armi/pull/1655>`_)
 #. TBD
 
 Bug Fixes


### PR DESCRIPTION
## What is the change?

Removing an unused method.

## Why is the change being made?

This method has never been used by ARMI or any downstream project (except one) in the last 4-5 years. So I am moving it to the downstream project.

I find this method to be a bit too specific to have in the `HexGrid` class.


---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.