### PR TITLE
pu frac storage update

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -25,6 +25,7 @@ import numpy
 from armi import runLog
 from armi.nucDirectory import nuclideBases
 from armi.reactor.flags import TypeSpec
+from armi.reactor import blocks
 from armi.utils import densityTools
 from armi.utils.units import getTk, getTc
 
@@ -155,7 +156,11 @@ class Material:
         """Return the grandparent (typically block) associated with this material"""
         # would be nice to use composite.getAncestor, but material is not a composite
         component = self.parent
-        return None if component is None else component.parent
+        return (
+            None
+            if component is None
+            else component.getAncestor(lambda x: isinstance(x, blocks.Block))
+        )
 
     def getChildrenWithFlags(self, typeSpec: TypeSpec, exactMatch=True):
         """Return empty list, representing that this object has no children."""
@@ -874,7 +879,7 @@ class FuelMaterial(Material):
         return self_puFrac
 
     @puFrac.setter
-    def x(self, puFrac):
+    def puFrac(self, puFrac):
         runLog.warning(
             "Materials should not store state, so this component will look at its (grand)parent for Pu fraction unless it us detached. "
             "Storing properties on the material objected will be deprecated in the near future.",

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -151,6 +151,12 @@ class Material:
         """Return empty list, representing that materials have no children."""
         return []
 
+    def getGrandparent(self):
+        """Return the grandparent (typically block) associated with this material"""
+        # would be nice to use composite.getAncestor, but material is not a composite
+        component = self.parent
+        return None if component is None else component.parent
+
     def getChildrenWithFlags(self, typeSpec: TypeSpec, exactMatch=True):
         """Return empty list, representing that this object has no children."""
         return []
@@ -845,9 +851,36 @@ class FuelMaterial(Material):
     class1_wt_frac = None
     class1_custom_isotopics = None
     class2_custom_isotopics = None
-    puFrac = 0.0
-    uFrac = 0.0
-    zrFrac = 0.0
+    puFracDefault = 0.0
+    uFracDefault = 0.0
+    zrFracDefault = 0.0
+
+    def __init__(self):
+        self._puFrac = 0
+        Material._init_()
+
+    @property
+    def puFrac(self):
+        """Get the Pu Frac."""
+        # ideally the parameters would be stored on component, not Block (parent, not grandparent)
+        myBlock = self.getGrandparent()
+        if myBlock is not None:
+            return myBlock.p.puFrac
+        runLog.warning(
+            "{self} has no block attached, deferring to internally stored Pu Frac. "
+            "Storing properties on the material objected will be deprecated in the near future.",
+            single=true,
+        )
+        return self_puFrac
+
+    @puFrac.setter
+    def x(self, puFrac):
+        runLog.warning(
+            "Materials should not store state, so this component will look at its (grand)parent for Pu fraction unless it us detached. "
+            "Storing properties on the material objected will be deprecated in the near future.",
+            single=true,
+        )
+        self._puFrac = puFrac
 
     def applyInputParams(
         self,

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -152,7 +152,7 @@ class Material:
         """Return empty list, representing that materials have no children."""
         return []
 
-    def getGrandparent(self):
+    def getAssociatedBlock(self):
         """Return the grandparent (typically block) associated with this material"""
         # would be nice to use composite.getAncestor, but material is not a composite
         component = self.parent
@@ -868,7 +868,7 @@ class FuelMaterial(Material):
     def puFrac(self):
         """Get the Pu Frac."""
         # ideally the parameters would be stored on component, not Block (parent, not grandparent)
-        myBlock = self.getGrandparent()
+        myBlock = self.getAssociatedBlock()
         if myBlock is not None:
             return myBlock.p.puFrac
         runLog.warning(
@@ -876,7 +876,7 @@ class FuelMaterial(Material):
             "Storing properties on the material objected will be deprecated in the near future.",
             single=true,
         )
-        return self_puFrac
+        return self._puFrac
 
     @puFrac.setter
     def puFrac(self, puFrac):


### PR DESCRIPTION
## What is the change?

Update materials to defer to the block's plutonium fraction 

## Why is the change being made?

material.puFrac is not stored in the database and materials are supposed to be stateless:
https://github.com/terrapower/armi/pull/1062


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `pyproject.toml`.