### PR TITLE
Fix MultipleComponentMerger with DerivedShape solvent

### DIFF
--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -311,7 +311,7 @@ class MultipleComponentMerger(BlockConverter):
                 soluteName, self.solventName, minID=self.specifiedMinID
             )
         solvent = self._sourceBlock.getComponentByName(self.solventName)
-        if not solvent.__class__ is components.DerivedShape:
+        if solvent.__class__ is not components.DerivedShape:
             BlockConverter._verifyExpansion(self, self.soluteNames, solvent)
         return self._sourceBlock
 

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -311,7 +311,8 @@ class MultipleComponentMerger(BlockConverter):
                 soluteName, self.solventName, minID=self.specifiedMinID
             )
         solvent = self._sourceBlock.getComponentByName(self.solventName)
-        BlockConverter._verifyExpansion(self, self.soluteNames, solvent)
+        if not solvent.__class__ is components.DerivedShape:
+            BlockConverter._verifyExpansion(self, self.soluteNames, solvent)
         return self._sourceBlock
 
 

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -81,6 +81,18 @@ class TestBlockConverter(unittest.TestCase):
         self.assertNotIn(soluteName, convertedBlock.getComponentNames())
         self._checkAreaAndComposition(block, convertedBlock)
 
+    def test_dissolveMultiple(self):
+        """Test dissolving multiple components into another."""
+        self._test_dissolve_multi(loadTestBlock(), ["wire", "clad"], "coolant")
+        self._test_dissolve_multi(loadTestBlock(), ["inner liner", "outer liner"], "clad")
+
+    def _test_dissolve_multi(self, block, soluteNames, solventName):
+        converter = blockConverters.MultipleComponentMerger(block, soluteNames, solventName)
+        convertedBlock = converter.convert()
+        for soluteName in soluteNames:
+            self.assertNotIn(soluteName, convertedBlock.getComponentNames())
+        self._checkAreaAndComposition(block, convertedBlock)
+
     def test_build_NthRing(self):
         """Test building of one ring."""
         RING = 6

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -84,10 +84,14 @@ class TestBlockConverter(unittest.TestCase):
     def test_dissolveMultiple(self):
         """Test dissolving multiple components into another."""
         self._test_dissolve_multi(loadTestBlock(), ["wire", "clad"], "coolant")
-        self._test_dissolve_multi(loadTestBlock(), ["inner liner", "outer liner"], "clad")
+        self._test_dissolve_multi(
+            loadTestBlock(), ["inner liner", "outer liner"], "clad"
+        )
 
     def _test_dissolve_multi(self, block, soluteNames, solventName):
-        converter = blockConverters.MultipleComponentMerger(block, soluteNames, solventName)
+        converter = blockConverters.MultipleComponentMerger(
+            block, soluteNames, solventName
+        )
         convertedBlock = converter.convert()
         for soluteName in soluteNames:
             self.assertNotIn(soluteName, convertedBlock.getComponentNames())


### PR DESCRIPTION
## What is the change?

Simple bug fix for `MultipleComponentMerger`.

Add a check to avoid attempting to run `_verifyExpansion` with a `DerivedShape` solvent. `ComponentMerger` bypasses this check (which doesn't make sense for a `DerivedShape` solvent) here:

https://github.com/terrapower/armi/blob/ed35e229b2b2f5fef1a4b5dd0801d811cae31e31/armi/reactor/converters/blockConverters.py#L97-L98

`MultipleComponentMerger` waits to verify expansion until all components are merged, but the direct call to `_verifyExpansion` avoids the `DerivedShape` component check. I manually added the check to the `_verifyExpansion` call in `MultipleComponentMerger`.

## Why is the change being made?

Currently, `MultipleComponentMerger` fails when solvent is a `DerivedShape` `Component`. Reproducible example of the bug:

```python
import armi
armi.configure()

# Using the FFTF case
o = armi.init(fName='FFTF.yaml')
# Get a block with coolant and wire
b = o.r.core.getBlocks()[200]
# ComponentMerger works fine
newb = armi.reactor.converters.blockConverters.ComponentMerger(b, "wire", "coolant").convert()
# MultipleComponentMerger breaks
newb = armi.reactor.converters.blockConverters.MultipleComponentMerger(b, ["wire"], "coolant").convert()
```

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.