### PR TITLE
Fixing units for multigroup gamma flux

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -86,7 +86,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "mgFluxGamma",
-            units=f"{units.GRAMS}*{units.CM}/{units.SECONDS}",
+            units=f"#*{units.CM}/{units.SECONDS}",
             description="multigroup gamma flux",
             location=ParamLocation.VOLUME_INTEGRATED,
             saveToDB=True,

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -110,7 +110,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "extSrc",
-            units=f"{units.GRAMS}/{units.CM}^3/{units.SECONDS}",
+            units=f"#/{units.CM}^3/{units.SECONDS}",
             description="multigroup external source",
             location=ParamLocation.AVERAGE,
             saveToDB=False,
@@ -120,7 +120,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "mgGammaSrc",
-            units=f"{units.GRAMS}/{units.CM}^3/{units.SECONDS}",
+            units=f"#/{units.CM}^3/{units.SECONDS}",
             description="multigroup gamma source",
             location=ParamLocation.AVERAGE,
             saveToDB=True,
@@ -133,7 +133,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "gammaSrc",
-            units=f"{units.GRAMS}/{units.CM}^3/{units.SECONDS}",
+            units=f"#/{units.CM}^3/{units.SECONDS}",
             description="gamma source",
             location=ParamLocation.AVERAGE,
             saveToDB=True,
@@ -183,7 +183,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "pinMgFluxesGamma",
-            units=f"{units.GRAMS}/{units.CM}^2/{units.SECONDS}",
+            units=f"#/{units.CM}^2/{units.SECONDS}",
             description="should be a blank 3-D array, but re-defined later (ng x nPins x nAxialSegments)",
             categories=[parameters.Category.pinQuantities, parameters.Category.gamma],
             saveToDB=False,
@@ -528,7 +528,7 @@ def _getNeutronicsBlockParams():
 
         pb.defParam(
             "fluxGamma",
-            units=f"{units.GRAMS}/{units.CM}^2/{units.SECONDS}",
+            units=f"#/{units.CM}^2/{units.SECONDS}",
             description="Gamma scalar flux",
             categories=[
                 parameters.Category.retainOnReplacement,


### PR DESCRIPTION
## What is the change?

Fixing units for multigroup gamma flux

## Why is the change being made?

Close #1712 , there was an error in documenting the units of a parameter.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.