### PR TITLE
Improving our detection of Interactive Mode

### DIFF
--- a/armi/context.py
+++ b/armi/context.py
@@ -125,7 +125,7 @@ try:
     MPI_NODENAME = MPI.Get_processor_name()
     MPI_NODENAMES = MPI_COMM.allgather(MPI_NODENAME)
 
-    # catch an exceptional case where MPI incorrectly identifies "interactive mode"
+    # fix an exceptional error case when we are not in "interactive mode"
     if MPI_SIZE > 1 and CURRENT_MODE == Mode.INTERACTIVE:
         CURRENT_MODE = Mode.BATCH
 except ImportError:

--- a/armi/context.py
+++ b/armi/context.py
@@ -125,6 +125,7 @@ try:
     MPI_NODENAME = MPI.Get_processor_name()
     MPI_NODENAMES = MPI_COMM.allgather(MPI_NODENAME)
 
+    # catch an exceptional case where MPI incorrectly identifies "interactive mode"
     if MPI_SIZE > 1 and CURRENT_MODE == Mode.INTERACTIVE:
         CURRENT_MODE = Mode.BATCH
 except ImportError:

--- a/armi/context.py
+++ b/armi/context.py
@@ -124,6 +124,9 @@ try:
     MPI_SIZE = MPI_COMM.Get_size()
     MPI_NODENAME = MPI.Get_processor_name()
     MPI_NODENAMES = MPI_COMM.allgather(MPI_NODENAME)
+
+    if MPI_SIZE > 1 and CURRENT_MODE == Mode.INTERACTIVE:
+        CURRENT_MODE = Mode.BATCH
 except ImportError:
     # stick with defaults
     pass


### PR DESCRIPTION
## What is the change?

This minor tweak improves our ability to correctly identify if ARMI is being run in "interactive mode" or on some sort of compute cluster.

## Why is the change being made?

While playing around with new backends for MPI, I found that some times OpenMPI would incorrectly identify that we were in a TTY case, when we were really in a batch mode.  While it might be possible to re-compile _most_ MPI backends to mpi4py to fix this, I can't really prove that. And, in any case, this is a very cheap solution to a complicated MPI question.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.