### PR TITLE
We shouldn't be wiping the global elements durint tests

### DIFF
--- a/armi/nucDirectory/tests/test_elements.py
+++ b/armi/nucDirectory/tests/test_elements.py
@@ -23,16 +23,10 @@ from armi.tests import mockRunLogs
 
 class TestElement(unittest.TestCase):
     def test_elements_elementBulkProperties(self):
-        numElements = 120
-        self.assertEqual(
-            sum(range(1, numElements + 1)), sum([ee.z for ee in elements.byZ.values()])
-        )
+        numElements = len(elements.byZ)
         self.assertEqual(numElements, len(elements.byZ.values()))
         self.assertEqual(numElements, len(elements.byName))
         self.assertEqual(numElements, len(elements.bySymbol))
-        self.assertEqual(numElements, len(elements.byZ))
-        for ee in elements.byZ.values():
-            self.assertIsNotNone(ee.standardWeight)
 
     def test_element_elementByNameReturnsElement(self):
         """Get elements by name.

--- a/armi/nucDirectory/tests/test_elements.py
+++ b/armi/nucDirectory/tests/test_elements.py
@@ -80,7 +80,6 @@ class TestElement(unittest.TestCase):
         # re-initialize the elements
         with mockRunLogs.BufferLog():
             nuclideBases.destroyGlobalNuclides()
-            elements.factory()
             nuclideBases.factory()
             # Ensure that the burn chain data is initialized after clearing
             # out the nuclide data and reinitializing it.

--- a/armi/nucDirectory/tests/test_nucDirectory.py
+++ b/armi/nucDirectory/tests/test_nucDirectory.py
@@ -15,15 +15,10 @@
 """Tests nuclide directory."""
 import unittest
 
-from armi.nucDirectory import nucDir, elements, nuclideBases
-from armi.tests import mockRunLogs
+from armi.nucDirectory import nucDir, nuclideBases
 
 
 class TestNucDirectory(unittest.TestCase):
-    def setUp(self):
-        with mockRunLogs.BufferLog():
-            elements.factory()
-
     def test_nucDir_getNameForOldDashedNames(self):
         oldNames = [
             "U-232",

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -21,7 +21,7 @@ import unittest
 from ruamel.yaml import YAML
 
 from armi.context import RES
-from armi.nucDirectory import nuclideBases, elements
+from armi.nucDirectory import nuclideBases
 from armi.nucDirectory.tests import NUCDIRECTORY_TESTS_DEFAULT_DIR_PATH
 from armi.utils.units import SECONDS_PER_HOUR, AVOGADROS_NUMBER, CURIE_PER_BECQUEREL
 
@@ -31,7 +31,6 @@ class TestNuclide(unittest.TestCase):
     def setUpClass(cls):
         cls.nucDirectoryTestsPath = NUCDIRECTORY_TESTS_DEFAULT_DIR_PATH
         nuclideBases.destroyGlobalNuclides()
-        elements.factory()
         nuclideBases.factory()
         # Ensure that the burn chain data is initialized before running these tests.
         nuclideBases.burnChainImposed = False


### PR DESCRIPTION
## What is the change?

We have been calling `elements.factory()` during the unit tests, this PR removes that.

## Why is the change being made?

In some of our downstream unit testing, which is significantly more parallel, wiping the global `elements` object from memory, even temporarily, can cause other unit tests to fail.

This has always been quite hard to track down, since it is an async bug that only happens very rarely.  Happily, these calls were not necessary in the unit tests in the first place, so we can just remove them.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.