### PR TITLE
Allow unknown flags when loading a DB

### DIFF
--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -172,8 +172,10 @@ class FlagSerializer(parameters.Serializer):
                 "The set of flags in the database includes unknown flags. For convenience, we will "
                 f"add these to the system: {missingFlags}"
             )
-            for mFlag in missingFlags:
-                setattr(Flags, mFlag, auto())
+            flagCls.extend({k: auto() for k in missingFlags})
+
+        flagOrderNow = flagCls.sortedFields()
+        flagSetNow = set(flagOrderNow)
 
         if all(i == j for i, j in zip(flagOrderPassed, flagOrderNow)):
             out = [flagCls.from_bytes(row.tobytes()) for row in data]

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -51,6 +51,7 @@ from armi.utils import densityTools
 from armi.utils import tabulate
 from armi.utils import units
 from armi.utils.densityTools import calculateNumberDensity
+from armi.utils.flags import auto
 
 
 class FlagSerializer(parameters.Serializer):
@@ -68,7 +69,7 @@ class FlagSerializer(parameters.Serializer):
     @staticmethod
     def pack(data):
         """
-        Flags are represented as a 2-D numpy array of uint8 (single-byte, unsigned
+        Flags are represented as a 2D numpy array of uint8 (single-byte, unsigned
         integers), where each row contains the bytes representing a single Flags
         instance. We also store the list of field names so that we can verify that the
         reader and the writer can agree on the meaning of each bit.
@@ -103,7 +104,6 @@ class FlagSerializer(parameters.Serializer):
         ----------
         inp : int
             input bitfield
-
         mapping : dict
             dictionary mapping from old bit position -> new bit position
         """
@@ -168,11 +168,12 @@ class FlagSerializer(parameters.Serializer):
         # Make sure that all of the old flags still exist
         if not flagSetIn.issubset(flagSetNow):
             missingFlags = flagSetIn - flagSetNow
-            raise ValueError(
-                "The set of flags in the database includes unknown flags. "
-                "Make sure you are using the correct ARMI app. Missing flags:\n"
-                "{}".format(missingFlags)
+            runLog.warning(
+                "The set of flags in the database includes unknown flags. For convenience, we will "
+                f"add these to the system: {missingFlags}"
             )
+            for mFlag in missingFlags:
+                setattr(Flags, mFlag, auto())
 
         if all(i == j for i, j in zip(flagOrderPassed, flagOrderNow)):
             out = [flagCls.from_bytes(row.tobytes()) for row in data]

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -14,6 +14,7 @@
 
 """Tests for the composite pattern."""
 from copy import deepcopy
+import logging
 import unittest
 
 from armi import nuclearDataIO
@@ -36,6 +37,7 @@ from armi.reactor.flags import Flags, TypeSpec
 from armi.reactor.tests.test_blocks import loadTestBlock
 from armi.reactor.tests.test_reactors import loadTestReactor
 from armi.tests import ISOAA_PATH
+from armi.tests import mockRunLogs
 
 
 class MockBP:
@@ -692,10 +694,19 @@ class TestFlagSerializer(unittest.TestCase):
 
         # missing flags in current version Flags
         attrs["flag_order"].append("NONEXISTANTFLAG")
-        with self.assertRaises(ValueError):
+        with mockRunLogs.BufferLog() as mock:
+            self.assertEqual("", mock.getStdout())
+            testName = "test_flagSerialization"
+            runLog.LOG.startLog(testName)
+            runLog.LOG.setVerbosity(logging.WARNING)
+
             data2 = composites.FlagSerializer.unpack(
                 flagsArray, composites.FlagSerializer.version, attrs
             )
+            flagLog = mock.getStdout()
+
+        self.assertIn("The set of flags", flagLog)
+        self.assertIn("NONEXISTANTFLAG", flagLog)
 
     def test_flagConversion(self):
         data = [


### PR DESCRIPTION
## What is the change?

When loading a DB, just allow any unknown flags. 

My hypothesis here is that a `Flag` contains no information, it is just a name. It's not like a missing `Setting`, `Material`, or geometry shape. All a setting is is the name.

## Why is the change being made?

We recently removed to unused flags, and that caused someone downstream some trouble loading an old DB that still had the flags.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.