### PR TITLE
Moving rxSwing core parameter to final time node

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -122,7 +122,7 @@ class GlobalFluxInterface(interfaces.Interface):
             eocKeff = self.r.core.p.keffUnc or self.r.core.p.keff
             swing = (eocKeff - self._bocKeff) / (eocKeff * self._bocKeff)
             self.r.core.p.rxSwing = swing * units.ABS_REACTIVITY_TO_PCM
-            runLog.important(
+            runLog.info(
                 f"BOC Uncontrolled keff: {self._bocKeff},  "
                 f"EOC Uncontrolled keff: {self.r.core.p.keffUnc}, "
                 f"Cycle Reactivity Swing: {self.r.core.p.rxSwing} pcm"

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -112,7 +112,7 @@ class GlobalFluxInterface(interfaces.Interface):
     def _setRxSwingRelatedParams(self):
         """Set Params Related to Rx Swing"""
         if self.r.p.timeNode == 0:
-            self._bocKeff = self.r.core.p.keff  # track boc keff for rxSwing param.
+            self._bocKeff = self.r.core.p.keffUnc  # track boc uncontrolled keff for rxSwing param.
 
         # A 1 burnstep cycle would have 2 nodes, and the last node would be node index 1 (first is zero)
         lastNodeInCycle = getBurnSteps(self.cs)[self.r.p.cycle]
@@ -123,7 +123,7 @@ class GlobalFluxInterface(interfaces.Interface):
             self.r.core.p.rxSwing = swing * units.ABS_REACTIVITY_TO_PCM
             runLog.important(
                 f"BOC Uncontrolled keff: {self._bocKeff},  "
-                f"EOC Uncontrolled keff: {self.r.core.p.keff}, "
+                f"EOC Uncontrolled keff: {self.r.core.p.keffUnc}, "
                 f"Cycle Reactivity Swing: {self.r.core.p.rxSwing} pcm"
             )
 

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -110,7 +110,7 @@ class GlobalFluxInterface(interfaces.Interface):
         self._setRxSwingRelatedParams()
 
     def _setRxSwingRelatedParams(self):
-        """Set Params Related to Rx Swing"""
+        """Set Params Related to Rx Swing."""
         if self.r.p.timeNode == 0:
             # track boc uncontrolled keff for rxSwing param.
             self._bocKeff = self.r.core.p.keffUnc or self.r.core.p.keff

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -112,14 +112,15 @@ class GlobalFluxInterface(interfaces.Interface):
     def _setRxSwingRelatedParams(self):
         """Set Params Related to Rx Swing"""
         if self.r.p.timeNode == 0:
-            self._bocKeff = self.r.core.p.keffUnc  # track boc uncontrolled keff for rxSwing param.
+            # track boc uncontrolled keff for rxSwing param.
+            self._bocKeff = self.r.core.p.keffUnc or self.r.core.p.keff
 
         # A 1 burnstep cycle would have 2 nodes, and the last node would be node index 1 (first is zero)
         lastNodeInCycle = getBurnSteps(self.cs)[self.r.p.cycle]
         if self.r.p.timeNode == lastNodeInCycle and self._bocKeff is not None:
-            swing = (self.r.core.p.keff - self._bocKeff) / (
-                self.r.core.p.keff * self._bocKeff
-            )
+
+            eocKeff = self.r.core.p.keffUnc or self.r.core.p.keff
+            swing = (eocKeff - self._bocKeff) / (eocKeff * self._bocKeff)
             self.r.core.p.rxSwing = swing * units.ABS_REACTIVITY_TO_PCM
             runLog.important(
                 f"BOC Uncontrolled keff: {self._bocKeff},  "


### PR DESCRIPTION
## What is the change?

After PR #1090, we don't write data calculated during EOC to database. RX swing is the main parameter to suffer as a consequence, so this PR moves its calculation to the last node rather than the EOC interaction.

Also adds a minor `runlog` statement, and bumped the example app submodule.

## Why is the change being made?

So that rx swing is stored in the database (it is zeroed out in interact BOL since its last cycle.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.