### PR TITLE
Clearing worker processor instances of reactor state after every interaction

### DIFF
--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -342,7 +342,7 @@ class SystemAndProcessMemoryUsage:
         self.processMemoryInMB: Optional[float] = None
         if _havePsutil:
             self.percentNodeRamUsed = psutil.virtual_memory().percent
-            self.processMemoryInMB = psutil.Process().memory_info().rss / (1012.0**2)
+            self.processMemoryInMB = psutil.Process().memory_info().rss / (1024.0**2)
 
     def __isub__(self, other):
         if self.percentNodeRamUsed is not None and other.percentNodeRamUsed is not None:

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -528,6 +528,9 @@ class Operator:
                     )
                 )
 
+            # Allow inherited classes to clean up things after an interaction
+            self._finalizeInteract()
+
         runLog.header(
             "===========  Completed {} Event ===========\n".format(
                 interactionName + cycleNodeTag
@@ -535,6 +538,13 @@ class Operator:
         )
 
         return halt
+
+    def _finalizeInteract(self):
+        """Member called after each interface has completed its interaction.
+
+        Useful for cleaning up data.
+        """
+        pass
 
     def printInterfaceSummary(self, interface, interactionName, statePointIndex, *args):
         """

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -164,7 +164,7 @@ class OperatorMPI(Operator):
                 if note != "wait":
                     raise RuntimeError('did not get "wait". Got {0}'.format(note))
             elif cmd == "reset":
-                runLog.info("Workers are being reset.")
+                runLog.extra("Workers are being reset.")
             else:
                 # we don't understand the command on our own. check the interfaces
                 # this allows all interfaces to have their own custom operation code.

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -163,6 +163,8 @@ class OperatorMPI(Operator):
                 note = context.MPI_COMM.bcast("wait", root=0)
                 if note != "wait":
                     raise RuntimeError('did not get "wait". Got {0}'.format(note))
+            elif cmd == "reset":
+                runLog.info("Workers are being reset.")
             else:
                 # we don't understand the command on our own. check the interfaces
                 # this allows all interfaces to have their own custom operation code.
@@ -193,13 +195,26 @@ class OperatorMPI(Operator):
             pm = getPluginManager()
             resetFlags = pm.hook.mpiActionRequiresReset(cmd=cmd)
             # only reset if all the plugins agree to reset
-            if all(resetFlags):
+            if all(resetFlags) or cmd == "reset":
                 self._resetWorker()
 
             # might be an mpi action which has a reactor and everything, preventing
             # garbage collection
             del cmd
             gc.collect()
+
+    def _finalizeInteract(self):
+        """Inherited member called after each interface has completed its interact.
+
+        This will force all the workers to clear their reactor data so that it
+        isn't carried around to the next interact.
+
+        Notes
+        -----
+        This is only called on the root processor. Worker processors will know
+        what to do with the "reset" broadcast.
+        """
+        context.MPI_COMM.bcast("reset", root=0)
 
     def _resetWorker(self):
         """

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -218,6 +218,7 @@ class OperatorMPI(Operator):
         what to do with the "reset" broadcast.
         """
         context.MPI_COMM.bcast("clear", root=0)
+        runLog.extra("Workers have been cleared.")
 
     def _clearWorker(self):
         """Clear out the reactor on the workers."""

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -239,6 +239,10 @@ class OperatorMPI(Operator):
 
         .. warning:: This should build empty non-core systems too.
         """
+        # Nothing to do if we never had anything
+        if self.r is None:
+            return
+
         cs = self.cs
         bp = self.r.blueprints
         spatialGrid = self.r.core.spatialGrid

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -91,6 +91,13 @@ class FailingInterface3(Interface):
         return False
 
 
+class MockInterface(Interface):
+    name = "mockInterface"
+
+    def interactInit(self):
+        pass
+
+
 class MpiOperatorTests(unittest.TestCase):
     """Testing the MPI parallelization operator."""
 
@@ -139,6 +146,31 @@ class MpiOperatorTests(unittest.TestCase):
             self.assertRaises(Exception, self.o.operate)
         else:
             self.o.operate()
+
+    @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
+    def test_finalizeInteract(self):
+        """Test to make sure workers are reset after interface interactions."""
+        # Add a random number of interfaces
+        interface = MockInterface(self.o.r, self.o.cs)
+        self.o.addInterface(interface)
+
+        with mockRunLogs.BufferLog() as mock:
+            if context.MPI_RANK == 0:
+                self.o.interactAllInit()
+                context.MPI_COMM.bcast("quit", root=0)
+                context.MPI_COMM.bcast("finished", root=0)
+            else:
+                self.o.workerOperate()
+
+            logMessage = (
+                "Workers have been reset."
+                if context.MPI_RANK == 0
+                else "Workers are being reset."
+            )
+            numCalls = len(
+                [line for line in mock.getStdout().splitlines() if logMessage in line]
+            )
+            self.assertGreaterEqual(numCalls, 1)
 
 
 # these two must be defined up here so that they can be pickled


### PR DESCRIPTION
## What is the change?

The PR creates a method in `Operator` that is called `_finalizeInteract` which is called inside interface loop of `_interactAll`. This method is overridden by `OperatorMPI` to "reset" worker processors by broadcasting a command to force execution of `_resetWorker`.

## Why is the change being made?

The purpose of this change to force worker resets after each interaction is complete, instead of relying on plugins to return the correct `mpiActionRequiresReset` during `MpiAction` invocations. The goal was to reduce memory when going to subsequent interfaces that don't require a distributed state. However, the addition of this reset call is not reducing memory on worker processors, which means the "reset" implementation may be flawed. However, the change proposed in this PR is still appropriate in principle and improvements to the reset functionality can be improved in the future.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.