### PR TITLE
Make new jaggedArray backwards compatible

### DIFF
--- a/armi/bookkeeping/db/jaggedArray.py
+++ b/armi/bookkeeping/db/jaggedArray.py
@@ -173,7 +173,7 @@ class JaggedArray:
             List of numpy arrays with varying dimensions (i.e., jagged arrays)
         """
         unpackedJaggedData: List[Optional[np.ndarray]] = []
-        shapeIndices = [i for i, x in enumerate(self.shapes) if not sum(x) == 0]
+        shapeIndices = [i for i, x in enumerate(self.shapes) if sum(x) != 0]
         numElements = len(shapeIndices) + len(self.nones)
         j = 0  # non-None element counter
         for i in range(numElements):

--- a/armi/bookkeeping/db/jaggedArray.py
+++ b/armi/bookkeeping/db/jaggedArray.py
@@ -173,17 +173,19 @@ class JaggedArray:
             List of numpy arrays with varying dimensions (i.e., jagged arrays)
         """
         unpackedJaggedData: List[Optional[np.ndarray]] = []
-        numElements = len(self.offsets) + len(self.nones)
+        shapeIndices = [i for i, x in enumerate(self.shapes) if not sum(x) == 0]
+        numElements = len(shapeIndices) + len(self.nones)
         j = 0  # non-None element counter
         for i in range(numElements):
             if i in self.nones:
                 unpackedJaggedData.append(None)
             else:
+                k = shapeIndices[j]
                 unpackedJaggedData.append(
                     np.ndarray(
-                        self.shapes[j],
+                        self.shapes[k],
                         dtype=self.dtype,
-                        buffer=self.flattenedArray[self.offsets[j] :],
+                        buffer=self.flattenedArray[self.offsets[k] :],
                     )
                 )
                 j += 1

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -14,7 +14,7 @@ New Features
 #. Reset ``Reactor`` data on worker processors after every interaction to free memory from state distribution.
    (`PR#1729 <https://github.com/terrapower/armi/pull/1729>`_ and `PR#1750 <https://github.com/terrapower/armi/pull/1750>`_)
 #. Density can be specified for components via ``custom isotopics`` in the blueprints. (`PR#1745 <https://github.com/terrapower/armi/pull/1745>`_)
-#. Implement a new `JaggedArray` class that handles HDF5 interface for jagged data. (`PR#1726 <https://github.com/terrapower/armi/pull/1726>`_)
+#. Implement a new `JaggedArray` class that handles HDF5 interface for jagged data. (`PR#1726 <https://github.com/terrapower/armi/pull/1726>`_, `PR#1778 <https://github.com/terrapower/armi/pull/1778>`_)
 #. TBD
 
 API Changes

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -14,7 +14,7 @@ New Features
 #. Reset ``Reactor`` data on worker processors after every interaction to free memory from state distribution.
    (`PR#1729 <https://github.com/terrapower/armi/pull/1729>`_ and `PR#1750 <https://github.com/terrapower/armi/pull/1750>`_)
 #. Density can be specified for components via ``custom isotopics`` in the blueprints. (`PR#1745 <https://github.com/terrapower/armi/pull/1745>`_)
-#. Implement a new `JaggedArray` class that handles HDF5 interface for jagged data. (`PR#1726 <https://github.com/terrapower/armi/pull/1726>`_, `PR#1778 <https://github.com/terrapower/armi/pull/1778>`_)
+#. Implement a new `JaggedArray` class that handles HDF5 interface for jagged data. (`PR#1726 <https://github.com/terrapower/armi/pull/1726>`_)
 #. TBD
 
 API Changes


### PR DESCRIPTION
## What is the change?

The recent new jagged array implementation broke backwards compatibility with old databases. Upon closer inspection, the two formats for storing the jagged array are pretty closely related, and it is possible to preserve backwards compatibility with just a little bit of extra work in the `unpack` routine.

## Why is the change being made?

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

This change is being made to maintain backwards compatibility with ARMI databases created before PR #1726 was merged. This will be extremely valuable to users, who will be able to load from old databases without having to revert to an older version of their app.


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.