### PR TITLE
Minor docstring fix in database3

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -1523,7 +1523,6 @@ def packSpecialData(
     composites that are storing the parameters. For instance, if we are dealing with a
     Block parameter, the first index in the numpy array of data is the block index; so
     if each block has a parameter that is a dictionary, ``data`` would be a ndarray,
-                    offset += arr.size
     where each element is a dictionary. This routine supports a number of different
     "strange" things:
 


### PR DESCRIPTION
## What is the change?

Removing an erroneously included line in docstring that is causing these warnings:

```
docstring of armi.bookkeeping.db.database3.packSpecialData:13: ERROR: Unexpected indentation.
docstring of armi.bookkeeping.db.database3:11: WARNING: Block quote ends without a blank line; unexpected unindent.
```

## Why is the change being made?

Same reasoning as #1769.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.