### PR TITLE
Removing custom density from refSmallReactorBase

### DIFF
--- a/armi/tests/refSmallReactorBase.yaml
+++ b/armi/tests/refSmallReactorBase.yaml
@@ -11,7 +11,6 @@ custom isotopics:
         U238: 0.0134125
     PuUZr:
         input format: mass fractions
-        density: 9.491820414019937
         PU239: 0.1
         U235: 0.15
         U238: 0.65


### PR DESCRIPTION
## What is the change?

Removing a single line, that sets a single custom density on `refSmallReactorBase.yaml`.

## Why is the change being made?

There is nothing intrinsically wrong with this idea, but it is causing some work downstream, and it doesn't really add anything to the model reactor.

---

## Checklist


- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.