### PR TITLE
Fix a few notes within User Manual

### DIFF
--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -577,8 +577,6 @@ material
     The temperature (in C) that the component dimensions will be thermal expanded to (using material properties based on
     the ``material`` input). To disable automatic thermal expansion, set |Tinput| and |Thot| both to the same value
 
-    .. note:: The T/H modules of ARMI will update the hot temperature when coupling is activated.
-
 mult
     Multiplicity specifies how many duplicates of this component exist in this block. If you want 169 pins per assembly,
     this would be 169. This does not explicitly describe the location of the pins. Note that many fast-neutron systems

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -760,15 +760,14 @@ A complete definition of an inner-core assembly may be seen below::
                 nozzleType: Inner
                 xs types: [A, B, C, D, E, F]
 
-.. note:: While component dimensions are entered as cold dimensions, axial heights must
-        be entered as hot dimensions. The reason for this is that each component with different
-        material will thermally expand at different rates. In the axial dimension, this is
-        problematic because after a change in temperature each component in the same block
-        will have a different height. The solution is to pre-expand each component
-        axially and enter hot axial block heights. After the reactor is created, further
-        temperature changes will cause dimension changes only in 2 dimensions (radially). Mass
-        is always conserved, but if temperature deviates significantly from hot axial heights,
-        density may deviate as well.
+.. note:: 
+        While component dimensions are entered as cold dimensions, axial heights may be entered as 
+        either cold or hot dimensions. In older versions of ARMI, it was required to enter heights 
+        in the hot dimension (this behavior is preserved by setting `inputHeightsConsideredHot: True`).
+        However, with the 
+        :py:class:`axial expansion changer <armi.reactor.converters.axialExpansionChanger.AxialExpansionChanger>`, 
+        heights may be entered at cold temperatures (`inputHeightsConsideredHot: False`). Each Assembly will then 
+        be expanded to its hot dimensions upon construction.
 
 For many cases, a shared height and axial mesh point definition is sufficient. These can be included
 globally as shown above and linked with anchors, or specified explicitly.

--- a/doc/user/manual_data_access.rst
+++ b/doc/user/manual_data_access.rst
@@ -25,7 +25,7 @@ Accessing Some Interesting Info
 Often times, you may be interested in the geometric dimensions of various blocks. These are stored on the
 :py:mod:`components <armi.reactor.components>`, and may be accessed as follows::
 
-    b = o.r.getFirstBlock(Flags.FUEL)
+    b = o.r.core.getFirstBlock(Flags.FUEL)
     fuel = b.getComponent(Flags.FUEL)
     od = fuel.getDimension('od',cold=True)  # fuel outer diameter in cm
     odHot = fuel.getDimension('od')  # hot dimension


### PR DESCRIPTION
## What is the change?

While reading parts of the UM, I've found a couple notes that are out-of-date. 
1.  There is no T/H module within ARMI so temperatures are not updated in ARMI with tight coupling. 
2. Block heights don't have to be input at hot temperatures. 

## Why is the change being made?

Having correct docs is important. 

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- ~[Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.~

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- ~The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.~
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.