### PR TITLE
Deleting objects that are still trying to hold on to old reactor after reset

### DIFF
--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -1077,6 +1077,8 @@ class Operator:
         """
         if self.r:
             self.r.o = None
+            for comp in self.r:
+                comp.parent = None
         self.r = None
         for i in self.interfaces:
             i.o = None

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -238,6 +238,7 @@ class OperatorMPI(Operator):
         cs = self.cs
         bp = self.r.blueprints
         spatialGrid = self.r.core.spatialGrid
+        spatialGrid.armiObject = None
         xsGroups = self.getInterface("xsGroups")
         if xsGroups:
             xsGroups.clearRepresentativeBlocks()
@@ -246,6 +247,7 @@ class OperatorMPI(Operator):
         core = reactors.Core("Core")
         self.r.add(core)
         core.spatialGrid = spatialGrid
+        core.spatialGrid.armiObject = core
         self.reattach(self.r, cs)
 
     @staticmethod

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -11,6 +11,8 @@ New Features
 #. Conserve mass by component in ``assembly.setBlockMesh()``. (`PR#1665 <https://github.com/terrapower/armi/pull/1665>`_)
 #. Removal of the ``Block.reactor`` property. (`PR#1425 <https://github.com/terrapower/armi/pull/1425>`_)
 #. System information is now also logged on Linux. (`PR#1689 <https://github.com/terrapower/armi/pull/1689>`_)
+#. Reset ``Reactor`` data on worker processors after every interaction to free memory from state distribution.
+   (`PR#1729 <https://github.com/terrapower/armi/pull/1729>`_ and `PR#1750 <https://github.com/terrapower/armi/pull/1750>`_)
 #. TBD
 
 API Changes


### PR DESCRIPTION
## What is the change?

This change is a follow on to #1729 after it was observed that the garbage collector was not clearing `Reactor` data from a state distribution on worker processors after a reset. This is due to objects retaining references to the distributed `Reactor`. Upon investigation, these references came from a cyclic reference between `Core`, `Reactor`, and `spatialGrid` objects, shown by this diagram created by `objgraph`:

![image](https://github.com/terrapower/armi/assets/12819067/6c73baf9-fe37-4876-9545-3199f051f103)

The solution was quite simple: setting `spatialGrid.armiObject` attribute to `None`, as well as the `parent` attribute in the `Reactor` children.

## Why is the change being made?

Retaining the distributed state of the `Reactor` on workers is unnecessary memory overhead for interactions that don't require a distributed state.


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.