### PR TITLE
Adding --skip-inspection to compare-suites

### DIFF
--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -86,7 +86,12 @@ class CaseSuite:
         return len(self._cases)
 
     def discover(
-        self, rootDir=None, patterns=None, ignorePatterns=None, recursive=True
+        self,
+        rootDir=None,
+        patterns=None,
+        ignorePatterns=None,
+        recursive=True,
+        skipInspection=False,
     ):
         """
         Finds case objects by searching for a pattern of file paths, and adds them to
@@ -104,6 +109,8 @@ class CaseSuite:
             file patterns to exclude matching file names
         recursive : bool, optional
             if True, recursively search for settings files
+        skipInspection : bool, optional
+            if True, skip running the check inputs
         """
         csFiles = settings.recursivelyLoadSettingsFiles(
             rootDir or os.path.abspath(os.getcwd()),
@@ -115,7 +122,8 @@ class CaseSuite:
 
         for cs in csFiles:
             case = armicase.Case(cs=cs, caseSuite=self)
-            case.checkInputs()
+            if skipInspection:
+                case.checkInputs()
             self.add(case)
 
     def echoConfiguration(self):

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -122,7 +122,7 @@ class CaseSuite:
 
         for cs in csFiles:
             case = armicase.Case(cs=cs, caseSuite=self)
-            if skipInspection:
+            if not skipInspection:
                 case.checkInputs()
             self.add(case)
 

--- a/armi/cli/compareCases.py
+++ b/armi/cli/compareCases.py
@@ -162,6 +162,15 @@ class CompareSuites(CompareCases):
             default=[],
             help="Pattern to search for inputs to ignore.",
         )
+        self.parser.add_argument(
+            "--skip-inspection",
+            "-I",
+            action="store_true",
+            default=False,
+            help="Skip inspection. By default, setting files are checked for integrity and consistency. These "
+            "checks result in needing to manually resolve a number of differences. Using this option will "
+            "suppress the inspection step.",
+        )
 
     def invoke(self):
         from armi import cases
@@ -188,6 +197,7 @@ class CompareSuites(CompareCases):
             rootDir=self.args.reference,
             patterns=allTests,
             ignorePatterns=self.args.ignore,
+            skipInspection=self.args.skip_inspection,
         )
 
         cmpSuite = cases.CaseSuite(self.cs)
@@ -195,6 +205,7 @@ class CompareSuites(CompareCases):
             rootDir=self.args.comparison,
             patterns=self.args.patterns,
             ignorePatterns=self.args.ignore,
+            skipInspection=self.args.skip_inspection,
         )
 
         nIssues = refSuite.compare(

--- a/armi/cli/compareCases.py
+++ b/armi/cli/compareCases.py
@@ -217,4 +217,4 @@ class CompareSuites(CompareCases):
         )
 
         if nIssues > 0:
-            sys.exit(nIssues)
+            sys.exit(1)

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -241,10 +241,11 @@ class TestCompareSuites(unittest.TestCase):
         with TemporaryDirectoryChanger():
             cs = CompareSuites()
             cs.addOptions()
-            cs.parse_args(["/path/to/fake1.h5", "/path/to/fake2.h5"])
+            cs.parse_args(["/path/to/fake1.h5", "/path/to/fake2.h5", "-I"])
 
             self.assertEqual(cs.name, "compare-suites")
             self.assertEqual(cs.args.reference, "/path/to/fake1.h5")
+            self.assertTrue(cs.args.skip_inspection)
             self.assertIsNone(cs.args.weights)
 
 

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -10,6 +10,7 @@ New Features
 ------------
 #. ARMI now supports Python 3.12. (`PR#1813 <https://github.com/terrapower/armi/pull/1813>`_)
 #. Removing the ``tabulate`` dependency by ingesting it to ``armi.utils.tabulate``. (`PR#1811 <https://github.com/terrapower/armi/pull/1811>`_)
+#. Adding ``--skip-inspection`` flag to ``CompareCases`` CLI. (`PR#1841 <https://github.com/terrapower/armi/pull/1842>`_)
 #. TBD
 
 API Changes

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -10,7 +10,7 @@ New Features
 ------------
 #. ARMI now supports Python 3.12. (`PR#1813 <https://github.com/terrapower/armi/pull/1813>`_)
 #. Removing the ``tabulate`` dependency by ingesting it to ``armi.utils.tabulate``. (`PR#1811 <https://github.com/terrapower/armi/pull/1811>`_)
-#. Adding ``--skip-inspection`` flag to ``CompareCases`` CLI. (`PR#1841 <https://github.com/terrapower/armi/pull/1842>`_)
+#. Adding ``--skip-inspection`` flag to ``CompareCases`` CLI. (`PR#1842 <https://github.com/terrapower/armi/pull/1842>`_)
 #. TBD
 
 API Changes


### PR DESCRIPTION
## What is the change?

Adding a `--skip-inspection` flag to the `CompareSuites` CLI, the flag will turn off the `checkInputs()` that validates the settings files in each DB that is being compared.

## Why is the change being made?

A feature request, to help streamline some downstream workflows.

close #1840

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.