### PR TITLE
Fixing issue with _finalizeInteract in serial jobs

### DIFF
--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -216,7 +216,7 @@ class OperatorMPI(Operator):
         """
         if context.MPI_SIZE > 1:
             context.MPI_COMM.bcast("reset", root=0)
-        runLog.extra("Workers have been reset.")
+            runLog.extra("Workers have been reset.")
 
     def _resetWorker(self):
         """

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -214,7 +214,8 @@ class OperatorMPI(Operator):
         This is only called on the root processor. Worker processors will know
         what to do with the "reset" broadcast.
         """
-        context.MPI_COMM.bcast("reset", root=0)
+        if context.MPI_SIZE > 1:
+            context.MPI_COMM.bcast("reset", root=0)
         runLog.extra("Workers have been reset.")
 
     def _resetWorker(self):


### PR DESCRIPTION
## What is the change?

The new method `OperatorMPI._finalizeInteract()` does not work for serial jobs, this PR fixes that.


## Why is the change being made?

A recent [PR](https://github.com/terrapower/armi/commit/e8a80beaa85a9719537f96f40b0a80b4dd2cab9b), a bug was introduced:

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.