### PR TITLE
Fix NEA document links in tutorial

### DIFF
--- a/armi/tests/tutorials/c5g7-blueprints.yaml
+++ b/armi/tests/tutorials/c5g7-blueprints.yaml
@@ -1,8 +1,9 @@
 # Simple description of the C5G7 benchmark problem
-# General description from: https://www.oecd-nea.org/science/docs/2003/nsc-doc2003-16.pdf
-# Composition/dimensions description from: https://www.oecd-nea.org/science/docs/1996/nsc-doc96-02-rev2.pdf
+# General description from: https://www.oecd-nea.org/upload/docs/application/pdf/2019-12/nsc-doc2003-16.pdf
+# Composition/dimensions description from: https://www.oecd-nea.org/upload/docs/application/pdf/2020-01/nsc-doc96-02-rev2.pdf
 # start-custom-isotopics
 custom isotopics:
+    # NEA/NSC/DOC(96)2 Table 2 - Isotopic Distributions for each medium
     mox low: # 4.3%
         input format: number densities
         U235: 5.00E-5
@@ -70,6 +71,7 @@ custom isotopics:
 # end-custom-isotopics
 blocks:
     uo2: &block_uo2
+        # NEA/NSC/DOC(96)2 Table 1 - Cell geometries
         grid name: UO2 grid
         fuel:
             shape: Circle

--- a/doc/tutorials/walkthrough_lwr_inputs.rst
+++ b/doc/tutorials/walkthrough_lwr_inputs.rst
@@ -6,9 +6,9 @@ In the :doc:`previous tutorial </tutorials/walkthrough_inputs>`,
 we introduced the basic input files and made a full
 input for a sodium-cooled fast reactor. In this tutorial, we will build simple
 inputs for the light-water reactor (LWR) benchmark problem called C5G7 as defined
-in `NEA/NSC/DOC(2003)16 <https://www.oecd-nea.org/science/docs/2003/nsc-doc2003-16.pdf>`_.
+in `NEA/NSC/DOC(2003)16 <https://www.oecd-nea.org/upload/docs/application/pdf/2019-12/nsc-doc2003-16.pdf>`_.
 The compositions are documented in
-`NEA/NSC/DOC(98)2 <https://www.oecd-nea.org/science/docs/1996/nsc-doc96-02-rev2.pdf>`_.
+`NEA/NSC/DOC(96)2 <https://www.oecd-nea.org/upload/docs/application/pdf/2020-01/nsc-doc96-02-rev2.pdf>`_.
 
 .. tip:: The full inputs created in this tutorial are available for download at the bottom of
     this page.
@@ -37,7 +37,8 @@ Custom isotopic vectors
 -----------------------
 When using materials that differ in properties or composition from the
 materials in the ARMI material library, you can use custom isotopics
-to specify their composition.
+to specify their composition. The composition details below are documented in Table 2 of
+`NEA/NSC/DOC(96)2 <https://www.oecd-nea.org/upload/docs/application/pdf/2020-01/nsc-doc96-02-rev2.pdf>`_.
 
 
 .. literalinclude:: ../../armi/tests/tutorials/c5g7-blueprints.yaml


### PR DESCRIPTION
## What is the change?

Update outdated NEA document links in the tutorial, as well as comments in tutorial input files.

## Why is the change being made?

When going through the tutorial, many constants are referenced from NEA documents.
Links to these documents are currently outdated and do not point to any valid PDFs.
This PR updates the links and cites the specific tables within comments in the input files.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.