### PR TITLE
Removing wxpython from the docs build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ docs = [
     "sphinxcontrib-jquery==4.1", # Handle missing jquery errors
     "jupyter-contrib-nbextensions", # A collections of JS extensions for jupyter notebooks
     "lxml<5.0.0", # Needed because the dep above is no longer an active project
-    "wxPython", # optional for default install, needed for docs build
 ]
 
 [project.scripts]


### PR DESCRIPTION
## What is the change?

Removed `wxpython` as a mandatory docs dependency.

## Why is the change being made?

This was causing the build to fail.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.