### PR TITLE
Fixing a bug where getReactionRates didn't work on Core

### DIFF
--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1230,7 +1230,6 @@ class Component(composites.Composite, metaclass=ComponentType):
         ----------
         adjoint : bool, optional
             Return adjoint flux instead of real
-
         gamma : bool, optional
             Whether to return the neutron flux or the gamma flux.
 
@@ -1242,6 +1241,7 @@ class Component(composites.Composite, metaclass=ComponentType):
             # no pin-level flux is available
             if not self.parent:
                 return numpy.zeros(1)
+
             volumeFraction = self.getVolume() / self.parent.getVolume()
             return volumeFraction * self.parent.getIntegratedMgFlux(adjoint, gamma)
 
@@ -1256,6 +1256,7 @@ class Component(composites.Composite, metaclass=ComponentType):
                 pinFluxes = self.parent.p.pinMgFluxesAdj
             else:
                 pinFluxes = self.parent.p.pinMgFluxes
+
         return pinFluxes[self.p.pinNum - 1] * self.getVolume()
 
     def density(self):

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -3031,6 +3031,7 @@ class Composite(ArmiObject):
         -----
         If you set nDensity to 1/CM2_PER_BARN this makes 1 group cross section generation easier
         """
+        from armi.reactor.assemblies import Assembly
         from armi.reactor.blocks import Block
         from armi.reactor.reactors import Core
 
@@ -3038,18 +3039,16 @@ class Composite(ArmiObject):
             nDensity = self.getNumberDensity(nucName)
 
         try:
-            core = self.getAncestor(lambda c: isinstance(c, Core))
-
-            try:
+            if isinstance(self, Assembly):
                 block = self.getChildren(
                     deep=True, predicate=lambda o: isinstance(o, Block)
                 )[0]
-            except Exception:
+            else:
                 block = self.getAncestor(lambda x: isinstance(x, Block))
 
             return getReactionRateDict(
                 nucName,
-                core.lib,
+                self.getAncestor(lambda c: isinstance(c, Core)).lib,
                 block.getMicroSuffix(),
                 self.getIntegratedMgFlux(),
                 nDensity,

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -3039,7 +3039,7 @@ class Composite(ArmiObject):
             nDensity = self.getNumberDensity(nucName)
 
         try:
-            if isinstance(self, Assembly):
+            if isinstance(self, (Assembly, Core)):
                 block = self.getChildren(
                     deep=True, predicate=lambda o: isinstance(o, Block)
                 )[0]

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -335,14 +335,19 @@ class TestCompositePattern(unittest.TestCase):
         self.assertEqual(len(rRates), 6)
         self.assertGreater(sum([r for r in rRates.values()]), 0)
 
-        # test on an assembly
+        # test on an Assembly
         assem = r.core.getFirstAssembly()
         rRates = assem.getReactionRates("U235")
         self.assertEqual(len(rRates), 6)
         self.assertGreater(sum([r for r in rRates.values()]), 0)
 
-        # test on a core
+        # test on a Core
         rRates = r.core.getReactionRates("U235")
+        self.assertEqual(len(rRates), 6)
+        self.assertGreater(sum([r for r in rRates.values()]), 0)
+
+        # test on a Reactor
+        rRates = r.getReactionRates("U235")
         self.assertEqual(len(rRates), 6)
         self.assertGreater(sum([r for r in rRates.values()]), 0)
 

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -58,7 +58,7 @@ Bug Fixes
 #. Fixed four bugs with "corners up" hex grids. (`PR#1649 <https://github.com/terrapower/armi/pull/1649>`_)
 #. Fixed ``safeCopy`` to work on both Windows and Linux with strict permissions (`PR#1691 <https://github.com/terrapower/armi/pull/1691>`_)
 #. When creating a new XS group, inherit settings from initial group. (`PR#1653 <https://github.com/terrapower/armi/pull/1653>`_, `PR#1751 <https://github.com/terrapower/armi/pull/1751>`_)
-
+#. Fixed a bug with ``Core.getReactionRates``. (`PR#1771 <https://github.com/terrapower/armi/pull/1771>`_)
 #. TBD
 
 Quality Work


### PR DESCRIPTION
## What is the change?

Fixing a bug where `getReactionRates()` didn't work on a `Core`.  Also, I added unit tests to ensure it is working at various other levels: `Block`, `Assembly`, `Core`, and `Reactor`.

## Why is the change being made?

To close #1754, which was found by @keckler.

---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.