### PR TITLE
Standardize `numpy` imports with `as np`

### DIFF
--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -377,9 +377,7 @@ def _diffSpecialData(
         if isinstance(dSrc, np.ndarray) and isinstance(dRef, np.ndarray):
             if dSrc.shape != dRef.shape:
                 out.writeln("Shapes did not match for {}".format(refData))
-                diffResults.addDiff(
-                    compName, paramName, np.inf, np.inf, np.inf
-                )
+                diffResults.addDiff(compName, paramName, np.inf, np.inf, np.inf)
                 return
 
             # make sure not to try to compare empty arrays. Numpy is mediocre at
@@ -501,9 +499,7 @@ def _compareComponentData(
                     paramName, refSpecial, srcSpecial
                 )
             )
-            diffResults.addDiff(
-                refGroup.name, paramName, np.inf, np.inf, np.inf
-            )
+            diffResults.addDiff(refGroup.name, paramName, np.inf, np.inf, np.inf)
             continue
 
         if srcSpecial or refSpecial:

--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -51,7 +51,7 @@ import traceback
 
 from tabulate import tabulate
 import h5py
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.bookkeeping.db import database3
@@ -315,7 +315,7 @@ def _diffSpecialData(
     Compare specially-formatted datasets.
 
     This employs the pack/unpackSpecialData functions to reconstitute complicated
-    datasets for comparison. These usually don't behave well as giant numpy arrays, so
+    datasets for comparison. These usually don't behave well as giant np arrays, so
     we go element-by-element to calculate the diffs, then concatenate them.
     """
     name = refData.name
@@ -329,7 +329,7 @@ def _diffSpecialData(
     diffResults.addStructureDiffs(nDiffs)
 
     if not keysMatch:
-        diffResults.addDiff(name, name, numpy.inf, numpy.inf, numpy.inf)
+        diffResults.addDiff(name, name, np.inf, np.inf, np.inf)
         return
 
     if srcData.attrs.get("dict", False):
@@ -341,7 +341,7 @@ def _diffSpecialData(
     for k, srcAttr in srcData.attrs.items():
         refAttr = refData.attrs[k]
 
-        if isinstance(srcAttr, numpy.ndarray) and isinstance(refAttr, numpy.ndarray):
+        if isinstance(srcAttr, np.ndarray) and isinstance(refAttr, np.ndarray):
             srcFlat = srcAttr.flatten()
             refFlat = refAttr.flatten()
             if len(srcFlat) != len(refFlat):
@@ -374,11 +374,11 @@ def _diffSpecialData(
 
     diff = []
     for dSrc, dRef in zip(src.tolist(), ref.tolist()):
-        if isinstance(dSrc, numpy.ndarray) and isinstance(dRef, numpy.ndarray):
+        if isinstance(dSrc, np.ndarray) and isinstance(dRef, np.ndarray):
             if dSrc.shape != dRef.shape:
                 out.writeln("Shapes did not match for {}".format(refData))
                 diffResults.addDiff(
-                    compName, paramName, numpy.inf, numpy.inf, numpy.inf
+                    compName, paramName, np.inf, np.inf, np.inf
                 )
                 return
 
@@ -395,7 +395,7 @@ def _diffSpecialData(
 
         if (dSrc is None) ^ (dRef is None):
             out.writeln("Mismatched Nones for {} in {}".format(paramName, compName))
-            diff.append([numpy.inf])
+            diff.append([np.inf])
             continue
 
         if dSrc is None:
@@ -410,12 +410,12 @@ def _diffSpecialData(
             if dSrc == dRef:
                 diff.append([0.0])
             else:
-                diff.append([numpy.inf])
+                diff.append([np.inf])
 
     if diff:
         try:
-            diff = [numpy.array(d).flatten() for d in diff]
-            diff = numpy.concatenate(diff)
+            diff = [np.array(d).flatten() for d in diff]
+            diff = np.concatenate(diff)
         except ValueError as e:
             out.writeln(
                 "Failed to concatenate diff data for {} in {}: {}".format(
@@ -424,10 +424,10 @@ def _diffSpecialData(
             )
             out.writeln("Because: {}".format(e))
             return
-        absDiff = numpy.abs(diff)
-        mean = numpy.nanmean(diff)
-        absMax = numpy.nanmax(absDiff)
-        absMean = numpy.nanmean(absDiff)
+        absDiff = np.abs(diff)
+        mean = np.nanmean(diff)
+        absMax = np.nanmax(absDiff)
+        absMean = np.nanmean(absDiff)
 
         diffResults.addDiff(compName, paramName, absMean, mean, absMax)
 
@@ -448,21 +448,21 @@ def _diffSimpleData(ref: h5py.Dataset, src: h5py.Dataset, diffResults: DiffResul
             runLog.error("Failed to compare {} in {}".format(paramName, compName))
             runLog.error("source: {}".format(src))
             runLog.error("reference: {}".format(ref))
-            diff = numpy.array([numpy.inf])
+            diff = np.array([np.inf])
     except ValueError:
         runLog.error("Failed to compare {} in {}".format(paramName, compName))
         runLog.error("source: {}".format(src))
         runLog.error("reference: {}".format(ref))
-        diff = numpy.array([numpy.inf])
+        diff = np.array([np.inf])
 
     if 0 in diff.shape:
         # Empty list, no diff
         return
 
-    absDiff = numpy.abs(diff)
-    mean = numpy.nanmean(diff)
-    absMax = numpy.nanmax(absDiff)
-    absMean = numpy.nanmean(absDiff)
+    absDiff = np.abs(diff)
+    mean = np.nanmean(diff)
+    absMax = np.nanmax(absDiff)
+    absMean = np.nanmean(absDiff)
 
     diffResults.addDiff(compName, paramName, absMean, mean, absMax)
 
@@ -502,7 +502,7 @@ def _compareComponentData(
                 )
             )
             diffResults.addDiff(
-                refGroup.name, paramName, numpy.inf, numpy.inf, numpy.inf
+                refGroup.name, paramName, np.inf, np.inf, np.inf
             )
             continue
 

--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -315,7 +315,7 @@ def _diffSpecialData(
     Compare specially-formatted datasets.
 
     This employs the pack/unpackSpecialData functions to reconstitute complicated
-    datasets for comparison. These usually don't behave well as giant np arrays, so
+    datasets for comparison. These usually don't behave well as giant numpy arrays, so
     we go element-by-element to calculate the diffs, then concatenate them.
     """
     name = refData.name

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -942,7 +942,7 @@ class Database3:
                     data = data.astype("S")
 
                 if data.dtype.kind == "O":
-                    # Something was added to the data array that caused np to want to
+                    # Something was added to the data array that caused numpy to want to
                     # treat it as a general-purpose Object array. This usually happens
                     # because:
                     # - the data contain NoDefaults
@@ -1058,7 +1058,7 @@ class Database3:
             if "linkedDims" in attrs:
                 linkedDims = np.char.decode(attrs["linkedDims"])
 
-            # iterating of np is not fast...
+            # iterating of numpy is not fast...
             for c, val, linkedDim in itertools.zip_longest(
                 comps, data.tolist(), linkedDims, fillvalue=""
             ):
@@ -1169,7 +1169,7 @@ class Database3:
 
         for h5TimeNodeGroup in self.genTimeStepGroups(timeSteps):
             if "layout" not in h5TimeNodeGroup:
-                # layout hasnt been written for this time step, so we can't get anything
+                # layout hasn't been written for this time step, so we can't get anything
                 # useful here. Perhaps the current value is of use, in which case the
                 # DatabaseInterface should be used.
                 continue
@@ -1194,7 +1194,7 @@ class Database3:
                 ]
             )
 
-            # This could also be way more efficient if lLocation were a np array
+            # This could also be way more efficient if lLocation were a numpy array
             objectLocationsInLayout = [lLocation[i] for i in objectIndicesInLayout]
 
             objectIndicesInData = np.array(layout.indexInData)[
@@ -1409,7 +1409,7 @@ class Database3:
                             len(reorderedComps),
                         )
 
-                    # iterating of np is not fast..
+                    # iterating of numpy is not fast..
                     for c, val in zip(reorderedComps, data.tolist()):
                         if paramName == "location":
                             val = tuple(val)
@@ -1510,17 +1510,17 @@ def packSpecialData(
     arrayData: [np.ndarray, JaggedArray], paramName: str
 ) -> Tuple[Optional[np.ndarray], Dict[str, Any]]:
     """
-    Reduce data that wouldn't otherwise play nicely with HDF5/np arrays to a format
+    Reduce data that wouldn't otherwise play nicely with HDF5/numpy arrays to a format
     that will.
 
     This is the main entry point for conforming "strange" data into something that will
-    both fit into a np array/HDF5 dataset, and be recoverable to its original-ish
+    both fit into a numpy array/HDF5 dataset, and be recoverable to its original-ish
     state when reading it back in. This is accomplished by detecting a handful of known
     offenders and using various HDF5 attributes to store necessary auxiliary data. It is
     important to keep in mind that the data that is passed in has already been converted
-    to a np array, so the top dimension is always representing the collection of
+    to a numpy array, so the top dimension is always representing the collection of
     composites that are storing the parameters. For instance, if we are dealing with a
-    Block parameter, the first index in the np array of data is the block index; so
+    Block parameter, the first index in the numpy array of data is the block index; so
     if each block has a parameter that is a dictionary, ``data`` would be a ndarray,
                     offset += arr.size
     where each element is a dictionary. This routine supports a number of different
@@ -1556,7 +1556,7 @@ def packSpecialData(
     if isinstance(arrayData, JaggedArray):
         data = arrayData.flattenedArray
     else:
-        # Check to make sure that we even need to do this. If the np data type is
+        # Check to make sure that we even need to do this. If the numpy data type is
         # not "O", chances are we have nice, clean data.
         if arrayData.dtype != "O":
             return arrayData, {}
@@ -1602,7 +1602,7 @@ def packSpecialData(
             # The data themselves are nasty. We could support this, but best to wait for
             # a credible use case.
             raise TypeError(
-                "Unable to coerce dictionary data into usable np array for "
+                "Unable to coerce dictionary data into usable numpy array for "
                 "{}".format(paramName)
             )
         attrs["keys"] = np.array(keys).astype("S")
@@ -1616,7 +1616,7 @@ def packSpecialData(
         attrs["noneLocations"] = arrayData.nones
         return data, attrs
 
-    # conform non-np arrays to np
+    # conform non-numpy arrays to numpy
     for i, val in enumerate(data):
         if isinstance(val, (list, tuple)):
             data[i] = np.array(val)
@@ -1632,7 +1632,7 @@ def packSpecialData(
 
     if len(nones) == 0:
         raise TypeError(
-            "Cannot write {} to the database, it did not resolve to a np/HDF5 "
+            "Cannot write {} to the database, it did not resolve to a numpy/HDF5 "
             "type.".format(paramName)
         )
 
@@ -1642,7 +1642,7 @@ def packSpecialData(
 
 def unpackSpecialData(data: np.ndarray, attrs, paramName: str) -> np.ndarray:
     """
-    Extract data from a specially-formatted HDF5 dataset into a np array.
+    Extract data from a specially-formatted HDF5 dataset into a numpy array.
 
     This should invert the operations performed by :py:func:`packSpecialData`.
 

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -922,9 +922,7 @@ class Database3:
                     else:
                         jagged = False
                     data = (
-                        JaggedArray(temp, paramDef.name)
-                        if jagged
-                        else np.array(temp)
+                        JaggedArray(temp, paramDef.name) if jagged else np.array(temp)
                     )
                     del temp
 

--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -54,7 +54,7 @@ from typing import (
 )
 
 import h5py
-import numpy
+import numpy as np
 
 from armi import context, getApp, meta, runLog, settings
 from armi.bookkeeping.db.jaggedArray import JaggedArray
@@ -218,7 +218,7 @@ class Database3:
             (os.path.abspath(sys.modules[p[1].__module__].__file__), p[1].__name__)
             for p in plugins
         ]
-        ps = numpy.array([str(p[0]) + ":" + str(p[1]) for p in ps]).astype("S")
+        ps = np.array([str(p[0]) + ":" + str(p[1]) for p in ps]).astype("S")
         self.h5db.attrs["pluginPaths"] = ps
         self.h5db.attrs["localCommitHash"] = Database3.grabLocalCommitHash()
 
@@ -241,7 +241,7 @@ class Database3:
         h5db.attrs["python"] = sys.version
         h5db.attrs["armiLocation"] = os.path.dirname(context.ROOT)
         h5db.attrs["startTime"] = context.START_TIME
-        h5db.attrs["machines"] = numpy.array(context.MPI_NODENAMES).astype("S")
+        h5db.attrs["machines"] = np.array(context.MPI_NODENAMES).astype("S")
 
         # store platform data
         platform_data = uname()
@@ -864,9 +864,9 @@ class Database3:
         return comp
 
     def _writeParams(self, h5group, comps) -> tuple:
-        def _getShape(arr: [numpy.ndarray, List, Tuple]):
-            """Get the shape of a numpy.ndarray, list, or tuple."""
-            if isinstance(arr, numpy.ndarray):
+        def _getShape(arr: [np.ndarray, List, Tuple]):
+            """Get the shape of a np.ndarray, list, or tuple."""
+            if isinstance(arr, np.ndarray):
                 return arr.shape
             elif isinstance(arr, (list, tuple)):
                 return (len(arr),)
@@ -899,9 +899,9 @@ class Database3:
                         linkedDims.append("")
                         data.append(val)
 
-                data = numpy.array(data)
+                data = np.array(data)
                 if any(linkedDims):
-                    attrs["linkedDims"] = numpy.array(linkedDims).astype("S")
+                    attrs["linkedDims"] = np.array(linkedDims).astype("S")
             else:
                 # NOTE: after loading, the previously unset values will be defaulted
                 temp = [c.p.get(paramDef.name, paramDef.default) for c in comps]
@@ -909,7 +909,7 @@ class Database3:
                     data, sAttrs = paramDef.serializer.pack(temp)
                     assert (
                         data.dtype.kind != "O"
-                    ), "{} failed to convert {} to a numpy-supported type.".format(
+                    ), "{} failed to convert {} to a np-supported type.".format(
                         paramDef.serializer.__name__, paramDef.name
                     )
                     attrs.update(sAttrs)
@@ -917,14 +917,14 @@ class Database3:
                     attrs[_SERIALIZER_VERSION] = paramDef.serializer.version
                 else:
                     # check if temp is a jagged array
-                    if any(isinstance(x, (numpy.ndarray, list)) for x in temp):
+                    if any(isinstance(x, (np.ndarray, list)) for x in temp):
                         jagged = len(set([_getShape(x) for x in temp])) != 1
                     else:
                         jagged = False
                     data = (
                         JaggedArray(temp, paramDef.name)
                         if jagged
-                        else numpy.array(temp)
+                        else np.array(temp)
                     )
                     del temp
 
@@ -936,13 +936,13 @@ class Database3:
                 data, specialAttrs = packSpecialData(data, paramDef.name)
                 attrs.update(specialAttrs)
 
-            else:  # numpy.ndarray
+            else:  # np.ndarray
                 # Convert Unicode to byte-string
                 if data.dtype.kind == "U":
                     data = data.astype("S")
 
                 if data.dtype.kind == "O":
-                    # Something was added to the data array that caused numpy to want to
+                    # Something was added to the data array that caused np to want to
                     # treat it as a general-purpose Object array. This usually happens
                     # because:
                     # - the data contain NoDefaults
@@ -1042,23 +1042,23 @@ class Database3:
                 assert dataSet.attrs[_SERIALIZER_NAME] == pDef.serializer.__name__
                 assert _SERIALIZER_VERSION in dataSet.attrs
 
-                data = numpy.array(
+                data = np.array(
                     pDef.serializer.unpack(
                         data, dataSet.attrs[_SERIALIZER_VERSION], attrs
                     )
                 )
 
-            if data.dtype.type is numpy.string_:
-                data = numpy.char.decode(data)
+            if data.dtype.type is np.string_:
+                data = np.char.decode(data)
 
             if attrs.get("specialFormatting", False):
                 data = unpackSpecialData(data, attrs, paramName)
 
             linkedDims = []
             if "linkedDims" in attrs:
-                linkedDims = numpy.char.decode(attrs["linkedDims"])
+                linkedDims = np.char.decode(attrs["linkedDims"])
 
-            # iterating of numpy is not fast...
+            # iterating of np is not fast...
             for c, val, linkedDim in itertools.zip_longest(
                 comps, data.tolist(), linkedDims, fillvalue=""
             ):
@@ -1186,7 +1186,7 @@ class Database3:
 
             lLocation = layout.location
             # filter for objects that live under the desired ancestor and at a desired location
-            objectIndicesInLayout = numpy.array(
+            objectIndicesInLayout = np.array(
                 [
                     i
                     for i, (ancestor, loc) in enumerate(zip(ancestors, lLocation))
@@ -1194,10 +1194,10 @@ class Database3:
                 ]
             )
 
-            # This could also be way more efficient if lLocation were a numpy array
+            # This could also be way more efficient if lLocation were a np array
             objectLocationsInLayout = [lLocation[i] for i in objectIndicesInLayout]
 
-            objectIndicesInData = numpy.array(layout.indexInData)[
+            objectIndicesInData = np.array(layout.indexInData)[
                 objectIndicesInLayout
             ].tolist()
 
@@ -1214,7 +1214,7 @@ class Database3:
             for paramName in params or h5GroupForType.keys():
                 if paramName == "location":
                     # location is special, since it is stored in layout/
-                    data = numpy.array(layout.location)[objectIndicesInLayout]
+                    data = np.array(layout.location)[objectIndicesInLayout]
                 elif paramName in h5GroupForType:
                     dataSet = h5GroupForType[paramName]
                     try:
@@ -1227,8 +1227,8 @@ class Database3:
                         )
                         raise
 
-                    if data.dtype.type is numpy.string_:
-                        data = numpy.char.decode(data)
+                    if data.dtype.type is np.string_:
+                        data = np.char.decode(data)
 
                     if dataSet.attrs.get("specialFormatting", False):
                         if dataSet.attrs.get("nones", False):
@@ -1243,7 +1243,7 @@ class Database3:
                             )
                 else:
                     # Nothing in the database for this param, so use the default value
-                    data = numpy.repeat(
+                    data = np.repeat(
                         parameters.byNameAndType(paramName, compType).default,
                         len(comps),
                     )
@@ -1349,7 +1349,7 @@ class Database3:
                         )
                     )
                     raise ee
-                layoutIndicesForType = numpy.where(layout.type == compTypeName)[0]
+                layoutIndicesForType = np.where(layout.type == compTypeName)[0]
                 serialNumsForType = layout.serialNum[layoutIndicesForType].tolist()
                 layoutIndexInData = layout.indexInData[layoutIndicesForType].tolist()
 
@@ -1375,7 +1375,7 @@ class Database3:
                         locs = []
                         for id in indexInData:
                             locs.append((layout.location[layoutIndicesForType[id]]))
-                        data = numpy.array(locs)
+                        data = np.array(locs)
                     elif paramName in h5GroupForType:
                         dataSet = h5GroupForType[paramName]
                         try:
@@ -1388,8 +1388,8 @@ class Database3:
                             )
                             raise
 
-                        if data.dtype.type is numpy.string_:
-                            data = numpy.char.decode(data)
+                        if data.dtype.type is np.string_:
+                            data = np.char.decode(data)
 
                         if dataSet.attrs.get("specialFormatting", False):
                             if dataSet.attrs.get("nones", False):
@@ -1404,17 +1404,17 @@ class Database3:
                                 )
                     else:
                         # Nothing in the database, so use the default value
-                        data = numpy.repeat(
+                        data = np.repeat(
                             parameters.byNameAndType(paramName, compType).default,
                             len(reorderedComps),
                         )
 
-                    # iterating of numpy is not fast..
+                    # iterating of np is not fast..
                     for c, val in zip(reorderedComps, data.tolist()):
                         if paramName == "location":
                             val = tuple(val)
                         elif isinstance(val, list):
-                            val = numpy.array(val)
+                            val = np.array(val)
 
                         histData[c][paramName][cycle, timeNode] = val
 
@@ -1507,20 +1507,20 @@ class Database3:
 
 
 def packSpecialData(
-    arrayData: [numpy.ndarray, JaggedArray], paramName: str
-) -> Tuple[Optional[numpy.ndarray], Dict[str, Any]]:
+    arrayData: [np.ndarray, JaggedArray], paramName: str
+) -> Tuple[Optional[np.ndarray], Dict[str, Any]]:
     """
-    Reduce data that wouldn't otherwise play nicely with HDF5/numpy arrays to a format
+    Reduce data that wouldn't otherwise play nicely with HDF5/np arrays to a format
     that will.
 
     This is the main entry point for conforming "strange" data into something that will
-    both fit into a numpy array/HDF5 dataset, and be recoverable to its original-ish
+    both fit into a np array/HDF5 dataset, and be recoverable to its original-ish
     state when reading it back in. This is accomplished by detecting a handful of known
     offenders and using various HDF5 attributes to store necessary auxiliary data. It is
     important to keep in mind that the data that is passed in has already been converted
-    to a numpy array, so the top dimension is always representing the collection of
+    to a np array, so the top dimension is always representing the collection of
     composites that are storing the parameters. For instance, if we are dealing with a
-    Block parameter, the first index in the numpy array of data is the block index; so
+    Block parameter, the first index in the np array of data is the block index; so
     if each block has a parameter that is a dictionary, ``data`` would be a ndarray,
                     offset += arr.size
     where each element is a dictionary. This routine supports a number of different
@@ -1556,7 +1556,7 @@ def packSpecialData(
     if isinstance(arrayData, JaggedArray):
         data = arrayData.flattenedArray
     else:
-        # Check to make sure that we even need to do this. If the numpy data type is
+        # Check to make sure that we even need to do this. If the np data type is
         # not "O", chances are we have nice, clean data.
         if arrayData.dtype != "O":
             return arrayData, {}
@@ -1570,7 +1570,7 @@ def packSpecialData(
 
     # find locations of Nones. The below works for ndarrays, whereas `data == None`
     # gives a single True/False value
-    nones = numpy.where([d is None for d in data])[0]
+    nones = np.where([d is None for d in data])[0]
 
     if len(nones) == data.shape[0]:
         # Everything is None, so why bother?
@@ -1597,15 +1597,15 @@ def packSpecialData(
         # for most keys.
         attrs["dict"] = True
         keys = sorted({k for d in data for k in d})
-        data = numpy.array([[d.get(k, numpy.nan) for k in keys] for d in data])
+        data = np.array([[d.get(k, np.nan) for k in keys] for d in data])
         if data.dtype == "O":
             # The data themselves are nasty. We could support this, but best to wait for
             # a credible use case.
             raise TypeError(
-                "Unable to coerce dictionary data into usable numpy array for "
+                "Unable to coerce dictionary data into usable np array for "
                 "{}".format(paramName)
             )
-        attrs["keys"] = numpy.array(keys).astype("S")
+        attrs["keys"] = np.array(keys).astype("S")
 
         return data, attrs
 
@@ -1616,23 +1616,23 @@ def packSpecialData(
         attrs["noneLocations"] = arrayData.nones
         return data, attrs
 
-    # conform non-numpy arrays to numpy
+    # conform non-np arrays to np
     for i, val in enumerate(data):
         if isinstance(val, (list, tuple)):
-            data[i] = numpy.array(val)
+            data[i] = np.array(val)
 
-    if not any(isinstance(d, numpy.ndarray) for d in data):
+    if not any(isinstance(d, np.ndarray) for d in data):
         # looks like 1-D plain-old-data
         data = replaceNonesWithNonsense(data, paramName, nones)
         return data, attrs
 
-    if any(isinstance(d, (tuple, list, numpy.ndarray)) for d in data):
+    if any(isinstance(d, (tuple, list, np.ndarray)) for d in data):
         data = replaceNonesWithNonsense(data, paramName, nones)
         return data, attrs
 
     if len(nones) == 0:
         raise TypeError(
-            "Cannot write {} to the database, it did not resolve to a numpy/HDF5 "
+            "Cannot write {} to the database, it did not resolve to a np/HDF5 "
             "type.".format(paramName)
         )
 
@@ -1640,9 +1640,9 @@ def packSpecialData(
     raise TypeError("Failed to process special data for {}".format(paramName))
 
 
-def unpackSpecialData(data: numpy.ndarray, attrs, paramName: str) -> numpy.ndarray:
+def unpackSpecialData(data: np.ndarray, attrs, paramName: str) -> np.ndarray:
     """
-    Extract data from a specially-formatted HDF5 dataset into a numpy array.
+    Extract data from a specially-formatted HDF5 dataset into a np array.
 
     This should invert the operations performed by :py:func:`packSpecialData`.
 
@@ -1659,7 +1659,7 @@ def unpackSpecialData(data: numpy.ndarray, attrs, paramName: str) -> numpy.ndarr
 
     Returns
     -------
-    numpy.ndarray
+    np.ndarray
         An ndarray containing the closest possible representation of the data that was
         originally written to the database.
 
@@ -1683,14 +1683,14 @@ def unpackSpecialData(data: numpy.ndarray, attrs, paramName: str) -> numpy.ndarr
         data = JaggedArray.fromH5(data, offsets, shapes, nones, data.dtype, paramName)
         return data
     if attrs.get("dict", False):
-        keys = numpy.char.decode(attrs["keys"])
+        keys = np.char.decode(attrs["keys"])
         unpackedData = []
         assert data.ndim == 2
         for d in data:
             unpackedData.append(
-                {key: value for key, value in zip(keys, d) if not numpy.isnan(value)}
+                {key: value for key, value in zip(keys, d) if not np.isnan(value)}
             )
-        return numpy.array(unpackedData)
+        return np.array(unpackedData)
 
     raise ValueError(
         "Do not recognize the type of special formatting that was applied "
@@ -1698,7 +1698,7 @@ def unpackSpecialData(data: numpy.ndarray, attrs, paramName: str) -> numpy.ndarr
     )
 
 
-def collectBlockNumberDensities(blocks) -> Dict[str, numpy.ndarray]:
+def collectBlockNumberDensities(blocks) -> Dict[str, np.ndarray]:
     """
     Collect block-by-block homogenized number densities for each nuclide.
 
@@ -1719,7 +1719,7 @@ def collectBlockNumberDensities(blocks) -> Dict[str, numpy.ndarray]:
     nucDensityMatrix = []
     for block in blocks:
         nucDensityMatrix.append(block.getNuclideNumberDensities(nucNames))
-    nucDensityMatrix = numpy.array(nucDensityMatrix)
+    nucDensityMatrix = np.array(nucDensityMatrix)
 
     dataDict = dict()
     for ni, nb in enumerate(nucBases):

--- a/armi/bookkeeping/db/jaggedArray.py
+++ b/armi/bookkeeping/db/jaggedArray.py
@@ -26,15 +26,15 @@ from armi import runLog
 
 class JaggedArray:
     """
-    Take a list of np arrays or lists and flatten them into a single 1D array.
+    Take a list of numpy arrays or lists and flatten them into a single 1D array.
 
-    This implementation can preserve the structure of a multi-dimensional np array
-    by storing the dimensions in self.shapes and then re-populating a np array of
+    This implementation can preserve the structure of a multi-dimensional numpy array
+    by storing the dimensions in self.shapes and then re-populating a numpy array of
     that shape from the flattened 1D array. However, it can only preserve one layer of
     jaggedness in a list of lists (or other iterables). For example, a list of tuples
     with varying lengths can be flattened and reconstituted exactly. But, if a list of
     lists of tuples is passed in, the tuples in that final layer of nesting will all be
-    flattened to a single 1D np array after a round trip. No structure is retained
+    flattened to a single 1D numpy array after a round trip. No structure is retained
     from nested lists of jagged lists or tuples.
     """
 
@@ -45,7 +45,7 @@ class JaggedArray:
         Parameters
         ----------
         jaggedData: list of np.ndarray
-            A list of np arrays (or lists or tuples) to be flattened into a single array
+            A list of numpy arrays (or lists or tuples) to be flattened into a single array
         paramName: str
             The name of the parameter represented by this data
         """
@@ -66,7 +66,7 @@ class JaggedArray:
                         offset += npArray.size
                         flattenedArray.extend(npArray.flatten())
                     except:  # noqa: E722
-                        # np might fail if it's jagged
+                        # numpy might fail if it's jagged
                         flattenedList = self.flatten(arr)
                         shapes.append(
                             len(flattenedList),
@@ -89,7 +89,7 @@ class JaggedArray:
             runLog.error(
                 "Error! It seems like ARMI may have tried to flatten a jagged array "
                 "where the elements have different numbers of dimensions. `shapes` "
-                "attribute of the JaggedArray for {} cannot be made into a np "
+                "attribute of the JaggedArray for {} cannot be made into a numpy "
                 "array; it might be jagged.".format(paramName)
             )
             runLog.error(shapes)
@@ -134,7 +134,7 @@ class JaggedArray:
         Parameters
         ----------
         data: np.ndarray
-            A flattened 1D np array read in from an HDF5 file
+            A flattened 1D numpy array read in from an HDF5 file
         offsets: np.ndarray
             Offset indices for the zeroth element of each constituent array
         shapes: np.ndarray
@@ -170,7 +170,7 @@ class JaggedArray:
         Returns
         -------
         unpackedJaggedData: list of np.ndarray
-            List of np arrays with varying dimensions (i.e., jagged arrays)
+            List of numpy arrays with varying dimensions (i.e., jagged arrays)
         """
         unpackedJaggedData: List[Optional[np.ndarray]] = []
         numElements = len(self.offsets) + len(self.nones)

--- a/armi/bookkeeping/db/jaggedArray.py
+++ b/armi/bookkeeping/db/jaggedArray.py
@@ -26,15 +26,15 @@ from armi import runLog
 
 class JaggedArray:
     """
-    Take a list of numpy arrays or lists and flatten them into a single 1D array.
+    Take a list of np arrays or lists and flatten them into a single 1D array.
 
-    This implementation can preserve the structure of a multi-dimensional numpy array
-    by storing the dimensions in self.shapes and then re-populating a numpy array of
+    This implementation can preserve the structure of a multi-dimensional np array
+    by storing the dimensions in self.shapes and then re-populating a np array of
     that shape from the flattened 1D array. However, it can only preserve one layer of
     jaggedness in a list of lists (or other iterables). For example, a list of tuples
     with varying lengths can be flattened and reconstituted exactly. But, if a list of
     lists of tuples is passed in, the tuples in that final layer of nesting will all be
-    flattened to a single 1D numpy array after a round trip. No structure is retained
+    flattened to a single 1D np array after a round trip. No structure is retained
     from nested lists of jagged lists or tuples.
     """
 
@@ -45,7 +45,7 @@ class JaggedArray:
         Parameters
         ----------
         jaggedData: list of np.ndarray
-            A list of numpy arrays (or lists or tuples) to be flattened into a single array
+            A list of np arrays (or lists or tuples) to be flattened into a single array
         paramName: str
             The name of the parameter represented by this data
         """
@@ -61,12 +61,12 @@ class JaggedArray:
                 else:
                     offsets.append(offset)
                     try:
-                        numpyArray = np.array(arr)
-                        shapes.append(numpyArray.shape)
-                        offset += numpyArray.size
-                        flattenedArray.extend(numpyArray.flatten())
+                        npArray = np.array(arr)
+                        shapes.append(npArray.shape)
+                        offset += npArray.size
+                        flattenedArray.extend(npArray.flatten())
                     except:  # noqa: E722
-                        # numpy might fail if it's jagged
+                        # np might fail if it's jagged
                         flattenedList = self.flatten(arr)
                         shapes.append(
                             len(flattenedList),
@@ -89,7 +89,7 @@ class JaggedArray:
             runLog.error(
                 "Error! It seems like ARMI may have tried to flatten a jagged array "
                 "where the elements have different numbers of dimensions. `shapes` "
-                "attribute of the JaggedArray for {} cannot be made into a numpy "
+                "attribute of the JaggedArray for {} cannot be made into a np "
                 "array; it might be jagged.".format(paramName)
             )
             runLog.error(shapes)
@@ -108,7 +108,7 @@ class JaggedArray:
     @staticmethod
     def flatten(x):
         """
-        Recursively flatten an iterable (list, tuple, or numpy.ndarray).
+        Recursively flatten an iterable (list, tuple, or np.ndarray).
 
         x : list, tuple, np.ndarray
             An iterable. Can be a nested iterable in which the elements
@@ -134,7 +134,7 @@ class JaggedArray:
         Parameters
         ----------
         data: np.ndarray
-            A flattened 1D numpy array read in from an HDF5 file
+            A flattened 1D np array read in from an HDF5 file
         offsets: np.ndarray
             Offset indices for the zeroth element of each constituent array
         shapes: np.ndarray
@@ -170,7 +170,7 @@ class JaggedArray:
         Returns
         -------
         unpackedJaggedData: list of np.ndarray
-            List of numpy arrays with varying dimensions (i.e., jagged arrays)
+            List of np arrays with varying dimensions (i.e., jagged arrays)
         """
         unpackedJaggedData: List[Optional[np.ndarray]] = []
         numElements = len(self.offsets) + len(self.nones)

--- a/armi/bookkeeping/db/layout.py
+++ b/armi/bookkeeping/db/layout.py
@@ -728,7 +728,7 @@ def replaceNonesWithNonsense(
     Parameters
     ----------
     data
-        The np array containing ``None`` values that need to be replaced.
+        The numpy array containing ``None`` values that need to be replaced.
 
     paramName
         The name of the parameter who's data we are treating. Only used for diagnostics.
@@ -742,8 +742,8 @@ def replaceNonesWithNonsense(
     Notes
     -----
     This only supports situations where the data is a straight-up ``None``, or a valid,
-    database-storable np array (or easily convertable to one (e.g. tuples/lists with
-    numerical values)). This does not support, for instance, a np ndarray with some
+    database-storable numpy array (or easily convertable to one (e.g. tuples/lists with
+    numerical values)). This does not support, for instance, a numpy ndarray with some
     Nones in it.
 
     For example, the following is supported::

--- a/armi/bookkeeping/db/layout.py
+++ b/armi/bookkeeping/db/layout.py
@@ -34,7 +34,7 @@ from typing import (
     List,
 )
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.reactor.components import Component
@@ -66,29 +66,29 @@ LOCATION_TYPE_LABELS = {
 NONE_MAP = {float: float("nan"), str: "<!None!>"}
 NONE_MAP.update(
     {
-        intType: numpy.iinfo(intType).min + 2
+        intType: np.iinfo(intType).min + 2
         for intType in (
             int,
-            numpy.int8,
-            numpy.int16,
-            numpy.int32,
-            numpy.int64,
+            np.int8,
+            np.int16,
+            np.int32,
+            np.int64,
         )
     }
 )
 NONE_MAP.update(
     {
-        intType: numpy.iinfo(intType).max - 2
+        intType: np.iinfo(intType).max - 2
         for intType in (
-            numpy.uint,
-            numpy.uint8,
-            numpy.uint16,
-            numpy.uint32,
-            numpy.uint64,
+            np.uint,
+            np.uint8,
+            np.uint16,
+            np.uint32,
+            np.uint64,
         )
     }
 )
-NONE_MAP.update({floatType: floatType("nan") for floatType in (float, numpy.float64)})
+NONE_MAP.update({floatType: floatType("nan") for floatType in (float, np.float64)})
 
 
 class Layout:
@@ -262,18 +262,18 @@ class Layout:
             # location is either an index, or a point
             # iter over list is faster
             locations = h5group["layout/location"][:].tolist()
-            self.locationType = numpy.char.decode(
+            self.locationType = np.char.decode(
                 h5group["layout/locationType"][:]
             ).tolist()
             self.location = _unpackLocations(
                 self.locationType, locations, self.version[1]
             )
-            self.type = numpy.char.decode(h5group["layout/type"][:])
-            self.name = numpy.char.decode(h5group["layout/name"][:])
+            self.type = np.char.decode(h5group["layout/type"][:])
+            self.name = np.char.decode(h5group["layout/name"][:])
             self.serialNum = h5group["layout/serialNum"][:]
             self.indexInData = h5group["layout/indexInData"][:]
             self.numChildren = h5group["layout/numChildren"][:]
-            self.material = numpy.char.decode(h5group["layout/material"][:])
+            self.material = np.char.decode(h5group["layout/material"][:])
             self.temperatures = h5group["layout/temperatures"][:]
             self.gridIndex = replaceNonsenseWithNones(
                 h5group["layout/gridIndex"][:], "layout/gridIndex"
@@ -403,12 +403,12 @@ class Layout:
         try:
             h5group.create_dataset(
                 "layout/type",
-                data=numpy.array(self.type).astype("S"),
+                data=np.array(self.type).astype("S"),
                 compression="gzip",
             )
             h5group.create_dataset(
                 "layout/name",
-                data=numpy.array(self.name).astype("S"),
+                data=np.array(self.name).astype("S"),
                 compression="gzip",
             )
             h5group.create_dataset(
@@ -425,12 +425,12 @@ class Layout:
             )
             h5group.create_dataset(
                 "layout/locationType",
-                data=numpy.array(self.locationType).astype("S"),
+                data=np.array(self.locationType).astype("S"),
                 compression="gzip",
             )
             h5group.create_dataset(
                 "layout/material",
-                data=numpy.array(self.material).astype("S"),
+                data=np.array(self.material).astype("S"),
                 compression="gzip",
             )
             h5group.create_dataset(
@@ -440,7 +440,7 @@ class Layout:
             h5group.create_dataset(
                 "layout/gridIndex",
                 data=replaceNonesWithNonsense(
-                    numpy.array(self.gridIndex), "layout/gridIndex"
+                    np.array(self.gridIndex), "layout/gridIndex"
                 ),
                 compression="gzip",
             )
@@ -448,7 +448,7 @@ class Layout:
             gridsGroup = h5group.create_group("layout/grids")
             gridsGroup.attrs["nGrids"] = len(self.gridParams)
             gridsGroup.create_dataset(
-                "type", data=numpy.array([gp[0] for gp in self.gridParams]).astype("S")
+                "type", data=np.array([gp[0] for gp in self.gridParams]).astype("S")
             )
 
             for igrid, gridParams in enumerate(gp[1] for gp in self.gridParams):
@@ -457,7 +457,7 @@ class Layout:
 
                 for ibound, bound in enumerate(gridParams.bounds):
                     if bound is not None:
-                        bound = numpy.array(bound)
+                        bound = np.array(bound)
                         thisGroup.create_dataset("bounds_{}".format(ibound), data=bound)
 
                 thisGroup.create_dataset(
@@ -719,8 +719,8 @@ def _unpackLocationsV2(locationTypes, locData):
 
 
 def replaceNonesWithNonsense(
-    data: numpy.ndarray, paramName: str, nones: numpy.ndarray = None
-) -> numpy.ndarray:
+    data: np.ndarray, paramName: str, nones: np.ndarray = None
+) -> np.ndarray:
     """
     Replace instances of ``None`` with nonsense values that can be detected/recovered
     when reading.
@@ -728,7 +728,7 @@ def replaceNonesWithNonsense(
     Parameters
     ----------
     data
-        The numpy array containing ``None`` values that need to be replaced.
+        The np array containing ``None`` values that need to be replaced.
 
     paramName
         The name of the parameter who's data we are treating. Only used for diagnostics.
@@ -742,8 +742,8 @@ def replaceNonesWithNonsense(
     Notes
     -----
     This only supports situations where the data is a straight-up ``None``, or a valid,
-    database-storable numpy array (or easily convertable to one (e.g. tuples/lists with
-    numerical values)). This does not support, for instance, a numpy ndarray with some
+    database-storable np array (or easily convertable to one (e.g. tuples/lists with
+    numerical values)). This does not support, for instance, a np ndarray with some
     Nones in it.
 
     For example, the following is supported::
@@ -760,7 +760,7 @@ def replaceNonesWithNonsense(
         Reverses this operation.
     """
     if nones is None:
-        nones = numpy.where([d is None for d in data])[0]
+        nones = np.where([d is None for d in data])[0]
 
     try:
         # loop to find what the default value should be. This is the first non-None
@@ -770,7 +770,7 @@ def replaceNonesWithNonsense(
         val = None
 
         for val in data:
-            if isinstance(val, numpy.ndarray):
+            if isinstance(val, np.ndarray):
                 # if multi-dimensional, val[0] could still be an array, val.flat is
                 # a flattened iterator, so next(val.flat) gives the first value in
                 # an n-dimensional array
@@ -779,8 +779,8 @@ def replaceNonesWithNonsense(
                 if realType is type(None):
                     continue
 
-                defaultValue = numpy.reshape(
-                    numpy.repeat(NONE_MAP[realType], val.size), val.shape
+                defaultValue = np.reshape(
+                    np.repeat(NONE_MAP[realType], val.size), val.shape
                 )
                 break
             else:
@@ -797,8 +797,8 @@ def replaceNonesWithNonsense(
             realType = float
             defaultValue = NONE_MAP[realType]
 
-        if isinstance(val, numpy.ndarray):
-            data = numpy.array([d if d is not None else defaultValue for d in data])
+        if isinstance(val, np.ndarray):
+            data = np.array([d if d is not None else defaultValue for d in data])
         else:
             data[nones] = defaultValue
 
@@ -833,7 +833,7 @@ def replaceNonesWithNonsense(
     return data
 
 
-def replaceNonsenseWithNones(data: numpy.ndarray, paramName: str) -> numpy.ndarray:
+def replaceNonsenseWithNones(data: np.ndarray, paramName: str) -> np.ndarray:
     """
     Replace special nonsense values with ``None``.
 
@@ -853,11 +853,11 @@ def replaceNonsenseWithNones(data: numpy.ndarray, paramName: str) -> numpy.ndarr
     replaceNonesWithNonsense
     """
     # NOTE: This is closely-related to the NONE_MAP.
-    if numpy.issubdtype(data.dtype, numpy.floating):
-        isNone = numpy.isnan(data)
-    elif numpy.issubdtype(data.dtype, numpy.integer):
-        isNone = data == numpy.iinfo(data.dtype).min + 2
-    elif numpy.issubdtype(data.dtype, numpy.str_):
+    if np.issubdtype(data.dtype, np.floating):
+        isNone = np.isnan(data)
+    elif np.issubdtype(data.dtype, np.integer):
+        isNone = data == np.iinfo(data.dtype).min + 2
+    elif np.issubdtype(data.dtype, np.str_):
         isNone = data == "<!None!>"
     else:
         raise TypeError(
@@ -865,18 +865,18 @@ def replaceNonsenseWithNones(data: numpy.ndarray, paramName: str) -> numpy.ndarr
         )
 
     if data.ndim > 1:
-        result = numpy.ndarray(data.shape[0], dtype=numpy.dtype("O"))
+        result = np.ndarray(data.shape[0], dtype=np.dtype("O"))
         for i in range(data.shape[0]):
             if isNone[i].all():
                 result[i] = None
             elif isNone[i].any():
                 # This is the meat of the logic to replace "nonsense" with None.
-                result[i] = numpy.array(data[i], dtype=numpy.dtype("O"))
+                result[i] = np.array(data[i], dtype=np.dtype("O"))
                 result[i][isNone[i]] = None
             else:
                 result[i] = data[i]
     else:
-        result = numpy.ndarray(data.shape, dtype=numpy.dtype("O"))
+        result = np.ndarray(data.shape, dtype=np.dtype("O"))
         result[:] = data
         result[isNone] = None
 

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -222,9 +222,9 @@ class TestDatabase3Smaller(unittest.TestCase):
 
     def _compareArrays(self, ref, src):
         """
-        Compare two np arrays.
+        Compare two numpy arrays.
 
-        Comparing np arrays that may have unsavory data (NaNs, Nones, jagged
+        Comparing numpy arrays that may have unsavory data (NaNs, Nones, jagged
         data, etc.) is really difficult. For now, convert to a list and compare
         element-by-element.
         """

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -17,7 +17,7 @@ import subprocess
 import unittest
 
 import h5py
-import numpy
+import numpy as np
 
 from armi.bookkeeping.db import _getH5File
 from armi.bookkeeping.db import database3
@@ -222,22 +222,22 @@ class TestDatabase3Smaller(unittest.TestCase):
 
     def _compareArrays(self, ref, src):
         """
-        Compare two numpy arrays.
+        Compare two np arrays.
 
-        Comparing numpy arrays that may have unsavory data (NaNs, Nones, jagged
+        Comparing np arrays that may have unsavory data (NaNs, Nones, jagged
         data, etc.) is really difficult. For now, convert to a list and compare
         element-by-element.
         """
         self.assertEqual(type(ref), type(src))
-        if isinstance(ref, numpy.ndarray):
+        if isinstance(ref, np.ndarray):
             ref = ref.tolist()
             src = src.tolist()
 
         for v1, v2 in zip(ref, src):
             # Entries may be None
-            if isinstance(v1, numpy.ndarray):
+            if isinstance(v1, np.ndarray):
                 v1 = v1.tolist()
-            if isinstance(v2, numpy.ndarray):
+            if isinstance(v2, np.ndarray):
                 v2 = v2.tolist()
             self.assertEqual(v1, v2)
 
@@ -318,19 +318,19 @@ class TestDatabase3Smaller(unittest.TestCase):
     # TODO: This should be expanded.
     def test_replaceNones(self):
         """Super basic test that we handle Nones correctly in database read/writes."""
-        data3 = numpy.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-        data1 = numpy.array([1, 2, 3, 4, 5, 6, 7, 8])
-        data1iNones = numpy.array([1, 2, None, 5, 6])
-        data1fNones = numpy.array([None, 2.0, None, 5.0, 6.0])
-        data2fNones = numpy.array(
+        data3 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        data1 = np.array([1, 2, 3, 4, 5, 6, 7, 8])
+        data1iNones = np.array([1, 2, None, 5, 6])
+        data1fNones = np.array([None, 2.0, None, 5.0, 6.0])
+        data2fNones = np.array(
             [None, [[1.0, 2.0, 6.0], [2.0, 3.0, 4.0]]], dtype=object
         )
-        twoByTwo = numpy.array([[1, 2], [3, 4]])
-        twoByOne = numpy.array([[1], [None]])
-        threeByThree = numpy.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        twoByTwo = np.array([[1, 2], [3, 4]])
+        twoByOne = np.array([[1], [None]])
+        threeByThree = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         dataJag = JaggedArray([twoByTwo, threeByThree], "testParam")
         dataJagNones = JaggedArray([twoByTwo, twoByOne, threeByThree], "testParam")
-        dataDict = numpy.array(
+        dataDict = np.array(
             [{"bar": 2, "baz": 3}, {"foo": 4, "baz": 6}, {"foo": 7, "bar": 8}]
         )
         self._compareRoundTrip(data3)
@@ -354,7 +354,7 @@ class TestDatabase3Smaller(unittest.TestCase):
             tnGroup["layout/serialNum"],
             tnGroup,
             {
-                "fakeBigData": numpy.eye(6400),
+                "fakeBigData": np.eye(6400),
                 "someString": "this isn't a reference to another dataset",
             },
         )
@@ -377,7 +377,7 @@ class TestDatabase3Smaller(unittest.TestCase):
             attrs = database3.Database3._resolveAttrs(
                 tnGroup["layout/serialNum"].attrs, tnGroup
             )
-            self.assertTrue(numpy.array_equal(attrs["fakeBigData"], numpy.eye(6400)))
+            self.assertTrue(np.array_equal(attrs["fakeBigData"], np.eye(6400)))
 
             keys = sorted(db2.keys())
             self.assertEqual(len(keys), 4)

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -322,9 +322,7 @@ class TestDatabase3Smaller(unittest.TestCase):
         data1 = np.array([1, 2, 3, 4, 5, 6, 7, 8])
         data1iNones = np.array([1, 2, None, 5, 6])
         data1fNones = np.array([None, 2.0, None, 5.0, 6.0])
-        data2fNones = np.array(
-            [None, [[1.0, 2.0, 6.0], [2.0, 3.0, 4.0]]], dtype=object
-        )
+        data2fNones = np.array([None, [[1.0, 2.0, 6.0], [2.0, 3.0, 4.0]]], dtype=object)
         twoByTwo = np.array([[1, 2], [3, 4]])
         twoByOne = np.array([[1], [None]])
         threeByThree = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -17,7 +17,7 @@ import types
 import unittest
 
 import h5py
-import numpy
+import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from armi import __version__ as version
@@ -320,7 +320,7 @@ class TestDatabaseReading(unittest.TestCase):
         def writeFlux(cycle, node):
             for bi, b in enumerate(o.r.core.getBlocks()):
                 b.p.flux = 1e6 * bi + cycle * 100 + node
-                b.p.mgFlux = numpy.repeat(b.p.flux / 33, 33)
+                b.p.mgFlux = np.repeat(b.p.flux / 33, 33)
 
         o.interfaces.insert(0, MockInterface(o.r, o.cs, writeFlux))
         with o:
@@ -408,8 +408,8 @@ class TestDatabaseReading(unittest.TestCase):
                     self.assertEqual(c1.name, c2.name)
                     if isinstance(c1.spatialLocator, grids.MultiIndexLocation):
                         assert_equal(
-                            numpy.array(c1.spatialLocator.indices),
-                            numpy.array(c2.spatialLocator.indices),
+                            np.array(c1.spatialLocator.indices),
+                            np.array(c2.spatialLocator.indices),
                         )
                     else:
                         assert_equal(
@@ -446,8 +446,8 @@ class TestDatabaseReading(unittest.TestCase):
         b1 = self.r.core.getFirstBlock(Flags.FUEL)
         b2 = r2.core.getFirstBlock(Flags.FUEL)
 
-        self.assertIsInstance(b1.p.mgFlux, numpy.ndarray)
-        self.assertIsInstance(b2.p.mgFlux, numpy.ndarray)
+        self.assertIsInstance(b1.p.mgFlux, np.ndarray)
+        self.assertIsInstance(b2.p.mgFlux, np.ndarray)
         assert_allclose(b1, b2)
 
         c1 = b1.getComponent(Flags.FUEL)

--- a/armi/bookkeeping/db/tests/test_jaggedArray.py
+++ b/armi/bookkeeping/db/tests/test_jaggedArray.py
@@ -15,7 +15,7 @@
 import unittest
 
 import h5py
-import numpy
+import numpy as np
 
 from armi.bookkeeping.db.jaggedArray import JaggedArray
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
@@ -33,7 +33,7 @@ class TestJaggedArray(unittest.TestCase):
 
     def test_roundTrip(self):
         """Basic test that we handle Nones correctly in database read/writes."""
-        dataSet = [1, 2.0, None, [], [3, 4], (5, 6, 7), numpy.array([8, 9, 10, 11])]
+        dataSet = [1, 2.0, None, [], [3, 4], (5, 6, 7), np.array([8, 9, 10, 11])]
         self._compareRoundTrip(dataSet, "test-numbers")
 
     def test_roundTripBool(self):
@@ -43,7 +43,7 @@ class TestJaggedArray(unittest.TestCase):
 
     def test_flatten(self):
         """Test the recursive flattening static method."""
-        testdata = [(1, 2), [3, 4, 5], [], None, 6, numpy.array([7, 8, 9])]
+        testdata = [(1, 2), [3, 4, 5], [], None, 6, np.array([7, 8, 9])]
         flatArray = JaggedArray.flatten(testdata)
         self.assertEqual(flatArray, [1, 2, 3, 4, 5, None, 6, 7, 8, 9])
 
@@ -82,9 +82,9 @@ class TestJaggedArray(unittest.TestCase):
 
     def _compareArrays(self, ref, src):
         """
-        Compare two numpy arrays.
+        Compare two np arrays.
 
-        Comparing numpy arrays that may have unsavory data (NaNs, Nones, jagged
+        Comparing np arrays that may have unsavory data (NaNs, Nones, jagged
         data, etc.) is really difficult. For now, convert to a list and compare
         element-by-element.
 
@@ -92,33 +92,33 @@ class TestJaggedArray(unittest.TestCase):
         here converts the initial data into the format expected to be produced
         by the round trip. The conversions are:
 
-        - For scalar values (int, float, etc.), the data becomes a numpy
+        - For scalar values (int, float, etc.), the data becomes a np
           array with a dimension of 1 after the round trip.
-        - Tuples and lists become numpy arrays
+        - Tuples and lists become np arrays
         - Empty lists become `None`
 
         """
         # self.assertEqual(type(src), JaggedArray)
-        if isinstance(ref, numpy.ndarray):
+        if isinstance(ref, np.ndarray):
             ref = ref.tolist()
             src = src.tolist()
 
         for v1, v2 in zip(ref, src):
             # Entries may be None
-            if isinstance(v1, numpy.ndarray):
+            if isinstance(v1, np.ndarray):
                 v1 = v1.tolist()
             elif isinstance(v1, tuple):
                 v1 = list(v1)
             elif isinstance(v1, int):
-                v1 = numpy.array([v1])
+                v1 = np.array([v1])
             elif isinstance(v1, float):
-                v1 = numpy.array([v1], dtype=numpy.float64)
+                v1 = np.array([v1], dtype=np.float64)
             elif v1 is None:
                 pass
             elif len(v1) == 0:
                 v1 = None
 
-            if isinstance(v2, numpy.ndarray):
+            if isinstance(v2, np.ndarray):
                 v2 = v2.tolist()
 
             self.assertEqual(v1, v2)

--- a/armi/bookkeeping/db/tests/test_jaggedArray.py
+++ b/armi/bookkeeping/db/tests/test_jaggedArray.py
@@ -82,9 +82,9 @@ class TestJaggedArray(unittest.TestCase):
 
     def _compareArrays(self, ref, src):
         """
-        Compare two np arrays.
+        Compare two numpy arrays.
 
-        Comparing np arrays that may have unsavory data (NaNs, Nones, jagged
+        Comparing numpy arrays that may have unsavory data (NaNs, Nones, jagged
         data, etc.) is really difficult. For now, convert to a list and compare
         element-by-element.
 
@@ -92,9 +92,9 @@ class TestJaggedArray(unittest.TestCase):
         here converts the initial data into the format expected to be produced
         by the round trip. The conversions are:
 
-        - For scalar values (int, float, etc.), the data becomes a np
+        - For scalar values (int, float, etc.), the data becomes a numpy
           array with a dimension of 1 after the round trip.
-        - Tuples and lists become np arrays
+        - Tuples and lists become numpy arrays
         - Empty lists become `None`
 
         """

--- a/armi/bookkeeping/report/newReportUtils.py
+++ b/armi/bookkeeping/report/newReportUtils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import collections
 import os
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.bookkeeping.report import newReports
@@ -486,7 +486,7 @@ def getPinDesignTable(core):
             designInfo["zrFrac"].append(fuel.getMassFrac("ZR"))
 
         # assumption made that all lists contain only numerical data
-        designInfo = {key: numpy.average(data) for key, data in designInfo.items()}
+        designInfo = {key: np.average(data) for key, data in designInfo.items()}
         dimensionless = {"sd", "hot sd", "zrFrac", "nPins"}
         for key, average_value in designInfo.items():
             dim = "{0:10s}".format(key)

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -27,7 +27,7 @@ import tabulate
 import textwrap
 import time
 
-import numpy
+import numpy as np
 
 from armi import context
 from armi import interfaces
@@ -701,7 +701,7 @@ def summarizePinDesign(core):
             designInfo["zrFrac"].append(fuel.getMassFrac("ZR"))
 
         # assumption made that all lists contain only numerical data
-        designInfo = {key: numpy.average(data) for key, data in designInfo.items()}
+        designInfo = {key: np.average(data) for key, data in designInfo.items()}
 
         dimensionless = {"sd", "hot sd", "zrFrac", "nPins"}
         for key, average_value in designInfo.items():

--- a/armi/bookkeeping/visualization/tests/test_vis.py
+++ b/armi/bookkeeping/visualization/tests/test_vis.py
@@ -15,7 +15,7 @@
 """Test report visualization."""
 import unittest
 
-import numpy
+import numpy as np
 from pyevtk.vtk import VtkTetra
 
 from armi import settings
@@ -41,12 +41,12 @@ class TestVtkMesh(unittest.TestCase):
         self.assertEqual(mesh.offsets.size, 0)
         self.assertEqual(mesh.cellTypes.size, 0)
 
-        verts = numpy.array(
+        verts = np.array(
             [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.25, 0.25, 0.5]]
         )
-        conn = numpy.array([0, 1, 2, 3])
-        offsets = numpy.array([4])
-        cellTypes = numpy.array([VtkTetra.tid])
+        conn = np.array([0, 1, 2, 3])
+        offsets = np.array([4])
+        cellTypes = np.array([VtkTetra.tid])
         newMesh = utils.VtkMesh(verts, conn, offsets, cellTypes)
 
         mesh.append(newMesh)

--- a/armi/bookkeeping/visualization/utils.py
+++ b/armi/bookkeeping/visualization/utils.py
@@ -203,9 +203,7 @@ def _createHexBlockMesh(b: blocks.HexBlock) -> VtkMesh:
     hexVerts2d = np.vstack((hexVerts2d, hexVerts2d))
 
     # fold in z locations to get 3d coordinates
-    hexVerts = np.hstack(
-        (hexVerts2d, np.array([[zMin] * 6 + [zMax] * 6]).transpose())
-    )
+    hexVerts = np.hstack((hexVerts2d, np.array([[zMin] * 6 + [zMax] * 6]).transpose()))
 
     return VtkMesh(
         hexVerts,
@@ -242,9 +240,7 @@ def _createCartesianBlockMesh(b: blocks.CartesianBlock) -> VtkMesh:
     boxVerts = np.vstack((rectVerts, rectVerts))
 
     # fold in z coordinates
-    boxVerts = np.hstack(
-        (boxVerts, np.array([[zMin] * 4 + [zMax] * 4]).transpose())
-    )
+    boxVerts = np.hstack((boxVerts, np.array([[zMin] * 4 + [zMax] * 4]).transpose()))
 
     return VtkMesh(
         boxVerts,

--- a/armi/bookkeeping/visualization/utils.py
+++ b/armi/bookkeeping/visualization/utils.py
@@ -22,7 +22,7 @@ for primitive shapes should be created.
 
 import math
 
-import numpy
+import numpy as np
 from pyevtk.hl import unstructuredGridToVTK
 from pyevtk.vtk import VtkHexahedron, VtkQuadraticHexahedron
 
@@ -54,13 +54,13 @@ class VtkMesh:
         """
         Parameters
         ----------
-        vertices : numpy array
-            An Nx3 numpy array with one row per (x,y,z) vertex
-        connectivity : numpy array
+        vertices : np array
+            An Nx3 np array with one row per (x,y,z) vertex
+        connectivity : np array
             A 1-D array containing the vertex indices belonging to each cell
-        offsets : numpy array
+        offsets : np array
             A 1-D array containing the index of the first vertex for the next cell
-        cellTypes : numpy array
+        cellTypes : np array
             A 1-D array contining the cell type ID for each cell
         """
         self.vertices = vertices
@@ -71,35 +71,35 @@ class VtkMesh:
     @staticmethod
     def empty():
         return VtkMesh(
-            numpy.empty((0, 3), dtype=numpy.float64),
-            numpy.array([], dtype=numpy.int32),
-            numpy.array([], dtype=numpy.int32),
-            numpy.array([], dtype=numpy.int32),
+            np.empty((0, 3), dtype=np.float64),
+            np.array([], dtype=np.int32),
+            np.array([], dtype=np.int32),
+            np.array([], dtype=np.int32),
         )
 
     @property
     def x(self):
-        return numpy.array(self.vertices[:, 0])
+        return np.array(self.vertices[:, 0])
 
     @property
     def y(self):
-        return numpy.array(self.vertices[:, 1])
+        return np.array(self.vertices[:, 1])
 
     @property
     def z(self):
-        return numpy.array(self.vertices[:, 2])
+        return np.array(self.vertices[:, 2])
 
     def append(self, other):
         """Add more cells to the mesh."""
         connectOffset = self.vertices.shape[0]
         offsetOffset = self.offsets[-1] if self.offsets.size > 0 else 0
 
-        self.vertices = numpy.vstack((self.vertices, other.vertices))
-        self.connectivity = numpy.append(
+        self.vertices = np.vstack((self.vertices, other.vertices))
+        self.connectivity = np.append(
             self.connectivity, other.connectivity + connectOffset
         )
-        self.offsets = numpy.append(self.offsets, other.offsets + offsetOffset)
-        self.cellTypes = numpy.append(self.cellTypes, other.cellTypes)
+        self.offsets = np.append(self.offsets, other.offsets + offsetOffset)
+        self.cellTypes = np.append(self.cellTypes, other.cellTypes)
 
     def write(self, path, data) -> str:
         """
@@ -193,25 +193,25 @@ def _createHexBlockMesh(b: blocks.HexBlock) -> VtkMesh:
     zMax = b.p.ztop
 
     gridOffset = b.spatialLocator.getGlobalCoordinates()[:2]
-    gridOffset = numpy.tile(gridOffset, (6, 1))
+    gridOffset = np.tile(gridOffset, (6, 1))
 
     pitch = b.getPitch()
-    hexVerts2d = numpy.array(hexagon.corners(rotation=0)) * pitch
+    hexVerts2d = np.array(hexagon.corners(rotation=0)) * pitch
     hexVerts2d += gridOffset
 
     # we need a top and bottom hex
-    hexVerts2d = numpy.vstack((hexVerts2d, hexVerts2d))
+    hexVerts2d = np.vstack((hexVerts2d, hexVerts2d))
 
     # fold in z locations to get 3d coordinates
-    hexVerts = numpy.hstack(
-        (hexVerts2d, numpy.array([[zMin] * 6 + [zMax] * 6]).transpose())
+    hexVerts = np.hstack(
+        (hexVerts2d, np.array([[zMin] * 6 + [zMax] * 6]).transpose())
     )
 
     return VtkMesh(
         hexVerts,
-        numpy.array(list(range(12))),
-        numpy.array([12]),
-        numpy.array([_HEX_PRISM_TID]),
+        np.array(list(range(12))),
+        np.array([12]),
+        np.array([_HEX_PRISM_TID]),
     )
 
 
@@ -222,13 +222,13 @@ def _createCartesianBlockMesh(b: blocks.CartesianBlock) -> VtkMesh:
     zMax = b.p.ztop
 
     gridOffset = b.spatialLocator.getGlobalCoordinates()[:2]
-    gridOffset = numpy.tile(gridOffset, (4, 1))
+    gridOffset = np.tile(gridOffset, (4, 1))
 
     pitch = b.getPitch()
     halfPitchX = pitch[0] * 0.5
     halfPitchY = pitch[0] * 0.5
 
-    rectVerts = numpy.array(
+    rectVerts = np.array(
         [
             [halfPitchX, halfPitchY],
             [-halfPitchX, halfPitchY],
@@ -239,18 +239,18 @@ def _createCartesianBlockMesh(b: blocks.CartesianBlock) -> VtkMesh:
     rectVerts += gridOffset
 
     # make top/bottom rectangles
-    boxVerts = numpy.vstack((rectVerts, rectVerts))
+    boxVerts = np.vstack((rectVerts, rectVerts))
 
     # fold in z coordinates
-    boxVerts = numpy.hstack(
-        (boxVerts, numpy.array([[zMin] * 4 + [zMax] * 4]).transpose())
+    boxVerts = np.hstack(
+        (boxVerts, np.array([[zMin] * 4 + [zMax] * 4]).transpose())
     )
 
     return VtkMesh(
         boxVerts,
-        numpy.array(list(range(8))),
-        numpy.array([8]),
-        numpy.array([VtkHexahedron.tid]),
+        np.array(list(range(8))),
+        np.array([8]),
+        np.array([VtkHexahedron.tid]),
     )
 
 
@@ -285,13 +285,13 @@ def _createTRZBlockMesh(b: blocks.ThRZBlock) -> VtkMesh:
         (rOut, thIn, (zIn + zOut) * 0.5),
         (rOut, thOut, (zIn + zOut) * 0.5),
     ]
-    vertsXYZ = numpy.array(
+    vertsXYZ = np.array(
         [[r * math.cos(th), r * math.sin(th), z] for r, th, z in vertsRTZ]
     )
 
     return VtkMesh(
         vertsXYZ,
-        numpy.array(list(range(20))),
-        numpy.array([20]),
-        numpy.array([VtkQuadraticHexahedron.tid]),
+        np.array(list(range(20))),
+        np.array([20]),
+        np.array([VtkQuadraticHexahedron.tid]),
     )

--- a/armi/bookkeeping/visualization/utils.py
+++ b/armi/bookkeeping/visualization/utils.py
@@ -54,13 +54,13 @@ class VtkMesh:
         """
         Parameters
         ----------
-        vertices : np array
-            An Nx3 np array with one row per (x,y,z) vertex
-        connectivity : np array
+        vertices : numpy array
+            An Nx3 numpy array with one row per (x,y,z) vertex
+        connectivity : numpy array
             A 1-D array containing the vertex indices belonging to each cell
-        offsets : np array
+        offsets : numpy array
             A 1-D array containing the index of the first vertex for the next cell
-        cellTypes : np array
+        cellTypes : numpy array
             A 1-D array contining the cell type ID for each cell
         """
         self.vertices = vertices

--- a/armi/bookkeeping/visualization/vtk.py
+++ b/armi/bookkeeping/visualization/vtk.py
@@ -32,7 +32,7 @@ that can be improved upon. For instance:
 
 from typing import Dict, Any, List, Optional, Set, Tuple
 
-import numpy
+import numpy as np
 from pyevtk.vtk import VtkGroup
 
 from armi import runLog
@@ -112,7 +112,7 @@ class VtkDumper(dumper.VisFileDumper):
         blockNdens = database3.collectBlockNumberDensities(blks)
         # we need to copy the number density vectors to guarantee unit stride, which
         # pyevtk requires. Kinda seems like something it could do for us, but oh well.
-        blockNdens = {key: numpy.array(value) for key, value in blockNdens.items()}
+        blockNdens = {key: np.array(value) for key, value in blockNdens.items()}
         blockData.update(blockNdens)
 
         fullPath = blockMesh.write(blockPath, blockData)
@@ -161,7 +161,7 @@ def _collectObjectData(
             val = obj.p[pDef.name]
             data.append(val)
 
-        data = numpy.array(data)
+        data = np.array(data)
 
         if data.dtype.kind == "S" or data.dtype.kind == "U":
             # no string support!
@@ -169,7 +169,7 @@ def _collectObjectData(
         if data.dtype.kind == "O":
             # datatype is "object", usually because it's jagged, or has Nones. We are
             # willing to try handling the Nones, but jagged also isnt visualizable.
-            nones = numpy.where([d is None for d in data])[0]
+            nones = np.where([d is None for d in data])[0]
 
             if len(nones) == data.shape[0]:
                 # all Nones, so give up

--- a/armi/bookkeeping/visualization/xdmf.py
+++ b/armi/bookkeeping/visualization/xdmf.py
@@ -44,7 +44,7 @@ from typing import Optional, Set, List, Tuple, Dict
 import xml.etree.ElementTree as ET
 import xml.dom.minidom
 
-import numpy
+import numpy as np
 import h5py
 
 from armi import runLog
@@ -67,7 +67,7 @@ _QUADRATIC_HEXAHEDRON = 48
 # proper XDMF, these need to be offset to the proper vertex indices in the full mesh,
 # and have the number of face vertices inserted into the proper locations (notice the
 # [0] placeholders).
-_HEX_PRISM_TOPO = numpy.array(
+_HEX_PRISM_TOPO = np.array(
     [0]
     + list(range(6))
     + [0]
@@ -87,25 +87,25 @@ _HEX_PRISM_TOPO = numpy.array(
 )
 
 # The indices of the placeholder zeros from _HEX_PRISM_TOPO array above
-_HEX_PRISM_FACE_SIZE_IDX = numpy.array([0, 7, 14, 19, 24, 29, 34, 39])
+_HEX_PRISM_FACE_SIZE_IDX = np.array([0, 7, 14, 19, 24, 29, 34, 39])
 
 # The number of vertices for each face
-_HEX_PRISM_FACE_SIZES = numpy.array([6, 6, 4, 4, 4, 4, 4, 4])
+_HEX_PRISM_FACE_SIZES = np.array([6, 6, 4, 4, 4, 4, 4, 4])
 
 
 def _getAttributesFromDataset(d: h5py.Dataset) -> Dict[str, str]:
     dataType = {
-        numpy.dtype("int32"): "Int",
-        numpy.dtype("int64"): "Int",
-        numpy.dtype("float32"): "Float",
-        numpy.dtype("float64"): "Float",
+        np.dtype("int32"): "Int",
+        np.dtype("int64"): "Int",
+        np.dtype("float32"): "Float",
+        np.dtype("float64"): "Float",
     }[d.dtype]
 
     precision = {
-        numpy.dtype("int32"): "4",
-        numpy.dtype("int64"): "8",
-        numpy.dtype("float32"): "4",
-        numpy.dtype("float64"): "8",
+        np.dtype("int32"): "4",
+        np.dtype("int64"): "8",
+        np.dtype("float32"): "4",
+        np.dtype("float64"): "8",
     }[d.dtype]
 
     return {
@@ -373,11 +373,11 @@ class XdmfDumper(dumper.VisFileDumper):
         verticesInH5 = groupName + "/blk_vertices"
         self._meshH5[verticesInH5] = verts
 
-        topoValues = numpy.array([], dtype=numpy.int32)
+        topoValues = np.array([], dtype=np.int32)
         offset = 0
         for b in blks:
             nVerts, cellTopo = _getTopologyFromShape(b, offset)
-            topoValues = numpy.append(topoValues, cellTopo)
+            topoValues = np.append(topoValues, cellTopo)
             offset += nVerts
 
         topoInH5 = groupName + "/blk_topology"
@@ -407,11 +407,11 @@ class XdmfDumper(dumper.VisFileDumper):
         verticesInH5 = groupName + "/asy_vertices"
         self._meshH5[verticesInH5] = verts
 
-        topoValues = numpy.array([], dtype=numpy.int32)
+        topoValues = np.array([], dtype=np.int32)
         offset = 0
         for a in asys:
             nVerts, cellTopo = _getTopologyFromShape(a[0], offset)
-            topoValues = numpy.append(topoValues, cellTopo)
+            topoValues = np.append(topoValues, cellTopo)
             offset += nVerts
 
         topoInH5 = groupName + "/asy_topology"
@@ -473,7 +473,7 @@ def _getTopologyFromShape(b: blocks.Block, offset: int) -> Tuple[int, List[int]]
         prefix = [_POLYHEDRON, 8]
         topo = _HEX_PRISM_TOPO + offset
         topo[_HEX_PRISM_FACE_SIZE_IDX] = _HEX_PRISM_FACE_SIZES
-        topo = numpy.append(prefix, topo)
+        topo = np.append(prefix, topo)
 
         return 12, topo
 

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -25,9 +25,7 @@ Tests must be invoked via pytest for this to have any affect, for example::
 
 """
 import os
-import numpy as np
 import matplotlib
-
 from armi import apps, configure, context
 from armi.settings import caseSettings
 from armi.tests import TEST_ROOT

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -25,7 +25,9 @@ Tests must be invoked via pytest for this to have any affect, for example::
 
 """
 import os
+
 import matplotlib
+
 from armi import apps, configure, context
 from armi.settings import caseSettings
 from armi.tests import TEST_ROOT

--- a/armi/conftest.py
+++ b/armi/conftest.py
@@ -25,7 +25,7 @@ Tests must be invoked via pytest for this to have any affect, for example::
 
 """
 import os
-
+import numpy as np
 import matplotlib
 
 from armi import apps, configure, context

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -29,7 +29,7 @@ from typing import NamedTuple
 from typing import List
 from typing import Dict
 
-import numpy
+import numpy as np
 from numpy.linalg import norm
 
 from armi import getPluginManagerOrFail, settings, utils
@@ -118,7 +118,7 @@ class TightCoupler:
         Maximum number of tight coupling iterations allowed
     """
 
-    _SUPPORTED_TYPES = [float, int, list, numpy.ndarray]
+    _SUPPORTED_TYPES = [float, int, list, np.ndarray]
 
     def __init__(self, param, tolerance, maxIters):
         self.parameter = param
@@ -126,7 +126,7 @@ class TightCoupler:
         self.maxIters = maxIters
         self._numIters = 0
         self._previousIterationValue = None
-        self.eps = numpy.inf
+        self.eps = np.inf
 
     def __repr__(self):
         return (
@@ -204,12 +204,12 @@ class TightCoupler:
         else:
             dim = self.getListDimension(val)
             if dim == 1:  # 1D array
-                self.eps = norm(numpy.subtract(val, previous), ord=2)
+                self.eps = norm(np.subtract(val, previous), ord=2)
             elif dim == 2:  # 2D array
                 epsVec = []
                 for old, new in zip(previous, val):
-                    epsVec.append(norm(numpy.subtract(old, new), ord=2))
-                self.eps = norm(epsVec, ord=numpy.inf)
+                    epsVec.append(norm(np.subtract(old, new), ord=2))
+                self.eps = norm(epsVec, ord=np.inf)
             else:
                 raise RuntimeError(
                     "Currently only support up to 2D arrays for calculating convergence of arrays."

--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Alloy-200 are wrought commercially pure nickel."""
+
 from numpy import interp
 
 from armi.materials.material import Material

--- a/armi/materials/inconel600.py
+++ b/armi/materials/inconel600.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Inconel600."""
-import numpy
+import numpy as np
 
 from armi.materials.material import Material
 from armi.utils.units import getTc
@@ -73,7 +73,7 @@ class Inconel600(Material):
         """
         Tc = [20.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0]
         k = [14.9, 15.9, 17.3, 19.0, 20.5, 22.1, 23.9, 25.7, 27.5]
-        return numpy.polyfit(numpy.array(Tc), numpy.array(k), power).tolist()
+        return np.polyfit(np.array(Tc), np.array(k), power).tolist()
 
     def thermalConductivity(self, Tk=None, Tc=None):
         r"""
@@ -113,7 +113,7 @@ class Inconel600(Material):
         """
         Tc = [20.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0]
         cp = [444.0, 465.0, 486.0, 502.0, 519.0, 536.0, 578.0, 595.0, 611.0, 628.0]
-        return numpy.polyfit(numpy.array(Tc), numpy.array(cp), power).tolist()
+        return np.polyfit(np.array(Tc), np.array(cp), power).tolist()
 
     def heatCapacity(self, Tk=None, Tc=None):
         r"""
@@ -174,8 +174,8 @@ class Inconel600(Material):
 
         Tc.insert(0, refTempC)
 
-        return numpy.polyfit(
-            numpy.array(Tc), numpy.array(linExpPercent), power
+        return np.polyfit(
+            np.array(Tc), np.array(linExpPercent), power
         ).tolist()
 
     def linearExpansionPercent(self, Tk=None, Tc=None):

--- a/armi/materials/inconel600.py
+++ b/armi/materials/inconel600.py
@@ -174,9 +174,7 @@ class Inconel600(Material):
 
         Tc.insert(0, refTempC)
 
-        return np.polyfit(
-            np.array(Tc), np.array(linExpPercent), power
-        ).tolist()
+        return np.polyfit(np.array(Tc), np.array(linExpPercent), power).tolist()
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         r"""

--- a/armi/materials/inconel625.py
+++ b/armi/materials/inconel625.py
@@ -203,9 +203,7 @@ class Inconel625(Material):
 
         Tc.insert(0, refTempC)
 
-        return np.polyfit(
-            np.array(Tc), np.array(linExpPercent), power
-        ).tolist()
+        return np.polyfit(np.array(Tc), np.array(linExpPercent), power).tolist()
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         """

--- a/armi/materials/inconel625.py
+++ b/armi/materials/inconel625.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Inconel625."""
-import numpy
+import numpy as np
 
 from armi.materials.material import Material
 from armi.utils.units import getTc
@@ -78,7 +78,7 @@ class Inconel625(Material):
         """
         Tc = [21.0, 38.0, 93.0, 204.0, 316.0, 427.0, 538.0, 649.0, 760.0, 871.0, 982.0]
         k = [9.8, 10.1, 10.8, 12.5, 14.1, 15.7, 17.5, 19.0, 20.8, 22.8, 25.2]
-        return numpy.polyfit(numpy.array(Tc), numpy.array(k), power).tolist()
+        return np.polyfit(np.array(Tc), np.array(k), power).tolist()
 
     def thermalConductivity(self, Tk=None, Tc=None):
         r"""
@@ -142,7 +142,7 @@ class Inconel625(Material):
             645.0,
             670.0,
         ]
-        return numpy.polyfit(numpy.array(Tc), numpy.array(cp), power).tolist()
+        return np.polyfit(np.array(Tc), np.array(cp), power).tolist()
 
     def heatCapacity(self, Tk=None, Tc=None):
         """
@@ -203,8 +203,8 @@ class Inconel625(Material):
 
         Tc.insert(0, refTempC)
 
-        return numpy.polyfit(
-            numpy.array(Tc), numpy.array(linExpPercent), power
+        return np.polyfit(
+            np.array(Tc), np.array(linExpPercent), power
         ).tolist()
 
     def linearExpansionPercent(self, Tk=None, Tc=None):

--- a/armi/materials/inconelX750.py
+++ b/armi/materials/inconelX750.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Inconel X750."""
-import numpy
+import numpy as np
 
 from armi.utils.units import getTc
 from armi.materials.material import Material
@@ -104,7 +104,7 @@ class InconelX750(Material):
             22.21,
             23.65,
         ]
-        return numpy.polyfit(numpy.array(Tc), numpy.array(k), power).tolist()
+        return np.polyfit(np.array(Tc), np.array(k), power).tolist()
 
     def thermalConductivity(self, Tk=None, Tc=None):
         r"""
@@ -144,7 +144,7 @@ class InconelX750(Material):
         """
         Tc = [21.1, 93.3, 204.4, 315.6, 426.7, 537.8, 648.9, 760.0, 871.1]
         cp = [431.2, 456.4, 485.7, 502.4, 523.4, 544.3, 573.6, 632.2, 715.9]
-        return numpy.polyfit(numpy.array(Tc), numpy.array(cp), power).tolist()
+        return np.polyfit(np.array(Tc), np.array(cp), power).tolist()
 
     def heatCapacity(self, Tk=None, Tc=None):
         r"""
@@ -207,8 +207,8 @@ class InconelX750(Material):
 
         Tc.insert(0, refTempC)
 
-        return numpy.polyfit(
-            numpy.array(Tc), numpy.array(linExpPercent), power
+        return np.polyfit(
+            np.array(Tc), np.array(linExpPercent), power
         ).tolist()
 
     def linearExpansionPercent(self, Tk=None, Tc=None):

--- a/armi/materials/inconelX750.py
+++ b/armi/materials/inconelX750.py
@@ -207,9 +207,7 @@ class InconelX750(Material):
 
         Tc.insert(0, refTempC)
 
-        return np.polyfit(
-            np.array(Tc), np.array(linExpPercent), power
-        ).tolist()
+        return np.polyfit(np.array(Tc), np.array(linExpPercent), power).tolist()
 
     def linearExpansionPercent(self, Tk=None, Tc=None):
         r"""

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -431,7 +431,7 @@ class Material:
         """Get the temperature at which the perturbed density occurs (in Celcius)."""
         # 0 at tempertature of targetDensity
         densFunc = lambda temp: self.density(Tc=temp) - targetDensity
-        # is a np array if fsolve is called
+        # is a numpy array if fsolve is called
         tAtTargetDensity = float(fsolve(densFunc, tempGuessInC))
         return tAtTargetDensity
 

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -20,7 +20,7 @@ Most temperatures may be specified in either K or C and the functions will conve
 import warnings
 
 from scipy.optimize import fsolve
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.nucDirectory import nuclideBases
@@ -344,8 +344,8 @@ class Material:
 
         # refDens could be zero, but cannot normalize to zero.
         density = self.refDens or 1.0
-        massDensities = numpy.array([self.massFrac[nuc] for nuc in nucsNames]) * density
-        atomicMasses = numpy.array(
+        massDensities = np.array([self.massFrac[nuc] for nuc in nucsNames]) * density
+        atomicMasses = np.array(
             [nuclideBases.byName[nuc].weight for nuc in nucsNames]
         )  # in AMU
         molesPerCC = massDensities / atomicMasses  # item-wise division
@@ -413,7 +413,7 @@ class Material:
         updatedDensity = updatedMassDensities.sum()
         massFracs = updatedMassDensities / updatedDensity
 
-        if not numpy.isclose(sum(massFracs), 1.0, atol=1e-10):
+        if not np.isclose(sum(massFracs), 1.0, atol=1e-10):
             raise RuntimeError(
                 f"The mass fractions {massFracs} in {self} do not sum to 1.0."
             )
@@ -431,7 +431,7 @@ class Material:
         """Get the temperature at which the perturbed density occurs (in Celcius)."""
         # 0 at tempertature of targetDensity
         densFunc = lambda temp: self.density(Tc=temp) - targetDensity
-        # is a numpy array if fsolve is called
+        # is a np array if fsolve is called
         tAtTargetDensity = float(fsolve(densFunc, tempGuessInC))
         return tAtTargetDensity
 
@@ -640,7 +640,7 @@ class Material:
             msg = "Temperature {0} out of range ({1} to {2}) for {3} {4}".format(
                 val, minT, maxT, self.name, label
             )
-            if FAIL_ON_RANGE or numpy.isnan(val):
+            if FAIL_ON_RANGE or np.isnan(val):
                 runLog.error(msg)
                 raise ValueError
             else:

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -20,7 +20,6 @@ Much info is from [AAAFuels]_.
 .. [AAAFuels]  Kim, Y S, and Hofman, G L. AAA fuels handbook.. United States: N. p., 2003. Web. doi:10.2172/822554. .
 """
 
-
 from numpy import interp
 
 from armi import runLog

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -20,6 +20,7 @@ Much info is from [AAAFuels]_.
 .. [AAAFuels]  Kim, Y S, and Hofman, G L. AAA fuels handbook.. United States: N. p., 2003. Web. doi:10.2172/822554. .
 """
 
+
 from numpy import interp
 
 from armi import runLog

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -96,7 +96,7 @@ Retrieve U-235 by the AAAZZZS ID:
 import os
 
 from ruamel.yaml import YAML
-import numpy
+import numpy as np
 
 from armi import context
 from armi import runLog
@@ -728,7 +728,7 @@ class NaturalNuclideBase(INuclide, IMcnpNuclide):
                 [nn.weight * nn.abundance for nn in element.getNaturalIsotopics()]
             ),
             abundance=0.0,
-            halflife=numpy.inf,
+            halflife=np.inf,
             name=name,
             label=name,
         )
@@ -827,7 +827,7 @@ class DummyNuclideBase(INuclide):
             state=0,
             weight=weight,
             abundance=0.0,
-            halflife=numpy.inf,
+            halflife=np.inf,
             name=name,
             label="DMP" + name[4],
         )
@@ -893,7 +893,7 @@ class LumpNuclideBase(INuclide):
             state=0,
             weight=weight,
             abundance=0.0,
-            halflife=numpy.inf,
+            halflife=np.inf,
             name=name,
             label=name[1:],
         )
@@ -1221,7 +1221,7 @@ def addNuclideBases():
             abun = float(lineData[6])
             halflife = lineData[7]
             if halflife == "inf":
-                halflife = numpy.inf
+                halflife = np.inf
             else:
                 halflife = float(halflife)
             nuSF = float(lineData[8])

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -715,7 +715,7 @@ def getBlockBandwidth(m, nintj, nblok):
 
     This function computes JL and JU for these purposes. It also converts
     JL and JU to zero based indices rather than 1 based ones, as is almost
-    always wanted when dealing with python/np matrices.
+    always wanted when dealing with python/numpy matrices.
 
     The term *bandwidth* refers to a kind of sparse matrix representation.
     Some rows only have columns JL to JH in them rather than 0 to JMAX.

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -77,7 +77,7 @@ import struct
 from copy import deepcopy
 from typing import List
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.nuclearDataIO import nuclearFileMetadata
@@ -243,7 +243,7 @@ class IORecord:
         # this little trick will make this work for both reading and writing, yay!
         if contents is None or len(contents) == 0:
             contents = [None for _ in range(length)]
-        return numpy.array([action(contents[ii]) for ii in range(length)])
+        return np.array([action(contents[ii]) for ii in range(length)])
 
     def rwMatrix(self, contents, *shape):
         """A method for reading and writing a matrix of floating point values.
@@ -289,20 +289,20 @@ class IORecord:
         Notes
         -----
         This can be important for performance when reading large matrices (e.g. scatter
-        matrices). It may be worth investigating ``numpy.frombuffer`` on read and
+        matrices). It may be worth investigating ``np.frombuffer`` on read and
         something similar on write.
 
         With shape, the first shape argument should be the outermost loop because
         these are stored in column major order (the FORTRAN way).
 
-        Note that numpy.ndarrays can be built with ``order="F"`` to have column-major ordering.
+        Note that np.ndarrays can be built with ``order="F"`` to have column-major ordering.
 
         So if you have ``((MR(I,J),I=1,NCINTI),J=1,NCINTJ)`` you would pass in
         the shape as (NCINTJ, NCINTI).
         """
         fortranShape = list(reversed(shape))
         if contents is None or contents.size == 0:
-            contents = numpy.empty(fortranShape)
+            contents = np.empty(fortranShape)
         for index in itertools.product(*[range(ii) for ii in shape]):
             fortranIndex = tuple(reversed(index))
             contents[fortranIndex] = func(contents[fortranIndex])
@@ -715,7 +715,7 @@ def getBlockBandwidth(m, nintj, nblok):
 
     This function computes JL and JU for these purposes. It also converts
     JL and JU to zero based indices rather than 1 based ones, as is almost
-    always wanted when dealing with python/numpy matrices.
+    always wanted when dealing with python/np matrices.
 
     The term *bandwidth* refers to a kind of sparse matrix representation.
     Some rows only have columns JL to JH in them rather than 0 to JMAX.

--- a/armi/nuclearDataIO/cccc/compxs.py
+++ b/armi/nuclearDataIO/cccc/compxs.py
@@ -74,7 +74,7 @@ additive terms, respectively.
 """
 from scipy.sparse import csc_matrix
 from traceback import format_exc
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.nuclearDataIO import cccc
@@ -451,9 +451,9 @@ class _CompxsScatterMatrix:
         self.indptr.append(len(dataj) + self.indptr[-1])
 
     def makeSparse(self, sparseFunc=csc_matrix):
-        self.data = numpy.array(self.data, dtype="d")
-        self.indices = numpy.array(self.indices, dtype="d")
-        self.indptr = numpy.array(self.indptr, dtype="d")
+        self.data = np.array(self.data, dtype="d")
+        self.indices = np.array(self.indices, dtype="d")
+        self.indptr = np.array(self.indptr, dtype="d")
         return sparseFunc((self.data, self.indices, self.indptr), shape=self.shape)
 
 
@@ -570,14 +570,14 @@ class CompxsRegion:
         :py:meth:`makeScatteringMatrices`
         """
         for xs in self._primaryXS:
-            self.macros[xs] = numpy.zeros(numGroups)
+            self.macros[xs] = np.zeros(numGroups)
 
         self.macros.totalScatter = _CompxsScatterMatrix((numGroups, numGroups))
 
         if self.metadata["chiFlag"]:
-            self.macros.fission = numpy.zeros(numGroups)
-            self.macros.nuSigF = numpy.zeros(numGroups)
-            self.macros.chi = numpy.zeros((numGroups, self.metadata["chiFlag"]))
+            self.macros.fission = np.zeros(numGroups)
+            self.macros.nuSigF = np.zeros(numGroups)
+            self.macros.chi = np.zeros((numGroups, self.metadata["chiFlag"]))
 
         if self._getFileMetadata()["maxScatteringOrder"]:
             for scatterOrder in range(
@@ -589,7 +589,7 @@ class CompxsRegion:
 
         for datum in REGIONXS_POWER_CONVERT_DIRECTIONAL_DIFF:
             self.metadata[datum] = (
-                numpy.zeros(numGroups) if "Additive" in datum else numpy.ones(numGroups)
+                np.zeros(numGroups) if "Additive" in datum else np.ones(numGroups)
             ).tolist()
 
     def makeScatteringMatrices(self):

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -69,9 +69,7 @@ class DelayedNeutronData:
     def __init__(self, numEnergyGroups, numPrecursorGroups):
         self.precursorDecayConstants = np.zeros(numPrecursorGroups)
         self.delayEmissionSpectrum = np.zeros((numPrecursorGroups, numEnergyGroups))
-        self.delayNeutronsPerFission = np.zeros(
-            (numPrecursorGroups, numEnergyGroups)
-        )
+        self.delayNeutronsPerFission = np.zeros((numPrecursorGroups, numEnergyGroups))
 
 
 def compare(lib1, lib2):

--- a/armi/nuclearDataIO/cccc/dlayxs.py
+++ b/armi/nuclearDataIO/cccc/dlayxs.py
@@ -23,7 +23,7 @@ This module implements reading and writing of the DLAYXS, consistent with [CCCC-
 """
 import collections
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.nucDirectory import nuclideBases
@@ -67,9 +67,9 @@ class DelayedNeutronData:
     """
 
     def __init__(self, numEnergyGroups, numPrecursorGroups):
-        self.precursorDecayConstants = numpy.zeros(numPrecursorGroups)
-        self.delayEmissionSpectrum = numpy.zeros((numPrecursorGroups, numEnergyGroups))
-        self.delayNeutronsPerFission = numpy.zeros(
+        self.precursorDecayConstants = np.zeros(numPrecursorGroups)
+        self.delayEmissionSpectrum = np.zeros((numPrecursorGroups, numEnergyGroups))
+        self.delayNeutronsPerFission = np.zeros(
             (numPrecursorGroups, numEnergyGroups)
         )
 
@@ -266,7 +266,7 @@ class DlayxsIO(cccc.Stream):
 
         # if the data objects are empty, then we are reading, otherwise the data already exists...
         # If we are reading, then we have to map all the metadata into the DelayedNeutronData structures
-        if not numpy.any(list(self.dlayxs.values())[0].delayEmissionSpectrum):
+        if not np.any(list(self.dlayxs.values())[0].delayEmissionSpectrum):
             for nuc, dlayData in self.dlayxs.items():
                 for ii, family in enumerate(self.dlayxs.nuclideFamily[nuc]):
                     dlayData.precursorDecayConstants[ii] = self.metadata[

--- a/armi/nuclearDataIO/cccc/fixsrc.py
+++ b/armi/nuclearDataIO/cccc/fixsrc.py
@@ -20,7 +20,7 @@ This enables photon transport problems. [CCCC-IV]_
 """
 import collections
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.nuclearDataIO import cccc
@@ -28,7 +28,7 @@ from armi.nuclearDataIO import cccc
 
 def readBinary(fileName):
     """Read a binary FIXSRC file."""
-    with FIXSRC(fileName, "rb", numpy.zeros((0, 0, 0, 0))) as fs:
+    with FIXSRC(fileName, "rb", np.zeros((0, 0, 0, 0))) as fs:
         fs.readWrite()
     return fs.fixSrc
 
@@ -60,7 +60,7 @@ class FIXSRC(cccc.Stream):
             If 'wb', this class writes a FIXSRC binary file.
             If 'rb', this class reads a preexisting FIXSRC binary file.
 
-        fixSrc : numpy array
+        fixSrc : np array
             Core-wide multigroup gamma fixed-source data.
         """
         cccc.Stream.__init__(self, fileName, fileMode)

--- a/armi/nuclearDataIO/cccc/fixsrc.py
+++ b/armi/nuclearDataIO/cccc/fixsrc.py
@@ -60,7 +60,7 @@ class FIXSRC(cccc.Stream):
             If 'wb', this class writes a FIXSRC binary file.
             If 'rb', this class reads a preexisting FIXSRC binary file.
 
-        fixSrc : np array
+        fixSrc : numpy array
             Core-wide multigroup gamma fixed-source data.
         """
         cccc.Stream.__init__(self, fileName, fileMode)

--- a/armi/nuclearDataIO/cccc/geodst.py
+++ b/armi/nuclearDataIO/cccc/geodst.py
@@ -29,7 +29,7 @@ Examples
 
 """
 
-import numpy
+import numpy as np
 
 from armi.nuclearDataIO import cccc
 
@@ -291,13 +291,13 @@ class GeodstStream(cccc.StreamWithDataContainer):
         if self._data.coarseMeshRegions is None:
             # initialize all-zeros here before reading now that we
             # have the matrix dimension metadata available.
-            self._data.coarseMeshRegions = numpy.zeros(
+            self._data.coarseMeshRegions = np.zeros(
                 (
                     self._metadata["NCINTI"],
                     self._metadata["NCINTJ"],
                     self._metadata["NCINTK"],
                 ),
-                dtype=numpy.int16,
+                dtype=np.int16,
             )
         for ki in range(self._metadata["NCINTK"]):
             with self.createRecord() as record:
@@ -312,13 +312,13 @@ class GeodstStream(cccc.StreamWithDataContainer):
         if self._data.fineMeshRegions is None:
             # initialize all-zeros here before reading now that we
             # have the matrix dimension metadata available.
-            self._data.fineMeshRegions = numpy.zeros(
+            self._data.fineMeshRegions = np.zeros(
                 (
                     self._metadata["NINTI"],
                     self._metadata["NINTJ"],
                     self._metadata["NINTK"],
                 ),
-                dtype=numpy.int16,
+                dtype=np.int16,
             )
         for ki in range(self._metadata["NINTK"]):
             with self.createRecord() as record:

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -40,7 +40,7 @@ Examples
 import traceback
 import itertools
 
-import numpy
+import numpy as np
 from scipy import sparse
 
 from armi import runLog
@@ -691,7 +691,7 @@ class _IsotxsNuclideIO:
         if scatter is None:
             # we're reading.
             scatter = sparse.csr_matrix(
-                (numpy.array(dataVals), indices, indptr), shape=(ng, ng)
+                (np.array(dataVals), indices, indptr), shape=(ng, ng)
             )
             scatter.eliminate_zeros()
             self._setScatterMatrix(blockNumIndex, scatter)
@@ -714,7 +714,7 @@ class _IsotxsNuclideIO:
             A index of the scatter matrix.
         """
         try:
-            return numpy.where(self._metadata["scatFlag"] == scatterType)[0][0]
+            return np.where(self._metadata["scatFlag"] == scatterType)[0][0]
         except IndexError:
             return None
 

--- a/armi/nuclearDataIO/cccc/pmatrx.py
+++ b/armi/nuclearDataIO/cccc/pmatrx.py
@@ -72,7 +72,7 @@ def compareNuclideXS(nuc1, nuc2):
     ]:
         val1 = getattr(nuc1, attrName)
         val2 = getattr(nuc2, attrName)
-        if not properties.npHackForEqual(val1, val2):
+        if not properties.numpyHackForEqual(val1, val2):
             runLog.important(
                 "{} and {} have different `{}` attributes:\n{}\n{}".format(
                     nuc1, nuc2, attrName, val1, val2

--- a/armi/nuclearDataIO/cccc/pmatrx.py
+++ b/armi/nuclearDataIO/cccc/pmatrx.py
@@ -72,7 +72,7 @@ def compareNuclideXS(nuc1, nuc2):
     ]:
         val1 = getattr(nuc1, attrName)
         val2 = getattr(nuc2, attrName)
-        if not properties.numpyHackForEqual(val1, val2):
+        if not properties.npHackForEqual(val1, val2):
             runLog.important(
                 "{} and {} have different `{}` attributes:\n{}\n{}".format(
                     nuc1, nuc2, attrName, val1, val2

--- a/armi/nuclearDataIO/cccc/pwdint.py
+++ b/armi/nuclearDataIO/cccc/pwdint.py
@@ -25,7 +25,7 @@ Examples
 
 """
 
-import numpy
+import numpy as np
 
 from armi.nuclearDataIO import cccc
 
@@ -54,7 +54,7 @@ class PwdintData(cccc.DataContainer):
 
     def __init__(self):
         cccc.DataContainer.__init__(self)
-        self.powerDensity = numpy.array([])
+        self.powerDensity = np.array([])
 
 
 class PwdintStream(cccc.StreamWithDataContainer):
@@ -111,9 +111,9 @@ class PwdintStream(cccc.StreamWithDataContainer):
         if self._data.powerDensity.size == 0:
             # initialize all-zeros here before reading now that we
             # have the matrix dimension metadata available.
-            self._data.powerDensity = numpy.zeros(
+            self._data.powerDensity = np.zeros(
                 (imax, jmax, kmax),
-                dtype=numpy.float32,
+                dtype=np.float32,
             )
         for ki in range(kmax):
             for bi in range(nblck):

--- a/armi/nuclearDataIO/cccc/rtflux.py
+++ b/armi/nuclearDataIO/cccc/rtflux.py
@@ -34,7 +34,7 @@ NHFLUX
 RZFLUX
     Reads/writes total fluxes from zones
 """
-import numpy
+import numpy as np
 
 from armi.nuclearDataIO import cccc
 
@@ -67,7 +67,7 @@ class RtfluxData(cccc.DataContainer):
     def __init__(self):
         cccc.DataContainer.__init__(self)
 
-        self.groupFluxes: numpy.ndarray = numpy.array([])
+        self.groupFluxes: np.ndarray = np.array([])
         """Maps i,j,k,g indices to total real or adjoint flux in n/cm^2-s"""
 
 
@@ -138,7 +138,7 @@ class RtfluxStream(cccc.StreamWithDataContainer):
         nblck = self._metadata["NBLOK"]
 
         if self._data.groupFluxes.size == 0:
-            self._data.groupFluxes = numpy.zeros((imax, jmax, kmax, ng))
+            self._data.groupFluxes = np.zeros((imax, jmax, kmax, ng))
 
         for gi in range(ng):
             gEff = self.getEnergyGroupIndex(gi)

--- a/armi/nuclearDataIO/cccc/rzflux.py
+++ b/armi/nuclearDataIO/cccc/rzflux.py
@@ -28,7 +28,7 @@ Examples
 """
 from enum import Enum
 
-import numpy
+import numpy as np
 
 from armi.nuclearDataIO import cccc
 
@@ -144,9 +144,9 @@ class RzfluxStream(cccc.StreamWithDataContainer):
         if self._data.groupFluxes is None:
             # initialize all-zeros here before reading now that we
             # have the matrix dimension metadata available.
-            self._data.groupFluxes = numpy.zeros(
+            self._data.groupFluxes = np.zeros(
                 (ng, nz),
-                dtype=numpy.float32,
+                dtype=np.float32,
             )
         for bi in range(nb):
             jLow, jUp = cccc.getBlockBandwidth(bi + 1, nz, nb)

--- a/armi/nuclearDataIO/cccc/tests/test_compxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_compxs.py
@@ -16,7 +16,7 @@
 import os
 import unittest
 
-import numpy
+import numpy as np
 from scipy.sparse import csc_matrix
 
 from armi import nuclearDataIO
@@ -149,7 +149,7 @@ class TestCompxs(unittest.TestCase):
         }
         for xsName, expectedXS in expectedMacros.items():
             actualXS = self.fissileRegion.macros[xsName]
-            self.assertTrue(numpy.allclose(actualXS, expectedXS))
+            self.assertTrue(np.allclose(actualXS, expectedXS))
 
     def test_totalScatterMatrix(self):
         """
@@ -164,7 +164,7 @@ class TestCompxs(unittest.TestCase):
         --------
         scipy.sparse.csc_matrix
         """
-        expectedSparseData = numpy.array(
+        expectedSparseData = np.array(
             [
                 1.15905297e-01,
                 1.50461698e-01,
@@ -290,7 +290,7 @@ class TestCompxs(unittest.TestCase):
             actualTotalScatter.shape,
         ).toarray()
 
-        self.assertTrue(numpy.allclose(actualTotalScatter, expectedTotalScatter))
+        self.assertTrue(np.allclose(actualTotalScatter, expectedTotalScatter))
 
     def test_binaryRW(self):
         """Test to make sure the binary read/writer reads/writes the exact same library."""

--- a/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
@@ -17,7 +17,7 @@ import copy
 import filecmp
 import unittest
 
-import numpy
+import numpy as np
 
 from armi.nucDirectory import nuclideBases
 from armi.nuclearDataIO.cccc import dlayxs
@@ -40,13 +40,13 @@ class DlayxsTests(unittest.TestCase):
         """
         delay = self.dlayxs3
         self.assertTrue(
-            numpy.allclose(
+            np.allclose(
                 delay[nuclideBases.byName["PU239"]].precursorDecayConstants,
                 [0.013271, 0.030881, 0.11337, 0.29249999, 0.85749, 2.72970009],
             )
         )
         self.assertTrue(
-            numpy.allclose(
+            np.allclose(
                 delay[nuclideBases.byName["U235"]].precursorDecayConstants,
                 [0.013336, 0.032739, 0.12078, 0.30278, 0.84948999, 2.85299993],
             )
@@ -56,7 +56,7 @@ class DlayxsTests(unittest.TestCase):
         """Test that all emission spectrum delayEmissionSpectrum is normalized."""
         delay = self.dlayxs3
         self.assertTrue(
-            numpy.allclose(
+            np.allclose(
                 delay[nuclideBases.byName["PU239"]].delayEmissionSpectrum[0, :],
                 [
                     0.00000000e00,
@@ -96,7 +96,7 @@ class DlayxsTests(unittest.TestCase):
             )
         )
         self.assertTrue(
-            numpy.allclose(
+            np.allclose(
                 delay[nuclideBases.byName["U235"]].delayEmissionSpectrum[0, :],
                 [
                     0.00000000e00,
@@ -146,7 +146,7 @@ class DlayxsTests(unittest.TestCase):
         # was used to make sure the data wasn't accidentally transposed, hence there are two nuclides with two vectors
         # being tested.
         self.assertTrue(
-            numpy.allclose(
+            np.allclose(
                 delay[nuclideBases.byName["PU239"]].delayNeutronsPerFission[0, :],
                 [
                     0.00015611,
@@ -186,7 +186,7 @@ class DlayxsTests(unittest.TestCase):
             )
         )
         self.assertTrue(
-            numpy.allclose(
+            np.allclose(
                 delay[nuclideBases.byName["PU239"]].delayNeutronsPerFission[1, :],
                 [
                     0.00101669,
@@ -226,7 +226,7 @@ class DlayxsTests(unittest.TestCase):
             )
         )
         self.assertTrue(
-            numpy.allclose(
+            np.allclose(
                 delay[nuclideBases.byName["U235"]].delayNeutronsPerFission[0, :],
                 [
                     0.000315,
@@ -266,7 +266,7 @@ class DlayxsTests(unittest.TestCase):
             )
         )
         self.assertTrue(
-            numpy.allclose(
+            np.allclose(
                 delay[nuclideBases.byName["U235"]].delayNeutronsPerFission[1, :],
                 [
                     0.0016254,
@@ -923,7 +923,7 @@ class DlayxsTests(unittest.TestCase):
             dlayData = self.dlayxs3[
                 nuclideBases.byName[nucName.strip()]
             ].precursorDecayConstants
-            self.assertTrue(numpy.allclose(dlayData, endfProvidedData, 1e-3))
+            self.assertTrue(np.allclose(dlayData, endfProvidedData, 1e-3))
         except AssertionError:
             # this is reraised because generating the message might take some time to format all the
             # data from the arrays
@@ -1061,14 +1061,14 @@ class DlayxsTests(unittest.TestCase):
             dlayData = self.dlayxs3[
                 nuclideBases.byName[nucName.strip()]
             ].delayNeutronsPerFission
-            numpyData = numpy.array(endfProvidedData)
-            self.assertTrue(numpy.allclose(dlayData, numpyData, 1e-3))
+            npData = np.array(endfProvidedData)
+            self.assertTrue(np.allclose(dlayData, npData, 1e-3))
         except AssertionError:
             # this is reraised because generating the message might take some time to format all the
             # data from the arrays
             raise AssertionError(
                 "{} was different,\nexpected:{}\nactual:{}".format(
-                    nucName, numpyData, dlayData
+                    nucName, npData, dlayData
                 )
             )
         except KeyError:
@@ -1117,12 +1117,12 @@ class DlayxsTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             _avg = self.dlayxs3.generateAverageDelayedNeutronConstants()
 
-        fracs = dict(zip(self.dlayxs3.keys(), numpy.zeros(len(self.dlayxs3))))
+        fracs = dict(zip(self.dlayxs3.keys(), np.zeros(len(self.dlayxs3))))
         u235 = nuclideBases.byName["U235"]
         fracs[u235] = 1.0
         self.dlayxs3.nuclideContributionFractions = fracs
         avg = self.dlayxs3.generateAverageDelayedNeutronConstants()
         dlayU235 = self.dlayxs3[u235]
         self.assertTrue(
-            numpy.allclose(avg.delayEmissionSpectrum, dlayU235.delayEmissionSpectrum)
+            np.allclose(avg.delayEmissionSpectrum, dlayU235.delayEmissionSpectrum)
         )

--- a/armi/nuclearDataIO/nuclearFileMetadata.py
+++ b/armi/nuclearDataIO/nuclearFileMetadata.py
@@ -110,7 +110,7 @@ class _Metadata:
             selfVal = self[key]
             otherVal = other[key]
             mergedVal = None
-            if not properties.numpyHackForEqual(selfVal, otherVal):
+            if not properties.npHackForEqual(selfVal, otherVal):
                 raise exceptionClass(
                     "{libType} {key} metadata differs between {lib1} and {lib2}; Cannot Merge\n"
                     "{key} has values of {val1} and {val2}".format(

--- a/armi/nuclearDataIO/nuclearFileMetadata.py
+++ b/armi/nuclearDataIO/nuclearFileMetadata.py
@@ -110,7 +110,7 @@ class _Metadata:
             selfVal = self[key]
             otherVal = other[key]
             mergedVal = None
-            if not properties.npHackForEqual(selfVal, otherVal):
+            if not properties.numpyHackForEqual(selfVal, otherVal):
                 raise exceptionClass(
                     "{libType} {key} metadata differs between {lib1} and {lib2}; Cannot Merge\n"
                     "{key} has values of {val1} and {val2}".format(

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -18,7 +18,7 @@ import os
 import traceback
 import unittest
 
-import numpy
+import numpy as np
 from six.moves import cPickle
 
 from armi.nucDirectory import nuclideBases
@@ -355,8 +355,8 @@ class TestXSlibraryMerging(TempFileMixin):
 
     def test_cannotMergeXSLibxWithDifferentGroupStructure(self):
         dummyXsLib = xsLibraries.IsotxsLibrary()
-        dummyXsLib.neutronEnergyUpperBounds = numpy.array([1, 2, 3])
-        dummyXsLib.gammaEnergyUpperBounds = numpy.array([1, 2, 3])
+        dummyXsLib.neutronEnergyUpperBounds = np.array([1, 2, 3])
+        dummyXsLib.gammaEnergyUpperBounds = np.array([1, 2, 3])
         with self.assertRaises(properties.ImmutablePropertyError):
             dummyXsLib.merge(self.libCombined)
 
@@ -438,7 +438,7 @@ class Pmatrx_merge_Tests(TestXSlibraryMerging):
 
     def test_cannotMergeXSLibsWithDifferentGammaGroupStructures(self):
         dummyXsLib = xsLibraries.IsotxsLibrary()
-        dummyXsLib.gammaEnergyUpperBounds = numpy.array([1, 2, 3])
+        dummyXsLib.gammaEnergyUpperBounds = np.array([1, 2, 3])
         with self.assertRaises(properties.ImmutablePropertyError):
             dummyXsLib.merge(self.libCombined)
 

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -99,7 +99,7 @@ class XSCollection:
 
     _zeroes = {}
     """
-    A dict of np arrays set to the size of XSLibrary.numGroups.
+    A dict of numpy arrays set to the size of XSLibrary.numGroups.
 
     This is used to initialize cross sections which may not exist for the specific nuclide.
     Consequently, there should never be a situation where a cross section does not exist.
@@ -161,7 +161,7 @@ class XSCollection:
         Notes
         -----
         These containers were originally
-        dicts, but upgraded to objects with np values as specialization
+        dicts, but upgraded to objects with numpy values as specialization
         was needed. This access method could/should be phased out.
         """
         return self.__dict__[key]
@@ -230,7 +230,7 @@ class XSCollection:
         """Zero out all the cross sections; this is useful for creating dummy cross sections."""
         for xsAttr in ALL_XS:
             value = getattr(self, xsAttr)
-            # it should either be a list, a np array, or a sparse matrix
+            # it should either be a list, a numpy array, or a sparse matrix
             if isinstance(value, list):
                 value = [0.0] * len(value)
             elif isinstance(value, np.ndarray):
@@ -625,7 +625,7 @@ def computeNeutronEnergyDepositionConstants(numberDensities, lib, microSuffix):
 
     Returns
     -------
-    energyDepositionConsts : np array
+    energyDepositionConsts : numpy array
         Neutron energy deposition group constants. (J/cm)
 
     Notes
@@ -664,7 +664,7 @@ def computeGammaEnergyDepositionConstants(numberDensities, lib, microSuffix):
 
     Returns
     -------
-    energyDepositionConsts : np array
+    energyDepositionConsts : numpy array
         gamma energy deposition group constants. (J/cm)
 
     Notes
@@ -855,7 +855,7 @@ def computeMacroscopicGroupConstants(
 
     Returns
     -------
-    macroGroupConstant : np array
+    macroGroupConstant : numpy array
         Macroscopic group constants for the requested reaction.
     """
     skippedNuclides = []

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -38,7 +38,7 @@ Examples
     blocksWithMacros = mc.createMacrosOnBlocklist(microLib, blocks)
 
 """
-import numpy
+import numpy as np
 from scipy import sparse
 
 from armi import runLog
@@ -99,7 +99,7 @@ class XSCollection:
 
     _zeroes = {}
     """
-    A dict of numpy arrays set to the size of XSLibrary.numGroups.
+    A dict of np arrays set to the size of XSLibrary.numGroups.
 
     This is used to initialize cross sections which may not exist for the specific nuclide.
     Consequently, there should never be a situation where a cross section does not exist.
@@ -116,7 +116,7 @@ class XSCollection:
     def getDefaultXs(cls, numGroups):
         default = cls._zeroes.get(numGroups, None)
         if default is None:
-            default = numpy.zeros(numGroups)
+            default = np.zeros(numGroups)
             cls._zeroes[numGroups] = default
         return default
 
@@ -161,7 +161,7 @@ class XSCollection:
         Notes
         -----
         These containers were originally
-        dicts, but upgraded to objects with numpy values as specialization
+        dicts, but upgraded to objects with np values as specialization
         was needed. This access method could/should be phased out.
         """
         return self.__dict__[key]
@@ -230,11 +230,11 @@ class XSCollection:
         """Zero out all the cross sections; this is useful for creating dummy cross sections."""
         for xsAttr in ALL_XS:
             value = getattr(self, xsAttr)
-            # it should either be a list, a numpy array, or a sparse matrix
+            # it should either be a list, a np array, or a sparse matrix
             if isinstance(value, list):
                 value = [0.0] * len(value)
-            elif isinstance(value, numpy.ndarray):
-                value = numpy.zeros(value.shape)
+            elif isinstance(value, np.ndarray):
+                value = np.zeros(value.shape)
             elif value is None:  # assume it is scipy.sparse
                 pass
             elif value.nnz >= 0:
@@ -268,7 +268,7 @@ class XSCollection:
         oneGroupXS : float
             The one group cross section in the same units as the input cross section.
         """
-        mult = numpy.array(crossSection) * numpy.array(weights)
+        mult = np.array(crossSection) * np.array(weights)
         return sum(mult) / sum(weights)
 
     def compare(self, other, flux, relativeTolerance=0, verbose=False):
@@ -289,7 +289,7 @@ class XSCollection:
                         )
 
             elif sparse.issparse(myXsData) and sparse.issparse(theirXsData):
-                if not numpy.allclose(
+                if not np.allclose(
                     myXsData.todense(),
                     theirXsData.todense(),
                     rtol=relativeTolerance,
@@ -448,7 +448,7 @@ class MacroscopicCrossSectionCreator:
     def _initializeMacros(self):
         m = self.macros
         for xsName in BASIC_XS + DERIVED_XS:
-            setattr(m, xsName, numpy.zeros(self.ng))
+            setattr(m, xsName, np.zeros(self.ng))
 
         for matrixName in BASIC_SCAT_MATRIX:
             # lil_matrices are good for indexing but bad for certain math operations.
@@ -574,7 +574,7 @@ def computeBlockAverageChi(b, isotxsLib):
     fission source weighting).
     """
     numGroups = isotxsLib.numGroups
-    numerator = numpy.zeros(numGroups)
+    numerator = np.zeros(numGroups)
     denominator = 0.0
     numberDensities = b.getNumberDensities()
     for nucObj in isotxsLib.getNuclides(b.getMicroSuffix()):
@@ -586,7 +586,7 @@ def computeBlockAverageChi(b, isotxsLib):
     if denominator != 0.0:
         return numerator / denominator
     else:
-        return numpy.zeros(numGroups)
+        return np.zeros(numGroups)
 
 
 def _getLibTypeSuffix(libType):
@@ -625,7 +625,7 @@ def computeNeutronEnergyDepositionConstants(numberDensities, lib, microSuffix):
 
     Returns
     -------
-    energyDepositionConsts : numpy array
+    energyDepositionConsts : np array
         Neutron energy deposition group constants. (J/cm)
 
     Notes
@@ -664,7 +664,7 @@ def computeGammaEnergyDepositionConstants(numberDensities, lib, microSuffix):
 
     Returns
     -------
-    energyDepositionConsts : numpy array
+    energyDepositionConsts : np array
         gamma energy deposition group constants. (J/cm)
 
     Notes
@@ -707,7 +707,7 @@ def computeFissionEnergyGenerationConstants(numberDensities, lib, microSuffix):
 
     Returns
     -------
-    fissionEnergyFactor: numpy.array
+    fissionEnergyFactor: np.array
         Fission energy generation group constants (in Joules/cm)
     """
     fissionEnergyFactor = computeMacroscopicGroupConstants(
@@ -751,14 +751,14 @@ def computeCaptureEnergyGenerationConstants(numberDensities, lib, microSuffix):
 
     Returns
     -------
-    captureEnergyFactor: numpy.array
+    captureEnergyFactor: np.array
         Capture energy generation group constants (in Joules/cm)
     """
     captureEnergyFactor = None
     for xs in CAPTURE_XS:
         if captureEnergyFactor is None:
-            captureEnergyFactor = numpy.zeros(
-                numpy.shape(
+            captureEnergyFactor = np.zeros(
+                np.shape(
                     computeMacroscopicGroupConstants(
                         xs, numberDensities, lib, microSuffix, libType="micros"
                     )
@@ -855,7 +855,7 @@ def computeMacroscopicGroupConstants(
 
     Returns
     -------
-    macroGroupConstant : numpy array
+    macroGroupConstant : np array
         Macroscopic group constants for the requested reaction.
     """
     skippedNuclides = []
@@ -890,16 +890,16 @@ def computeMacroscopicGroupConstants(
         multiplierVal = _getXsMultiplier(multLibNuclide, multConstant, libType)
 
         if macroGroupConstants is None:
-            macroGroupConstants = numpy.zeros(microGroupConstants.shape)
+            macroGroupConstants = np.zeros(microGroupConstants.shape)
 
         if (
             microGroupConstants.shape != macroGroupConstants.shape
             and not microGroupConstants.any()
         ):
-            microGroupConstants = numpy.zeros(macroGroupConstants.shape)
+            microGroupConstants = np.zeros(macroGroupConstants.shape)
 
         macroGroupConstants += (
-            numpy.asarray(numberDensity) * microGroupConstants * multiplierVal
+            np.asarray(numberDensity) * microGroupConstants * multiplierVal
         )
 
     if skippedNuclides:
@@ -930,7 +930,7 @@ def _getXsMultiplier(libNuclide, multiplier, libType):
     else:
         multiplierVal = 1.0
 
-    return numpy.asarray(multiplierVal)
+    return np.asarray(multiplierVal)
 
 
 def _getMicroGroupConstants(libNuclide, constantName, nuclideName, libType):
@@ -939,7 +939,7 @@ def _getMicroGroupConstants(libNuclide, constantName, nuclideName, libType):
     else:
         microCollection = libNuclide
 
-    microGroupConstants = numpy.asarray(getattr(microCollection, constantName))
+    microGroupConstants = np.asarray(getattr(microCollection, constantName))
 
     if not microGroupConstants.any():
         runLog.debug(

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -29,7 +29,7 @@ import os
 import re
 import warnings
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.physics.fuelCycle import assemblyRotationAlgorithms as rotAlgos
@@ -393,7 +393,7 @@ class FuelHandler:
             close, the assembly with the lesser assemNum wins. This should result in a
             more stable comparison than on floating-point comparisons alone.
             """
-            if numpy.isclose(candidate[0], current[0], rtol=1e-8, atol=1e-8):
+            if np.isclose(candidate[0], current[0], rtol=1e-8, atol=1e-8):
                 return candidate[1].p.assemNum < current[1].p.assemNum
             else:
                 return candidate[0] < current[0]
@@ -1427,7 +1427,7 @@ class FuelHandler:
             currentCoords = a.spatialLocator.getGlobalCoordinates()
             oldCoords = self.oldLocations.get(a.getName(), None)
             if oldCoords is None:
-                oldCoords = numpy.array((-50, -50, 0))
+                oldCoords = np.array((-50, -50, 0))
             elif any(currentCoords != oldCoords):
                 arrows.append((oldCoords, currentCoords))
 

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -251,9 +251,7 @@ def buildRingSchedule(
     # don't let it be smaller than 2 because linspace(1,5,1)= [1], linspace(1,5,2)= [1,5]
     numSteps = max(numSteps, 2)
 
-    baseRings = [
-        int(ring) for ring in np.linspace(dischargeRing, chargeRing, numSteps)
-    ]
+    baseRings = [int(ring) for ring in np.linspace(dischargeRing, chargeRing, numSteps)]
     # eliminate duplicates.
     newBaseRings = []
     for br in baseRings:

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -21,7 +21,7 @@ We are keeping these in ARMI even if they appear unused internally.
 """
 import math
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.reactor.flags import Flags
@@ -252,7 +252,7 @@ def buildRingSchedule(
     numSteps = max(numSteps, 2)
 
     baseRings = [
-        int(ring) for ring in numpy.linspace(dischargeRing, chargeRing, numSteps)
+        int(ring) for ring in np.linspace(dischargeRing, chargeRing, numSteps)
     ]
     # eliminate duplicates.
     newBaseRings = []
@@ -331,7 +331,7 @@ def buildConvergentRingSchedule(chargeRing, dischargeRing=1, coarseFactor=0.0):
     # don't let it be smaller than 2 because linspace(1,5,1)= [1], linspace(1,5,2)= [1,5]
     numSteps = max(numSteps, 2)
     convergent = [
-        int(ring) for ring in numpy.linspace(dischargeRing, chargeRing, numSteps)
+        int(ring) for ring in np.linspace(dischargeRing, chargeRing, numSteps)
     ]
 
     # step 2. eliminate duplicates
@@ -392,7 +392,7 @@ def _buildEqRingScheduleHelper(ringSchedule, numRings):
         toRing = ringSchedule[i + 1]
         numRings = abs(toRing - fromRing) + 1
 
-        ringList.extend([int(j) for j in numpy.linspace(fromRing, toRing, numRings)])
+        ringList.extend([int(j) for j in np.linspace(fromRing, toRing, numRings)])
 
     # eliminate doubles (but allow a ring to show up multiple times)
     newList = []
@@ -429,8 +429,8 @@ def _squaredDistanceFromOrigin(a):
     -------
     float: Distance from reactor center
     """
-    origin = numpy.array([0.0, 0.0, 0.0])
-    p = numpy.array(a.spatialLocator.getLocalCoordinates())
+    origin = np.array([0.0, 0.0, 0.0])
+    p = np.array(a.spatialLocator.getLocalCoordinates())
     return ((p - origin) ** 2).sum()
 
 

--- a/armi/physics/neutronics/__init__.py
+++ b/armi/physics/neutronics/__init__.py
@@ -33,7 +33,7 @@ independent interfaces:
 # ruff: noqa: F401, E402
 from enum import IntEnum
 
-import numpy
+import numpy as np
 import tabulate
 
 from armi import plugins, runLog
@@ -246,8 +246,8 @@ def applyEffectiveDelayedNeutronFractionToCore(core, cs):
             )
 
         core.p.beta = sum(beta)
-        core.p.betaComponents = numpy.array(beta)
-        core.p.betaDecayConstants = numpy.array(decayConstants)
+        core.p.betaComponents = np.array(beta)
+        core.p.betaDecayConstants = np.array(decayConstants)
 
         reportTableData.append(("Total Delayed Neutron Fraction", core.p.beta))
         for i, betaComponent in enumerate(core.p.betaComponents):

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -494,9 +494,7 @@ def getBlockNuclideTemperatureAvgTerms(block, allNucNames):
     vol = block.getVolume()
     components, volFracs = zip(*block.getVolumeFractions())
     # D = CxN matrix of number densities
-    ndens = np.array(
-        [getNumberDensitiesWithTrace(c, allNucNames) for c in components]
-    )
+    ndens = np.array([getNumberDensitiesWithTrace(c, allNucNames) for c in components])
     temperatures = np.array(
         [c.temperatureInC for c in components]
     )  # C-length temperature array

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -56,7 +56,7 @@ import os
 import shutil
 import string
 
-import numpy
+import numpy as np
 
 from armi import context, interfaces, runLog
 from armi.physics.neutronics import LatticePhysicsFrequency
@@ -359,7 +359,7 @@ class AverageBlockCollection(BlockCollection):
         """
         nuclides = self.allNuclidesInProblem
         blocks = self.getCandidateBlocks()
-        weights = numpy.array([self.getWeight(b) for b in blocks])
+        weights = np.array([self.getWeight(b) for b in blocks])
         weights /= weights.sum()  # normalize by total weight
         ndens = weights.dot([b.getNuclideNumberDensities(nuclides) for b in blocks])
         return dict(zip(nuclides, ndens))
@@ -372,8 +372,8 @@ class AverageBlockCollection(BlockCollection):
 
     def _getNucTempHelper(self):
         """All candidate blocks are used in the average."""
-        nvt = numpy.zeros(len(self.allNuclidesInProblem))
-        nv = numpy.zeros(len(self.allNuclidesInProblem))
+        nvt = np.zeros(len(self.allNuclidesInProblem))
+        nv = np.zeros(len(self.allNuclidesInProblem))
         for block in self.getCandidateBlocks():
             wt = self.getWeight(block)
             nvtBlock, nvBlock = getBlockNuclideTemperatureAvgTerms(
@@ -394,7 +394,7 @@ class AverageBlockCollection(BlockCollection):
         """
         nuclides = self.allNuclidesInProblem
         blocks = self.getCandidateBlocks()
-        weights = numpy.array([self.getWeight(b) for b in blocks])
+        weights = np.array([self.getWeight(b) for b in blocks])
         weights /= weights.sum()  # normalize by total weight
         components = [sorted(b.getComponents())[compIndex] for b in blocks]
         ndens = weights.dot([c.getNuclideNumberDensities(nuclides) for c in components])
@@ -418,7 +418,7 @@ class AverageBlockCollection(BlockCollection):
             nucName, ndens data (atoms/bn-cm)
         """
         blocks = self.getCandidateBlocks()
-        weights = numpy.array([self.getWeight(b) / b.getHeight() for b in blocks])
+        weights = np.array([self.getWeight(b) / b.getHeight() for b in blocks])
         weights /= weights.sum()  # normalize by total weight
         components = [sorted(b.getComponents())[compIndex] for b in blocks]
         weightedAvgComponentMass = sum(
@@ -426,11 +426,11 @@ class AverageBlockCollection(BlockCollection):
         )
         if weightedAvgComponentMass == 0.0:
             # if there is no component mass (e.g., gap), do a regular average
-            return numpy.mean(numpy.array([c.temperatureInC for c in components]))
+            return np.mean(np.array([c.temperatureInC for c in components]))
         else:
             return (
                 weights.dot(
-                    numpy.array([c.temperatureInC * c.getMass() for c in components])
+                    np.array([c.temperatureInC * c.getMass() for c in components])
                 )
                 / weightedAvgComponentMass
             )
@@ -494,14 +494,14 @@ def getBlockNuclideTemperatureAvgTerms(block, allNucNames):
     vol = block.getVolume()
     components, volFracs = zip(*block.getVolumeFractions())
     # D = CxN matrix of number densities
-    ndens = numpy.array(
+    ndens = np.array(
         [getNumberDensitiesWithTrace(c, allNucNames) for c in components]
     )
-    temperatures = numpy.array(
+    temperatures = np.array(
         [c.temperatureInC for c in components]
     )  # C-length temperature array
     nvBlock = (
-        ndens.T * numpy.array(volFracs) * vol
+        ndens.T * np.array(volFracs) * vol
     )  # multiply each component's values by volume frac, now NxC
     nvt = sum((nvBlock * temperatures).T)  # N-length array summing over components.
     nv = sum(nvBlock.T)  # N-length array
@@ -619,12 +619,12 @@ class CylindricalComponentsAverageBlockCollection(BlockCollection):
     def _getAverageComponentNucs(self, components, bWeights):
         """Compute average nuclide densities by block weights and component area fractions."""
         allNucNames = self._getAllNucs(components)
-        densities = numpy.zeros(len(allNucNames))
+        densities = np.zeros(len(allNucNames))
         totalWeight = 0.0
         for c, bWeight in zip(components, bWeights):
             weight = bWeight * c.getArea()
             totalWeight += weight
-            densities += weight * numpy.array(c.getNuclideNumberDensities(allNucNames))
+            densities += weight * np.array(c.getNuclideNumberDensities(allNucNames))
         return allNucNames, densities / totalWeight
 
     def _orderComponentsInGroup(self, repBlock):
@@ -638,8 +638,8 @@ class CylindricalComponentsAverageBlockCollection(BlockCollection):
 
     def _getNucTempHelper(self):
         """All candidate blocks are used in the average."""
-        nvt = numpy.zeros(len(self.allNuclidesInProblem))
-        nv = numpy.zeros(len(self.allNuclidesInProblem))
+        nvt = np.zeros(len(self.allNuclidesInProblem))
+        nv = np.zeros(len(self.allNuclidesInProblem))
         for block in self.getCandidateBlocks():
             wt = self.getWeight(block)
             nvtBlock, nvBlock = getBlockNuclideTemperatureAvgTerms(
@@ -785,12 +785,12 @@ class SlabComponentsAverageBlockCollection(BlockCollection):
     def _getAverageComponentNucs(self, components, bWeights):
         """Compute average nuclide densities by block weights and component area fractions."""
         allNucNames = self._getAllNucs(components)
-        densities = numpy.zeros(len(allNucNames))
+        densities = np.zeros(len(allNucNames))
         totalWeight = 0.0
         for c, bWeight in zip(components, bWeights):
             weight = bWeight * c.getArea()
             totalWeight += weight
-            densities += weight * numpy.array(c.getNuclideNumberDensities(allNucNames))
+            densities += weight * np.array(c.getNuclideNumberDensities(allNucNames))
         return allNucNames, densities / totalWeight
 
     def _orderComponentsInGroup(self, repBlock):

--- a/armi/physics/neutronics/energyGroups.py
+++ b/armi/physics/neutronics/energyGroups.py
@@ -17,7 +17,7 @@ import copy
 import itertools
 import math
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.utils.mathematics import findNearestValue
@@ -111,12 +111,12 @@ def getGroupStructure(name):
 
 def getGroupStructureType(neutronEnergyBoundsInEv):
     """Return neutron energy group structure name for a given set of neutron energy group bounds in eV."""
-    neutronEnergyBoundsInEv = numpy.array(neutronEnergyBoundsInEv)
+    neutronEnergyBoundsInEv = np.array(neutronEnergyBoundsInEv)
     for groupStructureType in GROUP_STRUCTURE:
-        refNeutronEnergyBoundsInEv = numpy.array(getGroupStructure(groupStructureType))
+        refNeutronEnergyBoundsInEv = np.array(getGroupStructure(groupStructureType))
         if len(refNeutronEnergyBoundsInEv) != len(neutronEnergyBoundsInEv):
             continue
-        if numpy.allclose(refNeutronEnergyBoundsInEv, neutronEnergyBoundsInEv, 1e-5):
+        if np.allclose(refNeutronEnergyBoundsInEv, neutronEnergyBoundsInEv, 1e-5):
             return groupStructureType
     raise ValueError(
         "Neutron energy group structure type does not exist for the given neutron energy bounds: {}".format(

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -18,7 +18,7 @@ and/or photon flux.
 import math
 from typing import Dict, Optional
 
-import numpy
+import numpy as np
 import scipy.integrate
 
 from armi import interfaces
@@ -723,7 +723,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
         currentCorePower = 0.0
         for b in self.r.core.getBlocks():
             # The multi-group flux is volume integrated, so J/cm * n-cm/s gives units of Watts
-            b.p.power = numpy.dot(
+            b.p.power = np.dot(
                 b.getTotalEnergyGenerationConstants(), b.getIntegratedMgFlux()
             )
             b.p.flux = sum(b.getMgFlux())
@@ -994,13 +994,13 @@ class DoseResultsMapper(GlobalFluxResultMapper):
             # if it is a non-hex block, this should be a no-op
             if b.p.pointsCornerDpaRate is not None:
                 if b.p.pointsCornerDpa is None:
-                    b.p.pointsCornerDpa = numpy.zeros((6,))
+                    b.p.pointsCornerDpa = np.zeros((6,))
                 b.p.pointsCornerDpa = (
                     b.p.pointsCornerDpa + b.p.pointsCornerDpaRate * stepTimeInSeconds
                 )
             if b.p.pointsEdgeDpaRate is not None:
                 if b.p.pointsEdgeDpa is None:
-                    b.p.pointsEdgeDpa = numpy.zeros((6,))
+                    b.p.pointsEdgeDpa = np.zeros((6,))
                 b.p.pointsEdgeDpa = (
                     b.p.pointsEdgeDpa + b.p.pointsEdgeDpaRate * stepTimeInSeconds
                 )
@@ -1199,7 +1199,7 @@ class DoseResultsMapper(GlobalFluxResultMapper):
         peakAvg = (0.0, None)
         loadPadTop = loadPadBottom + loadPadLength
 
-        zrange = numpy.linspace(loadPadBottom, loadPadTop, 100)
+        zrange = np.linspace(loadPadBottom, loadPadTop, 100)
         for a in self.r.core.getAssemblies(Flags.FUEL):
             # scan over the load pad to find the peak dpa
             # no caching.

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -16,7 +16,7 @@ import logging
 import unittest
 from unittest.mock import patch
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi import settings
@@ -368,10 +368,10 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         block = r.core.getFirstBlock()
         self.assertGreater(block.p.detailedDpaRate, 0)
         self.assertEqual(block.p.detailedDpa, 0)
-        block.p.pointsEdgeDpa = numpy.array([0 for i in range(6)])
-        block.p.pointsCornerDpa = numpy.array([0 for i in range(6)])
-        block.p.pointsEdgeDpaRate = numpy.array([1.0e-5 for i in range(6)])
-        block.p.pointsCornerDpaRate = numpy.array([1.0e-5 for i in range(6)])
+        block.p.pointsEdgeDpa = np.array([0 for i in range(6)])
+        block.p.pointsCornerDpa = np.array([0 for i in range(6)])
+        block.p.pointsEdgeDpaRate = np.array([1.0e-5 for i in range(6)])
+        block.p.pointsCornerDpaRate = np.array([1.0e-5 for i in range(6)])
 
         # Test DoseResultsMapper. Pass in full list of blocks to apply() in order
         # to exercise blockList option (does not change behavior, since this is what
@@ -381,8 +381,8 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
         dosemapper = globalFluxInterface.DoseResultsMapper(1000, opts)
         dosemapper.apply(r, blockList=r.core.getBlocks())
         self.assertGreater(block.p.detailedDpa, 0)
-        self.assertGreater(numpy.min(block.p.pointsCornerDpa), 0)
-        self.assertGreater(numpy.min(block.p.pointsEdgeDpa), 0)
+        self.assertGreater(np.min(block.p.pointsCornerDpa), 0)
+        self.assertGreater(np.min(block.p.pointsEdgeDpa), 0)
 
         mapper.clearFlux()
         self.assertEqual(len(block.p.mgFlux), 0)
@@ -526,4 +526,4 @@ def applyDummyFlux(r, ng=33):
     """Set arbitrary flux distribution on a Reactor."""
     for b in r.core.getBlocks():
         b.p.power = 1.0
-        b.p.mgFlux = numpy.arange(ng, dtype=numpy.float64)
+        b.p.mgFlux = np.arange(ng, dtype=np.float64)

--- a/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
+++ b/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
@@ -24,7 +24,7 @@ model doesn't need to import the isotopicDepletionInterface to function.
 import collections
 from typing import List
 
-import numpy
+import numpy as np
 
 from armi.nucDirectory import nucDir
 
@@ -106,7 +106,7 @@ class CrossSectionTable(collections.OrderedDict):
             microMultiGroupXS.np,
         )
 
-        oneGroupXS = numpy.asarray(mgCrossSections).dot(mgFlux) / totalFlux
+        oneGroupXS = np.asarray(mgCrossSections).dot(mgFlux) / totalFlux
 
         oneGroupXSbyName = {xsType: xs for xsType, xs in zip(xsTypes, oneGroupXS)}
         oneGroupXSbyName["n3n"] = 0.0

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -351,9 +351,7 @@ class LatticePhysicsWriter(interfaces.InputWriter):
         if not fuelComponents:
             fuelTemperatureInC = self.block.getAverageTempInC()
         else:
-            fuelTemperatureInC = np.mean(
-                [fc.temperatureInC for fc in fuelComponents]
-            )
+            fuelTemperatureInC = np.mean([fc.temperatureInC for fc in fuelComponents])
         if not fuelTemperatureInC or math.isnan(fuelTemperatureInC):
             raise ValueError(
                 "The fuel temperature of block {0} is {1} and is not valid".format(

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -24,7 +24,7 @@ physics codes.
 import math
 import collections
 
-import numpy
+import numpy as np
 import ordered_set
 
 from armi import runLog
@@ -351,7 +351,7 @@ class LatticePhysicsWriter(interfaces.InputWriter):
         if not fuelComponents:
             fuelTemperatureInC = self.block.getAverageTempInC()
         else:
-            fuelTemperatureInC = numpy.mean(
+            fuelTemperatureInC = np.mean(
                 [fc.temperatureInC for fc in fuelComponents]
             )
         if not fuelTemperatureInC or math.isnan(fuelTemperatureInC):

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -22,7 +22,7 @@ import math
 import pickle
 from random import randint
 
-import numpy
+import numpy as np
 from scipy import interpolate
 
 from armi import runLog
@@ -473,7 +473,7 @@ class Assembly(composites.Composite):
 
         # length of this is numBlocks + 1
         bounds = list(self.spatialGrid._bounds)
-        bounds[2] = numpy.array(mesh)
+        bounds[2] = np.array(mesh)
         self.spatialGrid._bounds = tuple(bounds)
 
     def getTotalHeight(self, typeSpec=None):
@@ -645,7 +645,7 @@ class Assembly(composites.Composite):
         for b in self:
             top = z + b.getHeight()
             try:
-                b.p.topIndex = numpy.where(numpy.isclose(refMesh, top))[0].tolist()[0]
+                b.p.topIndex = np.where(np.isclose(refMesh, top))[0].tolist()[0]
             except IndexError:
                 runLog.error(
                     "Height {0} in this assembly ({1} in {4}) is not in the reactor mesh "
@@ -806,7 +806,7 @@ class Assembly(composites.Composite):
 
     def setBlockHeights(self, blockHeights):
         """Set the block heights of all blocks in the assembly."""
-        mesh = numpy.cumsum(blockHeights)
+        mesh = np.cumsum(blockHeights)
         self.setBlockMesh(mesh)
 
     def dump(self, fName=None):
@@ -1027,7 +1027,7 @@ class Assembly(composites.Composite):
         return blocksHere
 
     def getParamValuesAtZ(
-        self, param, elevations, interpType="linear", fillValue=numpy.NaN
+        self, param, elevations, interpType="linear", fillValue=np.NaN
     ):
         """
         Interpolates a param axially to find it at any value of elevation z.
@@ -1072,7 +1072,7 @@ class Assembly(composites.Composite):
 
         Returns
         -------
-        valAtZ : numpy.ndarray
+        valAtZ : np.ndarray
             This will be of the shape (z,data-shape)
         """
         interpolator = self.getParamOfZFunction(
@@ -1080,7 +1080,7 @@ class Assembly(composites.Composite):
         )
         return interpolator(elevations)
 
-    def getParamOfZFunction(self, param, interpType="linear", fillValue=numpy.NaN):
+    def getParamOfZFunction(self, param, interpType="linear", fillValue=np.NaN):
         """
         Interpolates a param axially to find it at any value of elevation z.
 
@@ -1119,7 +1119,7 @@ class Assembly(composites.Composite):
 
         Returns
         -------
-        valAtZ : numpy.ndarray
+        valAtZ : np.ndarray
             This will be of the shape (z,data-shape)
         """
         paramDef = self[0].p.paramDefs[param]
@@ -1143,7 +1143,7 @@ class Assembly(composites.Composite):
             z.insert(0, 0.0)
             z.pop(-1)
 
-        z = numpy.asarray(z)
+        z = np.asarray(z)
 
         values = self.getChildParamValues(param).transpose()
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -23,7 +23,7 @@ import collections
 import copy
 import math
 
-import numpy
+import numpy as np
 
 from armi import nuclideBases
 from armi import runLog
@@ -93,7 +93,7 @@ class Block(composites.Composite):
         self.p.height = height
         self.p.heightBOL = height
 
-        self.p.orientation = numpy.array((0.0, 0.0, 0.0))
+        self.p.orientation = np.array((0.0, 0.0, 0.0))
 
         self.points = []
         self.macros = None
@@ -247,7 +247,7 @@ class Block(composites.Composite):
             )
 
         # Compute component areas
-        cladID = numpy.mean([clad.getDimension("id", cold=cold) for clad in clads])
+        cladID = np.mean([clad.getDimension("id", cold=cold) for clad in clads])
         innerCladdingArea = (
             math.pi * (cladID**2) / 4.0 * self.getNumComponents(Flags.FUEL)
         )
@@ -335,7 +335,7 @@ class Block(composites.Composite):
         flux = composites.ArmiObject.getMgFlux(
             self, adjoint=adjoint, average=False, volume=volume, gamma=gamma
         )
-        if average and numpy.any(self.p.lastMgFlux):
+        if average and np.any(self.p.lastMgFlux):
             volume = volume or self.getVolume()
             lastFlux = self.p.lastMgFlux / volume
             flux = (flux + lastFlux) / 2.0
@@ -382,7 +382,7 @@ class Block(composites.Composite):
                 thisPinFlux.append(fluxes[g][pinLoc - 1])
             pinFluxes.append(thisPinFlux)
 
-        pinFluxes = numpy.array(pinFluxes)
+        pinFluxes = np.array(pinFluxes)
         if gamma:
             if adjoint:
                 raise ValueError("Adjoint gamma flux is currently unsupported.")
@@ -1363,9 +1363,9 @@ class Block(composites.Composite):
         lib = self.core.lib
         flux = self.getMgFlux(gamma=gamma)
         flux = [fi / max(flux) for fi in flux]
-        mfpNumerator = numpy.zeros(len(flux))
-        absMfpNumerator = numpy.zeros(len(flux))
-        transportNumerator = numpy.zeros(len(flux))
+        mfpNumerator = np.zeros(len(flux))
+        absMfpNumerator = np.zeros(len(flux))
+        transportNumerator = np.zeros(len(flux))
 
         numDensities = self.getNumberDensities()
 
@@ -1508,7 +1508,7 @@ class Block(composites.Composite):
 
         Returns
         -------
-        integratedFlux : numpy.array
+        integratedFlux : np.array
             multigroup neutron tracklength in [n-cm/s]
         """
         if adjoint:
@@ -1520,7 +1520,7 @@ class Block(composites.Composite):
         else:
             integratedFlux = self.p.mgFlux
 
-        return numpy.array(integratedFlux)
+        return np.array(integratedFlux)
 
     def getLumpedFissionProductCollection(self):
         """
@@ -1608,7 +1608,7 @@ class Block(composites.Composite):
 
         Returns
         -------
-        totalEnergyGenConstant: numpy.array
+        totalEnergyGenConstant: np.array
             Total (fission + capture) energy generation group constants (Joules/cm)
         """
         return (
@@ -1625,7 +1625,7 @@ class Block(composites.Composite):
 
         Returns
         -------
-        fissionEnergyGenConstant: numpy.array
+        fissionEnergyGenConstant: np.array
             Energy generation group constants (Joules/cm)
 
         Raises
@@ -1652,7 +1652,7 @@ class Block(composites.Composite):
 
         Returns
         -------
-        fissionEnergyGenConstant: numpy.array
+        fissionEnergyGenConstant: np.array
             Energy generation group constants (Joules/cm)
 
         Raises
@@ -1676,7 +1676,7 @@ class Block(composites.Composite):
 
         Returns
         -------
-        energyDepConstants: numpy.array
+        energyDepConstants: np.array
             Neutron energy generation group constants (in Joules/cm)
 
         Raises
@@ -1700,7 +1700,7 @@ class Block(composites.Composite):
 
         Returns
         -------
-        energyDepConstants: numpy.array
+        energyDepConstants: np.array
             Energy generation group constants (in Joules/cm)
 
         Raises
@@ -1981,7 +1981,7 @@ class HexBlock(Block):
             )
 
         powerKey = f"linPowByPin{powerKeySuffix}"
-        self.p[powerKey] = numpy.zeros(numPins)
+        self.p[powerKey] = np.zeros(numPins)
 
         # Loop through rings. The *pinLocation* parameter is only accessed for fueled
         # blocks; it is assumed that non-fueled blocks do not use a rotation map.
@@ -2050,9 +2050,9 @@ class HexBlock(Block):
                         f"on {param}"
                     )
                     runLog.warning(msg)
-            elif isinstance(self.p[param], numpy.ndarray):
+            elif isinstance(self.p[param], np.ndarray):
                 if len(self.p[param]) == 6:
-                    self.p[param] = numpy.concatenate(
+                    self.p[param] = np.concatenate(
                         (self.p[param][-rotNum:], self.p[param][:-rotNum])
                     )
                 elif len(self.p[param]) == 0:
@@ -2291,7 +2291,7 @@ class HexBlock(Block):
     def getRotationNum(self):
         """Get index 0 through 5 indicating number of rotations counterclockwise around the z-axis."""
         return (
-            numpy.rint(self.p.orientation[2] / 360.0 * 6) % 6
+            np.rint(self.p.orientation[2] / 360.0 * 6) % 6
         )  # assume rotation only in Z
 
     def setRotationNum(self, rotNum):
@@ -2551,7 +2551,7 @@ class HexBlock(Block):
             correctionFactor = 1.0
             if isinstance(c, Helix):
                 # account for the helical wire wrap
-                correctionFactor = numpy.hypot(
+                correctionFactor = np.hypot(
                     1.0,
                     math.pi
                     * c.getDimension("helixDiameter")

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -105,7 +105,7 @@ from io import StringIO
 import itertools
 from typing import Tuple
 
-import numpy
+import numpy as np
 import yamlize
 from ruamel.yaml import scalarstring
 
@@ -296,8 +296,8 @@ class GridBlueprint(yamlize.Object):
                     )
 
             # convert to list, otherwise it is a CommentedSeq
-            theta = numpy.array(self.gridBounds["theta"])
-            radii = numpy.array(self.gridBounds["r"])
+            theta = np.array(self.gridBounds["theta"])
+            radii = np.array(self.gridBounds["r"])
             for lst, name in ((theta, "theta"), (radii, "radii")):
                 if not isMonotonic(lst, "<"):
                     raise InputError(

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -29,7 +29,7 @@ These objects hold the dimensions, temperatures, composition, and shape of react
 # ruff: noqa: F405
 import math
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.reactor.components.component import *  # noqa: undefined-local-with-import-star
@@ -132,7 +132,7 @@ class UnshapedComponent(Component):
         material,
         Tinput,
         Thot,
-        area=numpy.NaN,
+        area=np.NaN,
         modArea=None,
         isotopics=None,
         mergeWith=None,
@@ -217,12 +217,12 @@ class UnshapedVolumetricComponent(UnshapedComponent):
         material,
         Tinput,
         Thot,
-        area=numpy.NaN,
+        area=np.NaN,
         op=None,
         isotopics=None,
         mergeWith=None,
         components=None,
-        volume=numpy.NaN,
+        volume=np.NaN,
     ):
         Component.__init__(
             self,

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -20,7 +20,7 @@ This module contains the abstract definition of a Component.
 import copy
 import re
 
-import numpy
+import numpy as np
 
 from armi import materials
 from armi import runLog
@@ -553,7 +553,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         to the as-built geometry. Modules that need true geometries will have to
         handle this themselves.
         """
-        if numpy.isnan(area):
+        if np.isnan(area):
             return
 
         if area < 0.0:
@@ -576,7 +576,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         --------
         self._checkNegativeArea
         """
-        if numpy.isnan(volume):
+        if np.isnan(volume):
             return
 
         if volume < 0.0 and self.containsSolidMaterial():
@@ -1240,7 +1240,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         if self.p.pinNum is None:
             # no pin-level flux is available
             if not self.parent:
-                return numpy.zeros(1)
+                return np.zeros(1)
 
             volumeFraction = self.getVolume() / self.parent.getVolume()
             return volumeFraction * self.parent.getIntegratedMgFlux(adjoint, gamma)

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -38,7 +38,7 @@ import operator
 import timeit
 from typing import Dict, List, Optional, Tuple, Type, Union
 
-import numpy
+import numpy as np
 import six
 import tabulate
 
@@ -58,7 +58,7 @@ class FlagSerializer(parameters.Serializer):
 
     This operates by converting each set of Flags (too large to fit in a uint64) into a
     sequence of enough uint8 elements to represent all flags. These constitute a
-    dimension of a 2-D numpy array containing all Flags for all objects provided to the
+    dimension of a 2-D np array containing all Flags for all objects provided to the
     ``pack()`` function.
     """
 
@@ -67,7 +67,7 @@ class FlagSerializer(parameters.Serializer):
     @staticmethod
     def pack(data):
         """
-        Flags are represented as a 2-D numpy array of uint8 (single-byte, unsigned
+        Flags are represented as a 2-D np array of uint8 (single-byte, unsigned
         integers), where each row contains the bytes representing a single Flags
         instance. We also store the list of field names so that we can verify that the
         reader and the writer can agree on the meaning of each bit.
@@ -86,8 +86,8 @@ class FlagSerializer(parameters.Serializer):
         functionality without having to do unholy things to ARMI's actual set of
         ``reactor.flags.Flags``.
         """
-        npa = numpy.array(
-            [b for f in data for b in f.to_bytes()], dtype=numpy.uint8
+        npa = np.array(
+            [b for f in data for b in f.to_bytes()], dtype=np.uint8
         ).reshape((len(data), flagCls.width()))
 
         return npa, {"flag_order": flagCls.sortedFields()}
@@ -1282,7 +1282,7 @@ class ArmiObject(metaclass=CompositeModelType):
             multiplying the number densities within each child Composite by the volume
             of the child Composite and dividing by the total volume of the Composite.
         """
-        volumes = numpy.array(
+        volumes = np.array(
             [
                 c.getVolume() / (c.parent.getSymmetryFactor() if c.parent else 1.0)
                 for c in self
@@ -1299,7 +1299,7 @@ class ArmiObject(metaclass=CompositeModelType):
             densListForEachComp.append(
                 [numberDensityDict.get(nuc, 0.0) for nuc in nucNames]
             )
-        nucDensForEachComp = numpy.array(densListForEachComp)  # c x n
+        nucDensForEachComp = np.array(densListForEachComp)  # c x n
 
         return volumes.dot(nucDensForEachComp) / totalVol
 
@@ -1899,8 +1899,8 @@ class ArmiObject(metaclass=CompositeModelType):
             return realVal
 
     def getChildParamValues(self, param):
-        """Get the child parameter values in a numpy array."""
-        return numpy.array([child.p[param] for child in self])
+        """Get the child parameter values in a np array."""
+        return np.array([child.p[param] for child in self])
 
     def isFuel(self):
         """True if this is a fuel block."""
@@ -2102,7 +2102,7 @@ class ArmiObject(metaclass=CompositeModelType):
 
         Returns
         -------
-        flux : numpy.array
+        flux : np.array
             multigroup neutron flux in [n/cm^2/s]
         """
         if average:
@@ -2472,7 +2472,7 @@ class Composite(ArmiObject):
     **Details about spatial representation**
 
     Spatial representation of a ``Composite`` is handled through a combination of the
-    ``spatialLocator`` and ``spatialGrid`` parameters. The ``spatialLocator`` is a numpy
+    ``spatialLocator`` and ``spatialGrid`` parameters. The ``spatialLocator`` is a np
     triple representing either:
 
     1. Indices in the parent's ``spatialGrid`` (for lattices, etc.), used when the dtype
@@ -2856,8 +2856,8 @@ class Composite(ArmiObject):
                     # out of sync, and this parameter was also globally modified and
                     # readjusted to the original value.
                     curVal = self.p[key]
-                    if isinstance(val, numpy.ndarray) or isinstance(
-                        curVal, numpy.ndarray
+                    if isinstance(val, np.ndarray) or isinstance(
+                        curVal, np.ndarray
                     ):
                         if (val != curVal).any():
                             errors[self, key].append(nodeRank)
@@ -2997,10 +2997,10 @@ class Composite(ArmiObject):
 
         Returns
         -------
-        integratedFlux : numpy.array
+        integratedFlux : np.array
             multigroup neutron tracklength in [n-cm/s]
         """
-        integratedMgFlux = numpy.zeros(1)
+        integratedMgFlux = np.zeros(1)
         for c in self:
             mgFlux = c.getIntegratedMgFlux(adjoint=adjoint, gamma=gamma)
             if mgFlux is not None:
@@ -3255,7 +3255,7 @@ def getReactionRateDict(nucName, lib, xsSuffix, mgFlux, nDens):
     xsSuffix : str
         cross section suffix, consisting of the type followed by the burnup group, e.g. 'AB' for the
         second burnup group of type A
-    mgFlux : numpy.nArray
+    mgFlux : np.nArray
         integrated mgFlux (n-cm/s)
     nDens : float
         number density (atom/bn-cm)

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -86,9 +86,9 @@ class FlagSerializer(parameters.Serializer):
         functionality without having to do unholy things to ARMI's actual set of
         ``reactor.flags.Flags``.
         """
-        npa = np.array(
-            [b for f in data for b in f.to_bytes()], dtype=np.uint8
-        ).reshape((len(data), flagCls.width()))
+        npa = np.array([b for f in data for b in f.to_bytes()], dtype=np.uint8).reshape(
+            (len(data), flagCls.width())
+        )
 
         return npa, {"flag_order": flagCls.sortedFields()}
 
@@ -2856,9 +2856,7 @@ class Composite(ArmiObject):
                     # out of sync, and this parameter was also globally modified and
                     # readjusted to the original value.
                     curVal = self.p[key]
-                    if isinstance(val, np.ndarray) or isinstance(
-                        curVal, np.ndarray
-                    ):
+                    if isinstance(val, np.ndarray) or isinstance(curVal, np.ndarray):
                         if (val != curVal).any():
                             errors[self, key].append(nodeRank)
                     elif curVal != val:

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -58,7 +58,7 @@ class FlagSerializer(parameters.Serializer):
 
     This operates by converting each set of Flags (too large to fit in a uint64) into a
     sequence of enough uint8 elements to represent all flags. These constitute a
-    dimension of a 2-D np array containing all Flags for all objects provided to the
+    dimension of a 2-D numpy array containing all Flags for all objects provided to the
     ``pack()`` function.
     """
 
@@ -67,7 +67,7 @@ class FlagSerializer(parameters.Serializer):
     @staticmethod
     def pack(data):
         """
-        Flags are represented as a 2-D np array of uint8 (single-byte, unsigned
+        Flags are represented as a 2-D numpy array of uint8 (single-byte, unsigned
         integers), where each row contains the bytes representing a single Flags
         instance. We also store the list of field names so that we can verify that the
         reader and the writer can agree on the meaning of each bit.

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -709,9 +709,9 @@ class ExpansionData:
 
         Parameters
         ----------
-        tempGrid : numpy array
+        tempGrid : np array
             1D axial temperature grid (i.e., physical locations where temp is stored)
-        tempField : numpy array
+        tempField : np array
             temperature values along grid
 
         Notes

--- a/armi/reactor/converters/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger.py
@@ -709,9 +709,9 @@ class ExpansionData:
 
         Parameters
         ----------
-        tempGrid : np array
+        tempGrid : numpy array
             1D axial temperature grid (i.e., physical locations where temp is stored)
-        tempField : np array
+        tempField : numpy array
             temperature values along grid
 
         Notes

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -16,7 +16,7 @@
 import copy
 import math
 
-import numpy
+import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.patches import Wedge
@@ -479,7 +479,7 @@ class BlockAvgToCylConverter(BlockConverter):
             colors.append(circleComp.density())
         colorMap = matplotlib.cm
         p = PatchCollection(patches, alpha=1.0, linewidths=0.1, cmap=colorMap.YlGn)
-        p.set_array(numpy.array(colors))
+        p.set_array(np.array(colors))
         ax.add_collection(p)
         ax.autoscale_view(True, True, True)
         ax.set_aspect("equal")

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -33,7 +33,7 @@ import os
 
 import matplotlib
 import matplotlib.pyplot as plt
-import numpy
+import numpy as np
 
 from armi import materials
 from armi import runLog
@@ -267,7 +267,7 @@ class FuelAssemNumModifier(GeometryChanger):
         # first look through the core and finds the one farthest from the center
         maxDist = 0.0
         for assem in r.core.getAssemblies():
-            dist = numpy.linalg.norm(
+            dist = np.linalg.norm(
                 assem.spatialLocator.getGlobalCoordinates()
             )  # get distance from origin
             dist = round(
@@ -301,7 +301,7 @@ class FuelAssemNumModifier(GeometryChanger):
             assem = r.core.childrenByLocator.get(
                 locator
             )  # check on assemblies, moving radially outward
-            dist = numpy.linalg.norm(locator.getGlobalCoordinates())
+            dist = np.linalg.norm(locator.getGlobalCoordinates())
             dist = round(dist, 6)
             if dist <= newRingDist:  # check distance
                 if assem is None:  # no assembly in that position, add assembly
@@ -532,7 +532,7 @@ class HexToRZThetaConverter(GeometryConverter):
         # replace temporary index-based ring indices with actual radial distances
         self.convReactor.core.spatialGrid._bounds = (
             self.convReactor.core.spatialGrid._bounds[0],
-            numpy.array(radialMeshCm),
+            np.array(radialMeshCm),
             self.convReactor.core.spatialGrid._bounds[2],
         )
 
@@ -1595,7 +1595,7 @@ def _scaleParamsInBlock(b, bSymmetric, completeListOfParamsToScale):
     """Scale volume-integrated params to include their identical symmetric assemblies."""
     listOfVolumeIntegratedParamsToScale, fluxParamsToScale = completeListOfParamsToScale
     for paramName in [
-        pn for pn in listOfVolumeIntegratedParamsToScale if numpy.any(b.p[pn])
+        pn for pn in listOfVolumeIntegratedParamsToScale if np.any(b.p[pn])
     ]:
         runLog.debug(
             "Scaling {} in symmetric identical assemblies".format(paramName),

--- a/armi/reactor/converters/meshConverters.py
+++ b/armi/reactor/converters/meshConverters.py
@@ -18,7 +18,7 @@ import math
 import collections
 import itertools
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.reactor import grids
@@ -160,7 +160,7 @@ class RZThetaReactorMeshConverter(MeshConverter):
     def _generateUniformThetaMesh(self):
         """Create a uniform theta mesh over 2*pi using the user specified number of theta bins."""
         self.thetaMesh = list(
-            numpy.linspace(0, 2 * math.pi, self._numThetaMeshBins + 1)[1:]
+            np.linspace(0, 2 * math.pi, self._numThetaMeshBins + 1)[1:]
         )
 
     def _generateNonUniformThetaMesh(self):
@@ -396,7 +396,7 @@ def checkLastValueInList(
     msg = "The last value in {} is {} and should be {}".format(
         listName, inputList[-1], expectedValue
     )
-    if not numpy.isclose(inputList[-1], expectedValue, eps):
+    if not np.isclose(inputList[-1], expectedValue, eps):
         if adjustLastValue:
             del inputList[-1]
             inputList.append(expectedValue)

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -16,7 +16,7 @@
 import os
 import unittest
 
-import numpy
+import numpy as np
 
 from armi.reactor.converters import blockConverters
 from armi.reactor import blocks
@@ -326,7 +326,7 @@ class TestToCircles(unittest.TestCase):
     def test_fromHex(self):
         actualRadii = blockConverters.radiiFromHexPitches([7.47, 7.85, 8.15])
         expected = [3.92203, 4.12154, 4.27906]
-        self.assertTrue(numpy.allclose(expected, actualRadii, rtol=1e-5))
+        self.assertTrue(np.allclose(expected, actualRadii, rtol=1e-5))
 
     def test_fromRingOfRods(self):
         # JOYO-LMFR-RESR-001, rev 1, Table A.2, 5th layer (ring 6)
@@ -334,7 +334,7 @@ class TestToCircles(unittest.TestCase):
             0.76 * 5, 6 * 5, [0.28, 0.315]
         )
         expected = [3.24034, 3.28553, 3.62584, 3.67104]
-        self.assertTrue(numpy.allclose(expected, actualRadii, rtol=1e-5))
+        self.assertTrue(np.allclose(expected, actualRadii, rtol=1e-5))
 
 
 def _buildJoyoFuel():

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -58,7 +58,7 @@ import copy
 import collections
 from timeit import default_timer as timer
 
-import numpy
+import numpy as np
 
 import armi
 from armi import runLog
@@ -186,8 +186,8 @@ class UniformMeshGenerator:
             if len(aMesh) == refNumPoints:
                 allMeshes.append(aMesh)
 
-        averageMesh = average1DWithinTolerance(numpy.array(allMeshes))
-        self._commonMesh = numpy.array(averageMesh)
+        averageMesh = average1DWithinTolerance(np.array(allMeshes))
+        self._commonMesh = np.array(averageMesh)
 
     def _decuspAxialMesh(self):
         """
@@ -254,7 +254,7 @@ class UniformMeshGenerator:
             preference="top",
         )
 
-        self._commonMesh = numpy.array(combinedMesh)
+        self._commonMesh = np.array(combinedMesh)
 
     def _filterMesh(
         self, meshList, minimumMeshSize, anchorPoints, preference="bottom", warn=False
@@ -1392,7 +1392,7 @@ class ParamMapper:
             if val is None:
                 continue
 
-            if isinstance(val, (tuple, list, numpy.ndarray)):
+            if isinstance(val, (tuple, list, np.ndarray)):
                 ParamMapper._arrayParamSetter(block, [val], [paramName])
             else:
                 ParamMapper._scalarParamSetter(block, [val], [paramName])
@@ -1402,13 +1402,13 @@ class ParamMapper:
         paramVals = []
         for paramName in paramNames:
             val = block.p[paramName]
-            # list-like should be treated as a numpy array
-            if isinstance(val, (tuple, list, numpy.ndarray)):
-                paramVals.append(numpy.array(val) if len(val) > 0 else None)
+            # list-like should be treated as a np array
+            if isinstance(val, (tuple, list, np.ndarray)):
+                paramVals.append(np.array(val) if len(val) > 0 else None)
             else:
                 paramVals.append(val)
 
-        return numpy.array(paramVals, dtype=object)
+        return np.array(paramVals, dtype=object)
 
     @staticmethod
     def _scalarParamSetter(block, vals, paramNames):
@@ -1422,7 +1422,7 @@ class ParamMapper:
         for paramName, vals in zip(paramNames, arrayVals):
             if vals is None:
                 continue
-            block.p[paramName] = numpy.array(vals)
+            block.p[paramName] = np.array(vals)
 
 
 def setNumberDensitiesFromOverlaps(block, overlappingBlockInfo):

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -1402,7 +1402,7 @@ class ParamMapper:
         paramVals = []
         for paramName in paramNames:
             val = block.p[paramName]
-            # list-like should be treated as a np array
+            # list-like should be treated as a numpy array
             if isinstance(val, (tuple, list, np.ndarray)):
                 paramVals.append(np.array(val) if len(val) > 0 else None)
             else:

--- a/armi/reactor/grids/axial.py
+++ b/armi/reactor/grids/axial.py
@@ -14,7 +14,7 @@
 from typing import List, Optional, TYPE_CHECKING, NoReturn
 import warnings
 
-import numpy
+import numpy as np
 
 from armi.reactor.grids.locations import IJType, LocationBase
 from armi.reactor.grids.structuredGrid import StructuredGrid
@@ -45,7 +45,7 @@ class AxialGrid(StructuredGrid):
         """
         # Need float bounds or else we truncate integers
         return cls(
-            bounds=(None, None, numpy.arange(numCells + 1, dtype=numpy.float64)),
+            bounds=(None, None, np.arange(numCells + 1, dtype=np.float64)),
             armiObject=armiObject,
         )
 

--- a/armi/reactor/grids/cartesian.py
+++ b/armi/reactor/grids/cartesian.py
@@ -14,7 +14,7 @@
 import itertools
 from typing import Optional, NoReturn, Tuple
 
-import numpy
+import numpy as np
 
 from armi.reactor import geometry
 
@@ -94,7 +94,7 @@ class CartesianGrid(StructuredGrid):
             An object in a Composite model that the Grid should be bound to.
         """
         unitSteps = ((width, 0.0, 0.0), (0.0, height, 0.0), (0, 0, 0))
-        offset = numpy.array((width / 2.0, height / 2.0, 0.0)) if isOffset else None
+        offset = np.array((width / 2.0, height / 2.0, 0.0)) if isOffset else None
         return cls(
             unitSteps=unitSteps,
             unitStepLimits=((-numRings, numRings), (-numRings, numRings), (0, 1)),
@@ -228,12 +228,12 @@ class CartesianGrid(StructuredGrid):
         """
         xwOld = self._unitSteps[0][0]
         ywOld = self._unitSteps[1][1]
-        self._unitSteps = numpy.array(((xw, 0.0, 0.0), (0.0, yw, 0.0), (0, 0, 0)))[
+        self._unitSteps = np.array(((xw, 0.0, 0.0), (0.0, yw, 0.0), (0, 0, 0)))[
             self._stepDims
         ]
         newOffsetX = self._offset[0] * xw / xwOld
         newOffsetY = self._offset[1] * yw / ywOld
-        self._offset = numpy.array((newOffsetX, newOffsetY, 0.0))
+        self._offset = np.array((newOffsetX, newOffsetY, 0.0))
 
     def getSymmetricEquivalents(self, indices):
         symmetry = self.symmetry  # construct the symmetry object once up top

--- a/armi/reactor/grids/grid.py
+++ b/armi/reactor/grids/grid.py
@@ -14,7 +14,7 @@
 from abc import ABC, abstractmethod
 from typing import Union, Optional, Hashable, TYPE_CHECKING, Dict, Iterable, Tuple, List
 
-import numpy
+import numpy as np
 
 from armi.reactor import geometry
 
@@ -226,7 +226,7 @@ class Grid(ABC):
         self,
         indices: Union[IJKType, List[IJKType]],
         nativeCoords: bool = False,
-    ) -> numpy.ndarray:
+    ) -> np.ndarray:
         pass
 
     @abstractmethod
@@ -238,11 +238,11 @@ class Grid(ABC):
         """Restore state from backup."""
 
     @abstractmethod
-    def getCellBase(self, indices: IJKType) -> numpy.ndarray:
+    def getCellBase(self, indices: IJKType) -> np.ndarray:
         """Return the lower left case of this cell in cm."""
 
     @abstractmethod
-    def getCellTop(self, indices: IJKType) -> numpy.ndarray:
+    def getCellTop(self, indices: IJKType) -> np.ndarray:
         """Get the upper right of this cell in cm."""
 
     @staticmethod

--- a/armi/reactor/grids/hexagonal.py
+++ b/armi/reactor/grids/hexagonal.py
@@ -14,7 +14,7 @@
 from math import sqrt
 from typing import Tuple, List, Optional
 
-import numpy
+import numpy as np
 
 from armi.reactor import geometry
 from armi.utils import hexagon
@@ -31,7 +31,7 @@ from armi.reactor.grids.structuredGrid import StructuredGrid
 COS30 = sqrt(3) / 2.0
 SIN30 = 1.0 / 2.0
 # going counter-clockwise from "position 1" (top right)
-TRIANGLES_IN_HEXAGON = numpy.array(
+TRIANGLES_IN_HEXAGON = np.array(
     [
         (+COS30, SIN30),
         (+0, 1.0),
@@ -456,7 +456,7 @@ class HexGrid(StructuredGrid):
         identicals = [(-i - j, i), (j, -i - j)]
         return identicals
 
-    def triangleCoords(self, indices: IJKType) -> numpy.ndarray:
+    def triangleCoords(self, indices: IJKType) -> np.ndarray:
         """
         Return 6 coordinate pairs representing the centers of the 6 triangles in a
         hexagon centered here.
@@ -501,7 +501,7 @@ class HexGrid(StructuredGrid):
 
     def changePitch(self, newPitchCm: float):
         """Change the hex pitch."""
-        unitSteps = numpy.array(HexGrid._getRawUnitSteps(newPitchCm, self.cornersUp))
+        unitSteps = np.array(HexGrid._getRawUnitSteps(newPitchCm, self.cornersUp))
         self._unitSteps = unitSteps[self._stepDims]
 
     def locatorInDomain(self, locator, symmetryOverlap: Optional[bool] = False) -> bool:
@@ -569,7 +569,7 @@ class HexGrid(StructuredGrid):
         # round to avoid differences due to floating point math
         locList.sort(
             key=lambda loc: (
-                round(numpy.linalg.norm(loc.getGlobalCoordinates()), 6),
+                round(np.linalg.norm(loc.getGlobalCoordinates()), 6),
                 loc.i,
                 loc.j,
             )

--- a/armi/reactor/grids/locations.py
+++ b/armi/reactor/grids/locations.py
@@ -16,7 +16,7 @@ from typing import Optional, TYPE_CHECKING, Union, Hashable, Tuple, List, Iterat
 from abc import ABC, abstractmethod
 import math
 
-import numpy
+import numpy as np
 
 if TYPE_CHECKING:
     # Avoid some circular imports
@@ -158,13 +158,13 @@ class LocationBase(ABC):
 
     @property
     @abstractmethod
-    def indices(self) -> numpy.ndarray:
+    def indices(self) -> np.ndarray:
         """Get the non-grid indices (i,j,k) of this locator.
 
         This strips off the annoying ``grid`` tagalong which is there to ensure proper
         equality (i.e. (0,0,0) in a storage rack is not equal to (0,0,0) in a core).
 
-        It is a numpy array for two reasons:
+        It is a np array for two reasons:
 
         1. It can be added and subtracted for the recursive computations
            through different coordinate systems
@@ -239,21 +239,21 @@ class IndexLocation(LocationBase):
         return None
 
     @property
-    def indices(self) -> numpy.ndarray:
+    def indices(self) -> np.ndarray:
         """
         Get the non-grid indices (i,j,k) of this locator.
 
         This strips off the annoying ``grid`` tagalong which is there to ensure proper
         equality (i.e. (0,0,0) in a storage rack is not equal to (0,0,0) in a core).
 
-        It is a numpy array for two reasons:
+        It is a np array for two reasons:
 
         1. It can be added and subtracted for the recursive computations
            through different coordinate systems
         2. It can be written/read from the database.
 
         """
-        return numpy.array(self[:3])
+        return np.array(self[:3])
 
     def getCompleteIndices(self) -> IJKType:
         """
@@ -339,8 +339,8 @@ class IndexLocation(LocationBase):
         return math.sqrt(
             (
                 (
-                    numpy.array(self.getGlobalCoordinates())
-                    - numpy.array(other.getGlobalCoordinates())
+                    np.array(self.getGlobalCoordinates())
+                    - np.array(other.getGlobalCoordinates())
                 )
                 ** 2
             ).sum()
@@ -429,7 +429,7 @@ class MultiIndexLocation(IndexLocation):
         self._locations.pop(location)
 
     @property
-    def indices(self) -> List[numpy.ndarray]:
+    def indices(self) -> List[np.ndarray]:
         """
         Return indices for all locations.
 

--- a/armi/reactor/grids/locations.py
+++ b/armi/reactor/grids/locations.py
@@ -246,7 +246,7 @@ class IndexLocation(LocationBase):
         This strips off the annoying ``grid`` tagalong which is there to ensure proper
         equality (i.e. (0,0,0) in a storage rack is not equal to (0,0,0) in a core).
 
-        It is a np array for two reasons:
+        It is a numpy array for two reasons:
 
         1. It can be added and subtracted for the recursive computations
            through different coordinate systems

--- a/armi/reactor/grids/structuredGrid.py
+++ b/armi/reactor/grids/structuredGrid.py
@@ -159,7 +159,7 @@ class StructuredGrid(Grid):
             else:
                 self._boundDims.append(dimensionIndex)
 
-        # np prefers tuples like this to do slicing on arrays
+        # numpy prefers tuples like this to do slicing on arrays
         self._boundDims = (tuple(self._boundDims),)
         self._stepDims = (tuple(self._stepDims),)
 
@@ -200,7 +200,7 @@ class StructuredGrid(Grid):
         unitSteps = []
         compressedSteps = list(self._unitSteps[:])
         for i in range(3):
-            # Recall _stepDims are stored as a single-value tuple (for np indexing)
+            # Recall _stepDims are stored as a single-value tuple (for numpy indexing)
             # So this just is grabbing the actual data.
             if i in self._stepDims[0]:
                 unitSteps.append(compressedSteps.pop(0))

--- a/armi/reactor/grids/structuredGrid.py
+++ b/armi/reactor/grids/structuredGrid.py
@@ -15,7 +15,7 @@ import collections
 import itertools
 from typing import Tuple, Union, List, Iterable, Optional, Sequence
 
-import numpy
+import numpy as np
 
 from armi.reactor.grids.locations import (
     IJKType,
@@ -159,7 +159,7 @@ class StructuredGrid(Grid):
             else:
                 self._boundDims.append(dimensionIndex)
 
-        # numpy prefers tuples like this to do slicing on arrays
+        # np prefers tuples like this to do slicing on arrays
         self._boundDims = (tuple(self._boundDims),)
         self._stepDims = (tuple(self._stepDims),)
 
@@ -170,8 +170,8 @@ class StructuredGrid(Grid):
 
         # only represent unit steps in dimensions they're being used so as to not
         # pollute the dot product. This may reduce the length of this from 3 to 2 or 1
-        self._unitSteps = numpy.array(unitSteps)[self._stepDims]
-        self._offset = numpy.zeros(3) if offset is None else numpy.array(offset)
+        self._unitSteps = np.array(unitSteps)[self._stepDims]
+        self._offset = np.zeros(3) if offset is None else np.array(offset)
         self._locations = {}
         self._buildLocations()  # locations are owned by a grid, so the grid builds them.
 
@@ -200,7 +200,7 @@ class StructuredGrid(Grid):
         unitSteps = []
         compressedSteps = list(self._unitSteps[:])
         for i in range(3):
-            # Recall _stepDims are stored as a single-value tuple (for numpy indexing)
+            # Recall _stepDims are stored as a single-value tuple (for np indexing)
             # So this just is grabbing the actual data.
             if i in self._stepDims[0]:
                 unitSteps.append(compressedSteps.pop(0))
@@ -219,12 +219,12 @@ class StructuredGrid(Grid):
         )
 
     @property
-    def offset(self) -> numpy.ndarray:
+    def offset(self) -> np.ndarray:
         """Offset in cm for each axis."""
         return self._offset
 
     @offset.setter
-    def offset(self, offset: numpy.ndarray):
+    def offset(self, offset: np.ndarray):
         self._offset = offset
 
     def __repr__(self) -> str:
@@ -289,7 +289,7 @@ class StructuredGrid(Grid):
     def restoreBackup(self):
         self._unitSteps, self._bounds, self._offset = self._backup
 
-    def getCoordinates(self, indices, nativeCoords=False) -> numpy.ndarray:
+    def getCoordinates(self, indices, nativeCoords=False) -> np.ndarray:
         """Return the coordinates of the center of the mesh cell at the given indices
         in cm.
 
@@ -308,26 +308,26 @@ class StructuredGrid(Grid):
             all axes. There are no more complicated situations where we need to find
             the centroid of a octagon on a rectangular mesh, or the like.
         """
-        indices = numpy.array(indices)
+        indices = np.array(indices)
         return self._evaluateMesh(
             indices, self._centroidBySteps, self._centroidByBounds
         )
 
-    def getCellBase(self, indices) -> numpy.ndarray:
+    def getCellBase(self, indices) -> np.ndarray:
         """Get the mesh base (lower left) of this mesh cell in cm."""
-        indices = numpy.array(indices)
+        indices = np.array(indices)
         return self._evaluateMesh(
             indices, self._meshBaseBySteps, self._meshBaseByBounds
         )
 
-    def getCellTop(self, indices) -> numpy.ndarray:
+    def getCellTop(self, indices) -> np.ndarray:
         """Get the mesh top (upper right) of this mesh cell in cm."""
-        indices = numpy.array(indices) + 1
+        indices = np.array(indices) + 1
         return self._evaluateMesh(
             indices, self._meshBaseBySteps, self._meshBaseByBounds
         )
 
-    def _evaluateMesh(self, indices, stepOperator, boundsOperator) -> numpy.ndarray:
+    def _evaluateMesh(self, indices, stepOperator, boundsOperator) -> np.ndarray:
         """
         Evaluate some function of indices on this grid.
 
@@ -346,17 +346,17 @@ class StructuredGrid(Grid):
                 boundCoords.append(boundsOperator(indices[ii], bounds))
 
         # limit step operator to the step dimensions
-        stepCoords = stepOperator(numpy.array(indices)[self._stepDims])
+        stepCoords = stepOperator(np.array(indices)[self._stepDims])
 
         # now mix/match bounds coords with step coords appropriately.
-        result = numpy.zeros(len(indices))
+        result = np.zeros(len(indices))
         result[self._stepDims] = stepCoords
         result[self._boundDims] = boundCoords
 
         return result + self._offset
 
     def _centroidBySteps(self, indices):
-        return numpy.dot(self._unitSteps, indices)
+        return np.dot(self._unitSteps, indices)
 
     def _meshBaseBySteps(self, indices):
         return (
@@ -515,9 +515,9 @@ class StructuredGrid(Grid):
 
 
 def _tuplify(maybeArray) -> tuple:
-    if isinstance(maybeArray, (numpy.ndarray, list, tuple)):
+    if isinstance(maybeArray, (np.ndarray, list, tuple)):
         maybeArray = tuple(
-            tuple(row) if isinstance(row, (numpy.ndarray, list)) else row
+            tuple(row) if isinstance(row, (np.ndarray, list)) else row
             for row in maybeArray
         )
 

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -18,7 +18,7 @@ import math
 import unittest
 import pickle
 
-import numpy
+import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from armi.reactor import geometry
@@ -108,7 +108,7 @@ class TestSpatialLocator(unittest.TestCase):
         pinIndexLoc = grids.IndexLocation(1, 5, 0, blockGrid)
         pinFree = grids.CoordinateLocation(1.0, 2.0, 3.0, blockGrid)
 
-        assert_allclose(blockLoc.getCompleteIndices(), numpy.array((2, 3, 3)))
+        assert_allclose(blockLoc.getCompleteIndices(), np.array((2, 3, 3)))
         assert_allclose(blockLoc.getGlobalCoordinates(), (2.0, 3.0, 3.5))
         assert_allclose(blockLoc.getGlobalCellBase(), (1.5, 2.5, 3))
         assert_allclose(blockLoc.getGlobalCellTop(), (2.5, 3.5, 4))
@@ -457,7 +457,7 @@ class TestHexGrid(unittest.TestCase):
             grid = grids.HexGrid(
                 unitSteps=((1.5 / math.sqrt(3), 0.0, 0.0), (0.5, 1, 0.0), (0, 0, 0)),
                 unitStepLimits=((-3, 3), (-3, 3), (0, 1)),
-                offset=numpy.array([offset, offset, offset]),
+                offset=np.array([offset, offset, offset]),
             )
 
             # test number of rings before converting pitch
@@ -499,7 +499,7 @@ class TestHexGrid(unittest.TestCase):
                     (0, 0, 0),
                 ),
                 unitStepLimits=((-3, 3), (-3, 3), (0, 1)),
-                offset=numpy.array(offsets),
+                offset=np.array(offsets),
             )
 
             # test number of rings before converting pitch
@@ -510,7 +510,7 @@ class TestHexGrid(unittest.TestCase):
             grid.changePitch(2.0)
             self.assertAlmostEqual(grid.pitch, 2.0, delta=1e-9)
             v2 = grid.getCoordinates((1, 0, 0))
-            correction = numpy.array([0.5, math.sqrt(3) / 2, 0])
+            correction = np.array([0.5, math.sqrt(3) / 2, 0])
             assert_allclose(v1 + correction, v2)
 
             # basic sanity: test number of rings has not changed
@@ -625,7 +625,7 @@ class TestThetaRZGrid(unittest.TestCase):
 
     def test_positions(self):
         grid = grids.ThetaRZGrid(
-            bounds=(numpy.linspace(0, 2 * math.pi, 13), [0, 2, 2.5, 3], [0, 10, 20, 30])
+            bounds=(np.linspace(0, 2 * math.pi, 13), [0, 2, 2.5, 3], [0, 10, 20, 30])
         )
         assert_allclose(
             grid.getCoordinates((1, 0, 1)), (math.sqrt(2) / 2, math.sqrt(2) / 2, 15.0)

--- a/armi/reactor/grids/thetarz.py
+++ b/armi/reactor/grids/thetarz.py
@@ -14,7 +14,7 @@
 import math
 from typing import TYPE_CHECKING, Optional, NoReturn
 
-import numpy
+import numpy as np
 
 from armi.reactor.grids.locations import IJType, IJKType
 from armi.reactor.grids.structuredGrid import StructuredGrid
@@ -75,8 +75,8 @@ class ThetaRZGrid(StructuredGrid):
             radii.add(rad2)
             thetas.add(theta1)
             thetas.add(theta2)
-        radii = numpy.array(sorted(radii), dtype=numpy.float64)
-        thetaRadians = numpy.array(sorted(thetas), dtype=numpy.float64)
+        radii = np.array(sorted(radii), dtype=np.float64)
+        thetaRadians = np.array(sorted(thetas), dtype=np.float64)
 
         return ThetaRZGrid(
             bounds=(thetaRadians, radii, (0.0, 0.0)), armiObject=armiObject
@@ -89,7 +89,7 @@ class ThetaRZGrid(StructuredGrid):
     def getIndicesFromRingAndPos(ring: int, pos: int) -> IJType:
         return (pos - 1, ring - 1)
 
-    def getCoordinates(self, indices, nativeCoords=False) -> numpy.ndarray:
+    def getCoordinates(self, indices, nativeCoords=False) -> np.ndarray:
         meshCoords = theta, r, z = super().getCoordinates(
             indices, nativeCoords=nativeCoords
         )
@@ -100,7 +100,7 @@ class ThetaRZGrid(StructuredGrid):
             return meshCoords
         else:
             # return x, y ,z
-            return numpy.array((r * math.cos(theta), r * math.sin(theta), z))
+            return np.array((r * math.cos(theta), r * math.sin(theta), z))
 
     def indicesOfBounds(
         self,
@@ -131,8 +131,8 @@ class ThetaRZGrid(StructuredGrid):
         -------
         tuple : i, j, k of given bounds
         """
-        i = int(numpy.abs(self._bounds[0] - theta0).argmin())
-        j = int(numpy.abs(self._bounds[1] - rad0).argmin())
+        i = int(np.abs(self._bounds[0] - theta0).argmin())
+        j = int(np.abs(self._bounds[1] - rad0).argmin())
 
         return (i, j, 0)
 

--- a/armi/reactor/parameters/__init__.py
+++ b/armi/reactor/parameters/__init__.py
@@ -68,7 +68,7 @@ number densities, etc. Parameters can be any basic type (float, int, str), or an
 of any such types. The type within a given array should be homogeneous. Examples::
 
     >>> b.p.flux = 2.5e13
-    >>> b.p.fuelTemp = numpy.array(range(217), dtype=float)
+    >>> b.p.fuelTemp = np.array(range(217), dtype=float)
     >>> b.p.fuelTemp[58] = 600
 
 .. note::

--- a/armi/reactor/parameters/parameterCollections.py
+++ b/armi/reactor/parameters/parameterCollections.py
@@ -17,7 +17,7 @@ import pickle
 from typing import Any, Optional, List, Set
 import sys
 
-import numpy
+import numpy as np
 import six
 
 from armi import runLog
@@ -484,8 +484,8 @@ class ParameterCollection(metaclass=_ParameterCollectionType):
         for pd, currentValue in currentData.items():
             # correct for global paramDef.assigned assumption
             retainedValue = getattr(self, pd.fieldName)
-            if isinstance(retainedValue, numpy.ndarray) or isinstance(
-                currentValue, numpy.ndarray
+            if isinstance(retainedValue, np.ndarray) or isinstance(
+                currentValue, np.ndarray
             ):
                 if (retainedValue != currentValue).any():
                     setattr(self, pd.fieldName, currentValue)

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -30,7 +30,7 @@ import enum
 import functools
 import re
 
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.reactor.flags import Flags
@@ -63,7 +63,7 @@ class Category:
     -----
     * `cumulative` parameters are accumulated over many time steps
     * `pinQuantities` parameters are defined on the pin level within a block
-    * `multiGroupQuantities` parameters have group dependence (often a 1D numpy array)
+    * `multiGroupQuantities` parameters have group dependence (often a 1D np array)
     * `fluxQuantities` parameters are related to neutron or gamma flux
     * `neutronics` parameters are calculated in a neutronics global flux solve
     * `gamma` parameters are calculated in a fixed-source gamma solve
@@ -125,14 +125,14 @@ class Serializer:
     Abstract class describing serialize/deserialize operations for Parameter data.
 
     Parameters need to be stored to and read from database files. This currently requires that the
-    Parameter data be converted to a numpy array of a datatype supported by the ``h5py`` package.
-    Some parameters may contain data that are not trivially representable in numpy/HDF5, and need
+    Parameter data be converted to a np array of a datatype supported by the ``h5py`` package.
+    Some parameters may contain data that are not trivially representable in np/HDF5, and need
     special treatment. Subclassing ``Serializer`` and setting it as a ``Parameter``\ s
     ``serializer`` allows for special operations to be performed on the parameter values as they are
     stored to the database or read back in.
 
     The ``Database3`` already knows how to handle certain cases where the data are not
-    straightforward to get into a numpy array, such as when:
+    straightforward to get into a np array, such as when:
 
       - There are ``None``\ s.
 
@@ -160,7 +160,7 @@ class Serializer:
 
         Important physical parameters are stored in every ARMI object. These parameters represent
         the plant's state during execution of the model. Currently, this requires that the
-        parameters be serializable to a numpy array of a datatype supported by the ``h5py`` package
+        parameters be serializable to a np array of a datatype supported by the ``h5py`` package
         so that the data can be written to, and subsequently read from, an HDF5 file.
 
         This class allows for these parameters to be serialized in a custom manner by providing
@@ -180,7 +180,7 @@ class Serializer:
     version: Optional[str] = None
 
     @staticmethod
-    def pack(data: Sequence[any]) -> Tuple[numpy.ndarray, Dict[str, any]]:
+    def pack(data: Sequence[any]) -> Tuple[np.ndarray, Dict[str, any]]:
         """
         Given unpacked data, return packed data and a dictionary of attributes needed to unpack it.
 
@@ -196,7 +196,7 @@ class Serializer:
 
     @classmethod
     def unpack(
-        cls, data: numpy.ndarray, version: Any, attrs: Dict[str, any]
+        cls, data: np.ndarray, version: Any, attrs: Dict[str, any]
     ) -> Sequence[any]:
         """Given packed data and attributes, return the unpacked data."""
         raise NotImplementedError()
@@ -217,10 +217,10 @@ def isNumpyArray(paramStr):
     """
 
     def setParameter(selfObj, value):
-        if value is None or isinstance(value, numpy.ndarray):
+        if value is None or isinstance(value, np.ndarray):
             setattr(selfObj, "_p_" + paramStr, value)
         else:
-            setattr(selfObj, "_p_" + paramStr, numpy.array(value))
+            setattr(selfObj, "_p_" + paramStr, np.array(value))
 
     return setParameter
 
@@ -730,7 +730,7 @@ class ParameterBuilder:
         serializer: Optional subclass of Serializer
             A class describing how the parameter data should be stored to the database.
             This is usually only needed in exceptional cases where it is difficult to
-            store a parameter in a numpy array.
+            store a parameter in a np array.
 
         Notes
         -----

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -63,7 +63,7 @@ class Category:
     -----
     * `cumulative` parameters are accumulated over many time steps
     * `pinQuantities` parameters are defined on the pin level within a block
-    * `multiGroupQuantities` parameters have group dependence (often a 1D np array)
+    * `multiGroupQuantities` parameters have group dependence (often a 1D numpy array)
     * `fluxQuantities` parameters are related to neutron or gamma flux
     * `neutronics` parameters are calculated in a neutronics global flux solve
     * `gamma` parameters are calculated in a fixed-source gamma solve
@@ -125,14 +125,14 @@ class Serializer:
     Abstract class describing serialize/deserialize operations for Parameter data.
 
     Parameters need to be stored to and read from database files. This currently requires that the
-    Parameter data be converted to a np array of a datatype supported by the ``h5py`` package.
-    Some parameters may contain data that are not trivially representable in np/HDF5, and need
+    Parameter data be converted to a numpy array of a datatype supported by the ``h5py`` package.
+    Some parameters may contain data that are not trivially representable in numpy/HDF5, and need
     special treatment. Subclassing ``Serializer`` and setting it as a ``Parameter``\ s
     ``serializer`` allows for special operations to be performed on the parameter values as they are
     stored to the database or read back in.
 
     The ``Database3`` already knows how to handle certain cases where the data are not
-    straightforward to get into a np array, such as when:
+    straightforward to get into a numpy array, such as when:
 
       - There are ``None``\ s.
 
@@ -160,7 +160,7 @@ class Serializer:
 
         Important physical parameters are stored in every ARMI object. These parameters represent
         the plant's state during execution of the model. Currently, this requires that the
-        parameters be serializable to a np array of a datatype supported by the ``h5py`` package
+        parameters be serializable to a numpy array of a datatype supported by the ``h5py`` package
         so that the data can be written to, and subsequently read from, an HDF5 file.
 
         This class allows for these parameters to be serialized in a custom manner by providing
@@ -730,7 +730,7 @@ class ParameterBuilder:
         serializer: Optional subclass of Serializer
             A class describing how the parameter data should be stored to the database.
             This is usually only needed in exceptional cases where it is difficult to
-            store a parameter in a np array.
+            store a parameter in a numpy array.
 
         Notes
         -----

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -27,7 +27,7 @@ import itertools
 import os
 import time
 
-import numpy
+import numpy as np
 import tabulate
 
 from armi import getPluginManagerOrFail, materials, nuclearDataIO
@@ -1630,7 +1630,7 @@ class Core(composites.Composite):
                 newFlux.extend(oneGroup)
             flux = newFlux
 
-        return numpy.array(flux)
+        return np.array(flux)
 
     def getAssembliesOfType(self, typeSpec, exactMatch=False):
         """Return a list of assemblies in the core that are of type assemType."""
@@ -2087,7 +2087,7 @@ class Core(composites.Composite):
                 for axis, (collection, subdivisions) in enumerate(
                     zip((iMesh, jMesh, kMesh), numPoints)
                 ):
-                    axisVal = float(base[axis])  # convert from numpy.float64
+                    axisVal = float(base[axis])  # convert from np.float64
                     step = float(top[axis] - axisVal) / subdivisions
                     for _subdivision in range(subdivisions):
                         collection.add(round(axisVal, units.FLOAT_DIMENSION_DECIMALS))
@@ -2128,7 +2128,7 @@ class Core(composites.Composite):
         refAssem = self.refAssem
         refMesh = self.findAllAxialMeshPoints([refAssem])
         avgHeight = average1DWithinTolerance(
-            numpy.array(
+            np.array(
                 [
                     [
                         h
@@ -2140,7 +2140,7 @@ class Core(composites.Composite):
                 ]
             )
         )
-        self.p.axialMesh = list(numpy.append([0.0], avgHeight.cumsum()))
+        self.p.axialMesh = list(np.append([0.0], avgHeight.cumsum()))
 
     def findAxialMeshIndexOf(self, heightCm):
         """

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -39,7 +39,7 @@ from armi.reactor.assemblies import (
     Flags,
     grids,
     HexAssembly,
-    numpy,
+    np,
     runLog,
 )
 from armi.reactor.tests import test_reactors
@@ -632,7 +632,7 @@ class Assembly_TestCase(unittest.TestCase):
                     continue
                 ref = refBlock.p[refParam]
                 cur = curBlock.p[refParam]
-                if isinstance(cur, numpy.ndarray):
+                if isinstance(cur, np.ndarray):
                     self.assertTrue((cur == ref).all())
                 else:
                     if refParam == "location":
@@ -659,7 +659,7 @@ class Assembly_TestCase(unittest.TestCase):
                 continue
             ref = self.assembly.p[param]
             cur = assembly2.p[param]
-            if isinstance(cur, numpy.ndarray):
+            if isinstance(cur, np.ndarray):
                 assert_allclose(cur, ref)
             else:
                 self.assertEqual(cur, ref)
@@ -955,26 +955,26 @@ class Assembly_TestCase(unittest.TestCase):
             for b in self.assembly:
                 b.p.percentBu = None
             self.assertTrue(
-                numpy.isnan(self.assembly.getParamValuesAtZ("percentBu", 25.0))
+                np.isnan(self.assembly.getParamValuesAtZ("percentBu", 25.0))
             )
 
             # multiDimensional param
             for b, flux in zip(self.assembly, [[1, 10], [2, 8], [3, 6]]):
                 b.p.mgFlux = flux
             self.assertTrue(
-                numpy.allclose(
+                np.allclose(
                     [2.5, 7.0], self.assembly.getParamValuesAtZ("mgFlux", 20.0)
                 )
             )
             self.assertTrue(
-                numpy.allclose(
+                np.allclose(
                     [1.5, 9.0], self.assembly.getParamValuesAtZ("mgFlux", 10.0)
                 )
             )
             for b in self.assembly:
                 b.p.mgFlux = [0.0] * 2
             self.assertTrue(
-                numpy.allclose(
+                np.allclose(
                     [0.0, 0.0], self.assembly.getParamValuesAtZ("mgFlux", 10.0)
                 )
             )
@@ -983,7 +983,7 @@ class Assembly_TestCase(unittest.TestCase):
             for b, temp in zip(self.assembly, [100, 200, 300]):
                 b.p.THcornTemp = [temp + iCorner for iCorner in range(6)]
             value = self.assembly.getParamValuesAtZ("THcornTemp", 20.0)
-            self.assertTrue(numpy.allclose([200, 201, 202, 203, 204, 205], value))
+            self.assertTrue(np.allclose([200, 201, 202, 203, 204, 205], value))
         finally:
             percentBuDef.location = originalLoc
 

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -17,8 +17,6 @@ import math
 import pathlib
 import random
 import unittest
-
-import numpy as np
 from numpy.testing import assert_allclose
 
 from armi import settings
@@ -962,21 +960,15 @@ class Assembly_TestCase(unittest.TestCase):
             for b, flux in zip(self.assembly, [[1, 10], [2, 8], [3, 6]]):
                 b.p.mgFlux = flux
             self.assertTrue(
-                np.allclose(
-                    [2.5, 7.0], self.assembly.getParamValuesAtZ("mgFlux", 20.0)
-                )
+                np.allclose([2.5, 7.0], self.assembly.getParamValuesAtZ("mgFlux", 20.0))
             )
             self.assertTrue(
-                np.allclose(
-                    [1.5, 9.0], self.assembly.getParamValuesAtZ("mgFlux", 10.0)
-                )
+                np.allclose([1.5, 9.0], self.assembly.getParamValuesAtZ("mgFlux", 10.0))
             )
             for b in self.assembly:
                 b.p.mgFlux = [0.0] * 2
             self.assertTrue(
-                np.allclose(
-                    [0.0, 0.0], self.assembly.getParamValuesAtZ("mgFlux", 10.0)
-                )
+                np.allclose([0.0, 0.0], self.assembly.getParamValuesAtZ("mgFlux", 10.0))
             )
 
             # single value param at corner

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -19,7 +19,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 import io
 
-import numpy
+import numpy as np
 from numpy.testing import assert_allclose
 
 from armi import materials, runLog, settings, tests
@@ -324,11 +324,11 @@ class TestDetailedNDensUpdate(unittest.TestCase):
         block = self.r.core[0][0]
         # get nuclides in first component in block
         adjList = block[0].getNuclides()
-        block.p.detailedNDens = numpy.array([1.0])
+        block.p.detailedNDens = np.array([1.0])
         block.p.pdensDecay = 1.0
         block._updateDetailedNdens(frac=0.5, adjustList=adjList)
         self.assertEqual(block.p.pdensDecay, 0.5)
-        self.assertEqual(block.p.detailedNDens, numpy.array([0.5]))
+        self.assertEqual(block.p.detailedNDens, np.array([0.5]))
 
 
 class Block_TestCase(unittest.TestCase):
@@ -804,7 +804,7 @@ class Block_TestCase(unittest.TestCase):
         cur = self.block.getWettedPerimeter()
 
         wire = self.block.getComponent(Flags.WIRE)
-        correctionFactor = numpy.hypot(
+        correctionFactor = np.hypot(
             1.0,
             math.pi
             * wire.getDimension("helixDiameter")
@@ -1345,7 +1345,7 @@ class Block_TestCase(unittest.TestCase):
 
         # Test with no powerKeySuffix
         self.block.setPinPowers(neutronPower)
-        assert_allclose(self.block.p[totalPowerKey], numpy.array(neutronPower))
+        assert_allclose(self.block.p[totalPowerKey], np.array(neutronPower))
         self.assertIsNone(self.block.p[neutronPowerKey])
         self.assertIsNone(self.block.p[gammaPowerKey])
 
@@ -1354,8 +1354,8 @@ class Block_TestCase(unittest.TestCase):
             neutronPower,
             powerKeySuffix=NEUTRON,
         )
-        assert_allclose(self.block.p[totalPowerKey], numpy.array(neutronPower))
-        assert_allclose(self.block.p[neutronPowerKey], numpy.array(neutronPower))
+        assert_allclose(self.block.p[totalPowerKey], np.array(neutronPower))
+        assert_allclose(self.block.p[neutronPowerKey], np.array(neutronPower))
         self.assertIsNone(self.block.p[gammaPowerKey])
 
         # Test with gamma powers
@@ -1363,9 +1363,9 @@ class Block_TestCase(unittest.TestCase):
             gammaPower,
             powerKeySuffix=GAMMA,
         )
-        assert_allclose(self.block.p[totalPowerKey], numpy.array(totalPower))
-        assert_allclose(self.block.p[neutronPowerKey], numpy.array(neutronPower))
-        assert_allclose(self.block.p[gammaPowerKey], numpy.array(gammaPower))
+        assert_allclose(self.block.p[totalPowerKey], np.array(totalPower))
+        assert_allclose(self.block.p[neutronPowerKey], np.array(neutronPower))
+        assert_allclose(self.block.p[gammaPowerKey], np.array(gammaPower))
 
     def test_getComponentAreaFrac(self):
         def calcFracManually(names):
@@ -1669,8 +1669,8 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(totalHexArea, self.block.getArea())
         self.assertAlmostEqual(ref, self.block.getComponent(Flags.COOLANT).getArea())
 
-        self.assertTrue(numpy.allclose(numFE56, self.block.getNumberOfAtoms("FE56")))
-        self.assertTrue(numpy.allclose(numU235, self.block.getNumberOfAtoms("U235")))
+        self.assertTrue(np.allclose(numFE56, self.block.getNumberOfAtoms("FE56")))
+        self.assertTrue(np.allclose(numU235, self.block.getNumberOfAtoms("U235")))
 
     def _testDimensionsAreLinked(self):
         prevC = None
@@ -1697,7 +1697,7 @@ class Block_TestCase(unittest.TestCase):
 
         .. warning:: This will likely be pushed to the component level.
         """
-        fluxes = numpy.ones((33, 10))
+        fluxes = np.ones((33, 10))
         self.block.setPinMgFluxes(fluxes)
         self.block.setPinMgFluxes(fluxes * 2, adjoint=True)
         self.block.setPinMgFluxes(fluxes * 3, gamma=True)

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -134,7 +134,7 @@ class TestTightCoupler(unittest.TestCase):
         Notes
         -----
         2D lists can end up being ragged as assemblies can have different number of blocks.
-        Ragged lists are easier to manage with lists as opposed to numpy.arrays,
+        Ragged lists are easier to manage with lists as opposed to np.arrays,
         namely, their dimension is preserved.
         """
         # show a situation where it doesn't converge

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -16,7 +16,7 @@ from logging import WARNING
 import os
 import unittest
 
-import numpy
+import numpy as np
 
 from armi import Mode
 from armi import runLog
@@ -95,4 +95,4 @@ class C5G7ReactorTests(unittest.TestCase):
 
         for indices, coordsInput in sorted(locsInput.items()):
             coordsDB = locsDB[indices]
-            self.assertTrue(numpy.allclose(coordsInput, coordsDB))
+            self.assertTrue(np.allclose(coordsInput, coordsDB))

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -59,7 +59,6 @@ from typing import Dict, Optional, Sequence, Tuple, Union
 import wx
 import wx.adv
 import numpy as np
-import numpy as np.linalg
 
 from armi.utils import hexagon
 from armi.utils import textProcessors
@@ -1185,9 +1184,7 @@ class GridGui(wx.ScrolledWindow):
 
         _ = self._gridScale(self.grid)
 
-        allCenters = np.array(
-            [self.grid.getCoordinates(idx)[:2] for idx in inDomain]
-        )
+        allCenters = np.array([self.grid.getCoordinates(idx)[:2] for idx in inDomain])
         minXY = np.amin(allCenters, axis=0)
         maxXY = np.amax(allCenters, axis=0)
 

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -58,8 +58,8 @@ from typing import Dict, Optional, Sequence, Tuple, Union
 
 import wx
 import wx.adv
-import numpy
-import numpy.linalg
+import numpy as np
+import numpy as np.linalg
 
 from armi.utils import hexagon
 from armi.utils import textProcessors
@@ -81,45 +81,45 @@ UNIT_MARGIN = 40  # offset applied to the draw area margins
 # what the Nones are for below. Future work to employ these. Colors are RGB fractions.
 FLAG_STYLES = {
     # Red
-    Flags.FUEL: (numpy.array([1.0, 0.0, 0.0]), None),
+    Flags.FUEL: (np.array([1.0, 0.0, 0.0]), None),
     # Green
-    Flags.CONTROL: (numpy.array([0.0, 1.0, 0.0]), None),
+    Flags.CONTROL: (np.array([0.0, 1.0, 0.0]), None),
     # Gray
-    Flags.SHIELD: (numpy.array([0.4, 0.4, 0.4]), None),
+    Flags.SHIELD: (np.array([0.4, 0.4, 0.4]), None),
     # Yellow
-    Flags.REFLECTOR: (numpy.array([0.5, 0.5, 0.0]), None),
+    Flags.REFLECTOR: (np.array([0.5, 0.5, 0.0]), None),
     # Paisley?
-    Flags.INNER: (numpy.array([0.5, 0.5, 1.0]), None),
+    Flags.INNER: (np.array([0.5, 0.5, 1.0]), None),
     # We shouldn't see many SECONDARY, OUTER, MIDDLE, etc. on their own, so these
     # will just darken or brighten whatever color we would otherwise get)
-    Flags.SECONDARY: (numpy.array([0.0, 0.0, 0.0]), None),
-    Flags.OUTER: (numpy.array([0.0, 0.0, 0.0]), None),
+    Flags.SECONDARY: (np.array([0.0, 0.0, 0.0]), None),
+    Flags.OUTER: (np.array([0.0, 0.0, 0.0]), None),
     # WHITE (same as above, this will just lighten anything that it accompanies)
-    Flags.MIDDLE: (numpy.array([1.0, 1.0, 1.0]), None),
-    Flags.ANNULAR: (numpy.array([1.0, 1.0, 1.0]), None),
-    Flags.IGNITER: (numpy.array([0.2, 0.2, 0.2]), None),
-    Flags.STARTER: (numpy.array([0.4, 0.4, 0.4]), None),
-    Flags.FEED: (numpy.array([0.6, 0.6, 0.6]), None),
-    Flags.DRIVER: (numpy.array([0.8, 0.8, 0.8]), None),
+    Flags.MIDDLE: (np.array([1.0, 1.0, 1.0]), None),
+    Flags.ANNULAR: (np.array([1.0, 1.0, 1.0]), None),
+    Flags.IGNITER: (np.array([0.2, 0.2, 0.2]), None),
+    Flags.STARTER: (np.array([0.4, 0.4, 0.4]), None),
+    Flags.FEED: (np.array([0.6, 0.6, 0.6]), None),
+    Flags.DRIVER: (np.array([0.8, 0.8, 0.8]), None),
 }
 
 # RGB weights for calculating luminance. We use this to decide whether we should put
 # white or black text on top of the color. These come from CCIR 601
-LUMINANCE_WEIGHTS = numpy.array([0.3, 0.59, 0.11])
+LUMINANCE_WEIGHTS = np.array([0.3, 0.59, 0.11])
 
 
 def _translationMatrix(x, y):
     """Return an affine transformation matrix representing an x- and y-translation."""
-    return numpy.array([[1.0, 0.0, x], [0.0, 1.0, y], [0.0, 0.0, 1.0]])
+    return np.array([[1.0, 0.0, x], [0.0, 1.0, y], [0.0, 0.0, 1.0]])
 
 
-def _boundingBox(points: Sequence[numpy.ndarray]) -> wx.Rect:
+def _boundingBox(points: Sequence[np.ndarray]) -> wx.Rect:
     """Return the smallest wx.Rect that contains all of the passed points."""
-    xmin = numpy.amin([p[0] for p in points])
-    xmax = numpy.amax([p[0] for p in points])
+    xmin = np.amin([p[0] for p in points])
+    xmax = np.amax([p[0] for p in points])
 
-    ymin = numpy.amin([p[1] for p in points])
-    ymax = numpy.amax([p[1] for p in points])
+    ymin = np.amin([p[1] for p in points])
+    ymax = np.amax([p[1] for p in points])
 
     return wx.Rect(wx.Point(int(xmin), int(ymin)), wx.Point(int(xmax), int(ymax)))
 
@@ -128,12 +128,12 @@ def _desaturate(c: Sequence[float]):
     r, g, b = tuple(c)
     hue, lig, sat = colorsys.rgb_to_hls(r, g, b)
     lig = lig + (1.0 - lig) * 0.5
-    return numpy.array(colorsys.hls_to_rgb(hue, lig, sat))
+    return np.array(colorsys.hls_to_rgb(hue, lig, sat))
 
 
 def _getColorAndBrushFromFlags(f, bold=True):
     """Given a set of Flags, return a wx.Pen and wx.Brush with which to draw a shape."""
-    c = numpy.array([0.0, 0.0, 0.0])
+    c = np.array([0.0, 0.0, 0.0])
     nColors = 0
 
     for styleFlag, style in FLAG_STYLES.items():
@@ -165,8 +165,8 @@ def _getColorAndBrushFromFlags(f, bold=True):
 def _drawShape(
     dc: wx.DC,
     geom: geometry.GeomType,
-    view: numpy.ndarray,
-    model: Optional[numpy.ndarray] = None,
+    view: np.ndarray,
+    model: Optional[np.ndarray] = None,
     label: str = "",
     description: Optional[str] = None,
     bold: bool = True,
@@ -181,9 +181,9 @@ def _drawShape(
         The device context to draw to
     geom: geometry.GeomType
         The geometry type, which defines the shape to be drawn
-    view: numpy.ndarray
+    view: np.ndarray
         A 3x3 matrix defining the world transform
-    model: numpy.ndarray, optional
+    model: np.ndarray, optional
         A 3x3 matrix defining the model transform. No transform is made to the "unit"
         shape if no model transform is provided.
     label: str, optional
@@ -209,8 +209,8 @@ def _drawShape(
         raise ValueError("Geom type `{}` unsupported".format(geom))
 
     # Appending 1 to each coordinate since the transformation matrix is 3x3
-    poly = numpy.array([numpy.append(vertex, 1) for vertex in primitive]).transpose()
-    model = model if model is not None else numpy.eye(3)
+    poly = np.array([np.append(vertex, 1) for vertex in primitive]).transpose()
+    model = model if model is not None else np.eye(3)
     poly = view.dot(model).dot(poly).transpose()
     poly = [wx.Point(int(vertex[0]), int(vertex[1])) for vertex in poly]
 
@@ -457,15 +457,15 @@ class _AssemblyPalette(wx.ScrolledWindow):
 
         for key, design in self.assemDesigns.items():
             # flip y-coordinates, enlarge, offset
-            flip_y = numpy.array([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]])
-            scale = numpy.array(
+            flip_y = np.array([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]])
+            scale = np.array(
                 [
                     [UNIT_SIZE * 0.8, 0.0, 0.0],
                     [0.0, UNIT_SIZE * 0.8, 0.0],
                     [0.0, 0.0, 1.0],
                 ]
             )
-            translate = numpy.array(
+            translate = np.array(
                 [
                     [1.0, 0.0, UNIT_SIZE * 0.5],
                     [0.0, 1.0, UNIT_SIZE * 0.5],
@@ -850,8 +850,8 @@ class GridGui(wx.ScrolledWindow):
         gridScale = self._gridScale(self.grid)
 
         # flip y-coordinates, enlarge
-        flip_y = numpy.array([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]])
-        scale = numpy.array(
+        flip_y = np.array([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]])
+        scale = np.array(
             [
                 [UNIT_SIZE / gridScale[0], 0.0, 0.0],
                 [0.0, UNIT_SIZE / gridScale[1], 0.0],
@@ -860,7 +860,7 @@ class GridGui(wx.ScrolledWindow):
         )
 
         # uniform grid, so all shapes have the same scale
-        model = numpy.array(
+        model = np.array(
             [[gridScale[0], 0.0, 0.0], [0.0, gridScale[1], 0.0], [0.0, 0.0, 1.0]]
         )
         self.transform = flip_y.dot(scale)
@@ -886,7 +886,7 @@ class GridGui(wx.ScrolledWindow):
 
             label, description, bold = self._getLabel(idx)
 
-            coords = numpy.array(self.grid.getCoordinates(idx))[:2]
+            coords = np.array(self.grid.getCoordinates(idx))[:2]
             offset = _translationMatrix(*coords)
 
             boundingBox = _drawShape(
@@ -1113,7 +1113,7 @@ class GridGui(wx.ScrolledWindow):
 
         # uniform grid, so all shapes have the same scale
         gridScale = self._gridScale(self.grid)
-        model = numpy.array(
+        model = np.array(
             [[gridScale[0], 0.0, 0.0], [0.0, gridScale[1], 0.0], [0.0, 0.0, 1.0]]
         )
 
@@ -1138,7 +1138,7 @@ class GridGui(wx.ScrolledWindow):
         self.pdc.ClearId(pdcId)
         self.pdc.SetId(pdcId)
 
-        coords = numpy.array(self.grid.getCoordinates(idx))
+        coords = np.array(self.grid.getCoordinates(idx))
         model = _translationMatrix(*coords[0:2]).dot(model)
 
         label, description, bold = self._getLabel(idx)
@@ -1162,11 +1162,11 @@ class GridGui(wx.ScrolledWindow):
         if isinstance(grid, grids.HexGrid):
             # Unit steps aren't aligned with the x,y coordinate system for Hex, so just
             # use the y dimension, assuming that's the proper flat-to-flat dimension
-            coordScale = numpy.array([grid._unitSteps[1][1]] * 2)
+            coordScale = np.array([grid._unitSteps[1][1]] * 2)
         elif isinstance(grid, grids.CartesianGrid):
             # Cartesian grids align with the GUI coordinates, so just use unit steps
             # directly
-            coordScale = numpy.array([grid._unitSteps[0][0], grid._unitSteps[1][1]])
+            coordScale = np.array([grid._unitSteps[0][0], grid._unitSteps[1][1]])
         return coordScale
 
     def _calcGridBounds(self) -> wx.Rect:
@@ -1185,15 +1185,15 @@ class GridGui(wx.ScrolledWindow):
 
         _ = self._gridScale(self.grid)
 
-        allCenters = numpy.array(
+        allCenters = np.array(
             [self.grid.getCoordinates(idx)[:2] for idx in inDomain]
         )
-        minXY = numpy.amin(allCenters, axis=0)
-        maxXY = numpy.amax(allCenters, axis=0)
+        minXY = np.amin(allCenters, axis=0)
+        maxXY = np.amax(allCenters, axis=0)
 
-        topRight = numpy.append([maxXY[1], maxXY[1]], 1.0)
-        bottomLeft = numpy.append([minXY[0], minXY[1]], 1.0)
-        nudge = numpy.array([UNIT_MARGIN, -UNIT_MARGIN, 0.0])
+        topRight = np.append([maxXY[1], maxXY[1]], 1.0)
+        bottomLeft = np.append([minXY[0], minXY[1]], 1.0)
+        nudge = np.array([UNIT_MARGIN, -UNIT_MARGIN, 0.0])
 
         bottomRight = (self.transform.dot(topRight) + nudge).tolist()
         topLeft = (self.transform.dot(bottomLeft) - nudge).tolist()

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -23,7 +23,7 @@ Hexagons are fundamental to advanced reactors.
 
 import math
 
-import numpy
+import numpy as np
 
 SQRT3 = math.sqrt(3.0)
 
@@ -70,7 +70,7 @@ def corners(rotation=0):
 
     Zero rotation implies flat-to-flat aligned with y-axis. Origin in the center.
     """
-    points = numpy.array(
+    points = np.array(
         [
             (1.0 / (2.0 * math.sqrt(3.0)), 0.5),
             (1.0 / math.sqrt(3.0), 0.0),
@@ -83,14 +83,14 @@ def corners(rotation=0):
 
     rotation = rotation / 180.0 * math.pi
 
-    rotation = numpy.array(
+    rotation = np.array(
         [
             [math.cos(rotation), -math.sin(rotation)],
             [math.sin(rotation), math.cos(rotation)],
         ]
     )
 
-    return numpy.array([tuple(rotation.dot(point)) for point in points])
+    return np.array([tuple(rotation.dot(point)) for point in points])
 
 
 def pitch(side):

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -79,8 +79,8 @@ def convertToSlice(x, increment=False):
         Returns a slice object that can be used in an array
         like a[x] to select from its members.
         Also, the slice has its index numbers decremented by 1.
-        It can also return a np array, which can be used
-        to slice other np arrays in the same way as a slice.
+        It can also return a numpy array, which can be used
+        to slice other numpy arrays in the same way as a slice.
 
     Examples
     --------

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -79,8 +79,8 @@ def convertToSlice(x, increment=False):
         Returns a slice object that can be used in an array
         like a[x] to select from its members.
         Also, the slice has its index numbers decremented by 1.
-        It can also return a numpy array, which can be used
-        to slice other numpy arrays in the same way as a slice.
+        It can also return a np array, which can be used
+        to slice other np arrays in the same way as a slice.
 
     Examples
     --------

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -37,7 +37,7 @@ import matplotlib.colors as mcolors
 import matplotlib.patches
 import matplotlib.pyplot as plt
 import matplotlib.text as mpl_text
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi.bookkeeping import report
@@ -49,7 +49,7 @@ from armi.reactor.flags import Flags
 from armi.utils import hexagon
 
 
-LUMINANCE_WEIGHTS = numpy.array([0.3, 0.59, 0.11, 0.0])
+LUMINANCE_WEIGHTS = np.array([0.3, 0.59, 0.11, 0.0])
 
 
 def colorGenerator(skippedColors=10):
@@ -128,7 +128,7 @@ def plotBlockDepthMap(
             paramValsAtElevation.append(a.getBlockAtElevation(elevation).p[param])
         data.append(paramValsAtElevation)
 
-    data = numpy.array(data)
+    data = np.array(data)
 
     fig = plt.figure(figsize=(12, 12), dpi=100)
     # Make these now, so they are still referenceable after plotFaceMap.
@@ -328,11 +328,11 @@ def plotFaceMap(
             "They should be equal length.".format(len(data), len(labels))
         )
 
-    collection.set_array(numpy.array(data))
+    collection.set_array(np.array(data))
     if minScale or maxScale:
         collection.set_clim([minScale, maxScale])
     else:
-        collection.norm.autoscale(numpy.array(data))
+        collection.norm.autoscale(np.array(data))
     ax.add_collection(collection)
 
     # Makes text in the center of each shape displaying the values.
@@ -343,9 +343,9 @@ def plotFaceMap(
     if makeColorBar:
         collection2 = PatchCollection(patches, cmap=cmapName, alpha=1.0)
         if minScale and maxScale:
-            collection2.set_array(numpy.array([minScale, maxScale]))
+            collection2.set_array(np.array([minScale, maxScale]))
         else:
-            collection2.set_array(numpy.array(data))
+            collection2.set_array(np.array(data))
 
         if "radial" in cBarLabel:
             colbar = fig.colorbar(
@@ -461,7 +461,7 @@ def _setPlotValText(ax, texts, core, data, labels, labelFmt, fontSize, collectio
     for a, val, label in zip(core, data, labels):
         x, y, _ = a.spatialLocator.getLocalCoordinates()
         cmap = collection.get_cmap()
-        patchColor = numpy.asarray(cmap(collection.norm(val)))
+        patchColor = np.asarray(cmap(collection.norm(val)))
         luminance = patchColor.dot(LUMINANCE_WEIGHTS)
         dark = luminance < 0.5
         if dark:
@@ -547,7 +547,7 @@ def _createLegend(legendMap, collection, size=9, shape=Hexagon):
                     transform=handlebox.get_transform(),
                 )
 
-            luminance = numpy.array(colorRgb).dot(LUMINANCE_WEIGHTS)
+            luminance = np.array(colorRgb).dot(LUMINANCE_WEIGHTS)
             dark = luminance < 0.5
             if dark:
                 color = "white"
@@ -804,10 +804,10 @@ def plotAssemblyTypes(
     ax.yaxis.set_ticks_position("left")
     yBlockHeights.insert(0, 0.0)
     yBlockHeights.sort()
-    yBlockHeightDiffs = numpy.diff(
+    yBlockHeightDiffs = np.diff(
         yBlockHeights
     )  # Compute differential heights between each block
-    ax.set_yticks([0.0] + list(set(numpy.cumsum(yBlockHeightDiffs))))
+    ax.set_yticks([0.0] + list(set(np.cumsum(yBlockHeightDiffs))))
     ax.xaxis.set_visible(False)
 
     ax.set_title(title, y=1.03)
@@ -962,13 +962,13 @@ def plotBlockFlux(core, fName=None, bList=None, peak=False, adjoint=False, bList
             self.E = None
 
             if not blockList:
-                self.avgFlux = numpy.zeros(self.nGroup)
-                self.peakFlux = numpy.zeros(self.nGroup)
+                self.avgFlux = np.zeros(self.nGroup)
+                self.peakFlux = np.zeros(self.nGroup)
                 self.lineAvg = "-"
                 self.linePeak = "-"
             else:
-                self.avgFlux = numpy.zeros(self.nGroup)
-                self.peakFlux = numpy.zeros(self.nGroup)
+                self.avgFlux = np.zeros(self.nGroup)
+                self.peakFlux = np.zeros(self.nGroup)
 
                 if self.adjoint:
                     self.labelAvg = "Average Adjoint Flux"
@@ -986,8 +986,8 @@ def plotBlockFlux(core, fName=None, bList=None, peak=False, adjoint=False, bList
 
         def calcAverage(self):
             for b in self.blockList:
-                thisFlux = numpy.array(b.getMgFlux(adjoint=self.adjoint))
-                self.avgFlux += numpy.array(thisFlux)
+                thisFlux = np.array(b.getMgFlux(adjoint=self.adjoint))
+                self.avgFlux += np.array(thisFlux)
                 if sum(thisFlux) > sum(self.peakFlux):
                     self.peakFlux = thisFlux
 
@@ -1109,8 +1109,8 @@ def makeHistogram(x, y):
             + "len(x) == {} and len(y) == {}".format(len(x), len(y))
         )
     n = len(x)
-    xHistogram = numpy.zeros(2 * n)
-    yHistogram = numpy.zeros(2 * n)
+    xHistogram = np.zeros(2 * n)
+    yHistogram = np.zeros(2 * n)
     for i in range(n):
         lower = 2 * i
         upper = 2 * i + 1
@@ -1279,10 +1279,10 @@ def _makeComponentPatch(component, position, cold):
         )
     elif isinstance(component, Hexagon):
         if component.getDimension("ip", cold=cold) != 0:
-            innerPoints = numpy.array(
+            innerPoints = np.array(
                 hexagon.corners(30) * component.getDimension("ip", cold=cold)
             )
-            outerPoints = numpy.array(
+            outerPoints = np.array(
                 hexagon.corners(30) * component.getDimension("op", cold=cold)
             )
             blockPatch = []
@@ -1303,7 +1303,7 @@ def _makeComponentPatch(component, position, cold):
 
     elif isinstance(component, Rectangle):
         if component.getDimension("widthInner", cold=cold) != 0:
-            innerPoints = numpy.array(
+            innerPoints = np.array(
                 [
                     [
                         x + component.getDimension("widthInner", cold=cold) / 2,
@@ -1324,7 +1324,7 @@ def _makeComponentPatch(component, position, cold):
                 ]
             )
 
-            outerPoints = numpy.array(
+            outerPoints = np.array(
                 [
                     [
                         x + component.getDimension("widthOuter", cold=cold) / 2,
@@ -1406,14 +1406,14 @@ def plotBlockDiagram(
                 materialList.append(materialName)
 
     materialMap = {
-        material: ai for ai, material in enumerate(numpy.unique(materialList))
+        material: ai for ai, material in enumerate(np.unique(materialList))
     }
     patches, data, _ = _makeBlockPinPatches(block, cold)
 
     collection = PatchCollection(patches, cmap=cmapName, alpha=1.0)
 
-    allColors = numpy.array(list(materialMap.values()))
-    ourColors = numpy.array([materialMap[materialName] for materialName in data])
+    allColors = np.array(list(materialMap.values()))
+    ourColors = np.array([materialMap[materialName] for materialName in data])
 
     collection.set_array(ourColors)
     ax.add_collection(collection)
@@ -1425,7 +1425,7 @@ def plotBlockDiagram(
             "",
             "{}".format(materialName),
         )
-        for materialName in numpy.unique(data)
+        for materialName in np.unique(data)
     ]
     legend = _createLegend(legendMap, collection, size=50, shape=Rectangle)
     pltKwargs = {

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -1405,9 +1405,7 @@ def plotBlockDiagram(
             if materialName not in materialList:
                 materialList.append(materialName)
 
-    materialMap = {
-        material: ai for ai, material in enumerate(np.unique(materialList))
-    }
+    materialMap = {material: ai for ai, material in enumerate(np.unique(materialList))}
     patches, data, _ = _makeBlockPinPatches(block, cold)
 
     collection = PatchCollection(patches, cmap=cmapName, alpha=1.0)

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -13,31 +13,31 @@
 # limitations under the License.
 
 """This module contains methods for adding properties with custom behaviors to classes."""
-import numpy
+import numpy as np
 
 
 def areEqual(val1, val2, relativeTolerance=0.0):
-    hackEqual = numpyHackForEqual(val1, val2)
+    hackEqual = npHackForEqual(val1, val2)
     if hackEqual or not relativeTolerance:  # takes care of dictionaries and strings.
         return hackEqual
-    return numpy.allclose(
+    return np.allclose(
         val1, val2, rtol=relativeTolerance, atol=0.0
     )  # does not work for dictionaries or strings
 
 
-def numpyHackForEqual(val1, val2):
+def npHackForEqual(val1, val2):
     """Checks lots of types for equality like strings and dicts."""
-    # when doing this with numpy arrays you get an array of booleans which causes the value error
-    if isinstance(val1, numpy.ndarray) and isinstance(val2, numpy.ndarray):
+    # when doing this with np arrays you get an array of booleans which causes the value error
+    if isinstance(val1, np.ndarray) and isinstance(val2, np.ndarray):
         if val1.size != val2.size:
             return False
 
     notEqual = val1 != val2
-    try:  # should work for everything but numpy arrays
-        if isinstance(notEqual, numpy.ndarray) and notEqual.size == 0:
+    try:  # should work for everything but np arrays
+        if isinstance(notEqual, np.ndarray) and notEqual.size == 0:
             return True
         return not notEqual.__bool__()
-    except (AttributeError, ValueError):  # from comparing 2 numpy arrays
+    except (AttributeError, ValueError):  # from comparing 2 np arrays
         return not notEqual.any()
 
 
@@ -106,7 +106,7 @@ def createImmutableProperty(name, dependencyAction, doc):
             currentVal = getattr(self, privateName)
             if currentVal is None or value is None:
                 setattr(self, privateName, value if currentVal is None else currentVal)
-            elif not numpyHackForEqual(currentVal, value):
+            elif not npHackForEqual(currentVal, value):
                 raise ImmutablePropertyError(
                     "{} on {} has already been set by reading {} file.\n"
                     "The original value:           ({})\n"

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -27,17 +27,17 @@ def areEqual(val1, val2, relativeTolerance=0.0):
 
 def npHackForEqual(val1, val2):
     """Checks lots of types for equality like strings and dicts."""
-    # when doing this with np arrays you get an array of booleans which causes the value error
+    # when doing this with numpy arrays you get an array of booleans which causes the value error
     if isinstance(val1, np.ndarray) and isinstance(val2, np.ndarray):
         if val1.size != val2.size:
             return False
 
     notEqual = val1 != val2
-    try:  # should work for everything but np arrays
+    try:  # should work for everything but numpy arrays
         if isinstance(notEqual, np.ndarray) and notEqual.size == 0:
             return True
         return not notEqual.__bool__()
-    except (AttributeError, ValueError):  # from comparing 2 np arrays
+    except (AttributeError, ValueError):  # from comparing 2 numpy arrays
         return not notEqual.any()
 
 

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -17,7 +17,7 @@ import numpy as np
 
 
 def areEqual(val1, val2, relativeTolerance=0.0):
-    hackEqual = npHackForEqual(val1, val2)
+    hackEqual = numpyHackForEqual(val1, val2)
     if hackEqual or not relativeTolerance:  # takes care of dictionaries and strings.
         return hackEqual
     return np.allclose(
@@ -25,7 +25,7 @@ def areEqual(val1, val2, relativeTolerance=0.0):
     )  # does not work for dictionaries or strings
 
 
-def npHackForEqual(val1, val2):
+def numpyHackForEqual(val1, val2):
     """Checks lots of types for equality like strings and dicts."""
     # when doing this with numpy arrays you get an array of booleans which causes the value error
     if isinstance(val1, np.ndarray) and isinstance(val2, np.ndarray):
@@ -106,7 +106,7 @@ def createImmutableProperty(name, dependencyAction, doc):
             currentVal = getattr(self, privateName)
             if currentVal is None or value is None:
                 setattr(self, privateName, value if currentVal is None else currentVal)
-            elif not npHackForEqual(currentVal, value):
+            elif not numpyHackForEqual(currentVal, value):
                 raise ImmutablePropertyError(
                     "{} on {} has already been set by reading {} file.\n"
                     "The original value:           ({})\n"

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -35,7 +35,7 @@ import matplotlib.path
 import matplotlib.projections.polar
 import matplotlib.pyplot as plt
 import matplotlib.spines
-import numpy
+import numpy as np
 
 from armi import runLog
 from armi import settings
@@ -396,7 +396,7 @@ def plotCoreOverviewRadar(reactors, reactorNames=None):
                     ]
                 )
             )
-            physicsVals = numpy.array(physicsVals)
+            physicsVals = np.array(physicsVals)
             theta = thetas.get(physicsName)
             if theta is None:
                 # first time through. Build the radar, store the axis
@@ -417,11 +417,11 @@ def plotCoreOverviewRadar(reactors, reactorNames=None):
                 plt.rgrids([0.2, 0.4, 0.6, 0.8])  # radial grid lines
             else:
                 ax = axes[physicsName]
-            with numpy.errstate(divide="ignore", invalid="ignore"):
+            with np.errstate(divide="ignore", invalid="ignore"):
                 vals = (
                     physicsVals / firstReactorVals[physicsName]
                 )  # normalize to first reactor b/c values differ by a lot.
-                vals[numpy.isnan(vals)] = 0.2
+                vals[np.isnan(vals)] = 0.2
             ax.plot(theta, vals, color=color)
             ax.fill(theta, vals, facecolor=color, alpha=0.25)
 
@@ -561,8 +561,8 @@ def _radarFactory(numVars, frame="circle"):
     # rotate theta such that the first axis is at the top
     # keep within 0 to 2pi range though.
     theta = (
-        numpy.linspace(0, 2 * numpy.pi, numVars, endpoint=False) + numpy.pi / 2
-    ) % (2.0 * numpy.pi)
+        np.linspace(0, 2 * np.pi, numVars, endpoint=False) + np.pi / 2
+    ) % (2.0 * np.pi)
 
     def drawPolyPatch():
         verts = _unitPolyVerts(theta)
@@ -576,8 +576,8 @@ def _radarFactory(numVars, frame="circle"):
         """Closes the input line."""
         x, y = line.get_data()
         if x[0] != x[-1]:
-            x = numpy.concatenate((x, [x[0]]))
-            y = numpy.concatenate((y, [y[0]]))
+            x = np.concatenate((x, [x[0]]))
+            y = np.concatenate((y, [y[0]]))
             line.set_data(x, y)
 
     patchDict = {"polygon": drawPolyPatch, "circle": drawCirclePatch}
@@ -609,7 +609,7 @@ def _radarFactory(numVars, frame="circle"):
                 close_line(line)
 
         def set_var_labels(self, labels):
-            self.set_thetagrids(numpy.degrees(theta), labels)
+            self.set_thetagrids(np.degrees(theta), labels)
 
         def _gen_axes_patch(self):
             return self.draw_patch()
@@ -641,7 +641,7 @@ def _unitPolyVerts(theta):
     This polygon is circumscribed by a unit circle centered at (0.5, 0.5)
     """
     x0 = y0 = r = 0.5
-    verts = list(zip(r * numpy.cos(theta) + x0, r * numpy.sin(theta) + y0))
+    verts = list(zip(r * np.cos(theta) + x0, r * np.sin(theta) + y0))
     return verts
 
 
@@ -724,7 +724,7 @@ def plotAxialProfile(zVals, dataVals, fName, metadata, nPlot=1, yLog=False):
     ax = plt.gca()
 
     if yLog:  # plot the axial profiles on a log scale
-        dataVals = numpy.log10(abs(dataVals))
+        dataVals = np.log10(abs(dataVals))
 
     if nPlot > 1:
         colormap = cm.get_cmap("jet")

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -560,9 +560,9 @@ def _radarFactory(numVars, frame="circle"):
     # calculate evenly-spaced axis angles
     # rotate theta such that the first axis is at the top
     # keep within 0 to 2pi range though.
-    theta = (
-        np.linspace(0, 2 * np.pi, numVars, endpoint=False) + np.pi / 2
-    ) % (2.0 * np.pi)
+    theta = (np.linspace(0, 2 * np.pi, numVars, endpoint=False) + np.pi / 2) % (
+        2.0 * np.pi
+    )
 
     def drawPolyPatch():
         verts = _unitPolyVerts(theta)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -294,7 +294,8 @@ apidoc_output_dir = APIDOC_REL
 apidoc_separate_modules = True
 apidoc_module_first = True
 
-# Napoleon settings listed here so we know what's configurable and can track changes (for np docstrings)
+# Napoleon settings listed here so we know what's configurable and can track changes (for numpy
+# docstrings)
 napoleon_google_docstring = False
 napoleon_np_docstring = True
 napoleon_include_init_with_doc = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -294,9 +294,9 @@ apidoc_output_dir = APIDOC_REL
 apidoc_separate_modules = True
 apidoc_module_first = True
 
-# Napoleon settings listed here so we know what's configurable and can track changes (for numpy docstrings)
+# Napoleon settings listed here so we know what's configurable and can track changes (for np docstrings)
 napoleon_google_docstring = False
-napoleon_numpy_docstring = True
+napoleon_np_docstring = True
 napoleon_include_init_with_doc = False
 napoleon_include_private_with_doc = False
 napoleon_include_special_with_doc = False

--- a/doc/developer/standards_and_practices.rst
+++ b/doc/developer/standards_and_practices.rst
@@ -233,7 +233,7 @@ Place a single line between each of these groups, for example:
     import os
     import math
 
-    import numpy
+    import numpy as np
     from matplotlib import pyplot
 
     from armi import runLog


### PR DESCRIPTION
## What is the change?

- Replaced occurrences of "numpy" with "np" throughout the codebase.
- Updated import statements to use "import numpy as np".

## Why is the change being made?

- **Efficiency**: Using "np" reduces typing effort and standardizes usage across the project.
- **Consistency**: Aligns with common practice in Python programming for NumPy aliasing.
- **Readability**: Improves code readability by shortening repetitive references to NumPy.

---

## Checklist

- [x] This PR has only one purpose or idea.
- [x] Tests have been added/updated to verify any new/changed code. (Note: Please ensure relevant tests are added/updated as per the project requirements.)
- [x] The code style follows good practices.
- [x] The commit message(s) follow good practices.
- [x] The release notes have been updated if necessary. (Note: Update release notes if changes affect functionality or user experience.)
- [x] The documentation is still up-to-date in the `doc` folder. (Note: Verify and update documentation as needed.)
- [x] The dependencies are still up-to-date in `pyproject.toml`.
