### PR TITLE
Adding explanation to release docs

### DIFF
--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -116,7 +116,8 @@ minor PRs won't require a release note.
 In particular, in the release notes, you will find four sections in the releasee notes:
 
 1. **New Features** - A new feature (or major addition to a current feature) was added to the code.
-2. **API Changes** - ANY change to the public-facing API of ARMI.
+2. **API Changes** - ANY breaking change to the public-facing API of ARMI. (A breaking change is
+   when you change the existing API, not when you add something new to the API.)
 3. **Bug Fixes** - ANY bug fix in the code (not the documentation), no matter how minor.
 4. **Changes that Affect Requirements** - If you touch the code (``impl``) or test (``test``) for
    anything that currently has a requirement crumb. (This must be a non-trivial change.)

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -8,8 +8,8 @@ Release Date: TBD
 
 New Features
 ------------
-#. Conserve mass by component in assembly.setBlockMesh(). (`PR#1665 <https://github.com/terrapower/armi/pull/1665>`_)
-#. Removal of the Block.reactor property. (`PR#1425 <https://github.com/terrapower/armi/pull/1425>`_)
+#. Conserve mass by component in ``assembly.setBlockMesh()``. (`PR#1665 <https://github.com/terrapower/armi/pull/1665>`_)
+#. Removal of the ``Block.reactor`` property. (`PR#1425 <https://github.com/terrapower/armi/pull/1425>`_)
 #. System information is now also logged on Linux. (`PR#1689 <https://github.com/terrapower/armi/pull/1689>`_)
 #. TBD
 


### PR DESCRIPTION
## What is the change?

I have added some description to the release notes section of the docs.

## Why is the change being made?

I thought this idea wasn't clear enough.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.