### PR TITLE
Removing the setting doOrificedTH

### DIFF
--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -65,7 +65,6 @@ CONF_DETAIL_ALL_ASSEMS = "detailAllAssems"
 CONF_DETAIL_ASSEM_LOCATIONS_BOL = "detailAssemLocationsBOL"
 CONF_DETAIL_ASSEM_NUMS = "detailAssemNums"
 CONF_DETAILED_AXIAL_EXPANSION = "detailedAxialExpansion"
-CONF_DO_ORIFICED_TH = "doOrificedTH"  # zones
 CONF_DUMP_SNAPSHOT = "dumpSnapshot"
 CONF_EQ_DIRECT = "eqDirect"  # fuelCycle/equilibrium coupling
 CONF_EXPLICIT_REPEAT_SHUFFLES = "explicitRepeatShuffles"
@@ -507,13 +506,6 @@ def defineSettings() -> List[setting.Setting]:
             label="Dump Snapshot Files",
             description="List of snapshots to dump reactor physics kernel input and "
             "output files. Can be used to perform follow-on analysis.",
-        ),
-        setting.Setting(
-            CONF_DO_ORIFICED_TH,
-            default=False,
-            label="Perform Core Orificing",
-            description="Perform orificed thermal hydraulics (requires bounds file "
-            "from a previous case)",
         ),
         setting.Setting(
             CONF_EQ_DIRECT,

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -43,7 +43,7 @@ API Changes
     * Moving ``ArmiObject.getFissionEnergyGenerationConstants`` to ``Block``.
     * Moving ``ArmiObject.getCaptureEnergyGenerationConstants`` to ``Block``.
 #. Removing the parameters ``outsideFuelRing`` and ``outsideFuelRingFluxFr``. (`PR#1700 <https://github.com/terrapower/armi/pull/1700>`_)
-#. Removing the setting ``doOrificedTH``. (`PR#1705 <https://github.com/terrapower/armi/pull/1705>`_)
+#. Removing the setting ``doOrificedTH``. (`PR#1706 <https://github.com/terrapower/armi/pull/1706>`_)
 #. TBD
 
 Bug Fixes

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -42,7 +42,8 @@ API Changes
     * Moving ``ArmiObject.getTotalEnergyGenerationConstants`` to ``Block``.
     * Moving ``ArmiObject.getFissionEnergyGenerationConstants`` to ``Block``.
     * Moving ``ArmiObject.getCaptureEnergyGenerationConstants`` to ``Block``.
-#. Removing the parameeters ``outsideFuelRing`` and ``outsideFuelRingFluxFr``. (`PR#1700 <https://github.com/terrapower/armi/pull/1700>`_)
+#. Removing the parameters ``outsideFuelRing`` and ``outsideFuelRingFluxFr``. (`PR#1700 <https://github.com/terrapower/armi/pull/1700>`_)
+#. Removing the setting ``doOrificedTH``. (`PR#1705 <https://github.com/terrapower/armi/pull/1705>`_)
 #. TBD
 
 Bug Fixes


### PR DESCRIPTION
## What is the change?

Removed the setting `doOrificiedTH`

## Why is the change being made?

There were two major reasons for this:

1. This setting is not used in ARMI.
2. It's perhaps too specific to SFRs and not generally useful enough to a broader reactor design audience.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.