### PR TITLE
Forcing Parameters and Settings to have Descriptions

### DIFF
--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -32,7 +32,6 @@ import re
 
 import numpy
 
-from armi import runLog
 from armi.reactor.flags import Flags
 from armi.reactor.parameters.exceptions import ParameterError, ParameterDefinitionError
 
@@ -265,16 +264,12 @@ class Parameter:
         categories,
         serializer: Optional[Type[Serializer]] = None,
     ):
-        assert self._validName.match(name), "{} is not a valid param name".format(name)
         # nonsensical to have a serializer with no intention of saving to DB
         assert not (serializer is not None and not saveToDB)
         assert serializer is None or saveToDB
-        # TODO: This warning is temporary. At some point, it will become an AssertionError.
-        if not len(description):
-            runLog.warning(
-                f"DeprecationWarning: Parameter {name} defined without description.",
-                single=True,
-            )
+        assert self._validName.match(name), "{} is not a valid param name".format(name)
+        assert len(description), f"Parameter {name} defined without description."
+
         self.collectionType = _Undefined
         self.name = name
         self.fieldName = "_p_" + name

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -467,7 +467,9 @@ class Settings:
                 elif key in settings.__settings:
                     settings.__settings[key].setValue(val)
                 else:
-                    settings.__settings[key] = Setting(key, val)
+                    settings.__settings[key] = Setting(
+                        key, val, description="Description from cs.modified()"
+                    )
 
         return settings
 

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -65,7 +65,7 @@ class Setting:
         self,
         name,
         default,
-        description=None,
+        description,
         label=None,
         options=None,
         schema=None,
@@ -83,7 +83,7 @@ class Setting:
             the setting's name
         default : object
             The setting's default value
-        description : str, optional
+        description : str
             The description of the setting
         label : str, optional
             the shorter description used for the ARMI GUI

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -113,26 +113,23 @@ class Setting:
             will result in errors, requiring to user to update their input by hand to
             use more current settings.
         """
+        assert description, f"Setting {name} defined without description."
+        assert description != "None", f"Setting {name} defined without description."
+
         self.name = name
         self.description = description or name
-        if not description or description in ("None", "none"):
-            runLog.warning(
-                f"DeprecationWarning: Setting {name} defined without description.",
-                single=True,
-            )
         self.label = label or name
         self.options = options
         self.enforcedOptions = enforcedOptions
         self.subLabels = subLabels
         self.isEnvironment = isEnvironment
         self.oldNames: List[Tuple[str, Optional[datetime.date]]] = oldNames or []
-
         self._default = default
+        self._value = copy.deepcopy(default)  # break link from _default
         # Retain the passed schema so that we don't accidentally stomp on it in
         # addOptions(), et.al.
         self._customSchema = schema
         self._setSchema()
-        self._value = copy.deepcopy(default)  # break link from _default
 
     @property
     def underlyingType(self):

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -312,7 +312,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
             :id: T_ARMI_SETTINGS_DEFAULTS
             :tests: R_ARMI_SETTINGS_DEFAULTS
         """
-        a = setting.Setting("testsetting", 0)
+        a = setting.Setting("testsetting", 0, description="whatever")
         newDefault = setting.Default(5, "testsetting")
         a.changeDefault(newDefault)
         self.assertEqual(a.value, 5)
@@ -399,7 +399,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         removed by Setting.__getstate__, and that has been a problem in the past.
         """
         # get a baseline: show how the Setting object looks to start
-        s1 = setting.Setting("testCopy", 765)
+        s1 = setting.Setting("testCopy", 765, description="whatever")
         self.assertEqual(s1.name, "testCopy")
         self.assertEqual(s1._value, 765)
         self.assertTrue(hasattr(s1, "schema"))
@@ -417,7 +417,7 @@ assemblyRotationAlgorithm: buReducingAssemblyRotatoin
         when the Setting value is set to a non-default value.
         """
         # get a baseline: show how the Setting object looks to start
-        s1 = setting.Setting("testCopy", 765)
+        s1 = setting.Setting("testCopy", 765, description="whatever")
         s1.value = 999
         self.assertEqual(s1.name, "testCopy")
         self.assertEqual(s1._value, 999)
@@ -487,7 +487,9 @@ class TestFlagListSetting(unittest.TestCase):
         flagsAsStringList = ["DUCT", "FUEL", "CLAD"]
         flagsAsFlagList = [Flags.DUCT, Flags.FUEL, Flags.CLAD]
 
-        fs = setting.FlagListSetting(name="testFlagSetting", default=[])
+        fs = setting.FlagListSetting(
+            name="testFlagSetting", default=[], description="whatever"
+        )
         # Set the value as a list of strings first
         fs.value = flagsAsStringList
         self.assertEqual(fs.value, flagsAsFlagList)
@@ -500,7 +502,9 @@ class TestFlagListSetting(unittest.TestCase):
 
     def test_invalidFlagListTypeError(self):
         """Test raising a TypeError when a list is not provided."""
-        fs = setting.FlagListSetting(name="testFlagSetting", default=[])
+        fs = setting.FlagListSetting(
+            name="testFlagSetting", default=[], description="whatever"
+        )
         with self.assertRaises(TypeError):
             fs.value = "DUCT"
 


### PR DESCRIPTION
## What is the change?

This PR removes to `DeprecationWarning`s in ARMI, that allow for empty description fields in a `Setting` or `Parameter`.


## Why is the change being made?

A strong point of ARMI is that users / developers can create new settings to configure a run and parameters to model a reactor quite easily. However, people also tend to abandon settings and parameters silently, and we never know. OR a setting/parameter will be used in different ways by different people, thus leading to problems.

In the past, I have seen these problems only occur when the setting/parameter doesn't have a description, so we have had a long push to enforce this field.

This will close #1348 and close #1734


---

## Checklist

- [X] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [X] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [X] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [X] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [X] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [X] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [X] The dependencies are still up-to-date in `pyproject.toml`.