### PR TITLE
Reverting earlier change to plotting

### DIFF
--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -404,7 +404,6 @@ def plotFaceMap(
             )
     elif referencesToKeep:
         # Don't show yet, since it will be updated.
-        plt.close(fig)
         return fName
     else:
         plt.show()


### PR DESCRIPTION
## What is the change?

Reverting a change to a recent plotting PR:  https://github.com/terrapower/armi/pull/1698/files#r1604149437

## Why is the change being made?

There was a request to revert the change where we are closing this plot in this one place.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.