### PR TITLE
Removing outsideFuelRing parameters

### DIFF
--- a/.github/workflows/find_test_crumbs.py
+++ b/.github/workflows/find_test_crumbs.py
@@ -26,6 +26,8 @@ IGNORED_OBJECTS = [
     "armi/logs/armiRun.mpi.log",
     "armi/tests/tutorials/case-suite/",
     "armi/tests/tutorials/logs/",
+    "armiRun.h5",
+    "logs/",
 ]
 
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -122,7 +122,6 @@ def defineCoreParameters():
     pDefs = parameters.ParameterDefinitionCollection()
 
     with pDefs.createBuilder() as pb:
-
         pb.defParam(
             "detailedNucKeys",
             setter=isNumpyArray("detailedNucKeys"),
@@ -135,7 +134,6 @@ def defineCoreParameters():
         )
 
     with pDefs.createBuilder(location=ParamLocation.CENTROID) as pb:
-
         pb.defParam(
             "orientation",
             units=units.DEGREES,
@@ -147,7 +145,6 @@ def defineCoreParameters():
         )
 
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, default=0.0) as pb:
-
         pb.defParam(
             "maxAssemNum",
             units=units.UNITLESS,
@@ -158,7 +155,6 @@ def defineCoreParameters():
         pb.defParam("numMoves", units=units.UNITLESS, description="numMoves", default=0)
 
     with pDefs.createBuilder(location="N/A", categories=["control rods"]) as pb:
-
         pb.defParam(
             "crMostValuablePrimaryRodLocation",
             default="",
@@ -209,7 +205,6 @@ def defineCoreParameters():
         )
 
     with pDefs.createBuilder() as pb:
-
         pb.defParam(
             "axialMesh",
             units=units.CM,
@@ -219,7 +214,6 @@ def defineCoreParameters():
         )
 
     with pDefs.createBuilder(default=0.0, location="N/A") as pb:
-
         pb.defParam(
             "referenceBlockAxialMesh",
             units=units.CM,

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -315,18 +315,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "outsideFuelRing",
-            units=units.UNITLESS,
-            description="The ring (integer) with the fraction of flux that best meets the target",
-        )
-
-        pb.defParam(
-            "outsideFuelRingFluxFr",
-            units=units.UNITLESS,
-            description="Ratio of the flux in a ring to the total reactor fuel flux",
-        )
-
-        pb.defParam(
             "peakGridDpaAt60Years",
             units=units.DPA,
             description="Grid plate peak dpa after 60 years irradiation",

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -35,13 +35,14 @@ API Changes
     * Removing ``ArmiObject.printDensities()``.
     * Moving ``Composite.isOnWhichSymmetryLine()`` to ``Assembly``.
     * Removing ``Block.isOnWhichSymmetryLine()``.
-#. Removal of the ``Block.reactor`` property. (`PR#1425 <https://github.com/terrapower/armi/pull/1425>`_)
+#. Removing the ``Block.reactor`` property. (`PR#1425 <https://github.com/terrapower/armi/pull/1425>`_)
 #. Moving several ``ArmiObject`` methods. (`PR#1425 <https://github.com/terrapower/armi/pull/1425>`_)
     * Moving ``ArmiObject.getNeutronEnergyDepositionConstants`` to ``Block``.
     * Moving ``ArmiObject.getGammaEnergyDepositionConstants`` to ``Block``.
     * Moving ``ArmiObject.getTotalEnergyGenerationConstants`` to ``Block``.
     * Moving ``ArmiObject.getFissionEnergyGenerationConstants`` to ``Block``.
     * Moving ``ArmiObject.getCaptureEnergyGenerationConstants`` to ``Block``.
+#. Removing the parameeters ``outsideFuelRing`` and ``outsideFuelRingFluxFr``. (`PR#1700 <https://github.com/terrapower/armi/pull/1700>`_)
 #. TBD
 
 Bug Fixes


### PR DESCRIPTION
## What is the change?

Removing two parameters: `outsideFuelRing` and `outsideFuelRingFluxFr`.

## Why is the change being made?

After some discussion, we decided these parameters were unused.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.