### PR TITLE
Removing unused parameter rdIterNum

### DIFF
--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -22,19 +22,6 @@ from armi.utils import units
 def defineReactorParameters():
     pDefs = parameters.ParameterDefinitionCollection()
 
-    pDefs.add(
-        parameters.Parameter(
-            "rdIterNum",
-            units=units.UNITLESS,
-            description="Integer number of region-density equilibrium iterations",
-            location=ParamLocation.AVERAGE,
-            saveToDB=True,
-            default=parameters.NoDefault,
-            setter=parameters.NoDefault,
-            categories=set(),
-        )
-    )
-
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, default=0.0) as pb:
         pb.defParam(
             "cycle",

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -43,6 +43,7 @@ API Changes
     * Moving ``ArmiObject.getFissionEnergyGenerationConstants`` to ``Block``.
     * Moving ``ArmiObject.getCaptureEnergyGenerationConstants`` to ``Block``.
 #. Removing the parameeters ``outsideFuelRing`` and ``outsideFuelRingFluxFr``. (`PR#1700 <https://github.com/terrapower/armi/pull/1700>`_)
+#. Removing the parameeter ``rdIterNum``. (`PR#1704 <https://github.com/terrapower/armi/pull/1704>`_)
 #. TBD
 
 Bug Fixes


### PR DESCRIPTION
## What is the change?

Removed the unused parameter `rdIterNum`.

## Why is the change being made?

This parameter is very specific to one downstream project, and is not used anywhere else. So I judge this `Parameter` is not useful to a wide enough audience to be in ARMI.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.