### PR TITLE
Ingesting tabulate as an internal module

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,6 +2,8 @@ name: Coverage
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,8 +2,6 @@ name: Coverage
 
 on:
   push:
-    branches:
-      - main
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/mac_tests.yaml
+++ b/.github/workflows/mac_tests.yaml
@@ -2,6 +2,8 @@ name: ARMI MacOS Tests
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/mac_tests.yaml
+++ b/.github/workflows/mac_tests.yaml
@@ -2,8 +2,6 @@ name: ARMI MacOS Tests
 
 on:
   push:
-    branches:
-      - main
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: [3.9, '3.10', '3.11']
+        python: ['3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: ['3.11']
+        python: [3.9, '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -2,6 +2,8 @@ name: ARMI Windows tests
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -2,8 +2,6 @@ name: ARMI Windows tests
 
 on:
   push:
-    branches:
-      - main
     paths-ignore:
       - 'doc/**'
   pull_request:

--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -293,10 +293,10 @@ class HistoryTrackerInterface(interfaces.Interface):
             headers = [str(ts).replace(" ", "") for ts in times.keys()]
             out.write(
                 tabulate.tabulate(
+                    data=(times.values(),),
                     headers=headers,
-                    tabular_data=(times.values(),),
-                    tablefmt="plain",
-                    floatfmt="11.5E",
+                    tableFmt="plain",
+                    floatFmt="11.5E",
                 )
             )
             out.write("\n")
@@ -315,7 +315,7 @@ class HistoryTrackerInterface(interfaces.Interface):
                 out.write("\n\nkey: {0}\n".format(param))
 
                 data = [blockHistories[b][param].values() for b in blocks]
-                out.write(tabulate.tabulate(data, tablefmt="plain", floatfmt="11.5E"))
+                out.write(tabulate.tabulate(data, tableFmt="plain", floatFmt="11.5E"))
                 out.write("\n")
 
             # loc is a tuple, remove the spaces from the string representation so it is easy to load
@@ -325,14 +325,14 @@ class HistoryTrackerInterface(interfaces.Interface):
                 for loc in dbi.getHistory(a, ["location"])["location"].values()
             ]
             out.write("\n\nkey: location\n")
-            out.write(tabulate.tabulate((location,), tablefmt="plain"))
+            out.write(tabulate.tabulate((location,), tableFmt="plain"))
             out.write("\n\n\n")
 
             headers = "EOL bottom top center".split()
             data = [("", b.p.zbottom, b.p.ztop, b.p.z) for b in blocks]
             out.write(
                 tabulate.tabulate(
-                    data, headers=headers, tablefmt="plain", floatfmt="10.3f"
+                    data, headers=headers, tableFmt="plain", floatFmt="10.3f"
                 )
             )
 

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -434,6 +434,6 @@ class PrintSystemMemoryUsageAction(mpiActions.MpiAction):
                     "Average System RAM Usage",
                     "Processor Memory Usage (MB)",
                 ],
-                tablefmt="armi",
+                tableFmt="armi",
             )
         )

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -439,7 +439,7 @@ def writeTightCouplingConvergenceSummary(convergenceSummary):
     runLog.info("Tight Coupling Convergence Summary")
     runLog.info(
         tabulate.tabulate(
-            convergenceSummary, headers="keys", showindex=True, tablefmt="armi"
+            convergenceSummary, headers="keys", showIndex=True, tablefmt="armi"
         )
     )
 

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -84,7 +84,7 @@ def writeWelcomeHeaders(o, cs):
         ]
 
         runLog.header("=========== Case Information ===========")
-        runLog.info(tabulate.tabulate(caseInfo, tablefmt="armi"))
+        runLog.info(tabulate.tabulate(caseInfo, tableFmt="armi"))
 
     def _listInputFiles(cs):
         """
@@ -170,7 +170,7 @@ def writeWelcomeHeaders(o, cs):
             tabulate.tabulate(
                 inputFileData,
                 headers=["Input Type", "Path", "SHA-1 Hash"],
-                tablefmt="armi",
+                tableFmt="armi",
             )
         )
 
@@ -199,7 +199,7 @@ def writeWelcomeHeaders(o, cs):
                 tabulate.tabulate(
                     nodeMappingData,
                     headers=["Machine", "Number of Processors", "Ranks"],
-                    tablefmt="armi",
+                    tableFmt="armi",
                 )
             )
 
@@ -224,7 +224,7 @@ def writeWelcomeHeaders(o, cs):
             paramStr = [str(p) for p in param]
             operatingData.append((name, textwrap.fill(", ".join(paramStr))))
         runLog.header("=========== Reactor Cycle Information ===========")
-        runLog.info(tabulate.tabulate(operatingData, tablefmt="armi"))
+        runLog.info(tabulate.tabulate(operatingData, tableFmt="armi"))
 
     if context.MPI_RANK > 0:
         return  # prevent the worker nodes from printing the same thing
@@ -429,7 +429,7 @@ def getInterfaceStackSummary(o):
             "EOL order",
             "BOL forced",
         ),
-        tablefmt="armi",
+        tableFmt="armi",
     )
     text = text
     return text
@@ -439,7 +439,7 @@ def writeTightCouplingConvergenceSummary(convergenceSummary):
     runLog.info("Tight Coupling Convergence Summary")
     runLog.info(
         tabulate.tabulate(
-            convergenceSummary, headers="keys", showIndex=True, tablefmt="armi"
+            convergenceSummary, headers="keys", showIndex=True, tableFmt="armi"
         )
     )
 

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -605,7 +605,7 @@ class Case:
                     tabulate.tabulate(
                         queryData,
                         headers=["Number", "Statement", "Question"],
-                        tablefmt="armi",
+                        tableFmt="armi",
                     )
                 )
             if context.CURRENT_MODE == context.Mode.INTERACTIVE:

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -146,7 +146,7 @@ class CaseSuite:
                     for c in self
                 ],
                 headers=["Title", "Enabled", "Dependencies"],
-                tablefmt="armi",
+                tableFmt="armi",
             )
         )
 
@@ -301,7 +301,7 @@ class CaseSuite:
                 tabulate.tabulate(
                     [["Integration test directory: {}".format(os.getcwd())]],
                     ["SUMMARIZED INTEGRATION TEST DIFFERENCES:"],
-                    tablefmt=fmt,
+                    tableFmt=fmt,
                 )
             )
         )
@@ -313,10 +313,10 @@ class CaseSuite:
             data.append((testName, userFile, refFile, caseIssues))
             totalDiffs += caseIssues
 
-        print(tabulate.tabulate(data, header, tablefmt=fmt))
+        print(tabulate.tabulate(data, header, tableFmt=fmt))
         print(
             tabulate.tabulate(
-                [["Total number of differences: {}".format(totalDiffs)]], tablefmt=fmt
+                [["Total number of differences: {}".format(totalDiffs)]], tableFmt=fmt
             )
         )
 

--- a/armi/cli/checkInputs.py
+++ b/armi/cli/checkInputs.py
@@ -118,7 +118,7 @@ class CheckInputEntryPoint(EntryPoint):
             tabulate.tabulate(
                 table,
                 headers=["case", "can start", "input is self consistent"],
-                tablefmt="armi",
+                tableFmt="armi",
             )
         )
 

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -122,9 +122,9 @@ Retrieve elements that are classified as actinides:
             ]
 
         sortedElements = sorted(elements.byZ.values())
-        return createTable(tabulate(tabular_data=[getAttributes(elem) for elem in sortedElements],
+        return createTable(tabulate(data=[getAttributes(elem) for elem in sortedElements],
                                     headers=attributes,
-                                    tablefmt='rst'),
+                                    tableFmt='rst'),
                            caption='List of elements',
                            label='nuclide-bases-table')
 """

--- a/armi/physics/neutronics/__init__.py
+++ b/armi/physics/neutronics/__init__.py
@@ -268,7 +268,7 @@ def applyEffectiveDelayedNeutronFractionToCore(core, cs):
     else:
         runLog.extra(
             tabulate.tabulate(
-                ddata=reportTableData,
+                data=reportTableData,
                 headers=["Component", "Value"],
                 tableFmt="armi",
             )

--- a/armi/physics/neutronics/__init__.py
+++ b/armi/physics/neutronics/__init__.py
@@ -268,9 +268,9 @@ def applyEffectiveDelayedNeutronFractionToCore(core, cs):
     else:
         runLog.extra(
             tabulate.tabulate(
-                tabular_data=reportTableData,
+                ddata=reportTableData,
                 headers=["Component", "Value"],
-                tablefmt="armi",
+                tableFmt="armi",
             )
         )
 

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -479,7 +479,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
                             ),
                         ]
                     ],
-                    tablefmt="plain",
+                    tableFmt="plain",
                 ),
                 single=True,
             )

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -272,13 +272,13 @@ def summarizeMaterialData(container):
     materialData = sorted(materialData)
     runLog.info(
         tabulate.tabulate(
-            tabular_data=materialData,
+            data=materialData,
             headers=[
                 "Material Name",
                 "Source Location",
                 "Property Data was Modified\nfrom the Source?",
             ],
-            tablefmt="armi",
+            tableFmt="armi",
         )
     )
     return materialData

--- a/armi/reactor/parameters/parameterCollections.py
+++ b/armi/reactor/parameters/parameterCollections.py
@@ -35,13 +35,13 @@ GLOBAL_SERIAL_NUM = -1
 """
 The serial number for all ParameterCollections
 
-This is a counter of the number of instances of all types. They are useful for tracking
-items through the history of a database.
+This is a counter of the number of instances of all types. They are useful for tracking items
+through the history of a database.
 
 .. warning::
 
-        This is not MPI safe. We also have not done anything to make it thread safe,
-        except that the GIL exists.
+    This is not MPI safe. We also have not done anything to make it thread safe,
+    except that the GIL exists.
 """
 
 
@@ -70,8 +70,8 @@ class _ParameterCollectionType(type):
     """
     Simple metaclass to make sure that expected class attributes are present.
 
-    These attributes shouldn't  be shared among different subclasses, so this
-    makes sure that each subclass gets its own.
+    These attributes shouldn't  be shared among different subclasses, so this makes sure that each
+    subclass gets its own.
     """
 
     def __new__(mcl, name, bases, attrs):
@@ -85,15 +85,13 @@ class _ParameterCollectionType(type):
 class ParameterCollection(metaclass=_ParameterCollectionType):
     """An empty class for holding state information in the ARMI data structure.
 
-    A parameter collection stores one or more formally-defined values ("parameters").
-    Until a given ParameterCollection subclass has been instantiated, new parameters may
-    be added to its parameter definitions (e.g., from plugins). Upon first
-    instantiation, ``applyParameters()`` will be called, binding the parameter
-    definitions to the Collection class as descriptors.
+    A parameter collection stores one or more formally-defined values ("parameters"). Until a given
+    ParameterCollection subclass has been instantiated, new parameters may be added to its parameter
+    definitions (e.g., from plugins). Upon first instantiation, ``applyParameters()`` will be
+    called, binding the parameter definitions to the Collection class as descriptors.
 
-    It is illegal to redefine a parameter with the same name in the same class, or its
-    subclasses, and attempting to do so should result in exceptions in
-    ``applyParameters()``.
+    It is illegal to redefine a parameter with the same name in the same class, or its subclasses,
+    and attempting to do so should result in exceptions in ``applyParameters()``.
 
     Attributes
     ----------
@@ -104,13 +102,12 @@ class ParameterCollection(metaclass=_ParameterCollectionType):
         Keys are ``(paramName, timeStep)``.
 
     assigned : int Flag
-        indicates the synchronization state of the parameter collection. This is used to
-        reduce the amount of information that is transmitted during database, and MPI
-        operations as well as determine the collection's state when exiting a
-        ``Composite.retainState``.
+        indicates the synchronization state of the parameter collection. This is used to reduce the
+        amount of information that is transmitted during database, and MPI operations as well as
+        determine the collection's state when exiting a ``Composite.retainState``.
 
-        This attribute when used with the ``Parameter.assigned`` attribute allows us to
-        efficiently perform many operations.
+        This attribute when used with the ``Parameter.assigned`` attribute allows us to efficiently
+        perform many operations.
 
     See Also
     --------
@@ -125,9 +122,9 @@ class ParameterCollection(metaclass=_ParameterCollectionType):
     # The ArmiObject class that this ParameterCollection belongs to
     _ArmiObject = None
 
-    # A set of all instance attributes that are settable on an instance. This prevents
-    # inadvertent setting of values that aren't proper parameters. Named _slots, as
-    # it is used to emulate some of the behaviors of __slots__.
+    # A set of all instance attributes that are settable on an instance. This prevents inadvertent
+    # setting of values that aren't proper parameters. Named _slots, as it is used to emulate some
+    # of the behaviors of __slots__.
     _slots: Set[str] = set()
 
     def __init__(self, _state: Optional[List[Any]] = None):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -498,7 +498,7 @@ class Core(composites.Composite):
                     ("Fissile Mass (kg)", fissileMass),
                     ("Heavy Metal Mass (kg)", heavyMetalMass),
                 ],
-                tablefmt="armi",
+                tableFmt="armi",
             )
         )
 
@@ -1512,7 +1512,7 @@ class Core(composites.Composite):
                     ),
                 ],
                 headers=["Nuclide Category", "Nuclides"],
-                tablefmt="armi",
+                tableFmt="armi",
             )
         )
 

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -1008,7 +1008,7 @@ def _toStr(s, encoding="utf8", errors="ignore"):
 def tabulate(
     data,
     headers=(),
-    tablefmt="simple",
+    tableFmt="simple",
     floatfmt=_DEFAULT_FLOATFMT,
     intfmt=_DEFAULT_INTFMT,
     numAlign=_DEFAULT_ALIGN,
@@ -1101,7 +1101,7 @@ def tabulate(
     other   ?  2.7
     -----  --  ----
 
-    Various plain-text table formats (`tablefmt`) are supported: 'plain', 'simple', 'grid',
+    Various plain-text table formats (`tableFmt`) are supported: 'plain', 'simple', 'grid',
     'orgtbl', 'rst', and `tsv`. Variable `tabulateFormats` contains the list of currently supported
     formats.
 
@@ -1114,7 +1114,7 @@ def tabulate(
     spam         41.9999
     eggs        451
 
-    >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]], tablefmt="plain"))
+    >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]], tableFmt="plain"))
     spam   41.9999
     eggs  451
 
@@ -1127,7 +1127,7 @@ def tabulate(
     spam         41.9999
     eggs        451
 
-    >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]], tablefmt="simple"))
+    >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]], tableFmt="simple"))
     ----  --------
     spam   41.9999
     eggs  451
@@ -1145,7 +1145,7 @@ def tabulate(
     | eggs      |  451      |
     +-----------+-----------+
 
-    >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]], tablefmt="grid"))
+    >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]], tableFmt="grid"))
     +------+----------+
     | spam |  41.9999 |
     +------+----------+
@@ -1164,7 +1164,7 @@ def tabulate(
     eggs        451
     =========  =========
 
-    >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]], tablefmt="rst"))
+    >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]], tableFmt="rst"))
     ====  ========
     spam   41.9999
     eggs  451
@@ -1193,7 +1193,7 @@ def tabulate(
             'This is a rather long description that might look better if it is wrapped a bit')], \
           headers=("Issue Id", "Author", "Description"), \
           maxColWidths=[None, None, 30], \
-          tablefmt="grid"  \
+          tableFmt="grid"  \
         ))
     +------------+------------+-------------------------------+
     |   Issue Id | Author     | Description                   |
@@ -1244,14 +1244,14 @@ def tabulate(
 
     # empty values in the first column of RST tables should be escaped
     # "" should be escaped as "\\ " or ".."
-    if tablefmt == "rst":
+    if tableFmt == "rst":
         listOfLists, headers = _rstEscapeFirstColumn(listOfLists, headers)
 
     # PrettyTable formatting does not use any extra padding. Numbers are not parsed and are treated
     # the same as strings for alignment. Check if pretty is the format being used and override the
     # defaults so it does not impact other formats.
     minPadding = MIN_PADDING
-    if tablefmt == "pretty":
+    if tableFmt == "pretty":
         minPadding = 0
         disableNumParse = True
         numAlign = "center" if numAlign == _DEFAULT_ALIGN else numAlign
@@ -1278,11 +1278,11 @@ def tabulate(
     hasInvisible = _ansiCodes.search(plainText) is not None
 
     if (
-        not isinstance(tablefmt, TableFormat)
-        and tablefmt in multilineFormats
+        not isinstance(tableFmt, TableFormat)
+        and tableFmt in multilineFormats
         and _isMultiline(plainText)
     ):
-        tablefmt = multilineFormats.get(tablefmt, tablefmt)
+        tableFmt = multilineFormats.get(tableFmt, tableFmt)
         isMultiline = True
     else:
         isMultiline = False
@@ -1385,15 +1385,15 @@ def tabulate(
         minwidths = [max(widthFn(cl) for cl in c) for c in cols]
         rows = list(zip(*cols))
 
-    if not isinstance(tablefmt, TableFormat):
-        tablefmt = _tableFormats.get(tablefmt, _tableFormats["simple"])
+    if not isinstance(tableFmt, TableFormat):
+        tableFmt = _tableFormats.get(tableFmt, _tableFormats["simple"])
 
     raDefault = rowAlign if isinstance(rowAlign, str) else None
     rowAligns = _expandIterable(rowAlign, len(rows), raDefault)
     _reinsertSeparatingLines(rows, separatingLines)
 
     return _formatTable(
-        tablefmt,
+        tableFmt,
         headers,
         alignsHeaders,
         rows,

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -1484,14 +1484,14 @@ def _appendMultilineRow(
     lines, paddedMultilineCells, paddedWidths, colaligns, rowfmt, pad, rowalign=None
 ):
     colwidths = [w - 2 * pad for w in paddedWidths]
-    cells_lines = [c.splitlines() for c in paddedMultilineCells]
-    nlines = max(map(len, cells_lines))  # number of lines in the row
+    cellsLines = [c.splitlines() for c in paddedMultilineCells]
+    nlines = max(map(len, cellsLines))  # number of lines in the row
 
-    cells_lines = [
+    cellsLines = [
         _alignCellVeritically(cl, nlines, w, rowalign)
-        for cl, w in zip(cells_lines, colwidths)
+        for cl, w in zip(cellsLines, colwidths)
     ]
-    linesCells = [[cl[i] for cl in cells_lines] for i in range(nlines)]
+    linesCells = [[cl[i] for cl in cellsLines] for i in range(nlines)]
     for ln in linesCells:
         paddedLn = _padRow(ln, pad)
         _appendBasicRow(lines, paddedLn, colwidths, colaligns, rowfmt)

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -223,8 +223,7 @@ _tableFormats = {
 tabulateFormats = list(sorted(_tableFormats.keys()))
 
 # The table formats for which multiline cells will be folded into subsequent table rows. The key is
-# the original format specified at the API. The value is the format that will be used to represent
-# the original format.
+# the original format, the value is the format that will be used to represent it.
 multilineFormats = {
     "armi": "armi",
     "plain": "plain",
@@ -307,8 +306,6 @@ def _isnumberWithThousandsSeparator(string):
     True
     >>> _isnumberWithThousandsSeparator("1,0000")
     False
-    >>> _isnumberWithThousandsSeparator("1,000.1234")
-    True
     >>> _isnumberWithThousandsSeparator(b"1,000.1234")
     True
     >>> _isnumberWithThousandsSeparator("+1,000.1234")
@@ -818,8 +815,8 @@ def _normalizeTabularData(data, headers, showIndex="default"):
     * NumPy record arrays (usually used with headers="keys")
     * dict of iterables (usually used with headers="keys")
 
-    The first row can be used as headers if headers="firstrow",
-    column indices can be used as headers if headers="keys".
+    The first row can be used as headers if headers="firstrow", column indices can be used as
+    headers if headers="keys".
 
     If showIndex="always", show row indices for all types of data.
     If showIndex="never", don't show row indices for all types of data.
@@ -960,9 +957,8 @@ def _wrapTextToColWidths(listOfLists, colwidths, numparses=True):
 
             if width is not None:
                 wrapper = TextWrapper(width=width)
-                # Cast based on our internal type handling
-                # Any future custom formatting of types (such as datetimes)
-                # may need to be more explicit than just `str` of the object
+                # Cast based on our internal type handling. Any future custom formatting of types
+                # (such as datetimes) may need to be more explicit than just `str` of the object
                 castedCell = (
                     str(cell) if _isnumber(cell) else _type(cell, numparse)(cell)
                 )
@@ -1039,7 +1035,6 @@ def tabulate(
 
     Table headers
     -------------
-
     To print nice column headers, supply the second argument (`headers`):
 
       - `headers` can be an explicit list of column headers
@@ -1060,7 +1055,6 @@ def tabulate(
 
     Column and Headers alignment
     ----------------------------
-
     `tabulate` tries to detect column types automatically, and aligns the values properly. By
     default it aligns decimal points of the numbers (or flushes integer numbers to the right), and
     flushes everything else to the left. Possible column alignments (`numAlign`, `strAlign`) are:
@@ -1247,7 +1241,7 @@ def tabulate(
     if tableFmt == "rst":
         listOfLists, headers = _rstEscapeFirstColumn(listOfLists, headers)
 
-    # PrettyTable formatting does not use any extra padding. Numbers are not parsed and are treated
+    # Pretty table formatting does not use any extra padding. Numbers are not parsed and are treated
     # the same as strings for alignment. Check if pretty is the format being used and override the
     # defaults so it does not impact other formats.
     minPadding = MIN_PADDING
@@ -1270,7 +1264,7 @@ def tabulate(
             # headers
             map(_toStr, headers),
             # rows: chain the rows together into a single iterable after mapping the bytestring
-            # conversino to each cell value
+            # conversion to each cell value
             chain.from_iterable(map(_toStr, row) for row in listOfLists),
         )
     )
@@ -1427,7 +1421,7 @@ def _expandIterable(original, numDesired, default):
     is shorter than `numDesired`, it will be padded with the value in `default`.
 
     If `original` is not a list to begin with (i.e. scalar value) a list of length `numDesired`
-    completely populated with `default will be returned
+    completely populated with `default` will be returned
     """
     if isinstance(original, Iterable) and not isinstance(original, str):
         return original + [default] * (numDesired - len(original))
@@ -1566,8 +1560,7 @@ def _formatTable(
             or Line("", "", "", "")
         )
         for row in paddedRows:
-            # test to see if either the 1st column or the 2nd column (account for showIndex) has the
-            # SEPARATING_LINE flag
+            # test to see if either the 1st column or the 2nd column has the SEPARATING_LINE flag
             if _isSeparatingLine(row):
                 _appendLine(lines, paddedWidths, colAligns, separatingLine)
             else:
@@ -1578,5 +1571,5 @@ def _formatTable(
 
     if headers or rows:
         return "\n".join(lines)
-    else:  # a completely empty table
+    else:
         return ""

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -279,39 +279,39 @@ _ansiEscapePat = rf"""
         {_osc}8;;{_st}  # "closing" OSC sequence
     )
 """
-_ansi_codes = re.compile(_ansiEscapePat, re.VERBOSE)
-_ansi_codes_bytes = re.compile(_ansiEscapePat.encode("utf8"), re.VERBOSE)
-_ansi_color_reset_code = "\033[0m"
+_ansiCodes = re.compile(_ansiEscapePat, re.VERBOSE)
+_ansiCodesBytes = re.compile(_ansiEscapePat.encode("utf8"), re.VERBOSE)
+_ansiColorResetCode = "\033[0m"
 
-_float_with_thousands_separators = re.compile(
+_floatWithThousandsSeparators = re.compile(
     r"^(([+-]?[0-9]{1,3})(?:,([0-9]{3}))*)?(?(1)\.[0-9]*|\.[0-9]+)?$"
 )
 
 
-def _isnumber_with_thousands_separator(string):
+def _isnumberWithThousandsSeparator(string):
     """Function to test of a string is a number with a thousands separator.
 
-    >>> _isnumber_with_thousands_separator(".")
+    >>> _isnumberWithThousandsSeparator(".")
     False
-    >>> _isnumber_with_thousands_separator("1")
+    >>> _isnumberWithThousandsSeparator("1")
     True
-    >>> _isnumber_with_thousands_separator("1.")
+    >>> _isnumberWithThousandsSeparator("1.")
     True
-    >>> _isnumber_with_thousands_separator(".1")
+    >>> _isnumberWithThousandsSeparator(".1")
     True
-    >>> _isnumber_with_thousands_separator("1000")
+    >>> _isnumberWithThousandsSeparator("1000")
     False
-    >>> _isnumber_with_thousands_separator("1,000")
+    >>> _isnumberWithThousandsSeparator("1,000")
     True
-    >>> _isnumber_with_thousands_separator("1,0000")
+    >>> _isnumberWithThousandsSeparator("1,0000")
     False
-    >>> _isnumber_with_thousands_separator("1,000.1234")
+    >>> _isnumberWithThousandsSeparator("1,000.1234")
     True
-    >>> _isnumber_with_thousands_separator(b"1,000.1234")
+    >>> _isnumberWithThousandsSeparator(b"1,000.1234")
     True
-    >>> _isnumber_with_thousands_separator("+1,000.1234")
+    >>> _isnumberWithThousandsSeparator("+1,000.1234")
     True
-    >>> _isnumber_with_thousands_separator("-1,000.1234")
+    >>> _isnumberWithThousandsSeparator("-1,000.1234")
     True
     """
     try:
@@ -319,7 +319,7 @@ def _isnumber_with_thousands_separator(string):
     except (UnicodeDecodeError, AttributeError):
         pass
 
-    return bool(re.match(_float_with_thousands_separators, string))
+    return bool(re.match(_floatWithThousandsSeparators, string))
 
 
 def _isconvertible(conv, string):
@@ -388,7 +388,7 @@ def _isbool(string):
     )
 
 
-def _type(string, has_invisible=True, numparse=True):
+def _type(string, hasInvisible=True, numparse=True):
     r"""The least generic type (type(None), int, float, str, unicode).
 
     >>> _type(None) is type(None)
@@ -403,7 +403,7 @@ def _type(string, has_invisible=True, numparse=True):
     True
 
     """
-    if has_invisible and isinstance(string, (str, bytes)):
+    if hasInvisible and isinstance(string, (str, bytes)):
         string = _strip_ansi(string)
 
     if string is None:
@@ -438,7 +438,7 @@ def _afterpoint(string):
     2
 
     """
-    if _isnumber(string) or _isnumber_with_thousands_separator(string):
+    if _isnumber(string) or _isnumberWithThousandsSeparator(string):
         if _isint(string):
             return -1
         else:
@@ -505,9 +505,9 @@ def _strip_ansi(s):
 
     """
     if isinstance(s, str):
-        return _ansi_codes.sub(r"\4", s)
+        return _ansiCodes.sub(r"\4", s)
     else:  # a bytestring
-        return _ansi_codes_bytes.sub(r"\4", s)
+        return _ansiCodesBytes.sub(r"\4", s)
 
 
 def _visible_width(s):
@@ -537,9 +537,9 @@ def _multilineWidth(multiline_s, line_width_fn=len):
     return max(map(line_width_fn, re.split("[\r\n]", multiline_s)))
 
 
-def _choose_width_fn(has_invisible, is_multiline):
+def _choose_width_fn(hasInvisible, is_multiline):
     """Return a function to calculate visible cell width."""
-    if has_invisible:
+    if hasInvisible:
         line_width_fn = _visible_width
     else:
         line_width_fn = len
@@ -552,7 +552,7 @@ def _choose_width_fn(has_invisible, is_multiline):
     return width_fn
 
 
-def _align_column_choose_padfn(strings, alignment, has_invisible):
+def _alignColumnChoosePadfn(strings, alignment, hasInvisible):
     if alignment == "right":
         if not PRESERVE_WHITESPACE:
             strings = [s.strip() for s in strings]
@@ -562,7 +562,7 @@ def _align_column_choose_padfn(strings, alignment, has_invisible):
             strings = [s.strip() for s in strings]
         padfn = _padboth
     elif alignment == "decimal":
-        if has_invisible:
+        if hasInvisible:
             decimals = [_afterpoint(_strip_ansi(s)) for s in strings]
         else:
             decimals = [_afterpoint(s) for s in strings]
@@ -578,21 +578,21 @@ def _align_column_choose_padfn(strings, alignment, has_invisible):
     return strings, padfn
 
 
-def _align_column_choose_width_fn(has_invisible, is_multiline):
-    if has_invisible:
+def _alignColumnChooseWidthFn(hasInvisible, is_multiline):
+    if hasInvisible:
         line_width_fn = _visible_width
     else:
         line_width_fn = len
 
     if is_multiline:
-        width_fn = lambda s: _align_column_multilineWidth(s, line_width_fn)
+        width_fn = lambda s: _alignColumnMultilineWidth(s, line_width_fn)
     else:
         width_fn = line_width_fn
 
     return width_fn
 
 
-def _align_column_multilineWidth(multiline_s, line_width_fn=len):
+def _alignColumnMultilineWidth(multiline_s, line_width_fn=len):
     """Visible width of a potentially multiline content."""
     return list(map(line_width_fn, re.split("[\r\n]", multiline_s)))
 
@@ -608,17 +608,15 @@ def _flat_list(nested_list):
     return ret
 
 
-def _alignColumn(
-    strings, alignment, minwidth=0, has_invisible=True, is_multiline=False
-):
+def _alignColumn(strings, alignment, minwidth=0, hasInvisible=True, is_multiline=False):
     """[string] -> [padded_string]."""
-    strings, padfn = _align_column_choose_padfn(strings, alignment, has_invisible)
-    width_fn = _align_column_choose_width_fn(has_invisible, is_multiline)
+    strings, padfn = _alignColumnChoosePadfn(strings, alignment, hasInvisible)
+    width_fn = _alignColumnChooseWidthFn(hasInvisible, is_multiline)
 
     s_widths = list(map(width_fn, strings))
     maxwidth = max(max(_flat_list(s_widths)), minwidth)
     if is_multiline:
-        if not has_invisible:
+        if not hasInvisible:
             padded_strings = [
                 "\n".join([padfn(maxwidth, s) for s in ms.splitlines()])
                 for ms in strings
@@ -637,7 +635,7 @@ def _alignColumn(
                 for ms, mw in zip(strings, visible_widths)
             ]
     else:  # single-line cell values
-        if not has_invisible:
+        if not hasInvisible:
             padded_strings = [padfn(maxwidth, s) for s in strings]
         else:
             # enable wide-character width corrections
@@ -671,7 +669,7 @@ def _more_generic(type1, type2):
     return invtypes[moregeneric]
 
 
-def _column_type(strings, has_invisible=True, numparse=True):
+def _column_type(strings, hasInvisible=True, numparse=True):
     r"""The least generic type all column values are convertible to.
 
     >>> _column_type([True, False]) is bool
@@ -693,11 +691,11 @@ def _column_type(strings, has_invisible=True, numparse=True):
     True
 
     """
-    types = [_type(s, has_invisible, numparse) for s in strings]
+    types = [_type(s, hasInvisible, numparse) for s in strings]
     return reduce(_more_generic, types, bool)
 
 
-def _format(val, valtype, floatfmt, intfmt, missingval="", has_invisible=True):
+def _format(val, valtype, floatfmt, intfmt, missingval="", hasInvisible=True):
     r"""Format a value according to its type.
 
     Unicode is supported:
@@ -722,7 +720,7 @@ def _format(val, valtype, floatfmt, intfmt, missingval="", has_invisible=True):
         except (TypeError, UnicodeDecodeError):
             return str(val)
     elif valtype is float:
-        isAColoredNumber = has_invisible and isinstance(val, (str, bytes))
+        isAColoredNumber = hasInvisible and isinstance(val, (str, bytes))
         if isAColoredNumber:
             rawVal = _strip_ansi(val)
             formattedVal = format(float(rawVal), floatfmt)
@@ -1327,7 +1325,7 @@ def tabulate(
         )
     )
 
-    has_invisible = _ansi_codes.search(plain_text) is not None
+    hasInvisible = _ansiCodes.search(plain_text) is not None
 
     if (
         not isinstance(tablefmt, TableFormat)
@@ -1338,7 +1336,7 @@ def tabulate(
         is_multiline = True
     else:
         is_multiline = False
-    width_fn = _choose_width_fn(has_invisible, is_multiline)
+    width_fn = _choose_width_fn(hasInvisible, is_multiline)
 
     # format rows and columns, convert numeric values to strings
     cols = list(izip_longest(*listOfLists))
@@ -1365,7 +1363,7 @@ def tabulate(
         if len(missing_vals) < len(cols):
             missing_vals.extend((len(cols) - len(missing_vals)) * [_DEFAULT_MISSINGVAL])
     cols = [
-        [_format(v, ct, fl_fmt, int_fmt, miss_v, has_invisible) for v in c]
+        [_format(v, ct, fl_fmt, int_fmt, miss_v, hasInvisible) for v in c]
         for c, ct, fl_fmt, int_fmt, miss_v in zip(
             cols, coltypes, float_formats, int_formats, missing_vals
         )
@@ -1396,7 +1394,7 @@ def tabulate(
         [width_fn(h) + min_padding for h in headers] if headers else [0] * len(cols)
     )
     cols = [
-        _alignColumn(c, a, minw, has_invisible, is_multiline)
+        _alignColumn(c, a, minw, hasInvisible, is_multiline)
         for c, a, minw in zip(cols, aligns, minwidths)
     ]
 
@@ -1662,7 +1660,7 @@ class _CustomTextWrap(textwrap.TextWrapper):
         This function will also track any ANSI color codes in this string as well as add any colors
         from previous lines order to preserve the same formatting as a single unwrapped string.
         """
-        code_matches = [x for x in _ansi_codes.finditer(new_line)]
+        code_matches = [x for x in _ansiCodes.finditer(new_line)]
         color_codes = [
             code.string[code.span()[0] : code.span()[1]] for code in code_matches
         ]
@@ -1671,7 +1669,7 @@ class _CustomTextWrap(textwrap.TextWrapper):
         new_line = "".join(self._active_codes) + new_line
 
         for code in color_codes:
-            if code != _ansi_color_reset_code:
+            if code != _ansiColorResetCode:
                 self._active_codes.append(code)
             else:  # A single reset code resets everything
                 self._active_codes = []
@@ -1679,6 +1677,6 @@ class _CustomTextWrap(textwrap.TextWrapper):
         # Always ensure each line is color terminted if any colors are still active, otherwise
         # colors will bleed into other cells on the console
         if len(self._active_codes) > 0:
-            new_line = new_line + _ansi_color_reset_code
+            new_line = new_line + _ansiColorResetCode
 
         lines.append(new_line)

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -896,19 +896,7 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
                     "headers for a list of dicts is not a dict or a keyword"
                 )
             rows = [[row.get(k) for k in keys] for row in rows]
-        elif (
-            headers == "keys"
-            and hasattr(tabularData, "description")
-            and hasattr(tabularData, "fetchone")
-            and hasattr(tabularData, "rowcount")
-        ):
-            # Python Database API cursor object (PEP 0249)
-            headers = [column[0] for column in tabularData.description]
-        elif (
-            dataclasses is not None
-            and len(rows) > 0
-            and dataclasses.is_dataclass(rows[0])
-        ):
+        elif len(rows) > 0 and dataclasses.is_dataclass(rows[0]):
             # Python 3.7+'s dataclass
             fieldNames = [field.name for field in dataclasses.fields(rows[0])]
             if headers == "keys":

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -532,7 +532,7 @@ def _is_multiline(s):
         return bool(re.search(_multiline_codes_bytes, s))
 
 
-def _multiline_width(multiline_s, line_width_fn=len):
+def _multilineWidth(multiline_s, line_width_fn=len):
     """Visible width of a potentially multiline content."""
     return max(map(line_width_fn, re.split("[\r\n]", multiline_s)))
 
@@ -545,7 +545,7 @@ def _choose_width_fn(has_invisible, is_multiline):
         line_width_fn = len
 
     if is_multiline:
-        width_fn = lambda s: _multiline_width(s, line_width_fn)
+        width_fn = lambda s: _multilineWidth(s, line_width_fn)
     else:
         width_fn = line_width_fn
 
@@ -585,14 +585,14 @@ def _align_column_choose_width_fn(has_invisible, is_multiline):
         line_width_fn = len
 
     if is_multiline:
-        width_fn = lambda s: _align_column_multiline_width(s, line_width_fn)
+        width_fn = lambda s: _align_column_multilineWidth(s, line_width_fn)
     else:
         width_fn = line_width_fn
 
     return width_fn
 
 
-def _align_column_multiline_width(multiline_s, line_width_fn=len):
+def _align_column_multilineWidth(multiline_s, line_width_fn=len):
     """Visible width of a potentially multiline content."""
     return list(map(line_width_fn, re.split("[\r\n]", multiline_s)))
 

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -39,7 +39,7 @@ MIN_PADDING = 2
 # Whether or not to preserve leading/trailing whitespace in data.
 PRESERVE_WHITESPACE = False
 
-_DEFAULT_FLOATFMT = "g"
+_DEFAULT_floatFmt = "g"
 _DEFAULT_INTFMT = ""
 _DEFAULT_MISSING_VAL = ""
 # default align will be overwritten by "left", "center" or "decimal" depending on the formatter
@@ -696,7 +696,7 @@ def _columnType(strings, hasInvisible=True, numparse=True):
     return reduce(_moreGeneric, types, bool)
 
 
-def _format(val, valtype, floatfmt, intfmt, missingVal="", hasInvisible=True):
+def _format(val, valtype, floatFmt, intfmt, missingVal="", hasInvisible=True):
     r"""Format a value according to its type.
 
     Unicode is supported:
@@ -724,10 +724,10 @@ def _format(val, valtype, floatfmt, intfmt, missingVal="", hasInvisible=True):
         isAColoredNumber = hasInvisible and isinstance(val, (str, bytes))
         if isAColoredNumber:
             rawVal = _stripAnsi(val)
-            formattedVal = format(float(rawVal), floatfmt)
+            formattedVal = format(float(rawVal), floatFmt)
             return val.replace(rawVal, formattedVal)
         else:
-            return format(float(val), floatfmt)
+            return format(float(val), floatFmt)
     else:
         return f"{val}"
 
@@ -1009,7 +1009,7 @@ def tabulate(
     data,
     headers=(),
     tableFmt="simple",
-    floatfmt=_DEFAULT_FLOATFMT,
+    floatFmt=_DEFAULT_floatFmt,
     intfmt=_DEFAULT_INTFMT,
     numAlign=_DEFAULT_ALIGN,
     strAlign=_DEFAULT_ALIGN,
@@ -1086,10 +1086,10 @@ def tabulate(
     `intfmt` is a format specification used for columns which contain numeric data without a decimal
     point. This can also be a list or tuple of format strings, one per column.
 
-    `floatfmt` is a format specification used for columns which contain numeric data with a decimal
+    `floatFmt` is a format specification used for columns which contain numeric data with a decimal
     point. This can also be a list or tuple of format strings, one per column.
 
-    `None` values are replaced with a `missingVal` string (like `floatfmt`, this can also be a list
+    `None` values are replaced with a `missingVal` string (like `floatFmt`, this can also be a list
     of values for different columns):
 
     >>> print(tabulate([["spam", 1, None],
@@ -1292,13 +1292,13 @@ def tabulate(
     cols = list(zip_longest(*listOfLists))
     numparses = _expandNumparse(disableNumParse, len(cols))
     coltypes = [_columnType(col, numparse=np) for col, np in zip(cols, numparses)]
-    if isinstance(floatfmt, str):
+    if isinstance(floatFmt, str):
         # old version: just duplicate the string to use in each column
-        floatFormats = len(cols) * [floatfmt]
-    else:  # if floatfmt is list, tuple etc we have one per column
-        floatFormats = list(floatfmt)
+        floatFormats = len(cols) * [floatFmt]
+    else:  # if floatFmt is list, tuple etc we have one per column
+        floatFormats = list(floatFmt)
         if len(floatFormats) < len(cols):
-            floatFormats.extend((len(cols) - len(floatFormats)) * [_DEFAULT_FLOATFMT])
+            floatFormats.extend((len(cols) - len(floatFormats)) * [_DEFAULT_floatFmt])
     if isinstance(intfmt, str):
         # old version: just duplicate the string to use in each column
         intFormats = len(cols) * [intfmt]

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -22,7 +22,7 @@ https://github.com/astanin/python-tabulate
 from collections import namedtuple
 from collections.abc import Iterable, Sized
 from functools import reduce, partial
-from itertools import chain, zip_longest as izip_longest
+from itertools import chain, zip_longest
 from textwrap import TextWrapper
 import dataclasses
 import math
@@ -30,7 +30,7 @@ import re
 
 from armi import runLog
 
-__all__ = ["tabulate", "tabulate_formats"]
+__all__ = ["tabulate", "tabulateFormats"]
 
 
 # minimum extra space in headers
@@ -220,7 +220,7 @@ _table_formats = {
 }
 
 
-tabulate_formats = list(sorted(_table_formats.keys()))
+tabulateFormats = list(sorted(_table_formats.keys()))
 
 # The table formats for which multiline cells will be folded into subsequent table rows. The key is
 # the original format specified at the API. The value is the format that will be used to represent
@@ -837,7 +837,7 @@ def _normalizeTabularData(tabularData, headers, showIndex="default"):
         # dict-like
         keys = tabularData.keys()
         # columns have to be transposed
-        rows = list(izip_longest(*tabularData.values()))
+        rows = list(zip_longest(*tabularData.values()))
 
         if headers == "keys":
             # headers should be strings
@@ -1103,7 +1103,7 @@ def tabulate(
     -----  --  ----
 
     Various plain-text table formats (`tablefmt`) are supported: 'plain', 'simple', 'grid',
-    'orgtbl', 'rst', and `tsv`. Variable `tabulate_formats` contains the list of currently supported
+    'orgtbl', 'rst', and `tsv`. Variable `tabulateFormats` contains the list of currently supported
     formats.
 
     "plain" format doesn't use any pseudographics to draw tables, it separates columns with a double
@@ -1290,7 +1290,7 @@ def tabulate(
     widthFn = _chooseWidthFn(hasInvisible, isMultiline)
 
     # format rows and columns, convert numeric values to strings
-    cols = list(izip_longest(*listOfLists))
+    cols = list(zip_longest(*listOfLists))
     numparses = _expandNumparse(disableNumParse, len(cols))
     coltypes = [_columnType(col, numparse=np) for col, np in zip(cols, numparses)]
     if isinstance(floatfmt, str):

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# NOTE: This code originally started out as the MIT-licensed "tabulate":
-#       This was originally https://github.com/astanin/python-tabulate
 
 """Pretty-print tabular data.
 
-TODO: JOHN
+This file started out as the MIT-licensed "tabulate". Though we have made, and will continue to make
+many arbitrary changes as we need. Thanks to the tabulate team.
+
+https://github.com/astanin/python-tabulate
 """
 from collections import namedtuple
 from collections.abc import Iterable, Sized

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -696,7 +696,7 @@ def _columnType(strings, hasInvisible=True, numparse=True):
     return reduce(_moreGeneric, types, bool)
 
 
-def _format(val, valtype, floatFmt, intfmt, missingVal="", hasInvisible=True):
+def _format(val, valtype, floatFmt, intFmt, missingVal="", hasInvisible=True):
     r"""Format a value according to its type.
 
     Unicode is supported:
@@ -714,7 +714,7 @@ def _format(val, valtype, floatFmt, intfmt, missingVal="", hasInvisible=True):
     if valtype is str:
         return f"{val}"
     elif valtype is int:
-        return format(val, intfmt)
+        return format(val, intFmt)
     elif valtype is bytes:
         try:
             return str(val, "ascii")
@@ -1010,7 +1010,7 @@ def tabulate(
     headers=(),
     tableFmt="simple",
     floatFmt=_DEFAULT_floatFmt,
-    intfmt=_DEFAULT_INTFMT,
+    intFmt=_DEFAULT_INTFMT,
     numAlign=_DEFAULT_ALIGN,
     strAlign=_DEFAULT_ALIGN,
     missingVal=_DEFAULT_MISSING_VAL,
@@ -1083,7 +1083,7 @@ def tabulate(
 
     Table formats
     -------------
-    `intfmt` is a format specification used for columns which contain numeric data without a decimal
+    `intFmt` is a format specification used for columns which contain numeric data without a decimal
     point. This can also be a list or tuple of format strings, one per column.
 
     `floatFmt` is a format specification used for columns which contain numeric data with a decimal
@@ -1299,11 +1299,11 @@ def tabulate(
         floatFormats = list(floatFmt)
         if len(floatFormats) < len(cols):
             floatFormats.extend((len(cols) - len(floatFormats)) * [_DEFAULT_floatFmt])
-    if isinstance(intfmt, str):
+    if isinstance(intFmt, str):
         # old version: just duplicate the string to use in each column
-        intFormats = len(cols) * [intfmt]
-    else:  # if intfmt is list, tuple etc we have one per column
-        intFormats = list(intfmt)
+        intFormats = len(cols) * [intFmt]
+    else:  # if intFmt is list, tuple etc we have one per column
+        intFormats = list(intFmt)
         if len(intFormats) < len(cols):
             intFormats.extend((len(cols) - len(intFormats)) * [_DEFAULT_INTFMT])
     if isinstance(missingVal, str):

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -285,7 +285,6 @@ _ansiEscapePat = rf"""
 """
 _ansiCodes = re.compile(_ansiEscapePat, re.VERBOSE)
 _ansiCodesBytes = re.compile(_ansiEscapePat.encode("utf8"), re.VERBOSE)
-
 _floatWithThousandsSeparators = re.compile(
     r"^(([+-]?[0-9]{1,3})(?:,([0-9]{3}))*)?(?(1)\.[0-9]*|\.[0-9]+)?$"
 )
@@ -805,7 +804,7 @@ def _bool(val):
         return False
 
 
-def _normalizeTabularData(tabularData, headers, showIndex="default"):
+def _normalizeTabularData(data, headers, showIndex="default"):
     """Transform a supported data type to a list of lists & a list of headers, with header padding.
 
     Supported tabular data types:
@@ -833,29 +832,29 @@ def _normalizeTabularData(tabularData, headers, showIndex="default"):
         headers = list(headers)
 
     index = None
-    if type(tabularData) is dict:
+    if type(data) is dict:
         # dict-like
-        keys = tabularData.keys()
+        keys = data.keys()
         # columns have to be transposed
-        rows = list(zip_longest(*tabularData.values()))
+        rows = list(zip_longest(*data.values()))
 
         if headers == "keys":
             # headers should be strings
             headers = list(map(str, keys))
     else:
         # it's a usual iterable of iterables, or a NumPy array, or an iterable of dataclasses
-        rows = list(tabularData)
+        rows = list(data)
 
         if headers == "keys" and not rows:
             # an empty table
             headers = []
         elif (
             headers == "keys"
-            and hasattr(tabularData, "dtype")
-            and getattr(tabularData.dtype, "names")
+            and hasattr(data, "dtype")
+            and getattr(data.dtype, "names")
         ):
             # numpy record array
-            headers = tabularData.dtype.names
+            headers = data.dtype.names
         elif (
             headers == "keys"
             and len(rows) > 0
@@ -1007,7 +1006,7 @@ def _toStr(s, encoding="utf8", errors="ignore"):
 
 
 def tabulate(
-    tabular_data,
+    data,
     headers=(),
     tablefmt="simple",
     floatfmt=_DEFAULT_FLOATFMT,
@@ -1034,7 +1033,7 @@ def tabulate(
       2  10001
     ---  ---------
 
-    The first required argument (`tabular_data`) can be a list-of-lists (or another iterable of
+    The first required argument (`data`) can be a list-of-lists (or another iterable of
     iterables), a list of named tuples, a dictionary of iterables, an iterable of dictionaries, an
     iterable of dataclasses (Python 3.7+), a two-dimensional NumPy array, or NumPy record array.
 
@@ -1079,7 +1078,7 @@ def tabulate(
         values are: "global" (no override), "same" (follow column alignment), "right", "center",
         "left".
 
-    Note on intended behaviour: If there is no `tabular_data`, any column alignment argument is
+    Note on intended behaviour: If there is no `data`, any column alignment argument is
         ignored. Hence, in this case, header alignment cannot be inferred from column alignment.
 
     Table formats
@@ -1206,11 +1205,11 @@ def tabulate(
 
     Header column width can be specified in a similar way using `maxheadercolwidth`.
     """
-    if tabular_data is None:
-        tabular_data = []
+    if data is None:
+        data = []
 
     listOfLists, headers, headersPad = _normalizeTabularData(
-        tabular_data, headers, showIndex=showIndex
+        data, headers, showIndex=showIndex
     )
     listOfLists, separatingLines = _removeSeparatingLines(listOfLists)
 

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -126,7 +126,7 @@ def _rstEscapeFirstColumn(rows, headers):
     return newRows, newHeaders
 
 
-_table_formats = {
+_tableFormats = {
     "armi": TableFormat(
         lineabove=Line("", "-", "  ", ""),
         linebelowheader=Line("", "-", "  ", ""),
@@ -220,7 +220,7 @@ _table_formats = {
 }
 
 
-tabulateFormats = list(sorted(_table_formats.keys()))
+tabulateFormats = list(sorted(_tableFormats.keys()))
 
 # The table formats for which multiline cells will be folded into subsequent table rows. The key is
 # the original format specified at the API. The value is the format that will be used to represent
@@ -1387,7 +1387,7 @@ def tabulate(
         rows = list(zip(*cols))
 
     if not isinstance(tablefmt, TableFormat):
-        tablefmt = _table_formats.get(tablefmt, _table_formats["simple"])
+        tablefmt = _tableFormats.get(tablefmt, _tableFormats["simple"])
 
     raDefault = rowAlign if isinstance(rowAlign, str) else None
     rowAligns = _expandIterable(rowAlign, len(rows), raDefault)

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -1019,11 +1019,11 @@ def tabulate(
     disableNumParse=False,
     colGlobalAlign=None,
     colAlign=None,
-    maxcolwidths=None,
-    headersglobalalign=None,
-    headersalign=None,
-    rowalign=None,
-    maxheadercolwidths=None,
+    maxColWidths=None,
+    headersGlobalAlign=None,
+    headersAlign=None,
+    rowAlign=None,
+    maxHeaderColWidths=None,
 ):
     r"""Format a fixed width table for pretty printing.
 
@@ -1072,10 +1072,10 @@ def tabulate(
         "decimal", "left".
     `colAlign` allows for column-wise override starting from left-most column. Possible values are:
         "global" (no override), "right", "center", "decimal", "left".
-    `headersglobalalign` allows for global headers alignment, before any specific override from
-        `headersalign`. Possible values are: None (follow columns alignment), "right", "center",
+    `headersGlobalAlign` allows for global headers alignment, before any specific override from
+        `headersAlign`. Possible values are: None (follow columns alignment), "right", "center",
         "left".
-    `headersalign` allows for header-wise override starting from left-most given header. Possible
+    `headersAlign` allows for header-wise override starting from left-most given header. Possible
         values are: "global" (no override), "same" (follow column alignment), "right", "center",
         "left".
 
@@ -1193,7 +1193,7 @@ def tabulate(
           [('1', 'John Smith', \
             'This is a rather long description that might look better if it is wrapped a bit')], \
           headers=("Issue Id", "Author", "Description"), \
-          maxcolwidths=[None, None, 30], \
+          maxColWidths=[None, None, 30], \
           tablefmt="grid"  \
         ))
     +------------+------------+-------------------------------+
@@ -1214,33 +1214,33 @@ def tabulate(
     )
     listOfLists, separatingLines = _removeSeparatingLines(listOfLists)
 
-    if maxcolwidths is not None:
+    if maxColWidths is not None:
         if len(listOfLists):
             numCols = len(listOfLists[0])
         else:
             numCols = 0
-        if isinstance(maxcolwidths, int):  # Expand scalar for all columns
-            maxcolwidths = _expandIterable(maxcolwidths, numCols, maxcolwidths)
+        if isinstance(maxColWidths, int):  # Expand scalar for all columns
+            maxColWidths = _expandIterable(maxColWidths, numCols, maxColWidths)
         else:  # Ignore col width for any 'trailing' columns
-            maxcolwidths = _expandIterable(maxcolwidths, numCols, None)
+            maxColWidths = _expandIterable(maxColWidths, numCols, None)
 
         numparses = _expandNumparse(disableNumParse, numCols)
         listOfLists = _wrapTextToColWidths(
-            listOfLists, maxcolwidths, numparses=numparses
+            listOfLists, maxColWidths, numparses=numparses
         )
 
-    if maxheadercolwidths is not None:
+    if maxHeaderColWidths is not None:
         numCols = len(listOfLists[0])
-        if isinstance(maxheadercolwidths, int):  # Expand scalar for all columns
-            maxheadercolwidths = _expandIterable(
-                maxheadercolwidths, numCols, maxheadercolwidths
+        if isinstance(maxHeaderColWidths, int):  # Expand scalar for all columns
+            maxHeaderColWidths = _expandIterable(
+                maxHeaderColWidths, numCols, maxHeaderColWidths
             )
         else:  # Ignore col width for any 'trailing' columns
-            maxheadercolwidths = _expandIterable(maxheadercolwidths, numCols, None)
+            maxHeaderColWidths = _expandIterable(maxHeaderColWidths, numCols, None)
 
         numparses = _expandNumparse(disableNumParse, numCols)
         headers = _wrapTextToColWidths(
-            [headers], maxheadercolwidths, numparses=numparses
+            [headers], maxHeaderColWidths, numparses=numparses
         )[0]
 
     # empty values in the first column of RST tables should be escaped
@@ -1353,20 +1353,20 @@ def tabulate(
         # align headers and add headers
         tCols = cols or [[""]] * len(headers)
         # first set global alignment
-        if headersglobalalign is not None:  # if global alignment provided
-            alignsHeaders = [headersglobalalign] * len(tCols)
+        if headersGlobalAlign is not None:  # if global alignment provided
+            alignsHeaders = [headersGlobalAlign] * len(tCols)
         else:  # default
             alignsHeaders = aligns or [strAlign] * len(headers)
         # then specific header alignements
-        if headersalign is not None:
-            assert isinstance(headersalign, Iterable)
-            if isinstance(headersalign, str):
+        if headersAlign is not None:
+            assert isinstance(headersAlign, Iterable)
+            if isinstance(headersAlign, str):
                 runLog.warning(
-                    f"As a string, `headersalign` is interpreted as {[c for c in headersalign]}. "
-                    + f'Did you mean `headersglobalalign = "{headersalign}"` or `headersalign = '
-                    + f'("{headersalign}",)`?'
+                    f"As a string, `headersAlign` is interpreted as {[c for c in headersAlign]}. "
+                    + f'Did you mean `headersGlobalAlign = "{headersAlign}"` or `headersAlign = '
+                    + f'("{headersAlign}",)`?'
                 )
-            for idx, align in enumerate(headersalign):
+            for idx, align in enumerate(headersAlign):
                 hidx = headersPad + idx
                 if not hidx < len(alignsHeaders):
                     break
@@ -1389,8 +1389,8 @@ def tabulate(
     if not isinstance(tablefmt, TableFormat):
         tablefmt = _table_formats.get(tablefmt, _table_formats["simple"])
 
-    raDefault = rowalign if isinstance(rowalign, str) else None
-    rowaligns = _expandIterable(rowalign, len(rows), raDefault)
+    raDefault = rowAlign if isinstance(rowAlign, str) else None
+    rowAligns = _expandIterable(rowAlign, len(rows), raDefault)
     _reinsertSeparatingLines(rows, separatingLines)
 
     return _formatTable(
@@ -1401,7 +1401,7 @@ def tabulate(
         minwidths,
         aligns,
         isMultiline,
-        rowaligns=rowaligns,
+        rowAligns=rowAligns,
     )
 
 
@@ -1461,8 +1461,8 @@ def _buildRow(paddedCells, colwidths, colAligns, rowfmt):
         return _buildSimpleRow(paddedCells, rowfmt)
 
 
-def _appendBasicRow(lines, paddedCells, colwidths, colAligns, rowfmt, rowalign=None):
-    # NOTE: rowalign is ignored and exists for api compatibility with _appendMultilineRow
+def _appendBasicRow(lines, paddedCells, colwidths, colAligns, rowfmt, rowAlign=None):
+    # NOTE: rowAlign is ignored and exists for api compatibility with _appendMultilineRow
     lines.append(_buildRow(paddedCells, colwidths, colAligns, rowfmt))
     return lines
 
@@ -1481,14 +1481,14 @@ def _alignCellVeritically(textLines, numLines, columnWidth, rowAlignment):
 
 
 def _appendMultilineRow(
-    lines, paddedMultilineCells, paddedWidths, colAligns, rowfmt, pad, rowalign=None
+    lines, paddedMultilineCells, paddedWidths, colAligns, rowfmt, pad, rowAlign=None
 ):
     colwidths = [w - 2 * pad for w in paddedWidths]
     cellsLines = [c.splitlines() for c in paddedMultilineCells]
     nlines = max(map(len, cellsLines))  # number of lines in the row
 
     cellsLines = [
-        _alignCellVeritically(cl, nlines, w, rowalign)
+        _alignCellVeritically(cl, nlines, w, rowAlign)
         for cl, w in zip(cellsLines, colwidths)
     ]
     linesCells = [[cl[i] for cl in cellsLines] for i in range(nlines)]
@@ -1517,7 +1517,7 @@ def _appendLine(lines, colwidths, colAligns, linefmt):
 
 
 def _formatTable(
-    fmt, headers, headersaligns, rows, colwidths, colAligns, isMultiline, rowaligns
+    fmt, headers, headersAligns, rows, colwidths, colAligns, isMultiline, rowAligns
 ):
     """Produce a plain-text representation of the table."""
     lines = []
@@ -1540,14 +1540,14 @@ def _formatTable(
         _appendLine(lines, paddedWidths, colAligns, fmt.lineabove)
 
     if paddedHeaders:
-        appendRow(lines, paddedHeaders, paddedWidths, headersaligns, headerrow)
+        appendRow(lines, paddedHeaders, paddedWidths, headersAligns, headerrow)
         if fmt.linebelowheader and "linebelowheader" not in hidden:
             _appendLine(lines, paddedWidths, colAligns, fmt.linebelowheader)
 
     if paddedRows and fmt.linebetweenrows and "linebetweenrows" not in hidden:
         # initial rows with a line below
-        for row, ralign in zip(paddedRows[:-1], rowaligns):
-            appendRow(lines, row, paddedWidths, colAligns, fmt.datarow, rowalign=ralign)
+        for row, ralign in zip(paddedRows[:-1], rowAligns):
+            appendRow(lines, row, paddedWidths, colAligns, fmt.datarow, rowAlign=ralign)
             _appendLine(lines, paddedWidths, colAligns, fmt.linebetweenrows)
         # the last row without a line below
         appendRow(
@@ -1556,7 +1556,7 @@ def _formatTable(
             paddedWidths,
             colAligns,
             fmt.datarow,
-            rowalign=rowaligns[-1],
+            rowAlign=rowAligns[-1],
         )
     else:
         separatingLine = (

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -805,7 +805,7 @@ def _bool(val):
         return False
 
 
-def _normalizeTabularData(tabularData, headers, showindex="default"):
+def _normalizeTabularData(tabularData, headers, showIndex="default"):
     """Transform a supported data type to a list of lists & a list of headers, with header padding.
 
     Supported tabular data types:
@@ -822,9 +822,9 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
     The first row can be used as headers if headers="firstrow",
     column indices can be used as headers if headers="keys".
 
-    If showindex="always", show row indices for all types of data.
-    If showindex="never", don't show row indices for all types of data.
-    If showindex is an iterable, show its values as row indices.
+    If showIndex="always", show row indices for all types of data.
+    If showIndex="never", don't show row indices for all types of data.
+    If showIndex is an iterable, show its values as row indices.
     """
     try:
         bool(headers)
@@ -922,14 +922,14 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
     rows = list(map(lambda r: r if _isSeparatingLine(r) else list(r), rows))
 
     # add or remove an index column
-    showIndexIsSStr = type(showindex) in [str, bytes]
-    if showindex == "default" and index is not None:
+    showIndexIsSStr = type(showIndex) in [str, bytes]
+    if showIndex == "default" and index is not None:
         rows = _prependRowIndex(rows, index)
-    elif isinstance(showindex, Sized) and not showIndexIsSStr:
-        rows = _prependRowIndex(rows, list(showindex))
-    elif isinstance(showindex, Iterable) and not showIndexIsSStr:
-        rows = _prependRowIndex(rows, showindex)
-    elif showindex == "always" or (_bool(showindex) and not showIndexIsSStr):
+    elif isinstance(showIndex, Sized) and not showIndexIsSStr:
+        rows = _prependRowIndex(rows, list(showIndex))
+    elif isinstance(showIndex, Iterable) and not showIndexIsSStr:
+        rows = _prependRowIndex(rows, showIndex)
+    elif showIndex == "always" or (_bool(showIndex) and not showIndexIsSStr):
         if index is None:
             index = list(range(len(rows)))
         rows = _prependRowIndex(rows, index)
@@ -1015,7 +1015,7 @@ def tabulate(
     numAlign=_DEFAULT_ALIGN,
     strAlign=_DEFAULT_ALIGN,
     missingVal=_DEFAULT_missingVal,
-    showindex="default",
+    showIndex="default",
     disableNumparse=False,
     colglobalalign=None,
     colalign=None,
@@ -1210,7 +1210,7 @@ def tabulate(
         tabular_data = []
 
     listOfLists, headers, headersPad = _normalizeTabularData(
-        tabular_data, headers, showindex=showindex
+        tabular_data, headers, showIndex=showIndex
     )
     listOfLists, separatingLines = _removeSeparatingLines(listOfLists)
 
@@ -1567,7 +1567,7 @@ def _formatTable(
             or Line("", "", "", "")
         )
         for row in paddedRows:
-            # test to see if either the 1st column or the 2nd column (account for showindex) has the
+            # test to see if either the 1st column or the 2nd column (account for showIndex) has the
             # SEPARATING_LINE flag
             if _isSeparatingLine(row):
                 _appendLine(lines, paddedWidths, colaligns, separatingLine)

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -487,7 +487,7 @@ def _padboth(width, s):
     return fmt.format(s)
 
 
-def _padnone(ignore_width, s):
+def _padnone(ignoreWidth, s):
     return s
 
 
@@ -591,14 +591,14 @@ def _alignColumnChooseWidthFn(hasInvisible, isMultiline):
     return widthFn
 
 
-def _alignColumnMultilineWidth(multiline_s, lineWidthFn=len):
+def _alignColumnMultilineWidth(multilineS, lineWidthFn=len):
     """Visible width of a potentially multiline content."""
-    return list(map(lineWidthFn, re.split("[\r\n]", multiline_s)))
+    return list(map(lineWidthFn, re.split("[\r\n]", multilineS)))
 
 
-def _flatList(nested_list):
+def _flatList(nestedList):
     ret = []
-    for item in nested_list:
+    for item in nestedList:
         if isinstance(item, list):
             for subitem in item:
                 ret.append(subitem)
@@ -921,7 +921,6 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
             and hasattr(tabularData, "rowcount")
         ):
             # Python Database API cursor object (PEP 0249)
-            # print tabulate(cursor, headers='keys')
             headers = [column[0] for column in tabularData.description]
         elif (
             dataclasses is not None
@@ -986,10 +985,10 @@ def _wrapTextToColwidths(listOfLists, colwidths, numparses=True):
     result = []
 
     for row in listOfLists:
-        new_row = []
+        newRow = []
         for cell, width, numparse in zip(row, colwidths, numparses):
             if _isnumber(cell) and numparse:
-                new_row.append(cell)
+                newRow.append(cell)
                 continue
 
             if width is not None:
@@ -997,18 +996,18 @@ def _wrapTextToColwidths(listOfLists, colwidths, numparses=True):
                 # Cast based on our internal type handling
                 # Any future custom formatting of types (such as datetimes)
                 # may need to be more explicit than just `str` of the object
-                casted_cell = (
+                castedCell = (
                     str(cell) if _isnumber(cell) else _type(cell, numparse)(cell)
                 )
                 wrapped = [
                     "\n".join(wrapper.wrap(line))
-                    for line in casted_cell.splitlines()
+                    for line in castedCell.splitlines()
                     if line.strip() != ""
                 ]
-                new_row.append("\n".join(wrapped))
+                newRow.append("\n".join(wrapped))
             else:
-                new_row.append(cell)
-        result.append(new_row)
+                newRow.append(cell)
+        result.append(newRow)
 
     return result
 
@@ -1296,9 +1295,9 @@ def tabulate(
     # PrettyTable formatting does not use any extra padding. Numbers are not parsed and are treated
     # the same as strings for alignment. Check if pretty is the format being used and override the
     # defaults so it does not impact other formats.
-    min_padding = MIN_PADDING
+    minPadding = MIN_PADDING
     if tablefmt == "pretty":
-        min_padding = 0
+        minPadding = 0
         disableNumparse = True
         numalign = "center" if numalign == _DEFAULT_ALIGN else numalign
         stralign = "center" if stralign == _DEFAULT_ALIGN else stralign
@@ -1311,7 +1310,7 @@ def tabulate(
     #
     # convert the headers and rows into a single, tab-delimited string ensuring that any bytestrings
     # are decoded safely (i.e. errors ignored)
-    plain_text = "\t".join(
+    plainText = "\t".join(
         chain(
             # headers
             map(_toStr, headers),
@@ -1321,12 +1320,12 @@ def tabulate(
         )
     )
 
-    hasInvisible = _ansiCodes.search(plain_text) is not None
+    hasInvisible = _ansiCodes.search(plainText) is not None
 
     if (
         not isinstance(tablefmt, TableFormat)
         and tablefmt in multiline_formats
-        and _isMultiline(plain_text)
+        and _isMultiline(plainText)
     ):
         tablefmt = multiline_formats.get(tablefmt, tablefmt)
         isMultiline = True
@@ -1387,7 +1386,7 @@ def tabulate(
             elif align != "global":
                 aligns[idx] = align
     minwidths = (
-        [widthFn(h) + min_padding for h in headers] if headers else [0] * len(cols)
+        [widthFn(h) + minPadding for h in headers] if headers else [0] * len(cols)
     )
     cols = [
         _alignColumn(c, a, minw, hasInvisible, isMultiline)
@@ -1436,8 +1435,8 @@ def tabulate(
     if not isinstance(tablefmt, TableFormat):
         tablefmt = _table_formats.get(tablefmt, _table_formats["simple"])
 
-    ra_default = rowalign if isinstance(rowalign, str) else None
-    rowaligns = _expandIterable(rowalign, len(rows), ra_default)
+    raDefault = rowalign if isinstance(rowalign, str) else None
+    rowaligns = _expandIterable(rowalign, len(rows), raDefault)
     _reinsertSeparatingLines(rows, separatingLines)
 
     return _formatTable(
@@ -1515,22 +1514,22 @@ def _appendBasicRow(lines, paddedCells, colwidths, colaligns, rowfmt, rowalign=N
 
 
 def _alignCellVeritically(textLines, numLines, columnWidth, rowAlignment):
-    delta_lines = numLines - len(textLines)
+    deltaLines = numLines - len(textLines)
     blank = [" " * columnWidth]
     if rowAlignment == "bottom":
-        return blank * delta_lines + textLines
+        return blank * deltaLines + textLines
     elif rowAlignment == "center":
-        topDelta = delta_lines // 2
-        bottom_delta = delta_lines - topDelta
-        return topDelta * blank + textLines + bottom_delta * blank
+        topDelta = deltaLines // 2
+        bottomDelta = deltaLines - topDelta
+        return topDelta * blank + textLines + bottomDelta * blank
     else:
-        return textLines + blank * delta_lines
+        return textLines + blank * deltaLines
 
 
 def _appendMultilineRow(
-    lines, paddedMultilineCells, padded_widths, colaligns, rowfmt, pad, rowalign=None
+    lines, paddedMultilineCells, paddedWidths, colaligns, rowfmt, pad, rowalign=None
 ):
-    colwidths = [w - 2 * pad for w in padded_widths]
+    colwidths = [w - 2 * pad for w in paddedWidths]
     cells_lines = [c.splitlines() for c in paddedMultilineCells]
     nlines = max(map(len, cells_lines))  # number of lines in the row
 
@@ -1540,8 +1539,9 @@ def _appendMultilineRow(
     ]
     linesCells = [[cl[i] for cl in cells_lines] for i in range(nlines)]
     for ln in linesCells:
-        padded_ln = _padRow(ln, pad)
-        _appendBasicRow(lines, padded_ln, colwidths, colaligns, rowfmt)
+        paddedLn = _padRow(ln, pad)
+        _appendBasicRow(lines, paddedLn, colwidths, colaligns, rowfmt)
+
     return lines
 
 
@@ -1571,59 +1571,57 @@ def _formatTable(
     pad = fmt.padding
     headerrow = fmt.headerrow
 
-    padded_widths = [(w + 2 * pad) for w in colwidths]
+    paddedWidths = [(w + 2 * pad) for w in colwidths]
     if isMultiline:
-        pad_row = lambda row, _: row
-        append_row = partial(_appendMultilineRow, pad=pad)
+        padRow = lambda row, _: row
+        appendRow = partial(_appendMultilineRow, pad=pad)
     else:
-        pad_row = _padRow
-        append_row = _appendBasicRow
+        padRow = _padRow
+        appendRow = _appendBasicRow
 
-    padded_headers = pad_row(headers, pad)
-    padded_rows = [pad_row(row, pad) for row in rows]
+    paddedHeaders = padRow(headers, pad)
+    paddedRows = [padRow(row, pad) for row in rows]
 
     if fmt.lineabove and "lineabove" not in hidden:
-        _appendLine(lines, padded_widths, colaligns, fmt.lineabove)
+        _appendLine(lines, paddedWidths, colaligns, fmt.lineabove)
 
-    if padded_headers:
-        append_row(lines, padded_headers, padded_widths, headersaligns, headerrow)
+    if paddedHeaders:
+        appendRow(lines, paddedHeaders, paddedWidths, headersaligns, headerrow)
         if fmt.linebelowheader and "linebelowheader" not in hidden:
-            _appendLine(lines, padded_widths, colaligns, fmt.linebelowheader)
+            _appendLine(lines, paddedWidths, colaligns, fmt.linebelowheader)
 
-    if padded_rows and fmt.linebetweenrows and "linebetweenrows" not in hidden:
+    if paddedRows and fmt.linebetweenrows and "linebetweenrows" not in hidden:
         # initial rows with a line below
-        for row, ralign in zip(padded_rows[:-1], rowaligns):
-            append_row(
-                lines, row, padded_widths, colaligns, fmt.datarow, rowalign=ralign
-            )
-            _appendLine(lines, padded_widths, colaligns, fmt.linebetweenrows)
+        for row, ralign in zip(paddedRows[:-1], rowaligns):
+            appendRow(lines, row, paddedWidths, colaligns, fmt.datarow, rowalign=ralign)
+            _appendLine(lines, paddedWidths, colaligns, fmt.linebetweenrows)
         # the last row without a line below
-        append_row(
+        appendRow(
             lines,
-            padded_rows[-1],
-            padded_widths,
+            paddedRows[-1],
+            paddedWidths,
             colaligns,
             fmt.datarow,
             rowalign=rowaligns[-1],
         )
     else:
-        separating_line = (
+        separatingLine = (
             fmt.linebetweenrows
             or fmt.linebelowheader
             or fmt.linebelow
             or fmt.lineabove
             or Line("", "", "", "")
         )
-        for row in padded_rows:
+        for row in paddedRows:
             # test to see if either the 1st column or the 2nd column (account for showindex) has the
             # SEPARATING_LINE flag
             if _isSeparatingLine(row):
-                _appendLine(lines, padded_widths, colaligns, separating_line)
+                _appendLine(lines, paddedWidths, colaligns, separatingLine)
             else:
-                append_row(lines, row, padded_widths, colaligns, fmt.datarow)
+                appendRow(lines, row, paddedWidths, colaligns, fmt.datarow)
 
     if fmt.linebelow and "linebelow" not in hidden:
-        _appendLine(lines, padded_widths, colaligns, fmt.linebelow)
+        _appendLine(lines, paddedWidths, colaligns, fmt.linebelow)
 
     if headers or rows:
         return "\n".join(lines)
@@ -1637,8 +1635,7 @@ class _CustomTextWrap(textwrap.TextWrapper):
     """
 
     def __init__(self, *args, **kwargs):
-        self._active_codes = []
-        self.max_lines = None  # For python2 compatibility
+        self._activeCodes = []
         textwrap.TextWrapper.__init__(self, *args, **kwargs)
 
     @staticmethod
@@ -1649,29 +1646,29 @@ class _CustomTextWrap(textwrap.TextWrapper):
         stripped = _stripAnsi(item)
         return len(stripped)
 
-    def _updateLines(self, lines, new_line):
+    def _updateLines(self, lines, newLine):
         """Adds a new line to the list of lines the text is being wrapped into.
 
         This function will also track any ANSI color codes in this string as well as add any colors
         from previous lines order to preserve the same formatting as a single unwrapped string.
         """
-        code_matches = [x for x in _ansiCodes.finditer(new_line)]
-        color_codes = [
-            code.string[code.span()[0] : code.span()[1]] for code in code_matches
+        codeMatches = [x for x in _ansiCodes.finditer(newLine)]
+        colorCodes = [
+            code.string[code.span()[0] : code.span()[1]] for code in codeMatches
         ]
 
         # Add color codes from earlier in the unwrapped line, and then track any new ones we add.
-        new_line = "".join(self._active_codes) + new_line
+        newLine = "".join(self._activeCodes) + newLine
 
-        for code in color_codes:
+        for code in colorCodes:
             if code != _ansiColorResetCode:
-                self._active_codes.append(code)
+                self._activeCodes.append(code)
             else:  # A single reset code resets everything
-                self._active_codes = []
+                self._activeCodes = []
 
         # Always ensure each line is color terminted if any colors are still active, otherwise
         # colors will bleed into other cells on the console
-        if len(self._active_codes) > 0:
-            new_line = new_line + _ansiColorResetCode
+        if len(self._activeCodes) > 0:
+            newLine = newLine + _ansiColorResetCode
 
-        lines.append(new_line)
+        lines.append(newLine)

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -15,7 +15,10 @@
 # NOTE: This code originally started out as the MIT-licensed "tabulate":
 #       This was originally https://github.com/astanin/python-tabulate
 
-"""Pretty-print tabular data."""
+"""Pretty-print tabular data.
+
+TODO: JOHN
+"""
 from collections import namedtuple
 from collections.abc import Iterable, Sized
 from functools import reduce, partial
@@ -815,12 +818,10 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
     * 2D NumPy arrays
     * NumPy record arrays (usually used with headers="keys")
     * dict of iterables (usually used with headers="keys")
-    * pandas.DataFrame (usually used with headers="keys")
 
     The first row can be used as headers if headers="firstrow",
     column indices can be used as headers if headers="keys".
 
-    If showindex="default", show row indices of the pandas.DataFrame.
     If showindex="always", show row indices for all types of data.
     If showindex="never", don't show row indices for all types of data.
     If showindex is an iterable, show its values as row indices.
@@ -828,33 +829,17 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
     try:
         bool(headers)
     except ValueError:
-        # numpy.ndarray, pandas.core.index.Index, ...
+        # numpy.ndarray, ...
         headers = list(headers)
 
     index = None
     if hasattr(tabularData, "keys") and hasattr(tabularData, "values"):
-        # dict-like and pandas.DataFrame?
+        # dict-like?
         if hasattr(tabularData.values, "__call__"):
             # likely a conventional dict
             keys = tabularData.keys()
-            rows = list(
-                izip_longest(*tabularData.values())
-            )  # columns have to be transposed
-        elif hasattr(tabularData, "index"):
-            # values is a property, has .index => it's likely a pandas.DataFrame (pandas 0.11.0)
-            keys = list(tabularData)
-            if (
-                showindex in ["default", "always", True]
-                and tabularData.index.name is not None
-            ):
-                if isinstance(tabularData.index.name, list):
-                    keys[:0] = tabularData.index.name
-                else:
-                    keys[:0] = [tabularData.index.name]
-            vals = tabularData.values  # values matrix doesn't need to be transposed
-            # for DataFrames add an index per default
-            index = list(tabularData.index)
-            rows = [list(row) for row in vals]
+            # columns have to be transposed
+            rows = list(izip_longest(*tabularData.values()))
         else:
             raise ValueError("tabular data doesn't appear to be a dict or a DataFrame")
 
@@ -865,7 +850,7 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
         rows = list(tabularData)
 
         if headers == "keys" and not rows:
-            # an empty table (issue #81)
+            # an empty table
             headers = []
         elif (
             headers == "keys"
@@ -1068,8 +1053,7 @@ def tabulate(
 
     The first required argument (`tabular_data`) can be a list-of-lists (or another iterable of
     iterables), a list of named tuples, a dictionary of iterables, an iterable of dictionaries, an
-    iterable of dataclasses (Python 3.7+), a two-dimensional NumPy array, NumPy record array, or a
-    Pandas' dataframe.
+    iterable of dataclasses (Python 3.7+), a two-dimensional NumPy array, or NumPy record array.
 
     Table headers
     -------------
@@ -1083,7 +1067,7 @@ def tabulate(
     Otherwise a headerless table is produced.
 
     If the number of headers is less than the number of columns, they are supposed to be names of
-    the last columns. This is consistent with the plain-text format of R and Pandas' dataframes.
+    the last columns. This is consistent with the plain-text format of R.
 
     >>> print(tabulate([["sex","age"],["Alice","F",24],["Bob","M",19]],
     ...       headers="firstrow"))
@@ -1091,17 +1075,6 @@ def tabulate(
     -----  -----  -----
     Alice  F         24
     Bob    M         19
-
-    By default, pandas.DataFrame data have an additional column called row index. To add a similar
-    column to all other types of data, use `showindex="always"` or `showindex=True`. To suppress row
-    indices for all types of data, pass `showindex="never" or `showindex=False`. To add a custom row
-    index column, pass `showindex=some_iterable`.
-
-    >>> print(tabulate([["F",24],["M",19]], showindex="always"))
-    -  -  --
-    0  F  24
-    1  M  19
-    -  -  --
 
     Column and Headers alignment
     ----------------------------
@@ -1287,7 +1260,7 @@ def tabulate(
             [headers], maxheadercolwidths, numparses=numparses
         )[0]
 
-    # empty values in the first column of RST tables should be escaped (issue #82)
+    # empty values in the first column of RST tables should be escaped
     # "" should be escaped as "\\ " or ".."
     if tablefmt == "rst":
         listOfLists, headers = _rstEscapeFirstColumn(listOfLists, headers)

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -74,7 +74,7 @@ DataRow = namedtuple("DataRow", ["begin", "sep", "end"])
 #
 # padding (an integer) is the amount of white space around data values.
 #
-# with_header_hide:
+# withHeaderHide:
 #
 #   - either None, to display all table elements unconditionally,
 #   - or a list of elements not to be displayed if the table has column headers.
@@ -89,18 +89,18 @@ TableFormat = namedtuple(
         "headerrow",
         "datarow",
         "padding",
-        "with_header_hide",
+        "withHeaderHide",
     ],
 )
 
 
 def _isSeparatingLine(row):
-    row_type = type(row)
-    is_sl = (row_type is list or row_type is str) and (
+    rowType = type(row)
+    isSl = (rowType is list or rowType is str) and (
         (len(row) >= 1 and row[0] == SEPARATING_LINE)
         or (len(row) >= 2 and row[1] == SEPARATING_LINE)
     )
-    return is_sl
+    return isSl
 
 
 def _rstEscapeFirstColumn(rows, headers):
@@ -131,7 +131,7 @@ _table_formats = {
         headerrow=DataRow("", "  ", ""),
         datarow=DataRow("", "  ", ""),
         padding=0,
-        with_header_hide=None,
+        withHeaderHide=None,
     ),
     "simple": TableFormat(
         lineabove=Line("", "-", "  ", ""),
@@ -141,7 +141,7 @@ _table_formats = {
         headerrow=DataRow("", "  ", ""),
         datarow=DataRow("", "  ", ""),
         padding=0,
-        with_header_hide=["lineabove", "linebelow"],
+        withHeaderHide=["lineabove", "linebelow"],
     ),
     "plain": TableFormat(
         lineabove=None,
@@ -151,7 +151,7 @@ _table_formats = {
         headerrow=DataRow("", "  ", ""),
         datarow=DataRow("", "  ", ""),
         padding=0,
-        with_header_hide=None,
+        withHeaderHide=None,
     ),
     "grid": TableFormat(
         lineabove=Line("+", "-", "+", "+"),
@@ -161,7 +161,7 @@ _table_formats = {
         headerrow=DataRow("|", "|", "|"),
         datarow=DataRow("|", "|", "|"),
         padding=1,
-        with_header_hide=None,
+        withHeaderHide=None,
     ),
     "github": TableFormat(
         lineabove=Line("|", "-", "|", "|"),
@@ -171,7 +171,7 @@ _table_formats = {
         headerrow=DataRow("|", "|", "|"),
         datarow=DataRow("|", "|", "|"),
         padding=1,
-        with_header_hide=["lineabove"],
+        withHeaderHide=["lineabove"],
     ),
     "pretty": TableFormat(
         lineabove=Line("+", "-", "+", "+"),
@@ -181,7 +181,7 @@ _table_formats = {
         headerrow=DataRow("|", "|", "|"),
         datarow=DataRow("|", "|", "|"),
         padding=1,
-        with_header_hide=None,
+        withHeaderHide=None,
     ),
     "psql": TableFormat(
         lineabove=Line("+", "-", "+", "+"),
@@ -191,7 +191,7 @@ _table_formats = {
         headerrow=DataRow("|", "|", "|"),
         datarow=DataRow("|", "|", "|"),
         padding=1,
-        with_header_hide=None,
+        withHeaderHide=None,
     ),
     "rst": TableFormat(
         lineabove=Line("", "=", "  ", ""),
@@ -201,7 +201,7 @@ _table_formats = {
         headerrow=DataRow("", "  ", ""),
         datarow=DataRow("", "  ", ""),
         padding=0,
-        with_header_hide=None,
+        withHeaderHide=None,
     ),
     "tsv": TableFormat(
         lineabove=None,
@@ -211,7 +211,7 @@ _table_formats = {
         headerrow=DataRow("", "\t", ""),
         datarow=DataRow("", "\t", ""),
         padding=0,
-        with_header_hide=None,
+        withHeaderHide=None,
     ),
 }
 
@@ -517,11 +517,10 @@ def _visibleWidth(s):
     (5, 5)
 
     """
-    len_fn = len
     if isinstance(s, (str, bytes)):
-        return len_fn(_stripAnsi(s))
+        return len(_stripAnsi(s))
     else:
-        return len_fn(str(s))
+        return len(str(s))
 
 
 def _isMultiline(s):
@@ -532,24 +531,24 @@ def _isMultiline(s):
         return bool(re.search(_multilineCodesBytes, s))
 
 
-def _multilineWidth(multiline_s, line_width_fn=len):
+def _multilineWidth(multilineS, lineWidthFn=len):
     """Visible width of a potentially multiline content."""
-    return max(map(line_width_fn, re.split("[\r\n]", multiline_s)))
+    return max(map(lineWidthFn, re.split("[\r\n]", multilineS)))
 
 
 def _chooseWidthFn(hasInvisible, isMultiline):
     """Return a function to calculate visible cell width."""
     if hasInvisible:
-        line_width_fn = _visibleWidth
+        lineWidthFn = _visibleWidth
     else:
-        line_width_fn = len
+        lineWidthFn = len
 
     if isMultiline:
-        width_fn = lambda s: _multilineWidth(s, line_width_fn)
+        widthFn = lambda s: _multilineWidth(s, lineWidthFn)
     else:
-        width_fn = line_width_fn
+        widthFn = lineWidthFn
 
-    return width_fn
+    return widthFn
 
 
 def _alignColumnChoosePadfn(strings, alignment, hasInvisible):
@@ -580,21 +579,21 @@ def _alignColumnChoosePadfn(strings, alignment, hasInvisible):
 
 def _alignColumnChooseWidthFn(hasInvisible, isMultiline):
     if hasInvisible:
-        line_width_fn = _visibleWidth
+        lineWidthFn = _visibleWidth
     else:
-        line_width_fn = len
+        lineWidthFn = len
 
     if isMultiline:
-        width_fn = lambda s: _alignColumnMultilineWidth(s, line_width_fn)
+        widthFn = lambda s: _alignColumnMultilineWidth(s, lineWidthFn)
     else:
-        width_fn = line_width_fn
+        widthFn = lineWidthFn
 
-    return width_fn
+    return widthFn
 
 
-def _alignColumnMultilineWidth(multiline_s, line_width_fn=len):
+def _alignColumnMultilineWidth(multiline_s, lineWidthFn=len):
     """Visible width of a potentially multiline content."""
-    return list(map(line_width_fn, re.split("[\r\n]", multiline_s)))
+    return list(map(lineWidthFn, re.split("[\r\n]", multiline_s)))
 
 
 def _flatList(nested_list):
@@ -611,41 +610,41 @@ def _flatList(nested_list):
 def _alignColumn(strings, alignment, minwidth=0, hasInvisible=True, isMultiline=False):
     """[string] -> [padded_string]."""
     strings, padfn = _alignColumnChoosePadfn(strings, alignment, hasInvisible)
-    width_fn = _alignColumnChooseWidthFn(hasInvisible, isMultiline)
+    widthFn = _alignColumnChooseWidthFn(hasInvisible, isMultiline)
 
-    s_widths = list(map(width_fn, strings))
+    s_widths = list(map(widthFn, strings))
     maxwidth = max(max(_flatList(s_widths)), minwidth)
     if isMultiline:
         if not hasInvisible:
-            padded_strings = [
+            paddedStrings = [
                 "\n".join([padfn(maxwidth, s) for s in ms.splitlines()])
                 for ms in strings
             ]
         else:
             # enable wide-character width corrections
-            s_lens = [[len(s) for s in re.split("[\r\n]", ms)] for ms in strings]
+            sLens = [[len(s) for s in re.split("[\r\n]", ms)] for ms in strings]
             visibleWidths = [
                 [maxwidth - (w - ll) for w, ll in zip(mw, ml)]
-                for mw, ml in zip(s_widths, s_lens)
+                for mw, ml in zip(s_widths, sLens)
             ]
             # wcswidth and _visibleWidth don't count invisible characters;
             # padfn doesn't need to apply another correction
-            padded_strings = [
+            paddedStrings = [
                 "\n".join([padfn(w, s) for s, w in zip((ms.splitlines() or ms), mw)])
                 for ms, mw in zip(strings, visibleWidths)
             ]
     else:  # single-line cell values
         if not hasInvisible:
-            padded_strings = [padfn(maxwidth, s) for s in strings]
+            paddedStrings = [padfn(maxwidth, s) for s in strings]
         else:
             # enable wide-character width corrections
-            s_lens = list(map(len, strings))
-            visibleWidths = [maxwidth - (w - ll) for w, ll in zip(s_widths, s_lens)]
+            sLens = list(map(len, strings))
+            visibleWidths = [maxwidth - (w - ll) for w, ll in zip(s_widths, sLens)]
             # wcswidth and _visibleWidth don't count invisible characters;
             # padfn doesn't need to apply another correction
-            padded_strings = [padfn(w, s) for s, w in zip(strings, visibleWidths)]
+            paddedStrings = [padfn(w, s) for s, w in zip(strings, visibleWidths)]
 
-    return padded_strings
+    return paddedStrings
 
 
 def _moreGeneric(type1, type2):
@@ -732,13 +731,13 @@ def _format(val, valtype, floatfmt, intfmt, missingval="", hasInvisible=True):
 
 
 def _alignHeader(
-    header, alignment, width, visibleWidth, isMultiline=False, width_fn=None
+    header, alignment, width, visibleWidth, isMultiline=False, widthFn=None
 ):
     """Pad string header to width chars given known visibleWidth of the header."""
     if isMultiline:
         headerLines = re.split(_multilineCodes, header)
         paddedLines = [
-            _alignHeader(h, alignment, width, width_fn(h)) for h in headerLines
+            _alignHeader(h, alignment, width, widthFn(h)) for h in headerLines
         ]
         return "\n".join(paddedLines)
     # else: not multiline
@@ -803,7 +802,7 @@ def _bool(val):
         return False
 
 
-def _normalizeTabularData(tabular_data, headers, showindex="default"):
+def _normalizeTabularData(tabularData, headers, showindex="default"):
     """Transform a supported data type to a list of lists & a list of headers, with header padding.
 
     Supported tabular data types:
@@ -833,28 +832,28 @@ def _normalizeTabularData(tabular_data, headers, showindex="default"):
         headers = list(headers)
 
     index = None
-    if hasattr(tabular_data, "keys") and hasattr(tabular_data, "values"):
+    if hasattr(tabularData, "keys") and hasattr(tabularData, "values"):
         # dict-like and pandas.DataFrame?
-        if hasattr(tabular_data.values, "__call__"):
+        if hasattr(tabularData.values, "__call__"):
             # likely a conventional dict
-            keys = tabular_data.keys()
+            keys = tabularData.keys()
             rows = list(
-                izip_longest(*tabular_data.values())
+                izip_longest(*tabularData.values())
             )  # columns have to be transposed
-        elif hasattr(tabular_data, "index"):
+        elif hasattr(tabularData, "index"):
             # values is a property, has .index => it's likely a pandas.DataFrame (pandas 0.11.0)
-            keys = list(tabular_data)
+            keys = list(tabularData)
             if (
                 showindex in ["default", "always", True]
-                and tabular_data.index.name is not None
+                and tabularData.index.name is not None
             ):
-                if isinstance(tabular_data.index.name, list):
-                    keys[:0] = tabular_data.index.name
+                if isinstance(tabularData.index.name, list):
+                    keys[:0] = tabularData.index.name
                 else:
-                    keys[:0] = [tabular_data.index.name]
-            vals = tabular_data.values  # values matrix doesn't need to be transposed
+                    keys[:0] = [tabularData.index.name]
+            vals = tabularData.values  # values matrix doesn't need to be transposed
             # for DataFrames add an index per default
-            index = list(tabular_data.index)
+            index = list(tabularData.index)
             rows = [list(row) for row in vals]
         else:
             raise ValueError("tabular data doesn't appear to be a dict or a DataFrame")
@@ -863,18 +862,18 @@ def _normalizeTabularData(tabular_data, headers, showindex="default"):
             headers = list(map(str, keys))  # headers should be strings
 
     else:  # it's a usual iterable of iterables, or a NumPy array, or an iterable of dataclasses
-        rows = list(tabular_data)
+        rows = list(tabularData)
 
         if headers == "keys" and not rows:
             # an empty table (issue #81)
             headers = []
         elif (
             headers == "keys"
-            and hasattr(tabular_data, "dtype")
-            and getattr(tabular_data.dtype, "names")
+            and hasattr(tabularData, "dtype")
+            and getattr(tabularData.dtype, "names")
         ):
             # numpy record array
-            headers = tabular_data.dtype.names
+            headers = tabularData.dtype.names
         elif (
             headers == "keys"
             and len(rows) > 0
@@ -918,13 +917,13 @@ def _normalizeTabularData(tabular_data, headers, showindex="default"):
 
         elif (
             headers == "keys"
-            and hasattr(tabular_data, "description")
-            and hasattr(tabular_data, "fetchone")
-            and hasattr(tabular_data, "rowcount")
+            and hasattr(tabularData, "description")
+            and hasattr(tabularData, "fetchone")
+            and hasattr(tabularData, "rowcount")
         ):
             # Python Database API cursor object (PEP 0249)
             # print tabulate(cursor, headers='keys')
-            headers = [column[0] for column in tabular_data.description]
+            headers = [column[0] for column in tabularData.description]
 
         elif (
             dataclasses is not None
@@ -982,10 +981,10 @@ def _normalizeTabularData(tabular_data, headers, showindex="default"):
 
 def _wrapTextToColwidths(listOfLists, colwidths, numparses=True):
     if len(listOfLists):
-        num_cols = len(listOfLists[0])
+        numCols = len(listOfLists[0])
     else:
-        num_cols = 0
-    numparses = _expandIterable(numparses, num_cols, True)
+        numCols = 0
+    numparses = _expandIterable(numparses, numCols, True)
 
     result = []
 
@@ -1044,7 +1043,7 @@ def _toStr(s, encoding="utf8", errors="ignore"):
 
 
 def tabulate(
-    tabular_data,
+    tabularData,
     headers=(),
     tablefmt="simple",
     floatfmt=_DEFAULT_FLOATFMT,
@@ -1071,7 +1070,7 @@ def tabulate(
       2  10001
     ---  ---------
 
-    The first required argument (`tabular_data`) can be a list-of-lists (or another iterable of
+    The first required argument (`tabularData`) can be a list-of-lists (or another iterable of
     iterables), a list of named tuples, a dictionary of iterables, an iterable of dictionaries, an
     iterable of dataclasses (Python 3.7+), a two-dimensional NumPy array, NumPy record array, or a
     Pandas' dataframe.
@@ -1128,7 +1127,7 @@ def tabulate(
         values are: "global" (no override), "same" (follow column alignment), "right", "center",
         "left".
 
-    Note on intended behaviour: If there is no `tabular_data`, any column alignment argument is
+    Note on intended behaviour: If there is no `tabularData`, any column alignment argument is
         ignored. Hence, in this case, header alignment cannot be inferred from column alignment.
 
     Table formats
@@ -1255,39 +1254,39 @@ def tabulate(
 
     Header column width can be specified in a similar way using `maxheadercolwidth`.
     """
-    if tabular_data is None:
-        tabular_data = []
+    if tabularData is None:
+        tabularData = []
 
     listOfLists, headers, headers_pad = _normalizeTabularData(
-        tabular_data, headers, showindex=showindex
+        tabularData, headers, showindex=showindex
     )
     listOfLists, separatingLines = _removeSeparatingLines(listOfLists)
 
     if maxcolwidths is not None:
         if len(listOfLists):
-            num_cols = len(listOfLists[0])
+            numCols = len(listOfLists[0])
         else:
-            num_cols = 0
+            numCols = 0
         if isinstance(maxcolwidths, int):  # Expand scalar for all columns
-            maxcolwidths = _expandIterable(maxcolwidths, num_cols, maxcolwidths)
+            maxcolwidths = _expandIterable(maxcolwidths, numCols, maxcolwidths)
         else:  # Ignore col width for any 'trailing' columns
-            maxcolwidths = _expandIterable(maxcolwidths, num_cols, None)
+            maxcolwidths = _expandIterable(maxcolwidths, numCols, None)
 
-        numparses = _expandNumparse(disableNumparse, num_cols)
+        numparses = _expandNumparse(disableNumparse, numCols)
         listOfLists = _wrapTextToColwidths(
             listOfLists, maxcolwidths, numparses=numparses
         )
 
     if maxheadercolwidths is not None:
-        num_cols = len(listOfLists[0])
+        numCols = len(listOfLists[0])
         if isinstance(maxheadercolwidths, int):  # Expand scalar for all columns
             maxheadercolwidths = _expandIterable(
-                maxheadercolwidths, num_cols, maxheadercolwidths
+                maxheadercolwidths, numCols, maxheadercolwidths
             )
         else:  # Ignore col width for any 'trailing' columns
-            maxheadercolwidths = _expandIterable(maxheadercolwidths, num_cols, None)
+            maxheadercolwidths = _expandIterable(maxheadercolwidths, numCols, None)
 
-        numparses = _expandNumparse(disableNumparse, num_cols)
+        numparses = _expandNumparse(disableNumparse, numCols)
         headers = _wrapTextToColwidths(
             [headers], maxheadercolwidths, numparses=numparses
         )[0]
@@ -1336,7 +1335,7 @@ def tabulate(
         isMultiline = True
     else:
         isMultiline = False
-    width_fn = _chooseWidthFn(hasInvisible, isMultiline)
+    widthFn = _chooseWidthFn(hasInvisible, isMultiline)
 
     # format rows and columns, convert numeric values to strings
     cols = list(izip_longest(*listOfLists))
@@ -1363,8 +1362,8 @@ def tabulate(
         if len(missing_vals) < len(cols):
             missing_vals.extend((len(cols) - len(missing_vals)) * [_DEFAULT_MISSINGVAL])
     cols = [
-        [_format(v, ct, fl_fmt, int_fmt, miss_v, hasInvisible) for v in c]
-        for c, ct, fl_fmt, int_fmt, miss_v in zip(
+        [_format(v, ct, flFmt, intFmt, missV, hasInvisible) for v in c]
+        for c, ct, flFmt, intFmt, missV in zip(
             cols, coltypes, float_formats, int_formats, missing_vals
         )
     ]
@@ -1391,22 +1390,22 @@ def tabulate(
             elif align != "global":
                 aligns[idx] = align
     minwidths = (
-        [width_fn(h) + min_padding for h in headers] if headers else [0] * len(cols)
+        [widthFn(h) + min_padding for h in headers] if headers else [0] * len(cols)
     )
     cols = [
         _alignColumn(c, a, minw, hasInvisible, isMultiline)
         for c, a, minw in zip(cols, aligns, minwidths)
     ]
 
-    aligns_headers = None
+    alignsHeaders = None
     if headers:
         # align headers and add headers
-        t_cols = cols or [[""]] * len(headers)
+        tCols = cols or [[""]] * len(headers)
         # first set global alignment
         if headersglobalalign is not None:  # if global alignment provided
-            aligns_headers = [headersglobalalign] * len(t_cols)
+            alignsHeaders = [headersglobalalign] * len(tCols)
         else:  # default
-            aligns_headers = aligns or [stralign] * len(headers)
+            alignsHeaders = aligns or [stralign] * len(headers)
         # then specific header alignements
         if headersalign is not None:
             assert isinstance(headersalign, Iterable)
@@ -1419,23 +1418,22 @@ def tabulate(
                 )
             for idx, align in enumerate(headersalign):
                 hidx = headers_pad + idx
-                if not hidx < len(aligns_headers):
+                if not hidx < len(alignsHeaders):
                     break
                 elif align == "same" and hidx < len(aligns):  # same as column align
-                    aligns_headers[hidx] = aligns[hidx]
+                    alignsHeaders[hidx] = aligns[hidx]
                 elif align != "global":
-                    aligns_headers[hidx] = align
+                    alignsHeaders[hidx] = align
         minwidths = [
-            max(minw, max(width_fn(cl) for cl in c))
-            for minw, c in zip(minwidths, t_cols)
+            max(minw, max(widthFn(cl) for cl in c)) for minw, c in zip(minwidths, tCols)
         ]
         headers = [
-            _alignHeader(h, a, minw, width_fn(h), isMultiline, width_fn)
-            for h, a, minw in zip(headers, aligns_headers, minwidths)
+            _alignHeader(h, a, minw, widthFn(h), isMultiline, widthFn)
+            for h, a, minw in zip(headers, alignsHeaders, minwidths)
         ]
         rows = list(zip(*cols))
     else:
-        minwidths = [max(width_fn(cl) for cl in c) for c in cols]
+        minwidths = [max(widthFn(cl) for cl in c) for c in cols]
         rows = list(zip(*cols))
 
     if not isinstance(tablefmt, TableFormat):
@@ -1448,7 +1446,7 @@ def tabulate(
     return _formatTable(
         tablefmt,
         headers,
-        aligns_headers,
+        alignsHeaders,
         rows,
         minwidths,
         aligns,
@@ -1491,31 +1489,31 @@ def _expandIterable(original, numDesired, default):
 def _padRow(cells, padding):
     if cells:
         pad = " " * padding
-        padded_cells = [pad + cell + pad for cell in cells]
-        return padded_cells
+        paddedCells = [pad + cell + pad for cell in cells]
+        return paddedCells
     else:
         return cells
 
 
-def _buildSimpleRow(padded_cells, rowfmt):
+def _buildSimpleRow(paddedCells, rowfmt):
     """Format row according to DataRow format without padding."""
     begin, sep, end = rowfmt
-    return (begin + sep.join(padded_cells) + end).rstrip()
+    return (begin + sep.join(paddedCells) + end).rstrip()
 
 
-def _buildRow(padded_cells, colwidths, colaligns, rowfmt):
+def _buildRow(paddedCells, colwidths, colaligns, rowfmt):
     """Return a string which represents a row of data cells."""
     if not rowfmt:
         return None
     if hasattr(rowfmt, "__call__"):
-        return rowfmt(padded_cells, colwidths, colaligns)
+        return rowfmt(paddedCells, colwidths, colaligns)
     else:
-        return _buildSimpleRow(padded_cells, rowfmt)
+        return _buildSimpleRow(paddedCells, rowfmt)
 
 
-def _appendBasicRow(lines, padded_cells, colwidths, colaligns, rowfmt, rowalign=None):
+def _appendBasicRow(lines, paddedCells, colwidths, colaligns, rowfmt, rowalign=None):
     # NOTE: rowalign is ignored and exists for api compatibility with _appendMultilineRow
-    lines.append(_buildRow(padded_cells, colwidths, colaligns, rowfmt))
+    lines.append(_buildRow(paddedCells, colwidths, colaligns, rowfmt))
     return lines
 
 
@@ -1525,9 +1523,9 @@ def _alignCellVeritically(textLines, numLines, columnWidth, rowAlignment):
     if rowAlignment == "bottom":
         return blank * delta_lines + textLines
     elif rowAlignment == "center":
-        top_delta = delta_lines // 2
-        bottom_delta = delta_lines - top_delta
-        return top_delta * blank + textLines + bottom_delta * blank
+        topDelta = delta_lines // 2
+        bottom_delta = delta_lines - topDelta
+        return topDelta * blank + textLines + bottom_delta * blank
     else:
         return textLines + blank * delta_lines
 
@@ -1543,8 +1541,8 @@ def _appendMultilineRow(
         _alignCellVeritically(cl, nlines, w, rowalign)
         for cl, w in zip(cells_lines, colwidths)
     ]
-    lines_cells = [[cl[i] for cl in cells_lines] for i in range(nlines)]
-    for ln in lines_cells:
+    linesCells = [[cl[i] for cl in cells_lines] for i in range(nlines)]
+    for ln in linesCells:
         padded_ln = _padRow(ln, pad)
         _appendBasicRow(lines, padded_ln, colwidths, colaligns, rowfmt)
     return lines
@@ -1567,10 +1565,12 @@ def _appendLine(lines, colwidths, colaligns, linefmt):
     return lines
 
 
-def _formatTable(fmt, headers, headersaligns, rows, colwidths, colaligns, isMultiline, rowaligns):
+def _formatTable(
+    fmt, headers, headersaligns, rows, colwidths, colaligns, isMultiline, rowaligns
+):
     """Produce a plain-text representation of the table."""
     lines = []
-    hidden = fmt.with_header_hide if (headers and fmt.with_header_hide) else []
+    hidden = fmt.withHeaderHide if (headers and fmt.withHeaderHide) else []
     pad = fmt.padding
     headerrow = fmt.headerrow
 

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -14,10 +14,152 @@
 
 """Pretty-print tabular data.
 
-This file started out as the MIT-licensed "tabulate". Though we have made, and will continue to make
-many arbitrary changes as we need. Thanks to the tabulate team.
+This file started out as the MIT-licensed "tabulate". Though we have made, and will continue to
+make, many arbitrary changes as we need. Thanks to the tabulate team.
 
 https://github.com/astanin/python-tabulate
+
+Usage
+-----
+The module provides just one function, `tabulate`, which takes a list of lists or other tabular data
+type as the first argument, and outputs anicely-formatted plain-text table::
+
+    >>> from armi.utils.tabulate import tabulate
+
+    >>> table = [["Sun",696000,1989100000],["Earth",6371,5973.6],
+    ...          ["Moon",1737,73.5],["Mars",3390,641.85]]
+
+    >>> print(tabulate(table))
+    -----  ------  -------------
+    Sun    696000     1.9891e+09
+    Earth    6371  5973.6
+    Moon     1737    73.5
+    Mars     3390   641.85
+    -----  ------  -------------
+
+The following tabular data types are supported:
+
+- list of lists or another iterable of iterables
+- list or another iterable of dicts (keys as columns)
+- dict of iterables (keys as columns)
+- list of dataclasses (field names as columns)
+- two-dimensional NumPy array
+- NumPy record arrays (names as columns)
+
+Headers
+-------
+The second optional argument named `headers` defines a list of column headers to be used::
+
+    >>> print(tabulate(table, headers=["Planet","R (km)", "mass (x 10^29 kg)"]))
+    Planet      R (km)    mass (x 10^29 kg)
+    --------  --------  -------------------
+    Sun         696000           1.9891e+09
+    Earth         6371        5973.6
+    Moon          1737          73.5
+    Mars          3390         641.85
+
+If `headers="firstrow"`, then the first row of data is used::
+
+    >>> print(tabulate([["Name","Age"],["Alice",24],["Bob",19]],
+    ...                headers="firstrow"))
+    Name      Age
+    ------  -----
+    Alice      24
+    Bob        19
+
+If `headers="keys"`, then the keys of a dictionary, or column indices are used. It also works for
+NumPy record arrays and lists of dictionaries or named tuples::
+
+    >>> print(tabulate({"Name": ["Alice", "Bob"],
+    ...                 "Age": [24, 19]}, headers="keys"))
+      Age  Name
+    -----  ------
+       24  Alice
+       19  Bob
+
+Row Indices
+-----------
+To add a "row index" column to a table, pass `showIndex="always"` or `showIndex=True` argument to
+`tabulate()`. To suppress row indices for all types of data, pass `showIndex="never"` or
+`showIndex=False`. To add a custom row index column, pass `showIndex=rowIDs`, where `rowIDs` is some
+iterable::
+
+    >>> print(tabulate([["F",24],["M",19]], showIndex="always"))
+    -  -  --
+    0  F  24
+    1  M  19
+    -  -  --
+
+Table format
+------------
+There is more than one way to format a table in plain text. The third optional argument named
+`tableFmt` defines how the table is formatted. Supported table formats are:
+
+-   "armi"
+-   "github"
+-   "grid"
+-   "plain"
+-   "pretty"
+-   "psql"
+-   "rst"
+-   "simple"
+-   "tsv"
+
+
+Automating Multilines
+---------------------
+While tabulate supports data passed in with multilines entries explicitly provided, it also provides
+some support to help manage this work internally.
+
+The `maxcolwidths` argument is a list where each entry specifies the max width for it's respective
+column. Any cell that will exceed this will automatically wrap the content. To assign the same max
+width for all columns, a singular int scaler can be used.
+
+Use `None` for any columns where an explicit maximum does not need to be provided, and thus no
+automate multiline wrapping will take place.
+
+The wrapping uses the python standard
+[textwrap.wrap](https://docs.python.org/3/library/textwrap.html#textwrap.wrap) function with default
+parameters - aside from width.
+
+This example demonstrates usage of automatic multiline wrapping, though typically the lines being
+wrapped would probably be significantly longer::
+
+    >>> print(tabulate([["John Smith", "Middle Manager"]],
+              headers=["Name", "Title"],
+              tableFmt="grid",
+              maxColWidths=[None, 8]))
+
+    +------------+---------+
+    | Name       | Title   |
+    +============+=========+
+    | John Smith | Middle  |
+    |            | Manager |
+    +------------+---------+
+
+Adding Separating lines
+-----------------------
+One might want to add one or more separating lines to highlight different sections in a table.
+
+The separating lines will be of the same type as the one defined by the specified formatter as
+either the linebetweenrows, linebelowheader, linebelow, lineabove or just a simple empty line when
+none is defined for the formatter::
+
+    >>> from armi.utils.tabulate import tabulate, SEPARATING_LINE
+
+    table = [["Earth", 6371],
+             ["Mars", 3390],
+             SEPARATING_LINE,
+             ["Moon", 1737]]
+
+    print(tabulate(table, tableFmt="simple"))
+
+    -----  ----
+    Earth  6371
+    Mars   3390
+    -----  ----
+    Moon   1737
+    -----  ----
 """
 from collections import namedtuple
 from collections.abc import Iterable, Sized
@@ -1029,9 +1171,9 @@ def tabulate(
       2  10001
     ---  ---------
 
-    The first required argument (`data`) can be a list-of-lists (or another iterable of
-    iterables), a list of named tuples, a dictionary of iterables, an iterable of dictionaries, an
-    iterable of dataclasses (Python 3.7+), a two-dimensional NumPy array, or NumPy record array.
+    The first required argument (`data`) can be a list-of-lists (or another iterable of iterables),
+    a list of named tuples, a dictionary of iterables, an iterable of dictionaries, an iterable of
+    dataclasses (Python 3.7+), a two-dimensional NumPy array, or NumPy record array.
 
     Table headers
     -------------

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -1629,6 +1629,7 @@ def _formatTable(
         return ""
 
 
+# TODO: Remove all color stuff?
 class _CustomTextWrap(textwrap.TextWrapper):
     """A custom implementation of CPython's textwrap.TextWrapper. This supports both wide characters
     (Korea, Japanese, Chinese) - including mixed string.

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -1016,9 +1016,9 @@ def tabulate(
     strAlign=_DEFAULT_ALIGN,
     missingVal=_DEFAULT_missingVal,
     showIndex="default",
-    disableNumparse=False,
-    colglobalalign=None,
-    colalign=None,
+    disableNumParse=False,
+    colGlobalAlign=None,
+    colAlign=None,
     maxcolwidths=None,
     headersglobalalign=None,
     headersalign=None,
@@ -1067,10 +1067,10 @@ def tabulate(
     flushes everything else to the left. Possible column alignments (`numAlign`, `strAlign`) are:
     "right", "center", "left", "decimal" (only for `numAlign`), and None (to disable alignment).
 
-    `colglobalalign` allows for global alignment of columns, before any specific override from
-        `colalign`. Possible values are: None (defaults according to coltype), "right", "center",
+    `colGlobalAlign` allows for global alignment of columns, before any specific override from
+        `colAlign`. Possible values are: None (defaults according to coltype), "right", "center",
         "decimal", "left".
-    `colalign` allows for column-wise override starting from left-most column. Possible values are:
+    `colAlign` allows for column-wise override starting from left-most column. Possible values are:
         "global" (no override), "right", "center", "decimal", "left".
     `headersglobalalign` allows for global headers alignment, before any specific override from
         `headersalign`. Possible values are: None (follow columns alignment), "right", "center",
@@ -1178,9 +1178,9 @@ def tabulate(
     strings such as specific git SHAs e.g. "42992e1" will be parsed into the number 429920 and
     aligned as such.
 
-    To completely disable number parsing (and alignment), use `disableNumparse=True`. For more fine
+    To completely disable number parsing (and alignment), use `disableNumParse=True`. For more fine
     grained control, a list column indices is used to disable number parsing only on those columns
-    e.g. `disableNumparse=[0, 2]` would disable number parsing only on the first and third columns.
+    e.g. `disableNumParse=[0, 2]` would disable number parsing only on the first and third columns.
 
     Column Widths and Auto Line Wrapping
     ------------------------------------
@@ -1224,7 +1224,7 @@ def tabulate(
         else:  # Ignore col width for any 'trailing' columns
             maxcolwidths = _expandIterable(maxcolwidths, numCols, None)
 
-        numparses = _expandNumparse(disableNumparse, numCols)
+        numparses = _expandNumparse(disableNumParse, numCols)
         listOfLists = _wrapTextToColWidths(
             listOfLists, maxcolwidths, numparses=numparses
         )
@@ -1238,7 +1238,7 @@ def tabulate(
         else:  # Ignore col width for any 'trailing' columns
             maxheadercolwidths = _expandIterable(maxheadercolwidths, numCols, None)
 
-        numparses = _expandNumparse(disableNumparse, numCols)
+        numparses = _expandNumparse(disableNumParse, numCols)
         headers = _wrapTextToColWidths(
             [headers], maxheadercolwidths, numparses=numparses
         )[0]
@@ -1254,7 +1254,7 @@ def tabulate(
     minPadding = MIN_PADDING
     if tablefmt == "pretty":
         minPadding = 0
-        disableNumparse = True
+        disableNumParse = True
         numAlign = "center" if numAlign == _DEFAULT_ALIGN else numAlign
         strAlign = "center" if strAlign == _DEFAULT_ALIGN else strAlign
     else:
@@ -1291,7 +1291,7 @@ def tabulate(
 
     # format rows and columns, convert numeric values to strings
     cols = list(izip_longest(*listOfLists))
-    numparses = _expandNumparse(disableNumparse, len(cols))
+    numparses = _expandNumparse(disableNumParse, len(cols))
     coltypes = [_columnType(col, numparse=np) for col, np in zip(cols, numparses)]
     if isinstance(floatfmt, str):
         # old version: just duplicate the string to use in each column
@@ -1322,20 +1322,20 @@ def tabulate(
 
     # align columns
     # first set global alignment
-    if colglobalalign is not None:  # if global alignment provided
-        aligns = [colglobalalign] * len(cols)
+    if colGlobalAlign is not None:  # if global alignment provided
+        aligns = [colGlobalAlign] * len(cols)
     else:  # default
         aligns = [numAlign if ct in [int, float] else strAlign for ct in coltypes]
 
     # then specific alignements
-    if colalign is not None:
-        assert isinstance(colalign, Iterable)
-        if isinstance(colalign, str):
+    if colAlign is not None:
+        assert isinstance(colAlign, Iterable)
+        if isinstance(colAlign, str):
             runLog.warning(
-                f"As a string, `colalign` is interpreted as {[c for c in colalign]}. Did you "
-                + f'mean `colglobalalign = "{colalign}"` or `colalign = ("{colalign}",)`?'
+                f"As a string, `colAlign` is interpreted as {[c for c in colAlign]}. Did you "
+                + f'mean `colGlobalAlign = "{colAlign}"` or `colAlign = ("{colAlign}",)`?'
             )
-        for idx, align in enumerate(colalign):
+        for idx, align in enumerate(colAlign):
             if not idx < len(aligns):
                 break
             elif align != "global":
@@ -1405,21 +1405,21 @@ def tabulate(
     )
 
 
-def _expandNumparse(disableNumparse, columnCount):
+def _expandNumparse(disableNumParse, columnCount):
     """
     Return a list of bools of length `columnCount` which indicates whether number parsing should be
     used on each column.
 
-    If `disableNumparse` is a list of indices, each of those indices are False, and everything else
-    is True. If `disableNumparse` is a bool, then the returned list is all the same.
+    If `disableNumParse` is a list of indices, each of those indices are False, and everything else
+    is True. If `disableNumParse` is a bool, then the returned list is all the same.
     """
-    if isinstance(disableNumparse, Iterable):
+    if isinstance(disableNumParse, Iterable):
         numparses = [True] * columnCount
-        for index in disableNumparse:
+        for index in disableNumParse:
             numparses[index] = False
         return numparses
     else:
-        return [not disableNumparse] * columnCount
+        return [not disableNumParse] * columnCount
 
 
 def _expandIterable(original, numDesired, default):
@@ -1451,19 +1451,19 @@ def _buildSimpleRow(paddedCells, rowfmt):
     return (begin + sep.join(paddedCells) + end).rstrip()
 
 
-def _buildRow(paddedCells, colwidths, colaligns, rowfmt):
+def _buildRow(paddedCells, colwidths, colAligns, rowfmt):
     """Return a string which represents a row of data cells."""
     if not rowfmt:
         return None
     if hasattr(rowfmt, "__call__"):
-        return rowfmt(paddedCells, colwidths, colaligns)
+        return rowfmt(paddedCells, colwidths, colAligns)
     else:
         return _buildSimpleRow(paddedCells, rowfmt)
 
 
-def _appendBasicRow(lines, paddedCells, colwidths, colaligns, rowfmt, rowalign=None):
+def _appendBasicRow(lines, paddedCells, colwidths, colAligns, rowfmt, rowalign=None):
     # NOTE: rowalign is ignored and exists for api compatibility with _appendMultilineRow
-    lines.append(_buildRow(paddedCells, colwidths, colaligns, rowfmt))
+    lines.append(_buildRow(paddedCells, colwidths, colAligns, rowfmt))
     return lines
 
 
@@ -1481,7 +1481,7 @@ def _alignCellVeritically(textLines, numLines, columnWidth, rowAlignment):
 
 
 def _appendMultilineRow(
-    lines, paddedMultilineCells, paddedWidths, colaligns, rowfmt, pad, rowalign=None
+    lines, paddedMultilineCells, paddedWidths, colAligns, rowfmt, pad, rowalign=None
 ):
     colwidths = [w - 2 * pad for w in paddedWidths]
     cellsLines = [c.splitlines() for c in paddedMultilineCells]
@@ -1494,30 +1494,30 @@ def _appendMultilineRow(
     linesCells = [[cl[i] for cl in cellsLines] for i in range(nlines)]
     for ln in linesCells:
         paddedLn = _padRow(ln, pad)
-        _appendBasicRow(lines, paddedLn, colwidths, colaligns, rowfmt)
+        _appendBasicRow(lines, paddedLn, colwidths, colAligns, rowfmt)
 
     return lines
 
 
-def _buildLine(colwidths, colaligns, linefmt):
+def _buildLine(colwidths, colAligns, linefmt):
     """Return a string which represents a horizontal line."""
     if not linefmt:
         return None
     if hasattr(linefmt, "__call__"):
-        return linefmt(colwidths, colaligns)
+        return linefmt(colwidths, colAligns)
     else:
         begin, fill, sep, end = linefmt
         cells = [fill * w for w in colwidths]
         return _buildSimpleRow(cells, (begin, sep, end))
 
 
-def _appendLine(lines, colwidths, colaligns, linefmt):
-    lines.append(_buildLine(colwidths, colaligns, linefmt))
+def _appendLine(lines, colwidths, colAligns, linefmt):
+    lines.append(_buildLine(colwidths, colAligns, linefmt))
     return lines
 
 
 def _formatTable(
-    fmt, headers, headersaligns, rows, colwidths, colaligns, isMultiline, rowaligns
+    fmt, headers, headersaligns, rows, colwidths, colAligns, isMultiline, rowaligns
 ):
     """Produce a plain-text representation of the table."""
     lines = []
@@ -1537,24 +1537,24 @@ def _formatTable(
     paddedRows = [padRow(row, pad) for row in rows]
 
     if fmt.lineabove and "lineabove" not in hidden:
-        _appendLine(lines, paddedWidths, colaligns, fmt.lineabove)
+        _appendLine(lines, paddedWidths, colAligns, fmt.lineabove)
 
     if paddedHeaders:
         appendRow(lines, paddedHeaders, paddedWidths, headersaligns, headerrow)
         if fmt.linebelowheader and "linebelowheader" not in hidden:
-            _appendLine(lines, paddedWidths, colaligns, fmt.linebelowheader)
+            _appendLine(lines, paddedWidths, colAligns, fmt.linebelowheader)
 
     if paddedRows and fmt.linebetweenrows and "linebetweenrows" not in hidden:
         # initial rows with a line below
         for row, ralign in zip(paddedRows[:-1], rowaligns):
-            appendRow(lines, row, paddedWidths, colaligns, fmt.datarow, rowalign=ralign)
-            _appendLine(lines, paddedWidths, colaligns, fmt.linebetweenrows)
+            appendRow(lines, row, paddedWidths, colAligns, fmt.datarow, rowalign=ralign)
+            _appendLine(lines, paddedWidths, colAligns, fmt.linebetweenrows)
         # the last row without a line below
         appendRow(
             lines,
             paddedRows[-1],
             paddedWidths,
-            colaligns,
+            colAligns,
             fmt.datarow,
             rowalign=rowaligns[-1],
         )
@@ -1570,12 +1570,12 @@ def _formatTable(
             # test to see if either the 1st column or the 2nd column (account for showIndex) has the
             # SEPARATING_LINE flag
             if _isSeparatingLine(row):
-                _appendLine(lines, paddedWidths, colaligns, separatingLine)
+                _appendLine(lines, paddedWidths, colAligns, separatingLine)
             else:
-                appendRow(lines, row, paddedWidths, colaligns, fmt.datarow)
+                appendRow(lines, row, paddedWidths, colAligns, fmt.datarow)
 
     if fmt.linebelow and "linebelow" not in hidden:
-        _appendLine(lines, paddedWidths, colaligns, fmt.linebelow)
+        _appendLine(lines, paddedWidths, colAligns, fmt.linebelow)
 
     if headers or rows:
         return "\n".join(lines)

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -94,7 +94,7 @@ TableFormat = namedtuple(
 )
 
 
-def _is_separating_line(row):
+def _isSeparatingLine(row):
     row_type = type(row)
     is_sl = (row_type is list or row_type is str) and (
         (len(row) >= 1 and row[0] == SEPARATING_LINE)
@@ -103,23 +103,23 @@ def _is_separating_line(row):
     return is_sl
 
 
-def _rst_escape_first_column(rows, headers):
-    def escape_empty(val):
+def _rstEscapeFirstColumn(rows, headers):
+    def escapeEmpty(val):
         if isinstance(val, (str, bytes)) and not val.strip():
             return ".."
         else:
             return val
 
-    new_headers = list(headers)
-    new_rows = []
+    newHeaders = list(headers)
+    newRows = []
     if headers:
-        new_headers[0] = escape_empty(headers[0])
+        newHeaders[0] = escapeEmpty(headers[0])
     for row in rows:
-        new_row = list(row)
-        if new_row:
-            new_row[0] = escape_empty(row[0])
-        new_rows.append(new_row)
-    return new_rows, new_headers
+        newRow = list(row)
+        if newRow:
+            newRow[0] = escapeEmpty(row[0])
+        newRows.append(newRow)
+    return newRows, newHeaders
 
 
 _table_formats = {
@@ -231,8 +231,8 @@ multiline_formats = {
     "rst": "rst",
 }
 
-_multiline_codes = re.compile(r"\r|\n|\r\n")
-_multiline_codes_bytes = re.compile(b"\r|\n|\r\n")
+_multilineCodes = re.compile(r"\r|\n|\r\n")
+_multilineCodesBytes = re.compile(b"\r|\n|\r\n")
 
 # Handle ANSI escape sequences for both control sequence introducer (CSI) and operating system
 # command (OSC). Both of these begin with 0x1b (or octal 033), which will be shown below as ESC.
@@ -261,7 +261,7 @@ _csi = rf"{_esc}\["
 _osc = rf"{_esc}\]"
 _st = rf"{_esc}\\"
 
-_ansi_escape_pat = rf"""
+_ansiEscapePat = rf"""
     (
         # terminal colors, etc
         {_csi}        # CSI
@@ -279,8 +279,8 @@ _ansi_escape_pat = rf"""
         {_osc}8;;{_st}  # "closing" OSC sequence
     )
 """
-_ansi_codes = re.compile(_ansi_escape_pat, re.VERBOSE)
-_ansi_codes_bytes = re.compile(_ansi_escape_pat.encode("utf8"), re.VERBOSE)
+_ansi_codes = re.compile(_ansiEscapePat, re.VERBOSE)
+_ansi_codes_bytes = re.compile(_ansiEscapePat.encode("utf8"), re.VERBOSE)
 _ansi_color_reset_code = "\033[0m"
 
 _float_with_thousands_separators = re.compile(
@@ -526,10 +526,10 @@ def _visible_width(s):
 
 def _is_multiline(s):
     if isinstance(s, str):
-        return bool(re.search(_multiline_codes, s))
+        return bool(re.search(_multilineCodes, s))
     else:
         # a bytestring
-        return bool(re.search(_multiline_codes_bytes, s))
+        return bool(re.search(_multilineCodesBytes, s))
 
 
 def _multilineWidth(multiline_s, line_width_fn=len):
@@ -738,7 +738,7 @@ def _align_header(
 ):
     """Pad string header to width chars given known visible_width of the header."""
     if is_multiline:
-        header_lines = re.split(_multiline_codes, header)
+        header_lines = re.split(_multilineCodes, header)
         padded_lines = [
             _align_header(h, alignment, width, width_fn(h)) for h in header_lines
         ]
@@ -761,7 +761,7 @@ def _removeSeparatingLines(rows):
         separatingLines = []
         sans_rows = []
         for index, row in enumerate(rows):
-            if _is_separating_line(row):
+            if _isSeparatingLine(row):
                 separatingLines.append(index)
             else:
                 sans_rows.append(row)
@@ -956,7 +956,7 @@ def _normalizeTabularData(tabular_data, headers, showindex="default"):
         headers = []
 
     headers = list(map(str, headers))
-    rows = list(map(lambda r: r if _is_separating_line(r) else list(r), rows))
+    rows = list(map(lambda r: r if _isSeparatingLine(r) else list(r), rows))
 
     # add or remove an index column
     showindex_is_a_str = type(showindex) in [str, bytes]
@@ -1297,7 +1297,7 @@ def tabulate(
     # empty values in the first column of RST tables should be escaped (issue #82)
     # "" should be escaped as "\\ " or ".."
     if tablefmt == "rst":
-        listOfLists, headers = _rst_escape_first_column(listOfLists, headers)
+        listOfLists, headers = _rstEscapeFirstColumn(listOfLists, headers)
 
     # PrettyTable formatting does not use any extra padding. Numbers are not parsed and are treated
     # the same as strings for alignment. Check if pretty is the format being used and override the
@@ -1624,7 +1624,7 @@ def _format_table(
         for row in padded_rows:
             # test to see if either the 1st column or the 2nd column (account for showindex) has the
             # SEPARATING_LINE flag
-            if _is_separating_line(row):
+            if _isSeparatingLine(row):
                 _append_line(lines, padded_widths, colaligns, separating_line)
             else:
                 append_row(lines, row, padded_widths, colaligns, fmt.datarow)

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -833,20 +833,17 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
         headers = list(headers)
 
     index = None
-    if hasattr(tabularData, "keys") and hasattr(tabularData, "values"):
-        # dict-like?
-        if hasattr(tabularData.values, "__call__"):
-            # likely a conventional dict
-            keys = tabularData.keys()
-            # columns have to be transposed
-            rows = list(izip_longest(*tabularData.values()))
-        else:
-            raise ValueError("tabular data doesn't appear to be a dict or a DataFrame")
+    if type(tabularData) is dict:
+        # dict-like
+        keys = tabularData.keys()
+        # columns have to be transposed
+        rows = list(izip_longest(*tabularData.values()))
 
         if headers == "keys":
-            headers = list(map(str, keys))  # headers should be strings
-
-    else:  # it's a usual iterable of iterables, or a NumPy array, or an iterable of dataclasses
+            # headers should be strings
+            headers = list(map(str, keys))
+    else:
+        # it's a usual iterable of iterables, or a NumPy array, or an iterable of dataclasses
         rows = list(tabularData)
 
         if headers == "keys" and not rows:
@@ -948,8 +945,6 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
         if index is None:
             index = list(range(len(rows)))
         rows = _prependRowIndex(rows, index)
-    elif showindex == "never" or (not _bool(showindex) and not showIndexIsSStr):
-        pass
 
     # pad with empty headers for initial columns if necessary
     headersPad = 0

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -41,7 +41,7 @@ PRESERVE_WHITESPACE = False
 
 _DEFAULT_FLOATFMT = "g"
 _DEFAULT_INTFMT = ""
-_DEFAULT_MISSINGVAL = ""
+_DEFAULT_missingVal = ""
 # default align will be overwritten by "left", "center" or "decimal" depending on the formatter
 _DEFAULT_ALIGN = "default"
 
@@ -697,7 +697,7 @@ def _columnType(strings, hasInvisible=True, numparse=True):
     return reduce(_moreGeneric, types, bool)
 
 
-def _format(val, valtype, floatfmt, intfmt, missingval="", hasInvisible=True):
+def _format(val, valtype, floatfmt, intfmt, missingVal="", hasInvisible=True):
     r"""Format a value according to its type.
 
     Unicode is supported:
@@ -710,7 +710,7 @@ def _format(val, valtype, floatfmt, intfmt, missingval="", hasInvisible=True):
 
     """  # noqa
     if val is None:
-        return missingval
+        return missingVal
 
     if valtype is str:
         return f"{val}"
@@ -1014,7 +1014,7 @@ def tabulate(
     intfmt=_DEFAULT_INTFMT,
     numAlign=_DEFAULT_ALIGN,
     strAlign=_DEFAULT_ALIGN,
-    missingval=_DEFAULT_MISSINGVAL,
+    missingVal=_DEFAULT_missingVal,
     showindex="default",
     disableNumparse=False,
     colglobalalign=None,
@@ -1090,12 +1090,12 @@ def tabulate(
     `floatfmt` is a format specification used for columns which contain numeric data with a decimal
     point. This can also be a list or tuple of format strings, one per column.
 
-    `None` values are replaced with a `missingval` string (like `floatfmt`, this can also be a list
+    `None` values are replaced with a `missingVal` string (like `floatfmt`, this can also be a list
     of values for different columns):
 
     >>> print(tabulate([["spam", 1, None],
     ...                 ["eggs", 42, 3.14],
-    ...                 ["other", None, 2.7]], missingval="?"))
+    ...                 ["other", None, 2.7]], missingVal="?"))
     -----  --  ----
     spam    1  ?
     eggs   42  3.14
@@ -1307,12 +1307,12 @@ def tabulate(
         intFormats = list(intfmt)
         if len(intFormats) < len(cols):
             intFormats.extend((len(cols) - len(intFormats)) * [_DEFAULT_INTFMT])
-    if isinstance(missingval, str):
-        missingVals = len(cols) * [missingval]
+    if isinstance(missingVal, str):
+        missingVals = len(cols) * [missingVal]
     else:
-        missingVals = list(missingval)
+        missingVals = list(missingVal)
         if len(missingVals) < len(cols):
-            missingVals.extend((len(cols) - len(missingVals)) * [_DEFAULT_MISSINGVAL])
+            missingVals.extend((len(cols) - len(missingVals)) * [_DEFAULT_missingVal])
     cols = [
         [_format(v, ct, flFmt, intFmt, missV, hasInvisible) for v in c]
         for c, ct, flFmt, intFmt, missV in zip(

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -1012,8 +1012,8 @@ def tabulate(
     tablefmt="simple",
     floatfmt=_DEFAULT_FLOATFMT,
     intfmt=_DEFAULT_INTFMT,
-    numalign=_DEFAULT_ALIGN,
-    stralign=_DEFAULT_ALIGN,
+    numAlign=_DEFAULT_ALIGN,
+    strAlign=_DEFAULT_ALIGN,
     missingval=_DEFAULT_MISSINGVAL,
     showindex="default",
     disableNumparse=False,
@@ -1064,8 +1064,8 @@ def tabulate(
 
     `tabulate` tries to detect column types automatically, and aligns the values properly. By
     default it aligns decimal points of the numbers (or flushes integer numbers to the right), and
-    flushes everything else to the left. Possible column alignments (`numalign`, `stralign`) are:
-    "right", "center", "left", "decimal" (only for `numalign`), and None (to disable alignment).
+    flushes everything else to the left. Possible column alignments (`numAlign`, `strAlign`) are:
+    "right", "center", "left", "decimal" (only for `numAlign`), and None (to disable alignment).
 
     `colglobalalign` allows for global alignment of columns, before any specific override from
         `colalign`. Possible values are: None (defaults according to coltype), "right", "center",
@@ -1255,11 +1255,11 @@ def tabulate(
     if tablefmt == "pretty":
         minPadding = 0
         disableNumparse = True
-        numalign = "center" if numalign == _DEFAULT_ALIGN else numalign
-        stralign = "center" if stralign == _DEFAULT_ALIGN else stralign
+        numAlign = "center" if numAlign == _DEFAULT_ALIGN else numAlign
+        strAlign = "center" if strAlign == _DEFAULT_ALIGN else strAlign
     else:
-        numalign = "decimal" if numalign == _DEFAULT_ALIGN else numalign
-        stralign = "left" if stralign == _DEFAULT_ALIGN else stralign
+        numAlign = "decimal" if numAlign == _DEFAULT_ALIGN else numAlign
+        strAlign = "left" if strAlign == _DEFAULT_ALIGN else strAlign
 
     # optimization: look for ANSI control codes once, enable smart width functions only if a control
     # code is found
@@ -1325,7 +1325,7 @@ def tabulate(
     if colglobalalign is not None:  # if global alignment provided
         aligns = [colglobalalign] * len(cols)
     else:  # default
-        aligns = [numalign if ct in [int, float] else stralign for ct in coltypes]
+        aligns = [numAlign if ct in [int, float] else strAlign for ct in coltypes]
 
     # then specific alignements
     if colalign is not None:
@@ -1356,7 +1356,7 @@ def tabulate(
         if headersglobalalign is not None:  # if global alignment provided
             alignsHeaders = [headersglobalalign] * len(tCols)
         else:  # default
-            alignsHeaders = aligns or [stralign] * len(headers)
+            alignsHeaders = aligns or [strAlign] * len(headers)
         # then specific header alignements
         if headersalign is not None:
             assert isinstance(headersalign, Iterable)

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -943,7 +943,7 @@ def _normalizeTabularData(tabularData, headers, showindex="default"):
     return rows, headers, headersPad
 
 
-def _wrapTextToColwidths(listOfLists, colwidths, numparses=True):
+def _wrapTextToColWidths(listOfLists, colwidths, numparses=True):
     if len(listOfLists):
         numCols = len(listOfLists[0])
     else:
@@ -1225,7 +1225,7 @@ def tabulate(
             maxcolwidths = _expandIterable(maxcolwidths, numCols, None)
 
         numparses = _expandNumparse(disableNumparse, numCols)
-        listOfLists = _wrapTextToColwidths(
+        listOfLists = _wrapTextToColWidths(
             listOfLists, maxcolwidths, numparses=numparses
         )
 
@@ -1239,7 +1239,7 @@ def tabulate(
             maxheadercolwidths = _expandIterable(maxheadercolwidths, numCols, None)
 
         numparses = _expandNumparse(disableNumparse, numCols)
-        headers = _wrapTextToColwidths(
+        headers = _wrapTextToColWidths(
             [headers], maxheadercolwidths, numparses=numparses
         )[0]
 

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -225,7 +225,7 @@ tabulate_formats = list(sorted(_table_formats.keys()))
 # The table formats for which multiline cells will be folded into subsequent table rows. The key is
 # the original format specified at the API. The value is the format that will be used to represent
 # the original format.
-multiline_formats = {
+multilineFormats = {
     "armi": "armi",
     "plain": "plain",
     "simple": "simple",
@@ -1280,10 +1280,10 @@ def tabulate(
 
     if (
         not isinstance(tablefmt, TableFormat)
-        and tablefmt in multiline_formats
+        and tablefmt in multilineFormats
         and _isMultiline(plainText)
     ):
-        tablefmt = multiline_formats.get(tablefmt, tablefmt)
+        tablefmt = multilineFormats.get(tablefmt, tablefmt)
         isMultiline = True
     else:
         isMultiline = False

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -947,8 +947,8 @@ def _wrapTextToColWidths(listOfLists, colwidths, numparses=True):
         numCols = len(listOfLists[0])
     else:
         numCols = 0
-    numparses = _expandIterable(numparses, numCols, True)
 
+    numparses = _expandIterable(numparses, numCols, True)
     result = []
 
     for row in listOfLists:

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -41,7 +41,7 @@ PRESERVE_WHITESPACE = False
 
 _DEFAULT_FLOATFMT = "g"
 _DEFAULT_INTFMT = ""
-_DEFAULT_missingVal = ""
+_DEFAULT_MISSING_VAL = ""
 # default align will be overwritten by "left", "center" or "decimal" depending on the formatter
 _DEFAULT_ALIGN = "default"
 
@@ -1014,7 +1014,7 @@ def tabulate(
     intfmt=_DEFAULT_INTFMT,
     numAlign=_DEFAULT_ALIGN,
     strAlign=_DEFAULT_ALIGN,
-    missingVal=_DEFAULT_missingVal,
+    missingVal=_DEFAULT_MISSING_VAL,
     showIndex="default",
     disableNumParse=False,
     colGlobalAlign=None,
@@ -1312,7 +1312,7 @@ def tabulate(
     else:
         missingVals = list(missingVal)
         if len(missingVals) < len(cols):
-            missingVals.extend((len(cols) - len(missingVals)) * [_DEFAULT_missingVal])
+            missingVals.extend((len(cols) - len(missingVals)) * [_DEFAULT_MISSING_VAL])
     cols = [
         [_format(v, ct, flFmt, intFmt, missV, hasInvisible) for v in c]
         for c, ct, flFmt, intFmt, missV in zip(

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -608,7 +608,7 @@ def _flat_list(nested_list):
     return ret
 
 
-def _align_column(
+def _alignColumn(
     strings, alignment, minwidth=0, has_invisible=True, is_multiline=False
 ):
     """[string] -> [padded_string]."""
@@ -1396,7 +1396,7 @@ def tabulate(
         [width_fn(h) + min_padding for h in headers] if headers else [0] * len(cols)
     )
     cols = [
-        _align_column(c, a, minw, has_invisible, is_multiline)
+        _alignColumn(c, a, minw, has_invisible, is_multiline)
         for c, a, minw in zip(cols, aligns, minwidths)
     ]
 

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -672,3 +672,209 @@ class TestTabulateOutput(unittest.TestCase):
             maxheadercolwidths=[None, 2],
         )
         self.assertEqual(expected, result)
+
+    def test_simple(self):
+        """Output: simple with headers."""
+        expected = "\n".join(
+            [
+                "strings      numbers",
+                "---------  ---------",
+                "spam         41.9999",
+                "eggs        451",
+            ]
+        )
+        result = tabulate(_test_table, _test_table_headers, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_simple_with_sep_line(self):
+        """Output: simple with headers and separating line."""
+        expected = "\n".join(
+            [
+                "strings      numbers",
+                "---------  ---------",
+                "spam         41.9999",
+                "---------  ---------",
+                "eggs        451",
+            ]
+        )
+        result = tabulate(
+            _test_table_with_sep_line, _test_table_headers, tablefmt="simple"
+        )
+        self.assertEqual(expected, result)
+
+    def test_readme_example_with_sep(self):
+        table = [["Earth", 6371], ["Mars", 3390], SEPARATING_LINE, ["Moon", 1737]]
+        expected = "\n".join(
+            [
+                "-----  ----",
+                "Earth  6371",
+                "Mars   3390",
+                "-----  ----",
+                "Moon   1737",
+                "-----  ----",
+            ]
+        )
+        result = tabulate(table, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_simple_multiline_2(self):
+        """Output: simple with multiline cells."""
+        expected = "\n".join(
+            [
+                " key     value",
+                "-----  ---------",
+                " foo      bar",
+                "spam   multiline",
+                "         world",
+            ]
+        )
+        table = [["key", "value"], ["foo", "bar"], ["spam", "multiline\nworld"]]
+        result = tabulate(
+            table, headers="firstrow", stralign="center", tablefmt="simple"
+        )
+        self.assertEqual(expected, result)
+
+    def test_simple_multiline_2_with_sep_line(self):
+        """Output: simple with multiline cells."""
+        expected = "\n".join(
+            [
+                " key     value",
+                "-----  ---------",
+                " foo      bar",
+                "-----  ---------",
+                "spam   multiline",
+                "         world",
+            ]
+        )
+        table = [
+            ["key", "value"],
+            ["foo", "bar"],
+            SEPARATING_LINE,
+            ["spam", "multiline\nworld"],
+        ]
+        result = tabulate(
+            table, headers="firstrow", stralign="center", tablefmt="simple"
+        )
+        self.assertEqual(expected, result)
+
+    def test_simple_headerless(self):
+        """Output: simple without headers."""
+        expected = "\n".join(
+            ["----  --------", "spam   41.9999", "eggs  451", "----  --------"]
+        )
+        result = tabulate(_test_table, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_simple_headerless_with_sep_line(self):
+        """Output: simple without headers."""
+        expected = "\n".join(
+            [
+                "----  --------",
+                "spam   41.9999",
+                "----  --------",
+                "eggs  451",
+                "----  --------",
+            ]
+        )
+        result = tabulate(_test_table_with_sep_line, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_simple_multiline_headerless(self):
+        """Output: simple with multiline cells without headers."""
+        table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
+        expected = "\n".join(
+            [
+                "-------  ---------",
+                "foo bar    hello",
+                "  baz",
+                "  bau",
+                "         multiline",
+                "           world",
+                "-------  ---------",
+            ]
+        )
+        result = tabulate(table, stralign="center", tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_simple_multiline(self):
+        """Output: simple with multiline cells with headers."""
+        table = [[2, "foo\nbar"]]
+        headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
+        expected = "\n".join(
+            [
+                "       more  more spam",
+                "  spam \x1b[31meggs\x1b[0m  & eggs",
+                "-----------  -----------",
+                "          2  foo",
+                "             bar",
+            ]
+        )
+        result = tabulate(table, headers, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_simple_multiline_with_links(self):
+        """Output: simple with multiline cells with links and headers."""
+        table = [[2, "foo\nbar"]]
+        headers = (
+            "more\nspam \x1b]8;;target\x1b\\eggs\x1b]8;;\x1b\\",
+            "more spam\n& eggs",
+        )
+        expected = "\n".join(
+            [
+                "       more  more spam",
+                "  spam \x1b]8;;target\x1b\\eggs\x1b]8;;\x1b\\  & eggs",
+                "-----------  -----------",
+                "          2  foo",
+                "             bar",
+            ]
+        )
+        result = tabulate(table, headers, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_simple_multiline_with_empty_cells(self):
+        """Output: simple with multiline cells and empty cells with headers."""
+        table = [
+            ["hdr", "data", "fold"],
+            ["1", "", ""],
+            ["2", "very long data", "fold\nthis"],
+        ]
+        expected = "\n".join(
+            [
+                "  hdr  data            fold",
+                "-----  --------------  ------",
+                "    1",
+                "    2  very long data  fold",
+                "                       this",
+            ]
+        )
+        result = tabulate(table, headers="firstrow", tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_simple_multiline_with_empty_cells_headerless(self):
+        """Output: simple with multiline cells and empty cells without headers."""
+        table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+        expected = "\n".join(
+            [
+                "-  --------------  ----",
+                "0",
+                "1",
+                "2  very long data  fold",
+                "                   this",
+                "-  --------------  ----",
+            ]
+        )
+        result = tabulate(table, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_github(self):
+        """Output: github with headers."""
+        expected = "\n".join(
+            [
+                "| strings   |   numbers |",
+                "|-----------|-----------|",
+                "| spam      |   41.9999 |",
+                "| eggs      |  451      |",
+            ]
+        )
+        result = tabulate(_test_table, _test_table_headers, tablefmt="github")
+        self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -43,13 +43,13 @@ from armi.utils.tabulate import _visibleWidth
 from armi.utils.tabulate import _wrapTextToColWidths
 from armi.utils.tabulate import SEPARATING_LINE
 from armi.utils.tabulate import tabulate
-from armi.utils.tabulate import tabulate_formats
+from armi.utils.tabulate import tabulateFormats
 
 
 class TestTabulateAPI(unittest.TestCase):
     def test_tabulateFormats(self):
-        """API: tabulate_formats is a list of strings."""
-        supported = tabulate_formats
+        """API: tabulateFormats is a list of strings."""
+        supported = tabulateFormats
         self.assertEqual(type(supported), list)
         for fmt in supported:
             self.assertEqual(type(fmt), str)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -659,13 +659,13 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(
             ["strings      numbers", "spam         41.9999", "eggs        451"]
         )
-        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="plain")
+        result = tabulate(self.testTable, self.testTableHeaders, tableFmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainHeaderless(self):
         """Output: plain without headers."""
         expected = "\n".join(["spam   41.9999", "eggs  451"])
-        result = tabulate(self.testTable, tablefmt="plain")
+        result = tabulate(self.testTable, tableFmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainMultilineHeaderless(self):
@@ -680,7 +680,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "           world",
             ]
         )
-        result = tabulate(table, strAlign="center", tablefmt="plain")
+        result = tabulate(table, strAlign="center", tableFmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainMultiline(self):
@@ -695,7 +695,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "             bar",
             ]
         )
-        result = tabulate(table, headers, tablefmt="plain")
+        result = tabulate(table, headers, tableFmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainMultilineWithLinks(self):
@@ -713,7 +713,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "             bar",
             ]
         )
-        result = tabulate(table, headers, tablefmt="plain")
+        result = tabulate(table, headers, tableFmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainMultilineWithEmptyCells(self):
@@ -731,7 +731,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "                       this",
             ]
         )
-        result = tabulate(table, headers="firstrow", tablefmt="plain")
+        result = tabulate(table, headers="firstrow", tableFmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainMultilineWithEmptyCellsHeaderless(self):
@@ -740,7 +740,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(
             ["0", "1", "2  very long data  fold", "                   this"]
         )
-        result = tabulate(table, tablefmt="plain")
+        result = tabulate(table, tableFmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainMaxcolwidthAutowraps(self):
@@ -748,7 +748,7 @@ class TestTabulateOutput(unittest.TestCase):
         table = [["hdr", "fold"], ["1", "very long data"]]
         expected = "\n".join(["  hdr  fold", "    1  very long", "       data"])
         result = tabulate(
-            table, headers="firstrow", tablefmt="plain", maxColWidths=[10, 10]
+            table, headers="firstrow", tableFmt="plain", maxColWidths=[10, 10]
         )
         self.assertEqual(expected, result)
 
@@ -764,7 +764,7 @@ class TestTabulateOutput(unittest.TestCase):
             ["  hdr  fold", "    1  very long", "       data", "", "    2  last line"]
         )
         result = tabulate(
-            table, headers="firstrow", tablefmt="plain", maxColWidths=[10, 10]
+            table, headers="firstrow", tableFmt="plain", maxColWidths=[10, 10]
         )
         self.assertEqual(expected, result)
 
@@ -783,7 +783,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "                longer",
             ]
         )
-        result = tabulate(table, headers="firstrow", tablefmt="plain", maxColWidths=6)
+        result = tabulate(table, headers="firstrow", tableFmt="plain", maxColWidths=6)
         self.assertEqual(expected, result)
 
     def test_maxcolwidthPadTailingWidths(self):
@@ -801,7 +801,7 @@ class TestTabulateOutput(unittest.TestCase):
             ]
         )
         result = tabulate(
-            table, headers="firstrow", tablefmt="plain", maxColWidths=[None, 6]
+            table, headers="firstrow", tableFmt="plain", maxColWidths=[None, 6]
         )
         self.assertEqual(expected, result)
 
@@ -824,7 +824,7 @@ class TestTabulateOutput(unittest.TestCase):
             ]
         )
         # Grid makes showing the alignment difference a little easier
-        result = tabulate(table, tablefmt="grid", maxColWidths=6, disableNumParse=[2])
+        result = tabulate(table, tableFmt="grid", maxColWidths=6, disableNumParse=[2])
         self.assertEqual(expected, result)
 
     def test_plainmaxHeaderColWidthsAutowraps(self):
@@ -836,7 +836,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(
             table,
             headers="firstrow",
-            tablefmt="plain",
+            tableFmt="plain",
             maxColWidths=[10, 10],
             maxHeaderColWidths=[None, 2],
         )
@@ -852,7 +852,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs        451",
             ]
         )
-        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="simple")
+        result = tabulate(self.testTable, self.testTableHeaders, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleWithSepLine(self):
@@ -867,7 +867,7 @@ class TestTabulateOutput(unittest.TestCase):
             ]
         )
         result = tabulate(
-            self.testTableWithSepLine, self.testTableHeaders, tablefmt="simple"
+            self.testTableWithSepLine, self.testTableHeaders, tableFmt="simple"
         )
         self.assertEqual(expected, result)
 
@@ -883,7 +883,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "-----  ----",
             ]
         )
-        result = tabulate(table, tablefmt="simple")
+        result = tabulate(table, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleMultiline2(self):
@@ -899,7 +899,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         table = [["key", "value"], ["foo", "bar"], ["spam", "multiline\nworld"]]
         result = tabulate(
-            table, headers="firstrow", strAlign="center", tablefmt="simple"
+            table, headers="firstrow", strAlign="center", tableFmt="simple"
         )
         self.assertEqual(expected, result)
 
@@ -922,7 +922,7 @@ class TestTabulateOutput(unittest.TestCase):
             ["spam", "multiline\nworld"],
         ]
         result = tabulate(
-            table, headers="firstrow", strAlign="center", tablefmt="simple"
+            table, headers="firstrow", strAlign="center", tableFmt="simple"
         )
         self.assertEqual(expected, result)
 
@@ -931,7 +931,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(
             ["----  --------", "spam   41.9999", "eggs  451", "----  --------"]
         )
-        result = tabulate(self.testTable, tablefmt="simple")
+        result = tabulate(self.testTable, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleHeaderlessWithSepLine(self):
@@ -945,7 +945,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "----  --------",
             ]
         )
-        result = tabulate(self.testTableWithSepLine, tablefmt="simple")
+        result = tabulate(self.testTableWithSepLine, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleMultilineHeaderless(self):
@@ -962,7 +962,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "-------  ---------",
             ]
         )
-        result = tabulate(table, strAlign="center", tablefmt="simple")
+        result = tabulate(table, strAlign="center", tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleMultiline(self):
@@ -978,7 +978,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "             bar",
             ]
         )
-        result = tabulate(table, headers, tablefmt="simple")
+        result = tabulate(table, headers, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleMultilineWithLinks(self):
@@ -997,7 +997,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "             bar",
             ]
         )
-        result = tabulate(table, headers, tablefmt="simple")
+        result = tabulate(table, headers, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleMultilineWithEmptyCells(self):
@@ -1016,7 +1016,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "                       this",
             ]
         )
-        result = tabulate(table, headers="firstrow", tablefmt="simple")
+        result = tabulate(table, headers="firstrow", tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleMultilineWithEmptyCellsHeaderless(self):
@@ -1032,7 +1032,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "-  --------------  ----",
             ]
         )
-        result = tabulate(table, tablefmt="simple")
+        result = tabulate(table, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_github(self):
@@ -1045,7 +1045,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "| eggs      |  451      |",
             ]
         )
-        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="github")
+        result = tabulate(self.testTable, self.testTableHeaders, tableFmt="github")
         self.assertEqual(expected, result)
 
     def test_grid(self):
@@ -1061,7 +1061,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+-----------+-----------+",
             ]
         )
-        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="grid")
+        result = tabulate(self.testTable, self.testTableHeaders, tableFmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridHeaderless(self):
@@ -1075,7 +1075,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+------+----------+",
             ]
         )
-        result = tabulate(self.testTable, tablefmt="grid")
+        result = tabulate(self.testTable, tableFmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridMultilineHeaderless(self):
@@ -1093,7 +1093,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+---------+-----------+",
             ]
         )
-        result = tabulate(table, strAlign="center", tablefmt="grid")
+        result = tabulate(table, strAlign="center", tableFmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridMultiline(self):
@@ -1111,7 +1111,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+-------------+-------------+",
             ]
         )
-        result = tabulate(table, headers, tablefmt="grid")
+        result = tabulate(table, headers, tableFmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridMultilineWithEmptyCells(self):
@@ -1133,7 +1133,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+-------+----------------+--------+",
             ]
         )
-        result = tabulate(table, headers="firstrow", tablefmt="grid")
+        result = tabulate(table, headers="firstrow", tableFmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridMultilineWithEmptyCellsHeaderless(self):
@@ -1151,7 +1151,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+---+----------------+------+",
             ]
         )
-        result = tabulate(table, tablefmt="grid")
+        result = tabulate(table, tableFmt="grid")
         self.assertEqual(expected, result)
 
     def test_pretty(self):
@@ -1166,7 +1166,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+---------+---------+",
             ]
         )
-        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="pretty")
+        result = tabulate(self.testTable, self.testTableHeaders, tableFmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyHeaderless(self):
@@ -1179,7 +1179,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+------+---------+",
             ]
         )
-        result = tabulate(self.testTable, tablefmt="pretty")
+        result = tabulate(self.testTable, tableFmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyMultilineHeaderless(self):
@@ -1196,7 +1196,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+---------+-----------+",
             ]
         )
-        result = tabulate(table, tablefmt="pretty")
+        result = tabulate(table, tableFmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyMultiline(self):
@@ -1214,7 +1214,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+-----------+-----------+",
             ]
         )
-        result = tabulate(table, headers, tablefmt="pretty")
+        result = tabulate(table, headers, tableFmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyMultilineWithLinks(self):
@@ -1235,7 +1235,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+-----------+-----------+",
             ]
         )
-        result = tabulate(table, headers, tablefmt="pretty")
+        result = tabulate(table, headers, tableFmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyMultilineWithEmptyCells(self):
@@ -1256,7 +1256,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+-----+----------------+------+",
             ]
         )
-        result = tabulate(table, headers="firstrow", tablefmt="pretty")
+        result = tabulate(table, headers="firstrow", tableFmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyMultilineWithEmptyCellsHeaderless(self):
@@ -1272,7 +1272,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+---+----------------+------+",
             ]
         )
-        result = tabulate(table, tablefmt="pretty")
+        result = tabulate(table, tableFmt="pretty")
         self.assertEqual(expected, result)
 
     def test_rst(self):
@@ -1287,7 +1287,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "=========  =========",
             ]
         )
-        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="rst")
+        result = tabulate(self.testTable, self.testTableHeaders, tableFmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstWithEmptyValuesInFirstColumn(self):
@@ -1304,7 +1304,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "====  ======",
             ]
         )
-        result = tabulate(test_data, test_headers, tablefmt="rst")
+        result = tabulate(test_data, test_headers, tableFmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstHeaderless(self):
@@ -1312,7 +1312,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(
             ["====  ========", "spam   41.9999", "eggs  451", "====  ========"]
         )
-        result = tabulate(self.testTable, tablefmt="rst")
+        result = tabulate(self.testTable, tableFmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstMultiline(self):
@@ -1330,7 +1330,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "===========  ===========",
             ]
         )
-        result = tabulate(table, headers, tablefmt="rst")
+        result = tabulate(table, headers, tableFmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstMultilineWithLinks(self):
@@ -1351,7 +1351,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "===========  ===========",
             ]
         )
-        result = tabulate(table, headers, tablefmt="rst")
+        result = tabulate(table, headers, tableFmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstMultilineWithEmptyCells(self):
@@ -1372,7 +1372,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "=====  ==============  ======",
             ]
         )
-        result = tabulate(table, headers="firstrow", tablefmt="rst")
+        result = tabulate(table, headers="firstrow", tableFmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstMultilineWithEmptyCellsHeaderless(self):
@@ -1388,36 +1388,36 @@ class TestTabulateOutput(unittest.TestCase):
                 "=  ==============  ====",
             ]
         )
-        result = tabulate(table, tablefmt="rst")
+        result = tabulate(table, tableFmt="rst")
         self.assertEqual(expected, result)
 
     def test_noData(self):
         """Output: table with no data."""
         expected = "\n".join(["strings    numbers", "---------  ---------"])
-        result = tabulate(None, self.testTableHeaders, tablefmt="simple")
+        result = tabulate(None, self.testTableHeaders, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_emptyData(self):
         """Output: table with empty data."""
         expected = "\n".join(["strings    numbers", "---------  ---------"])
-        result = tabulate([], self.testTableHeaders, tablefmt="simple")
+        result = tabulate([], self.testTableHeaders, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_noDataWithoutHeaders(self):
         """Output: table with no data and no headers."""
         expected = ""
-        result = tabulate(None, tablefmt="simple")
+        result = tabulate(None, tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_emptyDataWithoutHeaders(self):
         """Output: table with empty data and no headers."""
         expected = ""
-        result = tabulate([], tablefmt="simple")
+        result = tabulate([], tableFmt="simple")
         self.assertEqual(expected, result)
 
     def test_intfmt(self):
         """Output: integer format."""
-        result = tabulate([[10000], [10]], intfmt=",", tablefmt="plain")
+        result = tabulate([[10000], [10]], intfmt=",", tableFmt="plain")
         expected = "10,000\n    10"
         self.assertEqual(expected, result)
 
@@ -1429,14 +1429,14 @@ class TestTabulateOutput(unittest.TestCase):
 
     def test_floatfmt(self):
         """Output: floating point format."""
-        result = tabulate([["1.23456789"], [1.0]], floatfmt=".3f", tablefmt="plain")
+        result = tabulate([["1.23456789"], [1.0]], floatfmt=".3f", tableFmt="plain")
         expected = "1.235\n1.000"
         self.assertEqual(expected, result)
 
     def test_floatfmtMulti(self):
         """Output: floating point format different for each column."""
         result = tabulate(
-            [[0.12345, 0.12345, 0.12345]], floatfmt=(".1f", ".3f"), tablefmt="plain"
+            [[0.12345, 0.12345, 0.12345]], floatfmt=(".1f", ".3f"), tableFmt="plain"
         )
         expected = "0.1  0.123  0.12345"
         self.assertEqual(expected, result)
@@ -1444,7 +1444,7 @@ class TestTabulateOutput(unittest.TestCase):
     def test_colAlignMulti(self):
         """Output: string columns with custom colAlign."""
         result = tabulate(
-            [["one", "two"], ["three", "four"]], colAlign=("right",), tablefmt="plain"
+            [["one", "two"], ["three", "four"]], colAlign=("right",), tableFmt="plain"
         )
         expected = "  one  two\nthree  four"
         self.assertEqual(expected, result)
@@ -1454,7 +1454,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(
             [["one", "two"], SEPARATING_LINE, ["three", "four"]],
             colAlign=("right",),
-            tablefmt="plain",
+            tableFmt="plain",
         )
         expected = "  one  two\n\nthree  four"
         self.assertEqual(expected, result)
@@ -1528,7 +1528,7 @@ class TestTabulateOutput(unittest.TestCase):
             ["eggs", "451.0", 66.2222, "inf", 123.1234, "-inf"],
             ["asd", "437e6548", 1.234e2, float("inf"), float("nan"), 0.22e23],
         ]
-        result = tabulate(testTable, test_headers, tablefmt="grid")
+        result = tabulate(testTable, test_headers, tableFmt="grid")
         expected = "\n".join(
             [
                 "+-------+-------------+--------------+------------+------------+-------------+",
@@ -1547,7 +1547,7 @@ class TestTabulateOutput(unittest.TestCase):
     def test_missingVal(self):
         """Output: substitution of missing values."""
         result = tabulate(
-            [["Alice", 10], ["Bob", None]], missingVal="n/a", tablefmt="plain"
+            [["Alice", 10], ["Bob", None]], missingVal="n/a", tableFmt="plain"
         )
         expected = "Alice   10\nBob    n/a"
         self.assertEqual(expected, result)
@@ -1557,7 +1557,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(
             [["Alice", "Bob", "Charlie"], [None, None, None]],
             missingVal=("n/a", "?"),
-            tablefmt="plain",
+            tableFmt="plain",
         )
         expected = "Alice  Bob  Charlie\nn/a    ?"
         self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -1555,60 +1555,6 @@ class TestTabulateTextWrapper(unittest.TestCase):
 
             self.assertEqual(orig.wrap(data), cust.wrap(data))
 
-    def test_wrapper_len_ignores_color_chars(self):
-        data = "\033[31m\033[104mtenletters\033[0m"
-        result = CTW._len(data)
-        self.assertEqual(10, result)
-
-    def test_wrapFullLineColor(self):
-        """TextWrapper: Wrap a line when the full thing is enclosed in color tags."""
-        # This has both a text color and a background color
-        data = "\033[31m\033[104mThis is a test string for testing TextWrap with colors\033[0m"
-
-        expected = [
-            "\033[31m\033[104mThis is a test\033[0m",
-            "\033[31m\033[104mstring for testing\033[0m",
-            "\033[31m\033[104mTextWrap with colors\033[0m",
-        ]
-        print("xxxxxxxxxxxxxxxxx")
-        print(expected)
-        print("xxxxxxxxxxxxxxxxx")
-        wrapper = CTW(width=20)
-        result = wrapper.wrap(data)
-        self.assertEqual(expected, result)
-
-    def test_wrapColorInSingleLine(self):
-        """TextWrapper: Wrap a line - preserve internal color tags, and don't
-        propagate them to other lines when they don't need to be.
-        """
-        # This has both a text color and a background color
-        data = "This is a test string for testing \033[31mTextWrap\033[0m with colors"
-
-        expected = [
-            "This is a test string for",
-            "testing \033[31mTextWrap\033[0m with",
-            "colors",
-        ]
-        wrapper = CTW(width=25)
-        result = wrapper.wrap(data)
-        self.assertEqual(expected, result)
-
-    def test_wrapColorLineSplillover(self):
-        """TextWrapper: Wrap a line - preserve internal color tags and wrap them to
-        other lines when required, requires adding the colors tags to other lines as appropriate.
-        """
-        # This has both a text color and a background color
-        data = "This is a \033[31mtest string for testing TextWrap\033[0m with colors"
-
-        expected = [
-            "This is a \033[31mtest string for\033[0m",
-            "\033[31mtesting TextWrap\033[0m with",
-            "colors",
-        ]
-        wrapper = CTW(width=25)
-        result = wrapper.wrap(data)
-        self.assertEqual(expected, result)
-
     def test_wrapDatetime(self):
         """TextWrapper: Show that datetimes can be wrapped without crashing."""
         data = [

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -27,10 +27,12 @@ import numpy as np
 from armi.utils.tabulate import _alignCellVeritically
 from armi.utils.tabulate import _alignColumn
 from armi.utils.tabulate import _bool
+from armi.utils.tabulate import _buildRow
 from armi.utils.tabulate import _format
 from armi.utils.tabulate import _isMultiline
 from armi.utils.tabulate import _multilineWidth
 from armi.utils.tabulate import _normalizeTabularData
+from armi.utils.tabulate import _table_formats
 from armi.utils.tabulate import _type
 from armi.utils.tabulate import _visibleWidth
 from armi.utils.tabulate import SEPARATING_LINE
@@ -369,6 +371,19 @@ class TestTabulateInternal(unittest.TestCase):
         self.assertTrue(_bool(123))
         self.assertFalse(_bool(np.array([1, 0, -1])))
 
+    def test_buildRow(self):
+        """Basic sanity test of internal _buildRow() function."""
+        rowFormat = _table_formats["armi"].datarow
+        self.assertEqual(_buildRow("", [2, 2], ["center", "center"], rowFormat), "")
+
+        d = {"a": 1, "b": 2}
+        self.assertEqual(_buildRow(d, [2, 2], ["center", "center"], rowFormat), "a  b")
+
+        lst = ["ab", "cd"]
+        self.assertEqual(
+            _buildRow(lst, [2, 2], ["center", "center"], rowFormat), "ab  cd"
+        )
+
     def test_format(self):
         """Basic sanity test of internal _format() function."""
         self.assertEqual(_format(None, str, "8", "", "X", True), "X")
@@ -377,7 +392,6 @@ class TestTabulateInternal(unittest.TestCase):
         self.assertEqual(
             _format(bytes("abc", "utf-8"), bytes, "8", "", "X", True), "abc"
         )
-        self.assertEqual(_format("\t", bytes, "8", "", "X", True), "X")
         self.assertEqual(_format("3.14", float, "4", "", "X", True), "3.14")
         colorNum = "\x1b[31m3.14\x1b[0m"
         self.assertEqual(_format(colorNum, float, "4", "", "X", True), colorNum)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -19,11 +19,13 @@
 from collections import namedtuple
 from collections import OrderedDict
 from collections import UserDict
+from datetime import datetime
 import unittest
 
 import numpy as np
 
 from armi.utils.tabulate import _alignColumn, _alignCellVeritically, _multilineWidth
+from armi.utils.tabulate import _type, _visibleWidth
 from armi.utils.tabulate import SEPARATING_LINE
 from armi.utils.tabulate import tabulate, tabulate_formats
 
@@ -353,6 +355,20 @@ class TestTabulateInputs(unittest.TestCase):
 
 
 class TestTabulateInternal(unittest.TestCase):
+    def test_type(self):
+        """Basic sanity test of internal _type() function."""
+        self.assertEqual(_type(None), type(None))
+        self.assertEqual(_type("foo"), type(""))
+        self.assertEqual(_type("1"), type(1))
+        self.assertEqual(_type("\x1b[31m42\x1b[0m"), type(42))
+        self.assertEqual(_type("\x1b[31m42\x1b[0m"), type(42))
+        self.assertEqual(_type(datetime.now()), type("2024-12-31"))
+
+    def test_visibleWidth(self):
+        self.assertEqual(_visibleWidth("world"), 5)
+        self.assertEqual(_visibleWidth("\x1b[31mhello\x1b[0m"), 5)
+        self.assertEqual(_visibleWidth(np.ones(3)), 10)
+
     def test_multilineWidth(self):
         """Internal: _multilineWidth()."""
         multilineString = "\n".join(["foo", "barbaz", "spam"])

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -30,6 +30,7 @@ from armi.utils.tabulate import _bool
 from armi.utils.tabulate import _format
 from armi.utils.tabulate import _isMultiline
 from armi.utils.tabulate import _multilineWidth
+from armi.utils.tabulate import _normalizeTabularData
 from armi.utils.tabulate import _type
 from armi.utils.tabulate import _visibleWidth
 from armi.utils.tabulate import SEPARATING_LINE
@@ -376,7 +377,7 @@ class TestTabulateInternal(unittest.TestCase):
         self.assertEqual(
             _format(bytes("abc", "utf-8"), bytes, "8", "", "X", True), "abc"
         )
-        self.assertEqual(_format(None, bytes, "8", "", "X", True), "X")
+        self.assertEqual(_format("\t", bytes, "8", "", "X", True), "X")
         self.assertEqual(_format("3.14", float, "4", "", "X", True), "3.14")
         colorNum = "\x1b[31m3.14\x1b[0m"
         self.assertEqual(_format(colorNum, float, "4", "", "X", True), colorNum)
@@ -395,6 +396,23 @@ class TestTabulateInternal(unittest.TestCase):
         self.assertEqual(_multilineWidth(multilineString), 6)
         onelineString = "12345"
         self.assertEqual(_multilineWidth(onelineString), len(onelineString))
+
+    def test_normalizeTabularData(self):
+        """Basic sanity test of internal _normalizeTabularData() function."""
+        res = _normalizeTabularData([[1, 2], [3, 4]], np.array(["a", "b"]), "default")
+        self.assertEqual(res[0], [[1, 2], [3, 4]])
+        self.assertEqual(res[1], ["a", "b"])
+        self.assertEqual(res[2], 0)
+
+        res = _normalizeTabularData([], "keys", "default")
+        self.assertEqual(len(res[0]), 0)
+        self.assertEqual(len(res[1]), 0)
+        self.assertEqual(res[2], 0)
+
+        res = _normalizeTabularData([], "firstrow", "default")
+        self.assertEqual(len(res[0]), 0)
+        self.assertEqual(len(res[1]), 0)
+        self.assertEqual(res[2], 0)
 
     def test_type(self):
         """Basic sanity test of internal _type() function."""

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -22,6 +22,7 @@ https://github.com/astanin/python-tabulate
 from collections import namedtuple
 from collections import OrderedDict
 from collections import UserDict
+from dataclasses import dataclass
 from datetime import datetime
 import unittest
 
@@ -443,6 +444,22 @@ class TestTabulateInternal(unittest.TestCase):
         res = _normalizeTabularData([], "firstrow", "default")
         self.assertEqual(len(res[0]), 0)
         self.assertEqual(len(res[1]), 0)
+        self.assertEqual(res[2], 0)
+
+        @dataclass
+        class row:
+            a: int
+            b: int
+
+        rows = [row(1, 2), row(3, 4)]
+        res = _normalizeTabularData(rows, "keys", "default")
+        self.assertEqual(res[0], [[1, 2], [3, 4]])
+        self.assertEqual(res[1], ["a", "b"])
+        self.assertEqual(res[2], 0)
+
+        res = _normalizeTabularData(rows, ["x", "y"], "default")
+        self.assertEqual(res[0], [[1, 2], [3, 4]])
+        self.assertEqual(res[1], ["x", "y"])
         self.assertEqual(res[2], 0)
 
     def test_type(self):

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -1427,16 +1427,16 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate([], headers="firstrow")
         self.assertEqual(expected, result)
 
-    def test_floatfmt(self):
+    def test_floatFmt(self):
         """Output: floating point format."""
-        result = tabulate([["1.23456789"], [1.0]], floatfmt=".3f", tableFmt="plain")
+        result = tabulate([["1.23456789"], [1.0]], floatFmt=".3f", tableFmt="plain")
         expected = "1.235\n1.000"
         self.assertEqual(expected, result)
 
-    def test_floatfmtMulti(self):
+    def test_floatFmtMulti(self):
         """Output: floating point format different for each column."""
         result = tabulate(
-            [[0.12345, 0.12345, 0.12345]], floatfmt=(".1f", ".3f"), tableFmt="plain"
+            [[0.12345, 0.12345, 0.12345]], floatFmt=(".1f", ".3f"), tableFmt="plain"
         )
         expected = "0.1  0.123  0.12345"
         self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -1415,9 +1415,9 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate([], tableFmt="simple")
         self.assertEqual(expected, result)
 
-    def test_intfmt(self):
+    def test_intFmt(self):
         """Output: integer format."""
-        result = tabulate([[10000], [10]], intfmt=",", tableFmt="plain")
+        result = tabulate([[10000], [10]], intFmt=",", tableFmt="plain")
         expected = "10,000\n    10"
         self.assertEqual(expected, result)
 

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -88,7 +88,7 @@ class TestTabulateInputs(unittest.TestCase):
         expected = "\n".join(
             ["-  -  -  -  -", "0  1  2  3  4", "5  4  3  2  1", "-  -  -  -  -"]
         )
-        result = tabulate(ii)
+        result = tabulate(ii, headersalign="center")
         self.assertEqual(expected, result)
 
     def test_iterableOfIterablesHeaders(self):

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -21,10 +21,11 @@ import unittest
 
 import numpy  # TODO: as np
 
+from armi.utils.tabulate import _multilineWidth
 from armi.utils.tabulate import tabulate, tabulate_formats
 
 
-class TestTabulate(unittest.TestCase):
+class TestTabulateAPI(unittest.TestCase):
     def test_tabulateFormats(self):
         """API: tabulate_formats is a list of strings."""
         supported = tabulate_formats
@@ -32,6 +33,8 @@ class TestTabulate(unittest.TestCase):
         for fmt in supported:
             self.assertEqual(type(fmt), str)
 
+
+class TestTabulateInputs(unittest.TestCase):
     def test_iterableOfIterables(self):
         """Input: an interable of iterables."""
         ii = iter(map(lambda x: iter(x), [range(5), range(5, 0, -1)]))
@@ -348,3 +351,12 @@ class TestTabulate(unittest.TestCase):
         )
         result = tabulate(lb, headers=["bytes"])
         self.assertEqual(expected, result)
+
+
+class TestTabulateInternal(unittest.TestCase):
+    def test_multilineWidth(self):
+        """Internal: _multilineWidth()."""
+        multilineString = "\n".join(["foo", "barbaz", "spam"])
+        self.assertEqual(_multilineWidth(multilineString), 6)
+        onelineString = "12345"
+        self.assertEqual(_multilineWidth(onelineString), len(onelineString))

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -59,7 +59,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(ii, "abcde")
         self.assertEqual(expected, result)
 
-    def test_iterable_of_iterables_firstrow(self):
+    def test_iterableOfIterablesFirstrow(self):
         """Input: an interable of iterables with the first row as headers."""
         ii = iter(map(lambda x: iter(x), ["abcde", range(5), range(5, 0, -1)]))
         expected = "\n".join(
@@ -73,7 +73,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(ii, "firstrow")
         self.assertEqual(expected, result)
 
-    def test_list_of_lists(self):
+    def test_listOfLists(self):
         """Input: a list of lists with headers."""
         ll = [["a", "one", 1], ["b", "two", None]]
         expected = "\n".join(
@@ -87,7 +87,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(ll, headers=["string", "number"])
         self.assertEqual(expected, result)
 
-    def test_list_of_lists_firstrow(self):
+    def test_listOfListsFirstrow(self):
         """Input: a list of lists with the first row as headers."""
         ll = [["string", "number"], ["a", "one", 1], ["b", "two", None]]
         expected = "\n".join(
@@ -101,7 +101,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(ll, headers="firstrow")
         self.assertEqual(expected, result)
 
-    def test_list_of_lists_keys(self):
+    def test_listOfListsKeys(self):
         """Input: a list of lists with column indices as headers."""
         ll = [["a", "one", 1], ["b", "two", None]]
         expected = "\n".join(
@@ -110,7 +110,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(ll, headers="keys")
         self.assertEqual(expected, result)
 
-    def testDictLike(self):
+    def test_dictLike(self):
         """Input: a dict of iterables with keys as headers."""
         # columns should be padded with None, keys should be used as headers
         dd = {"a": range(3), "b": range(101, 105)}
@@ -122,7 +122,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(dd, "keys")
         self.assertEqual(result, expected1)
 
-    def test_numpy_2d(self):
+    def test_numpy2d(self):
         """Input: a 2D NumPy array with headers."""
         na = (numpy.arange(1, 10, dtype=numpy.float32).reshape((3, 3)) ** 3) * 0.5
         expected = "\n".join(
@@ -137,7 +137,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(na, ["a", "b", "c"])
         self.assertEqual(expected, result)
 
-    def test_numpy_2d_firstrow(self):
+    def test_numpy2dFirstrow(self):
         """Input: a 2D NumPy array with the first row as headers."""
         na = numpy.arange(1, 10, dtype=numpy.int32).reshape((3, 3)) ** 3
         expected = "\n".join(
@@ -146,7 +146,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(na, headers="firstrow")
         self.assertEqual(expected, result)
 
-    def test_numpy_2d_keys(self):
+    def test_numpy2dKeys(self):
         """Input: a 2D NumPy array with column indices as headers."""
         na = (numpy.arange(1, 10, dtype=numpy.float32).reshape((3, 3)) ** 3) * 0.5
         expected = "\n".join(
@@ -161,7 +161,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(na, headers="keys")
         self.assertEqual(expected, result)
 
-    def test_numpy_record_array(self):
+    def test_numpyRecordArray(self):
         """Input: a 2D NumPy record array without header."""
         na = numpy.asarray(
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
@@ -181,7 +181,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(na)
         self.assertEqual(expected, result)
 
-    def test_numpy_record_array_keys(self):
+    def test_numpyRecordArrayKeys(self):
         """Input: a 2D NumPy record array with column names as headers."""
         na = numpy.asarray(
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
@@ -201,7 +201,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(na, headers="keys")
         self.assertEqual(expected, result)
 
-    def test_numpy_record_array_headers(self):
+    def test_numpyRecordArrayHeaders(self):
         """Input: a 2D NumPy record array with user-supplied headers."""
         na = numpy.asarray(
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
@@ -221,7 +221,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(na, headers=["person", "years", "cm"])
         self.assertEqual(expected, result)
 
-    def test_list_of_namedtuples(self):
+    def test_listOf_namedtuples(self):
         """Input: a list of named tuples with field names as headers."""
         from collections import namedtuple
 
@@ -231,7 +231,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(lt)
         self.assertEqual(expected, result)
 
-    def test_list_of_namedtuples_keys(self):
+    def test_listOfNamedtuplesKeys(self):
         """Input: a list of named tuples with field names as headers."""
         from collections import namedtuple
 
@@ -243,7 +243,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(lt, headers="keys")
         self.assertEqual(expected, result)
 
-    def test_list_of_dicts(self):
+    def test_listOfDicts(self):
         """Input: a list of dictionaries."""
         lod = [{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}]
         expected1 = "\n".join(["-  -", "1  2", "3  4", "-  -"])
@@ -251,7 +251,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(lod)
         self.assertIn(result, [expected1, expected2])
 
-    def test_list_of_userdicts(self):
+    def test_listOfUserdicts(self):
         """Input: a list of UserDicts."""
         lod = [UserDict(foo=1, bar=2), UserDict(foo=3, bar=4)]
         expected1 = "\n".join(["-  -", "1  2", "3  4", "-  -"])
@@ -259,7 +259,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(lod)
         self.assertIn(result, [expected1, expected2])
 
-    def test_list_of_dicts_keys(self):
+    def test_listOfDictsKeys(self):
         """Input: a list of dictionaries, with keys as headers."""
         lod = [{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}]
         expected1 = "\n".join(
@@ -271,7 +271,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(lod, headers="keys")
         self.assertIn(result, [expected1, expected2])
 
-    def test_list_of_userdicts_keys(self):
+    def test_listOfUserdictsKeys(self):
         """Input: a list of UserDicts."""
         lod = [UserDict(foo=1, bar=2), UserDict(foo=3, bar=4)]
         expected1 = "\n".join(
@@ -283,7 +283,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(lod, headers="keys")
         self.assertIn(result, [expected1, expected2])
 
-    def test_list_of_dicts_with_missing_keys(self):
+    def test_listOfDictsWithMissingKeys(self):
         """Input: a list of dictionaries, with missing keys."""
         lod = [{"foo": 1}, {"bar": 2}, {"foo": 4, "baz": 3}]
         expected = "\n".join(
@@ -298,7 +298,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(lod, headers="keys")
         self.assertEqual(expected, result)
 
-    def test_list_of_dicts_firstrow(self):
+    def test_listOfDictsFirstrow(self):
         """Input: a list of dictionaries, with the first dict as headers."""
         lod = [{"foo": "FOO", "bar": "BAR"}, {"foo": 3, "bar": 4, "baz": 5}]
         # if some key is missing in the first dict, use the key name instead
@@ -311,7 +311,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(lod, headers="firstrow")
         self.assertIn(result, [expected1, expected2])
 
-    def test_list_of_dicts_with_dict_of_headers(self):
+    def test_listOfDictsWithDictOfHeaders(self):
         """Input: a dict of user headers for a list of dicts."""
         table = [{"letters": "ABCDE", "digits": 12345}]
         headers = {"digits": "DIGITS", "letters": "LETTERS"}
@@ -324,14 +324,14 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(table, headers=headers)
         self.assertIn(result, [expected1, expected2])
 
-    def test_list_of_dicts_with_list_of_headers(self):
+    def test_listOfDicts_with_list_of_headers(self):
         """Input: ValueError on a list of headers with a list of dicts."""
         table = [{"letters": "ABCDE", "digits": 12345}]
         headers = ["DIGITS", "LETTERS"]
         with self.assertRaises(ValueError):
             tabulate(table, headers=headers)
 
-    def test_list_of_ordereddicts(self):
+    def test_listOfOrdereddicts(self):
         """Input: a list of OrderedDicts."""
         od = OrderedDict([("b", 1), ("a", 2)])
         lod = [od, od]
@@ -339,7 +339,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(lod, headers="keys")
         self.assertEqual(expected, result)
 
-    def test_list_bytes(self):
+    def test_listBytes(self):
         """Input: a list of bytes."""
         lb = [["你好".encode("utf-8")], ["你好"]]
         expected = "\n".join(
@@ -362,7 +362,7 @@ class TestTabulateInternal(unittest.TestCase):
         onelineString = "12345"
         self.assertEqual(_multilineWidth(onelineString), len(onelineString))
 
-    def test_align_column_decimal(self):
+    def test_alignColumnDecimal(self):
         """Internal: _align_column(..., 'decimal')."""
         column = ["12.345", "-1234.5", "1.23", "1234.5", "1e+234", "1.0e234"]
         result = _alignColumn(column, "decimal")
@@ -376,7 +376,7 @@ class TestTabulateInternal(unittest.TestCase):
         ]
         self.assertEqual(expected, result)
 
-    def test_align_column_decimal_with_thousand_separators(self):
+    def test_alignColumnDecimalWithThousandSeparators(self):
         """Internal: _align_column(..., 'decimal')."""
         column = ["12.345", "-1234.5", "1.23", "1,234.5", "1e+234", "1.0e234"]
         output = _alignColumn(column, "decimal")
@@ -390,7 +390,7 @@ class TestTabulateInternal(unittest.TestCase):
         ]
         self.assertEqual(expected, output)
 
-    def test_align_column_decimal_with_incorrect_thousand_separators(self):
+    def test_alignColumnDecimalWithIncorrectThousandSeparators(self):
         """Internal: _align_column(..., 'decimal')."""
         column = ["12.345", "-1234.5", "1.23", "12,34.5", "1e+234", "1.0e234"]
         output = _alignColumn(column, "decimal")
@@ -418,7 +418,7 @@ class TestTabulateInternal(unittest.TestCase):
         expected = ["  1  ", " 123 ", "12345" + "\n" + "  6  "]
         self.assertEqual(expected, output)
 
-    def test_align_cell_veritically_one_line_only(self):
+    def test_alignCellVeriticallyOneLineOnly(self):
         """Internal: Aligning a single height cell is same regardless of alignment value."""
         lines = ["one line"]
         column_width = 8
@@ -431,32 +431,32 @@ class TestTabulateInternal(unittest.TestCase):
         expected = ["one line"]
         assert top == center == bottom == none == expected
 
-    def test_align_cell_veritically_top_single_text_multiple_pad(self):
+    def test_alignCellVeriticallyTopSingleTextMultiplePad(self):
         """Internal: Align single cell text to top."""
         result = _alignCellVeritically(["one line"], 3, 8, "top")
         expected = ["one line", "        ", "        "]
         self.assertEqual(expected, result)
 
-    def test_align_cell_veritically_center_single_text_multiple_pad(self):
+    def test_alignCellVeriticallyCenterSingleTextMultiplePad(self):
         """Internal: Align single cell text to center."""
         result = _alignCellVeritically(["one line"], 3, 8, "center")
         expected = ["        ", "one line", "        "]
         self.assertEqual(expected, result)
 
-    def test_align_cell_veritically_bottom_single_text_multiple_pad(self):
+    def test_alignCellVeriticallyBottomSingleTextMultiplePad(self):
         """Internal: Align single cell text to bottom."""
         result = _alignCellVeritically(["one line"], 3, 8, "bottom")
         expected = ["        ", "        ", "one line"]
         self.assertEqual(expected, result)
 
-    def test_align_cell_veritically_top_multi_text_multiple_pad(self):
+    def test_alignCellVeriticallyTopMultiTextMultiplePad(self):
         """Internal: Align multiline celltext text to top."""
         text = ["just", "one ", "cell"]
         result = _alignCellVeritically(text, 6, 4, "top")
         expected = ["just", "one ", "cell", "    ", "    ", "    "]
         self.assertEqual(expected, result)
 
-    def test_align_cell_veritically_center_multi_text_multiple_pad(self):
+    def test_alignCellVeriticallyCenterMultiTextMultiplePad(self):
         """Internal: Align multiline celltext text to center."""
         text = ["just", "one ", "cell"]
         result = _alignCellVeritically(text, 6, 4, "center")
@@ -466,7 +466,7 @@ class TestTabulateInternal(unittest.TestCase):
         expected = ["    ", "just", "one ", "cell", "    ", "    "]
         self.assertEqual(expected, result)
 
-    def test_align_cell_veritically_bottom_multi_text_multiple_pad(self):
+    def test_alignCellVeriticallyBottomMultiTextMultiplePad(self):
         """Internal: Align multiline celltext text to bottom."""
         text = ["just", "one ", "cell"]
         result = _alignCellVeritically(text, 6, 4, "bottom")
@@ -493,13 +493,13 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, _test_table_headers, tablefmt="plain")
         self.assertEqual(expected, result)
 
-    def test_plain_headerless(self):
+    def test_plainHeaderless(self):
         """Output: plain without headers."""
         expected = "\n".join(["spam   41.9999", "eggs  451"])
         result = tabulate(_test_table, tablefmt="plain")
         self.assertEqual(expected, result)
 
-    def test_plain_multiline_headerless(self):
+    def test_plainMultilineHeaderless(self):
         """Output: plain with multiline cells without headers."""
         table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
         expected = "\n".join(
@@ -514,7 +514,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, stralign="center", tablefmt="plain")
         self.assertEqual(expected, result)
 
-    def test_plain_multiline(self):
+    def test_plainMultiline(self):
         """Output: plain with multiline cells with headers."""
         table = [[2, "foo\nbar"]]
         headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
@@ -529,7 +529,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="plain")
         self.assertEqual(expected, result)
 
-    def test_plain_multiline_with_links(self):
+    def test_plainMultilineWithLinks(self):
         """Output: plain with multiline cells with links and headers."""
         table = [[2, "foo\nbar"]]
         headers = (
@@ -547,7 +547,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="plain")
         self.assertEqual(expected, result)
 
-    def test_plain_multiline_with_empty_cells(self):
+    def test_plainMultilineWithEmptyCells(self):
         """Output: plain with multiline cells and empty cells with headers."""
         table = [
             ["hdr", "data", "fold"],
@@ -565,7 +565,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers="firstrow", tablefmt="plain")
         self.assertEqual(expected, result)
 
-    def test_plain_multiline_with_empty_cells_headerless(self):
+    def test_plainMultilineWithEmptyCellsHeaderless(self):
         """Output: plain with multiline cells and empty cells without headers."""
         table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
         expected = "\n".join(
@@ -574,7 +574,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, tablefmt="plain")
         self.assertEqual(expected, result)
 
-    def test_plain_maxcolwidth_autowraps(self):
+    def test_plainMaxcolwidthAutowraps(self):
         """Output: maxcolwidth will result in autowrapping longer cells."""
         table = [["hdr", "fold"], ["1", "very long data"]]
         expected = "\n".join(["  hdr  fold", "    1  very long", "       data"])
@@ -583,7 +583,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_plain_maxcolwidth_autowraps_with_sep(self):
+    def test_plainMaxcolwidthAutowrapsWithSep(self):
         """Output: maxcolwidth will result in autowrapping longer cells and separating line."""
         table = [
             ["hdr", "fold"],
@@ -599,7 +599,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_maxcolwidth_single_value(self):
+    def test_maxcolwidthSingleValue(self):
         """Output: maxcolwidth can be specified as a single number that works for each column."""
         table = [
             ["hdr", "fold1", "fold2"],
@@ -617,7 +617,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers="firstrow", tablefmt="plain", maxcolwidths=6)
         self.assertEqual(expected, result)
 
-    def test_maxcolwidth_pad_tailing_widths(self):
+    def test_maxcolwidthPadTailingWidths(self):
         """Output: maxcolwidth, if only partly specified, pads tailing cols with None."""
         table = [
             ["hdr", "fold1", "fold2"],
@@ -636,7 +636,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_maxcolwidth_honor_disable_parsenum(self):
+    def test_maxcolwidthHonorDisableParsenum(self):
         """Output: Using maxcolwidth in conjunction with disable_parsenum is honored."""
         table = [
             ["first number", 123.456789, "123.456789"],
@@ -658,7 +658,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, tablefmt="grid", maxcolwidths=6, disableNumparse=[2])
         self.assertEqual(expected, result)
 
-    def test_plain_maxheadercolwidths_autowraps(self):
+    def test_plainMaxheadercolwidthsAutowraps(self):
         """Output: maxheadercolwidths will result in autowrapping header cell."""
         table = [["hdr", "fold"], ["1", "very long data"]]
         expected = "\n".join(
@@ -686,7 +686,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, _test_table_headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_simple_with_sep_line(self):
+    def test_simpleWithSepLine(self):
         """Output: simple with headers and separating line."""
         expected = "\n".join(
             [
@@ -702,7 +702,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_readme_example_with_sep(self):
+    def test_readmeExampleWithSep(self):
         table = [["Earth", 6371], ["Mars", 3390], SEPARATING_LINE, ["Moon", 1737]]
         expected = "\n".join(
             [
@@ -717,7 +717,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_simple_multiline_2(self):
+    def testSimpleMultiline2(self):
         """Output: simple with multiline cells."""
         expected = "\n".join(
             [
@@ -734,7 +734,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_simple_multiline_2_with_sep_line(self):
+    def testSimpleMultiline2WithSepLine(self):
         """Output: simple with multiline cells."""
         expected = "\n".join(
             [
@@ -757,7 +757,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_simple_headerless(self):
+    def test_simpleHeaderless(self):
         """Output: simple without headers."""
         expected = "\n".join(
             ["----  --------", "spam   41.9999", "eggs  451", "----  --------"]
@@ -765,7 +765,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_simple_headerless_with_sep_line(self):
+    def test_simpleHeaderlessWithSepLine(self):
         """Output: simple without headers."""
         expected = "\n".join(
             [
@@ -779,7 +779,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table_with_sep_line, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_simple_multiline_headerless(self):
+    def testSimpleMultilineHeaderless(self):
         """Output: simple with multiline cells without headers."""
         table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
         expected = "\n".join(
@@ -796,7 +796,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, stralign="center", tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_simple_multiline(self):
+    def test_simpleMultiline(self):
         """Output: simple with multiline cells with headers."""
         table = [[2, "foo\nbar"]]
         headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
@@ -812,7 +812,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_simple_multiline_with_links(self):
+    def testSimpleMultilineWithLinks(self):
         """Output: simple with multiline cells with links and headers."""
         table = [[2, "foo\nbar"]]
         headers = (
@@ -831,7 +831,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_simple_multiline_with_empty_cells(self):
+    def testSimpleMultilineWithEmptyCells(self):
         """Output: simple with multiline cells and empty cells with headers."""
         table = [
             ["hdr", "data", "fold"],
@@ -850,7 +850,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers="firstrow", tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_simple_multiline_with_empty_cells_headerless(self):
+    def testSimpleMultilineWithEmptyCellsHeaderless(self):
         """Output: simple with multiline cells and empty cells without headers."""
         table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
         expected = "\n".join(
@@ -895,7 +895,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, _test_table_headers, tablefmt="grid")
         self.assertEqual(expected, result)
 
-    def test_grid_headerless(self):
+    def test_gridHeaderless(self):
         """Output: grid without headers."""
         expected = "\n".join(
             [
@@ -909,7 +909,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, tablefmt="grid")
         self.assertEqual(expected, result)
 
-    def test_grid_multiline_headerless(self):
+    def test_gridMultilineHeaderless(self):
         """Output: grid with multiline cells without headers."""
         table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
         expected = "\n".join(
@@ -927,7 +927,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, stralign="center", tablefmt="grid")
         self.assertEqual(expected, result)
 
-    def test_grid_multiline(self):
+    def test_gridMultiline(self):
         """Output: grid with multiline cells with headers."""
         table = [[2, "foo\nbar"]]
         headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
@@ -945,7 +945,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="grid")
         self.assertEqual(expected, result)
 
-    def test_grid_multiline_with_empty_cells(self):
+    def test_gridMultilineWithEmptyCells(self):
         """Output: grid with multiline cells and empty cells with headers."""
         table = [
             ["hdr", "data", "fold"],
@@ -967,7 +967,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers="firstrow", tablefmt="grid")
         self.assertEqual(expected, result)
 
-    def test_grid_multiline_with_empty_cells_headerless(self):
+    def test_gridMultilineWithEmptyCellsHeaderless(self):
         """Output: grid with multiline cells and empty cells without headers."""
         table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
         expected = "\n".join(
@@ -1000,7 +1000,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, _test_table_headers, tablefmt="pretty")
         self.assertEqual(expected, result)
 
-    def test_pretty_headerless(self):
+    def test_prettyHeaderless(self):
         """Output: pretty without headers."""
         expected = "\n".join(
             [
@@ -1013,7 +1013,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, tablefmt="pretty")
         self.assertEqual(expected, result)
 
-    def test_pretty_multiline_headerless(self):
+    def test_prettyMultilineHeaderless(self):
         """Output: pretty with multiline cells without headers."""
         table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
         expected = "\n".join(
@@ -1030,7 +1030,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, tablefmt="pretty")
         self.assertEqual(expected, result)
 
-    def test_pretty_multiline(self):
+    def test_prettyMultiline(self):
         """Output: pretty with multiline cells with headers."""
         table = [[2, "foo\nbar"]]
         headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
@@ -1048,7 +1048,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="pretty")
         self.assertEqual(expected, result)
 
-    def test_pretty_multiline_with_links(self):
+    def test_prettyMultilineWithLinks(self):
         """Output: pretty with multiline cells with headers."""
         table = [[2, "foo\nbar"]]
         headers = (
@@ -1069,7 +1069,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="pretty")
         self.assertEqual(expected, result)
 
-    def test_pretty_multiline_with_empty_cells(self):
+    def test_prettyMultilineWithEmptyCells(self):
         """Output: pretty with multiline cells and empty cells with headers."""
         table = [
             ["hdr", "data", "fold"],
@@ -1090,7 +1090,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers="firstrow", tablefmt="pretty")
         self.assertEqual(expected, result)
 
-    def test_pretty_multiline_with_empty_cells_headerless(self):
+    def test_prettyMultilineWithEmptyCellsHeaderless(self):
         """Output: pretty with multiline cells and empty cells without headers."""
         table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
         expected = "\n".join(
@@ -1121,7 +1121,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, _test_table_headers, tablefmt="rst")
         self.assertEqual(expected, result)
 
-    def test_rst_with_empty_values_in_first_column(self):
+    def test_rstWithEmptyValuesInFirstColumn(self):
         """Output: rst with dots in first column."""
         test_headers = ["", "what"]
         test_data = [("", "spam"), ("", "eggs")]
@@ -1138,7 +1138,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(test_data, test_headers, tablefmt="rst")
         self.assertEqual(expected, result)
 
-    def test_rst_headerless(self):
+    def test_rstHeaderless(self):
         """Output: rst without headers."""
         expected = "\n".join(
             ["====  ========", "spam   41.9999", "eggs  451", "====  ========"]
@@ -1146,7 +1146,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, tablefmt="rst")
         self.assertEqual(expected, result)
 
-    def test_rst_multiline(self):
+    def test_rstMultiline(self):
         """Output: rst with multiline cells with headers."""
         table = [[2, "foo\nbar"]]
         headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
@@ -1164,7 +1164,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="rst")
         self.assertEqual(expected, result)
 
-    def test_rst_multiline_with_links(self):
+    def test_rstMultilineWithLinks(self):
         """Output: rst with multiline cells with headers."""
         table = [[2, "foo\nbar"]]
         headers = (
@@ -1185,7 +1185,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="rst")
         self.assertEqual(expected, result)
 
-    def test_rst_multiline_with_empty_cells(self):
+    def test_rstMultilineWithEmptyCells(self):
         """Output: rst with multiline cells and empty cells with headers."""
         table = [
             ["hdr", "data", "fold"],
@@ -1206,7 +1206,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers="firstrow", tablefmt="rst")
         self.assertEqual(expected, result)
 
-    def test_rst_multiline_with_empty_cells_headerless(self):
+    def test_rstMultilineWithEmptyCellsHeaderless(self):
         """Output: rst with multiline cells and empty cells without headers."""
         table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
         expected = "\n".join(
@@ -1222,25 +1222,25 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, tablefmt="rst")
         self.assertEqual(expected, result)
 
-    def test_no_data(self):
+    def test_noData(self):
         """Output: table with no data."""
         expected = "\n".join(["strings    numbers", "---------  ---------"])
         result = tabulate(None, _test_table_headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_empty_data(self):
+    def test_emptyData(self):
         """Output: table with empty data."""
         expected = "\n".join(["strings    numbers", "---------  ---------"])
         result = tabulate([], _test_table_headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_no_data_without_headers(self):
+    def test_noDataWithoutHeaders(self):
         """Output: table with no data and no headers."""
         expected = ""
         result = tabulate(None, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def test_empty_data_without_headers(self):
+    def test_emptyDataWithoutHeaders(self):
         """Output: table with empty data and no headers."""
         expected = ""
         result = tabulate([], tablefmt="simple")
@@ -1252,7 +1252,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "10,000\n    10"
         self.assertEqual(expected, result)
 
-    def test_empty_data_with_headers(self):
+    def test_emptyDataWithHeaders(self):
         """Output: table with empty data and headers as firstrow."""
         expected = ""
         result = tabulate([], headers="firstrow")
@@ -1264,7 +1264,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "1.235\n1.000"
         self.assertEqual(expected, result)
 
-    def test_floatfmt_multi(self):
+    def test_floatfmtMulti(self):
         """Output: floating point format different for each column."""
         result = tabulate(
             [[0.12345, 0.12345, 0.12345]], floatfmt=(".1f", ".3f"), tablefmt="plain"
@@ -1272,7 +1272,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "0.1  0.123  0.12345"
         self.assertEqual(expected, result)
 
-    def test_colalign_multi(self):
+    def test_colalignMulti(self):
         """Output: string columns with custom colalign."""
         result = tabulate(
             [["one", "two"], ["three", "four"]], colalign=("right",), tablefmt="plain"
@@ -1280,7 +1280,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "  one  two\nthree  four"
         self.assertEqual(expected, result)
 
-    def test_colalign_multi_with_sep_line(self):
+    def test_colalignMultiWithSepLine(self):
         """Output: string columns with custom colalign."""
         result = tabulate(
             [["one", "two"], SEPARATING_LINE, ["three", "four"]],
@@ -1290,7 +1290,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "  one  two\n\nthree  four"
         self.assertEqual(expected, result)
 
-    def test_column_global_and_specific_alignment(self):
+    def test_columnGlobalAndSpecificAlignment(self):
         """Test `colglobalalign` and `"global"` parameter for `colalign`."""
         table = [[1, 2, 3, 4], [111, 222, 333, 444]]
         colglobalalign = "center"
@@ -1306,7 +1306,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_headers_global_and_specific_alignment(self):
+    def test_headersGlobalAndSpecificAlignment(self):
         """Test `headersglobalalign` and `headersalign`."""
         table = [[1, 2, 3, 4, 5, 6], [111, 222, 333, 444, 555, 666]]
         colglobalalign = "center"
@@ -1332,7 +1332,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_colalign_or_headersalign_too_long(self):
+    def test_colalignOrHeadersalignTooLong(self):
         """Test `colalign` and `headersalign` too long."""
         table = [[1, 2], [111, 222]]
         colalign = ("global", "left", "center")
@@ -1344,7 +1344,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(["      h", "---  ---", "  1  2", "111  222"])
         self.assertEqual(expected, result)
 
-    def test_float_conversions(self):
+    def test_floatConversions(self):
         """Output: float format parsed."""
         test_headers = [
             "str",
@@ -1383,7 +1383,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "Alice   10\nBob    n/a"
         self.assertEqual(expected, result)
 
-    def test_missingval_multi(self):
+    def test_missingvalMulti(self):
         """Output: substitution of missing values with different values per column."""
         result = tabulate(
             [["Alice", "Bob", "Charlie"], [None, None, None]],
@@ -1393,7 +1393,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "Alice  Bob  Charlie\nn/a    ?"
         self.assertEqual(expected, result)
 
-    def test_column_alignment(self):
+    def test_columnAlignment(self):
         """Output: custom alignment for text and numbers."""
         expected = "\n".join(["-----  ---", "Alice   1", "  Bob  333", "-----  ---"])
         result = tabulate(
@@ -1401,14 +1401,14 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_dict_like_with_index(self):
+    def test_dictLikeWithIndex(self):
         """Output: a table with a running index."""
         dd = {"b": range(101, 104)}
         expected = "\n".join(["      b", "--  ---", " 0  101", " 1  102", " 2  103"])
         result = tabulate(dd, "keys", showindex=True)
         self.assertEqual(expected, result)
 
-    def test_list_of_lists_with_index(self):
+    def test_listOfListsWithIndex(self):
         """Output: a table with a running index."""
         dd = zip(*[range(3), range(101, 104)])
         # keys' order (hence columns' order) is not deterministic in Python 3
@@ -1425,7 +1425,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(dd, headers=["a", "b"], showindex=True)
         self.assertEqual(expected, result)
 
-    def test_list_of_lists_with_index_with_sep_line(self):
+    def test_listOfListsWithIndexWithSepLine(self):
         """Output: a table with a running index."""
         dd = [(0, 101), SEPARATING_LINE, (1, 102), (2, 103)]
         # keys' order (hence columns' order) is not deterministic in Python 3
@@ -1443,7 +1443,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(dd, headers=["a", "b"], showindex=True)
         self.assertEqual(expected, result)
 
-    def test_list_of_lists_with_supplied_index(self):
+    def test_listOfListsWithSuppliedIndex(self):
         """Output: a table with a supplied index."""
         dd = zip(*[list(range(3)), list(range(101, 104))])
         expected = "\n".join(
@@ -1461,7 +1461,7 @@ class TestTabulateOutput(unittest.TestCase):
         with self.assertRaises(ValueError):
             tabulate(dd, headers=["a", "b"], showindex=[1, 2])
 
-    def test_list_of_lists_with_index_firstrow(self):
+    def test_listOfListsWithIndexFirstrow(self):
         """Output: a table with a running index and header='firstrow'."""
         dd = zip(*[["a"] + list(range(3)), ["b"] + list(range(101, 104))])
         expected = "\n".join(
@@ -1479,7 +1479,7 @@ class TestTabulateOutput(unittest.TestCase):
         with self.assertRaises(ValueError):
             tabulate(dd, headers="firstrow", showindex=[1, 2])
 
-    def test_disable_numparse_default(self):
+    def test_disableNumparseDefault(self):
         """Output: Default table output with number parsing and alignment."""
         expected = "\n".join(
             [
@@ -1494,7 +1494,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, _test_table_headers, disableNumparse=False)
         self.assertEqual(expected, result)
 
-    def test_disable_numparse_true(self):
+    def test_disableNumparseTrue(self):
         """Output: Default table output, but without number parsing and alignment."""
         expected = "\n".join(
             [
@@ -1507,7 +1507,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(_test_table, _test_table_headers, disableNumparse=True)
         self.assertEqual(expected, result)
 
-    def test_disable_numparse_list(self):
+    def test_disableNumparseList(self):
         """Output: Default table output, but with number parsing selectively disabled."""
         table_headers = ["h1", "h2", "h3"]
         test_table = [["foo", "bar", "42992e1"]]

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -88,7 +88,7 @@ class TestTabulateInputs(unittest.TestCase):
         expected = "\n".join(
             ["-  -  -  -  -", "0  1  2  3  4", "5  4  3  2  1", "-  -  -  -  -"]
         )
-        result = tabulate(ii, headersalign="center")
+        result = tabulate(ii, headersAlign="center")
         self.assertEqual(expected, result)
 
     def test_iterableOfIterablesHeaders(self):
@@ -748,7 +748,7 @@ class TestTabulateOutput(unittest.TestCase):
         table = [["hdr", "fold"], ["1", "very long data"]]
         expected = "\n".join(["  hdr  fold", "    1  very long", "       data"])
         result = tabulate(
-            table, headers="firstrow", tablefmt="plain", maxcolwidths=[10, 10]
+            table, headers="firstrow", tablefmt="plain", maxColWidths=[10, 10]
         )
         self.assertEqual(expected, result)
 
@@ -764,11 +764,11 @@ class TestTabulateOutput(unittest.TestCase):
             ["  hdr  fold", "    1  very long", "       data", "", "    2  last line"]
         )
         result = tabulate(
-            table, headers="firstrow", tablefmt="plain", maxcolwidths=[10, 10]
+            table, headers="firstrow", tablefmt="plain", maxColWidths=[10, 10]
         )
         self.assertEqual(expected, result)
 
-    def test_maxcolwidthSingleValue(self):
+    def test_maxColWidthsingleValue(self):
         """Output: maxcolwidth can be specified as a single number that works for each column."""
         table = [
             ["hdr", "fold1", "fold2"],
@@ -783,7 +783,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "                longer",
             ]
         )
-        result = tabulate(table, headers="firstrow", tablefmt="plain", maxcolwidths=6)
+        result = tabulate(table, headers="firstrow", tablefmt="plain", maxColWidths=6)
         self.assertEqual(expected, result)
 
     def test_maxcolwidthPadTailingWidths(self):
@@ -801,7 +801,7 @@ class TestTabulateOutput(unittest.TestCase):
             ]
         )
         result = tabulate(
-            table, headers="firstrow", tablefmt="plain", maxcolwidths=[None, 6]
+            table, headers="firstrow", tablefmt="plain", maxColWidths=[None, 6]
         )
         self.assertEqual(expected, result)
 
@@ -824,11 +824,11 @@ class TestTabulateOutput(unittest.TestCase):
             ]
         )
         # Grid makes showing the alignment difference a little easier
-        result = tabulate(table, tablefmt="grid", maxcolwidths=6, disableNumParse=[2])
+        result = tabulate(table, tablefmt="grid", maxColWidths=6, disableNumParse=[2])
         self.assertEqual(expected, result)
 
-    def test_plainMaxheadercolwidthsAutowraps(self):
-        """Output: maxheadercolwidths will result in autowrapping header cell."""
+    def test_plainmaxHeaderColWidthsAutowraps(self):
+        """Output: maxHeaderColWidths will result in autowrapping header cell."""
         table = [["hdr", "fold"], ["1", "very long data"]]
         expected = "\n".join(
             ["  hdr  fo", "       ld", "    1  very long", "       data"]
@@ -837,8 +837,8 @@ class TestTabulateOutput(unittest.TestCase):
             table,
             headers="firstrow",
             tablefmt="plain",
-            maxcolwidths=[10, 10],
-            maxheadercolwidths=[None, 2],
+            maxColWidths=[10, 10],
+            maxHeaderColWidths=[None, 2],
         )
         self.assertEqual(expected, result)
 
@@ -1476,20 +1476,20 @@ class TestTabulateOutput(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_headersGlobalAndSpecificAlignment(self):
-        """Test `headersglobalalign` and `headersalign`."""
+        """Test `headersGlobalAlign` and `headersAlign`."""
         table = [[1, 2, 3, 4, 5, 6], [111, 222, 333, 444, 555, 666]]
         colGlobalAlign = "center"
         colAlign = ("left",)
         headers = ["h", "e", "a", "d", "e", "r"]
-        headersglobalalign = "right"
-        headersalign = ("same", "same", "left", "global", "center")
+        headersGlobalAlign = "right"
+        headersAlign = ("same", "same", "left", "global", "center")
         result = tabulate(
             table,
             headers=headers,
             colGlobalAlign=colGlobalAlign,
             colAlign=colAlign,
-            headersglobalalign=headersglobalalign,
-            headersalign=headersalign,
+            headersGlobalAlign=headersGlobalAlign,
+            headersAlign=headersAlign,
         )
         expected = "\n".join(
             [
@@ -1501,14 +1501,14 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_colAlignOrHeadersalignTooLong(self):
-        """Test `colAlign` and `headersalign` too long."""
+    def test_colAlignOrheadersAlignTooLong(self):
+        """Test `colAlign` and `headersAlign` too long."""
         table = [[1, 2], [111, 222]]
         colAlign = ("global", "left", "center")
         headers = ["h"]
-        headersalign = ("center", "right", "same")
+        headersAlign = ("center", "right", "same")
         result = tabulate(
-            table, headers=headers, colAlign=colAlign, headersalign=headersalign
+            table, headers=headers, colAlign=colAlign, headersAlign=headersAlign
         )
         expected = "\n".join(["      h", "---  ---", "  1  2", "111  222"])
         self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -40,6 +40,7 @@ from armi.utils.tabulate import _normalizeTabularData
 from armi.utils.tabulate import _table_formats
 from armi.utils.tabulate import _type
 from armi.utils.tabulate import _visibleWidth
+from armi.utils.tabulate import _wrapTextToColWidths
 from armi.utils.tabulate import SEPARATING_LINE
 from armi.utils.tabulate import tabulate
 from armi.utils.tabulate import tabulate_formats
@@ -470,6 +471,21 @@ class TestTabulateInternal(unittest.TestCase):
         self.assertEqual(_type("\x1b[31m42\x1b[0m"), type(42))
         self.assertEqual(_type("\x1b[31m42\x1b[0m"), type(42))
         self.assertEqual(_type(datetime.now()), type("2024-12-31"))
+
+    def test_wrapTextToColWidths(self):
+        """Basic sanity test of internal _wrapTextToColWidths() function."""
+        res = _wrapTextToColWidths([], [2, 2], True)
+        self.assertEqual(len(res), 0)
+
+        res = _wrapTextToColWidths([[1], [2]], [2, 2], True)
+        self.assertEqual(res[0][0], 1)
+        self.assertEqual(res[1][0], 2)
+
+        res = _wrapTextToColWidths([["1"], ["2"]], [2, 2], False)
+        self.assertEqual(res[0][0], "1")
+        self.assertEqual(res[1][0], "2")
+
+    # TODO: JOHN: alphabetize tests
 
     def test_assortedRareEdgeCases(self):
         """Test some of the more rare edge cases in the purely internal functions."""

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -11,11 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# NOTE: This code originally started out as the MIT-licensed "tabulate":
-#       This was originally https://github.com/astanin/python-tabulate
 
-"""Tests for tabulate."""
+"""Tests for tabulate.
+
+This file started out as the MIT-licensed "tabulate". Though we have made, and will continue to make
+many arbitrary changes as we need. Thanks to the tabulate team.
+
+https://github.com/astanin/python-tabulate
+"""
 from collections import namedtuple
 from collections import OrderedDict
 from collections import UserDict

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -27,6 +27,7 @@ import numpy as np
 from armi.utils.tabulate import _alignCellVeritically
 from armi.utils.tabulate import _alignColumn
 from armi.utils.tabulate import _bool
+from armi.utils.tabulate import _buildLine
 from armi.utils.tabulate import _buildRow
 from armi.utils.tabulate import _format
 from armi.utils.tabulate import _isMultiline
@@ -376,13 +377,24 @@ class TestTabulateInternal(unittest.TestCase):
         rowFormat = _table_formats["armi"].datarow
         self.assertEqual(_buildRow("", [2, 2], ["center", "center"], rowFormat), "")
 
+        formatter = lambda a, b, c: "xyz"
         d = {"a": 1, "b": 2}
-        self.assertEqual(_buildRow(d, [2, 2], ["center", "center"], rowFormat), "a  b")
+        self.assertEqual(_buildRow(d, [2, 2], ["center", "center"], formatter), "xyz")
 
         lst = ["ab", "cd"]
         self.assertEqual(
             _buildRow(lst, [2, 2], ["center", "center"], rowFormat), "ab  cd"
         )
+
+    def test_buildLine(self):
+        """Basic sanity test of internal _buildLine() function."""
+        lineFormat = _table_formats["armi"].lineabove
+        self.assertEqual(_buildLine([2, 2], ["center", "center"], lineFormat), "--  --")
+
+        formatter = lambda a, b: "xyz"
+        self.assertEqual(_buildLine([2, 2], ["center", "center"], formatter), "xyz")
+
+        self.assertIsNone(_buildLine([2, 2], ["center", "center"], None))
 
     def test_format(self):
         """Basic sanity test of internal _format() function."""

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -19,14 +19,11 @@
 from collections import namedtuple
 from collections import OrderedDict
 from collections import UserDict
-from datetime import datetime
-from textwrap import TextWrapper as OTW
 import unittest
 
 import numpy as np
 
 from armi.utils.tabulate import _alignColumn, _alignCellVeritically, _multilineWidth
-from armi.utils.tabulate import _CustomTextWrap as CTW
 from armi.utils.tabulate import SEPARATING_LINE
 from armi.utils.tabulate import tabulate, tabulate_formats
 
@@ -1526,60 +1523,4 @@ class TestTabulateOutput(unittest.TestCase):
             ["h1    h2        h3", "----  ----  ------", "foo   bar   429920"]
         )
         result = tabulate(test_table, table_headers, disableNumparse=[0, 1])
-        self.assertEqual(expected, result)
-
-
-class TestTabulateTextWrapper(unittest.TestCase):
-    def test_wrapMultiwordNonWide(self):
-        """TextWrapper: non-wide character regression tests."""
-        data = "this is a test string for regression splitting"
-        for width in range(1, len(data)):
-            orig = OTW(width=width)
-            cust = CTW(width=width)
-
-            self.assertEqual(orig.wrap(data), cust.wrap(data))
-
-    def test_wrapMultiwordNonWideWithHypens(self):
-        """TextWrapper: non-wide character regression tests that contain hyphens."""
-        data = "how should-we-split-this non-sense string that-has-lots-of-hypens"
-        for width in range(1, len(data)):
-            orig = OTW(width=width)
-            cust = CTW(width=width)
-
-            self.assertEqual(orig.wrap(data), cust.wrap(data))
-
-    def test_wrapLongwordNonWide(self):
-        """TextWrapper: Some non-wide character regression tests."""
-        data = "ThisIsASingleReallyLongWordThatWeNeedToSplit"
-        for width in range(1, len(data)):
-            orig = OTW(width=width)
-            cust = CTW(width=width)
-
-            self.assertEqual(orig.wrap(data), cust.wrap(data))
-
-    def test_wrapDatetime(self):
-        """TextWrapper: Show that datetimes can be wrapped without crashing."""
-        data = [
-            ["First Entry", datetime(2020, 1, 1, 5, 6, 7)],
-            ["Second Entry", datetime(2021, 2, 2, 0, 0, 0)],
-        ]
-        headers = ["Title", "When"]
-        result = tabulate(data, headers=headers, tablefmt="grid", maxcolwidths=[7, 5])
-
-        expected = [
-            "+---------+--------+",
-            "| Title   | When   |",
-            "+=========+========+",
-            "| First   | 2020-  |",
-            "| Entry   | 01-01  |",
-            "|         | 05:06  |",
-            "|         | :07    |",
-            "+---------+--------+",
-            "| Second  | 2021-  |",
-            "| Entry   | 02-02  |",
-            "|         | 00:00  |",
-            "|         | :00    |",
-            "+---------+--------+",
-        ]
-        expected = "\n".join(expected)
         self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -598,3 +598,77 @@ class TestTabulateOutput(unittest.TestCase):
             table, headers="firstrow", tablefmt="plain", maxcolwidths=[10, 10]
         )
         self.assertEqual(expected, result)
+
+    def test_maxcolwidth_single_value(self):
+        """Output: maxcolwidth can be specified as a single number that works for each column."""
+        table = [
+            ["hdr", "fold1", "fold2"],
+            ["mini", "this is short", "this is a bit longer"],
+        ]
+        expected = "\n".join(
+            [
+                "hdr    fold1    fold2",
+                "mini   this     this",
+                "       is       is a",
+                "       short    bit",
+                "                longer",
+            ]
+        )
+        result = tabulate(table, headers="firstrow", tablefmt="plain", maxcolwidths=6)
+        self.assertEqual(expected, result)
+
+    def test_maxcolwidth_pad_tailing_widths(self):
+        """Output: maxcolwidth, if only partly specified, pads tailing cols with None."""
+        table = [
+            ["hdr", "fold1", "fold2"],
+            ["mini", "this is short", "this is a bit longer"],
+        ]
+        expected = "\n".join(
+            [
+                "hdr    fold1    fold2",
+                "mini   this     this is a bit longer",
+                "       is",
+                "       short",
+            ]
+        )
+        result = tabulate(
+            table, headers="firstrow", tablefmt="plain", maxcolwidths=[None, 6]
+        )
+        self.assertEqual(expected, result)
+
+    def test_maxcolwidth_honor_disable_parsenum(self):
+        """Output: Using maxcolwidth in conjunction with disable_parsenum is honored."""
+        table = [
+            ["first number", 123.456789, "123.456789"],
+            ["second number", "987654321.123", "987654321.123"],
+        ]
+        expected = "\n".join(
+            [
+                "+--------+---------------+--------+",
+                "| first  | 123.457       | 123.45 |",
+                "| number |               | 6789   |",
+                "+--------+---------------+--------+",
+                "| second |   9.87654e+08 | 987654 |",
+                "| number |               | 321.12 |",
+                "|        |               | 3      |",
+                "+--------+---------------+--------+",
+            ]
+        )
+        # Grid makes showing the alignment difference a little easier
+        result = tabulate(table, tablefmt="grid", maxcolwidths=6, disableNumparse=[2])
+        self.assertEqual(expected, result)
+
+    def test_plain_maxheadercolwidths_autowraps(self):
+        """Output: maxheadercolwidths will result in autowrapping header cell."""
+        table = [["hdr", "fold"], ["1", "very long data"]]
+        expected = "\n".join(
+            ["  hdr  fo", "       ld", "    1  very long", "       data"]
+        )
+        result = tabulate(
+            table,
+            headers="firstrow",
+            tablefmt="plain",
+            maxcolwidths=[10, 10],
+            maxheadercolwidths=[None, 2],
+        )
+        self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -56,6 +56,32 @@ class TestTabulateAPI(unittest.TestCase):
 
 
 class TestTabulateInputs(unittest.TestCase):
+    def test_iterableOfEmpties(self):
+        """Input: test various empty inputs."""
+        ii = iter(map(lambda x: iter(x), []))
+        result = tabulate(ii, "firstrow")
+        self.assertEqual("", result)
+
+        ij = iter(map(lambda x: iter(x), ["abcde"]))
+        expected = "\n".join(
+            [
+                "a    b    c    d    e",
+                "---  ---  ---  ---  ---",
+            ]
+        )
+        result = tabulate(ij, "firstrow")
+        self.assertEqual(expected, result)
+
+        ik = iter([])
+        expected = "\n".join(
+            [
+                "a    b    c",
+                "---  ---  ---",
+            ]
+        )
+        result = tabulate(ik, "abc")
+        self.assertEqual(expected, result)
+
     def test_iterableOfIterables(self):
         """Input: an interable of iterables."""
         ii = iter(map(lambda x: iter(x), [range(5), range(5, 0, -1)]))

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -1221,3 +1221,71 @@ class TestTabulateOutput(unittest.TestCase):
         )
         result = tabulate(table, tablefmt="rst")
         self.assertEqual(expected, result)
+
+    def test_no_data(self):
+        """Output: table with no data."""
+        expected = "\n".join(["strings    numbers", "---------  ---------"])
+        result = tabulate(None, _test_table_headers, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_empty_data(self):
+        """Output: table with empty data."""
+        expected = "\n".join(["strings    numbers", "---------  ---------"])
+        result = tabulate([], _test_table_headers, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_no_data_without_headers(self):
+        """Output: table with no data and no headers."""
+        expected = ""
+        result = tabulate(None, tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_empty_data_without_headers(self):
+        """Output: table with empty data and no headers."""
+        expected = ""
+        result = tabulate([], tablefmt="simple")
+        self.assertEqual(expected, result)
+
+    def test_intfmt(self):
+        """Output: integer format."""
+        result = tabulate([[10000], [10]], intfmt=",", tablefmt="plain")
+        expected = "10,000\n    10"
+        self.assertEqual(expected, result)
+
+    def test_empty_data_with_headers(self):
+        """Output: table with empty data and headers as firstrow."""
+        expected = ""
+        result = tabulate([], headers="firstrow")
+        self.assertEqual(expected, result)
+
+    def test_floatfmt(self):
+        """Output: floating point format."""
+        result = tabulate([["1.23456789"], [1.0]], floatfmt=".3f", tablefmt="plain")
+        expected = "1.235\n1.000"
+        self.assertEqual(expected, result)
+
+    def test_floatfmt_multi(self):
+        """Output: floating point format different for each column."""
+        result = tabulate(
+            [[0.12345, 0.12345, 0.12345]], floatfmt=(".1f", ".3f"), tablefmt="plain"
+        )
+        expected = "0.1  0.123  0.12345"
+        self.assertEqual(expected, result)
+
+    def test_colalign_multi(self):
+        """Output: string columns with custom colalign."""
+        result = tabulate(
+            [["one", "two"], ["three", "four"]], colalign=("right",), tablefmt="plain"
+        )
+        expected = "  one  two\nthree  four"
+        self.assertEqual(expected, result)
+
+    def test_colalign_multi_with_sep_line(self):
+        """Output: string columns with custom colalign."""
+        result = tabulate(
+            [["one", "two"], SEPARATING_LINE, ["three", "four"]],
+            colalign=("right",),
+            tablefmt="plain",
+        )
+        expected = "  one  two\n\nthree  four"
+        self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -389,6 +389,8 @@ class TestTabulateInternal(unittest.TestCase):
             _buildRow(lst, [2, 2], ["center", "center"], rowFormat), "ab  cd"
         )
 
+        self.assertIsNone(_buildRow("ab", [2, 2], ["center", "center"], ""))
+
     def test_buildLine(self):
         """Basic sanity test of internal _buildLine() function."""
         lineFormat = _table_formats["armi"].lineabove

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -1574,7 +1574,7 @@ class TestTabulateOutput(unittest.TestCase):
         """Output: a table with a running index."""
         dd = {"b": range(101, 104)}
         expected = "\n".join(["      b", "--  ---", " 0  101", " 1  102", " 2  103"])
-        result = tabulate(dd, "keys", showindex=True)
+        result = tabulate(dd, "keys", showIndex=True)
         self.assertEqual(expected, result)
 
     def test_listOfListsWithIndex(self):
@@ -1591,7 +1591,7 @@ class TestTabulateOutput(unittest.TestCase):
                 " 2    2  103",
             ]
         )
-        result = tabulate(dd, headers=["a", "b"], showindex=True)
+        result = tabulate(dd, headers=["a", "b"], showIndex=True)
         self.assertEqual(expected, result)
 
     def test_listOfListsWithIndexWithSepLine(self):
@@ -1609,7 +1609,7 @@ class TestTabulateOutput(unittest.TestCase):
                 " 2    2  103",
             ]
         )
-        result = tabulate(dd, headers=["a", "b"], showindex=True)
+        result = tabulate(dd, headers=["a", "b"], showIndex=True)
         self.assertEqual(expected, result)
 
     def test_listOfListsWithSuppliedIndex(self):
@@ -1624,11 +1624,11 @@ class TestTabulateOutput(unittest.TestCase):
                 " 3    2  103",
             ]
         )
-        result = tabulate(dd, headers=["a", "b"], showindex=[1, 2, 3])
+        result = tabulate(dd, headers=["a", "b"], showIndex=[1, 2, 3])
         self.assertEqual(expected, result)
         # the index must be as long as the number of rows
         with self.assertRaises(ValueError):
-            tabulate(dd, headers=["a", "b"], showindex=[1, 2])
+            tabulate(dd, headers=["a", "b"], showIndex=[1, 2])
 
     def test_listOfListsWithIndexFirstrow(self):
         """Output: a table with a running index and header='firstrow'."""
@@ -1642,11 +1642,11 @@ class TestTabulateOutput(unittest.TestCase):
                 " 2    2  103",
             ]
         )
-        result = tabulate(dd, headers="firstrow", showindex=True)
+        result = tabulate(dd, headers="firstrow", showIndex=True)
         self.assertEqual(expected, result)
         # the index must be as long as the number of rows
         with self.assertRaises(ValueError):
-            tabulate(dd, headers="firstrow", showindex=[1, 2])
+            tabulate(dd, headers="firstrow", showIndex=[1, 2])
 
     def test_disableNumparseDefault(self):
         """Output: Default table output with number parsing and alignment."""

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -65,7 +65,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(ii)
         self.assertEqual(expected, result)
 
-    def test_iterable_of_iterables_headers(self):
+    def test_iterableOfIterablesHeaders(self):
         """Input: an interable of iterables with headers."""
         ii = iter(map(lambda x: iter(x), [range(5), range(5, 0, -1)]))
         expected = "\n".join(
@@ -241,7 +241,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(na, headers=["person", "years", "cm"])
         self.assertEqual(expected, result)
 
-    def test_listOf_namedtuples(self):
+    def test_listOfNamedtuples(self):
         """Input: a list of named tuples with field names as headers."""
         NT = namedtuple("NT", ["foo", "bar"])
         lt = [NT(1, 2), NT(3, 4)]
@@ -340,7 +340,7 @@ class TestTabulateInputs(unittest.TestCase):
         result = tabulate(table, headers=headers)
         self.assertIn(result, [expected1, expected2])
 
-    def test_listOfDicts_with_list_of_headers(self):
+    def test_listOfDictsWithListOfHeaders(self):
         """Input: ValueError on a list of headers with a list of dicts."""
         table = [{"letters": "ABCDE", "digits": 12345}]
         headers = ["DIGITS", "LETTERS"]
@@ -371,142 +371,6 @@ class TestTabulateInputs(unittest.TestCase):
 
 
 class TestTabulateInternal(unittest.TestCase):
-    def test_bool(self):
-        self.assertTrue(_bool("stuff"))
-        self.assertFalse(_bool(""))
-        self.assertTrue(_bool(123))
-        self.assertFalse(_bool(np.array([1, 0, -1])))
-
-    def test_buildRow(self):
-        """Basic sanity test of internal _buildRow() function."""
-        rowFormat = _table_formats["armi"].datarow
-        self.assertEqual(_buildRow("", [2, 2], ["center", "center"], rowFormat), "")
-
-        formatter = lambda a, b, c: "xyz"
-        d = {"a": 1, "b": 2}
-        self.assertEqual(_buildRow(d, [2, 2], ["center", "center"], formatter), "xyz")
-
-        lst = ["ab", "cd"]
-        self.assertEqual(
-            _buildRow(lst, [2, 2], ["center", "center"], rowFormat), "ab  cd"
-        )
-
-        self.assertIsNone(_buildRow("ab", [2, 2], ["center", "center"], ""))
-
-    def test_buildLine(self):
-        """Basic sanity test of internal _buildLine() function."""
-        lineFormat = _table_formats["armi"].lineabove
-        self.assertEqual(_buildLine([2, 2], ["center", "center"], lineFormat), "--  --")
-
-        formatter = lambda a, b: "xyz"
-        self.assertEqual(_buildLine([2, 2], ["center", "center"], formatter), "xyz")
-
-        self.assertIsNone(_buildLine([2, 2], ["center", "center"], None))
-
-    def test_format(self):
-        """Basic sanity test of internal _format() function."""
-        self.assertEqual(_format(None, str, "8", "", "X", True), "X")
-        self.assertEqual(_format(123, str, "8", "", "X", True), "123")
-        self.assertEqual(_format("123", int, "8", "", "X", True), "123")
-        self.assertEqual(
-            _format(bytes("abc", "utf-8"), bytes, "8", "", "X", True), "abc"
-        )
-        self.assertEqual(_format("3.14", float, "4", "", "X", True), "3.14")
-        colorNum = "\x1b[31m3.14\x1b[0m"
-        self.assertEqual(_format(colorNum, float, "4", "", "X", True), colorNum)
-        self.assertEqual(_format(None, None, "8", "", "X", True), "X")
-
-    def test_isMultiline(self):
-        """Basic sanity test of internal _isMultiline() function."""
-        self.assertFalse(_isMultiline("world"))
-        self.assertTrue(_isMultiline("hello\nworld"))
-        self.assertFalse(_isMultiline(bytes("world", "utf-8")))
-        self.assertTrue(_isMultiline(bytes("hello\nworld", "utf-8")))
-
-    def test_multilineWidth(self):
-        """Internal: _multilineWidth()."""
-        multilineString = "\n".join(["foo", "barbaz", "spam"])
-        self.assertEqual(_multilineWidth(multilineString), 6)
-        onelineString = "12345"
-        self.assertEqual(_multilineWidth(onelineString), len(onelineString))
-
-    def test_normalizeTabularData(self):
-        """Basic sanity test of internal _normalizeTabularData() function."""
-        res = _normalizeTabularData([[1, 2], [3, 4]], np.array(["a", "b"]), "default")
-        self.assertEqual(res[0], [[1, 2], [3, 4]])
-        self.assertEqual(res[1], ["a", "b"])
-        self.assertEqual(res[2], 0)
-
-        res = _normalizeTabularData([], "keys", "default")
-        self.assertEqual(len(res[0]), 0)
-        self.assertEqual(len(res[1]), 0)
-        self.assertEqual(res[2], 0)
-
-        res = _normalizeTabularData([], "firstrow", "default")
-        self.assertEqual(len(res[0]), 0)
-        self.assertEqual(len(res[1]), 0)
-        self.assertEqual(res[2], 0)
-
-        @dataclass
-        class row:
-            a: int
-            b: int
-
-        rows = [row(1, 2), row(3, 4)]
-        res = _normalizeTabularData(rows, "keys", "default")
-        self.assertEqual(res[0], [[1, 2], [3, 4]])
-        self.assertEqual(res[1], ["a", "b"])
-        self.assertEqual(res[2], 0)
-
-        res = _normalizeTabularData(rows, ["x", "y"], "default")
-        self.assertEqual(res[0], [[1, 2], [3, 4]])
-        self.assertEqual(res[1], ["x", "y"])
-        self.assertEqual(res[2], 0)
-
-    def test_type(self):
-        """Basic sanity test of internal _type() function."""
-        self.assertEqual(_type(None), type(None))
-        self.assertEqual(_type("foo"), type(""))
-        self.assertEqual(_type("1"), type(1))
-        self.assertEqual(_type("\x1b[31m42\x1b[0m"), type(42))
-        self.assertEqual(_type("\x1b[31m42\x1b[0m"), type(42))
-        self.assertEqual(_type(datetime.now()), type("2024-12-31"))
-
-    def test_wrapTextToColWidths(self):
-        """Basic sanity test of internal _wrapTextToColWidths() function."""
-        res = _wrapTextToColWidths([], [2, 2], True)
-        self.assertEqual(len(res), 0)
-
-        res = _wrapTextToColWidths([[1], [2]], [2, 2], True)
-        self.assertEqual(res[0][0], 1)
-        self.assertEqual(res[1][0], 2)
-
-        res = _wrapTextToColWidths([["1"], ["2"]], [2, 2], False)
-        self.assertEqual(res[0][0], "1")
-        self.assertEqual(res[1][0], "2")
-
-    # TODO: JOHN: alphabetize tests
-
-    def test_assortedRareEdgeCases(self):
-        """Test some of the more rare edge cases in the purely internal functions."""
-        from armi.utils.tabulate import _alignHeader
-        from armi.utils.tabulate import _prependRowIndex
-        from armi.utils.tabulate import _removeSeparatingLines
-
-        self.assertEqual(_alignHeader("123", False, 3, 3, False, None), "123")
-
-        result = _removeSeparatingLines(123)
-        self.assertEqual(result[0], 123)
-        self.assertIsNone(result[1])
-
-        self.assertEqual(_prependRowIndex([123], None), [123])
-
-    def test_visibleWidth(self):
-        """Basic sanity test of internal _visibleWidth() function."""
-        self.assertEqual(_visibleWidth("world"), 5)
-        self.assertEqual(_visibleWidth("\x1b[31mhello\x1b[0m"), 5)
-        self.assertEqual(_visibleWidth(np.ones(3)), 10)
-
     def test_alignColumnDecimal(self):
         """Internal: _align_column(..., 'decimal')."""
         column = ["12.345", "-1234.5", "1.23", "1234.5", "1e+234", "1.0e234"]
@@ -617,6 +481,140 @@ class TestTabulateInternal(unittest.TestCase):
         result = _alignCellVeritically(text, 6, 4, "bottom")
         expected = ["    ", "    ", "    ", "just", "one ", "cell"]
         self.assertEqual(expected, result)
+
+    def test_assortedRareEdgeCases(self):
+        """Test some of the more rare edge cases in the purely internal functions."""
+        from armi.utils.tabulate import _alignHeader
+        from armi.utils.tabulate import _prependRowIndex
+        from armi.utils.tabulate import _removeSeparatingLines
+
+        self.assertEqual(_alignHeader("123", False, 3, 3, False, None), "123")
+
+        result = _removeSeparatingLines(123)
+        self.assertEqual(result[0], 123)
+        self.assertIsNone(result[1])
+
+        self.assertEqual(_prependRowIndex([123], None), [123])
+
+    def test_bool(self):
+        self.assertTrue(_bool("stuff"))
+        self.assertFalse(_bool(""))
+        self.assertTrue(_bool(123))
+        self.assertFalse(_bool(np.array([1, 0, -1])))
+
+    def test_buildLine(self):
+        """Basic sanity test of internal _buildLine() function."""
+        lineFormat = _table_formats["armi"].lineabove
+        self.assertEqual(_buildLine([2, 2], ["center", "center"], lineFormat), "--  --")
+
+        formatter = lambda a, b: "xyz"
+        self.assertEqual(_buildLine([2, 2], ["center", "center"], formatter), "xyz")
+
+        self.assertIsNone(_buildLine([2, 2], ["center", "center"], None))
+
+    def test_buildRow(self):
+        """Basic sanity test of internal _buildRow() function."""
+        rowFormat = _table_formats["armi"].datarow
+        self.assertEqual(_buildRow("", [2, 2], ["center", "center"], rowFormat), "")
+
+        formatter = lambda a, b, c: "xyz"
+        d = {"a": 1, "b": 2}
+        self.assertEqual(_buildRow(d, [2, 2], ["center", "center"], formatter), "xyz")
+
+        lst = ["ab", "cd"]
+        self.assertEqual(
+            _buildRow(lst, [2, 2], ["center", "center"], rowFormat), "ab  cd"
+        )
+
+        self.assertIsNone(_buildRow("ab", [2, 2], ["center", "center"], ""))
+
+    def test_format(self):
+        """Basic sanity test of internal _format() function."""
+        self.assertEqual(_format(None, str, "8", "", "X", True), "X")
+        self.assertEqual(_format(123, str, "8", "", "X", True), "123")
+        self.assertEqual(_format("123", int, "8", "", "X", True), "123")
+        self.assertEqual(
+            _format(bytes("abc", "utf-8"), bytes, "8", "", "X", True), "abc"
+        )
+        self.assertEqual(_format("3.14", float, "4", "", "X", True), "3.14")
+        colorNum = "\x1b[31m3.14\x1b[0m"
+        self.assertEqual(_format(colorNum, float, "4", "", "X", True), colorNum)
+        self.assertEqual(_format(None, None, "8", "", "X", True), "X")
+
+    def test_isMultiline(self):
+        """Basic sanity test of internal _isMultiline() function."""
+        self.assertFalse(_isMultiline("world"))
+        self.assertTrue(_isMultiline("hello\nworld"))
+        self.assertFalse(_isMultiline(bytes("world", "utf-8")))
+        self.assertTrue(_isMultiline(bytes("hello\nworld", "utf-8")))
+
+    def test_multilineWidth(self):
+        """Internal: _multilineWidth()."""
+        multilineString = "\n".join(["foo", "barbaz", "spam"])
+        self.assertEqual(_multilineWidth(multilineString), 6)
+        onelineString = "12345"
+        self.assertEqual(_multilineWidth(onelineString), len(onelineString))
+
+    def test_normalizeTabularData(self):
+        """Basic sanity test of internal _normalizeTabularData() function."""
+        res = _normalizeTabularData([[1, 2], [3, 4]], np.array(["a", "b"]), "default")
+        self.assertEqual(res[0], [[1, 2], [3, 4]])
+        self.assertEqual(res[1], ["a", "b"])
+        self.assertEqual(res[2], 0)
+
+        res = _normalizeTabularData([], "keys", "default")
+        self.assertEqual(len(res[0]), 0)
+        self.assertEqual(len(res[1]), 0)
+        self.assertEqual(res[2], 0)
+
+        res = _normalizeTabularData([], "firstrow", "default")
+        self.assertEqual(len(res[0]), 0)
+        self.assertEqual(len(res[1]), 0)
+        self.assertEqual(res[2], 0)
+
+        @dataclass
+        class row:
+            a: int
+            b: int
+
+        rows = [row(1, 2), row(3, 4)]
+        res = _normalizeTabularData(rows, "keys", "default")
+        self.assertEqual(res[0], [[1, 2], [3, 4]])
+        self.assertEqual(res[1], ["a", "b"])
+        self.assertEqual(res[2], 0)
+
+        res = _normalizeTabularData(rows, ["x", "y"], "default")
+        self.assertEqual(res[0], [[1, 2], [3, 4]])
+        self.assertEqual(res[1], ["x", "y"])
+        self.assertEqual(res[2], 0)
+
+    def test_type(self):
+        """Basic sanity test of internal _type() function."""
+        self.assertEqual(_type(None), type(None))
+        self.assertEqual(_type("foo"), type(""))
+        self.assertEqual(_type("1"), type(1))
+        self.assertEqual(_type("\x1b[31m42\x1b[0m"), type(42))
+        self.assertEqual(_type("\x1b[31m42\x1b[0m"), type(42))
+        self.assertEqual(_type(datetime.now()), type("2024-12-31"))
+
+    def test_visibleWidth(self):
+        """Basic sanity test of internal _visibleWidth() function."""
+        self.assertEqual(_visibleWidth("world"), 5)
+        self.assertEqual(_visibleWidth("\x1b[31mhello\x1b[0m"), 5)
+        self.assertEqual(_visibleWidth(np.ones(3)), 10)
+
+    def test_wrapTextToColWidths(self):
+        """Basic sanity test of internal _wrapTextToColWidths() function."""
+        res = _wrapTextToColWidths([], [2, 2], True)
+        self.assertEqual(len(res), 0)
+
+        res = _wrapTextToColWidths([[1], [2]], [2, 2], True)
+        self.assertEqual(res[0][0], 1)
+        self.assertEqual(res[1][0], 2)
+
+        res = _wrapTextToColWidths([["1"], ["2"]], [2, 2], False)
+        self.assertEqual(res[0][0], "1")
+        self.assertEqual(res[1][0], "2")
 
 
 class TestTabulateOutput(unittest.TestCase):
@@ -862,7 +860,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def testSimpleMultiline2(self):
+    def test_simpleMultiline2(self):
         """Output: simple with multiline cells."""
         expected = "\n".join(
             [
@@ -879,7 +877,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def testSimpleMultiline2WithSepLine(self):
+    def test_simpleMultiline2WithSepLine(self):
         """Output: simple with multiline cells."""
         expected = "\n".join(
             [
@@ -924,7 +922,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(self.test_table_with_sep_line, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def testSimpleMultilineHeaderless(self):
+    def test_simpleMultilineHeaderless(self):
         """Output: simple with multiline cells without headers."""
         table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
         expected = "\n".join(
@@ -957,7 +955,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def testSimpleMultilineWithLinks(self):
+    def test_simpleMultilineWithLinks(self):
         """Output: simple with multiline cells with links and headers."""
         table = [[2, "foo\nbar"]]
         headers = (
@@ -976,7 +974,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def testSimpleMultilineWithEmptyCells(self):
+    def test_simpleMultilineWithEmptyCells(self):
         """Output: simple with multiline cells and empty cells with headers."""
         table = [
             ["hdr", "data", "fold"],
@@ -995,7 +993,7 @@ class TestTabulateOutput(unittest.TestCase):
         result = tabulate(table, headers="firstrow", tablefmt="simple")
         self.assertEqual(expected, result)
 
-    def testSimpleMultilineWithEmptyCellsHeaderless(self):
+    def test_simpleMultilineWithEmptyCellsHeaderless(self):
         """Output: simple with multiline cells and empty cells without headers."""
         table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
         expected = "\n".join(

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -646,8 +646,8 @@ class TestTabulateInternal(unittest.TestCase):
 class TestTabulateOutput(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.test_table = [["spam", 41.9999], ["eggs", "451.0"]]
-        cls.test_table_with_sep_line = [
+        cls.testTable = [["spam", 41.9999], ["eggs", "451.0"]]
+        cls.testTableWithSepLine = [
             ["spam", 41.9999],
             SEPARATING_LINE,
             ["eggs", "451.0"],
@@ -659,13 +659,13 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(
             ["strings      numbers", "spam         41.9999", "eggs        451"]
         )
-        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="plain")
+        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainHeaderless(self):
         """Output: plain without headers."""
         expected = "\n".join(["spam   41.9999", "eggs  451"])
-        result = tabulate(self.test_table, tablefmt="plain")
+        result = tabulate(self.testTable, tablefmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainMultilineHeaderless(self):
@@ -680,7 +680,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "           world",
             ]
         )
-        result = tabulate(table, stralign="center", tablefmt="plain")
+        result = tabulate(table, strAlign="center", tablefmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainMultiline(self):
@@ -852,7 +852,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs        451",
             ]
         )
-        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="simple")
+        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleWithSepLine(self):
@@ -867,7 +867,7 @@ class TestTabulateOutput(unittest.TestCase):
             ]
         )
         result = tabulate(
-            self.test_table_with_sep_line, self.testTableHeaders, tablefmt="simple"
+            self.testTableWithSepLine, self.testTableHeaders, tablefmt="simple"
         )
         self.assertEqual(expected, result)
 
@@ -899,7 +899,7 @@ class TestTabulateOutput(unittest.TestCase):
         )
         table = [["key", "value"], ["foo", "bar"], ["spam", "multiline\nworld"]]
         result = tabulate(
-            table, headers="firstrow", stralign="center", tablefmt="simple"
+            table, headers="firstrow", strAlign="center", tablefmt="simple"
         )
         self.assertEqual(expected, result)
 
@@ -922,7 +922,7 @@ class TestTabulateOutput(unittest.TestCase):
             ["spam", "multiline\nworld"],
         ]
         result = tabulate(
-            table, headers="firstrow", stralign="center", tablefmt="simple"
+            table, headers="firstrow", strAlign="center", tablefmt="simple"
         )
         self.assertEqual(expected, result)
 
@@ -931,7 +931,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(
             ["----  --------", "spam   41.9999", "eggs  451", "----  --------"]
         )
-        result = tabulate(self.test_table, tablefmt="simple")
+        result = tabulate(self.testTable, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleHeaderlessWithSepLine(self):
@@ -945,7 +945,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "----  --------",
             ]
         )
-        result = tabulate(self.test_table_with_sep_line, tablefmt="simple")
+        result = tabulate(self.testTableWithSepLine, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleMultilineHeaderless(self):
@@ -962,7 +962,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "-------  ---------",
             ]
         )
-        result = tabulate(table, stralign="center", tablefmt="simple")
+        result = tabulate(table, strAlign="center", tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleMultiline(self):
@@ -1045,7 +1045,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "| eggs      |  451      |",
             ]
         )
-        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="github")
+        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="github")
         self.assertEqual(expected, result)
 
     def test_grid(self):
@@ -1061,7 +1061,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+-----------+-----------+",
             ]
         )
-        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="grid")
+        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridHeaderless(self):
@@ -1075,7 +1075,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+------+----------+",
             ]
         )
-        result = tabulate(self.test_table, tablefmt="grid")
+        result = tabulate(self.testTable, tablefmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridMultilineHeaderless(self):
@@ -1093,7 +1093,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+---------+-----------+",
             ]
         )
-        result = tabulate(table, stralign="center", tablefmt="grid")
+        result = tabulate(table, strAlign="center", tablefmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridMultiline(self):
@@ -1166,7 +1166,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+---------+---------+",
             ]
         )
-        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="pretty")
+        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyHeaderless(self):
@@ -1179,7 +1179,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+------+---------+",
             ]
         )
-        result = tabulate(self.test_table, tablefmt="pretty")
+        result = tabulate(self.testTable, tablefmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyMultilineHeaderless(self):
@@ -1287,7 +1287,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "=========  =========",
             ]
         )
-        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="rst")
+        result = tabulate(self.testTable, self.testTableHeaders, tablefmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstWithEmptyValuesInFirstColumn(self):
@@ -1312,7 +1312,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(
             ["====  ========", "spam   41.9999", "eggs  451", "====  ========"]
         )
-        result = tabulate(self.test_table, tablefmt="rst")
+        result = tabulate(self.testTable, tablefmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstMultiline(self):
@@ -1523,12 +1523,12 @@ class TestTabulateOutput(unittest.TestCase):
             "with_nan",
             "neg_inf",
         ]
-        test_table = [
+        testTable = [
             ["spam", 41.9999, "123.345", "12.2", "nan", "0.123123"],
             ["eggs", "451.0", 66.2222, "inf", 123.1234, "-inf"],
             ["asd", "437e6548", 1.234e2, float("inf"), float("nan"), 0.22e23],
         ]
-        result = tabulate(test_table, test_headers, tablefmt="grid")
+        result = tabulate(testTable, test_headers, tablefmt="grid")
         expected = "\n".join(
             [
                 "+-------+-------------+--------------+------------+------------+-------------+",
@@ -1566,7 +1566,7 @@ class TestTabulateOutput(unittest.TestCase):
         """Output: custom alignment for text and numbers."""
         expected = "\n".join(["-----  ---", "Alice   1", "  Bob  333", "-----  ---"])
         result = tabulate(
-            [["Alice", 1], ["Bob", 333]], stralign="right", numalign="center"
+            [["Alice", 1], ["Bob", 333]], strAlign="right", numAlign="center"
         )
         self.assertEqual(expected, result)
 
@@ -1658,9 +1658,9 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs        451",
             ]
         )
-        result = tabulate(self.test_table, self.testTableHeaders)
+        result = tabulate(self.testTable, self.testTableHeaders)
         self.assertEqual(expected, result)
-        result = tabulate(self.test_table, self.testTableHeaders, disableNumparse=False)
+        result = tabulate(self.testTable, self.testTableHeaders, disableNumparse=False)
         self.assertEqual(expected, result)
 
     def test_disableNumparseTrue(self):
@@ -1673,21 +1673,21 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs       451.0",
             ]
         )
-        result = tabulate(self.test_table, self.testTableHeaders, disableNumparse=True)
+        result = tabulate(self.testTable, self.testTableHeaders, disableNumparse=True)
         self.assertEqual(expected, result)
 
     def test_disableNumparseList(self):
         """Output: Default table output, but with number parsing selectively disabled."""
-        table_headers = ["h1", "h2", "h3"]
-        test_table = [["foo", "bar", "42992e1"]]
+        tableHeaders = ["h1", "h2", "h3"]
+        testTable = [["foo", "bar", "42992e1"]]
         expected = "\n".join(
             ["h1    h2    h3", "----  ----  -------", "foo   bar   42992e1"]
         )
-        result = tabulate(test_table, table_headers, disableNumparse=[2])
+        result = tabulate(testTable, tableHeaders, disableNumparse=[2])
         self.assertEqual(expected, result)
 
         expected = "\n".join(
             ["h1    h2        h3", "----  ----  ------", "foo   bar   429920"]
         )
-        result = tabulate(test_table, table_headers, disableNumparse=[0, 1])
+        result = tabulate(testTable, tableHeaders, disableNumparse=[0, 1])
         self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -37,7 +37,7 @@ from armi.utils.tabulate import _format
 from armi.utils.tabulate import _isMultiline
 from armi.utils.tabulate import _multilineWidth
 from armi.utils.tabulate import _normalizeTabularData
-from armi.utils.tabulate import _table_formats
+from armi.utils.tabulate import _tableFormats
 from armi.utils.tabulate import _type
 from armi.utils.tabulate import _visibleWidth
 from armi.utils.tabulate import _wrapTextToColWidths
@@ -530,7 +530,7 @@ class TestTabulateInternal(unittest.TestCase):
 
     def test_buildLine(self):
         """Basic sanity test of internal _buildLine() function."""
-        lineFormat = _table_formats["armi"].lineabove
+        lineFormat = _tableFormats["armi"].lineabove
         self.assertEqual(_buildLine([2, 2], ["center", "center"], lineFormat), "--  --")
 
         formatter = lambda a, b: "xyz"
@@ -540,7 +540,7 @@ class TestTabulateInternal(unittest.TestCase):
 
     def test_buildRow(self):
         """Basic sanity test of internal _buildRow() function."""
-        rowFormat = _table_formats["armi"].datarow
+        rowFormat = _tableFormats["armi"].datarow
         self.assertEqual(_buildRow("", [2, 2], ["center", "center"], rowFormat), "")
 
         formatter = lambda a, b, c: "xyz"

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -984,3 +984,124 @@ class TestTabulateOutput(unittest.TestCase):
         )
         result = tabulate(table, tablefmt="grid")
         self.assertEqual(expected, result)
+
+    def test_pretty(self):
+        """Output: pretty with headers."""
+        expected = "\n".join(
+            [
+                "+---------+---------+",
+                "| strings | numbers |",
+                "+---------+---------+",
+                "|  spam   | 41.9999 |",
+                "|  eggs   |  451.0  |",
+                "+---------+---------+",
+            ]
+        )
+        result = tabulate(_test_table, _test_table_headers, tablefmt="pretty")
+        self.assertEqual(expected, result)
+
+    def test_pretty_headerless(self):
+        """Output: pretty without headers."""
+        expected = "\n".join(
+            [
+                "+------+---------+",
+                "| spam | 41.9999 |",
+                "| eggs |  451.0  |",
+                "+------+---------+",
+            ]
+        )
+        result = tabulate(_test_table, tablefmt="pretty")
+        self.assertEqual(expected, result)
+
+    def test_pretty_multiline_headerless(self):
+        """Output: pretty with multiline cells without headers."""
+        table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
+        expected = "\n".join(
+            [
+                "+---------+-----------+",
+                "| foo bar |   hello   |",
+                "|   baz   |           |",
+                "|   bau   |           |",
+                "|         | multiline |",
+                "|         |   world   |",
+                "+---------+-----------+",
+            ]
+        )
+        result = tabulate(table, tablefmt="pretty")
+        self.assertEqual(expected, result)
+
+    def test_pretty_multiline(self):
+        """Output: pretty with multiline cells with headers."""
+        table = [[2, "foo\nbar"]]
+        headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
+        expected = "\n".join(
+            [
+                "+-----------+-----------+",
+                "|   more    | more spam |",
+                "| spam \x1b[31meggs\x1b[0m |  & eggs   |",
+                "+-----------+-----------+",
+                "|     2     |    foo    |",
+                "|           |    bar    |",
+                "+-----------+-----------+",
+            ]
+        )
+        result = tabulate(table, headers, tablefmt="pretty")
+        self.assertEqual(expected, result)
+
+    def test_pretty_multiline_with_links(self):
+        """Output: pretty with multiline cells with headers."""
+        table = [[2, "foo\nbar"]]
+        headers = (
+            "more\nspam \x1b]8;;target\x1b\\eggs\x1b]8;;\x1b\\",
+            "more spam\n& eggs",
+        )
+        expected = "\n".join(
+            [
+                "+-----------+-----------+",
+                "|   more    | more spam |",
+                "| spam \x1b]8;;target\x1b\\eggs\x1b]8;;\x1b\\ |  & eggs   |",
+                "+-----------+-----------+",
+                "|     2     |    foo    |",
+                "|           |    bar    |",
+                "+-----------+-----------+",
+            ]
+        )
+        result = tabulate(table, headers, tablefmt="pretty")
+        self.assertEqual(expected, result)
+
+    def test_pretty_multiline_with_empty_cells(self):
+        """Output: pretty with multiline cells and empty cells with headers."""
+        table = [
+            ["hdr", "data", "fold"],
+            ["1", "", ""],
+            ["2", "very long data", "fold\nthis"],
+        ]
+        expected = "\n".join(
+            [
+                "+-----+----------------+------+",
+                "| hdr |      data      | fold |",
+                "+-----+----------------+------+",
+                "|  1  |                |      |",
+                "|  2  | very long data | fold |",
+                "|     |                | this |",
+                "+-----+----------------+------+",
+            ]
+        )
+        result = tabulate(table, headers="firstrow", tablefmt="pretty")
+        self.assertEqual(expected, result)
+
+    def test_pretty_multiline_with_empty_cells_headerless(self):
+        """Output: pretty with multiline cells and empty cells without headers."""
+        table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+        expected = "\n".join(
+            [
+                "+---+----------------+------+",
+                "| 0 |                |      |",
+                "| 1 |                |      |",
+                "| 2 | very long data | fold |",
+                "|   |                | this |",
+                "+---+----------------+------+",
+            ]
+        )
+        result = tabulate(table, tablefmt="pretty")
+        self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -824,7 +824,7 @@ class TestTabulateOutput(unittest.TestCase):
             ]
         )
         # Grid makes showing the alignment difference a little easier
-        result = tabulate(table, tablefmt="grid", maxcolwidths=6, disableNumparse=[2])
+        result = tabulate(table, tablefmt="grid", maxcolwidths=6, disableNumParse=[2])
         self.assertEqual(expected, result)
 
     def test_plainMaxheadercolwidthsAutowraps(self):
@@ -1441,30 +1441,30 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "0.1  0.123  0.12345"
         self.assertEqual(expected, result)
 
-    def test_colalignMulti(self):
-        """Output: string columns with custom colalign."""
+    def test_colAlignMulti(self):
+        """Output: string columns with custom colAlign."""
         result = tabulate(
-            [["one", "two"], ["three", "four"]], colalign=("right",), tablefmt="plain"
+            [["one", "two"], ["three", "four"]], colAlign=("right",), tablefmt="plain"
         )
         expected = "  one  two\nthree  four"
         self.assertEqual(expected, result)
 
-    def test_colalignMultiWithSepLine(self):
-        """Output: string columns with custom colalign."""
+    def test_colAlignMultiWithSepLine(self):
+        """Output: string columns with custom colAlign."""
         result = tabulate(
             [["one", "two"], SEPARATING_LINE, ["three", "four"]],
-            colalign=("right",),
+            colAlign=("right",),
             tablefmt="plain",
         )
         expected = "  one  two\n\nthree  four"
         self.assertEqual(expected, result)
 
     def test_columnGlobalAndSpecificAlignment(self):
-        """Test `colglobalalign` and `"global"` parameter for `colalign`."""
+        """Test `colGlobalAlign` and `"global"` parameter for `colAlign`."""
         table = [[1, 2, 3, 4], [111, 222, 333, 444]]
-        colglobalalign = "center"
-        colalign = ("global", "left", "right")
-        result = tabulate(table, colglobalalign=colglobalalign, colalign=colalign)
+        colGlobalAlign = "center"
+        colAlign = ("global", "left", "right")
+        result = tabulate(table, colGlobalAlign=colGlobalAlign, colAlign=colAlign)
         expected = "\n".join(
             [
                 "---  ---  ---  ---",
@@ -1478,16 +1478,16 @@ class TestTabulateOutput(unittest.TestCase):
     def test_headersGlobalAndSpecificAlignment(self):
         """Test `headersglobalalign` and `headersalign`."""
         table = [[1, 2, 3, 4, 5, 6], [111, 222, 333, 444, 555, 666]]
-        colglobalalign = "center"
-        colalign = ("left",)
+        colGlobalAlign = "center"
+        colAlign = ("left",)
         headers = ["h", "e", "a", "d", "e", "r"]
         headersglobalalign = "right"
         headersalign = ("same", "same", "left", "global", "center")
         result = tabulate(
             table,
             headers=headers,
-            colglobalalign=colglobalalign,
-            colalign=colalign,
+            colGlobalAlign=colGlobalAlign,
+            colAlign=colAlign,
             headersglobalalign=headersglobalalign,
             headersalign=headersalign,
         )
@@ -1501,14 +1501,14 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_colalignOrHeadersalignTooLong(self):
-        """Test `colalign` and `headersalign` too long."""
+    def test_colAlignOrHeadersalignTooLong(self):
+        """Test `colAlign` and `headersalign` too long."""
         table = [[1, 2], [111, 222]]
-        colalign = ("global", "left", "center")
+        colAlign = ("global", "left", "center")
         headers = ["h"]
         headersalign = ("center", "right", "same")
         result = tabulate(
-            table, headers=headers, colalign=colalign, headersalign=headersalign
+            table, headers=headers, colAlign=colAlign, headersalign=headersalign
         )
         expected = "\n".join(["      h", "---  ---", "  1  2", "111  222"])
         self.assertEqual(expected, result)
@@ -1648,7 +1648,7 @@ class TestTabulateOutput(unittest.TestCase):
         with self.assertRaises(ValueError):
             tabulate(dd, headers="firstrow", showIndex=[1, 2])
 
-    def test_disableNumparseDefault(self):
+    def test_disableNumParseDefault(self):
         """Output: Default table output with number parsing and alignment."""
         expected = "\n".join(
             [
@@ -1660,10 +1660,10 @@ class TestTabulateOutput(unittest.TestCase):
         )
         result = tabulate(self.testTable, self.testTableHeaders)
         self.assertEqual(expected, result)
-        result = tabulate(self.testTable, self.testTableHeaders, disableNumparse=False)
+        result = tabulate(self.testTable, self.testTableHeaders, disableNumParse=False)
         self.assertEqual(expected, result)
 
-    def test_disableNumparseTrue(self):
+    def test_disableNumParseTrue(self):
         """Output: Default table output, but without number parsing and alignment."""
         expected = "\n".join(
             [
@@ -1673,21 +1673,21 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs       451.0",
             ]
         )
-        result = tabulate(self.testTable, self.testTableHeaders, disableNumparse=True)
+        result = tabulate(self.testTable, self.testTableHeaders, disableNumParse=True)
         self.assertEqual(expected, result)
 
-    def test_disableNumparseList(self):
+    def test_disableNumParseList(self):
         """Output: Default table output, but with number parsing selectively disabled."""
         tableHeaders = ["h1", "h2", "h3"]
         testTable = [["foo", "bar", "42992e1"]]
         expected = "\n".join(
             ["h1    h2    h3", "----  ----  -------", "foo   bar   42992e1"]
         )
-        result = tabulate(testTable, tableHeaders, disableNumparse=[2])
+        result = tabulate(testTable, tableHeaders, disableNumParse=[2])
         self.assertEqual(expected, result)
 
         expected = "\n".join(
             ["h1    h2        h3", "----  ----  ------", "foo   bar   429920"]
         )
-        result = tabulate(testTable, tableHeaders, disableNumparse=[0, 1])
+        result = tabulate(testTable, tableHeaders, disableNumParse=[0, 1])
         self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -878,3 +878,109 @@ class TestTabulateOutput(unittest.TestCase):
         )
         result = tabulate(_test_table, _test_table_headers, tablefmt="github")
         self.assertEqual(expected, result)
+
+    def test_grid(self):
+        """Output: grid with headers."""
+        expected = "\n".join(
+            [
+                "+-----------+-----------+",
+                "| strings   |   numbers |",
+                "+===========+===========+",
+                "| spam      |   41.9999 |",
+                "+-----------+-----------+",
+                "| eggs      |  451      |",
+                "+-----------+-----------+",
+            ]
+        )
+        result = tabulate(_test_table, _test_table_headers, tablefmt="grid")
+        self.assertEqual(expected, result)
+
+    def test_grid_headerless(self):
+        """Output: grid without headers."""
+        expected = "\n".join(
+            [
+                "+------+----------+",
+                "| spam |  41.9999 |",
+                "+------+----------+",
+                "| eggs | 451      |",
+                "+------+----------+",
+            ]
+        )
+        result = tabulate(_test_table, tablefmt="grid")
+        self.assertEqual(expected, result)
+
+    def test_grid_multiline_headerless(self):
+        """Output: grid with multiline cells without headers."""
+        table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
+        expected = "\n".join(
+            [
+                "+---------+-----------+",
+                "| foo bar |   hello   |",
+                "|   baz   |           |",
+                "|   bau   |           |",
+                "+---------+-----------+",
+                "|         | multiline |",
+                "|         |   world   |",
+                "+---------+-----------+",
+            ]
+        )
+        result = tabulate(table, stralign="center", tablefmt="grid")
+        self.assertEqual(expected, result)
+
+    def test_grid_multiline(self):
+        """Output: grid with multiline cells with headers."""
+        table = [[2, "foo\nbar"]]
+        headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
+        expected = "\n".join(
+            [
+                "+-------------+-------------+",
+                "|        more | more spam   |",
+                "|   spam \x1b[31meggs\x1b[0m | & eggs      |",
+                "+=============+=============+",
+                "|           2 | foo         |",
+                "|             | bar         |",
+                "+-------------+-------------+",
+            ]
+        )
+        result = tabulate(table, headers, tablefmt="grid")
+        self.assertEqual(expected, result)
+
+    def test_grid_multiline_with_empty_cells(self):
+        """Output: grid with multiline cells and empty cells with headers."""
+        table = [
+            ["hdr", "data", "fold"],
+            ["1", "", ""],
+            ["2", "very long data", "fold\nthis"],
+        ]
+        expected = "\n".join(
+            [
+                "+-------+----------------+--------+",
+                "|   hdr | data           | fold   |",
+                "+=======+================+========+",
+                "|     1 |                |        |",
+                "+-------+----------------+--------+",
+                "|     2 | very long data | fold   |",
+                "|       |                | this   |",
+                "+-------+----------------+--------+",
+            ]
+        )
+        result = tabulate(table, headers="firstrow", tablefmt="grid")
+        self.assertEqual(expected, result)
+
+    def test_grid_multiline_with_empty_cells_headerless(self):
+        """Output: grid with multiline cells and empty cells without headers."""
+        table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+        expected = "\n".join(
+            [
+                "+---+----------------+------+",
+                "| 0 |                |      |",
+                "+---+----------------+------+",
+                "| 1 |                |      |",
+                "+---+----------------+------+",
+                "| 2 | very long data | fold |",
+                "|   |                | this |",
+                "+---+----------------+------+",
+            ]
+        )
+        result = tabulate(table, tablefmt="grid")
+        self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -17,11 +17,14 @@
 
 """Tests for tabulate."""
 from collections import OrderedDict, UserDict
+from datetime import datetime
+from textwrap import TextWrapper as OTW
 import unittest
 
 import numpy  # TODO: as np
 
 from armi.utils.tabulate import _alignColumn, _alignCellVeritically, _multilineWidth
+from armi.utils.tabulate import _CustomTextWrap as CTW
 from armi.utils.tabulate import SEPARATING_LINE
 from armi.utils.tabulate import tabulate, tabulate_formats
 
@@ -1521,4 +1524,114 @@ class TestTabulateOutput(unittest.TestCase):
             ["h1    h2        h3", "----  ----  ------", "foo   bar   429920"]
         )
         result = tabulate(test_table, table_headers, disableNumparse=[0, 1])
+        self.assertEqual(expected, result)
+
+
+class TestTabulateTextWrapper(unittest.TestCase):
+    def test_wrapMultiwordNonWide(self):
+        """TextWrapper: non-wide character regression tests."""
+        data = "this is a test string for regression splitting"
+        for width in range(1, len(data)):
+            orig = OTW(width=width)
+            cust = CTW(width=width)
+
+            self.assertEqual(orig.wrap(data), cust.wrap(data))
+
+    def test_wrapMultiwordNonWideWithHypens(self):
+        """TextWrapper: non-wide character regression tests that contain hyphens."""
+        data = "how should-we-split-this non-sense string that-has-lots-of-hypens"
+        for width in range(1, len(data)):
+            orig = OTW(width=width)
+            cust = CTW(width=width)
+
+            self.assertEqual(orig.wrap(data), cust.wrap(data))
+
+    def test_wrapLongwordNonWide(self):
+        """TextWrapper: Some non-wide character regression tests."""
+        data = "ThisIsASingleReallyLongWordThatWeNeedToSplit"
+        for width in range(1, len(data)):
+            orig = OTW(width=width)
+            cust = CTW(width=width)
+
+            self.assertEqual(orig.wrap(data), cust.wrap(data))
+
+    def test_wrapper_len_ignores_color_chars(self):
+        data = "\033[31m\033[104mtenletters\033[0m"
+        result = CTW._len(data)
+        self.assertEqual(10, result)
+
+    def test_wrapFullLineColor(self):
+        """TextWrapper: Wrap a line when the full thing is enclosed in color tags."""
+        # This has both a text color and a background color
+        data = "\033[31m\033[104mThis is a test string for testing TextWrap with colors\033[0m"
+
+        expected = [
+            "\033[31m\033[104mThis is a test\033[0m",
+            "\033[31m\033[104mstring for testing\033[0m",
+            "\033[31m\033[104mTextWrap with colors\033[0m",
+        ]
+        print("xxxxxxxxxxxxxxxxx")
+        print(expected)
+        print("xxxxxxxxxxxxxxxxx")
+        wrapper = CTW(width=20)
+        result = wrapper.wrap(data)
+        self.assertEqual(expected, result)
+
+    def test_wrapColorInSingleLine(self):
+        """TextWrapper: Wrap a line - preserve internal color tags, and don't
+        propagate them to other lines when they don't need to be.
+        """
+        # This has both a text color and a background color
+        data = "This is a test string for testing \033[31mTextWrap\033[0m with colors"
+
+        expected = [
+            "This is a test string for",
+            "testing \033[31mTextWrap\033[0m with",
+            "colors",
+        ]
+        wrapper = CTW(width=25)
+        result = wrapper.wrap(data)
+        self.assertEqual(expected, result)
+
+    def test_wrapColorLineSplillover(self):
+        """TextWrapper: Wrap a line - preserve internal color tags and wrap them to
+        other lines when required, requires adding the colors tags to other lines as appropriate.
+        """
+        # This has both a text color and a background color
+        data = "This is a \033[31mtest string for testing TextWrap\033[0m with colors"
+
+        expected = [
+            "This is a \033[31mtest string for\033[0m",
+            "\033[31mtesting TextWrap\033[0m with",
+            "colors",
+        ]
+        wrapper = CTW(width=25)
+        result = wrapper.wrap(data)
+        self.assertEqual(expected, result)
+
+    def test_wrapDatetime(self):
+        """TextWrapper: Show that datetimes can be wrapped without crashing."""
+        data = [
+            ["First Entry", datetime(2020, 1, 1, 5, 6, 7)],
+            ["Second Entry", datetime(2021, 2, 2, 0, 0, 0)],
+        ]
+        headers = ["Title", "When"]
+        result = tabulate(data, headers=headers, tablefmt="grid", maxcolwidths=[7, 5])
+
+        expected = [
+            "+---------+--------+",
+            "| Title   | When   |",
+            "+=========+========+",
+            "| First   | 2020-  |",
+            "| Entry   | 01-01  |",
+            "|         | 05:06  |",
+            "|         | :07    |",
+            "+---------+--------+",
+            "| Second  | 2021-  |",
+            "| Entry   | 02-02  |",
+            "|         | 00:00  |",
+            "|         | :00    |",
+            "+---------+--------+",
+        ]
+        expected = "\n".join(expected)
         self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -652,14 +652,14 @@ class TestTabulateOutput(unittest.TestCase):
             SEPARATING_LINE,
             ["eggs", "451.0"],
         ]
-        cls.test_table_headers = ["strings", "numbers"]
+        cls.testTableHeaders = ["strings", "numbers"]
 
     def test_plain(self):
         """Output: plain with headers."""
         expected = "\n".join(
             ["strings      numbers", "spam         41.9999", "eggs        451"]
         )
-        result = tabulate(self.test_table, self.test_table_headers, tablefmt="plain")
+        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainHeaderless(self):
@@ -852,7 +852,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs        451",
             ]
         )
-        result = tabulate(self.test_table, self.test_table_headers, tablefmt="simple")
+        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleWithSepLine(self):
@@ -867,7 +867,7 @@ class TestTabulateOutput(unittest.TestCase):
             ]
         )
         result = tabulate(
-            self.test_table_with_sep_line, self.test_table_headers, tablefmt="simple"
+            self.test_table_with_sep_line, self.testTableHeaders, tablefmt="simple"
         )
         self.assertEqual(expected, result)
 
@@ -1045,7 +1045,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "| eggs      |  451      |",
             ]
         )
-        result = tabulate(self.test_table, self.test_table_headers, tablefmt="github")
+        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="github")
         self.assertEqual(expected, result)
 
     def test_grid(self):
@@ -1061,7 +1061,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+-----------+-----------+",
             ]
         )
-        result = tabulate(self.test_table, self.test_table_headers, tablefmt="grid")
+        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridHeaderless(self):
@@ -1166,7 +1166,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+---------+---------+",
             ]
         )
-        result = tabulate(self.test_table, self.test_table_headers, tablefmt="pretty")
+        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyHeaderless(self):
@@ -1287,7 +1287,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "=========  =========",
             ]
         )
-        result = tabulate(self.test_table, self.test_table_headers, tablefmt="rst")
+        result = tabulate(self.test_table, self.testTableHeaders, tablefmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstWithEmptyValuesInFirstColumn(self):
@@ -1394,13 +1394,13 @@ class TestTabulateOutput(unittest.TestCase):
     def test_noData(self):
         """Output: table with no data."""
         expected = "\n".join(["strings    numbers", "---------  ---------"])
-        result = tabulate(None, self.test_table_headers, tablefmt="simple")
+        result = tabulate(None, self.testTableHeaders, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_emptyData(self):
         """Output: table with empty data."""
         expected = "\n".join(["strings    numbers", "---------  ---------"])
-        result = tabulate([], self.test_table_headers, tablefmt="simple")
+        result = tabulate([], self.testTableHeaders, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_noDataWithoutHeaders(self):
@@ -1658,11 +1658,9 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs        451",
             ]
         )
-        result = tabulate(self.test_table, self.test_table_headers)
+        result = tabulate(self.test_table, self.testTableHeaders)
         self.assertEqual(expected, result)
-        result = tabulate(
-            self.test_table, self.test_table_headers, disableNumparse=False
-        )
+        result = tabulate(self.test_table, self.testTableHeaders, disableNumparse=False)
         self.assertEqual(expected, result)
 
     def test_disableNumparseTrue(self):
@@ -1675,9 +1673,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs       451.0",
             ]
         )
-        result = tabulate(
-            self.test_table, self.test_table_headers, disableNumparse=True
-        )
+        result = tabulate(self.test_table, self.testTableHeaders, disableNumparse=True)
         self.assertEqual(expected, result)
 
     def test_disableNumparseList(self):

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -16,12 +16,14 @@
 #       This was originally https://github.com/astanin/python-tabulate
 
 """Tests for tabulate."""
-from collections import OrderedDict, UserDict
+from collections import namedtuple
+from collections import OrderedDict
+from collections import UserDict
 from datetime import datetime
 from textwrap import TextWrapper as OTW
 import unittest
 
-import numpy  # TODO: as np
+import numpy as np
 
 from armi.utils.tabulate import _alignColumn, _alignCellVeritically, _multilineWidth
 from armi.utils.tabulate import _CustomTextWrap as CTW
@@ -127,7 +129,7 @@ class TestTabulateInputs(unittest.TestCase):
 
     def test_numpy2d(self):
         """Input: a 2D NumPy array with headers."""
-        na = (numpy.arange(1, 10, dtype=numpy.float32).reshape((3, 3)) ** 3) * 0.5
+        na = (np.arange(1, 10, dtype=np.float32).reshape((3, 3)) ** 3) * 0.5
         expected = "\n".join(
             [
                 "    a      b      c",
@@ -142,7 +144,7 @@ class TestTabulateInputs(unittest.TestCase):
 
     def test_numpy2dFirstrow(self):
         """Input: a 2D NumPy array with the first row as headers."""
-        na = numpy.arange(1, 10, dtype=numpy.int32).reshape((3, 3)) ** 3
+        na = np.arange(1, 10, dtype=np.int32).reshape((3, 3)) ** 3
         expected = "\n".join(
             ["  1    8    27", "---  ---  ----", " 64  125   216", "343  512   729"]
         )
@@ -151,7 +153,7 @@ class TestTabulateInputs(unittest.TestCase):
 
     def test_numpy2dKeys(self):
         """Input: a 2D NumPy array with column indices as headers."""
-        na = (numpy.arange(1, 10, dtype=numpy.float32).reshape((3, 3)) ** 3) * 0.5
+        na = (np.arange(1, 10, dtype=np.float32).reshape((3, 3)) ** 3) * 0.5
         expected = "\n".join(
             [
                 "    0      1      2",
@@ -166,7 +168,7 @@ class TestTabulateInputs(unittest.TestCase):
 
     def test_numpyRecordArray(self):
         """Input: a 2D NumPy record array without header."""
-        na = numpy.asarray(
+        na = np.asarray(
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
             dtype={
                 "names": ["name", "age", "height"],
@@ -186,7 +188,7 @@ class TestTabulateInputs(unittest.TestCase):
 
     def test_numpyRecordArrayKeys(self):
         """Input: a 2D NumPy record array with column names as headers."""
-        na = numpy.asarray(
+        na = np.asarray(
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
             dtype={
                 "names": ["name", "age", "height"],
@@ -206,7 +208,7 @@ class TestTabulateInputs(unittest.TestCase):
 
     def test_numpyRecordArrayHeaders(self):
         """Input: a 2D NumPy record array with user-supplied headers."""
-        na = numpy.asarray(
+        na = np.asarray(
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
             dtype={
                 "names": ["name", "age", "height"],
@@ -226,8 +228,6 @@ class TestTabulateInputs(unittest.TestCase):
 
     def test_listOf_namedtuples(self):
         """Input: a list of named tuples with field names as headers."""
-        from collections import namedtuple
-
         NT = namedtuple("NT", ["foo", "bar"])
         lt = [NT(1, 2), NT(3, 4)]
         expected = "\n".join(["-  -", "1  2", "3  4", "-  -"])
@@ -236,8 +236,6 @@ class TestTabulateInputs(unittest.TestCase):
 
     def test_listOfNamedtuplesKeys(self):
         """Input: a list of named tuples with field names as headers."""
-        from collections import namedtuple
-
         NT = namedtuple("NT", ["foo", "bar"])
         lt = [NT(1, 2), NT(3, 4)]
         expected = "\n".join(

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -24,10 +24,17 @@ import unittest
 
 import numpy as np
 
-from armi.utils.tabulate import _alignColumn, _alignCellVeritically, _multilineWidth
-from armi.utils.tabulate import _isMultiline, _type, _visibleWidth, _format
+from armi.utils.tabulate import _alignCellVeritically
+from armi.utils.tabulate import _alignColumn
+from armi.utils.tabulate import _bool
+from armi.utils.tabulate import _format
+from armi.utils.tabulate import _isMultiline
+from armi.utils.tabulate import _multilineWidth
+from armi.utils.tabulate import _type
+from armi.utils.tabulate import _visibleWidth
 from armi.utils.tabulate import SEPARATING_LINE
-from armi.utils.tabulate import tabulate, tabulate_formats
+from armi.utils.tabulate import tabulate
+from armi.utils.tabulate import tabulate_formats
 
 
 class TestTabulateAPI(unittest.TestCase):
@@ -355,6 +362,12 @@ class TestTabulateInputs(unittest.TestCase):
 
 
 class TestTabulateInternal(unittest.TestCase):
+    def test_bool(self):
+        self.assertTrue(_bool("stuff"))
+        self.assertFalse(_bool(""))
+        self.assertTrue(_bool(123))
+        self.assertFalse(_bool(np.array([1, 0, -1])))
+
     def test_format(self):
         """Basic sanity test of internal _format() function."""
         self.assertEqual(_format(None, str, "8", "", "X", True), "X")
@@ -395,8 +408,8 @@ class TestTabulateInternal(unittest.TestCase):
     def test_assortedRareEdgeCases(self):
         """Test some of the more rare edge cases in the purely internal functions."""
         from armi.utils.tabulate import _alignHeader
-        from armi.utils.tabulate import _removeSeparatingLines
         from armi.utils.tabulate import _prependRowIndex
+        from armi.utils.tabulate import _removeSeparatingLines
 
         self.assertEqual(_alignHeader("123", False, 3, 3, False, None), "123")
 

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -414,7 +414,7 @@ class TestTabulateInternal(unittest.TestCase):
     def test_alignColumnMultiline(self):
         """Internal: _align_column(..., is_multiline=True)."""
         column = ["1", "123", "12345\n6"]
-        output = _alignColumn(column, "center", is_multiline=True)
+        output = _alignColumn(column, "center", isMultiline=True)
         expected = ["  1  ", " 123 ", "12345" + "\n" + "  6  "]
         self.assertEqual(expected, output)
 

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -1105,3 +1105,119 @@ class TestTabulateOutput(unittest.TestCase):
         )
         result = tabulate(table, tablefmt="pretty")
         self.assertEqual(expected, result)
+
+    def test_rst(self):
+        """Output: rst with headers."""
+        expected = "\n".join(
+            [
+                "=========  =========",
+                "strings      numbers",
+                "=========  =========",
+                "spam         41.9999",
+                "eggs        451",
+                "=========  =========",
+            ]
+        )
+        result = tabulate(_test_table, _test_table_headers, tablefmt="rst")
+        self.assertEqual(expected, result)
+
+    def test_rst_with_empty_values_in_first_column(self):
+        """Output: rst with dots in first column."""
+        test_headers = ["", "what"]
+        test_data = [("", "spam"), ("", "eggs")]
+        expected = "\n".join(
+            [
+                "====  ======",
+                "..    what",
+                "====  ======",
+                "..    spam",
+                "..    eggs",
+                "====  ======",
+            ]
+        )
+        result = tabulate(test_data, test_headers, tablefmt="rst")
+        self.assertEqual(expected, result)
+
+    def test_rst_headerless(self):
+        """Output: rst without headers."""
+        expected = "\n".join(
+            ["====  ========", "spam   41.9999", "eggs  451", "====  ========"]
+        )
+        result = tabulate(_test_table, tablefmt="rst")
+        self.assertEqual(expected, result)
+
+    def test_rst_multiline(self):
+        """Output: rst with multiline cells with headers."""
+        table = [[2, "foo\nbar"]]
+        headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
+        expected = "\n".join(
+            [
+                "===========  ===========",
+                "       more  more spam",
+                "  spam \x1b[31meggs\x1b[0m  & eggs",
+                "===========  ===========",
+                "          2  foo",
+                "             bar",
+                "===========  ===========",
+            ]
+        )
+        result = tabulate(table, headers, tablefmt="rst")
+        self.assertEqual(expected, result)
+
+    def test_rst_multiline_with_links(self):
+        """Output: rst with multiline cells with headers."""
+        table = [[2, "foo\nbar"]]
+        headers = (
+            "more\nspam \x1b]8;;target\x1b\\eggs\x1b]8;;\x1b\\",
+            "more spam\n& eggs",
+        )
+        expected = "\n".join(
+            [
+                "===========  ===========",
+                "       more  more spam",
+                "  spam \x1b]8;;target\x1b\\eggs\x1b]8;;\x1b\\  & eggs",
+                "===========  ===========",
+                "          2  foo",
+                "             bar",
+                "===========  ===========",
+            ]
+        )
+        result = tabulate(table, headers, tablefmt="rst")
+        self.assertEqual(expected, result)
+
+    def test_rst_multiline_with_empty_cells(self):
+        """Output: rst with multiline cells and empty cells with headers."""
+        table = [
+            ["hdr", "data", "fold"],
+            ["1", "", ""],
+            ["2", "very long data", "fold\nthis"],
+        ]
+        expected = "\n".join(
+            [
+                "=====  ==============  ======",
+                "  hdr  data            fold",
+                "=====  ==============  ======",
+                "    1",
+                "    2  very long data  fold",
+                "                       this",
+                "=====  ==============  ======",
+            ]
+        )
+        result = tabulate(table, headers="firstrow", tablefmt="rst")
+        self.assertEqual(expected, result)
+
+    def test_rst_multiline_with_empty_cells_headerless(self):
+        """Output: rst with multiline cells and empty cells without headers."""
+        table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+        expected = "\n".join(
+            [
+                "=  ==============  ====",
+                "0",
+                "1",
+                "2  very long data  fold",
+                "                   this",
+                "=  ==============  ====",
+            ]
+        )
+        result = tabulate(table, tablefmt="rst")
+        self.assertEqual(expected, result)

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -1544,19 +1544,19 @@ class TestTabulateOutput(unittest.TestCase):
         )
         self.assertEqual(expected, result)
 
-    def test_missingval(self):
+    def test_missingVal(self):
         """Output: substitution of missing values."""
         result = tabulate(
-            [["Alice", 10], ["Bob", None]], missingval="n/a", tablefmt="plain"
+            [["Alice", 10], ["Bob", None]], missingVal="n/a", tablefmt="plain"
         )
         expected = "Alice   10\nBob    n/a"
         self.assertEqual(expected, result)
 
-    def test_missingvalMulti(self):
+    def test_missingValMulti(self):
         """Output: substitution of missing values with different values per column."""
         result = tabulate(
             [["Alice", "Bob", "Charlie"], [None, None, None]],
-            missingval=("n/a", "?"),
+            missingVal=("n/a", "?"),
             tablefmt="plain",
         )
         expected = "Alice  Bob  Charlie\nn/a    ?"

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -475,29 +475,29 @@ class TestTabulateInternal(unittest.TestCase):
         self.assertEqual(expected, result)
 
 
-# TODO: JOHN: reformat data
-# _test_table shows
-#  - coercion of a string to a number,
-#  - left alignment of text,
-#  - decimal point alignment of numbers
-_test_table = [["spam", 41.9999], ["eggs", "451.0"]]
-_test_table_with_sep_line = [["spam", 41.9999], SEPARATING_LINE, ["eggs", "451.0"]]
-_test_table_headers = ["strings", "numbers"]
-
-
 class TestTabulateOutput(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.test_table = [["spam", 41.9999], ["eggs", "451.0"]]
+        cls.test_table_with_sep_line = [
+            ["spam", 41.9999],
+            SEPARATING_LINE,
+            ["eggs", "451.0"],
+        ]
+        cls.test_table_headers = ["strings", "numbers"]
+
     def test_plain(self):
         """Output: plain with headers."""
         expected = "\n".join(
             ["strings      numbers", "spam         41.9999", "eggs        451"]
         )
-        result = tabulate(_test_table, _test_table_headers, tablefmt="plain")
+        result = tabulate(self.test_table, self.test_table_headers, tablefmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainHeaderless(self):
         """Output: plain without headers."""
         expected = "\n".join(["spam   41.9999", "eggs  451"])
-        result = tabulate(_test_table, tablefmt="plain")
+        result = tabulate(self.test_table, tablefmt="plain")
         self.assertEqual(expected, result)
 
     def test_plainMultilineHeaderless(self):
@@ -684,7 +684,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs        451",
             ]
         )
-        result = tabulate(_test_table, _test_table_headers, tablefmt="simple")
+        result = tabulate(self.test_table, self.test_table_headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleWithSepLine(self):
@@ -699,7 +699,7 @@ class TestTabulateOutput(unittest.TestCase):
             ]
         )
         result = tabulate(
-            _test_table_with_sep_line, _test_table_headers, tablefmt="simple"
+            self.test_table_with_sep_line, self.test_table_headers, tablefmt="simple"
         )
         self.assertEqual(expected, result)
 
@@ -763,7 +763,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(
             ["----  --------", "spam   41.9999", "eggs  451", "----  --------"]
         )
-        result = tabulate(_test_table, tablefmt="simple")
+        result = tabulate(self.test_table, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_simpleHeaderlessWithSepLine(self):
@@ -777,7 +777,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "----  --------",
             ]
         )
-        result = tabulate(_test_table_with_sep_line, tablefmt="simple")
+        result = tabulate(self.test_table_with_sep_line, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def testSimpleMultilineHeaderless(self):
@@ -877,7 +877,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "| eggs      |  451      |",
             ]
         )
-        result = tabulate(_test_table, _test_table_headers, tablefmt="github")
+        result = tabulate(self.test_table, self.test_table_headers, tablefmt="github")
         self.assertEqual(expected, result)
 
     def test_grid(self):
@@ -893,7 +893,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+-----------+-----------+",
             ]
         )
-        result = tabulate(_test_table, _test_table_headers, tablefmt="grid")
+        result = tabulate(self.test_table, self.test_table_headers, tablefmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridHeaderless(self):
@@ -907,7 +907,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+------+----------+",
             ]
         )
-        result = tabulate(_test_table, tablefmt="grid")
+        result = tabulate(self.test_table, tablefmt="grid")
         self.assertEqual(expected, result)
 
     def test_gridMultilineHeaderless(self):
@@ -998,7 +998,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+---------+---------+",
             ]
         )
-        result = tabulate(_test_table, _test_table_headers, tablefmt="pretty")
+        result = tabulate(self.test_table, self.test_table_headers, tablefmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyHeaderless(self):
@@ -1011,7 +1011,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "+------+---------+",
             ]
         )
-        result = tabulate(_test_table, tablefmt="pretty")
+        result = tabulate(self.test_table, tablefmt="pretty")
         self.assertEqual(expected, result)
 
     def test_prettyMultilineHeaderless(self):
@@ -1119,7 +1119,7 @@ class TestTabulateOutput(unittest.TestCase):
                 "=========  =========",
             ]
         )
-        result = tabulate(_test_table, _test_table_headers, tablefmt="rst")
+        result = tabulate(self.test_table, self.test_table_headers, tablefmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstWithEmptyValuesInFirstColumn(self):
@@ -1144,7 +1144,7 @@ class TestTabulateOutput(unittest.TestCase):
         expected = "\n".join(
             ["====  ========", "spam   41.9999", "eggs  451", "====  ========"]
         )
-        result = tabulate(_test_table, tablefmt="rst")
+        result = tabulate(self.test_table, tablefmt="rst")
         self.assertEqual(expected, result)
 
     def test_rstMultiline(self):
@@ -1226,13 +1226,13 @@ class TestTabulateOutput(unittest.TestCase):
     def test_noData(self):
         """Output: table with no data."""
         expected = "\n".join(["strings    numbers", "---------  ---------"])
-        result = tabulate(None, _test_table_headers, tablefmt="simple")
+        result = tabulate(None, self.test_table_headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_emptyData(self):
         """Output: table with empty data."""
         expected = "\n".join(["strings    numbers", "---------  ---------"])
-        result = tabulate([], _test_table_headers, tablefmt="simple")
+        result = tabulate([], self.test_table_headers, tablefmt="simple")
         self.assertEqual(expected, result)
 
     def test_noDataWithoutHeaders(self):
@@ -1490,9 +1490,11 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs        451",
             ]
         )
-        result = tabulate(_test_table, _test_table_headers)
+        result = tabulate(self.test_table, self.test_table_headers)
         self.assertEqual(expected, result)
-        result = tabulate(_test_table, _test_table_headers, disableNumparse=False)
+        result = tabulate(
+            self.test_table, self.test_table_headers, disableNumparse=False
+        )
         self.assertEqual(expected, result)
 
     def test_disableNumparseTrue(self):
@@ -1505,7 +1507,9 @@ class TestTabulateOutput(unittest.TestCase):
                 "eggs       451.0",
             ]
         )
-        result = tabulate(_test_table, _test_table_headers, disableNumparse=True)
+        result = tabulate(
+            self.test_table, self.test_table_headers, disableNumparse=True
+        )
         self.assertEqual(expected, result)
 
     def test_disableNumparseList(self):

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -42,7 +42,7 @@ def writeInitialVolumeFractions(b):
     """Write out the initial temperatures and component volume fractions."""
     headers = ["Component", "Temperature, °C", "Volume Fraction"]
     data = [(c, c.temperatureInC, volFrac) for c, volFrac in b.getVolumeFractions()]
-    print(tabulate.tabulate(tabular_data=data, headers=headers) + "\n")
+    print(tabulate.tabulate(data=data, headers=headers) + "\n")
 
 
 def plotVolFracsWithComponentTemps(b, uniformTemps):

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -8,7 +8,7 @@ Release Date: TBD
 
 New Features
 ------------
-#. TBD
+#. Removing the ``tabulate`` dependency by ingesting it to ``armi.utils.tabulate``. (`PR#1811 <https://github.com/terrapower/armi/pull/1811>`_)
 
 API Changes
 -----------

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -845,8 +845,8 @@ material modifications
       data.sort(key=lambda t: t[0])
       return tabulate(
           headers=("Material Name", "Available Modifications"),
-          tabular_data=data,
-          tablefmt="rst",
+          data=data,
+          tableFmt="rst",
       )
 
   The class 1/class 2 modifications in fuel materials are used to identify mixtures of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "ruamel.yaml.clib<=0.2.7", # C-based core of ruamel below
     "ruamel.yaml<=0.17.21", # Our foundational YAML library
     "scipy>=1.7.0", # Used for curve-fitting and matrix math
+    "tabulate>=0.8.9", # Used to pretty-print tabular data
     "toml>0.9.5", # Needed to parse the pyproject.toml file
     "voluptuous>=0.12.1", # Used to validate YAML data files
     "yamlize==0.7.1", # Custom YAML-to-object library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "ruamel.yaml.clib<=0.2.7", # C-based core of ruamel below
     "ruamel.yaml<=0.17.21", # Our foundational YAML library
     "scipy>=1.7.0", # Used for curve-fitting and matrix math
-    "tabulate>=0.8.9", # Used to pretty-print tabular data
     "toml>0.9.5", # Needed to parse the pyproject.toml file
     "voluptuous>=0.12.1", # Used to validate YAML data files
     "yamlize==0.7.1", # Custom YAML-to-object library


### PR DESCRIPTION
## What is the change?

I removed the `tabulate` dependency, and just ingested the parts of that tool we use to `armi.utils.tabulate`.

## Why is the change being made?

To close #1749

The problem is that `tabulate` appears to be a nigh abandoned project, and it is keeping us from being able to support modern PIP versions.

(Arrielle also points out that we could just _replace_ `tabulate` with something else, like `prettytable`. I am not super convinced my approach here is better than that one. I went this route first because it was easy for me to do, and would be easier to make the update for our downstream repos.)

## Code Coverage

The [code coverage](https://coveralls.io/builds/69122857/source?filename=armi%2Futils%2Ftabulate.py) on this file is pretty high:

![image](https://github.com/user-attachments/assets/3324cdb0-07a1-48b3-b598-ff0d38b82172)

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.