### PR TITLE
Adding code coverage to FH & GlobalFluxInt

### DIFF
--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -874,6 +874,25 @@ class TestFuelHandler(FuelHandlerTestHelper):
         with self.assertRaises(ValueError):
             fh.dischargeSwap(a2, a1)
 
+    def test_getAssembliesInRings(self):
+        fh = fuelHandlers.FuelHandler(self.o)
+        aList0 = fh._getAssembliesInRings([0], Flags.FUEL, False, None, False)
+        self.assertEqual(len(aList0), 1)
+
+        aList1 = fh._getAssembliesInRings([0, 1, 2], Flags.FUEL, False, None, False)
+        self.assertEqual(len(aList1), 3)
+
+        aList2 = fh._getAssembliesInRings([0, 1, 2], Flags.FUEL, True, None, False)
+        self.assertEqual(len(aList2), 3)
+
+        aList3 = fh._getAssembliesInRings(
+            [0, 1, 2, "SFP"], Flags.FUEL, True, None, False
+        )
+        self.assertEqual(len(aList3), 4)
+
+        aList4 = fh._getAssembliesInRings([0, 1, 2], Flags.FUEL, False, None, True)
+        self.assertEqual(len(aList4), 3)
+
 
 class TestFuelPlugin(unittest.TestCase):
     """Tests that make sure the plugin is being discovered well."""

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for generic global flux interface."""
+import logging
 import unittest
 from unittest.mock import patch
 
 import numpy
 
+from armi import runLog
 from armi import settings
 from armi.nuclearDataIO.cccc import isotxs
 from armi.physics.neutronics.globalFlux import globalFluxInterface
@@ -30,6 +32,7 @@ from armi.reactor.flags import Flags
 from armi.reactor.tests import test_blocks
 from armi.reactor.tests import test_reactors
 from armi.tests import ISOAA_PATH
+from armi.tests import mockRunLogs
 
 
 class MockReactorParams:
@@ -362,7 +365,7 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         # Test DoseResultsMapper. Pass in full list of blocks to apply() in order
         # to exercise blockList option (does not change behavior, since this is what
         # apply() does anyway)
-        opts = globalFluxInterface.GlobalFluxOptions("test")
+        opts = globalFluxInterface.GlobalFluxOptions("test_mapper")
         opts.fromUserSettings(o.cs)
         dosemapper = globalFluxInterface.DoseResultsMapper(1000, opts)
         dosemapper.apply(r, blockList=r.core.getBlocks())
@@ -372,6 +375,70 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
 
         mapper.clearFlux()
         self.assertEqual(len(block.p.mgFlux), 0)
+
+    @patch("armi.reactor.composites.ArmiObject.getMaxParam")
+    def test_updateCycleDoseParams(self, mockGetMaxParam):
+        # set up situation
+        mockGetMaxParam.return_value = 1.23
+        o, r = test_reactors.loadTestReactor(customSettings={CONF_XS_KERNEL: "MC2v2"})
+        applyDummyFlux(r)
+        r.core.lib = isotxs.readBinary(ISOAA_PATH)
+        r.p.timeNode = 1
+        r.p.cycleLength = 365
+        opts = globalFluxInterface.GlobalFluxOptions("test_updateCycleDoseParams")
+        opts.fromUserSettings(o.cs)
+        opts.aclpDoseLimit = 100
+
+        # build the mapper
+        mapper = globalFluxInterface.DoseResultsMapper(1000, opts)
+        mapper.r = r
+
+        # test the starting position
+        self.assertEqual(mapper.r.core.p.elevationOfACLP3Cycles, 0)
+        self.assertEqual(mapper.r.core.p.elevationOfACLP7Cycles, 0)
+        self.assertEqual(mapper.r.core.p.dpaFullWidthHalfMax, 0)
+
+        # test the logs, as this case won't change the param values
+        with mockRunLogs.BufferLog() as mock:
+            self.assertEqual("", mock.getStdout())
+            runLog.LOG.startLog("test_updateCycleDoseParams")
+            runLog.LOG.setVerbosity(logging.INFO)
+            mapper.updateCycleDoseParams()
+            stdOut = mock.getStdout()
+            somethingStrange = "Something strange with detailedDpaThisCycle"
+            self.assertIn(somethingStrange, stdOut)
+            self.assertEqual(stdOut.count(somethingStrange), 3)
+
+        # test the ending position
+        self.assertEqual(mapper.r.core.p.elevationOfACLP3Cycles, 0)
+        self.assertEqual(mapper.r.core.p.elevationOfACLP7Cycles, 0)
+        self.assertEqual(mapper.r.core.p.dpaFullWidthHalfMax, 0)
+
+    def test_updateLoadpadDose(self):
+        # init test reactor
+        o, r = test_reactors.loadTestReactor(customSettings={CONF_XS_KERNEL: "MC2v2"})
+
+        # init options
+        opts = globalFluxInterface.GlobalFluxOptions("test_updateLoadpadDose")
+        opts.fromUserSettings(o.cs)
+        opts.aclpDoseLimit = 100
+        opts.loadPadElevation = 12
+        opts.loadPadLength = 24
+
+        # init mapper
+        mapper = globalFluxInterface.DoseResultsMapper(1000, opts)
+        mapper.r = r
+
+        # test logging from updateLoadpadDose
+        with mockRunLogs.BufferLog() as mock:
+            self.assertEqual("", mock.getStdout())
+            runLog.LOG.startLog("test_updateLoadpadDose")
+            runLog.LOG.setVerbosity(logging.INFO)
+
+            mapper.updateLoadpadDose()
+            self.assertIn("Above-core load", mock.getStdout())
+            self.assertIn("The peak ACLP dose", mock.getStdout())
+            self.assertIn("The max avg", mock.getStdout())
 
     def test_getDpaXs(self):
         cs = settings.Settings()

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -213,7 +213,7 @@ class TestGlobalFluxInterfaceWithExecuters(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.cs = settings.Settings()
-        _o, cls.r = test_reactors.loadTestReactor()
+        cls.r = test_reactors.loadTestReactor()[1]
 
     def setUp(self):
         self.r.core.p.keff = 1.0
@@ -380,7 +380,7 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
     def test_updateCycleDoseParams(self, mockGetMaxParam):
         # set up situation
         mockGetMaxParam.return_value = 1.23
-        o, r = test_reactors.loadTestReactor(customSettings={CONF_XS_KERNEL: "MC2v2"})
+        o, r = test_reactors.loadTestReactor()
         applyDummyFlux(r)
         r.core.lib = isotxs.readBinary(ISOAA_PATH)
         r.p.timeNode = 1
@@ -416,7 +416,7 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
 
     def test_updateLoadpadDose(self):
         # init test reactor
-        o, r = test_reactors.loadTestReactor(customSettings={CONF_XS_KERNEL: "MC2v2"})
+        o, r = test_reactors.loadTestReactor()
 
         # init options
         opts = globalFluxInterface.GlobalFluxOptions("test_updateLoadpadDose")


### PR DESCRIPTION
## What is the change?

Just adding a few unit tests to the `FuelHandler` and the `GlobalFluxInterface`.

## Why is the change being made?

I found a few methods with no code coverage, and I am trying to bump the ARMI code coverage over 90%.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.