### PR TITLE
Cleaning out unused code and adding coverage

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -281,15 +281,13 @@ class FuelHandler:
 
         maxParam : float or list, optional
             a parameter to compare to maxVal for setting upper bounds of acceptable assemblies.
-            If list,
-            must correspond to parameters in maxVal in order.
+            If list, must correspond to parameters in maxVal in order.
 
         minVal : float or list, optional
             a value or a (parameter, multiplier) tuple for setting lower bounds
 
-            For instance, if minParam = 'timeToLimit' and minVal=10, only assemblies with
-            timeToLimit higher than 10 will be returned.  (Of course, there is also maxParam and
-            maxVal)
+            For instance, if minParam='timeToLimit' and minVal=10, only assemblies with timeToLimit
+            higher than 10 will be returned. (Of course, there is also maxParam and maxVal)
 
         maxVal : float or list, optional
             a value or a (parameter, multiplier) tuple for setting upper bounds
@@ -333,20 +331,19 @@ class FuelHandler:
             default: false.
 
         findFromSfp : bool, optional
-            if true, will look in the spent-fuel pool instead of in the core.
+            If true, will look in the spent-fuel pool instead of in the core.
 
         maxNumAssems : int, optional
             The maximum number of assemblies to return. Only relevant if findMany==True
 
         circularRingFlag : bool, optional
-            A flag to toggle on using rings that are based on distance from the center of the
-            reactor
+            Toggle using rings that are based on distance from the center of the reactor
 
         Notes
         -----
-        The call signature on this method may have gotten slightly out of hand as
-        valuable capabilities were added in fuel management studies. For additional expansion,
-        it may be worth reconsidering the design of these query operations ;).
+        The call signature on this method may have gotten slightly out of hand as valuable
+        capabilities were added in fuel management studies. For additional expansion, it may be
+        worth reconsidering the design of these query operations.
 
         Returns
         -------

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -213,9 +213,11 @@ class FuelHandler:
             return candidate[0] < current[0]
 
     @staticmethod
-    def _getParamWithBlockLevelMax(a, paramName, blockLevelMax):
+    def _getParamMax(a, paramName, blockLevelMax=True):
+        """Get parameter with Block-level maximum."""
         if blockLevelMax:
             return a.getChildParamValues(paramName).max()
+
         return a.p[paramName]
 
     def findAssembly(
@@ -412,10 +414,7 @@ class FuelHandler:
             compVal = compareTo * mult
         elif param:
             # assume compareTo is an assembly
-            compVal = (
-                FuelHandler._getParamWithBlockLevelMax(compareTo, param, blockLevelMax)
-                * mult
-            )
+            compVal = FuelHandler._getParamMax(compareTo, param, blockLevelMax) * mult
 
         if coords:
             # find the assembly closest to xt,yt if coords are given without considering params.
@@ -464,18 +463,14 @@ class FuelHandler:
                         if isinstance(minVal, tuple):
                             # tuple turned in. it's a multiplier and a param
                             realMinVal = (
-                                FuelHandler._getParamWithBlockLevelMax(
-                                    a, minVal[0], blockLevelMax
-                                )
+                                FuelHandler._getParamMax(a, minVal[0], blockLevelMax)
                                 * minVal[1]
                             )
                         else:
                             realMinVal = minVal
 
                         if (
-                            FuelHandler._getParamWithBlockLevelMax(
-                                a, minParam, blockLevelMax
-                            )
+                            FuelHandler._getParamMax(a, minParam, blockLevelMax)
                             < realMinVal
                         ):
                             # this assembly does not meet the minVal specifications. Skip it.
@@ -492,18 +487,14 @@ class FuelHandler:
                         if isinstance(maxVal, tuple):
                             # tuple turned in. it's a multiplier and a param
                             realMaxVal = (
-                                FuelHandler._getParamWithBlockLevelMax(
-                                    a, maxVal[0], blockLevelMax
-                                )
+                                FuelHandler._getParamMax(a, maxVal[0], blockLevelMax)
                                 * maxVal[1]
                             )
                         else:
                             realMaxVal = maxVal
 
                         if (
-                            FuelHandler._getParamWithBlockLevelMax(
-                                a, maxParam, blockLevelMax
-                            )
+                            FuelHandler._getParamMax(a, maxParam, blockLevelMax)
                             > realMaxVal
                         ):
                             # this assembly has a maxParam that's higher than maxVal and therefore
@@ -531,26 +522,19 @@ class FuelHandler:
                 # Now find the assembly with the param closest to the target val.
                 if param:
                     diff = abs(
-                        FuelHandler._getParamWithBlockLevelMax(a, param, blockLevelMax)
-                        - compVal
+                        FuelHandler._getParamMax(a, param, blockLevelMax) - compVal
                     )
 
                     if (
                         forceSide == 1
-                        and FuelHandler._getParamWithBlockLevelMax(
-                            a, param, blockLevelMax
-                        )
-                        > compVal
+                        and FuelHandler._getParamMax(a, param, blockLevelMax) > compVal
                         and FuelHandler._compareAssem((diff, a), minDiff)
                     ):
                         # forceSide=1, so that means look in rings further out
                         minDiff = (diff, a)
                     elif (
                         forceSide == -1
-                        and FuelHandler._getParamWithBlockLevelMax(
-                            a, param, blockLevelMax
-                        )
-                        < compVal
+                        and FuelHandler._getParamMax(a, param, blockLevelMax) < compVal
                         and FuelHandler._compareAssem((diff, a), minDiff)
                     ):
                         # forceSide=-1, so that means look in rings closer in from the targetRing

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -54,19 +54,9 @@ class FuelHandler:
     """
 
     def __init__(self, operator):
-        # we need access to the operator to find the core, get settings, grab
-        # other interfaces, etc.
+        # we need access to the operator to find the core, get settings, grab other interfaces, etc.
         self.o = operator
         self.moved = []
-        self._handleBackwardsCompatibility()
-
-    def _handleBackwardsCompatibility(self):
-        # prepSearch used to be part of the API but is deprecated. This will
-        # trigger a warning if it's implemented.
-        # We have to do this hack until we phase out old inputs.
-        # This basically asks: "Did the custom subclass override prepSearch?"
-        if self.prepSearch.__func__ is not FuelHandler.prepSearch:
-            self.prepSearch()
 
     @property
     def cycle(self):
@@ -206,31 +196,6 @@ class FuelHandler:
     def prepCore(self):
         """Aux function to run before XS generation (do moderation, etc)."""
         pass
-
-    def prepSearch(self, *args, **kwargs):
-        """
-        Optional method that can be implemented in preparation of shuffling.
-
-        Often used to prepare the scope of a shuffling branch search.
-
-        Notes
-        -----
-        This was used historically to keep a long-lived fuel handler in sync
-        with the reactor and can now technically be removed from the API, but
-        many historical fuel management inputs still expect it to be called
-        by the framework, so here it remains. New developments should
-        avoid using it. Most code using it has been refactored to just use
-        a ``_prepSearch`` private method.
-
-        It now should not be used and will trigger a DeprecationWarning
-        in the constructor. It's still here because old user-input code
-        calls the parent's prepSearch, which is this.
-        """
-        warnings.warn(
-            "`FuelHandler.prepSearch` is being deprecated from the framework. Please "
-            "change your fuel management input to call this method directly.",
-            DeprecationWarning,
-        )
 
     def findAssembly(
         self,

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -154,13 +154,13 @@ class MockXSGM(CrossSectionGroupManager):
 
 
 class TestFuelHandler(FuelHandlerTestHelper):
-    def test_getParamWithBlockLevelMax(self):
+    def test_getParamMax(self):
         a = self.assembly
 
-        res = fuelHandlers.FuelHandler._getParamWithBlockLevelMax(a, "kInf", True)
+        res = fuelHandlers.FuelHandler._getParamMax(a, "kInf", True)
         self.assertEqual(res, 0.0)
 
-        res = fuelHandlers.FuelHandler._getParamWithBlockLevelMax(a, "kInf", False)
+        res = fuelHandlers.FuelHandler._getParamMax(a, "kInf", False)
         self.assertEqual(res, 0.0)
 
     def test_interactBOC(self):

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -416,8 +416,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         expected = lastB.parent
         self.assertIs(assem, expected)
 
-        # test the impossible: an block with burnup less than
-        # 110% of its own burnup
+        # test the impossible: an block with burnup less than 110% of its own burnup
         assem = fh.findAssembly(
             param="percentBu",
             compareTo=100,

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -212,6 +212,18 @@ class TestFuelHandler(FuelHandlerTestHelper):
         fh.outage(factor=1.0)
         self.assertEqual(len(fh.moved), 0)
 
+    def test_outageEdgeCase(self):
+        class MockFH(fuelHandlers.FuelHandler):
+            def chooseSwaps(self, factor=1.0):
+                self.moved = [None]
+
+        # mock up a fuel handler
+        fh = MockFH(self.o)
+
+        # test edge case
+        with self.assertRaises(AttributeError):
+            fh.outage(factor=1.0)
+
     def test_isAssemblyInAZone(self):
         # build a fuel handler
         fh = fuelHandlers.FuelHandler(self.o)

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -154,6 +154,15 @@ class MockXSGM(CrossSectionGroupManager):
 
 
 class TestFuelHandler(FuelHandlerTestHelper):
+    def test_getParamWithBlockLevelMax(self):
+        a = self.assembly
+
+        res = fuelHandlers.FuelHandler._getParamWithBlockLevelMax(a, "kInf", True)
+        self.assertEqual(res, 0.0)
+
+        res = fuelHandlers.FuelHandler._getParamWithBlockLevelMax(a, "kInf", False)
+        self.assertEqual(res, 0.0)
+
     def test_interactBOC(self):
         # set up mock interface
         self.o.addInterface(MockLatticePhysicsInterface(self.r, self.o.cs))

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -20,9 +20,9 @@ Parent classes for codes responsible for generating broad-group cross sections
 import os
 import shutil
 
+from armi import interfaces
 from armi import nuclearDataIO
-from armi import interfaces, runLog
-from armi.utils import codeTiming
+from armi import runLog
 from armi.physics import neutronics
 from armi.physics.neutronics.const import CONF_CROSS_SECTION
 from armi.physics.neutronics.settings import (
@@ -32,18 +32,10 @@ from armi.physics.neutronics.settings import (
     CONF_XS_KERNEL,
     CONF_LATTICE_PHYSICS_FREQUENCY,
 )
-from armi.utils.customExceptions import important
 from armi.physics.neutronics import LatticePhysicsFrequency
-
+from armi.utils import codeTiming
 
 LATTICE_PHYSICS = "latticePhysics"
-
-
-@important
-def SkippingXsGen_BuChangedLessThanTolerance(tolerance):
-    return "Skipping XS Generation this cycle because median block burnups changes less than {}%".format(
-        tolerance
-    )
 
 
 def setBlockNeutronVelocities(r, neutronVelocities):
@@ -503,9 +495,6 @@ class LatticePhysicsInterface(interfaces.Interface):
                             "Burnup has changed in xsID {} from {} to {}. "
                             "Recalculating Cross-sections".format(xsID, buOld, buNow)
                         )
-
-            if not idsChangedBurnup:
-                SkippingXsGen_BuChangedLessThanTolerance(self._burnupTolerance)
 
         return idsChangedBurnup
 

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -44,6 +44,8 @@ def setBlockNeutronVelocities(r, neutronVelocities):
 
     Parameters
     ----------
+    r : Reactor
+        A Reactor object, that we want to modify.
     neutronVelocities : dict
         Dictionary that is keyed with the ``representativeBlock`` XS IDs with values of multigroup neutron
         velocity data computed by MC2.

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -209,6 +209,9 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         self.latticeInterface.interactCoupled(iteration=1)
         self.assertIsNone(self.o.r.core.lib)
 
+    def test_getSuffix(self):
+        self.assertEqual(self.latticeInterface._getSuffix(7), "")
+
 
 class TestLatticePhysicsLibraryCreation(TestLatticePhysicsInterfaceBase):
     """Test variations of _newLibraryShouldBeCreated."""

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -20,6 +20,9 @@ from armi.physics.neutronics.const import CONF_CROSS_SECTION
 from armi.physics.neutronics.fissionProductModel.fissionProductModelSettings import (
     CONF_FP_MODEL,
 )
+from armi.physics.neutronics.latticePhysics.latticePhysicsInterface import (
+    setBlockNeutronVelocities,
+)
 from armi.physics.neutronics.latticePhysics.latticePhysicsWriter import (
     LatticePhysicsWriter,
 )
@@ -65,6 +68,13 @@ class TestLatticePhysicsWriter(unittest.TestCase):
         )
         self.block = self.r.core.getFirstBlock()
         self.w = FakeLatticePhysicsWriter(self.block, self.r, self.o)
+
+    def test_setBlockNeutronVelocities(self):
+        d = defaultdict(float)
+        d["AA"] = 10.0
+        setBlockNeutronVelocities(self.r, d)
+        tot = sum([b.p.mgNeutronVelocity for b in self.r.core.getBlocks()])
+        self.assertGreater(tot, 3000.0)
 
     def test_latticePhysicsWriter(self):
         """Super basic test of the LatticePhysicsWriter."""

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -701,6 +701,16 @@ class TestCrossSectionGroupManager(unittest.TestCase):
         self.csm._setBuGroupBounds([3, 10, 30, 100])
         self.csm.interactBOL()
 
+    def test_enableBuGroupUpdates(self):
+        self.csm._buGroupUpdatesEnabled = False
+        self.csm.enableBuGroupUpdates()
+        self.assertTrue(self.csm.enableBuGroupUpdates)
+
+    def test_disableBuGroupUpdates(self):
+        self.csm._buGroupUpdatesEnabled = False
+        res = self.csm.disableBuGroupUpdates()
+        self.assertFalse(res)
+
     def test_updateBurnupGroups(self):
         self.blockList[1].p.percentBu = 3.1
         self.blockList[2].p.percentBu = 10.0

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -175,7 +175,6 @@ class FlagSerializer(parameters.Serializer):
             flagCls.extend({k: auto() for k in missingFlags})
 
         flagOrderNow = flagCls.sortedFields()
-        flagSetNow = set(flagOrderNow)
 
         if all(i == j for i, j in zip(flagOrderPassed, flagOrderNow)):
             out = [flagCls.from_bytes(row.tobytes()) for row in data]

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -15,6 +15,8 @@ New Features
 API Changes
 -----------
 #. Removing flags ``CORE`` and ``REACTOR``. (`PR#1835 <https://github.com/terrapower/armi/pull/1835>`_)
+#. Removing deprecated method ``prepSearch``. (`PR#1845 <https://github.com/terrapower/armi/pull/1845>`_)
+#. Removing unused function ``SkippingXsGen_BuChangedLessThanTolerance``. (`PR#1845 <https://github.com/terrapower/armi/pull/1845>`_)
 #. TBD
 
 Bug Fixes


### PR DESCRIPTION
## What is the change?

This is just a general cleanup PR.

1. Removed `prepSearch()`, which was fully deprecated years ago, and verified that it wasn't used anywhere downstream.
2. Removed a strange staticmethod `SkippingXsGen_BuChangedLessThanTolerance`, which was fundamentally unused.
3. Fixed the `interactBOL` test in DB interface to stop leaving test crumbs (FINALLY, this took a long time to find).
4. Moved two functions that were inside the `FuelHandler.getAssembly()` out of that function, to make them testable.
5. Added a ton some generic code coverage.

## Why is the change being made?

I just ran afoul of the deprecated function, and wanted to do some cleanup.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.