### PR TITLE
Add qualified_code option to all impl and test tags

### DIFF
--- a/armi/__init__.py
+++ b/armi/__init__.py
@@ -121,6 +121,7 @@ def init(choice=None, fName=None, cs=None):
     .. impl:: Settings are used to define an ARMI run.
         :id: I_ARMI_SETTING1
         :implements: R_ARMI_SETTING
+        :qualified_code: Nala
 
         This method initializes an ARMI run, and if successful returns an Operator.
         That operator is designed to drive the reactor simulation through time steps to

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -48,6 +48,7 @@ class App:
     .. impl:: An App has a plugin manager.
         :id: I_ARMI_APP_PLUGINS
         :implements: R_ARMI_APP_PLUGINS
+        :qualified_code: Nala
 
         The App class is intended to be subclassed in order to customize the functionality
         and look-and-feel of the ARMI Framework for a specific use case. An App contains a
@@ -131,6 +132,7 @@ class App:
         .. impl:: Applications will not allow duplicate settings.
             :id: I_ARMI_SETTINGS_UNIQUE
             :implements: R_ARMI_SETTINGS_UNIQUE
+            :qualified_code: Nala
 
             Each ARMI application includes a collection of Plugins. Among other
             things, these plugins can register new settings in addition to

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -112,6 +112,7 @@ class Database3:
     .. impl:: The database files are H5, and thus language agnostic.
         :id: I_ARMI_DB_H51
         :implements: R_ARMI_DB_H5
+        :qualified_code: Nala
 
         This class implements a light wrapper around H5 files, so they can be used to
         store ARMI outputs. H5 files are commonly used in scientific applications in
@@ -234,6 +235,7 @@ class Database3:
         .. impl:: Add system attributes to the database.
             :id: I_ARMI_DB_QA
             :implements: R_ARMI_DB_QA
+            :qualified_code: Nala
 
             This method writes some basic system information to the H5 file. This is
             designed as a starting point, so users can see information about the system
@@ -470,6 +472,7 @@ class Database3:
         .. impl:: The run settings are saved the settings file.
             :id: I_ARMI_DB_CS
             :implements: R_ARMI_DB_CS
+            :qualified_code: Nala
 
             A ``Settings`` object is passed into this method, and then the settings are
             converted into a YAML string stream. That stream is then written to the H5
@@ -479,6 +482,7 @@ class Database3:
         .. impl:: The reactor blueprints are saved the settings file.
             :id: I_ARMI_DB_BP
             :implements: R_ARMI_DB_BP
+            :qualified_code: Nala
 
             A ``Blueprints`` string is optionally passed into this method, and then
             written to the H5 file. If it is not passed in, this method will attempt to
@@ -710,6 +714,7 @@ class Database3:
         .. impl:: Users can load a reactor from a DB.
             :id: I_ARMI_DB_R_LOAD
             :implements: R_ARMI_DB_R_LOAD
+            :qualified_code: Nala
 
             This method creates a ``Reactor`` object by reading the reactor state out
             of an ARMI database file. This is done by passing in mandatory arguements

--- a/armi/bookkeeping/db/databaseInterface.py
+++ b/armi/bookkeeping/db/databaseInterface.py
@@ -225,6 +225,7 @@ class DatabaseInterface(interfaces.Interface):
         .. impl:: Runs at a particular timenode can be re-instantiated for a snapshot.
             :id: I_ARMI_SNAPSHOT_RESTART
             :implements: R_ARMI_SNAPSHOT_RESTART
+            :qualified_code: Nala
 
             This method loads the state of a reactor from a particular point in time
             from a standard ARMI

--- a/armi/bookkeeping/db/layout.py
+++ b/armi/bookkeeping/db/layout.py
@@ -386,6 +386,7 @@ class Layout:
         .. impl:: Write data to the DB for a given time step.
             :id: I_ARMI_DB_TIME
             :implements: R_ARMI_DB_TIME
+            :qualified_code: Nala
 
             This method writes a snapshot of the current state of the reactor to the
             database. It takes a pointer to an existing HDF5 file as input, and it

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -99,6 +99,7 @@ class HistoryTrackerInterface(interfaces.Interface):
         than the database.
         :id: I_ARMI_HIST_TRACK
         :implements: R_ARMI_HIST_TRACK
+        :qualified_code: Nala
 
         This is a special :py:class:`Interface <armi.interfaces.Interface>` that is
         designed to store assembly and cross section data throughout time. This is done

--- a/armi/bookkeeping/snapshotInterface.py
+++ b/armi/bookkeeping/snapshotInterface.py
@@ -48,6 +48,7 @@ class SnapshotInterface(interfaces.Interface):
     .. impl:: Save extra data to be saved from a run, at specified time nodes.
         :id: I_ARMI_SNAPSHOT0
         :implements: R_ARMI_SNAPSHOT
+        :qualified_code: Nala
 
         This is a special :py:class:`Interface <armi.interfaces.Interface>` that is
         designed to run along all the other Interfaces during a simulation, to save off

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -335,6 +335,7 @@ class Case:
         .. impl:: The case class allows for a generic ARMI simulation.
             :id: I_ARMI_CASE
             :implements: R_ARMI_CASE
+            :qualified_code: Nala
 
             This method is responsible for "running" the ARMI simulation
             instigated by the inputted settings. This initializes an
@@ -568,6 +569,7 @@ class Case:
         .. impl:: Perform validity checks on case inputs.
             :id: I_ARMI_CASE_CHECK
             :implements: R_ARMI_CASE_CHECK
+            :qualified_code: Nala
 
             This method checks the validity of the current settings. It relies
             on an :py:class:`~armi.operators.settingsValidation.Inspector`

--- a/armi/cases/inputModifiers/inputModifiers.py
+++ b/armi/cases/inputModifiers/inputModifiers.py
@@ -21,6 +21,7 @@ class InputModifier:
     .. impl:: A generic tool to modify user inputs on multiple cases.
         :id: I_ARMI_CASE_MOD1
         :implements: R_ARMI_CASE_MOD
+        :qualified_code: Nala
 
         This class serves as an abstract base class for modifying the inputs of
         a case, typically case settings. Child classes must implement a

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -47,6 +47,7 @@ class CaseSuite:
     .. impl:: CaseSuite allows for one case to start after another completes.
         :id: I_ARMI_CASE_SUITE
         :implements: R_ARMI_CASE_SUITE
+        :qualified_code: Nala
 
         The CaseSuite object allows multiple, often related,
         :py:class:`~armi.cases.case.Case` objects to be run sequentially. A CaseSuite

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -48,6 +48,7 @@ class SuiteBuilder:
     .. impl:: A generic tool to modify user inputs on multiple cases.
         :id: I_ARMI_CASE_MOD0
         :implements: R_ARMI_CASE_MOD
+        :qualified_code: Nala
 
         This class provides the capability to create a
         :py:class:`~armi.cases.suite.CaseSuite` based on programmatic

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -107,6 +107,7 @@ class ArmiCLI:
     .. impl:: The basic ARMI CLI, for running a simulation.
         :id: I_ARMI_CLI_CS
         :implements: R_ARMI_CLI_CS
+        :qualified_code: Nala
 
         Provides a basic command-line interface (CLI) for running an ARMI simulation. Available
         commands can be listed with ``-l``. Information on individual commands can be obtained by

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -57,6 +57,7 @@ class EntryPoint:
     .. impl:: Generic CLI base class for developers to use.
         :id: I_ARMI_CLI_GEN
         :implements: R_ARMI_CLI_GEN
+        :qualified_code: Nala
 
         Provides a base class for plugin developers to use in creating application-specific CLIs.
         Valid subclasses must at least provide a ``name`` class attribute.

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -48,6 +48,7 @@ class STACK_ORDER:  # noqa: invalid-class-name
     .. impl:: Define an ordered list of interfaces.
         :id: I_ARMI_OPERATOR_INTERFACES0
         :implements: R_ARMI_OPERATOR_INTERFACES
+        :qualified_code: Nala
 
         At each time node during a simulation, an ordered colletion of Interfaces
         are run (referred to as the interface stack). But ARMI does not force the order upon the analyst.
@@ -90,6 +91,7 @@ class TightCoupler:
     .. impl:: The TightCoupler defines the convergence criteria for physics coupling.
         :id: I_ARMI_OPERATOR_PHYSICS0
         :implements: R_ARMI_OPERATOR_PHYSICS
+        :qualified_code: Nala
 
         During a simulation, the developers of an ARMI application frequently want to
         iterate on some physical calculation until that calculation has converged to
@@ -259,6 +261,7 @@ class Interface:
     .. impl:: The interface shall allow code execution at important operational points in time.
         :id: I_ARMI_INTERFACE
         :implements: R_ARMI_INTERFACE
+        :qualified_code: Nala
 
         The Interface class defines a number methods with names like ``interact***``.
         These methods are called in order at each time node. This allows for an

--- a/armi/materials/__init__.py
+++ b/armi/materials/__init__.py
@@ -52,6 +52,7 @@ def setMaterialNamespaceOrder(order):
         of duplicates.
         :id: I_ARMI_MAT_ORDER
         :implements: R_ARMI_MAT_ORDER
+        :qualified_code: Nala
 
         An ARMI application will need materials. Materials can be imported from
         any code the application has access to, like plugin packages. This leads to
@@ -144,6 +145,7 @@ def resolveMaterialClassByName(name: str, namespaceOrder: List[str] = None):
     .. impl:: Materials can be searched across packages in a defined namespace.
         :id: I_ARMI_MAT_NAMESPACE
         :implements: R_ARMI_MAT_NAMESPACE
+        :qualified_code: Nala
 
         During the runtime of an ARMI application, but particularly during the
         construction of the reactor in memory, materials will be requested by name. At

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -39,6 +39,7 @@ class Material:
     .. impl:: The abstract material class.
         :id: I_ARMI_MAT_PROPERTIES
         :implements: R_ARMI_MAT_PROPERTIES
+        :qualified_code: Nala
 
         The ARMI Materials library is based on the Object-Oriented Programming design
         approach, and uses this generic ``Material`` base class. In this class we
@@ -49,6 +50,7 @@ class Material:
     .. impl:: Materials generate nuclide mass fractions at instantiation.
         :id: I_ARMI_MAT_FRACS
         :implements: R_ARMI_MAT_FRACS
+        :qualified_code: Nala
 
         An ARMI material is meant to be able to represent real world materials that
         might be used in the construction of a nuclear reactor. As such, they are
@@ -121,6 +123,7 @@ class Material:
         .. impl:: The name of a material is accessible.
             :id: I_ARMI_MAT_NAME
             :implements: R_ARMI_MAT_NAME
+            :qualified_code: Nala
 
             Every instance of an ARMI material must have a simple, human-readable
             string name. And, if possible, we want this string to match the class
@@ -743,6 +746,7 @@ class Fluid(Material):
         .. impl:: Fluid materials are not thermally expandable.
             :id: I_ARMI_MAT_FLUID
             :implements: R_ARMI_MAT_FLUID
+            :qualified_code: Nala
 
             ARMI does not model thermal expansion of fluids. The ``Fluid`` superclass
             therefore sets the thermal expansion coefficient to zero. All fluids

--- a/armi/materials/void.py
+++ b/armi/materials/void.py
@@ -26,6 +26,7 @@ class Void(material.Fluid):
     .. impl:: Define a void material with zero density.
         :id: I_ARMI_MAT_VOID
         :implements: R_ARMI_MAT_VOID
+        :qualified_code: Nala
 
         To help with expansion, it is sometimes useful to put a small section of void
         material into the reactor model. This is not meant to represent a true void,

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -19,6 +19,7 @@ and applications.
 .. impl:: A tool for querying basic data for elements of the periodic table.
     :id: I_ARMI_ND_ELEMENTS0
     :implements: R_ARMI_ND_ELEMENTS
+    :qualified_code: Nala
 
     The :py:mod:`elements <armi.nucDirectory.elements>` module defines the
     :py:class:`Element <armi.nucDirectory.elements.Element>` class which acts as
@@ -171,6 +172,7 @@ class Element:
         .. impl:: An element of the periodic table.
             :id: I_ARMI_ND_ELEMENTS1
             :implements: R_ARMI_ND_ELEMENTS
+            :qualified_code: Nala
 
             The :py:class:`Element <armi.nucDirectory.elements.Element>` class
             acts as a data structure for organizing information about an

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -18,6 +18,7 @@ framework and applications.
 .. impl:: Isotopes and isomers can be queried by name, label, MC2-3 ID, MCNP ID, and AAAZZZS ID.
     :id: I_ARMI_ND_ISOTOPES0
     :implements: R_ARMI_ND_ISOTOPES
+    :qualified_code: Nala
 
     The :py:mod:`nuclideBases <armi.nucDirectory.nuclideBases>` module defines
     the :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
@@ -498,6 +499,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
     .. impl:: Isotopes and isomers can be queried by name and label.
         :id: I_ARMI_ND_ISOTOPES1
         :implements: R_ARMI_ND_ISOTOPES
+        :qualified_code: Nala
 
         The :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
         class provides a data structure for information about a single nuclide,
@@ -582,6 +584,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
         .. impl:: Isotopes and isomers can be queried by MC2-2 ID.
             :id: I_ARMI_ND_ISOTOPES2
             :implements: R_ARMI_ND_ISOTOPES
+            :qualified_code: Nala
 
             This method returns the ``mcc2id`` attribute of a
             :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
@@ -596,6 +599,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
         .. impl:: Isotopes and isomers can be queried by MC2-3 ID.
             :id: I_ARMI_ND_ISOTOPES3
             :implements: R_ARMI_ND_ISOTOPES
+            :qualified_code: Nala
 
             This method returns the ``mcc3id`` attribute of a
             :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
@@ -611,6 +615,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
         .. impl:: Isotopes and isomers can be queried by MCNP ID.
             :id: I_ARMI_ND_ISOTOPES4
             :implements: R_ARMI_ND_ISOTOPES
+            :qualified_code: Nala
 
             This method generates the MCNP ID for an isotope using the standard
             MCNP format based on the atomic number A, number of protons Z, and
@@ -646,6 +651,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
         .. impl:: Isotopes and isomers can be queried by AAAZZZS ID.
             :id: I_ARMI_ND_ISOTOPES5
             :implements: R_ARMI_ND_ISOTOPES
+            :qualified_code: Nala
 
             This method generates the AAAZZZS format ID for an isotope. Where
             AAA is the mass number, ZZZ is the atomic number, and S is the
@@ -1195,6 +1201,7 @@ def addNuclideBases():
     .. impl:: Separating natural abundance data from code.
         :id: I_ARMI_ND_DATA0
         :implements: R_ARMI_ND_DATA
+        :qualified_code: Nala
 
         This function reads the ``nuclides.dat`` file from the ARMI resources
         folder. This file contains metadata for 4,614 nuclides, including
@@ -1264,6 +1271,7 @@ def readMCCNuclideData():
     .. impl:: Separating MCC data from code.
         :id: I_ARMI_ND_DATA1
         :implements: R_ARMI_ND_DATA
+        :qualified_code: Nala
 
         This function reads the mcc-nuclides.yaml file from the ARMI resources
         folder. This file contains the MC\ :sup:`2`-2 ID (from ENDF/B-V.2) and MC\ :sup:`2`-3 ID
@@ -1297,6 +1305,7 @@ def updateNuclideBasesForSpecialCases():
     .. impl:: The special case name Am242g is supported.
         :id: I_ARMI_ND_ISOTOPES6
         :implements: R_ARMI_ND_ISOTOPES
+        :qualified_code: Nala
 
         This function updates the keys for the :py:class:`NuclideBase
         <armi.nucDirectory.nuclideBases.NuclideBase>` instances for Am-242m and

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -24,6 +24,7 @@ for reactor physics codes.
                  R_ARMI_NUCDATA_DIF3D,
                  R_ARMI_NUCDATA_PMATRX,
                  R_ARMI_NUCDATA_DLAYXS
+    :qualified_code: Nala
 
     This module provides a number of base classes that implement general
     capabilities for binary and ASCII file I/O. The :py:class:`IORecord` serves

--- a/armi/nuclearDataIO/cccc/dif3d.py
+++ b/armi/nuclearDataIO/cccc/dif3d.py
@@ -204,6 +204,7 @@ class Dif3dStream(cccc.StreamWithDataContainer):
         .. impl:: Tool to read and write DIF3D files.
             :id: I_ARMI_NUCDATA_DIF3D
             :implements: R_ARMI_NUCDATA_DIF3D
+            :qualified_code: Nala
 
             The reading and writing of the DIF3D binary file is performed using
             :py:class:`StreamWithDataContainer <.cccc.StreamWithDataContainer>`

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -229,6 +229,7 @@ class DlayxsIO(cccc.Stream):
         .. impl:: Tool to read and write DLAYXS files.
             :id: I_ARMI_NUCDATA_DLAYXS
             :implements: R_ARMI_NUCDATA_DLAYXS
+            :qualified_code: Nala
 
             Reading and writing DLAYXS delayed neutron data files is performed
             using the general nuclear data I/O functionalities described in

--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -21,6 +21,7 @@ contained within a :py:class:`~armi.nuclearDataIO.xsLibraries.XSLibrary`.
 .. impl:: Tool to read and write GAMISO files.
     :id: I_ARMI_NUCDATA_GAMISO
     :implements: R_ARMI_NUCDATA_GAMISO
+    :qualified_code: Nala
 
     The majority of the functionality in this module is inherited from the
     :py:mod:`~armi.nuclearDataIO.cccc.isotxs` module. See

--- a/armi/nuclearDataIO/cccc/geodst.py
+++ b/armi/nuclearDataIO/cccc/geodst.py
@@ -136,6 +136,7 @@ class GeodstStream(cccc.StreamWithDataContainer):
         .. impl:: Tool to read and write GEODST files.
             :id: I_ARMI_NUCDATA_GEODST
             :implements: R_ARMI_NUCDATA_GEODST
+            :qualified_code: Nala
 
             Reading and writing GEODST files is performed using the general
             nuclear data I/O functionalities described in

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -268,6 +268,7 @@ class IsotxsIO(cccc.Stream):
         .. impl:: Tool to read and write ISOTXS files.
             :id: I_ARMI_NUCDATA_ISOTXS
             :implements: R_ARMI_NUCDATA_ISOTXS
+            :qualified_code: Nala
 
             Reading and writing ISOTXS files is performed using the general
             nuclear data I/O functionalities described in

--- a/armi/nuclearDataIO/cccc/pmatrx.py
+++ b/armi/nuclearDataIO/cccc/pmatrx.py
@@ -189,6 +189,7 @@ class PmatrxIO(cccc.Stream):
         .. impl:: Tool to read and write PMATRX files.
             :id: I_ARMI_NUCDATA_PMATRX
             :implements: R_ARMI_NUCDATA_PMATRX
+            :qualified_code: Nala
 
             Reading and writing PMATRX files is performed using the general
             nuclear data I/O functionalities described in

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -790,6 +790,7 @@ def computeMacroscopicGroupConstants(
     .. impl:: Compute macroscopic cross sections from microscopic cross sections and number densities.
         :id: I_ARMI_NUCDATA_MACRO
         :implements: R_ARMI_NUCDATA_MACRO
+        :qualified_code: Nala
 
         This function computes the macroscopic cross sections of a specified
         reaction type from inputted microscopic cross sections and number

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -80,6 +80,7 @@ class Operator:
     .. impl:: An operator will have a reactor object to communicate between plugins.
         :id: I_ARMI_OPERATOR_COMM
         :implements: R_ARMI_OPERATOR_COMM
+        :qualified_code: Nala
 
         A major design feature of ARMI is that the Operator orchestrates the
         simulation, and as part of that, the Operator has access to the
@@ -93,6 +94,7 @@ class Operator:
     .. impl:: An operator is built from user settings.
         :id: I_ARMI_OPERATOR_SETTINGS
         :implements: R_ARMI_OPERATOR_SETTINGS
+        :qualified_code: Nala
 
         A major design feature of ARMI is that a run is built from user settings.
         In code, this means that a case ``Settings`` object is passed into this
@@ -203,6 +205,7 @@ class Operator:
         .. impl:: Calculate step lengths from cycles and burn steps.
             :id: I_ARMI_FW_HISTORY
             :implements: R_ARMI_FW_HISTORY
+            :qualified_code: Nala
 
             In all computational modeling of physical systems, it is
             necessary to break time into discrete chunks. In reactor
@@ -668,6 +671,7 @@ class Operator:
         .. impl:: Physics coupling is driven from Operator.
             :id: I_ARMI_OPERATOR_PHYSICS1
             :implements: R_ARMI_OPERATOR_PHYSICS
+            :qualified_code: Nala
 
             This method runs all the interfaces that are defined as part
             of the tight physics coupling of the reactor. Then it returns
@@ -965,6 +969,7 @@ class Operator:
         .. impl:: An operator will expose an ordered list of interfaces.
             :id: I_ARMI_OPERATOR_INTERFACES
             :implements: R_ARMI_OPERATOR_INTERFACES
+            :qualified_code: Nala
 
             This method returns an ordered list of instances of the Interface
             class. This list is useful because at any time node in the

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -18,6 +18,7 @@ The MPI-aware variant of the standard ARMI operator.
 .. impl:: There is an MPI-aware variant of the ARMI Operator.
     :id: I_ARMI_OPERATOR_MPI
     :implements: R_ARMI_OPERATOR_MPI
+    :qualified_code: Nala
 
     This sets up the main Operator on the primary MPI node and initializes
     worker processes on all other MPI nodes. At certain points in the run,

--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -49,6 +49,7 @@ class Query:
     .. impl:: Rules to validate and customize a setting's behavior.
         :id: I_ARMI_SETTINGS_RULES
         :implements: R_ARMI_SETTINGS_RULES
+        :qualified_code: Nala
 
         This class is meant to represent a generic validation test against a setting.
         The goal is: developers create new settings and they want to make sure those

--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -32,6 +32,7 @@ class ExecutionOptions:
     .. impl:: Options for executing external calculations.
         :id: I_ARMI_EX0
         :implements: R_ARMI_EX
+        :qualified_code: Nala
 
         Implements a basic container to hold and report options to be used in
         the execution of an external code (see :need:`I_ARMI_EX1`).
@@ -187,6 +188,7 @@ class DefaultExecuter(Executer):
     .. impl:: Default tool for executing external calculations.
         :id: I_ARMI_EX1
         :implements: R_ARMI_EX
+        :qualified_code: Nala
 
         Facilitates the execution of external calculations by accepting ``options`` (an
         :py:class:`~armi.physics.executers.ExecutionOptions` object) and providing

--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -35,6 +35,7 @@ class FuelHandlerInterface(interfaces.Interface):
     .. impl:: ARMI provides a shuffle logic interface.
         :id: I_ARMI_SHUFFLE
         :implements: R_ARMI_SHUFFLE
+        :qualified_code: Nala
 
         This interface allows for a user to define custom shuffle logic that
         modifies to the core model. Being based on the :py:class:`~armi.interfaces.Interface`

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -727,6 +727,7 @@ class FuelHandler:
         .. impl:: Assemblies can be moved from one place to another.
             :id: I_ARMI_SHUFFLE_MOVE
             :implements: R_ARMI_SHUFFLE_MOVE
+            :qualified_code: Nala
 
             For the two assemblies that are passed in, call to their :py:meth:`~armi.reactor.assemblies.Assembly.moveTo`
             methods to transfer their underlying ``spatialLocator`` attributes to
@@ -736,6 +737,7 @@ class FuelHandler:
         .. impl:: User-specified blocks can be left in place during within-core swaps.
             :id: I_ARMI_SHUFFLE_STATIONARY0
             :implements: R_ARMI_SHUFFLE_STATIONARY
+            :qualified_code: Nala
 
             Before assemblies are moved,
             the ``_transferStationaryBlocks`` class method is called to
@@ -844,6 +846,7 @@ class FuelHandler:
         .. impl:: User-specified blocks can be left in place for the discharge swap.
             :id: I_ARMI_SHUFFLE_STATIONARY1
             :implements: R_ARMI_SHUFFLE_STATIONARY
+            :qualified_code: Nala
 
             Before assemblies are moved, the ``_transferStationaryBlocks`` class method is called to
             check if there are any block types specified by the user as stationary via the

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -319,6 +319,7 @@ class AverageBlockCollection(BlockCollection):
     .. impl:: Create representative blocks using volume-weighted averaging.
         :id: I_ARMI_XSGM_CREATE_REPR_BLOCKS0
         :implements: R_ARMI_XSGM_CREATE_REPR_BLOCKS
+        :qualified_code: Nala
 
         This class constructs new blocks from an existing block list based on a
         volume-weighted average. Inheriting functionality from the abstract
@@ -519,6 +520,7 @@ class CylindricalComponentsAverageBlockCollection(BlockCollection):
     .. impl:: Create representative blocks using custom cylindrical averaging.
         :id: I_ARMI_XSGM_CREATE_REPR_BLOCKS1
         :implements: R_ARMI_XSGM_CREATE_REPR_BLOCKS
+        :qualified_code: Nala
 
         This class constructs representative blocks based on a volume-weighted average
         using cylindrical blocks from an existing block list. Inheriting functionality from the abstract
@@ -859,6 +861,7 @@ class CrossSectionGroupManager(interfaces.Interface):
             BOL.
             :id: I_ARMI_XSGM_FREQ0
             :implements: R_ARMI_XSGM_FREQ
+            :qualified_code: Nala
 
             This method sets the cross-section block averaging method and and logic for whether all
             blocks in a cross section group should be used when generating a representative block.
@@ -893,6 +896,7 @@ class CrossSectionGroupManager(interfaces.Interface):
             BOC.
             :id: I_ARMI_XSGM_FREQ1
             :implements: R_ARMI_XSGM_FREQ
+            :qualified_code: Nala
 
             This method updates representative blocks and block burnups at the beginning-of-cycle
             for each cross-section ID if the control logic for lattice physics frequency updates is
@@ -922,6 +926,7 @@ class CrossSectionGroupManager(interfaces.Interface):
             every time node.
             :id: I_ARMI_XSGM_FREQ2
             :implements: R_ARMI_XSGM_FREQ
+            :qualified_code: Nala
 
             This method updates representative blocks and block burnups at every node for each
             cross-section ID if the control logic for lattices physics frequency updates is set for
@@ -941,6 +946,7 @@ class CrossSectionGroupManager(interfaces.Interface):
             during coupling.
             :id: I_ARMI_XSGM_FREQ3
             :implements: R_ARMI_XSGM_FREQ
+            :qualified_code: Nala
 
             This method updates representative blocks and block burnups at every node and the first
             coupled iteration for each cross-section ID if the control logic for lattices physics
@@ -1133,6 +1139,7 @@ class CrossSectionGroupManager(interfaces.Interface):
         .. impl:: Create collections of blocks based on cross-section type and burn-up group.
             :id: I_ARMI_XSGM_CREATE_XS_GROUPS
             :implements: R_ARMI_XSGM_CREATE_XS_GROUPS
+            :qualified_code: Nala
 
             This method constructs the representative blocks and block burnups
             for each cross-section ID in the reactor model. Starting with the making of cross-section groups, it will

--- a/armi/physics/neutronics/energyGroups.py
+++ b/armi/physics/neutronics/energyGroups.py
@@ -37,6 +37,7 @@ def getFastFluxGroupCutoff(eGrpStruc):
     .. impl:: Return the energy group index which contains a given energy threshold.
         :id: I_ARMI_EG_FE
         :implements: R_ARMI_EG_FE
+        :qualified_code: Nala
 
         This function returns the energy group within a given group structure
         that contains the fast flux threshold energy. The threshold energy is
@@ -86,6 +87,7 @@ def getGroupStructure(name):
     .. impl:: Provide the neutron energy group bounds for a given group structure.
         :id: I_ARMI_EG_NE
         :implements: R_ARMI_EG_NE
+        :qualified_code: Nala
 
         There are several built-in group structures that are defined in this
         module, which are stored in a dictionary. This function takes a group

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -125,6 +125,7 @@ class GlobalFluxInterface(interfaces.Interface):
         .. impl:: Validate the energy generation matches user specifications.
             :id: I_ARMI_FLUX_CHECK_POWER
             :implements: R_ARMI_FLUX_CHECK_POWER
+            :qualified_code: Nala
 
             This method checks that the global power computed from flux
             evaluation matches the global power specified from the user within a
@@ -255,6 +256,7 @@ class GlobalFluxInterfaceUsingExecuters(GlobalFluxInterface):
         .. impl:: Return k-eff or assembly-wise power distribution for coupled interactions.
             :id: I_ARMI_FLUX_COUPLING_VALUE
             :implements: R_ARMI_FLUX_COUPLING_VALUE
+            :qualified_code: Nala
 
             This method either returns the k-eff or assembly-wise power
             distribution. If the :py:class:`coupler
@@ -366,6 +368,7 @@ class GlobalFluxOptions(executers.ExecutionOptions):
     .. impl:: Options for neutronics solvers.
         :id: I_ARMI_FLUX_OPTIONS
         :implements: R_ARMI_FLUX_OPTIONS
+        :qualified_code: Nala
 
         This class functions as a data structure for setting and retrieving
         execution options for performing flux evaluations, these options
@@ -557,6 +560,7 @@ class GlobalFluxExecuter(executers.DefaultExecuter):
     .. impl:: Ensure the mesh in the reactor model is appropriate for neutronics solver execution.
         :id: I_ARMI_FLUX_GEOM_TRANSFORM
         :implements: R_ARMI_FLUX_GEOM_TRANSFORM
+        :qualified_code: Nala
 
         The primary purpose of this class is perform geometric and mesh
         transformations on the reactor model to ensure a flux evaluation can
@@ -1243,6 +1247,7 @@ def computeDpaRate(mgFlux, dpaXs):
     .. impl:: Compute DPA rates.
         :id: I_ARMI_FLUX_DPA
         :implements: R_ARMI_FLUX_DPA
+        :qualified_code: Nala
 
         This method calculates DPA rates using the inputted multigroup flux and DPA cross sections.
         Displacements calculated by displacement cross-section:
@@ -1330,6 +1335,7 @@ def calcReactionRates(obj, keff, lib):
     .. impl:: Return the reaction rates for a given ArmiObject
         :id: I_ARMI_FLUX_RX_RATES
         :implements: R_ARMI_FLUX_RX_RATES
+        :qualified_code: Nala
 
         This method computes 1-group reaction rates for the inputted
         :py:class:`ArmiObject <armi.reactor.composites.ArmiObject>` These

--- a/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
+++ b/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
@@ -131,6 +131,7 @@ class CrossSectionTable(collections.OrderedDict):
         .. impl:: Generate a formatted cross section table.
             :id: I_ARMI_DEPL_TABLES1
             :implements: R_ARMI_DEPL_TABLES
+            :qualified_code: Nala
 
             Loops over the reaction rates stored as ``self`` to produce a string with the cross
             sections for each nuclide in the block. Cross sections may be populated by
@@ -177,6 +178,7 @@ def makeReactionRateTable(obj, nuclides: List = None):
         reactions.
         :id: I_ARMI_DEPL_TABLES0
         :implements: R_ARMI_DEPL_TABLES
+        :qualified_code: Nala
 
         For a given composite object ``obj`` and a list of nuclides ``nuclides`` in that object,
         call ``obj.getReactionRates()`` for each nuclide with a ``nDensity`` parameter of 1.0. If

--- a/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
+++ b/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
@@ -44,6 +44,7 @@ def isDepletable(obj: composites.ArmiObject):
     .. impl:: Determine if any component is depletable.
         :id: I_ARMI_DEPL_DEPLETABLE
         :implements: R_ARMI_DEPL_DEPLETABLE
+        :qualified_code: Nala
 
         Uses :py:meth:`~armi.reactor.composite.ArmiObject.hasFlags` or
         :py:meth:`~armi.reactor.composite.ArmiObject.containsAtLeastOneChildWithFlags`
@@ -86,6 +87,7 @@ class AbstractIsotopicDepleter:
     .. impl:: ARMI provides a base class to deplete isotopes.
         :id: I_ARMI_DEPL_ABC
         :implements: R_ARMI_DEPL_ABC
+        :qualified_code: Nala
 
         This class provides some basic infrastructure typically needed in depletion
         calculations within the ARMI framework. It stores a reactor, operator,

--- a/armi/physics/neutronics/macroXSGenerationInterface.py
+++ b/armi/physics/neutronics/macroXSGenerationInterface.py
@@ -148,6 +148,7 @@ class MacroXSGenerationInterface(interfaces.Interface):
         .. impl:: Build macroscopic cross sections for blocks.
             :id: I_ARMI_MACRO_XS
             :implements: R_ARMI_MACRO_XS
+            :qualified_code: Nala
 
             This method builds macroscopic cross sections for a user-specified
             set of blocks using a specified microscopic neutron or gamma cross

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -88,6 +88,7 @@ def defineSettings():
     .. impl:: Users to select if gamma cross sections are generated.
         :id: I_ARMI_GAMMA_XS
         :implements: R_ARMI_GAMMA_XS
+        :qualified_code: Nala
 
         A single boolean setting can be used to turn on/off the calculation of gamma
         cross sections. This is implemented with the usual boolean ``Setting`` logic.

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -145,6 +145,7 @@ class ArmiPlugin:
     .. impl:: Plugins add code to the application through interfaces.
         :id: I_ARMI_PLUGIN
         :implements: R_ARMI_PLUGIN
+        :qualified_code: Nala
 
         Each plugin has the option of implementing the ``exposeInterfaces`` method, and
         this will be used as a plugin hook to add one or more Interfaces to the ARMI
@@ -165,6 +166,7 @@ class ArmiPlugin:
         .. impl:: Plugins can add interfaces to the operator.
             :id: I_ARMI_PLUGIN_INTERFACES
             :implements: R_ARMI_PLUGIN_INTERFACES
+            :qualified_code: Nala
 
             This method takes in a Settings object and returns a list of Interfaces,
             the position of each Interface in the Interface stack, and a list of
@@ -194,6 +196,7 @@ class ArmiPlugin:
         .. impl:: Plugins can add parameters to the reactor data model.
             :id: I_ARMI_PLUGIN_PARAMS
             :implements: R_ARMI_PLUGIN_PARAMS
+            :qualified_code: Nala
 
             Through this method, plugin developers can create new Parameters. A
             parameter can represent any physical property an analyst might want to
@@ -204,6 +207,7 @@ class ArmiPlugin:
         .. impl:: Define an arbitrary physical parameter.
             :id: I_ARMI_PARAM
             :implements: R_ARMI_PARAM
+            :qualified_code: Nala
 
             Through this method, plugin developers can create new Parameters. A
             parameter can represent any physical property an analyst might want to
@@ -278,6 +282,7 @@ class ArmiPlugin:
         .. impl:: Plugins can define new, unique flags to the system.
             :id: I_ARMI_FLAG_EXTEND1
             :implements: R_ARMI_FLAG_EXTEND
+            :qualified_code: Nala
 
             This method allows a plugin developers to provide novel values for
             the Flags system. This method returns a dictionary mapping flag names
@@ -409,6 +414,7 @@ class ArmiPlugin:
         .. impl:: Plugins can add settings to the run.
             :id: I_ARMI_PLUGIN_SETTINGS
             :implements: R_ARMI_PLUGIN_SETTINGS
+            :qualified_code: Nala
 
             This hook allows plugin developers to provide their own configuration
             settings, which can participate in the

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -179,6 +179,7 @@ class Assembly(composites.Composite):
         .. impl:: Assemblies are made up of type Block.
             :id: I_ARMI_ASSEM_BLOCKS
             :implements: R_ARMI_ASSEM_BLOCKS
+            :qualified_code: Nala
 
             Adds a unique Block to the top of the Assembly. If the Block already
             exists in the Assembly, an error is raised in
@@ -227,6 +228,7 @@ class Assembly(composites.Composite):
         .. impl:: Assembly location is retrievable.
             :id: I_ARMI_ASSEM_POSI0
             :implements: R_ARMI_ASSEM_POSI
+            :qualified_code: Nala
 
             This method returns a string label indicating the location
             of an Assembly. There are three options: 1) the Assembly
@@ -251,6 +253,7 @@ class Assembly(composites.Composite):
         .. impl:: Assembly coordinates are retrievable.
             :id: I_ARMI_ASSEM_POSI1
             :implements: R_ARMI_ASSEM_POSI
+            :qualified_code: Nala
 
             In this method, the spatialLocator of an Assembly is leveraged to return
             its physical (x,y) coordinates in cm.
@@ -268,6 +271,7 @@ class Assembly(composites.Composite):
         .. impl:: Assembly area is retrievable.
             :id: I_ARMI_ASSEM_DIMS0
             :implements: R_ARMI_ASSEM_DIMS
+            :qualified_code: Nala
 
             Returns the area of the first block in the Assembly. If there are no
             blocks in the Assembly, a warning is issued and a default area of 1.0
@@ -287,6 +291,7 @@ class Assembly(composites.Composite):
         .. impl:: Assembly volume is retrievable.
             :id: I_ARMI_ASSEM_DIMS1
             :implements: R_ARMI_ASSEM_DIMS
+            :qualified_code: Nala
 
             The volume of the Assembly is calculated as the product of the
             area of the first block (via ``getArea``) and the total height
@@ -498,6 +503,7 @@ class Assembly(composites.Composite):
         .. impl:: Assembly height is retrievable.
             :id: I_ARMI_ASSEM_DIMS2
             :implements: R_ARMI_ASSEM_DIMS
+            :qualified_code: Nala
 
             The height of the Assembly is calculated by taking the sum of the
             constituent Blocks. If a ``typeSpec`` is provided, the total height
@@ -1216,6 +1222,7 @@ class Assembly(composites.Composite):
         .. impl:: Assembly dimensions are retrievable.
             :id: I_ARMI_ASSEM_DIMS3
             :implements: R_ARMI_ASSEM_DIMS
+            :qualified_code: Nala
 
             This method searches for the first Component that matches the
             given ``typeSpec`` and returns the dimension as specified by
@@ -1250,6 +1257,7 @@ class Assembly(composites.Composite):
         .. impl:: An assembly can be rotated about its z-axis.
             :id: I_ARMI_SHUFFLE_ROTATE
             :implements: R_ARMI_SHUFFLE_ROTATE
+            :qualified_code: Nala
 
             This method loops through every ``Block`` in this ``Assembly`` and rotates
             it by a given angle (in radians). The rotation angle is positive in the

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -586,6 +586,7 @@ class Block(composites.Composite):
         .. impl:: Location of a block is retrievable.
             :id: I_ARMI_BLOCK_POSI0
             :implements: R_ARMI_BLOCK_POSI
+            :qualified_code: Nala
 
             If the block does not have its ``core`` attribute set, if the block's
             parent does not have a ``spatialGrid`` attribute, or if the block
@@ -612,6 +613,7 @@ class Block(composites.Composite):
         .. impl:: Coordinates of a block are queryable.
             :id: I_ARMI_BLOCK_POSI1
             :implements: R_ARMI_BLOCK_POSI
+            :qualified_code: Nala
 
             Calls to the :py:meth:`~armi.reactor.grids.locations.IndexLocation.getGlobalCoordinates`
             method of the block's ``spatialLocator`` attribute, which recursively
@@ -699,6 +701,7 @@ class Block(composites.Composite):
         .. impl:: Volume of block is retrievable.
             :id: I_ARMI_BLOCK_DIMS0
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             Loops over all the components in the block, calling
             :py:meth:`~armi.reactor.components.component.Component.getVolume` on
@@ -1106,6 +1109,7 @@ class Block(composites.Composite):
         .. impl:: Get the number of pins in a block.
             :id: I_ARMI_BLOCK_NPINS
             :implements: R_ARMI_BLOCK_NPINS
+            :qualified_code: Nala
 
             Uses some simple criteria to infer the number of pins in the block.
 
@@ -1274,6 +1278,7 @@ class Block(composites.Composite):
         .. impl:: Pitch of block is retrievable.
             :id: I_ARMI_BLOCK_DIMS1
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             Uses the block's ``_pitchDefiningComponent`` to identify the component
             in the block that defines the pitch. Then uses the
@@ -1607,6 +1612,7 @@ class Block(composites.Composite):
         .. impl:: Set the target axial expansion components on a given block.
             :id: I_ARMI_MANUAL_TARG_COMP
             :implements: R_ARMI_MANUAL_TARG_COMP
+            :qualified_code: Nala
 
             Sets the ``axialExpTargetComponent`` parameter on the block to the name
             of the Component which is passed in. This is then used by the
@@ -1661,6 +1667,7 @@ class HexBlock(Block):
     .. impl:: ARMI has the ability to create hex shaped blocks.
         :id: I_ARMI_BLOCK_HEX
         :implements: R_ARMI_BLOCK_HEX
+        :qualified_code: Nala
 
         This class defines hexagonal-shaped Blocks. It inherits functionality from the parent
         class, Block, and defines hexagonal-specific methods including, but not limited to,
@@ -1680,6 +1687,7 @@ class HexBlock(Block):
         .. impl:: Coordinates of a block are queryable.
             :id: I_ARMI_BLOCK_POSI2
             :implements: R_ARMI_BLOCK_POSI
+            :qualified_code: Nala
 
             Calls to the :py:meth:`~armi.reactor.grids.locations.IndexLocation.getGlobalCoordinates`
             method of the block's ``spatialLocator`` attribute, which recursively
@@ -1704,6 +1712,7 @@ class HexBlock(Block):
         .. impl:: Block compositions can be homogenized.
             :id: I_ARMI_BLOCK_HOMOG
             :implements: R_ARMI_BLOCK_HOMOG
+            :qualified_code: Nala
 
             This method creates and returns a homogenized representation of itself in the form of a new Block.
             The homogenization occurs in the following manner. A single Hexagon Component is created
@@ -1804,6 +1813,7 @@ class HexBlock(Block):
         .. impl:: Area of block is retrievable.
             :id: I_ARMI_BLOCK_DIMS2
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             This method first retrieves the pitch of the hexagonal Block
             (:need:`I_ARMI_UTIL_HEXAGON0`) and then leverages the
@@ -1822,6 +1832,7 @@ class HexBlock(Block):
         .. impl:: IP dimension is retrievable.
             :id: I_ARMI_BLOCK_DIMS3
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             This method retrieves the duct Component and quieries
             it's inner pitch directly. If the duct is missing or if there
@@ -1837,6 +1848,7 @@ class HexBlock(Block):
         .. impl:: OP dimension is retrievable.
             :id: I_ARMI_BLOCK_DIMS4
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             This method retrieves the duct Component and quieries
             its outer pitch directly. If the duct is missing or if there
@@ -2145,6 +2157,7 @@ class HexBlock(Block):
         .. impl:: Pin to duct gap of block is retrievable.
             :id: I_ARMI_BLOCK_DIMS5
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             Requires that the outer most duct be Hexagonal and wire and clad Components
             be present. The flat-to-flat distance between the radial exterior of opposing
@@ -2337,6 +2350,7 @@ class HexBlock(Block):
         .. impl:: Pin pitch within block is retrievable.
             :id: I_ARMI_BLOCK_DIMS6
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             This implementation requires that clad and wire Components are present.
             If not, an error is raised. If present, the pin pitch is calculated
@@ -2379,6 +2393,7 @@ class HexBlock(Block):
         .. impl:: Wetted perimeter of block is retrievable.
             :id: I_ARMI_BLOCK_DIMS7
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             This implementation computes wetted perimeters for specific Components, as specified
             by their Flags (:need:`R_ARMI_FLAG_DEFINE`). Hollow hexagons and circular pin Components
@@ -2487,6 +2502,7 @@ class HexBlock(Block):
         .. impl:: Flow area of block is retrievable.
             :id: I_ARMI_BLOCK_DIMS8
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             Retrieving the flow area requires that there be a single coolant Component.
             If available, the area is calculated (:need:`I_ARMI_COMP_VOL0`).
@@ -2505,6 +2521,7 @@ class HexBlock(Block):
         .. impl:: Hydraulic diameter of block is retrievable.
             :id: I_ARMI_BLOCK_DIMS9
             :implements: R_ARMI_BLOCK_DIMS
+            :qualified_code: Nala
 
             The hydraulic diamter is calculated via
 

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -79,6 +79,7 @@ class MaterialModifications(yamlize.Map):
     .. impl:: User-impact on material definitions.
         :id: I_ARMI_MAT_USER_INPUT0
         :implements: R_ARMI_MAT_USER_INPUT
+        :qualified_code: Nala
 
         Defines a yaml map attribute for the assembly portion of the blueprints
         (see :py:class:`~armi.blueprints.assemblyBlueprint.AssemblyBlueprint`) that
@@ -118,6 +119,7 @@ class AssemblyBlueprint(yamlize.Object):
     .. impl:: Create assembly from blueprint file.
         :id: I_ARMI_BP_ASSEM
         :implements: R_ARMI_BP_ASSEM
+        :qualified_code: Nala
 
         Defines a yaml construct that allows the user to specify attributes of an
         assembly from within their blueprints file, including a name, flags, specifier

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -47,6 +47,7 @@ class BlockBlueprint(yamlize.KeyedList):
     .. impl:: Create a Block from blueprint file.
         :id: I_ARMI_BP_BLOCK
         :implements: R_ARMI_BP_BLOCK
+        :qualified_code: Nala
 
         Defines a yaml construct that allows the user to specify attributes of a
         block from within their blueprints file, including a name, flags, a radial

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -123,6 +123,7 @@ class ComponentBlueprint(yamlize.Object):
     .. impl:: Construct component from blueprint file.
         :id: I_ARMI_BP_COMP
         :implements: R_ARMI_BP_COMP
+        :qualified_code: Nala
 
         Defines a yaml construct that allows the user to specify attributes of a
         component from within their blueprints file, including a name, flags, shape,
@@ -191,6 +192,7 @@ class ComponentBlueprint(yamlize.Object):
         .. impl:: User-defined on material alterations are applied here.
             :id: I_ARMI_MAT_USER_INPUT1
             :implements: R_ARMI_MAT_USER_INPUT
+            :qualified_code: Nala
 
             Allows for user input to impact a component's materials by applying
             the "material modifications" section of a blueprints file (see :need:`I_ARMI_MAT_USER_INPUT0`)
@@ -336,6 +338,7 @@ def insertDepletableNuclideKeys(c, blueprint):
     .. impl:: Insert any depletable blueprint flags onto this component.
         :id: I_ARMI_BP_NUC_FLAGS0
         :implements: R_ARMI_BP_NUC_FLAGS
+        :qualified_code: Nala
 
         This is called during the component construction process for each component from within
         :py:meth:`~armi.reactor.blueprints.componentBlueprint.ComponentBlueprint.construct`.

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -147,6 +147,7 @@ class GridBlueprint(yamlize.Object):
     .. impl:: Define a lattice map in reactor core.
         :id: I_ARMI_BP_GRID
         :implements: R_ARMI_BP_GRID
+        :qualified_code: Nala
 
         Defines a yaml construct that allows the user to specify a grid
         from within their blueprints file, including a name, geometry, dimensions,
@@ -554,6 +555,7 @@ def saveToStream(stream, bluep, full=False, tryMap=False):
     .. impl:: Write a blueprint file from a blueprint object.
         :id: I_ARMI_BP_TO_DB
         :implements: R_ARMI_BP_TO_DB
+        :qualified_code: Nala
 
         First makes a copy of the blueprints that are passed in. Then modifies
         any grids specified in the blueprints into a canonical lattice map style,

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -61,6 +61,7 @@ class NuclideFlag(yamlize.Object):
     .. impl:: The blueprint object that represents a nuclide flag.
         :id: I_ARMI_BP_NUC_FLAGS1
         :implements: R_ARMI_BP_NUC_FLAGS
+        :qualified_code: Nala
 
         This class creates a yaml interface for the user to specify in their blueprints which
         isotopes should be depleted. It is incorporated into the "nuclide flags" section of a
@@ -166,6 +167,7 @@ class CustomIsotopic(yamlize.Map):
     .. impl:: Certain material modifications will be applied using this code.
         :id: I_ARMI_MAT_USER_INPUT2
         :implements: R_ARMI_MAT_USER_INPUT
+        :qualified_code: Nala
 
         Defines a yaml construct that allows the user to define a custom isotopic vector from within
         their blueprints file, including a name and key-value pairs corresponding to nuclide names

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -52,6 +52,7 @@ class SystemBlueprint(yamlize.Object):
     .. impl:: Build core and spent fuel pool from blueprints
         :id: I_ARMI_BP_SYSTEMS
         :implements: R_ARMI_BP_SYSTEMS, R_ARMI_BP_CORE
+        :qualified_code: Nala
 
         This class creates a yaml interface for the user to define systems with
         grids, such as cores or spent fuel pools, each having their own name,

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -329,6 +329,7 @@ class DerivedShape(UnshapedComponent):
             them.
             :id: I_ARMI_COMP_FLUID0
             :implements: R_ARMI_COMP_FLUID
+            :qualified_code: Nala
 
             Computing the volume of a ``DerivedShape`` means looking at the solid
             materials around it, and finding what shaped space is left over in between

--- a/armi/reactor/components/basicShapes.py
+++ b/armi/reactor/components/basicShapes.py
@@ -30,6 +30,7 @@ class Circle(ShapedComponent):
     .. impl:: Circle shaped Component
         :id: I_ARMI_COMP_SHAPES0
         :implements: R_ARMI_COMP_SHAPES
+        :qualified_code: Nala
 
         This class provides the implementation of a Circle Component. This includes
         setting key parameters such as its material, temperature, and dimensions. It
@@ -99,6 +100,7 @@ class Hexagon(ShapedComponent):
     .. impl:: Hexagon shaped Component
         :id: I_ARMI_COMP_SHAPES1
         :implements: R_ARMI_COMP_SHAPES
+        :qualified_code: Nala
 
         This class provides the implementation of a hexagonal Component. This
         includes setting key parameters such as its material, temperature, and
@@ -190,6 +192,7 @@ class Rectangle(ShapedComponent):
     .. impl:: Rectangle shaped Component
         :id: I_ARMI_COMP_SHAPES2
         :implements: R_ARMI_COMP_SHAPES
+        :qualified_code: Nala
 
         This class provides the implementation for a rectangular Component. This
         includes setting key parameters such as its material, temperature, and
@@ -341,6 +344,7 @@ class Square(Rectangle):
     .. impl:: Square shaped Component
         :id: I_ARMI_COMP_SHAPES3
         :implements: R_ARMI_COMP_SHAPES
+        :qualified_code: Nala
 
         This class provides the implementation for a square Component. This class
         subclasses the ``Rectangle`` class because a square is a type of rectangle.
@@ -422,6 +426,7 @@ class Triangle(ShapedComponent):
     .. impl:: Triangle shaped Component
         :id: I_ARMI_COMP_SHAPES4
         :implements: R_ARMI_COMP_SHAPES
+        :qualified_code: Nala
 
         This class provides the implementation for defining a triangular Component. This
         includes setting key parameters such as its material, temperature, and

--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -27,6 +27,7 @@ class HoledHexagon(basicShapes.Hexagon):
     .. impl:: Holed hexagon shaped Component
         :id: I_ARMI_COMP_SHAPES5
         :implements: R_ARMI_COMP_SHAPES
+        :qualified_code: Nala
 
         This class provides an implementation for a holed hexagonal Component. This
         includes setting key parameters such as its material, temperature, and
@@ -205,6 +206,7 @@ class HoledSquare(basicShapes.Square):
     .. impl:: Holed square shaped Component
         :id: I_ARMI_COMP_SHAPES6
         :implements: R_ARMI_COMP_SHAPES
+        :qualified_code: Nala
 
         This class provides an implementation for a holed square Component. This
         includes setting key parameters such as its material, temperature, and
@@ -266,6 +268,7 @@ class Helix(ShapedComponent):
     .. impl:: Helix shaped Component
         :id: I_ARMI_COMP_SHAPES7
         :implements: R_ARMI_COMP_SHAPES
+        :qualified_code: Nala
 
         This class provides the implementation for a helical Component. This
         includes setting key parameters such as its material, temperature, and

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -172,6 +172,7 @@ class Component(composites.Composite, metaclass=ComponentType):
     .. impl:: Define a physical piece of a reactor.
         :id: I_ARMI_COMP_DEF
         :implements: R_ARMI_COMP_DEF
+        :qualified_code: Nala
 
         The primitive object in an ARMI reactor is a Component. A Component is comprised
         of a shape and composition. This class serves as a base class which all
@@ -185,6 +186,7 @@ class Component(composites.Composite, metaclass=ComponentType):
     .. impl:: Order Components by their outermost diameter (using the < operator).
         :id: I_ARMI_COMP_ORDER
         :implements: R_ARMI_COMP_ORDER
+        :qualified_code: Nala
 
         Determining Component order by outermost diameters is implemented via
         the ``__lt__()`` method, which is used to control ``sort()`` as the
@@ -304,6 +306,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: The volume of some defined shapes depend on the solid components surrounding them.
             :id: I_ARMI_COMP_FLUID1
             :implements: R_ARMI_COMP_FLUID
+            :qualified_code: Nala
 
             Some Components are fluids and are thus defined by the shapes surrounding
             them. This method cycles through each dimension defining the border of this
@@ -416,12 +419,14 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: Material properties are retrievable.
             :id: I_ARMI_COMP_MAT0
             :implements: R_ARMI_COMP_MAT
+            :qualified_code: Nala
 
             This method returns the material object that is assigned to the Component.
 
         .. impl:: Components have one-and-only-one material.
             :id: I_ARMI_COMP_1MAT
             :implements: R_ARMI_COMP_1MAT
+            :qualified_code: Nala
 
             This method returns the material object that is assigned to the Component.
         """
@@ -467,6 +472,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: Get a dimension of a Component.
             :id: I_ARMI_COMP_VOL0
             :implements: R_ARMI_COMP_VOL
+            :qualified_code: Nala
 
             This method returns the area of a Component.
 
@@ -494,6 +500,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: Get a dimension of a Component.
             :id: I_ARMI_COMP_VOL1
             :implements: R_ARMI_COMP_VOL
+            :qualified_code: Nala
 
             This method returns the volume of a Component.
 
@@ -599,6 +606,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: Determine if a material is solid.
             :id: I_ARMI_COMP_SOLID
             :implements: R_ARMI_COMP_SOLID
+            :qualified_code: Nala
 
             For certain operations it is important to know if a Component is a solid or
             fluid material. This method will return a boolean indicating if the material
@@ -705,6 +713,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: Setting nuclide fractions.
             :id: I_ARMI_COMP_NUCLIDE_FRACS0
             :implements: R_ARMI_COMP_NUCLIDE_FRACS
+            :qualified_code: Nala
 
             The method allows a user or plugin to set the number density of a Component.
             It also indicates to other processes that may depend on a Component's
@@ -731,6 +740,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: Setting nuclide fractions.
             :id: I_ARMI_COMP_NUCLIDE_FRACS1
             :implements: R_ARMI_COMP_NUCLIDE_FRACS
+            :qualified_code: Nala
 
             The method allows a user or plugin to set the number densities of a
             Component. In contrast to the ``setNumberDensity`` method, it sets all
@@ -842,6 +852,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: Set a Component dimension, considering thermal expansion.
             :id: I_ARMI_COMP_EXPANSION1
             :implements: R_ARMI_COMP_EXPANSION
+            :qualified_code: Nala
 
             Dimensions should be set considering the impact of thermal expansion. This
             method allows for a user or plugin to set a dimension and indicate if the
@@ -891,6 +902,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: Retrieve a dimension at a specified temperature.
             :id: I_ARMI_COMP_DIMS
             :implements: R_ARMI_COMP_DIMS
+            :qualified_code: Nala
 
             Due to thermal expansion, Component dimensions depend on their temperature.
             This method retrieves a dimension from the Component at a particular
@@ -974,6 +986,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         .. impl:: Calculates radial thermal expansion factor.
             :id: I_ARMI_COMP_EXPANSION0
             :implements: R_ARMI_COMP_EXPANSION
+            :qualified_code: Nala
 
             This method enables the calculation of the thermal expansion factor
             for a given material. If the material is solid, the difference

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -303,6 +303,7 @@ class ArmiObject(metaclass=CompositeModelType):
     .. impl:: Parameters are accessible throughout the armi tree.
         :id: I_ARMI_PARAM_PART
         :implements: R_ARMI_PARAM_PART
+        :qualified_code: Nala
 
         An ARMI reactor model is composed of collections of ARMIObject objects. These
         objects are combined in a hierarchical manner. Each level of the composite tree
@@ -636,6 +637,7 @@ class ArmiObject(metaclass=CompositeModelType):
         .. impl:: Composites (and all ARMI objects) have parameter collections.
             :id: I_ARMI_CMP_PARAMS
             :implements: R_ARMI_CMP_PARAMS
+            :qualified_code: Nala
 
             This class method allows a user to obtain the
             ``paramCollection`` object, which is the object containing the interface for
@@ -675,6 +677,7 @@ class ArmiObject(metaclass=CompositeModelType):
         .. impl:: Composite name is accessible.
             :id: I_ARMI_CMP_GET_NAME
             :implements: R_ARMI_CMP_GET_NAME
+            :qualified_code: Nala
 
             This method returns the name of a Composite.
         """
@@ -690,6 +693,7 @@ class ArmiObject(metaclass=CompositeModelType):
         .. impl:: Composites have queryable flags.
             :id: I_ARMI_CMP_FLAG0
             :implements: R_ARMI_CMP_FLAG
+            :qualified_code: Nala
 
             This method queries the flags (i.e. the ``typeID``) of the Composite for a
             given type, returning a boolean representing whether or not the candidate
@@ -796,6 +800,7 @@ class ArmiObject(metaclass=CompositeModelType):
         .. impl:: Composites have modifiable flags.
             :id: I_ARMI_CMP_FLAG1
             :implements: R_ARMI_CMP_FLAG
+            :qualified_code: Nala
 
             This method allows for the setting of flags parameter of the Composite.
 
@@ -916,6 +921,7 @@ class ArmiObject(metaclass=CompositeModelType):
         .. impl:: Return mass of composite.
             :id: I_ARMI_CMP_GET_MASS
             :implements: R_ARMI_CMP_GET_MASS
+            :qualified_code: Nala
 
             This method allows for the querying of the mass of a Composite.
             If the ``nuclideNames`` argument is included, it will filter for the mass
@@ -1267,6 +1273,7 @@ class ArmiObject(metaclass=CompositeModelType):
         .. impl:: Get number density for a specific nuclide
             :id: I_ARMI_CMP_NUC0
             :implements: R_ARMI_CMP_NUC
+            :qualified_code: Nala
 
             This method queries the number density
             of a specific nuclide within the Composite. It invokes the
@@ -1292,6 +1299,7 @@ class ArmiObject(metaclass=CompositeModelType):
         .. impl:: Get number densities for specific nuclides.
             :id: I_ARMI_CMP_NUC1
             :implements: R_ARMI_CMP_NUC
+            :qualified_code: Nala
 
             This method provides the capability to query the volume weighted number
             densities for a list of nuclides within a given Composite. It provides the
@@ -1338,6 +1346,7 @@ class ArmiObject(metaclass=CompositeModelType):
         .. impl:: Number density of composite is retrievable.
             :id: I_ARMI_CMP_GET_NDENS
             :implements: R_ARMI_CMP_GET_NDENS
+            :qualified_code: Nala
 
             This method provides a way for retrieving the number densities
             of all nuclides within the Composite. It does this by leveraging the
@@ -2505,6 +2514,7 @@ class ArmiObject(metaclass=CompositeModelType):
         .. impl:: Get child component by name.
             :id: I_ARMI_CMP_BY_NAME
             :implements: R_ARMI_CMP_BY_NAME
+            :qualified_code: Nala
 
             Each Composite has a name, and some Composites are made up
             of collections of child Composites. This method retrieves a child
@@ -2726,6 +2736,7 @@ class Composite(ArmiObject):
     .. impl:: Composites are a physical part of the reactor in a hierarchical data model.
         :id: I_ARMI_CMP0
         :implements: R_ARMI_CMP
+        :qualified_code: Nala
 
         An ARMI reactor model is composed of collections of ARMIObject objects. This
         class is a child-class of the ARMIObject class and provides a structure
@@ -2843,6 +2854,7 @@ class Composite(ArmiObject):
         .. impl:: Composites have children in the hierarchical data model.
             :id: I_ARMI_CMP1
             :implements: R_ARMI_CMP
+            :qualified_code: Nala
 
             This method retrieves all children within a given Composite object. Children
             of any generation can be retrieved. This is achieved by visiting all
@@ -2973,6 +2985,7 @@ class Composite(ArmiObject):
         .. impl:: Composites can be synchronized across MPI threads.
             :id: I_ARMI_CMP_MPI
             :implements: R_ARMI_CMP_MPI
+            :qualified_code: Nala
 
             Parameters need to be handled properly during parallel code execution.This
             method synchronizes all parameters of the composite object across all

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -68,6 +68,7 @@ def expandColdDimsToHot(
     .. impl:: Perform expansion during core construction based on block heights at a specified temperature.
         :id: I_ARMI_INP_COLD_HEIGHT
         :implements: R_ARMI_INP_COLD_HEIGHT
+        :qualified_code: Nala
 
         This method is designed to be used during core construction to axially thermally expand the
         assemblies to their "hot" temperatures (as determined by ``Thot`` values in blueprints).
@@ -161,6 +162,7 @@ class AxialExpansionChanger:
         .. impl:: Perform expansion/contraction, given a list of components and expansion coefficients.
             :id: I_ARMI_AXIAL_EXP_PRESC
             :implements: R_ARMI_AXIAL_EXP_PRESC
+            :qualified_code: Nala
 
             This method performs component-wise axial expansion for an Assembly given expansion coefficients
             and a corresponding list of Components. In ``setAssembly``, the Assembly is prepared
@@ -204,6 +206,7 @@ class AxialExpansionChanger:
             over an assembly.
             :id: I_ARMI_AXIAL_EXP_THERM
             :implements: R_ARMI_AXIAL_EXP_THERM
+            :qualified_code: Nala
 
             This method performs component-wise thermal expansion for an assembly given a discrete
             temperature distribution over the axial length of the Assembly. In ``setAssembly``, the
@@ -310,6 +313,7 @@ class AxialExpansionChanger:
         .. impl:: Preserve the total height of an ARMI assembly, during expansion.
             :id: I_ARMI_ASSEM_HEIGHT_PRES
             :implements: R_ARMI_ASSEM_HEIGHT_PRES
+            :qualified_code: Nala
 
             The total height of an Assembly is preserved by not changing the ``ztop`` position
             of the top-most Block in an Assembly. The ``zbottom`` of the top-most Block is

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -216,6 +216,7 @@ class ComponentMerger(BlockConverter):
     .. impl:: Homogenize one component into another.
         :id: I_ARMI_BLOCKCONV0
         :implements: R_ARMI_BLOCKCONV
+        :qualified_code: Nala
 
         This subclass of ``BlockConverter`` is meant as a one-time-use tool, to convert
         a ``Block`` into one ``Component``. A ``Block`` is a ``Composite`` that may
@@ -267,6 +268,7 @@ class MultipleComponentMerger(BlockConverter):
     .. impl:: Homogenize multiple components into one.
         :id: I_ARMI_BLOCKCONV1
         :implements: R_ARMI_BLOCKCONV
+        :qualified_code: Nala
 
         This subclass of ``BlockConverter`` is meant as a one-time-use tool, to convert
         a multiple ``Components`` into one. This means averaging the material
@@ -560,6 +562,7 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
         .. impl:: Convert hex blocks to cylindrical blocks.
             :id:  I_ARMI_BLOCKCONV_HEX_TO_CYL
             :implements: R_ARMI_BLOCKCONV_HEX_TO_CYL
+            :qualified_code: Nala
 
             This method converts a ``HexBlock`` to a cylindrical ``Block``. Obviously,
             this is not a physically meaningful transition; it is a helpful

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -438,6 +438,7 @@ class HexToRZThetaConverter(GeometryConverter):
         .. impl:: Tool to convert a hex core to an RZTheta core.
             :id: I_ARMI_CONV_3DHEX_TO_2DRZ
             :implements: R_ARMI_CONV_3DHEX_TO_2DRZ
+            :qualified_code: Nala
 
             This method converts the hex-z mesh to r-theta-z mesh.
             It first verifies that the geometry type of the input reactor ``r``
@@ -1274,6 +1275,7 @@ class ThirdCoreHexToFullCoreChanger(GeometryChanger):
         .. impl:: Convert a one-third-core geometry to a full-core geometry.
             :id: I_ARMI_THIRD_TO_FULL_CORE0
             :implements: R_ARMI_THIRD_TO_FULL_CORE
+            :qualified_code: Nala
 
             This method first checks if the input reactor is already full core.
             If full-core symmetry is detected, the input reactor is returned.
@@ -1379,6 +1381,7 @@ class ThirdCoreHexToFullCoreChanger(GeometryChanger):
         .. impl:: Restore a one-third-core geometry to a full-core geometry.
             :id: I_ARMI_THIRD_TO_FULL_CORE1
             :implements: R_ARMI_THIRD_TO_FULL_CORE
+            :qualified_code: Nala
 
             This method is a reverse process of the method ``convert``. It converts
             the full-core reactor model back to the original one-third core reactor model by removing
@@ -1425,6 +1428,7 @@ class EdgeAssemblyChanger(GeometryChanger):
         .. impl:: Add assemblies along the 120-degree line to a reactor.
             :id: I_ARMI_ADD_EDGE_ASSEMS0
             :implements: R_ARMI_ADD_EDGE_ASSEMS
+            :qualified_code: Nala
 
             Edge assemblies on the 120-degree symmetric line of a one-third core reactor model are added
             because they are needed for DIF3D-finite difference or MCNP models. This is done
@@ -1500,6 +1504,7 @@ class EdgeAssemblyChanger(GeometryChanger):
         .. impl:: Remove assemblies along the 120-degree line from a reactor.
             :id: I_ARMI_ADD_EDGE_ASSEMS1
             :implements: R_ARMI_ADD_EDGE_ASSEMS
+            :qualified_code: Nala
 
             This method is the reverse process of the method ``addEdgeAssemblies``. It is
             needed for the DIF3D-Nodal calculation. It removes the assemblies on the 120-degree

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -122,6 +122,7 @@ class UniformMeshGenerator:
         .. impl:: Try to preserve the boundaries of fuel and control material.
             :id: I_ARMI_UMC_NON_UNIFORM
             :implements: R_ARMI_UMC_NON_UNIFORM
+            :qualified_code: Nala
 
             A core-wide mesh is computed via ``_computeAverageAxialMesh`` which
             operates by first collecting all the mesh points for every assembly
@@ -135,6 +136,7 @@ class UniformMeshGenerator:
         .. impl:: Produce a mesh with a size no smaller than a user-specified value.
             :id: I_ARMI_UMC_MIN_MESH
             :implements: R_ARMI_UMC_MIN_MESH
+            :qualified_code: Nala
 
             If a minimum mesh size ``minimumMeshSize`` is provided, calls
             ``_decuspAxialMesh`` on the core-wide mesh to maintain that minimum size
@@ -448,6 +450,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         .. impl:: Make a copy of the reactor where the new core has a uniform axial mesh.
             :id: I_ARMI_UMC
             :implements: R_ARMI_UMC
+            :qualified_code: Nala
 
             Given a source Reactor, ``r``, as input and when ``_hasNonUniformAssems`` is ``False``,
             a new Reactor is created in ``initNewReactor``. This new Reactor contains copies of select
@@ -463,6 +466,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         .. impl:: Map select parameters from composites on the original mesh to the new mesh.
             :id: I_ARMI_UMC_PARAM_FORWARD
             :implements: R_ARMI_UMC_PARAM_FORWARD
+            :qualified_code: Nala
 
             In ``_mapStateFromReactorToOther``, Core-level parameters are mapped from the source Reactor
             to the new Reactor. If requested, block-level parameters can be mapped using an averaging
@@ -586,6 +590,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         .. impl:: Map select parameters from composites on the new mesh to the original mesh.
             :id: I_ARMI_UMC_PARAM_BACKWARD
             :implements: R_ARMI_UMC_PARAM_BACKWARD
+            :qualified_code: Nala
 
             To ensure that the parameters on the original Reactor are from the converted Reactor,
             the first step is to clear the Reactor-level parameters on the original Reactor

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -290,6 +290,7 @@ class Flags(Flag):
         .. impl:: Retrieve flag from a string.
             :id: I_ARMI_FLAG_TO_STR0
             :implements: R_ARMI_FLAG_TO_STR
+            :qualified_code: Nala
 
             For a string passed as ``typeSpec``, first converts the whole string
             to uppercase. Then tries to parse the string for any special phrases, as
@@ -311,6 +312,7 @@ class Flags(Flag):
         .. impl:: Convert a flag to string.
             :id: I_ARMI_FLAG_TO_STR1
             :implements: R_ARMI_FLAG_TO_STR
+            :qualified_code: Nala
 
             This converts the representation of a bunch of flags from ``typeSpec``,
             which might look like ``Flags.A|B``,

--- a/armi/reactor/grids/grid.py
+++ b/armi/reactor/grids/grid.py
@@ -38,6 +38,7 @@ class Grid(ABC):
     .. impl:: Grids can nest.
         :id: I_ARMI_GRID_NEST
         :implements: R_ARMI_GRID_NEST
+        :qualified_code: Nala
 
         The reactor will usually have (i,j,k) coordinates to define a
         simple mesh for locating objects in the reactor. But inside that mesh can
@@ -102,6 +103,7 @@ class Grid(ABC):
         .. impl:: Grids shall be able to repesent 1/3 and full core symmetries.
             :id: I_ARMI_GRID_SYMMETRY0
             :implements: R_ARMI_GRID_SYMMETRY
+            :qualified_code: Nala
 
             Every grid contains a :py:class:`armi.reactor.geometry.SymmetryType` or
             string that defines a grid as full core or a partial core: 1/3, 1/4, 1/8, or 1/16

--- a/armi/reactor/grids/hexagonal.py
+++ b/armi/reactor/grids/hexagonal.py
@@ -53,6 +53,7 @@ class HexGrid(StructuredGrid):
     .. impl:: Construct a hexagonal lattice.
         :id: I_ARMI_GRID_HEX
         :implements: R_ARMI_GRID_HEX
+        :qualified_code: Nala
 
         This class represents a hexagonal ``StructuredGrid``, that is one where the
         mesh maps to real, physical coordinates. This hexagonal grid is 2D, and divides
@@ -122,6 +123,7 @@ class HexGrid(StructuredGrid):
         .. impl:: Hexagonal grids can be points-up or flats-up.
             :id: I_ARMI_GRID_HEX_TYPE
             :implements: R_ARMI_GRID_HEX_TYPE
+            :qualified_code: Nala
 
             When this method creates a ``HexGrid`` object, it can create a hexagonal
             grid with one of two rotations: flats up (where two sides of the hexagons
@@ -132,6 +134,7 @@ class HexGrid(StructuredGrid):
         .. impl:: When creating a hexagonal grid, the user can specify the symmetry.
             :id: I_ARMI_GRID_SYMMETRY1
             :implements: R_ARMI_GRID_SYMMETRY
+            :qualified_code: Nala
 
             When this method creates a ``HexGrid`` object, it takes as an input the
             symmetry of the resultant grid. This symmetry can be a string (e.g. "full")
@@ -425,6 +428,7 @@ class HexGrid(StructuredGrid):
         .. impl:: Equivalent contents in 1/3-core geometries are retrievable.
             :id: I_ARMI_GRID_EQUIVALENTS
             :implements: R_ARMI_GRID_EQUIVALENTS
+            :qualified_code: Nala
 
             This method takes in (I,J,K) indices, and if this ``HexGrid`` is full core,
             it returns nothing. If this ``HexGrid`` is 1/3-core, this method will return
@@ -517,6 +521,7 @@ class HexGrid(StructuredGrid):
         .. impl:: Determine if grid is in first third.
             :id: I_ARMI_GRID_SYMMETRY_LOC
             :implements: R_ARMI_GRID_SYMMETRY_LOC
+            :qualified_code: Nala
 
             This is a simple helper method to determine if a given locator (from an
             ArmiObject) is in the first 1/3 of the ``HexGrid``. This method does not

--- a/armi/reactor/grids/locations.py
+++ b/armi/reactor/grids/locations.py
@@ -358,6 +358,7 @@ class MultiIndexLocation(IndexLocation):
     .. impl:: Store components with multiplicity greater than 1
         :id: I_ARMI_GRID_MULT
         :implements: R_ARMI_GRID_MULT
+        :qualified_code: Nala
 
         As not all grids are "full core symmetry", ARMI will sometimes need to track
         multiple positions for a single object: one for each symmetric portion of the
@@ -437,6 +438,7 @@ class MultiIndexLocation(IndexLocation):
             multiplicity greater than 1.
             :id: I_ARMI_GRID_ELEM_LOC
             :implements: R_ARMI_GRID_ELEM_LOC
+            :qualified_code: Nala
 
             This method returns the indices of all the ``IndexLocation`` objects. To be
             clear, this does not return the ``IndexLocation`` objects themselves. This

--- a/armi/reactor/grids/structuredGrid.py
+++ b/armi/reactor/grids/structuredGrid.py
@@ -296,6 +296,7 @@ class StructuredGrid(Grid):
         .. impl:: Get the coordinates from a location in a grid.
             :id: I_ARMI_GRID_GLOBAL_POS
             :implements: R_ARMI_GRID_GLOBAL_POS
+            :qualified_code: Nala
 
             Probably the most common request of a structure grid will be to give the
             grid indices and return the physical coordinates of the center of the mesh

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -155,6 +155,7 @@ class Serializer:
     .. impl:: Users can define custom parameter serializers.
         :id: I_ARMI_PARAM_SERIALIZE
         :implements: R_ARMI_PARAM_SERIALIZE
+        :qualified_code: Nala
 
         Important physical parameters are stored in every ARMI object.
         These parameters represent the plant's state during execution
@@ -354,6 +355,7 @@ class Parameter:
         .. impl:: Provide a way to signal if a parameter needs updating across processes.
             :id: I_ARMI_PARAM_PARALLEL
             :implements: R_ARMI_PARAM_PARALLEL
+            :qualified_code: Nala
 
             Parameters need to be handled properly during parallel code execution. This
             includes notifying processes if a parameter has been updated by
@@ -604,6 +606,7 @@ class ParameterDefinitionCollection:
         .. impl:: Filter parameters to write to DB.
             :id: I_ARMI_PARAM_DB
             :implements: R_ARMI_PARAM_DB
+            :qualified_code: Nala
 
             This method is called when writing the parameters to the database file. It
             queries the parameter's ``saveToDB`` attribute to ensure that this parameter

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -78,6 +78,7 @@ class Reactor(composites.Composite):
     .. impl:: The user-specified reactor.
         :id: I_ARMI_R
         :implements: R_ARMI_R
+        :qualified_code: Nala
 
         The :py:class:`Reactor <armi.reactor.reactors.Reactor>` is the top level of the composite
         structure, which can represent all components within a reactor core. The reactor contains a
@@ -253,6 +254,7 @@ class Core(composites.Composite):
     .. impl:: Represent a reactor core as a composite object.
         :id: I_ARMI_R_CORE
         :implements: R_ARMI_R_CORE
+        :qualified_code: Nala
 
         A :py:class:`Core <armi.reactor.reactors.Core>` object is typically a child of a
         :py:class:`Reactor <armi.reactor.reactors.Reactor>` object. A Reactor can contain multiple
@@ -373,6 +375,7 @@ class Core(composites.Composite):
         .. impl:: Get core symmetry.
             :id: I_ARMI_R_SYMM
             :implements: R_ARMI_R_SYMM
+            :qualified_code: Nala
 
             This property getter returns the symmetry attribute of the spatialGrid instance
             attribute. The spatialGrid is an instance of a child of the abstract base class
@@ -813,6 +816,7 @@ class Core(composites.Composite):
         .. impl:: Retrieve number of rings in core.
             :id: I_ARMI_R_NUM_RINGS
             :implements: R_ARMI_R_NUM_RINGS
+            :qualified_code: Nala
 
             This method determines the number of rings in the reactor. If the
             setting ``circularRingMode`` is enabled (by default it is false), the
@@ -1178,6 +1182,7 @@ class Core(composites.Composite):
         .. impl:: Get assembly by name.
             :id: I_ARMI_R_GET_ASSEM_NAME
             :implements: R_ARMI_R_GET_ASSEM_NAME
+            :qualified_code: Nala
 
             This method returns the :py:class:`assembly
             <armi.reactor.core.assemblies.Assembly>` with a name matching the
@@ -1700,6 +1705,7 @@ class Core(composites.Composite):
         .. impl:: Get assembly by location.
             :id: I_ARMI_R_GET_ASSEM_LOC
             :implements: R_ARMI_R_GET_ASSEM_LOC
+            :qualified_code: Nala
 
             This method returns the :py:class:`assembly
             <armi.reactor.core.assemblies.Assembly>` located in the requested
@@ -1751,6 +1757,7 @@ class Core(composites.Composite):
         .. impl:: Retrieve neighboring assemblies of a given assembly.
             :id: I_ARMI_R_FIND_NEIGHBORS
             :implements: R_ARMI_R_FIND_NEIGHBORS
+            :qualified_code: Nala
 
             This method takes an :py:class:`Assembly
             <armi.reactor.assemblies.Assembly>` as an input parameter and returns
@@ -2029,6 +2036,7 @@ class Core(composites.Composite):
         .. impl:: Construct a mesh based on core blocks.
             :id: I_ARMI_R_MESH
             :implements: R_ARMI_R_MESH
+            :qualified_code: Nala
 
             This method iterates through all of the assemblies provided, or all
             assemblies in the core if no list of ``assems`` is provided, and

--- a/armi/reactor/zones.py
+++ b/armi/reactor/zones.py
@@ -32,6 +32,7 @@ class Zone:
     .. impl:: A user can define a collection of armi locations.
         :id: I_ARMI_ZONE
         :implements: R_ARMI_ZONE
+        :qualified_code: Nala
 
         The Zone class facilitates the creation of a Zone object representing a
         collection of locations in the Core. A Zone contains a group of locations
@@ -217,6 +218,7 @@ class Zones:
     .. impl:: A user can define a collection of armi zones.
         :id: I_ARMI_ZONES
         :implements: R_ARMI_ZONES
+        :qualified_code: Nala
 
         The Zones class facilitates the creation of a Zones object representing a
         collection of Zone objects. Methods are provided to add or remove one

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -326,6 +326,7 @@ def concatenateLogs(logDir=None):
     .. impl:: Log files from different processes are combined.
         :id: I_ARMI_LOG_MPI
         :implements: R_ARMI_LOG_MPI
+        :qualified_code: Nala
 
         The log files are plain text files. Since ARMI is frequently run in parallel,
         the situation arises where each ARMI process generates its own plain text log
@@ -512,6 +513,7 @@ class RunLogger(logging.Logger):
     .. impl:: A simulation-wide log, with user-specified verbosity.
         :id: I_ARMI_LOG
         :implements: R_ARMI_LOG
+        :qualified_code: Nala
 
         Log statements are any text a user wants to record during a run. For instance,
         basic notifications of what is happening in the run, simple warnings, or hard
@@ -535,6 +537,7 @@ class RunLogger(logging.Logger):
     .. impl:: Logging is done to the screen and to file.
         :id: I_ARMI_LOG_IO
         :implements: R_ARMI_LOG_IO
+        :qualified_code: Nala
 
         This logger makes it easy for users to add log statements to and ARMI
         application, and ARMI will control the flow of those log statements. In

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -51,6 +51,7 @@ class Settings:
     .. impl:: Settings are used to define an ARMI run.
         :id: I_ARMI_SETTING0
         :implements: R_ARMI_SETTING
+        :qualified_code: Nala
 
         The Settings object is accessible to most ARMI objects through self.cs
         (for 'case settings'). It acts largely as a dictionary, and setting values
@@ -113,6 +114,7 @@ class Settings:
         .. impl:: Define a case title to go with the settings.
             :id: I_ARMI_SETTINGS_META0
             :implements: R_ARMI_SETTINGS_META
+            :qualified_code: Nala
 
             Every Settings object has a "case title"; a string for users to
             help identify their run. This case title is used in log file

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -126,6 +126,7 @@ def defineSettings() -> List[setting.Setting]:
     .. impl:: There is a setting for total core power.
         :id: I_ARMI_SETTINGS_POWER
         :implements: R_ARMI_SETTINGS_POWER
+        :qualified_code: Nala
 
         ARMI defines a collection of settings by default to be associated
         with all runs, and one such setting is ``power``. This is the
@@ -138,6 +139,7 @@ def defineSettings() -> List[setting.Setting]:
     .. impl:: Define a comment and a versions list to go with the settings.
         :id: I_ARMI_SETTINGS_META1
         :implements: R_ARMI_SETTINGS_META
+        :qualified_code: Nala
 
         Because nuclear analysts have a lot to keep track of when doing
         various simulations of a reactor, ARMI provides a ``comment``

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -49,6 +49,7 @@ class Setting:
     .. impl:: The setting default is mandatory.
         :id: I_ARMI_SETTINGS_DEFAULTS
         :implements: R_ARMI_SETTINGS_DEFAULTS
+        :qualified_code: Nala
 
         Setting objects hold all associated information of a setting in ARMI and should
         typically be accessed through the Settings methods rather than directly.

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -144,6 +144,7 @@ class SettingsReader:
     .. impl:: The setting use a human-readable, plain text file as input.
         :id: I_ARMI_SETTINGS_IO_TXT
         :implements: R_ARMI_SETTINGS_IO_TXT
+        :qualified_code: Nala
 
         ARMI uses the YAML standard for settings files. ARMI uses industry-standard
         ``ruamel.yaml`` Python libraray to read these files. ARMI does not bend or

--- a/armi/utils/densityTools.py
+++ b/armi/utils/densityTools.py
@@ -27,6 +27,7 @@ def getNDensFromMasses(rho, massFracs, normalize=False):
     .. impl:: Number densities are retrievable from masses.
         :id: I_ARMI_UTIL_MASS2N_DENS
         :implements: R_ARMI_UTIL_MASS2N_DENS
+        :qualified_code: Nala
 
         Loops over all provided nuclides (given as keys in the ``massFracs`` vector) and calculates
         number densities of each, at a given material ``density``. Mass fractions can be provided
@@ -179,6 +180,7 @@ def formatMaterialCard(
     .. impl:: Create MCNP material card.
         :id: I_ARMI_UTIL_MCNP_MAT_CARD
         :implements: R_ARMI_UTIL_MCNP_MAT_CARD
+        :qualified_code: Nala
 
         Loops over a vector of nuclides (of type ``nuclideBase``) provided in ``densities`` and
         formats them into a list of strings consistent with MCNP material card syntax, skipping
@@ -284,6 +286,7 @@ def normalizeNuclideList(nuclideVector, normalization=1.0):
     .. impl:: Normalize nuclide vector.
         :id: I_ARMI_UTIL_DENS_TOOLS
         :implements: R_ARMI_UTIL_DENS_TOOLS
+        :qualified_code: Nala
 
         Given a vector of nuclides ``nuclideVector`` indexed by nuclide identifiers (``nucNames`` or ``nuclideBases``),
         normalizes to the provided ``normalization`` value.
@@ -324,6 +327,7 @@ def expandElementalMassFracsToNuclides(
     .. impl:: Expand mass fractions to nuclides.
         :id: I_ARMI_UTIL_EXP_MASS_FRACS
         :implements: R_ARMI_UTIL_EXP_MASS_FRACS
+        :qualified_code: Nala
 
         Given a vector of elements and nuclides with associated mass fractions (``massFracs``),
         expands the elements in-place into a set of nuclides using

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -126,6 +126,7 @@ class Flag(metaclass=_FlagMeta):
     .. impl:: No two flags have equivalence.
         :id: I_ARMI_FLAG_DEFINE
         :implements: R_ARMI_FLAG_DEFINE
+        :qualified_code: Nala
 
         A bitwise flag class intended to emulate the standard library's ``enum.Flag``, with the
         added functionality that it allows for extension after the class has been defined. Each Flag
@@ -232,6 +233,7 @@ class Flag(metaclass=_FlagMeta):
         .. impl:: Set of flags are extensible without loss of uniqueness.
             :id: I_ARMI_FLAG_EXTEND0
             :implements: R_ARMI_FLAG_EXTEND
+            :qualified_code: Nala
 
             A class method to extend a ``Flag`` with a vector of provided additional ``fields``,
             with field names as keys, without loss of uniqueness. Values for the additional

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -35,6 +35,7 @@ def area(pitch):
     .. impl:: Compute hexagonal area
         :id: I_ARMI_UTIL_HEXAGON0
         :implements: R_ARMI_UTIL_HEXAGON
+        :qualified_code: Nala
 
         Computes the area of a hexagon given the flat-to-flat ``pitch``.
 
@@ -140,6 +141,7 @@ def numPositionsInRing(ring):
     .. impl:: Compute number of positions in a ring of a hex lattice
         :id: I_ARMI_UTIL_HEXAGON1
         :implements: R_ARMI_UTIL_HEXAGON
+        :qualified_code: Nala
 
         In a hexagonal lattice, calculate the number of positions in a given ``ring``. The number of
         rings is indexed to 1, i.e. the centermost position in the lattice is ``ring=1``.


### PR DESCRIPTION
## What is the change?

Adding an option to all `impl` and `test` tags to denote whether or not the requirement it's attached to applies to Pylot or Nala.

## Why is the change being made?

So we know if a change affects the baseline of either project and who to include on SCRs.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.