### PR TITLE
Removing 109-page-long nuclide list from API docs

### DIFF
--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -91,46 +91,6 @@ Retrieve U-235 by the AAAZZZS ID:
 >>> nuclideBases.byAAAZZZSId['2350920']
 <NuclideBase U235:  Z:92, A:235, S:0, W:2.350439e+02, Label:U235>, HL:2.22160758861e+16, Abund:7.204000e-03>
 
-.. only:: html
-
-    .. _nuclide-bases-table:
-
-    .. exec::
-        import numpy
-        from tabulate import tabulate
-        from armi.nucDirectory import nuclideBases
-        from dochelpers import createTable
-
-        attributes = ['name',
-                    'type',
-                    'a',
-                    'z',
-                    'state',
-                    'abundance',
-                    'weight',
-                    'halflife']
-
-        def getAttributes(nuc):
-            if nuc.halflife == numpy.inf:
-                halflife = "inf"
-            else:
-                halflife = f'{nuc.halflife:<12.6e}'
-            return [
-                f'``{nuc.name}``',
-                f':py:class:`~armi.nucDirectory.nuclideBases.{nuc.__class__.__name__}`',
-                f'``{nuc.a}``',
-                f'``{nuc.z}``',
-                f'``{nuc.state}``',
-                f'``{nuc.abundance:<12.6e}``',
-                f'``{nuc.weight:<12.6e}``',
-                f'``{halflife}``',
-            ]
-
-        sortedNucs = sorted(nuclideBases.instances)
-        return createTable(tabulate(tabular_data=[getAttributes(nuc) for nuc in sortedNucs],
-                                    headers=attributes,
-                                    tablefmt='rst'),
-                                    caption='List of nuclides')
 """
 
 import os


### PR DESCRIPTION
## What is the change?

Removing 109-page-long nuclide list from API docs

## Why is the change being made?

I can find no one anywhere who tells me they have ever referred to this table. Thus, it is unused an unneeded.  Also, this does not belong in the API docs, it is not part of the API.  

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.