### PR TITLE
Filling in descriptions on settings

### DIFF
--- a/armi/settings/fwSettings/databaseSettings.py
+++ b/armi/settings/fwSettings/databaseSettings.py
@@ -18,7 +18,6 @@ import voluptuous as vol
 
 from armi.settings import setting
 
-
 CONF_DB = "db"
 CONF_DEBUG_DB = "debugDB"
 CONF_RELOAD_DB_NAME = "reloadDBName"
@@ -38,7 +37,12 @@ def defineSettings():
             label="Activate Database",
             description="Write the state information to a database at every timestep",
         ),
-        setting.Setting(CONF_DEBUG_DB, default=False, label="Debug Database"),
+        setting.Setting(
+            CONF_DEBUG_DB,
+            default=False,
+            label="Debug Database",
+            description="Write state to DB with a unique timestamp or label.",
+        ),
         setting.Setting(
             CONF_RELOAD_DB_NAME,
             default="",

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -96,9 +96,19 @@ class SettingsRenameTests(unittest.TestCase):
             "testSetting1",
             default=None,
             oldNames=[("oSetting1", None), ("osetting1", datetime.date.today())],
+            description="Just a unit test setting.",
         ),
-        setting.Setting("testSetting2", default=None, oldNames=[("oSetting2", None)]),
-        setting.Setting("testSetting3", default=None),
+        setting.Setting(
+            "testSetting2",
+            default=None,
+            oldNames=[("oSetting2", None)],
+            description="Just a unit test setting.",
+        ),
+        setting.Setting(
+            "testSetting3",
+            default=None,
+            description="Just a unit test setting.",
+        ),
     ]
 
     def test_rename(self):
@@ -123,7 +133,10 @@ class SettingsRenameTests(unittest.TestCase):
             for setting in self.testSettings
             + [
                 setting.Setting(
-                    "someOtherSetting", default=None, oldNames=[("oSetting1", None)]
+                    "someOtherSetting",
+                    default=None,
+                    oldNames=[("oSetting1", None)],
+                    description="Just a unit test setting.",
                 )
             ]
         }


### PR DESCRIPTION
## What is the change?

Filling in the `description` field on some `Setting`s.

## Why is the change being made?

We want to make descriptions mandatory on settings soon. And in the past I forgot to fill in the settings that are defined for unit test purposes.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.