### PR TITLE
Fix interactive versus batch mode check

### DIFF
--- a/armi/context.py
+++ b/armi/context.py
@@ -95,8 +95,10 @@ START_TIME = time.ctime()
 
 # Set batch mode if not a TTY, which means you're on a cluster writing to a stdout file
 # In this mode you cannot respond to prompts or anything
-# stdout gave True on a linux cluster but stdin works
-CURRENT_MODE = Mode.INTERACTIVE if sys.stdin.isatty() else Mode.BATCH
+# This does not work replabliy for both windows and linux so an os-specific solution is
+# applied
+isatty = sys.stdout.isatty() if "win" in sys.platform else sys.stdin.isatty()
+CURRENT_MODE = Mode.INTERACTIVE if isatty else Mode.BATCH
 Mode.setMode(CURRENT_MODE)
 
 MPI_COMM = None

--- a/armi/context.py
+++ b/armi/context.py
@@ -95,7 +95,8 @@ START_TIME = time.ctime()
 
 # Set batch mode if not a TTY, which means you're on a cluster writing to a stdout file
 # In this mode you cannot respond to prompts or anything
-CURRENT_MODE = Mode.INTERACTIVE if sys.stdout.isatty() else Mode.BATCH
+# stdout gave True on a linux cluster but stdin works
+CURRENT_MODE = Mode.INTERACTIVE if sys.stdin.isatty() else Mode.BATCH
 Mode.setMode(CURRENT_MODE)
 
 MPI_COMM = None
@@ -125,10 +126,6 @@ try:
     MPI_SIZE = MPI_COMM.Get_size()
     MPI_NODENAME = MPI.Get_processor_name()
     MPI_NODENAMES = MPI_COMM.allgather(MPI_NODENAME)
-
-    # fix an exceptional error case when we are not in "interactive mode"
-    if MPI_SIZE > 1 and CURRENT_MODE == Mode.INTERACTIVE:
-        CURRENT_MODE = Mode.BATCH
 except ImportError:
     # stick with defaults
     pass

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -62,6 +62,7 @@ Bug Fixes
 #. Fixed ``safeCopy`` to work on both Windows and Linux with strict permissions (`PR#1691 <https://github.com/terrapower/armi/pull/1691>`_)
 #. When creating a new XS group, inherit settings from initial group. (`PR#1653 <https://github.com/terrapower/armi/pull/1653>`_, `PR#1751 <https://github.com/terrapower/armi/pull/1751>`_)
 #. Fixed a bug with ``Core.getReactionRates``. (`PR#1771 <https://github.com/terrapower/armi/pull/1771>`_)
+#. Fixed a bug with interactive versus batch mode checking on windows versus linux. (`PR#1786 <https://github.com/terrapower/armi/pull/1786>`_)
 #. TBD
 
 Quality Work


### PR DESCRIPTION
## What is the change?

For determining if the current mode is batch or interactive, there is an `isatty()` check performed. This check worked properly on windows, but for some reason not on a linux cluster. It appears `stdout` works for windows and `stdin` works for linux but not vice versa. So I added an os-specific check.

## Why is the change being made?

The hack that was made didn't work for cases with 1 task. This update works on both clusters, and removes a little hack we had put in place.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.