### PR TITLE
Documenting TightCoupling in the GlobalFluxInterface

### DIFF
--- a/doc/user/physics_coupling.rst
+++ b/doc/user/physics_coupling.rst
@@ -76,3 +76,12 @@ The total convergence of the power distribution is finally measured through the 
 
 .. math::
     \epsilon = \| \xi \|_{\inf} = \max \xi.
+
+
+The Global Flux Interface
+-------------------------
+The :py:class:`Global Flux Interface <armi.physics.neutronics.globalFlux.globalFluxInterface.GlobalFluxInterface>`
+class will attempt to set its own ``TightCoupler`` based on ``keff``. To see the specifics, see:
+:py:meth:`_setTightCouplingDefaults <armi.physics.neutronics.globalFlux.globalFluxInterface.GlobalFluxInterface._setTightCouplingDefaults>`.
+If you want to change the tight coupling performance of the ``GlobalFluxInterface``, it would be
+easiest to just sublass the interface and over-write the `_setTightCouplingDefaults` method.


### PR DESCRIPTION
## What is the change?

The `GlobalFluxInterface` has a default `TightCoupling`. That was documented, but only deep inside the class, in the private method `_setTightCouplingDefaults()` where it was implemented.

So we are adding a note to this in the ARMI docs, to make this fact more visible.

## Why is the change being made?

Drew ran into this problem, and lost some time until he found this method. So, that's no good.  We are adding this to the docs, for better visibility.

To close #1570

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.