### PR TITLE
Adding logging dedupication to ARMI docs

### DIFF
--- a/doc/developer/tooling.rst
+++ b/doc/developer/tooling.rst
@@ -251,6 +251,31 @@ For reference, here are the log levels that ARMI supports:
       - Use ONLY to define major sections in the log files.
 
 
+Blocking Duplicate Logs
+-----------------------
+Sometimes you want to add a log message, but based on program logic it might pop up in the final log
+file multiple times, even thousands of times. And probably you do not want that. Happily, the
+``runLog`` tool provides a simple argument that will stop a single log line from being logged more
+than once.
+
+Here is a (silly) example of a heavily duplicate log message:
+
+.. code-block:: python
+
+    for _i in range(1000):
+        runLog.warning("Something wicked this way comes.")
+
+That log message gets printed 1,000 times, but we can ensure it is only printed once:
+
+.. code-block:: python
+
+    for _i in range(1000):
+        runLog.warning("Something wicked this way comes.", single=True)
+
+Obviously, this will not be useful in every scenario. But it is a handy tool to clean up your log
+files.
+
+
 Module-Level Logging
 --------------------
 The ``runLog`` tool also allows for you to log one module differently from the rest of the code


### PR DESCRIPTION
## What is the change?

Documenting the `single=True`, logging de-duplication tool to the ARMI docs.

## Why is the change being made?

1. Because documentation is good.
2. To close #1829 

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.