### PR TITLE
Fixing a matplotlib update bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "coverage>=7.2.0", # Code coverage tool. Sadly baked into every Case.
     "h5py>=3.0,<=3.9", # Needed because our database files are H5 format
     "htmltree>=0.7.6", # Our reports have HTML output
-    "matplotlib>=3.5.3", # Important plotting library
+    "matplotlib>=3.5.3,<3.8.0", # Important plotting library
     "numpy>=1.21,<=1.23.5", # Important math library
     "ordered-set>=3.1.1", # A useful data structure
     "pluggy>=1.2.0", # Central tool behind the ARMI Plugin system


### PR DESCRIPTION
## What is the change?

Giving matplotlib a max version in ARMI.

## Why is the change being made?

This morning, matplotlib released a new version to PyPI.org today. This removed (or changed?) the old color map logic we are using:

https://github.com/terrapower/armi/blob/872e2dac316d937d06a9d3a7a314c48075204a2b/armi/utils/reportPlotting.py#L732

You will see get_cmap() in [matplotlib==3.7.5](https://matplotlib.org/3.7.5/api/cm_api.html), but not in [matplotlib==3.8.4](https://matplotlib.org/3.8.4/api/cm_api.html).

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.