### PR TITLE
Cleaning out the overly-specific methods in ArmiObject

### DIFF
--- a/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/lumpedFissionProduct.py
@@ -180,23 +180,6 @@ class LumpedFissionProduct:
             massFracDenom += self[nuc] * nuc.weight
         return massFracDenom
 
-    def printDensities(self, lfpDens):
-        """
-        Print number densities of nuclides within the lumped fission product.
-
-        Parameters
-        ----------
-        lfpDens : float
-            Number density (atom/b-cm) of the lumped fission product
-
-        Notes
-        -----
-        This multiplies the provided number density for the lumped fission
-        product by the yield of each nuclide.
-        """
-        for n in sorted(self.keys()):
-            runLog.info("{0:6s} {1:.7E}".format(n.name, lfpDens * self[n]))
-
 
 class LumpedFissionProductCollection(dict):
     """

--- a/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
@@ -118,11 +118,6 @@ class TestLumpedFissionProduct(unittest.TestCase):
         # data for these tests.
         self.assertEqual(lfp.getGaseousYieldFraction(), 8.9000e-05)
 
-    def test_printDensities(self):
-        _ = nuclideBases.fromName("XE135")
-        lfp = self.fpd.createSingleLFPFromFile("LFP38")
-        lfp.printDensities(10.0)
-
     def test_isGas(self):
         """Tests that a nuclide is a gas or not at STP based on its chemical phase."""
         nb = nuclideBases.byName["H1"]

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1269,6 +1269,10 @@ class Assembly(composites.Composite):
         for b in self.getBlocks():
             b.rotate(rad)
 
+    def isOnWhichSymmetryLine(self):
+        grid = self.parent.spatialGrid
+        return grid.overlapsWhichSymmetryLine(self.spatialLocator.getCompleteIndices())
+
 
 class HexAssembly(Assembly):
     """Placeholder, so users can explicitly define a hex-based Assembly."""

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1653,6 +1653,15 @@ class Block(composites.Composite):
                 coords.append(clad.spatialLocator.getLocalCoordinates())
         return coords
 
+    def getBoronMassEnrich(self):
+        """Return B-10 mass fraction."""
+        b10 = self.getMass("B10")
+        b11 = self.getMass("B11")
+        total = b11 + b10
+        if total == 0.0:
+            return 0.0
+        return b10 / total
+
 
 class HexBlock(Block):
     """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -30,6 +30,7 @@ import numpy
 from armi import nuclideBases
 from armi import runLog
 from armi.bookkeeping import report
+from armi.nucDirectory import elements
 from armi.physics.neutronics import GAMMA
 from armi.physics.neutronics import NEUTRON
 from armi.reactor import blockParameters
@@ -1661,6 +1662,18 @@ class Block(composites.Composite):
         if total == 0.0:
             return 0.0
         return b10 / total
+
+    def getPuMoles(self):
+        """Returns total number of moles of Pu isotopes."""
+        nucNames = [nuc.name for nuc in elements.byZ[94].nuclides]
+        puN = sum(self.getNuclideNumberDensities(nucNames))
+
+        return (
+            puN
+            / units.MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
+            * self.getVolume()
+            * self.getSymmetryFactor()
+        )
 
 
 class HexBlock(Block):

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1670,6 +1670,14 @@ class Block(composites.Composite):
             * self.getSymmetryFactor()
         )
 
+    def getUraniumMassEnrich(self):
+        """Returns U-235 mass fraction assuming U-235 and U-238 only."""
+        u5 = self.getMass("U235")
+        if u5 < 1e-10:
+            return 0.0
+        u8 = self.getMass("U238")
+        return u5 / (u8 + u5)
+
 
 class HexBlock(Block):
     """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -635,17 +635,6 @@ class Block(composites.Composite):
     def getMaxArea(self):
         raise NotImplementedError
 
-    def getMaxVolume(self):
-        """
-        The maximum volume of this object if it were totally full.
-
-        Returns
-        -------
-        vol : float
-            volume in cm^3.
-        """
-        return self.getMaxArea() * self.getHeight()
-
     def getArea(self, cold=False):
         """
         Return the area of a block for a full core or a 1/3 core model.

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -734,11 +734,6 @@ class Block(composites.Composite):
         """
         return 1.0
 
-    def isOnWhichSymmetryLine(self):
-        """Block symmetry lines are determined by the reactor, not the parent."""
-        grid = self.core.spatialGrid
-        return grid.overlapsWhichSymmetryLine(self.spatialLocator.getCompleteIndices())
-
     def adjustDensity(self, frac, adjustList, returnMass=False):
         """
         adjusts the total density of each nuclide in adjustList by frac.

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -344,7 +344,7 @@ class DerivedShape(UnshapedComponent):
     @staticmethod
     def getMaxVolume(block):
         """
-        The maximum volume of the given Block if it were totally full.
+        The maximum volume of the parent Block.
 
         Parameters
         ----------

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -341,22 +341,16 @@ class DerivedShape(UnshapedComponent):
         """
         return self._deriveVolumeAndArea()
 
-    @staticmethod
-    def getMaxVolume(block):
+    def getMaxVolume(self):
         """
         The maximum volume of the parent Block.
-
-        Parameters
-        ----------
-        block : Block
-            Block of interest.
 
         Returns
         -------
         vol : float
             volume in cm^3.
         """
-        return block.getMaxArea() * block.getHeight()
+        return self.parent.getMaxArea() * self.parent.getHeight()
 
     def _deriveVolumeAndArea(self):
         """
@@ -400,7 +394,7 @@ class DerivedShape(UnshapedComponent):
             except:  # noqa: bare-except
                 siblingArea = None
 
-        remainingVolume = DerivedShape.getMaxVolume(self.parent) - siblingVolume
+        remainingVolume = self.getMaxVolume() - siblingVolume
         if siblingArea:
             remainingArea = self.parent.getMaxArea() - siblingArea
 
@@ -410,7 +404,7 @@ class DerivedShape(UnshapedComponent):
                 f"The component areas in {self.parent} exceed the maximum "
                 "allowable volume based on the geometry. Check that the "
                 "geometry is defined correctly.\n"
-                f"Maximum allowable volume: {DerivedShape.getMaxVolume(self.parent)} "
+                f"Maximum allowable volume: {self.getMaxVolume()} "
                 f"cm^3\nVolume of all non-derived shape components: {siblingVolume} cm^3\n"
             )
             runLog.error(msg)

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -341,6 +341,23 @@ class DerivedShape(UnshapedComponent):
         """
         return self._deriveVolumeAndArea()
 
+    @staticmethod
+    def getMaxVolume(block):
+        """
+        The maximum volume of the given Block if it were totally full.
+
+        Parameters
+        ----------
+        block : Block
+            Block of interest.
+
+        Returns
+        -------
+        vol : float
+            volume in cm^3.
+        """
+        return block.getMaxArea() * block.getHeight()
+
     def _deriveVolumeAndArea(self):
         """
         Derive the volume and area of a ``DerivedShape``.
@@ -383,7 +400,7 @@ class DerivedShape(UnshapedComponent):
             except:  # noqa: bare-except
                 siblingArea = None
 
-        remainingVolume = self.parent.getMaxVolume() - siblingVolume
+        remainingVolume = DerivedShape.getMaxVolume(self.parent) - siblingVolume
         if siblingArea:
             remainingArea = self.parent.getMaxArea() - siblingArea
 
@@ -393,8 +410,8 @@ class DerivedShape(UnshapedComponent):
                 f"The component areas in {self.parent} exceed the maximum "
                 "allowable volume based on the geometry. Check that the "
                 "geometry is defined correctly.\n"
-                f"Maximum allowable volume: {self.parent.getMaxVolume()} cm^3\n"
-                f"Volume of all non-derived shape components: {siblingVolume} cm^3\n"
+                f"Maximum allowable volume: {DerivedShape.getMaxVolume(self.parent)} "
+                f"cm^3\nVolume of all non-derived shape components: {siblingVolume} cm^3\n"
             )
             runLog.error(msg)
             raise ValueError(

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1765,15 +1765,6 @@ class ArmiObject(metaclass=CompositeModelType):
         else:
             return 0.0
 
-    def getBoronMassEnrich(self):
-        """Return B-10 mass fraction."""
-        b10 = self.getMass("B10")
-        b11 = self.getMass("B11")
-        total = b11 + b10
-        if total == 0.0:
-            return 0.0
-        return b10 / total
-
     def getUraniumMassEnrich(self):
         """Returns U-235 mass fraction assuming U-235 and U-238 only."""
         u5 = self.getMass("U235")

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2169,16 +2169,6 @@ class ArmiObject(metaclass=CompositeModelType):
         else:
             return pu / hm
 
-    def getZrFrac(self):
-        """Return the total zr/(hm+zr) fraction in this assembly."""
-        hm = self.getHMMass()
-        zrNucs = [nuc.name for nuc in elements.bySymbol["ZR"].nuclides]
-        zr = self.getMass(zrNucs)
-        if hm + zr > 0:
-            return zr / (hm + zr)
-        else:
-            return 0.0
-
     def getFPMass(self):
         """Returns mass of fission products in this block in grams."""
         nucs = []

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2122,14 +2122,6 @@ class ArmiObject(metaclass=CompositeModelType):
         hmDens = sum(self.getNuclideNumberDensities(hmNuclides))
         return hmDens
 
-    def getPuMass(self):
-        """Get the mass of Pu in this object in grams."""
-        nucs = []
-        for nucName in [nuc.name for nuc in elements.byZ[94].nuclides]:
-            nucs.append(nucName)
-        pu = self.getMass(nucs)
-        return pu
-
     def getPuFrac(self):
         """
         Compute the Pu/HM mass fraction in this object.
@@ -2140,10 +2132,14 @@ class ArmiObject(metaclass=CompositeModelType):
             The pu mass fraction in heavy metal in this assembly
         """
         hm = self.getHMMass()
-        pu = self.getPuMass()
         if hm == 0.0:
             return 0.0
         else:
+            # Get the mass of Pu in this object in grams.
+            nucs = []
+            for nucName in [nuc.name for nuc in elements.byZ[94].nuclides]:
+                nucs.append(nucName)
+            pu = self.getMass(nucs)
             return pu / hm
 
     def getFPMass(self):

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2513,16 +2513,6 @@ class ArmiObject(metaclass=CompositeModelType):
 
         return reportGroups
 
-    def printDensities(self, expandFissionProducts=False):
-        """Get lines that have the number densities of a object."""
-        numberDensities = self.getNumberDensities(
-            expandFissionProducts=expandFissionProducts
-        )
-        lines = []
-        for nucName, nucDens in numberDensities.items():
-            lines.append("{0:6s} {1:.7E}".format(nucName, nucDens))
-        return lines
-
     def expandAllElementalsToIsotopics(self):
         reactorNucs = self.getNuclides()
         for elemental in nuclideBases.where(

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1765,14 +1765,6 @@ class ArmiObject(metaclass=CompositeModelType):
         else:
             return 0.0
 
-    def getUraniumMassEnrich(self):
-        """Returns U-235 mass fraction assuming U-235 and U-238 only."""
-        u5 = self.getMass("U235")
-        if u5 < 1e-10:
-            return 0.0
-        u8 = self.getMass("U238")
-        return u5 / (u8 + u5)
-
     def getUraniumNumEnrich(self):
         """Returns U-235 number fraction."""
         u8 = self.getNumberDensity("U238")

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2179,14 +2179,6 @@ class ArmiObject(metaclass=CompositeModelType):
         else:
             return 0.0
 
-    def getMaxUraniumMassEnrich(self):
-        maxV = 0
-        for child in self:
-            v = child.getUraniumMassEnrich()
-            if v > maxV:
-                maxV = v
-        return maxV
-
     def getFPMass(self):
         """Returns mass of fission products in this block in grams."""
         nucs = []

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1781,20 +1781,6 @@ class ArmiObject(metaclass=CompositeModelType):
         u5 = self.getNumberDensity("U235")
         return u5 / (u8 + u5)
 
-    def getPuN(self):
-        """Returns total number density of Pu isotopes."""
-        nucNames = [nuc.name for nuc in elements.byZ[94].nuclides]
-        return sum(self.getNuclideNumberDensities(nucNames))
-
-    def getPuMoles(self):
-        """Returns total number of moles of Pu isotopes."""
-        return (
-            self.getPuN()
-            / units.MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
-            * self.getVolume()
-            * self.getSymmetryFactor()
-        )
-
     def calcTotalParam(
         self,
         param,

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2103,26 +2103,6 @@ class ArmiObject(metaclass=CompositeModelType):
         hmDens = sum(self.getNuclideNumberDensities(hmNuclides))
         return hmDens
 
-    def getPuFrac(self):
-        """
-        Compute the Pu/HM mass fraction in this object.
-
-        Returns
-        -------
-        puFrac : float
-            The pu mass fraction in heavy metal in this assembly
-        """
-        hm = self.getHMMass()
-        if hm == 0.0:
-            return 0.0
-        else:
-            # Get the mass of Pu in this object in grams.
-            nucs = []
-            for nucName in [nuc.name for nuc in elements.byZ[94].nuclides]:
-                nucs.append(nucName)
-            pu = self.getMass(nucs)
-            return pu / hm
-
     def getFPMass(self):
         """Returns mass of fission products in this block in grams."""
         nucs = []

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -898,17 +898,6 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         raise NotImplementedError()
 
-    def getMaxVolume(self):
-        """
-        The maximum volume of this object if it were totally full.
-
-        Returns
-        -------
-        vol : float
-            volume in cm^3.
-        """
-        raise NotImplementedError()
-
     def getMass(self, nuclideNames=None):
         """
         Determine the mass in grams of nuclide(s) and/or elements in this object.

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -3269,10 +3269,6 @@ class Composite(ArmiObject):
         for c in self.getChildren():
             c.printContents(includeNuclides=includeNuclides)
 
-    def isOnWhichSymmetryLine(self):
-        grid = self.parent.spatialGrid
-        return grid.overlapsWhichSymmetryLine(self.spatialLocator.getCompleteIndices())
-
     def _genChildByLocationLookupTable(self):
         """Update the childByLocation lookup table."""
         runLog.extra("Generating location-to-child lookup table.")

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -483,18 +483,6 @@ class Assembly_TestCase(unittest.TestCase):
         ref = sum(bi.getMass(["U235", "PU239"]) for bi in self.assembly)
         self.assertAlmostEqual(cur, ref)
 
-    def test_getPuFrac(self):
-        puAssem = self.assembly.getPuFrac()
-        fuelBlock = self.assembly[1]
-        puBlock = fuelBlock.getPuFrac()
-        self.assertAlmostEqual(puAssem, puBlock)
-
-        #
-        fuelComp = fuelBlock.getComponent(Flags.FUEL)
-        fuelComp.setNumberDensity("PU239", 0.012)
-        self.assertGreater(self.assembly.getPuFrac(), puAssem)
-        self.assertGreater(fuelBlock.getPuFrac(), puAssem)
-
     def test_getMass(self):
         mass0 = self.assembly.getMass("U235")
         mass1 = sum(bi.getMass("U235") for bi in self.assembly)

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -505,9 +505,6 @@ class Assembly_TestCase(unittest.TestCase):
         fuelBlock.setMass("U238", 0.0)
         self.assertAlmostEqual(blockU35Mass * 2, fuelBlock.getMass("U235"))
 
-    def test_getZrFrac(self):
-        self.assertAlmostEqual(self.assembly.getZrFrac(), 0.1)
-
     def test_getAge(self):
         res = 5.0
         for b in self.assembly:

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -270,6 +270,10 @@ class Assembly_TestCase(unittest.TestCase):
 
         self.assembly.calculateZCoords()
 
+    def test_isOnWhichSymmetryLine(self):
+        line = self.assembly.isOnWhichSymmetryLine()
+        self.assertEqual(line, 2)
+
     def test_notesParameter(self):
         self.assertEqual(self.assembly.p.notes, "")
 

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -508,12 +508,6 @@ class Assembly_TestCase(unittest.TestCase):
     def test_getZrFrac(self):
         self.assertAlmostEqual(self.assembly.getZrFrac(), 0.1)
 
-    def test_getMaxUraniumMassEnrich(self):
-        baseEnrich = self.assembly[0].getUraniumMassEnrich()
-        self.assertAlmostEqual(self.assembly.getMaxUraniumMassEnrich(), baseEnrich)
-        self.assembly[2].setNumberDensity("U235", 2e-1)
-        self.assertGreater(self.assembly.getMaxUraniumMassEnrich(), baseEnrich)
-
     def test_getAge(self):
         res = 5.0
         for b in self.assembly:

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1943,9 +1943,6 @@ class HexBlock_TestCase(unittest.TestCase):
         self.assertEqual(v0 / 3.0, self.HexBlock.getVolume())
         self.assertAlmostEqual(m0 / 3.0, self.HexBlock.getMass())
 
-        symmetryLine = self.HexBlock.isOnWhichSymmetryLine()
-        self.assertEqual(grids.BOUNDARY_CENTER, symmetryLine)
-
     def test_retainState(self):
         """Ensure retainState restores params and spatialGrids."""
         self.HexBlock.spatialGrid = grids.HexGrid.fromPitch(1.0)

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1064,16 +1064,7 @@ class Block_TestCase(unittest.TestCase):
             * self.block.getVolume()
             * self.block.getSymmetryFactor()
         )
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
-
-        # test mass
-        cur = self.block.getPuMass()
-        pu = 0.0
-        for nucName in refDict.keys():
-            if nucName in ["PU238", "PU239", "PU240", "PU241", "PU242"]:
-                pu += self.block.getMass(nucName)
-        self.assertAlmostEqual(cur, pu)
+        self.assertAlmostEqual(cur, ref, places=6)
 
     def test_adjustDensity(self):
         u235Dens = 0.003
@@ -1088,12 +1079,11 @@ class Block_TestCase(unittest.TestCase):
 
         cur = self.block.getNumberDensity("U235")
         ref = densAdj * u235Dens
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
         cur = self.block.getNumberDensity("U238")
         ref = densAdj * u238Dens
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
         self.assertAlmostEqual(mass2 - mass1, massDiff)
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1079,11 +1079,11 @@ class Block_TestCase(unittest.TestCase):
 
         cur = self.block.getNumberDensity("U235")
         ref = densAdj * u235Dens
-        self.assertAlmostEqual(cur, ref, places=6)
+        self.assertAlmostEqual(cur, ref, places=9)
 
         cur = self.block.getNumberDensity("U238")
         ref = densAdj * u238Dens
-        self.assertAlmostEqual(cur, ref, places=6)
+        self.assertAlmostEqual(cur, ref, places=9)
 
         self.assertAlmostEqual(mass2 - mass1, massDiff)
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1052,16 +1052,6 @@ class Block_TestCase(unittest.TestCase):
         }
         fuel.setNumberDensities({nuc: v / vFrac for nuc, v in refDict.items()})
 
-        # test number density
-        cur = self.block.getPuN()
-        ndens = 0.0
-        for nucName in refDict.keys():
-            if nucName in ["PU238", "PU239", "PU240", "PU241", "PU242"]:
-                ndens += self.block.getNumberDensity(nucName)
-        ref = ndens
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
-
         # test moles
         cur = self.block.getPuMoles()
         ndens = 0.0

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -760,10 +760,6 @@ class TestMiscMethods(unittest.TestCase):
         report = self.obj.setComponentDimensionsReport()
         self.assertEqual(len(report), len(self.obj))
 
-    def test_printDensities(self):
-        lines = self.obj.printDensities()
-        self.assertEqual(len(lines), len(self.obj.getNuclides()))
-
     def test_getAtomicWeight(self):
         weight = self.obj.getAtomicWeight()
         self.assertTrue(50 < weight < 100)

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -18,6 +18,19 @@ API Changes
 #. Removed unused methods: ``Reactor.getAllNuclidesIn()``, ``plotTriangleFlux()``. (`PR#1656 <https://github.com/terrapower/armi/pull/1656>`_)
 #. Removed ``armi.utils.dochelpers``; not relevant to nuclear modeling. (`PR#1662 <https://github.com/terrapower/armi/pull/1662>`_)
 #. Removing old tools created to help people convert to the current database format: ``armi.bookkeeping.db.convertDatabase()`` and ``ConvertDB``. (`PR#1658 <https://github.com/terrapower/armi/pull/1658>`_)
+#. Removing extraneous ``ArmiOjbect`` methods. (`PR#1667 <https://github.com/terrapower/armi/pull/1667>`_)
+    * Moving ``ArmiObject.getBoronMassEnrich()`` to ``Block``.
+    * Moving ``ArmiObject.getPuMoles()`` to ``Block``.
+    * Moving ``ArmiObject.getUraniumMassEnrich()`` to ``Block``.
+    * Removing ``ArmiObject.getMaxUraniumMassEnrich.()``.
+    * Removing ``ArmiObject.getMaxVolume()`` & ``Block.getMaxVolume()``.
+    * Removing ``ArmiObject.getPuFrac()``.
+    * Removing ``ArmiObject.getPuMass()``.
+    * Removing ``ArmiObject.getPuN()``.
+    * Removing ``ArmiObject.getZrFrac()``.
+    * Removing ``ArmiObject.printDensities()``.
+    * Moving ``Composite.isOnWhichSymmetryLine()`` to ``Assembly``.
+    * Removed ``Block.isOnWhichSymmetryLine()``.
 #. TBD
 
 Bug Fixes

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -30,7 +30,7 @@ API Changes
     * Removing ``ArmiObject.getZrFrac()``.
     * Removing ``ArmiObject.printDensities()``.
     * Moving ``Composite.isOnWhichSymmetryLine()`` to ``Assembly``.
-    * Removed ``Block.isOnWhichSymmetryLine()``.
+    * Removing ``Block.isOnWhichSymmetryLine()``.
 #. TBD
 
 Bug Fixes


### PR DESCRIPTION
## What is the change?

Removing extraneous `ArmiOjbect` methods:

* Moving `ArmiObject.getBoronMassEnrich()` to `Block`
* Moving `ArmiObject.getPuMoles()` to `Block`
* Moving `ArmiObject.getUraniumMassEnrich()` to `Block`
* Removing `ArmiObject.getMaxUraniumMassEnrich.()`
* Removing `ArmiObject.getMaxVolume()` & `Block.getMaxVolume()`
* Removing `ArmiObject.getPuFrac()`
* Removing `ArmiObject.getPuMass()`
* Removing `ArmiObject.getPuN()`
* Removing `ArmiObject.getZrFrac()`
* Removing `ArmiObject.printDensities()`
* Moving `Composite.isOnWhichSymmetryLine()` to `Assembly`
* Removing `Block.isOnWhichSymmetryLine()`

## Why is the change being made?

There are several methods in `ArmiObject` (and `Composite`) that seem a little too specific to be included everywhere in the ARMI object tree.  And after doing some research, some of them are entirely unused anyway.

Close #1375


---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.