### PR TITLE
Fixing docs build on MacOS, and fixing docs docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ venv*/
 *.h5
 *.txt
 
+# metadata file specific to MacOS
+.DS_Store
+
 # vis files
 *.vtu
 *.vtd

--- a/doc/developer/documenting.rst
+++ b/doc/developer/documenting.rst
@@ -25,7 +25,7 @@ Building the documentation
 Before building documentation, ensure that you have installed the test requirements into
 your ARMI virtual environment with::
 
-    pip install -e .[test]
+    pip install -e .[docs]
 
 You also need to have the following utilities available in your PATH:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ docs = [
     "sphinxcontrib-jquery==4.1", # Handle missing jquery errors
     "jupyter-contrib-nbextensions", # A collections of JS extensions for jupyter notebooks
     "lxml<5.0.0", # Needed because the dep above is no longer an active project
+    "wxPython", # optional for default install, needed for docs build
 ]
 
 [project.scripts]


### PR DESCRIPTION
## What is the change?
Closes #1718 and adds a line in the `.gitignore` for `.DS_Store` files in MacOS. 

## Why is the change being made?
Functioning docs builds are good! And not accidentally ending up with a MacOS metadata file in the repo is ideal. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- ~[Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.~

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.