### PR TITLE
Fixing DerivedShape.getArea() for cold=true

### DIFF
--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -453,6 +453,15 @@ class DerivedShape(UnshapedComponent):
         cold : bool, optional
             Ignored for this component
         """
+        if cold:
+            # At cold temp, the DerivedShape has the area of the parent minus the other siblings
+            parentArea = self.parent.getArea()
+            # NOTE: the assumption is there is only one DerivedShape in each Component
+            siblings = sum(
+                [c.getArea(cold=True) for c in self.parent if type(c) != DerivedShape]
+            )
+            return parentArea - siblings
+
         if self.parent.derivedMustUpdate:
             self.computeVolume()
 

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -158,7 +158,7 @@ class UnshapedComponent(Component):
         Parameters
         ----------
         cold : bool, optional
-            Compute the area with as-input dimensions, instead of thermally-expanded?
+            If True, compute the area with as-input dimensions, instead of thermally-expanded.
         """
         coldArea = self.p.area
         if cold:
@@ -178,7 +178,7 @@ class UnshapedComponent(Component):
         Tc : float
             Ignored for this component
         cold : bool, optional
-            Compute the area with as-input dimensions, instead of thermally-expanded?
+            If True, compute the area with as-input dimensions, instead of thermally-expanded.
 
         Notes
         -----
@@ -458,7 +458,7 @@ class DerivedShape(UnshapedComponent):
         Parameters
         ----------
         cold : bool, optional
-            Compute the area with as-input dimensions, instead of thermally-expanded?
+            If True, compute the area with as-input dimensions, instead of thermally-expanded.
         """
         if cold:
             # At cold temp, the DerivedShape has the area of the parent minus the other siblings

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -158,7 +158,7 @@ class UnshapedComponent(Component):
         Parameters
         ----------
         cold : bool, optional
-            Ignored for this component
+            Compute the area with as-input dimensions, instead of thermally-expanded?
         """
         coldArea = self.p.area
         if cold:
@@ -172,6 +172,13 @@ class UnshapedComponent(Component):
 
         This is the smallest it can possibly be. Since this is used to determine
         the outer component, it will never be allowed to be the outer one.
+
+        Parameters
+        ----------
+        Tc : float
+            Ignored for this component
+        cold : bool, optional
+            Compute the area with as-input dimensions, instead of thermally-expanded?
 
         Notes
         -----
@@ -451,7 +458,7 @@ class DerivedShape(UnshapedComponent):
         Parameters
         ----------
         cold : bool, optional
-            Ignored for this component
+            Compute the area with as-input dimensions, instead of thermally-expanded?
         """
         if cold:
             # At cold temp, the DerivedShape has the area of the parent minus the other siblings

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -500,12 +500,12 @@ class TestDerivedShapeGetArea(unittest.TestCase):
         self.assertIn(Hexagon, shapes)
 
         # prove that getArea works on the block level
-        self.assertEqual(b.getArea(cold=True), b.getArea(cold=False))
+        self.assertAlmostEqual(b.getArea(cold=True), b.getArea(cold=False), delta=1e-10)
 
         # prove that getArea preserves the sum of all the areas, even if there is a DerivedShape
         totalAreaCold = sum([c.getArea(cold=True) for c in b])
         totalAreaHot = sum([c.getArea(cold=False) for c in b])
-        self.assertEqual(totalAreaCold, totalAreaHot)
+        self.assertAlmostEqual(totalAreaCold, totalAreaHot, delta=1e-10)
 
 
 class TestCircle(TestShapedComponent):

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -17,6 +17,7 @@ import copy
 import math
 import unittest
 
+from armi.materials import air, alloy200
 from armi.materials.material import Material
 from armi.reactor import components
 from armi.reactor import flags
@@ -44,7 +45,7 @@ from armi.reactor.components import (
     ComponentType,
 )
 from armi.reactor.components import materials
-from armi.materials import air, alloy200
+from armi.reactor.tests.test_reactors import loadTestReactor
 
 
 class TestComponentFactory(unittest.TestCase):
@@ -480,6 +481,31 @@ class TestDerivedShape(TestShapedComponent):
 
         # test the computeVolume method on the one DerivedShape in thi block
         self.assertAlmostEqual(c.computeVolume(), 1386.5232044586771)
+
+
+class TestDerivedShapeGetArea(unittest.TestCase):
+    def test_getAreaColdTrue(self):
+        """Prove that the DerivedShape.getArea() works at cold=True."""
+        # load one-block test reactor
+        _o, r = loadTestReactor(
+            inputFileName="smallestTestReactor/armiRunSmallest.yaml"
+        )
+        b = r.core[0][0]
+
+        # ensure there is a DerivedShape in this Block
+        shapes = set([type(c) for c in b])
+        self.assertIn(Circle, shapes)
+        self.assertIn(DerivedShape, shapes)
+        self.assertIn(Helix, shapes)
+        self.assertIn(Hexagon, shapes)
+
+        # prove that getArea works on the block level
+        self.assertEqual(b.getArea(cold=True), b.getArea(cold=False))
+
+        # prove that getArea preserves the sum of all the areas, even if there is a DerivedShape
+        totalAreaCold = sum([c.getArea(cold=True) for c in b])
+        totalAreaHot = sum([c.getArea(cold=False) for c in b])
+        self.assertEqual(totalAreaCold, totalAreaHot)
 
 
 class TestCircle(TestShapedComponent):

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -24,6 +24,7 @@ Bug Fixes
 Quality Work
 ------------
 #. Removing code that causes a deprecation warning (converting ``axialUnitGrid`` to ``AxialGrid.fromNCells``) (`PR#1809 <https://github.com/terrapower/armi/pull/1809>`_)
+#. TBD
 
 Changes that Affect Requirements
 --------------------------------

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -18,6 +18,7 @@ API Changes
 
 Bug Fixes
 ---------
+#. Fixed ``DerivedShape.getArea`` for ``cold=True``. (`PR#1831 <https://github.com/terrapower/armi/pull/1831>`_)
 #. TBD
 
 Quality Work


### PR DESCRIPTION
## What is the change?

Fixed a bug in `DerivedShape.getArea()` in the case when `cold=true`.

## Why is the change being made?

To close #1424

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.