### PR TITLE
Clean up a minor bug in #1653

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -1235,10 +1235,13 @@ class CrossSectionGroupManager(interfaces.Interface):
 
             # create a new block collection that inherits all of the properties
             # and settings from oldBlockCollection.
-            if len(oldBlockCollection._validRepresentativeBlockTypes) > 0:
-                validBlockTypes = []
-                for flag in oldBlockCollection._validRepresentativeBlockTypes:
-                    validBlockTypes.append(flags._toString(Flags, flag))
+            if oldBlockCollection._validRepresentativeBlockTypes is not None:
+                if len(oldBlockCollection._validRepresentativeBlockTypes) > 0:
+                    validBlockTypes = []
+                    for flag in oldBlockCollection._validRepresentativeBlockTypes:
+                        validBlockTypes.append(flags._toString(Flags, flag))
+                else:
+                    validBlockTypes = None
             else:
                 validBlockTypes = None
             newBlockCollection = oldBlockCollection.__class__(

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -53,7 +53,7 @@ Bug Fixes
 ---------
 #. Fixed four bugs with "corners up" hex grids. (`PR#1649 <https://github.com/terrapower/armi/pull/1649>`_)
 #. Fixed ``safeCopy`` to work on both Windows and Linux with strict permissions (`PR#1691 <https://github.com/terrapower/armi/pull/1691>`_)
-#. When creating a new XS group, inherit settings from initial group. (`PR#1653 <https://github.com/terrapower/armi/pull/1653>`_)
+#. When creating a new XS group, inherit settings from initial group. (`PR#1653 <https://github.com/terrapower/armi/pull/1653>`_, `PR#1751 <https://github.com/terrapower/armi/pull/1751>`_)
 
 #. TBD
 


### PR DESCRIPTION
## What is the change?

Change logic in `CrossSectionGroupManager` to handle the case where `BlockCollection._validRepresentativeBlockTypes` is `None`. 

## Why is the change being made?

This logic was introduced in PR #1653. The logic checks for the length of `_validRepresentativeBlockTypes`, assuming it is always a `list`. It did not consider the case where `_validRepresentativeBlockTypes` is None.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.