### PR TITLE
Fix safeCopy on Windows

### DIFF
--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -813,17 +813,18 @@ def safeCopy(src: str, dst: str) -> None:
         dst = os.path.join(dst, os.path.basename(src))
     srcSize = os.path.getsize(src)
     if "win" in sys.platform:
-        cmd = f'copy "{src}" "{dst}"'
+        shutil.copyfile(src, dst)
+        shutil.copymode(src, dst)
     elif "linux" in sys.platform:
         cmd = f'cp "{src}" "{dst}"'
+        os.system(cmd)
     else:
         raise OSError(
             "Cannot perform ``safeCopy`` on files because ARMI only supports "
             + "Linux and Windows."
         )
-    os.system(cmd)
     waitTime = 0.01  # 10 ms
-    maxWaitTime = 1800  # 30 min
+    maxWaitTime = 300  # 5 min
     totalWaitTime = 0
     while True:
         dstSize = os.path.getsize(dst)


### PR DESCRIPTION
## What is the change?

1. Reverting the `os.system(cmd)` for windows to `shutil.copyfile`/`shutil.copymode`
2. Reducing the wait time to 5 minutes 

## Why is the change being made?

1. `copy` via `os.system` on Windows was taking an obscenely long time. And really we just needed the update from #1691 for linux functionality.
2. 30 min for a wait time is bonkers, so given some tests run we think we can safely reduce it to 5 min.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] ~[Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.~ No updates needed

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.