### PR TITLE
Removing unused setting

### DIFF
--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -54,7 +54,6 @@ CONF_CYCLE_LENGTH = "cycleLength"
 CONF_CYCLE_LENGTHS = "cycleLengths"
 CONF_CYCLES = "cycles"
 CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION = "cyclesSkipTightCouplingInteraction"
-CONF_DEBUG = "debug"
 CONF_DEBUG_MEM = "debugMem"
 CONF_DEBUG_MEM_SIZE = "debugMemSize"
 CONF_DECAY_CONSTANTS = "decayConstants"
@@ -452,9 +451,6 @@ def defineSettings() -> List[setting.Setting]:
             description="A list of directories to copy provided files into at the start of a run."
             "This list can be of length zero (copy to working dir), 1 (copy all files to the same "
             f"place), or it must be the same length as {CONF_COPY_FILES_FROM}",
-        ),
-        setting.Setting(
-            CONF_DEBUG, default=False, label="Python Debug Mode", description="None"
         ),
         setting.Setting(
             CONF_DEBUG_MEM,


### PR DESCRIPTION
## What is the change?

This `debug` setting is entirely unused in the ecosystem, and so is being removed.

## Why is the change being made?

This setting also has no description, which is causing unwanted log noise.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.