### PR TITLE
Update C5G7 blueprints from reference

### DIFF
--- a/armi/tests/tutorials/c5g7-blueprints.yaml
+++ b/armi/tests/tutorials/c5g7-blueprints.yaml
@@ -46,13 +46,13 @@ custom isotopics:
         input format: number densities
         H: 6.70e-2
         O: 3.35E-2
-        B: 2.87E-5
+        B: 2.78E-5
     Zr clad:
         input format: number densities
         ZR: 4.30E-2
     Al clad:
         input format: number densities
-        AL: 6.00e-2
+        AL27: 6.00e-2
     fission chamber:
         # Fission Chamber composition isn't well defined so this is a guess...
         # U235 density is based on Macros of UO2 for fission XS in group 3. Group 3
@@ -65,9 +65,8 @@ custom isotopics:
         input format: number densities
         H: 6.70e-2
         O: 3.35E-2
-        B: 2.87E-5
-        U235: 6.0e-8
-        U238: 6.0e-9
+        B: 2.78E-5
+        U235: 1.0e-8
 # end-custom-isotopics
 blocks:
     uo2: &block_uo2


### PR DESCRIPTION
## What is the change?

Update a few numbers in C5G7 blueprints to match the reference document.

<!-- MANDATORY: Describe the change -->

These specs are from Table 2 on page 6 of the composition/dimensions reference at [https://www.oecd-nea.org/upload/docs/application/pdf/2020-01/nsc-doc96-02-rev2.pdf](https://www.oecd-nea.org/upload/docs/application/pdf/2020-01/nsc-doc96-02-rev2.pdf):
1. Boron density in the moderator is specified as 2.78e-5 rather than 2.87e-5
2. Aluminum clad is composed of Al-27 rather than natural Aluminum
3. Fission chamber/central guide tube is stated to contain moderator plus 1.0e-8 atom/(b cm) U-235 (above Table 2 on page 6).

## Why is the change being made?

<!-- MANDATORY: Explain why the change is necessary -->
I happened to catch a couple minor transcription errors between the C5G7 blueprints in ARMI and the reference while running the C5G7 benchmark problem with the openmc plugin.

<!-- Optional: Link to any related GitHub Issues -->


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.