### PR TITLE
Reverting chmod change

### DIFF
--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -160,14 +160,13 @@ def store(exePath, inputPaths, outputFiles, cacheDir):
     folderLoc = _getCachedFolder(exePath, inputPaths, cacheDir)
     if os.path.exists(folderLoc):
         deleteCache(folderLoc)
-    os.makedirs(folderLoc, mode=0o770)
+    os.makedirs(folderLoc)
     _makeOutputManifest(outputsThatExist, folderLoc)
 
     for outputFile in outputsThatExist:
         baseName = os.path.basename(outputFile)
         cachedLoc = os.path.join(folderLoc, baseName)
         shutil.copy(outputFile, cachedLoc)
-        os.chmod(cachedLoc, 0o770)
 
     runLog.info("Added outputs for {} to the cache.".format(exePath))
 


### PR DESCRIPTION
## What is the change?

This PR reverts #1808.

## Why is the change being made?

The `chmod()` change in question did not serve its purpose, so we are removing it.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.