### PR TITLE
Allow SpentFuelPool types

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -31,7 +31,14 @@ import numpy
 
 from armi import getPluginManagerOrFail, materials, nuclearDataIO, runLog
 from armi.nuclearDataIO import xsLibraries
-from armi.reactor import composites, geometry, grids, parameters, reactorParameters, zones
+from armi.reactor import (
+    composites,
+    geometry,
+    grids,
+    parameters,
+    reactorParameters,
+    zones,
+)
 from armi.reactor.assemblyLists import SpentFuelPool
 from armi.reactor.flags import Flags
 from armi.reactor.systemLayoutInput import SystemLayoutInput
@@ -49,7 +56,12 @@ from armi.settings.fwSettings.globalSettings import (
     CONF_TRACK_ASSEMS,
     CONF_ZONE_DEFINITIONS,
 )
-from armi.utils import createFormattedStrWithDelimiter, directoryChangers, tabulate, units
+from armi.utils import (
+    createFormattedStrWithDelimiter,
+    directoryChangers,
+    tabulate,
+    units,
+)
 from armi.utils.iterables import Sequence
 from armi.utils.mathematics import average1DWithinTolerance
 
@@ -115,7 +127,8 @@ class Reactor(composites.Composite):
     def add(self, container):
         composites.Composite.add(self, container)
         cores = [
-            c for c in self.getChildren(deep=True)
+            c
+            for c in self.getChildren(deep=True)
             if isinstance(c, Core) and not isinstance(c, SpentFuelPool)
         ]
         if cores:


### PR DESCRIPTION
## What is the change?

<!-- MANDATORY: Describe the change -->

ARMI only allows there to be one child composite of a reactor that is the reactor core itself. This was previously checked with the flag `Flags.CORE`.

A recent PR (https://github.com/terrapower/armi/pull/1835) switched to checking the type of the composite, i.e. `if isinstance(c, Core)`. This broke downstream unit tests because some models have a `SpentFuelPool` which is a subclass of `Core`. The check needs to be updated to accept a `SpentFuelPool` in addition to a `Core`.

## Why is the change being made?

<!-- MANDATORY: Explain why the change is necessary -->

Downstream unit tests broke as a result of a recent PR changing the logic of what is allowed to be defined in blueprints.

<!-- Optional: Link to any related GitHub Issues -->


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.