### PR TITLE
Giving user and group read/write/execute permissions on files created in output cache

### DIFF
--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -167,6 +167,7 @@ def store(exePath, inputPaths, outputFiles, cacheDir):
         baseName = os.path.basename(outputFile)
         cachedLoc = os.path.join(folderLoc, baseName)
         shutil.copy(outputFile, cachedLoc)
+        os.chmod(cachedLoc, 0o770)
 
     runLog.info("Added outputs for {} to the cache.".format(exePath))
 

--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -160,7 +160,7 @@ def store(exePath, inputPaths, outputFiles, cacheDir):
     folderLoc = _getCachedFolder(exePath, inputPaths, cacheDir)
     if os.path.exists(folderLoc):
         deleteCache(folderLoc)
-    os.makedirs(folderLoc)
+    os.makedirs(folderLoc, mode=0o770)
     _makeOutputManifest(outputsThatExist, folderLoc)
 
     for outputFile in outputsThatExist:


### PR DESCRIPTION
## What is the change?

This PR explicitly assigns permissions when storing files in the output cache. The specific `chmod` permission is 770 (user and group read/write/execute).

## Why is the change being made?

This change in permission ensures that cached data can be used by other users (within the same group at least). It is necessary because certain platforms have ambiguous default permissions when creating and moving files.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.