### PR TITLE
Add virt memory attribute to memory profiler

### DIFF
--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -340,14 +340,19 @@ class SystemAndProcessMemoryUsage:
         # directly by the standard operator and reports, so easier said than done.
         self.percentNodeRamUsed: Optional[float] = None
         self.processMemoryInMB: Optional[float] = None
+        self.processVirtualMemoryInMB: Optional[float] = None
         if _havePsutil:
             self.percentNodeRamUsed = psutil.virtual_memory().percent
             self.processMemoryInMB = psutil.Process().memory_info().rss / (1024.0**2)
+            self.processVirtualMemoryInMB = psutil.Process().memory_info().vms / (
+                1024.0**2
+            )
 
     def __isub__(self, other):
         if self.percentNodeRamUsed is not None and other.percentNodeRamUsed is not None:
             self.percentNodeRamUsed -= other.percentNodeRamUsed
             self.processMemoryInMB -= other.processMemoryInMB
+            self.processVirtualMemoryInMB -= other.processVirtualMemoryInMB
         return self
 
 


### PR DESCRIPTION
## What is the change?

Add `processVirtualMemoryInMB` attribute to `SystemAndProcessMemoryUsage`, but do nothing else (not adding or changing what prints out with ARMI's memory profiler).

This isn't able to be tested at all via GH actions. I do not think this warrants an entry in the release notes but let me know if I'm wrong.

## Why is the change being made?

I want to measure virtual memory usage for a downstream application, since there are sometimes large discrepancies between physical and virtual and I've had some OOM errors as a result. this enables me to take a more conservative approach to memory usage.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] ~[Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.~

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.