### PR TITLE
Removing defunct flags CORE and REACTOR

### DIFF
--- a/armi/bookkeeping/db/database3.py
+++ b/armi/bookkeeping/db/database3.py
@@ -72,9 +72,8 @@ from armi.reactor.assemblies import Assembly
 from armi.reactor.blocks import Block
 from armi.reactor.components import Component
 from armi.reactor.composites import ArmiObject
-from armi.reactor.flags import Flags
 from armi.reactor.parameters import parameterCollections
-from armi.reactor.reactors import Core
+from armi.reactor.reactors import Core, Reactor
 from armi.settings.fwSettings.globalSettings import CONF_SORT_REACTOR
 from armi.utils import getNodesPerCycle
 from armi.utils.textProcessors import resolveMarkupInclusions
@@ -854,11 +853,7 @@ class Database3:
             comp.add(child)
 
         if isinstance(comp, Core):
-            # TODO: This is also an issue related to geoms and which core is "The Core".
-            # We only have a good geom for the main core, so can't do process loading on
-            # the SFP, etc.
-            if comp.hasFlags(Flags.CORE):
-                comp.processLoading(cs, dbLoad=True)
+            comp.processLoading(cs, dbLoad=True)
         elif isinstance(comp, Assembly):
             comp.calculateZCoords()
 
@@ -1311,8 +1306,7 @@ class Database3:
         Returns
         -------
         dict
-            Dictionary ArmiObject (input): dict of str/list pairs containing ((cycle,
-            node), value).
+            Dictionary ArmiObject (input): dict of str/list pairs containing ((cycle, node), value).
         """
         histData: Histories = {
             c: collections.defaultdict(collections.OrderedDict) for c in comps
@@ -1329,8 +1323,7 @@ class Database3:
             if "layout" not in h5TimeNodeGroup:
                 # Layout hasn't been written for this time step, so whatever is in there
                 # didn't come from the DatabaseInterface. Probably because it's the
-                # current time step and something has created the group to store aux
-                # data
+                # current time step and something has created the group to store aux data
                 continue
 
             cycle = h5TimeNodeGroup.attrs["cycle"]
@@ -1419,7 +1412,7 @@ class Database3:
 
                         histData[c][paramName][cycle, timeNode] = val
 
-        r = comps[0].getAncestorWithFlags(Flags.REACTOR)
+        r = comps[0].getAncestor(lambda c: isinstance(c, Reactor))
         cycleNode = r.p.cycle, r.p.timeNode
         for c, paramHistories in histData.items():
             for paramName, hist in paramHistories.items():

--- a/armi/physics/neutronics/tests/test_crossSectionTable.py
+++ b/armi/physics/neutronics/tests/test_crossSectionTable.py
@@ -20,7 +20,6 @@ from armi.physics.neutronics.isotopicDepletion import (
     isotopicDepletionInterface as idi,
 )
 from armi.physics.neutronics.latticePhysics import ORDER
-from armi.reactor.flags import Flags
 from armi.reactor.tests.test_blocks import loadTestBlock
 from armi.reactor.tests.test_reactors import loadTestReactor
 from armi.settings import Settings
@@ -37,7 +36,7 @@ class TestCrossSectionTable(unittest.TestCase):
         """
         obj = loadTestBlock()
         obj.p.mgFlux = range(33)
-        core = obj.getAncestorWithFlags(Flags.CORE)
+        core = obj.parent.parent
         core.lib = isotxs.readBinary(ISOAA_PATH)
         table = crossSectionTable.makeReactionRateTable(obj)
 

--- a/armi/reactor/assemblyLists.py
+++ b/armi/reactor/assemblyLists.py
@@ -201,7 +201,6 @@ class SpentFuelPool(AssemblyList):
         ----------
         assem : Assembly
             The Assembly to add to the list
-
         loc : LocationBase, optional
             If provided, the assembly is inserted at that location. If it is not
             provided, the locator on the Assembly object will be used. If the

--- a/armi/reactor/flags.py
+++ b/armi/reactor/flags.py
@@ -205,9 +205,6 @@ class Flags(Flag):
     MEDIUM = auto()
     LOW = auto()
 
-    CORE = auto()
-    REACTOR = auto()
-
     # general kinds of assemblies or blocks
     MATERIAL = auto()
     FUEL = auto()

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -98,7 +98,6 @@ class Reactor(composites.Composite):
         self.spatialLocator = None
         self.p.maxAssemNum = 0
         self.p.cycle = 0
-        self.p.flags |= Flags.REACTOR
         self.core = None
         self.sfp = None
         self.blueprints = blueprints
@@ -123,7 +122,7 @@ class Reactor(composites.Composite):
 
     def add(self, container):
         composites.Composite.add(self, container)
-        cores = self.getChildrenWithFlags(Flags.CORE)
+        cores = [c for c in self.getChildren(deep=True) if isinstance(c, Core)]
         if cores:
             if len(cores) != 1:
                 raise ValueError(
@@ -283,7 +282,6 @@ class Core(composites.Composite):
             Name of the object. Flags will inherit from this.
         """
         composites.Composite.__init__(self, name)
-        self.p.flags = Flags.fromStringIgnoreErrors(name)
         self.assembliesByName = {}
         self.circularRingList = {}
         self.blocksByName = {}  # lookup tables

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -250,10 +250,9 @@ class Core(composites.Composite):
         :implements: R_ARMI_R_CORE
 
         A :py:class:`Core <armi.reactor.reactors.Core>` object is typically a child of a
-        :py:class:`Reactor <armi.reactor.reactors.Reactor>` object. A Reactor can contain multiple
-        objects of the Core type. The instance attribute name ``r.core`` is reserved for the object
-        representating the active core. A reactor may also have a spent fuel pool instance
-        attribute, ``r.sfp``\ , which is also of type :py:class:`core <armi.reactor.reactors.Core>`.
+        :py:class:`Reactor <armi.reactor.reactors.Reactor>` object. A Reactor should only contain
+        one object of the Core type. The instance attribute name ``r.core`` is reserved for the
+        object representating the active core.
 
         Most of the operations to retrieve information from the ARMI reactor data model are mediated
         through Core objects. For example,
@@ -265,7 +264,6 @@ class Core(composites.Composite):
     params : dict
         Core-level parameters are scalar values that have time dependence. Examples are keff,
         maxPercentBu, etc.
-
     assemblies : list
         List of assembly objects that are currently in the core
     """

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -605,8 +605,8 @@ class Assembly_TestCase(unittest.TestCase):
 
         for refBlock, curBlock in zip(self.assembly, assembly2):
             numNucs = 0
-            for nuc in self.assembly.getAncestorWithFlags(
-                Flags.REACTOR
+            for nuc in self.assembly.getAncestor(
+                lambda c: isinstance(c, reactors.Reactor)
             ).blueprints.allNuclidesInProblem:
                 numNucs += 1
                 # Block level density

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -14,6 +14,7 @@ New Features
 
 API Changes
 -----------
+#. Removing flags ``CORE`` and ``REACTOR``. (`PR#1835 <https://github.com/terrapower/armi/pull/1835>`_)
 #. TBD
 
 Bug Fixes
@@ -24,6 +25,7 @@ Bug Fixes
 Quality Work
 ------------
 #. Removing code that causes a deprecation warning (converting ``axialUnitGrid`` to ``AxialGrid.fromNCells``) (`PR#1809 <https://github.com/terrapower/armi/pull/1809>`_)
+#. TBD
 
 Changes that Affect Requirements
 --------------------------------


### PR DESCRIPTION
## What is the change?

Here I removed two flags that are barely used and are definitely unnecessary.

## Why is the change being made?

To close #1833

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.