### PR TITLE
Fixing deprecation warnings with axial grid method

### DIFF
--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -110,7 +110,7 @@ class FuelHandlerTestHelper(ArmiTestHelper):
 
         # generate an assembly
         self.assembly = assemblies.HexAssembly("TestAssemblyType")
-        self.assembly.spatialGrid = grids.axialUnitGrid(1)
+        self.assembly.spatialGrid = grids.AxialGrid.fromNCells(1)
         for _ in range(1):
             self.assembly.add(copy.deepcopy(self.block))
 

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -65,7 +65,7 @@ class TestLatticePhysicsInterfaceBase(unittest.TestCase):
         cls.o.r.core = Core("testCore")
         # add an assembly with a single block
         cls.assembly = HexAssembly("testAssembly")
-        cls.assembly.spatialGrid = grids.axialUnitGrid(1)
+        cls.assembly.spatialGrid = grids.AxialGrid.fromNCells(1)
         cls.assembly.spatialGrid.armiObject = cls.assembly
         cls.assembly.add(buildSimpleFuelBlock())
         # cls.o.r.core.add(assembly)

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1179,7 +1179,7 @@ class Assembly(composites.Composite):
             reordering.
         """
         # replace grid with one that has the right number of locations
-        self.spatialGrid = grids.axialUnitGrid(len(self))
+        self.spatialGrid = grids.AxialGrid.fromNCells(len(self))
         self.spatialGrid.armiObject = self
         for zi, b in enumerate(self):
             b.spatialLocator = self.spatialGrid[0, 0, zi]

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -347,7 +347,7 @@ class Assembly(composites.Composite):
                 bx.clearCache()
 
         self.removeAll()
-        self.spatialGrid = grids.axialUnitGrid(len(newBlockStack))
+        self.spatialGrid = grids.AxialGrid.fromNCells(len(newBlockStack))
         for b in newBlockStack:
             self.add(b)
         self.reestablishBlockOrder()
@@ -401,7 +401,7 @@ class Assembly(composites.Composite):
                 )
 
         self.removeAll()
-        self.spatialGrid = grids.axialUnitGrid(len(newBlockStack))
+        self.spatialGrid = grids.AxialGrid.fromNCells(len(newBlockStack))
         for b in newBlockStack:
             self.add(b)
         self.reestablishBlockOrder()

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -205,7 +205,7 @@ class AssemblyBlueprint(yamlize.Object):
             a.p.flags = flags
 
         # set a basic grid with the right number of blocks with bounds to be adjusted.
-        a.spatialGrid = grids.axialUnitGrid(len(blocks))
+        a.spatialGrid = grids.AxialGrid.fromNCells(len(blocks))
         a.spatialGrid.armiObject = a
 
         # TODO: Remove mesh points from blueprints entirely. Submeshing should be

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -756,7 +756,7 @@ class HexToRZThetaConverter(GeometryConverter):
             thetaIndex, radialIndex, 0
         ]
         newAssembly.p.AziMesh = 2
-        newAssembly.spatialGrid = grids.axialUnitGrid(
+        newAssembly.spatialGrid = grids.AxialGrid.fromNCells(
             len(self.meshConverter.axialMesh), armiObject=newAssembly
         )
 

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -451,7 +451,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         """
         # build test assembly with ACLP
         assembly = HexAssembly("testAssemblyType")
-        assembly.spatialGrid = grids.axialUnitGrid(numCells=1)
+        assembly.spatialGrid = grids.AxialGrid.fromNCells(numCells=1)
         assembly.spatialGrid.armiObject = assembly
         assembly.add(_buildTestBlock("shield", "FakeMat", 25.0, 10.0))
         assembly.add(_buildTestBlock("fuel", "FakeMat", 25.0, 10.0))
@@ -564,7 +564,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
     def test_isTopDummyBlockPresent(self):
         # build test assembly without dummy
         assembly = HexAssembly("testAssemblyType")
-        assembly.spatialGrid = grids.axialUnitGrid(numCells=1)
+        assembly.spatialGrid = grids.AxialGrid.fromNCells(numCells=1)
         assembly.spatialGrid.armiObject = assembly
         assembly.add(_buildTestBlock("shield", "FakeMat", 25.0, 10.0))
         assembly.calculateZCoords()
@@ -1131,7 +1131,7 @@ def buildTestAssemblyWithFakeMaterial(name: str, hot: bool = False):
         height = 10.0 + 0.02 * (250.0 - 25.0)
 
     assembly = HexAssembly("testAssemblyType")
-    assembly.spatialGrid = grids.axialUnitGrid(numCells=1)
+    assembly.spatialGrid = grids.AxialGrid.fromNCells(numCells=1)
     assembly.spatialGrid.armiObject = assembly
     assembly.add(_buildTestBlock("shield", name, hotTemp, height))
     assembly.add(_buildTestBlock("fuel", name, hotTemp, height))

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -1028,7 +1028,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
     @staticmethod
     def _createNewAssembly(sourceAssembly):
         a = sourceAssembly.__class__(sourceAssembly.getType())
-        a.spatialGrid = grids.axialUnitGrid(len(sourceAssembly))
+        a.spatialGrid = grids.AxialGrid.fromNCells(len(sourceAssembly))
         a.setName(sourceAssembly.getName())
         return a
 

--- a/armi/reactor/grids/__init__.py
+++ b/armi/reactor/grids/__init__.py
@@ -80,7 +80,7 @@ from armi.reactor.grids.locations import (
 
 from armi.reactor.grids.grid import Grid
 from armi.reactor.grids.structuredGrid import StructuredGrid, GridParameters, _tuplify
-from armi.reactor.grids.axial import AxialGrid, axialUnitGrid
+from armi.reactor.grids.axial import AxialGrid
 from armi.reactor.grids.cartesian import CartesianGrid
 from armi.reactor.grids.hexagonal import HexGrid, COS30, SIN30, TRIANGLES_IN_HEXAGON
 from armi.reactor.grids.thetarz import ThetaRZGrid, TAU

--- a/armi/reactor/grids/axial.py
+++ b/armi/reactor/grids/axial.py
@@ -85,21 +85,3 @@ class AxialGrid(StructuredGrid):
             Pitch in cm
 
         """
-
-
-def axialUnitGrid(
-    numCells: int, armiObject: Optional["ArmiObject"] = None
-) -> AxialGrid:
-    """
-    Build a 1-D unit grid in the k-direction based on a number of times. Each mesh is 1cm wide.
-
-    .. deprecated:: 0.3
-        Use :class:`AxialUnitGrid` class instead
-
-    """
-    warnings.warn(
-        "Use grids.AxialGrid class rather than function",
-        PendingDeprecationWarning,
-        stacklevel=2,
-    )
-    return AxialGrid.fromNCells(numCells, armiObject)

--- a/armi/reactor/grids/axial.py
+++ b/armi/reactor/grids/axial.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List, Optional, TYPE_CHECKING, NoReturn
-import warnings
 
 import numpy
 

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -134,7 +134,7 @@ def buildTestAssemblies():
     assemblieObjs = []
     for numBlocks, blockTemplate in zip([1, 1, 5, 4], [block, block2, block, block]):
         assembly = assemblies.HexAssembly("testAssemblyType")
-        assembly.spatialGrid = grids.axialUnitGrid(numBlocks)
+        assembly.spatialGrid = grids.AxialGrid.fromNCells(numBlocks)
         assembly.spatialGrid.armiObject = assembly
         for _i in range(numBlocks):
             newBlock = copy.deepcopy(blockTemplate)
@@ -184,7 +184,7 @@ def makeTestAssembly(
 ):
     coreGrid = r.core.spatialGrid if r is not None else spatialGrid
     a = HexAssembly("TestAssem", assemNum=assemNum)
-    a.spatialGrid = grids.axialUnitGrid(numBlocks)
+    a.spatialGrid = grids.AxialGrid.fromNCells(numBlocks)
     a.spatialGrid.armiObject = a
     a.spatialLocator = coreGrid[2, 2, 0]
     return a

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -498,7 +498,7 @@ class TestCompositeTree(unittest.TestCase):
 
     def test_ordering(self):
         a = assemblies.Assembly("dummy")
-        a.spatialGrid = grids.axialUnitGrid(2, armiObject=a)
+        a.spatialGrid = grids.AxialGrid.fromNCells(2, armiObject=a)
         otherBlock = deepcopy(self.block)
         a.add(self.block)
         a.add(otherBlock)
@@ -510,7 +510,7 @@ class TestCompositeTree(unittest.TestCase):
 
     def test_summing(self):
         a = assemblies.Assembly("dummy")
-        a.spatialGrid = grids.axialUnitGrid(2, armiObject=a)
+        a.spatialGrid = grids.AxialGrid.fromNCells(2, armiObject=a)
         otherBlock = deepcopy(self.block)
         a.add(self.block)
         a.add(otherBlock)

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -72,7 +72,7 @@ def buildOperatorOfEmptyHexBlocks(customSettings=None):
     o.initializeInterfaces(r)
 
     a = assemblies.HexAssembly("fuel")
-    a.spatialGrid = grids.axialUnitGrid(1)
+    a.spatialGrid = grids.AxialGrid.fromNCells(1)
     b = blocks.HexBlock("TestBlock")
     b.setType("fuel")
     dims = {"Tinput": 600, "Thot": 600, "op": 16.0, "ip": 1, "mult": 1}
@@ -109,7 +109,7 @@ def buildOperatorOfEmptyCartesianBlocks(customSettings=None):
     o.initializeInterfaces(r)
 
     a = assemblies.CartesianAssembly("fuel")
-    a.spatialGrid = grids.axialUnitGrid(1)
+    a.spatialGrid = grids.AxialGrid.fromNCells(1)
     b = blocks.CartesianBlock("TestBlock")
     b.setType("fuel")
     dims = {

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -235,7 +235,7 @@ class SettingsReader:
             self.inputVersion = setts[CONF_VERSIONS]["armi"]
         else:
             runLog.warning(
-                "Versions setting section not found. Continuing with uncontrolled verisons."
+                "Versions setting section not found. Continuing with uncontrolled versions."
             )
             self.inputVersion = "uncontrolled"
 

--- a/doc/gallery-src/framework/run_computeReactionRates.py
+++ b/doc/gallery-src/framework/run_computeReactionRates.py
@@ -80,7 +80,7 @@ def createDummyReactor():
 
     # Create a single fuel assembly
     a = assemblies.HexAssembly("fuel assembly")
-    a.spatialGrid = grids.axialUnitGrid(1)
+    a.spatialGrid = grids.AxialGrid.fromNCells(1)
     a.spatialLocator = r.core.spatialGrid[1, 0, 0]
 
     # Create a single fuel block

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -20,7 +20,7 @@ Bug Fixes
 
 Quality Work
 ------------
-#. TBD
+#. Removing code that causes a deprecation warning (converting ``axialUnitGrid`` to ``AxialGrid.fromNCells``) (`PR#1809 <https://github.com/terrapower/armi/pull/1809>`_)
 
 Changes that Affect Requirements
 --------------------------------


### PR DESCRIPTION
## What is the change?

Updated `axialUnitGrid` to `AxialGrid.fromNCells` per the deprecation warning

## Why is the change being made?

The unit tests have thousands of warnings and this was some low hanging fruit.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.