### PR TITLE
Adding year to time logging

### DIFF
--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -234,7 +234,7 @@ class TestArmiCase(unittest.TestCase):
                 self.assertIn("Triggering BOL Event", mock.getStdout())
                 self.assertIn("xsGroups", mock.getStdout())
                 self.assertIn(
-                    "Completed EveryNode - timestep: cycle 0, node 0 Event",
+                    "Completed EveryNode - timestep: cycle 0, node 0, year 0.0 Event",
                     mock.getStdout(),
                 )
 

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -234,7 +234,7 @@ class TestArmiCase(unittest.TestCase):
                 self.assertIn("Triggering BOL Event", mock.getStdout())
                 self.assertIn("xsGroups", mock.getStdout())
                 self.assertIn(
-                    "Completed EveryNode - timestep: cycle 0, node 0, year 0.0 Event",
+                    "Completed EveryNode - timestep: cycle 0, node 0, year 0.00 Event",
                     mock.getStdout(),
                 )
 

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -568,7 +568,8 @@ class Operator:
         if interactionName == "Coupled":
             cycleNodeInfo = (
                 f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}, "
-                f"year {self.r.p.time} - iteration {self.r.core.p.coupledIteration}"
+                f"year {'{0:.2f}'.format(self.r.p.time)} - iteration "
+                f"{self.r.core.p.coupledIteration}"
             )
         elif interactionName in ("BOC", "EOC"):
             cycleNodeInfo = f" - timestep: cycle {self.r.p.cycle}"
@@ -578,7 +579,7 @@ class Operator:
         else:
             cycleNodeInfo = (
                 f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}, "
-                f"year {self.r.p.time}"
+                f"year {'{0:.2f}'.format(self.r.p.time)}"
             )
 
         return cycleNodeInfo

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -567,17 +567,20 @@ class Operator:
         """
         if interactionName == "Coupled":
             cycleNodeInfo = (
-                f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}"
-                f" - iteration {self.r.core.p.coupledIteration}"
+                f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}, "
+                f"year {self.r.p.time} - iteration {self.r.core.p.coupledIteration}"
             )
         elif interactionName in ("BOC", "EOC"):
             cycleNodeInfo = f" - timestep: cycle {self.r.p.cycle}"
+            # - timestep: cycle 2
         elif interactionName in ("Init", "BOL", "EOL"):
             cycleNodeInfo = ""
         else:
             cycleNodeInfo = (
-                f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}"
+                f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}, "
+                f"year {self.r.p.time}"
             )
+
         return cycleNodeInfo
 
     def _debugDB(self, interactionName, interfaceName, statePointIndex=0):

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -551,6 +551,7 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
         )
         cls.r.p.cycle = 0
         cls.r.p.timeNode = 1
+        cls.r.p.time = 11
         cls.r.core.p.coupledIteration = 7
 
     def test_expandCycleAndTimeNodeArgs_Empty(self):
@@ -572,7 +573,8 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
         """When cycleNodeInfo should return the cycle and node."""
         self.assertEqual(
             self.o._expandCycleAndTimeNodeArgs(interactionName="EveryNode"),
-            f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}",
+            f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}, "
+            f"year {self.r.p.time}",
         )
 
     def test_expandCycleAndTimeNodeArgs_Coupled(self):
@@ -580,7 +582,7 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
         self.assertEqual(
             self.o._expandCycleAndTimeNodeArgs(interactionName="Coupled"),
             (
-                f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode} "
-                f"- iteration {self.r.core.p.coupledIteration}"
+                f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}, "
+                f"year {self.r.p.time} - iteration {self.r.core.p.coupledIteration}"
             ),
         )

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -551,7 +551,7 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
         )
         cls.r.p.cycle = 0
         cls.r.p.timeNode = 1
-        cls.r.p.time = 11
+        cls.r.p.time = 11.01
         cls.r.core.p.coupledIteration = 7
 
     def test_expandCycleAndTimeNodeArgs_Empty(self):
@@ -574,7 +574,7 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
         self.assertEqual(
             self.o._expandCycleAndTimeNodeArgs(interactionName="EveryNode"),
             f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}, "
-            f"year {self.r.p.time}",
+            f"year {'{0:.2f}'.format(self.r.p.time)}",
         )
 
     def test_expandCycleAndTimeNodeArgs_Coupled(self):
@@ -582,7 +582,7 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
         self.assertEqual(
             self.o._expandCycleAndTimeNodeArgs(interactionName="Coupled"),
             (
-                f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}, "
-                f"year {self.r.p.time} - iteration {self.r.core.p.coupledIteration}"
+                f" - timestep: cycle {self.r.p.cycle}, node {self.r.p.timeNode}, year "
+                f"{'{0:.2f}'.format(self.r.p.time)} - iteration {self.r.core.p.coupledIteration}"
             ),
         )

--- a/doc/release/0.3.rst
+++ b/doc/release/0.3.rst
@@ -20,6 +20,7 @@ New Features
 API Changes
 -----------
 #. Replacing the concrete material with a better reference. (`PR#1717 <https://github.com/terrapower/armi/pull/1717>`_)
+#. Adding more detailed time information to logging. (`PR#1796 <https://github.com/terrapower/armi/pull/1796>`_)
 #. Renaming ``structuredgrid.py`` to camelCase. (`PR#1650 <https://github.com/terrapower/armi/pull/1650>`_)
 #. Removing unused argument from ``Block.coords()``. (`PR#1651 <https://github.com/terrapower/armi/pull/1651>`_)
 #. Removing unused method ``HexGrid.allPositionsInThird()``. (`PR#1655 <https://github.com/terrapower/armi/pull/1655>`_)


### PR DESCRIPTION
## What is the change?

Adding year to time logging.

The reactor time in ARMI is given in years, and the request was made to add the exact year to the log line.

## Why is the change being made?

To close #1781

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.