### PR TITLE
Moving where we create log dirs

### DIFF
--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -175,9 +175,6 @@ class _RunLog:
         In this situation, we do the mangling needed to get the log level to the correct number.
         And we do some custom string manipulation so we can handle de-duplicating warnings.
         """
-        if not os.path.exists(LOG_DIR):
-            createLogDir(LOG_DIR)
-
         # Determine the log level: users can optionally pass in custom strings ("debug")
         msgLevel = msgType if isinstance(msgType, int) else self.logLevels[msgType][0]
 
@@ -347,14 +344,6 @@ def concatenateLogs(logDir=None):
     stdoutFiles = sorted(glob(os.path.join(logDir, "*.stdout")))
     if not len(stdoutFiles):
         info("No log files found to concatenate.")
-
-        # If the log dir is empty, we can delete it.
-        try:
-            os.rmdir(logDir)
-        except:  # noqa: bare-except
-            # low priority concern: it's an empty log dir.
-            pass
-
         return
 
     info("Concatenating {0} log files".format(len(stdoutFiles)))
@@ -724,6 +713,10 @@ def createLogDir(logDir: str = None) -> None:
             raise OSError("Was unable to create the log directory: {}".format(logDir))
 
         time.sleep(secondsWait)
+
+
+if not os.path.exists(LOG_DIR):
+    createLogDir(LOG_DIR)
 
 
 def logFactory():


### PR DESCRIPTION
## What is the change?

1. I am moving where in the code we create the log directory
2. I am stopping the removal of empty log dirs

## Why is the change being made?

This was causing big slow downs in our code, so I am reverting the change made in #1744.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.