### PR TITLE
Fixing broken path in user docs

### DIFF
--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -62,7 +62,7 @@ This file is a YAML file that you can edit manually with a text editor or with t
 
 Here is an excerpt from a settings file:
 
-.. literalinclude:: ../../../armi/tests/armiRun.yaml
+.. literalinclude:: ../../armi/tests/armiRun.yaml
     :language: yaml
     :lines: 3-15
 


### PR DESCRIPTION
## What is the change?

There was a broken path in the docs, so I fixed it.

## Why is the change being made?

The YAML file wasn't being properly rendered in the docs.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.