### PR TITLE
Adding system info logging for Linux

### DIFF
--- a/armi/bookkeeping/report/newReportUtils.py
+++ b/armi/bookkeeping/report/newReportUtils.py
@@ -45,10 +45,10 @@ def insertGeneralReportContent(cs, r, report, stage):
 
     Parameters
     ----------
-    cs : armi.settings.caseSettings.Settings
-    r : Reactor
-    report : ReportContents
-    blueprint : Blueprint
+        cs : case settings
+        r : reactor
+        report : ReportContents object
+        blueprint : blueprint
     """
     # These items only happen once at BOL
     if stage == newReports.ReportStage.Begin:
@@ -61,7 +61,7 @@ def comprehensiveBOLContent(cs, r, report):
 
     Parameters
     ----------
-    cs: armi.settings.caseSettings.Settings
+    cs: Case Settings
     r: Reactor
     report: ReportContent
     """
@@ -84,6 +84,7 @@ def insertDesignContent(r, report):
     ----------
     r: reactor
     report: ReportContent
+
     """
     report[DESIGN][PIN_ASSEMBLY_DESIGN_SUMMARY] = getPinDesignTable(r.core)
 
@@ -102,13 +103,14 @@ def insertDesignContent(r, report):
 
 
 def insertBlockDesignReport(blueprint, report, cs):
-    """Summarize the block designs from the loading file.
+    r"""Summarize the block designs from the loading file.
 
     Parameters
     ----------
     blueprint : Blueprint
     report: ReportContent
-    cs: armi.settings.caseSettings.Settings
+    cs: Case Settings
+
     """
     report[DESIGN]["Block Summaries"] = newReports.Section("Block Summaries")
 
@@ -168,14 +170,12 @@ def insertBlockDesignReport(blueprint, report, cs):
 
 
 def insertCoreDesignReport(core, cs, report):
-    """Builds report to summarize core design inputs.
+    r"""Builds report to summarize core design inputs.
 
     Parameters
     ----------
-    core: armi.reactor.reactors.Core
+    core:  armi.reactor.reactors.Core
     cs: armi.settings.caseSettings.Settings
-    report : ReportContent
-        The report to be added to.
     """
     coreDesignTable = newReports.Table("Core Report Table")
     coreDesignTable.header = ["", "Input Parameter"]
@@ -211,7 +211,7 @@ def _setGeneralCoreParametersData(core, cs, coreDesignTable):
     Parameters
     ----------
     core: Core
-    cs: armi.settings.caseSettings.Settings
+    cs: Case Settings
     coreDesignTable: newReports.Table
         Current state of table to be added to
     """
@@ -317,6 +317,7 @@ def insertEndOfLifeContent(r, report):
     Parameters
     ----------
     r : Reactor
+        the reactor
     report : ReportContent
         The report to be added to.
     """
@@ -346,7 +347,7 @@ def insertBlockDiagrams(cs, blueprint, report, cold):
 
     Parameters
     ----------
-    cs: armi.settings.caseSettings.Settings
+    cs: Case Settings
     blueprint: Blueprint
     report: ReportContent
     cold: boolean
@@ -387,7 +388,7 @@ def insertMetaTable(cs, report):
 
     Parameters
     ----------
-    cs: armi.settings.caseSettings.Settings
+    cs: Case Settings
     report: ReportContent
     """
     section = report[COMPREHENSIVE_REPORT]
@@ -406,7 +407,7 @@ def insertSettingsData(cs, report):
 
     Parameters
     ----------
-    cs: armi.settings.caseSettings.Settings
+    cs: Case Settings
     report: ReportContent
         The report to be added to
     """
@@ -616,7 +617,7 @@ def createDimensionReport(comp):
 def insertCoreAndAssemblyMaps(
     r, cs, report, blueprint, generateFullCoreMap=False, showBlockAxMesh=True
 ):
-    """Create core and assembly design plots.
+    r"""Create core and assembly design plots.
 
     Parameters
     ----------

--- a/armi/bookkeeping/report/newReportUtils.py
+++ b/armi/bookkeeping/report/newReportUtils.py
@@ -45,10 +45,10 @@ def insertGeneralReportContent(cs, r, report, stage):
 
     Parameters
     ----------
-        cs : case settings
-        r : reactor
-        report : ReportContents object
-        blueprint : blueprint
+    cs : armi.settings.caseSettings.Settings
+    r : Reactor
+    report : ReportContents
+    blueprint : Blueprint
     """
     # These items only happen once at BOL
     if stage == newReports.ReportStage.Begin:
@@ -61,7 +61,7 @@ def comprehensiveBOLContent(cs, r, report):
 
     Parameters
     ----------
-    cs: Case Settings
+    cs: armi.settings.caseSettings.Settings
     r: Reactor
     report: ReportContent
     """
@@ -84,7 +84,6 @@ def insertDesignContent(r, report):
     ----------
     r: reactor
     report: ReportContent
-
     """
     report[DESIGN][PIN_ASSEMBLY_DESIGN_SUMMARY] = getPinDesignTable(r.core)
 
@@ -103,14 +102,13 @@ def insertDesignContent(r, report):
 
 
 def insertBlockDesignReport(blueprint, report, cs):
-    r"""Summarize the block designs from the loading file.
+    """Summarize the block designs from the loading file.
 
     Parameters
     ----------
     blueprint : Blueprint
     report: ReportContent
-    cs: Case Settings
-
+    cs: armi.settings.caseSettings.Settings
     """
     report[DESIGN]["Block Summaries"] = newReports.Section("Block Summaries")
 
@@ -170,12 +168,14 @@ def insertBlockDesignReport(blueprint, report, cs):
 
 
 def insertCoreDesignReport(core, cs, report):
-    r"""Builds report to summarize core design inputs.
+    """Builds report to summarize core design inputs.
 
     Parameters
     ----------
-    core:  armi.reactor.reactors.Core
+    core: armi.reactor.reactors.Core
     cs: armi.settings.caseSettings.Settings
+    report : ReportContent
+        The report to be added to.
     """
     coreDesignTable = newReports.Table("Core Report Table")
     coreDesignTable.header = ["", "Input Parameter"]
@@ -211,7 +211,7 @@ def _setGeneralCoreParametersData(core, cs, coreDesignTable):
     Parameters
     ----------
     core: Core
-    cs: Case Settings
+    cs: armi.settings.caseSettings.Settings
     coreDesignTable: newReports.Table
         Current state of table to be added to
     """
@@ -317,7 +317,6 @@ def insertEndOfLifeContent(r, report):
     Parameters
     ----------
     r : Reactor
-        the reactor
     report : ReportContent
         The report to be added to.
     """
@@ -347,7 +346,7 @@ def insertBlockDiagrams(cs, blueprint, report, cold):
 
     Parameters
     ----------
-    cs: Case Settings
+    cs: armi.settings.caseSettings.Settings
     blueprint: Blueprint
     report: ReportContent
     cold: boolean
@@ -388,7 +387,7 @@ def insertMetaTable(cs, report):
 
     Parameters
     ----------
-    cs: Case Settings
+    cs: armi.settings.caseSettings.Settings
     report: ReportContent
     """
     section = report[COMPREHENSIVE_REPORT]
@@ -407,7 +406,7 @@ def insertSettingsData(cs, report):
 
     Parameters
     ----------
-    cs: Case Settings
+    cs: armi.settings.caseSettings.Settings
     report: ReportContent
         The report to be added to
     """
@@ -617,7 +616,7 @@ def createDimensionReport(comp):
 def insertCoreAndAssemblyMaps(
     r, cs, report, blueprint, generateFullCoreMap=False, showBlockAxMesh=True
 ):
-    r"""Create core and assembly design plots.
+    """Create core and assembly design plots.
 
     Parameters
     ----------

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -236,7 +236,7 @@ def writeWelcomeHeaders(o, cs):
 
 
 def getNodeName():
-    """Get the name of this comput node.
+    """Get the name of this compute node.
 
     First, look in context.py. Then try various Linux tools. Then try Windows commands.
 

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -193,6 +193,13 @@ def writeWelcomeHeaders(o, cs):
                 )
                 # If this is on Windows: run sys info on each unique node too
                 if "win" in sys.platform:
+                    """Example results:
+
+                    OS Name:         Microsoft Windows 10 Enterprise
+                    OS Version:      10.0.19041 N/A Build 19041
+                    Processor(s):    1 Processor(s) Installed.
+                                     [01]: Intel64 Family 6 Model 142 Stepping 12 GenuineIntel ~801 Mhz
+                    """
                     sysInfoCmd = (
                         'systeminfo | findstr /B /C:"OS Name" /B /C:"OS Version" /B '
                         '/C:"Processor" && systeminfo | findstr /E /C:"Mhz"'
@@ -201,6 +208,12 @@ def writeWelcomeHeaders(o, cs):
                         sysInfoCmd, capture_output=True, text=True, shell=True
                     )
                     sysInfo += out.stdout
+                elif "linux" in sys.platform:
+                    pass
+                else:
+                    # TODO: JOHN
+                    pass
+
             runLog.header("=========== Machine Information ===========")
             runLog.info(
                 tabulate.tabulate(

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -78,7 +78,7 @@ def writeWelcomeHeaders(o, cs):
             (Operator_ArmiCodebase, context.ROOT),
             (Operator_WorkingDirectory, os.getcwd()),
             (Operator_PythonInterperter, sys.version),
-            (Operator_MasterMachine, os.environ.get("COMPUTERNAME", "?")),
+            (Operator_MasterMachine, getNodeName()),
             (Operator_NumProcessors, context.MPI_SIZE),
             (Operator_Date, context.START_TIME),
         ]
@@ -233,6 +233,30 @@ def writeWelcomeHeaders(o, cs):
     _writeInputFileInformation(cs)
     _writeMachineInformation()
     _writeReactorCycleInformation(o, cs)
+
+
+def getNodeName():
+    """Get the name of this comput node.
+
+    First, look in context.py. Then try various Linux tools. Then try Windows commands.
+
+    Returns
+    -------
+    str
+        Compute node name.
+    """
+    hostNames = [
+        context.MPI_NODENAME,
+        context.MPI_NODENAMES[0],
+        subprocess.run("hostname", capture_output=True, text=True, shell=True).stdout,
+        subprocess.run("uname -n", capture_output=True, text=True, shell=True).stdout,
+        os.environ.get("COMPUTERNAME", context.LOCAL),
+    ]
+    for nodeName in hostNames:
+        if nodeName and nodeName != context.LOCAL:
+            return nodeName
+
+    return context.LOCAL
 
 
 def _getSystemInfoWindows():

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -262,6 +262,11 @@ def _getSystemInfoWindows():
 def _getSystemInfoLinux():
     """Get system information, assuming the system is Linux.
 
+    This method uses multiple, redundant variations on common Linux command utilities to get the
+    information necessary. While it is not possible to guarantee what programs or files will be
+    available on "all Linux operating system", this collection of tools is widely supported and
+    should provide a reasonably broad-distribution coverage.
+
     Returns
     -------
     str
@@ -326,30 +331,14 @@ def _getSystemInfoLinux():
 def getSystemInfo():
     """Get system information, assuming the system is Windows or Linux.
 
+    Notes
+    -----
+    The format of the system information will be different on Windows vs Linux.
+
     Returns
     -------
     str
         Basic system information: OS name, OS version, basic processor information
-
-    Examples
-    --------
-    Example Windows:
-
-        OS Name:         Microsoft Windows 10 Enterprise
-        OS Version:      10.0.19041 N/A Build 19041
-        Processor(s):    1 Processor(s) Installed.
-                         [01]: Intel64 Family 6 Model 142 Stepping 12 GenuineIntel ~801 Mhz
-
-    Example Linux results:
-
-        OS Info:  Ubuntu 22.04.3 LTS
-        Processor(s):
-            processor   : 0
-            vendor_id   : GenuineIntel
-            cpu family  : 6
-            model       : 126
-            model name  : Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz
-            ...
     """
     # Get basic system information (on Windows and Linux)
     if "win" in sys.platform:

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -192,7 +192,7 @@ def writeWelcomeHeaders(o, cs):
                     (uniqueName, numProcessors, ", ".join(matchingProcs))
                 )
 
-                sysInfo += getSystemInfo
+                sysInfo += getSystemInfo()
 
             runLog.header("=========== Machine Information ===========")
             runLog.info(

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -49,27 +49,29 @@ class _MockReturnResult:
 
 class TestReportingUtils(unittest.TestCase):
     def test_getSystemInfoLinux(self):
-        catOsName = 'NAME="Ubuntu"\n'
-        catOsPrettyName = 'PRETTY_NAME="Ubuntu 22.04.3 LTS"\n'
-        catProcInfo = """processor : 0
+        """Test _getSystemInfoLinux() on any operating system, by mocking the system calls."""
+        osInfo = '"Ubuntu 22.04.3 LTS"'
+        procInfo = """processor : 0
 vendor_id   : GenuineIntel
 cpu family  : 6
 model       : 126
 model name  : Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz
+...
 """
-        correctResult = """OS Name:       Ubuntu
-OS Version:    Ubuntu 22.04.3 LTS
-Processor(s):  1 Processor(s) Installed.
-               [1]: Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz"""
+        correctResult = """OS Info:  "Ubuntu 22.04.3 LTS"
+Processor(s):
+    processor : 0
+    vendor_id   : GenuineIntel
+    cpu family  : 6
+    model       : 126
+    model name  : Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz
+    ..."""
 
         def __mockSubprocessRun(*args, **kwargs):
             if "os-release" in args[0]:
-                if "PRETTY" in args[0]:
-                    return _MockReturnResult(catOsPrettyName)
-                else:
-                    return _MockReturnResult(catOsName)
+                return _MockReturnResult(osInfo)
             else:
-                return _MockReturnResult(catProcInfo)
+                return _MockReturnResult(procInfo)
 
         with patch.object(subprocess, "run", side_effect=__mockSubprocessRun):
             out = _getSystemInfoLinux()
@@ -77,6 +79,7 @@ Processor(s):  1 Processor(s) Installed.
 
     @patch("subprocess.run")
     def test_getSystemInfoWindows(self, mockSubprocess):
+        """Test _getSystemInfoWindows() on any operating system, by mocking the system call."""
         windowsResult = """OS Name:         Microsoft Windows 10 Enterprise
 OS Version:      10.0.19041 N/A Build 19041
 Processor(s):    1 Processor(s) Installed.
@@ -90,15 +93,15 @@ Processor(s):    1 Processor(s) Installed.
     def test_getSystemInfo(self):
         """Basic sanity check of getSystemInfo() running in the wild.
 
-        This test should pass if it is run on Window or mainstream Linux distros. But we expect this to fail
-        if the test is run on some other OS.
+        This test should pass if it is run on Window or mainstream Linux distros. But we expect this
+        to fail if the test is run on some other OS.
         """
         out = getSystemInfo()
-        substrings = ["OS Name:", "OS Version", "Processor(s):"]
+        substrings = ["OS ", "Processor(s):"]
         for sstr in substrings:
             self.assertIn(sstr, out)
 
-        self.assertGreater(len(out), sum(len(sstr) + 3 for sstr in substrings))
+        self.assertGreater(len(out), sum(len(sstr) + 5 for sstr in substrings))
 
 
 class TestReport(unittest.TestCase):

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -41,7 +41,7 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class _MockReturnResult:
-    """Mocking the subproces.run() return object."""
+    """Mocking the subprocess.run() return object."""
 
     def __init__(self, stdout):
         self.stdout = stdout

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -25,6 +25,7 @@ from armi.bookkeeping.report import data, reportInterface
 from armi.bookkeeping.report.reportingUtils import (
     _getSystemInfoLinux,
     _getSystemInfoWindows,
+    getNodeName,
     getSystemInfo,
     makeBlockDesignReport,
     setNeutronBalancesReport,
@@ -102,6 +103,15 @@ Processor(s):    1 Processor(s) Installed.
             self.assertIn(sstr, out)
 
         self.assertGreater(len(out), sum(len(sstr) + 5 for sstr in substrings))
+
+    def test_getNodeName(self):
+        """Test that the getNodeName() method returns a non-empty string.
+
+        It is hard to know what string SHOULD be return here, and it would depend on how the OS is
+        set up on your machine or cluster. But this simple test needs to pass as-is on Windows
+        and Linux.
+        """
+        self.assertGreater(len(getNodeName()), 0)
 
 
 class TestReport(unittest.TestCase):

--- a/armi/context.py
+++ b/armi/context.py
@@ -104,8 +104,9 @@ MPI_COMM = None
 # MPI_SIZE is the total number of CPUs
 MPI_RANK = 0
 MPI_SIZE = 1
-MPI_NODENAME = "local"
-MPI_NODENAMES = ["local"]
+LOCAL = "local"
+MPI_NODENAME = LOCAL
+MPI_NODENAMES = [LOCAL]
 
 
 try:

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -9,6 +9,7 @@ Release Date: TBD
 New Features
 ------------
 #. Conserve mass by component in assembly.setBlockMesh(). (`PR#1665 <https://github.com/terrapower/armi/pull/1665>`_)
+#. System information is now also logged on Linux. (`PR#1689 <https://github.com/terrapower/armi/pull/1689>`_)
 #. TBD
 
 API Changes


### PR DESCRIPTION
## What is the change?

Adding detailed system information for OS and processors, for a wide range of Linux operating systems.

Because there are so many different flavors of Linux, the new system info logging has multiple redundant ways to find the same OS/processor information. The code will try each one in turn before giving up and trying the next one. In this way, we should support a wide array of Linux flavors seamlessly.

## Why is the change being made?

ARMI is supposed to support Windows _and_ Linux.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.