### PR TITLE
Updating installation instructions for PIP version limitation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,17 +68,21 @@ commands. You probably want to do this in a virtual environment as described in 
 documentation <https://terrapower.github.io/armi/installation.html>`_. Otherwise, the
 dependencies could conflict with your system dependencies.
 
-::
+First, upgrade your version of pip::
+
+    $ pip install pip>=22.1
+
+Now clone and install ARMI::
 
     $ git clone https://github.com/terrapower/armi
     $ cd armi
     $ pip install -e .
-    $ armi
+    $ armi --help
 
 The easiest way to run the tests is to install `tox <https://tox.readthedocs.io/en/latest/>`_
 and then run::
 
-    $ pip install -e .[test]
+    $ pip install -e ".[test]"
     $ tox -- -n 6
 
 This runs the unit tests in parallel on 6 processes. Omit the ``-n 6`` argument
@@ -86,7 +90,7 @@ to run on a single process.
 
 The tests can also be run directly, using ``pytest``::
 
-    $ pip install -e .[test]
+    $ pip install -e ".[test]"
     $ pytest -n 4 armi
 
 From here, we recommend going through a few of our `gallery examples

--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -63,6 +63,18 @@ Getting the code
 ================
 Choose one of the following two installation methods depending on your needs.
 
+Step 0: Update PIP
+------------------
+In order to use the commands below, you're going to want to use a version of ``pip>=22.1``.
+Two common ways of solving that are::
+
+    (armi-venv) $ pip install pip>=22.1
+
+or, in most cases::
+
+    (armi-venv) $ pip install -U pip
+
+
 Option 1: Install as a library
 ------------------------------
 If you plan on running ARMI without viewing or modifying source code, you may
@@ -71,6 +83,7 @@ dependencies. This is useful for quick evaluations or to use it as a dependency
 in another project::
 
    	(armi-venv) $ pip install https://github.com/terrapower/armi/archive/main.zip
+
 
 Option 2: Install as a repository (for developers)
 --------------------------------------------------
@@ -86,7 +99,7 @@ the git repository with::
 Now install ARMI with all its dependencies::
 
     (armi-venv) $ cd armi
-    (armi-venv) $ pip install -e .[test]
+    (armi-venv) $ pip install -e ".[test]"
 
 .. tip:: If you don't want to install ARMI into your venv, you will need to add the ARMI source
 	location to your system's ``PYTHONPATH`` environment variable so that


### PR DESCRIPTION
## What is the change?

Updating the installation docs to explicitly state the PIP version limitation.

## Why is the change being made?

ARMI depends on the `pyproject.toml` feature set, which is not fully supported until `pip>=22.1` (which was released in May 2022).  So, this version limit is mandatory.

Notes
------
@albeanth :
1. This is a SCR-like change, because the "User Installation" guide is part of our official documentation.
2. All our downstream projects already explicitly state the `pip>=22.1` dependency limit; so no change needs to be made to those projects.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.