### PR TITLE
Add OpenMC label to ThermalScattering

### DIFF
--- a/armi/nucDirectory/tests/test_thermalScattering.py
+++ b/armi/nucDirectory/tests/test_thermalScattering.py
@@ -92,6 +92,22 @@ class TestThermalScattering(unittest.TestCase):
         fe56tsl = ts.ThermalScattering(fe56)
         self.assertEqual(fe56tsl._genACELabel(), "fe-56")
 
+    def test_OpenMCCompound(self):
+        si = nb.byName["SI"]
+        o = nb.byName["O"]
+        sio2 = ts.ThermalScattering((si, o), "SiO2_alpha")
+        self.assertEqual(sio2._genOpenMCLabel(), "c_SiO2_alpha")
+
+    def test_OpenMCElementInCompound(self):
+        hyd = nb.byName["H"]
+        hInH2O = ts.ThermalScattering(hyd, "H2O")
+        self.assertEqual(hInH2O._genOpenMCLabel(), "c_H_in_H2O")
+
+    def test_OpenMCIsotope(self):
+        fe56 = nb.byName["FE56"]
+        fe56tsl = ts.ThermalScattering(fe56)
+        self.assertEqual(fe56tsl._genOpenMCLabel(), "c_Fe56")
+
     def test_failOnMultiple(self):
         """HT9 has carbon in it with no TSL, while graphite has C with TSL. This should crash."""
         b = buildBlockWithTSL()

--- a/armi/nucDirectory/thermalScattering.py
+++ b/armi/nucDirectory/thermalScattering.py
@@ -100,6 +100,7 @@ class ThermalScattering:
         compoundName: str = None,
         endf8Label: str = None,
         aceLabel: str = None,
+        openmcLabel: str = None,
     ):
         if isinstance(nuclideBases, nb.INuclide):
             # handle common single entry for convenience
@@ -108,6 +109,7 @@ class ThermalScattering:
         self.compoundName = compoundName
         self.endf8Label = endf8Label or self._genENDFB8Label()
         self.aceLabel = aceLabel or self._genACELabel()
+        self.openmcLabel = openmcLabel or self._genOpenMCLabel()
 
     def __repr__(self):
         return f"<ThermalScatteringLaw - Compound: {self.compoundName}, Nuclides: {self.nbs}"
@@ -199,6 +201,41 @@ class ThermalScattering:
             raise ValueError(f"{self} label cannot be generated")
         return label
 
+    def _genOpenMCLabel(self):
+        """
+        Derive the OpenMC label of a TSL.
+        
+        Similar to ENDFB8 label generator:
+        * If nuclideBases is length one and contains a ``NaturalNuclideBase``, then the
+          name will be assumed to be ``Element_in_compoundName``
+        * If nuclideBases is length one and is a NuclideBase, it is assumed to be an isotope
+          like Fe-56 and  the label will be (for example) c_Fe56
+        * If nuclideBases has length greater than one, the compoundName will form the
+          entire of the label. So, if Si and O are in the bases, the compoundName must
+          be ``SiO2_alpha`` in order to get ``c_SiO2_alpha`` as a OpenMC label.
+          
+        Similar to ACE label generator, some labels must be provided
+        by the user upon instantiation, for example:
+
+        * ``c_Graphite_10p``
+        * ``c_Graphite_30p``
+        * ``c_Graphite``
+        
+        """
+        first = next(iter(self.nbs))
+        if len(self.nbs) > 1:
+            # just compound (like SiO2)
+            label = f"c_{self.compoundName}"
+        elif isinstance(first, nb.NaturalNuclideBase):
+            # element in compound
+            label = f"c_{first.element.symbol.capitalize()}_in_{self.compoundName}"
+        elif isinstance(first, nb.NuclideBase):
+            # just isotope
+            label = f"c_{first.name.capitalize()}"
+        else:
+            raise ValueError(f"{self} label cannot be generated")
+        return label
+
 
 def factory():
     """
@@ -238,7 +275,7 @@ def factory():
         byNbAndCompound[isotope, None] = ThermalScattering(isotope)
 
     byNbAndCompound[be, BE_METAL] = ThermalScattering(
-        be, BE_METAL, endf8Label=f"tsl-{BE_METAL}.endf", aceLabel="be-met"
+        be, BE_METAL, endf8Label=f"tsl-{BE_METAL}.endf", aceLabel="be-met", openmcLabel="c_Be"
     )
     byNbAndCompound[be, BEO] = ThermalScattering(
         be, BEO, endf8Label=BEO, aceLabel="be-beo"
@@ -256,11 +293,11 @@ def factory():
     byNbAndCompound[zr, ZRH] = ThermalScattering(zr, ZRH)
     byNbAndCompound[si, SIC] = ThermalScattering(si, SIC)
     byNbAndCompound[c, CRYSTALLINE_GRAPHITE] = ThermalScattering(
-        c, CRYSTALLINE_GRAPHITE, f"tsl-{CRYSTALLINE_GRAPHITE}.endf", "grph"
+        c, CRYSTALLINE_GRAPHITE, f"tsl-{CRYSTALLINE_GRAPHITE}.endf", "grph", "c_Graphite"
     )
     byNbAndCompound[c, GRAPHITE_10P] = ThermalScattering(
-        c, GRAPHITE_10P, f"tsl-{GRAPHITE_10P}.endf", "grph10"
+        c, GRAPHITE_10P, f"tsl-{GRAPHITE_10P}.endf", "grph10", "c_Graphite_10p"
     )
     byNbAndCompound[c, GRAPHITE_30P] = ThermalScattering(
-        c, GRAPHITE_30P, f"tsl-{GRAPHITE_30P}.endf", "grph30"
+        c, GRAPHITE_30P, f"tsl-{GRAPHITE_30P}.endf", "grph30", "c_Graphite_30p"
     )

--- a/armi/nucDirectory/thermalScattering.py
+++ b/armi/nucDirectory/thermalScattering.py
@@ -204,7 +204,7 @@ class ThermalScattering:
     def _genOpenMCLabel(self):
         """
         Derive the OpenMC label of a TSL.
-        
+
         Similar to ENDFB8 label generator:
         * If nuclideBases is length one and contains a ``NaturalNuclideBase``, then the
           name will be assumed to be ``Element_in_compoundName``
@@ -212,15 +212,16 @@ class ThermalScattering:
           like Fe-56 and  the label will be (for example) c_Fe56
         * If nuclideBases has length greater than one, the compoundName will form the
           entire of the label. So, if Si and O are in the bases, the compoundName must
-          be ``SiO2_alpha`` in order to get ``c_SiO2_alpha`` as a OpenMC label.
-          
+          be ``SiO2_alpha`` (note the underscore vs hyphen in ENDFB8 Label) in order to
+          get ``c_SiO2_alpha`` as an OpenMC label.
+
         Similar to ACE label generator, some labels must be provided
         by the user upon instantiation, for example:
 
         * ``c_Graphite_10p``
         * ``c_Graphite_30p``
         * ``c_Graphite``
-        
+
         """
         first = next(iter(self.nbs))
         if len(self.nbs) > 1:
@@ -275,7 +276,11 @@ def factory():
         byNbAndCompound[isotope, None] = ThermalScattering(isotope)
 
     byNbAndCompound[be, BE_METAL] = ThermalScattering(
-        be, BE_METAL, endf8Label=f"tsl-{BE_METAL}.endf", aceLabel="be-met", openmcLabel="c_Be"
+        be,
+        BE_METAL,
+        endf8Label=f"tsl-{BE_METAL}.endf",
+        aceLabel="be-met",
+        openmcLabel="c_Be",
     )
     byNbAndCompound[be, BEO] = ThermalScattering(
         be, BEO, endf8Label=BEO, aceLabel="be-beo"
@@ -293,7 +298,11 @@ def factory():
     byNbAndCompound[zr, ZRH] = ThermalScattering(zr, ZRH)
     byNbAndCompound[si, SIC] = ThermalScattering(si, SIC)
     byNbAndCompound[c, CRYSTALLINE_GRAPHITE] = ThermalScattering(
-        c, CRYSTALLINE_GRAPHITE, f"tsl-{CRYSTALLINE_GRAPHITE}.endf", "grph", "c_Graphite"
+        c,
+        CRYSTALLINE_GRAPHITE,
+        f"tsl-{CRYSTALLINE_GRAPHITE}.endf",
+        "grph",
+        "c_Graphite",
     )
     byNbAndCompound[c, GRAPHITE_10P] = ThermalScattering(
         c, GRAPHITE_10P, f"tsl-{GRAPHITE_10P}.endf", "grph10", "c_Graphite_10p"


### PR DESCRIPTION
## What is the change?

<!-- MANDATORY: Describe the change -->
Added support for thermal scattering data labels in OpenMC's syntax (usually something like `"c_H_in_H2O"`) analogous to current support for ENDFB8 and ACE labels. Also added tests similar to the existing ENDFB8 and ACE label tests. The label generator does not currently work for all thermal scattering data available to OpenMC (for example `"c_O_in_H2O_solid"` or `"c_ortho_H"`), but it works for all thermal scattering laws used in ARMI in `thermalScattering.byNbAndCompound`.

## Why is the change being made?

<!-- MANDATORY: Explain why the change is necessary -->
An OpenMC label generator is necessary to use thermal scattering data in the ARMI [OpenMC plugin](https://github.com/terrapower/armicontrib-openmc), and it is simpler to include it in ARMI's thermal scattering module rather than in the plugin itself.

<!-- Optional: Link to any related GitHub Issues -->


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.