### PR TITLE
Adding descriptions to fuel cycle settings

### DIFF
--- a/armi/physics/fuelCycle/settings.py
+++ b/armi/physics/fuelCycle/settings.py
@@ -101,13 +101,19 @@ def getFuelCycleSettings():
             label="Plot shuffle arrows",
         ),
         setting.Setting(
-            CONF_JUMP_RING_NUM, default=8, label="Jump Ring Number", description="None"
+            CONF_JUMP_RING_NUM,
+            default=8,
+            label="Jump Ring Number",
+            description="The number of hex rings jumped when distributing the feed assemblies in "
+            "the alternating concentric rings or checkerboard shuffle patterns (convergent / "
+            "divergent shuffling).",
         ),
         setting.Setting(
             CONF_LEVELS_PER_CASCADE,
             default=14,
             label="Move per cascade",
-            description="None",
+            description="The number of moves made per cascade when performing convergent or "
+            "divergent shuffle patterns.",
         ),
     ]
     return settings

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -530,7 +530,7 @@ def defineSettings() -> List[setting.Setting]:
             CONF_FRESH_FEED_TYPE,
             default="feed fuel",
             label="Fresh Feed Type",
-            description="The type of fresh fuel added to the core, used in fuel shuffling logic.",
+            description="The type of fresh fuel added to the core, used in certain pre-defined fuel shuffling logic sequences.",
             options=["feed fuel", "igniter fuel", "inner driver fuel"],
         ),
         setting.Setting(

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -530,7 +530,8 @@ def defineSettings() -> List[setting.Setting]:
             CONF_FRESH_FEED_TYPE,
             default="feed fuel",
             label="Fresh Feed Type",
-            description="The type of fresh fuel added to the core, used in certain pre-defined fuel shuffling logic sequences.",
+            description="The type of fresh fuel added to the core, used in certain pre-defined "
+            "fuel shuffling logic sequences.",
             options=["feed fuel", "igniter fuel", "inner driver fuel"],
         ),
         setting.Setting(

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -423,7 +423,8 @@ def defineSettings() -> List[setting.Setting]:
             CONF_BURNUP_PEAKING_FACTOR,
             default=0.0,
             label="Burn-up Peaking Factor",
-            description="None",
+            description="The peak/avg factor for burnup and DPA. If it is not set the current flux "
+            "peaking is used (this is typically conservatively high).",
             schema=vol.All(vol.Coerce(float), vol.Range(min=0)),
         ),
         setting.Setting(
@@ -529,7 +530,7 @@ def defineSettings() -> List[setting.Setting]:
             CONF_FRESH_FEED_TYPE,
             default="feed fuel",
             label="Fresh Feed Type",
-            description="None",
+            description="The type of fresh fuel added to the core.",
             options=["feed fuel", "igniter fuel", "inner driver fuel"],
         ),
         setting.Setting(
@@ -668,7 +669,10 @@ def defineSettings() -> List[setting.Setting]:
             schema=vol.All(vol.Coerce(float), vol.Range(min=0)),
         ),
         setting.Setting(
-            CONF_REMOVE_PER_CYCLE, default=3, label="Move per Cycle", description="None"
+            CONF_REMOVE_PER_CYCLE,
+            default=3,
+            label="Remove per Cycle",
+            description="The number of fuel assemblies removed per cycle at equilibrium.",
         ),
         setting.Setting(
             CONF_RUN_TYPE,

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -530,7 +530,7 @@ def defineSettings() -> List[setting.Setting]:
             CONF_FRESH_FEED_TYPE,
             default="feed fuel",
             label="Fresh Feed Type",
-            description="The type of fresh fuel added to the core.",
+            description="The type of fresh fuel added to the core, used in fuel shuffling logic.",
             options=["feed fuel", "igniter fuel", "inner driver fuel"],
         ),
         setting.Setting(


### PR DESCRIPTION
## What is the change?

Adding descriptions to the last settings that don't have them.

## Why is the change being made?

This is an effort to close #1755 , and make progress on #1734

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.