### PR TITLE
Cleaning up build tools

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 # use workaround due to: https://github.com/psf/black/issues/2079#issuecomment-812359146
 jobs:
     check-formatting:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python 3.11

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -30,5 +30,5 @@ jobs:
         run: |
           pip install -e .[memprof,mpi,test]
           pytest -n 4 armi
-          mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiFeatures.py || true
-          mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiParameters.py || true
+          mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --ignore=venv armi/tests/test_mpiFeatures.py || true
+          mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --ignore=venv armi/tests/test_mpiParameters.py || true

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -11,10 +11,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: [3.9, '3.10', '3.11', '3.12']
+        python: [3.9, '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']

--- a/.github/workflows/unittests_old.yaml
+++ b/.github/workflows/unittests_old.yaml
@@ -30,5 +30,5 @@ jobs:
         run: |
           pip install -e .[memprof,mpi,test]
           pytest -n 4 armi
-          mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiFeatures.py || true
-          mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiParameters.py || true
+          mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --ignore=venv armi/tests/test_mpiFeatures.py || true
+          mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --ignore=venv armi/tests/test_mpiParameters.py || true

--- a/.github/workflows/unittests_old.yaml
+++ b/.github/workflows/unittests_old.yaml
@@ -1,4 +1,4 @@
-name: ARMI unit tests
+name: unit tests - older Pythons
 
 on:
   push:
@@ -11,10 +11,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: [3.9, '3.10', '3.11', '3.12']
+        python: [3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the Database3 class."""
-from distutils.spawn import find_executable
+import shutil
 import subprocess
 import unittest
 
@@ -31,9 +31,9 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 # determine if this is a parallel run, and git is installed
 GIT_EXE = None
-if find_executable("git") is not None:
+if shutil.which("git") is not None:
     GIT_EXE = "git"
-elif find_executable("git.exe") is not None:
+elif shutil.which("git.exe") is not None:
     GIT_EXE = "git.exe"
 
 

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -24,9 +24,9 @@ mpiexec -n 2 python -m pytest armi/tests/test_mpiFeatures.py
 or
 mpiexec.exe -n 2 python -m pytest armi/tests/test_mpiFeatures.py
 """
-from distutils.spawn import find_executable
 from unittest.mock import patch
 import os
+import shutil
 import unittest
 
 from armi import context
@@ -47,9 +47,9 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 # determine if this is a parallel run, and MPI is installed
 MPI_EXE = None
-if find_executable("mpiexec.exe") is not None:
+if shutil.which("mpiexec.exe") is not None:
     MPI_EXE = "mpiexec.exe"
-elif find_executable("mpiexec") is not None:
+elif shutil.which("mpiexec") is not None:
     MPI_EXE = "mpiexec"
 
 MPI_COMM = context.MPI_COMM

--- a/armi/tests/test_mpiParameters.py
+++ b/armi/tests/test_mpiParameters.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests of the MPI portion of the Parameters class."""
-from distutils.spawn import find_executable
+import shutil
 import unittest
 
 from armi import context
@@ -21,9 +21,9 @@ from armi.reactor import parameters
 
 # determine if this is a parallel run, and MPI is installed
 MPI_EXE = None
-if find_executable("mpiexec.exe") is not None:
+if shutil.which("mpiexec.exe") is not None:
     MPI_EXE = "mpiexec.exe"
-elif find_executable("mpiexec") is not None:
+elif shutil.which("mpiexec") is not None:
     MPI_EXE = "mpiexec"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,19 +15,9 @@
 #######################################################################
 #                        GENERAL PYTHON CONFIG                        #
 #######################################################################
-#[build-system]
-#requires = ["setuptools>=61.2"]
-#build-backend = "setuptools.build_meta"
-#
-#[tool.setuptools.packages]
-#find = {}
-
 [build-system]
-requires = ["hatchling>=1.24.2"]
-build-backend = "hatchling.build"
-
-[tool.hatch.metadata]
-allow-direct-references = true
+requires = ["setuptools>=61.2"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "armi"
@@ -70,7 +60,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
 
@@ -126,6 +115,9 @@ docs = [
 
 [project.scripts]
 armi = "armi.__main__:main"
+
+[tool.setuptools.packages]
+find = {}
 
 
 #######################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,19 @@
 #######################################################################
 #                        GENERAL PYTHON CONFIG                        #
 #######################################################################
+#[build-system]
+#requires = ["setuptools>=61.2"]
+#build-backend = "setuptools.build_meta"
+#
+#[tool.setuptools.packages]
+#find = {}
+
 [build-system]
-requires = ["setuptools>=61.2"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling>=1.24.2"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [project]
 name = "armi"
@@ -116,9 +126,6 @@ docs = [
 
 [project.scripts]
 armi = "armi.__main__:main"
-
-[tool.setuptools.packages]
-find = {}
 
 
 #######################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
 


### PR DESCRIPTION
## What is the change?

Here I clean up our build tools in twoways:

1. Splitting our unit test Worflows into two parts:
  * Older versions of Python get Ubuntu 22.04
  * Newer versions of Python need Ubuntu 24.04
2. Dropping direct usage of `distutils`

## Why is the change being made?

With this PR I was originally trying to support Python 3.12 but found that we couldn't due to [our NumPy jagged array issue](https://github.com/terrapower/armi/issues/246).

> But this PR gets ARMI 99.9% ready for Python 3.12; everything except our NumPy woes.

---

## Checklist

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.