### PR TITLE
Adding a couple little unit tests for context.py

### DIFF
--- a/armi/context.py
+++ b/armi/context.py
@@ -15,7 +15,8 @@
 """
 Module containing global constants that reflect the executing context of ARMI.
 
-Things like the MPI environment, executing user, etc. live here.
+ARMI's global state information: operating system information, environment data, user data, memory
+parallelism, temporary storage locations, and if operational mode (interactive, gui, or batch).
 """
 from logging import DEBUG
 import datetime

--- a/armi/context.py
+++ b/armi/context.py
@@ -79,7 +79,7 @@ USER = getpass.getuser()
 START_TIME = time.ctime()
 
 # Set batch mode if not a TTY, which means you're on a cluster writing to a stdout file. In this
-# mode you cannot respond to prompts. (This does not work replabliy for both Windows and Linux so an
+# mode you cannot respond to prompts. (This does not work reliably for both Windows and Linux so an
 # os-specific solution is applied.)
 isatty = sys.stdout.isatty() if "win" in sys.platform else sys.stdin.isatty()
 CURRENT_MODE = Mode.INTERACTIVE if isatty else Mode.BATCH

--- a/armi/context.py
+++ b/armi/context.py
@@ -15,10 +15,7 @@
 """
 Module containing global constants that reflect the executing context of ARMI.
 
-This contains information about the circumstatces under which an ARMI application is
-running. Things like the MPI environment, executing user, etc. live here. These are
-re-exported by the `armi` package, but live here so that import loops won't lead to
-as many issues.
+Things like the MPI environment, executing user, etc. live here.
 """
 from logging import DEBUG
 import datetime
@@ -29,14 +26,8 @@ import os
 import sys
 import time
 
-# h5py needs to be imported here, so that the disconnectAllHdfDBs() call that gets bound
-# to atexit below doesn't lead to a segfault on python exit. The Database3 module is
-# imported at call time, since it itself needs stuff that is initialized in this module
-# to import properly.  However, if that import leads to the first time that h5py is
-# imported in this process, doing so will cause a segfault. The theory here is that this
-# happens because the h5py extension module is not safe to import (for whatever reason)
-# when the python interpreter is in whatever state it's in when the atexit callbacks are
-# being invoked.  Importing early avoids this.
+# h5py needs to be imported here, so that the disconnectAllHdfDBs() call that gets bound to atexit
+# below doesn't lead to a segfault on python exit.
 #
 # Minimal code to reproduce the issue:
 #
@@ -53,25 +44,19 @@ import h5py  # noqa: F401
 BLUEPRINTS_IMPORTED = False
 BLUEPRINTS_IMPORT_CONTEXT = ""
 
-# App name is used when spawning new tasks that should invoke a specific ARMI
-# application. For instance, the framework provides some features to help with
-# submitting tasks to an HPC cluster. Sometimes these tasks are themselves only using
-# ARMI functionality, so running `python -m armi` is fine. Other times, the task is
-# specific to an application, requiring something like `python -m myArmiApp`
+# App name is used when spawning new tasks that should invoke a specific ARMI application. Sometimes
+# these tasks only use ARMI functionality, so running `python -m armi` is fine. Other times, the
+# task is specific to an application, requiring something like: `python -m myArmiApp`
 APP_NAME = "armi"
 
 
 class Mode(enum.Enum):
     """
-    Mode represents different run modes possible in ARMI.
+    Mode represents different run types possible in ARMI.
 
-    The modes can be Batch, Interactive, or GUI. In different modes, there are different
-    types of interactions possible.
-
-    Mode is generally auto-detected based on your terminal. It can also be set in
-    various CLI entry points, which are the implementations of
-    :py:class:`armi.cli.entryPoint.EntryPoint`. Lastly, each entry point has a
-    ``--batch`` command line argument that can force Batch mode.
+    The modes can be Batch, Interactive, or GUI. Mode is generally auto-detected based on your
+    terminal. It can also be set in various CLI entry points. Each entry point has a ``--batch``
+    command line argument that can force Batch mode.
     """
 
     BATCH = 1
@@ -93,10 +78,9 @@ DOC = os.path.abspath(os.path.join(PROJECT_ROOT, "doc"))
 USER = getpass.getuser()
 START_TIME = time.ctime()
 
-# Set batch mode if not a TTY, which means you're on a cluster writing to a stdout file
-# In this mode you cannot respond to prompts or anything
-# This does not work replabliy for both windows and linux so an os-specific solution is
-# applied
+# Set batch mode if not a TTY, which means you're on a cluster writing to a stdout file. In this
+# mode you cannot respond to prompts. (This does not work replabliy for both Windows and Linux so an
+# os-specific solution is applied.)
 isatty = sys.stdout.isatty() if "win" in sys.platform else sys.stdin.isatty()
 CURRENT_MODE = Mode.INTERACTIVE if isatty else Mode.BATCH
 Mode.setMode(CURRENT_MODE)
@@ -104,8 +88,8 @@ Mode.setMode(CURRENT_MODE)
 MPI_COMM = None
 # MPI_RANK represents the index of the CPU that is running.
 # 0 is typically the primary CPU, while 1+ are typically workers.
-# MPI_SIZE is the total number of CPUs
 MPI_RANK = 0
+# MPI_SIZE is the total number of CPUs.
 MPI_SIZE = 1
 LOCAL = "local"
 MPI_NODENAME = LOCAL
@@ -113,13 +97,11 @@ MPI_NODENAMES = [LOCAL]
 
 
 try:
-    # Check for MPI
-    # The mpi4py module uses cPickle to serialize python objects in preparation for
-    # network transmission. Sometimes, when cPickle fails, it gives very cryptic error
-    # messages that do not help much. If you uncomment th following line, you can trick
-    # mpi4py into using the pure-python pickle module in place of cPickle and now you
-    # will generally get much more meaningful and useful error messages Then comment it
-    # back out because it's slow.
+    # Check for MPI. The mpi4py module uses cPickle to serialize python objects in preparation for
+    # network transmission. Sometimes, when cPickle fails, it gives very cryptic error messages that
+    # do not help much. If you uncomment th following line, you can trick mpi4py into using the
+    # pure-python pickle module in place of cPickle and now you will generally get much more
+    # meaningful and useful error messages Then comment it back out because it's slow.
     # import sys, pickle; sys.modules['cPickle'] = pickle
     from mpi4py import MPI
 
@@ -133,11 +115,11 @@ except ImportError:
     pass
 
 try:
-    # trying a windows approach
+    # trying a Windows approach
     APP_DATA = os.path.join(os.environ["APPDATA"], "armi")
     APP_DATA = APP_DATA.replace("/", "\\")
 except Exception:
-    # non-windows
+    # non-Windows
     APP_DATA = os.path.expanduser("~/.armi")
 
 if MPI_NODENAMES.index(MPI_NODENAME) == MPI_RANK:
@@ -150,13 +132,14 @@ if MPI_NODENAMES.index(MPI_NODENAME) == MPI_RANK:
         raise OSError("Directory doesn't exist {0}".format(APP_DATA))
 
 if MPI_COMM is not None:
-    MPI_COMM.barrier()  # make sure app data exists before workers proceed.
+    # Make sure app data exists before workers proceed.
+    MPI_COMM.barrier()
 
 MPI_DISTRIBUTABLE = MPI_SIZE > 1
 
 _FAST_PATH = os.path.join(os.getcwd())
 """
-A directory available for high-performance I/O
+A directory available for high-performance I/O.
 
 .. warning:: This is not a constant and can change at runtime.
 """
@@ -169,17 +152,16 @@ def activateLocalFastPath() -> None:
     """
     Specify a local temp directory to be the fast path.
 
-    ``FAST_PATH`` is often a local hard drive on a cluster node. It's a high-performance
+    ``FAST_PATH`` is often a local hard drive on a cluster node. It should be a high-performance
     scratch space. Different processors on the same node should have different fast paths.
-    Some old code may MPI_RANK-dependent folders/filenames as well, but this is no longer
-    necessary.
 
-    .. warning:: This path will be obliterated when the job ends so be careful.
+    Notes
+    -----
+    This path will be obliterated when the job ends.
 
-    Note also
-    that this path is set at import time, so if a series of unit tests come through that
-    instantiate one operator after the other, the path will already exist the second time.
-    The directory is created in the Operator constructor.
+    This path is set at import time, so if a series of unit tests come through that instantiate one
+    operator after the other, the path will already exist the second time. The directory is created
+    in the Operator constructor.
     """
     global _FAST_PATH, _FAST_PATH_IS_TEMPORARY, APP_DATA
 
@@ -205,9 +187,8 @@ def getFastPath() -> str:
 
     Notes
     -----
-    It's too dangerous to use ``FAST_PATH`` directly as it can change between import and runtime.
-    For example, a module that does ``from armi.context import FAST_PATH`` is disconnected from the
-    official ``FAST_PATH`` controlled by this module.
+    This exists because it's dangerous to use ``FAST_PATH`` directly. as it can change between
+    import and runtime.
     """
     return _FAST_PATH
 
@@ -216,12 +197,12 @@ def cleanTempDirs(olderThanDays=None):
     """
     Clean up temporary files after a run.
 
-    The Windows HPC system sends a SIGBREAK signal when the user cancels a job, which is NOT handled
-    by ``atexit``. Notably SIGBREAK doesn't exist off Windows. For the SIGBREAK signal to work with
-    a Microsoft HPC, the ``TaskCancelGracePeriod`` option must be configured to be non-zero. This
-    sets the period between SIGBREAK and SIGTERM/SIGINT. To do cleanups in this case, we must use
-    the ``signal`` module. Actually, even then it does not work because MS ``mpiexec`` does not pass
-    signals through.
+    Some Windows HPC systems send a SIGBREAK signal when the user cancels a job, which is NOT
+    handled by ``atexit``. Notably, SIGBREAK does not exist outside Windows. For the SIGBREAK signal
+    to work with a Windows HPC, the ``TaskCancelGracePeriod`` option must be configured to be non-
+    zero. This sets the period between SIGBREAK and SIGTERM/SIGINT. To do cleanups in this case, we
+    must use the ``signal`` module. Actually, even then it does not work because MS ``mpiexec`` does
+    not pass signals through.
 
     Parameters
     ----------

--- a/armi/tests/test_context.py
+++ b/armi/tests/test_context.py
@@ -1,0 +1,39 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Context module."""
+import unittest
+
+from armi import context
+
+
+class TestContext(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_mpiSizeAndRank(self):
+        if context.MPI_SIZE > 1:
+            self.assertGreater(context.MPI_RANK, -1)
+        else:
+            self.assertEqual(context.MPI_RANK, 0)
+            self.assertEqual(context.MPI_SIZE, 1)
+
+    def test_nonNoneData(self):
+        self.assertGreater(len(context.APP_DATA), 0)
+        self.assertGreater(len(context.DOC), 0)
+        self.assertGreater(len(context.getFastPath()), 0)
+        self.assertGreater(len(context.PROJECT_ROOT), 0)
+        self.assertGreater(len(context.RES), 0)
+        self.assertGreater(len(context.ROOT), 0)
+        self.assertGreater(len(context.USER), 0)

--- a/armi/tests/test_context.py
+++ b/armi/tests/test_context.py
@@ -1,4 +1,4 @@
-# Copyright 2019 TerraPower, LLC
+# Copyright 2024 TerraPower, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/armi/tests/test_context.py
+++ b/armi/tests/test_context.py
@@ -12,23 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the Context module."""
+"""Serial tests for the Context module."""
 import unittest
 
 from armi import context
 
 
-class TestContext(unittest.TestCase):
-    def setUp(self):
-        pass
+class TestContextSerial(unittest.TestCase):
+    """Serial tests for the Context module."""
 
-    def test_mpiSizeAndRank(self):
+    @unittest.skipIf(context.MPI_SIZE > 1, "Serial test only")
+    def test_rank(self):
         if context.MPI_SIZE > 1:
             self.assertGreater(context.MPI_RANK, -1)
         else:
             self.assertEqual(context.MPI_RANK, 0)
             self.assertEqual(context.MPI_SIZE, 1)
 
+    @unittest.skipIf(context.MPI_SIZE > 1, "Serial test only")
     def test_nonNoneData(self):
         self.assertGreater(len(context.APP_DATA), 0)
         self.assertGreater(len(context.DOC), 0)

--- a/armi/tests/test_context.py
+++ b/armi/tests/test_context.py
@@ -23,11 +23,8 @@ class TestContextSerial(unittest.TestCase):
 
     @unittest.skipIf(context.MPI_SIZE > 1, "Serial test only")
     def test_rank(self):
-        if context.MPI_SIZE > 1:
-            self.assertGreater(context.MPI_RANK, -1)
-        else:
-            self.assertEqual(context.MPI_RANK, 0)
-            self.assertEqual(context.MPI_SIZE, 1)
+        self.assertEqual(context.MPI_RANK, 0)
+        self.assertEqual(context.MPI_SIZE, 1)
 
     @unittest.skipIf(context.MPI_SIZE > 1, "Serial test only")
     def test_nonNoneData(self):

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -351,3 +351,21 @@ class MpiPathToolsTests(unittest.TestCase):
             pathTools.cleanPath(dir3, mpiRank=context.MPI_RANK)
             MPI_COMM.barrier()
             self.assertFalse(os.path.exists(dir3))
+
+
+class TestContextMpi(unittest.TestCase):
+    """Parallel tests for the Context module."""
+
+    @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
+    def test_rank(self):
+        self.assertGreater(context.MPI_RANK, -1)
+
+    @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
+    def test_nonNoneData(self):
+        self.assertGreater(len(context.APP_DATA), 0)
+        self.assertGreater(len(context.DOC), 0)
+        self.assertGreater(len(context.getFastPath()), 0)
+        self.assertGreater(len(context.PROJECT_ROOT), 0)
+        self.assertGreater(len(context.RES), 0)
+        self.assertGreater(len(context.ROOT), 0)
+        self.assertGreater(len(context.USER), 0)


### PR DESCRIPTION
## What is the change?

* Adding a couple little unit tests for context.py
* Also, I went through and cleaned a lot of rambling out of the `context.py` comments and docstrings.

## Why is the change being made?

GitHub will run all the unit tests in ARMI in series, and in parallel under MPI.  We also have GitHub run all the unit tests under Mac, Windows, and Linux.

So the tests here really aren't much, just a starting place. But they WILL be run in a full 2x3 grid of variations, which is useful for something as critical as `context.py`.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.