### PR TITLE
Rotation cleanup: Remove Assembly.rotatePins, make Block.rotatePins private

### DIFF
--- a/armi/physics/fuelCycle/assemblyRotationAlgorithms.py
+++ b/armi/physics/fuelCycle/assemblyRotationAlgorithms.py
@@ -31,6 +31,7 @@ from armi.physics.fuelCycle.settings import CONF_ASSEM_ROTATION_STATIONARY
 
 
 def _rotationNumberToRadians(rot: int) -> float:
+    """Convert a rotation number to radians, assuming a HexAssembly."""
     return rot * math.pi / 3
 
 

--- a/armi/physics/fuelCycle/assemblyRotationAlgorithms.py
+++ b/armi/physics/fuelCycle/assemblyRotationAlgorithms.py
@@ -76,7 +76,6 @@ def _rotateByComparingLocations(aNow, aPrev):
     aPrev : Assembly
         Assembly that previously occupied the location of this assembly.
         If ``aNow`` has not been moved, this should be ``aNow``
-
     """
     rot = getOptimalAssemblyOrientation(aNow, aPrev)
     radians = _rotationNumberToRadians(rot)

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -24,6 +24,7 @@ import math
 import numpy as np
 
 from armi import runLog
+from armi.utils.hexagon import getIndexOfRotatedCell
 from armi.reactor.flags import Flags
 from armi.utils.mathematics import findClosest
 
@@ -101,10 +102,7 @@ def getOptimalAssemblyOrientation(a, aPrev):
             prevAssemPowHereMIN = float("inf")
 
             for possibleRotation in range(6):
-                # get rotated pin index
-                indexLookup = maxBuBlock.rotatePins(possibleRotation, justCompute=True)
-                # rotated index of highest-BU pin
-                index = int(indexLookup[maxBuPinIndexAssem])
+                index = getIndexOfRotatedCell(maxBuPinIndexAssem, possibleRotation)
                 # get pin power at this index in the previously assembly located here
                 # power previously at rotated index
                 prevAssemPowHere = aPrev[bIndexMaxBu].p.linPowByPin[index - 1]

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1243,8 +1243,7 @@ class Assembly(composites.Composite):
 
             This method loops through every ``Block`` in this ``Assembly`` and rotates
             it by a given angle (in radians). The rotation angle is positive in the
-            counter-clockwise direction, and must be divisible by increments of PI/3
-            (60 degrees). To actually perform the ``Block`` rotation, the
+            counter-clockwise direction. To perform the ``Block`` rotation, the
             :py:meth:`armi.reactor.blocks.Block.rotate` method is called.
 
         Parameters
@@ -1252,9 +1251,6 @@ class Assembly(composites.Composite):
         rad: float
             number (in radians) specifying the angle of counter clockwise rotation
 
-        Warning
-        -------
-        rad must be in 60-degree increments! (i.e., PI/3, PI, 2 * PI/3, etc)
         """
         for b in self:
             b.rotate(rad)
@@ -1267,7 +1263,27 @@ class Assembly(composites.Composite):
 class HexAssembly(Assembly):
     """Placeholder, so users can explicitly define a hex-based Assembly."""
 
-    pass
+    def rotate(self, rad: float):
+        """Rotate an assembly and its children.
+
+        Parameters
+        ----------
+        rad : float
+            Counter clockwise rotation in radians. **MUST** be in increments of
+            60 degrees (PI / 3)
+
+        Raises
+        ------
+        ValueError
+            If rotation is not divisible by pi / 3.
+
+        """
+        if math.isclose(rad % (math.pi / 3), 0, abs_tol=1e-12):
+            return super().rotate(rad)
+        raise ValueError(
+            f"Rotation must be in 60 degree increments, got {math.degrees(rad)} "
+            f"degrees ({rad} radians)"
+        )
 
 
 class CartesianAssembly(Assembly):

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1243,7 +1243,7 @@ class Assembly(composites.Composite):
 
             This method loops through every ``Block`` in this ``Assembly`` and rotates
             it by a given angle (in radians). The rotation angle is positive in the
-            counter-clockwise direction, and must be divisible by increments of PI/6
+            counter-clockwise direction, and must be divisible by increments of PI/3
             (60 degrees). To actually perform the ``Block`` rotation, the
             :py:meth:`armi.reactor.blocks.Block.rotate` method is called.
 
@@ -1254,9 +1254,9 @@ class Assembly(composites.Composite):
 
         Warning
         -------
-        rad must be in 60-degree increments! (i.e., PI/6, PI/3, PI, 2 * PI/3, etc)
+        rad must be in 60-degree increments! (i.e., PI/3, PI, 2 * PI/3, etc)
         """
-        for b in self.getBlocks():
+        for b in self:
             b.rotate(rad)
 
     def isOnWhichSymmetryLine(self):

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -315,11 +315,6 @@ class Assembly(composites.Composite):
 
         return sum(plenumTemps) / len(plenumTemps)
 
-    def rotatePins(self, *args, **kwargs):
-        """Rotate an assembly, which means rotating the indexing of pins."""
-        for b in self:
-            b.rotatePins(*args, **kwargs)
-
     def doubleResolution(self):
         """
         Turns each block into two half-size blocks.

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1276,7 +1276,6 @@ class HexAssembly(Assembly):
         ------
         ValueError
             If rotation is not divisible by pi / 3.
-
         """
         if math.isclose(rad % (math.pi / 3), 0, abs_tol=1e-12):
             return super().rotate(rad)

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2032,6 +2032,25 @@ class HexBlock(Block):
         """
         rotNum = round((rad % (2 * math.pi)) / math.radians(60))
         self.rotatePins(rotNum)
+        self._rotateBoundaryParameters(rotNum)
+        # This specifically uses the .get() functionality to avoid an error if this
+        # parameter does not exist.
+        dispx = self.p.get("displacementX")
+        dispy = self.p.get("displacementY")
+        if (dispx is not None) and (dispy is not None):
+            self.p.displacementX = dispx * math.cos(rad) - dispy * math.sin(rad)
+            self.p.displacementY = dispx * math.sin(rad) + dispy * math.cos(rad)
+
+    def _rotateBoundaryParameters(self, rotNum: int):
+        """Rotate any parameters defined on the corners or edge of bounding hexagon.
+
+        Parameters
+        ----------
+        rotNum : int
+            Rotation number between zero and five, inclusive, specifying how many
+            rotations have taken place.
+
+        """
         params = self.p.paramDefs.atLocation(ParamLocation.CORNERS).names
         params += self.p.paramDefs.atLocation(ParamLocation.EDGES).names
         for param in params:
@@ -2074,13 +2093,6 @@ class HexBlock(Block):
                     f"b.rotate() method received unexpected data type for {param} on block {self}\n"
                     + f"expected list, np.ndarray, int, or float. received {self.p[param]}"
                 )
-        # This specifically uses the .get() functionality to avoid an error if this
-        # parameter does not exist.
-        dispx = self.p.get("displacementX")
-        dispy = self.p.get("displacementY")
-        if (dispx is not None) and (dispy is not None):
-            self.p.displacementX = dispx * math.cos(rad) - dispy * math.sin(rad)
-            self.p.displacementY = dispx * math.sin(rad) + dispy * math.cos(rad)
 
     def rotatePins(self, rotNum, justCompute=False):
         """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -45,6 +45,7 @@ from armi.reactor.flags import Flags
 from armi.reactor.parameters import ParamLocation
 from armi.utils import densityTools
 from armi.utils import hexagon
+from armi.utils import iterables
 from armi.utils import units
 from armi.utils.plotting import plotBlockFlux
 from armi.utils.units import TRACE_NUMBER_DENSITY
@@ -2049,24 +2050,10 @@ class HexBlock(Block):
         names += self.p.paramDefs.atLocation(ParamLocation.EDGES).names
         for name in names:
             original = self.p[name]
-            if isinstance(original, list):
+            if isinstance(original, (list, np.ndarray)):
                 if len(original) == 6:
-                    self.p[name] = original[-rotNum:] + original[:-rotNum]
-                elif original == []:
-                    # List hasn't been defined yet, no warning needed.
-                    pass
-                else:
-                    msg = (
-                        "No rotation method defined for spatial parameters that aren't "
-                        "defined once per hex edge/corner. No rotation performed "
-                        f"on {name}"
-                    )
-                    runLog.warning(msg)
-            elif isinstance(original, np.ndarray):
-                if len(original) == 6:
-                    self.p[name] = np.concatenate(
-                        (original[-rotNum:], original[:-rotNum])
-                    )
+                    # Rotate by making the -rotNum item be first
+                    self.p[name] = iterables.pivot(original, -rotNum)
                 elif len(original) == 0:
                     # Hasn't been defined yet, no warning needed.
                     pass

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2045,47 +2045,48 @@ class HexBlock(Block):
             rotations have taken place.
 
         """
-        params = self.p.paramDefs.atLocation(ParamLocation.CORNERS).names
-        params += self.p.paramDefs.atLocation(ParamLocation.EDGES).names
-        for param in params:
-            if isinstance(self.p[param], list):
-                if len(self.p[param]) == 6:
-                    self.p[param] = self.p[param][-rotNum:] + self.p[param][:-rotNum]
-                elif self.p[param] == []:
+        names = self.p.paramDefs.atLocation(ParamLocation.CORNERS).names
+        names += self.p.paramDefs.atLocation(ParamLocation.EDGES).names
+        for name in names:
+            original = self.p[name]
+            if isinstance(original, list):
+                if len(original) == 6:
+                    self.p[name] = original[-rotNum:] + original[:-rotNum]
+                elif original == []:
                     # List hasn't been defined yet, no warning needed.
                     pass
                 else:
                     msg = (
                         "No rotation method defined for spatial parameters that aren't "
                         "defined once per hex edge/corner. No rotation performed "
-                        f"on {param}"
+                        f"on {name}"
                     )
                     runLog.warning(msg)
-            elif isinstance(self.p[param], np.ndarray):
-                if len(self.p[param]) == 6:
-                    self.p[param] = np.concatenate(
-                        (self.p[param][-rotNum:], self.p[param][:-rotNum])
+            elif isinstance(original, np.ndarray):
+                if len(original) == 6:
+                    self.p[name] = np.concatenate(
+                        (original[-rotNum:], original[:-rotNum])
                     )
-                elif len(self.p[param]) == 0:
+                elif len(original) == 0:
                     # Hasn't been defined yet, no warning needed.
                     pass
                 else:
                     msg = (
                         "No rotation method defined for spatial parameters that aren't "
                         "defined once per hex edge/corner. No rotation performed "
-                        f"on {param}"
+                        f"on {name}"
                     )
                     runLog.warning(msg)
-            elif isinstance(self.p[param], (int, float)):
+            elif isinstance(original, (int, float)):
                 # this is a scalar and there shouldn't be any rotation.
                 pass
-            elif self.p[param] is None:
+            elif original is None:
                 # param is not set yet. no rotations as well.
                 pass
             else:
                 raise TypeError(
-                    f"b.rotate() method received unexpected data type for {param} on block {self}\n"
-                    + f"expected list, np.ndarray, int, or float. received {self.p[param]}"
+                    f"b.rotate() method received unexpected data type for {name} on block {self}\n"
+                    + f"expected list, np.ndarray, int, or float. received {original}"
                 )
 
     def _rotateDisplacement(self, rad: float):

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2032,7 +2032,7 @@ class HexBlock(Block):
         :py:meth:`rotatePins <armi.reactor.blocks.HexBlock.rotatePins>`
         """
         rotNum = round((rad % (2 * math.pi)) / math.radians(60))
-        self.rotatePins(rotNum)
+        self._rotatePins(rotNum)
         self._rotateBoundaryParameters(rotNum)
         self._rotateDisplacement(rad)
 
@@ -2085,7 +2085,7 @@ class HexBlock(Block):
             self.p.displacementX = dispx * math.cos(rad) - dispy * math.sin(rad)
             self.p.displacementY = dispx * math.sin(rad) + dispy * math.cos(rad)
 
-    def rotatePins(self, rotNum, justCompute=False):
+    def _rotatePins(self, rotNum, justCompute=False):
         """
         Rotate the pins of a block, which means rotating the indexing of pins. Note that this does
         not rotate all block quantities, just the pins.

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2033,13 +2033,7 @@ class HexBlock(Block):
         rotNum = round((rad % (2 * math.pi)) / math.radians(60))
         self.rotatePins(rotNum)
         self._rotateBoundaryParameters(rotNum)
-        # This specifically uses the .get() functionality to avoid an error if this
-        # parameter does not exist.
-        dispx = self.p.get("displacementX")
-        dispy = self.p.get("displacementY")
-        if (dispx is not None) and (dispy is not None):
-            self.p.displacementX = dispx * math.cos(rad) - dispy * math.sin(rad)
-            self.p.displacementY = dispx * math.sin(rad) + dispy * math.cos(rad)
+        self._rotateDisplacement(rad)
 
     def _rotateBoundaryParameters(self, rotNum: int):
         """Rotate any parameters defined on the corners or edge of bounding hexagon.
@@ -2093,6 +2087,15 @@ class HexBlock(Block):
                     f"b.rotate() method received unexpected data type for {param} on block {self}\n"
                     + f"expected list, np.ndarray, int, or float. received {self.p[param]}"
                 )
+
+    def _rotateDisplacement(self, rad: float):
+        # This specifically uses the .get() functionality to avoid an error if this
+        # parameter does not exist.
+        dispx = self.p.get("displacementX")
+        dispy = self.p.get("displacementY")
+        if (dispx is not None) and (dispy is not None):
+            self.p.displacementX = dispx * math.cos(rad) - dispy * math.sin(rad)
+            self.p.displacementY = dispx * math.sin(rad) + dispy * math.cos(rad)
 
     def rotatePins(self, rotNum, justCompute=False):
         """

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2160,13 +2160,11 @@ class HexBlock(Block):
                 # Rotation to reference orientation. Pin locations are pin IDs.
                 pass
             else:
-                # Determine the pin ring. Rotation does not change the pin ring!
-                ring = int(
-                    math.ceil((3.0 + math.sqrt(9.0 - 12.0 * (1.0 - pinNum))) / 6.0)
-                )
+                # Rotation does not change the pin ring!
+                ring = hexagon.numRingsToHoldNumCells(pinNum)
 
-                # Rotate the pin position (within the ring, which does not change)
-                tot_pins = 1 + 3 * ring * (ring - 1)
+                # Rotate the pin position within the ring
+                tot_pins = hexagon.numPositionsInRing(ring)
                 newPinLocation = pinNum + (ring - 1) * rotNum
                 if newPinLocation > tot_pins:
                     newPinLocation -= (ring - 1) * 6

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2017,8 +2017,7 @@ class HexBlock(Block):
         Python list of length 6 in order to be eligible for rotation; all parameters that
         do not meet these two criteria are not rotated.
 
-        The pin indexing, as stored on the pinLocation parameter, is also updated via
-        :py:meth:`rotatePins <armi.reactor.blocks.HexBlock.rotatePins>`.
+        The pin indexing, as stored on the ``pinLocation`` parameter, is also updated.
 
         Parameters
         ----------
@@ -2027,9 +2026,6 @@ class HexBlock(Block):
             in 60-degree increments (i.e., PI/6, PI/3, PI, 2 * PI/3, 5 * PI/6,
             and 2 * PI)
 
-        See Also
-        --------
-        :py:meth:`rotatePins <armi.reactor.blocks.HexBlock.rotatePins>`
         """
         rotNum = round((rad % (2 * math.pi)) / math.radians(60))
         self._rotatePins(rotNum)

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2160,15 +2160,7 @@ class HexBlock(Block):
                 # Rotation to reference orientation. Pin locations are pin IDs.
                 pass
             else:
-                # Rotation does not change the pin ring!
-                ring = hexagon.numRingsToHoldNumCells(pinNum)
-
-                # Rotate the pin position within the ring
-                tot_pins = hexagon.numPositionsInRing(ring)
-                newPinLocation = pinNum + (ring - 1) * rotNum
-                if newPinLocation > tot_pins:
-                    newPinLocation -= (ring - 1) * 6
-
+                newPinLocation = hexagon.getIndexOfRotatedCell(pinNum, rotNum)
                 # Assign "before" and "after" pin indices to the index lookup
                 rotateIndexLookup[pinNum] = newPinLocation
 

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1090,6 +1090,9 @@ class Assembly_TestCase(unittest.TestCase):
             a.rotate(math.radians(120))
             self.assertIn("No rotation method defined", mock.getStdout())
 
+        with self.assertRaisesRegex(ValueError, expected_regex="60 degree"):
+            a.rotate(math.radians(40))
+
     def test_assem_block_types(self):
         """Test that all children of an assembly are blocks, ordered from top to bottom.
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2627,3 +2627,23 @@ class MassConservationTests(unittest.TestCase):
             10,
             "Sum of component mass {0} != total block mass {1}. ".format(tMass, bMass),
         )
+
+
+class EmptyBlockRotateTest(unittest.TestCase):
+    """Rotation tests on an empty hexagonal block.
+
+    Useful for enforcing rotation works on blocks without pins.
+
+    """
+
+    def setUp(self):
+        self.block = blocks.HexBlock("empty")
+
+    def test_orientation(self):
+        """Test the orientation parameter is updated on a rotated empty block."""
+        rotDegrees = 60
+        preRotateOrientation = self.block.p.orientation[2]
+        self.block.rotate(math.radians(rotDegrees))
+        postRotationOrientation = self.block.p.orientation[2]
+        self.assertNotEqual(preRotateOrientation, postRotationOrientation)
+        self.assertEqual(postRotationOrientation, rotDegrees)

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1455,33 +1455,33 @@ class Block_TestCase(unittest.TestCase):
     def test_rotatePins(self):
         b = self.block
         b.setRotationNum(0)
-        index = b.rotatePins(0, justCompute=True)
+        index = b._rotatePins(0, justCompute=True)
         self.assertEqual(b.getRotationNum(), 0)
         self.assertEqual(index[5], 5)
         self.assertEqual(index[2], 2)  # pin 1 is center and never rotates.
 
-        index = b.rotatePins(1)
+        index = b._rotatePins(1)
         self.assertEqual(b.getRotationNum(), 1)
         self.assertEqual(index[2], 3)
         self.assertEqual(b.p.pinLocation[1], 3)
 
-        index = b.rotatePins(1)
+        index = b._rotatePins(1)
         self.assertEqual(b.getRotationNum(), 2)
         self.assertEqual(index[2], 4)
         self.assertEqual(b.p.pinLocation[1], 4)
 
-        index = b.rotatePins(2)
-        index = b.rotatePins(4)  # over-rotate to check modulus
+        index = b._rotatePins(2)
+        index = b._rotatePins(4)  # over-rotate to check modulus
         self.assertEqual(b.getRotationNum(), 2)
         self.assertEqual(index[2], 4)
         self.assertEqual(index[6], 2)
         self.assertEqual(b.p.pinLocation[1], 4)
         self.assertEqual(b.p.pinLocation[5], 2)
 
-        self.assertRaises(ValueError, b.rotatePins, -1)
-        self.assertRaises(ValueError, b.rotatePins, 10)
-        self.assertRaises((ValueError, TypeError), b.rotatePins, None)
-        self.assertRaises((ValueError, TypeError), b.rotatePins, "a")
+        self.assertRaises(ValueError, b._rotatePins, -1)
+        self.assertRaises(ValueError, b._rotatePins, 10)
+        self.assertRaises((ValueError, TypeError), b._rotatePins, None)
+        self.assertRaises((ValueError, TypeError), b._rotatePins, "a")
 
     def test_expandElementalToIsotopics(self):
         r"""Tests the expand to elementals capability."""

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -147,7 +147,7 @@ def numPositionsInRing(ring):
     return (ring - 1) * 6 if ring != 1 else 1
 
 
-def totalPositionUpToRing(ring: int) -> int:
+def totalPositionsUpToRing(ring: int) -> int:
     """Return the number of positions in a hexagon with a given number of rings."""
     return 1 + 3 * ring * (ring - 1)
 
@@ -183,7 +183,7 @@ def getIndexOfRotatedCell(initialCellIndex: int, orientationNumber: int) -> int:
         if orientationNumber == 0:
             return initialCellIndex
         ring = numRingsToHoldNumCells(initialCellIndex)
-        tot_pins = totalPositionUpToRing(ring)
+        tot_pins = totalPositionsUpToRing(ring)
         newPinLocation = initialCellIndex + (ring - 1) * orientationNumber
         if newPinLocation > tot_pins:
             newPinLocation -= (ring - 1) * 6

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -174,7 +174,6 @@ def getIndexOfRotatedCell(initialCellIndex: int, orientationNumber: int) -> int:
     ValueError
         If ``initialCellIndex`` is not positive.
         If ``orientationNumber`` is less than zero or greater than five.
-
     """
     if orientationNumber < 0 or orientationNumber > 5:
         raise ValueError(

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -145,3 +145,50 @@ def numPositionsInRing(ring):
         rings is indexed to 1, i.e. the centermost position in the lattice is ``ring=1``.
     """
     return (ring - 1) * 6 if ring != 1 else 1
+
+
+def totalPositionUpToRing(ring: int) -> int:
+    """Return the number of positions in a hexagon with a given number of rings."""
+    return 1 + 3 * ring * (ring - 1)
+
+
+def getIndexOfRotatedCell(initialCellIndex: int, orientationNumber: int) -> int:
+    """Obtain a new cell number after placing a hexagon in a new orientation.
+
+    Parameters
+    ----------
+    initialCellIndex : int
+        Positive number for this cell's position in a hexagonal lattice.
+    orientationNumber :
+        Orientation in number of 60 degree, counter clockwise rotations. An orientation
+        of zero means the first cell in each ring of a flags up hexagon is in the upper
+        right corner.
+
+    Returns
+    -------
+    int
+        New cell number across the rotation
+
+    Raises
+    ------
+    ValueError
+        If ``initialCellIndex`` is not positive.
+        If ``orientationNumber`` is less than zero or greater than five.
+
+    """
+    if orientationNumber < 0 or orientationNumber > 5:
+        raise ValueError(
+            f"Orientation number must be in [0:5], got {orientationNumber}"
+        )
+    if initialCellIndex > 1:
+        if orientationNumber == 0:
+            return initialCellIndex
+        ring = numRingsToHoldNumCells(initialCellIndex)
+        tot_pins = totalPositionUpToRing(ring)
+        newPinLocation = initialCellIndex + (ring - 1) * orientationNumber
+        if newPinLocation > tot_pins:
+            newPinLocation -= (ring - 1) * 6
+        return newPinLocation
+    elif initialCellIndex == 1:
+        return initialCellIndex
+    raise ValueError(f"Cell number must be positive, got {initialCellIndex}")

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -18,6 +18,8 @@ import struct
 
 from six.moves import filterfalse, map, xrange, filter
 
+import numpy as np
+
 
 def flatten(lst):
     """Flattens an iterable of iterables by one level.
@@ -241,3 +243,28 @@ class Sequence:
     def __iadd__(self, other):
         self.extend(Sequence(other))
         return self
+
+
+def pivot(items, position: int):
+    """Pivot the items in an iterable to start at a given position.
+
+    Functionally just ``items[position:] + items[:position]`` with
+    some logic to handle numpy arrays (concatenation not summation)
+
+    Parameters
+    ----------
+    items : list or numpy.ndarray
+        Sequence to be re-ordered
+    position : int
+        Position that will be the first item in the sequence after the pivot
+
+    Returns
+    -------
+    list or numpy.ndarray
+
+    """
+    if isinstance(items, np.ndarray):
+        return np.concatenate((items[position:], items[:position]))
+    elif isinstance(items, list):
+        return items[position:] + items[:position]
+    raise TypeError(f"Pivoting {type(items)} not supported : {items}")

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -261,7 +261,6 @@ def pivot(items, position: int):
     Returns
     -------
     list or numpy.ndarray
-
     """
     if isinstance(items, np.ndarray):
         return np.concatenate((items[position:], items[:position]))

--- a/armi/utils/tests/test_hexagon.py
+++ b/armi/utils/tests/test_hexagon.py
@@ -79,7 +79,7 @@ class TestHexagon(unittest.TestCase):
         initialRing = hexagon.numRingsToHoldNumCells(initialCell)
         newRing = hexagon.numRingsToHoldNumCells(newCell)
         self.assertEqual(newRing, initialRing, msg=testInfoMsg)
-        # If we un-rotate, we should get our initial ring
+        # If we un-rotate, we should get our initial cell
         reverseRot = (6 - rot) % 6
         reverseCell = hexagon.getIndexOfRotatedCell(newCell, reverseRot)
         self.assertEqual(reverseCell, initialCell, msg=testInfoMsg)

--- a/armi/utils/tests/test_hexagon.py
+++ b/armi/utils/tests/test_hexagon.py
@@ -113,7 +113,7 @@ class TestHexagon(unittest.TestCase):
             hexagon.getIndexOfRotatedCell(index, 0)
 
     def test_rotatedCellOrientationErrors(self):
-        """ "Test errors for invalid orientation numbers during rotation."""
+        """Test errors for invalid orientation numbers during rotation."""
         for _ in range(self.N_FUZZY_DRAWS):
             upper = random.randint(6, 100)
             self._testRotOrientation(upper)

--- a/armi/utils/tests/test_hexagon.py
+++ b/armi/utils/tests/test_hexagon.py
@@ -84,3 +84,17 @@ class TestHexagon(unittest.TestCase):
         reverseRot = (6 - rot) % 6
         reverseCell = hexagon.getIndexOfRotatedCell(newCell, reverseRot)
         self.assertEqual(reverseCell, initialCell, msg=testInfoMsg)
+
+    def test_positionsUpToRing(self):
+        """Test totalPositionsUpToRing is consistent with numPositionsInRing."""
+        self.assertEqual(hexagon.totalPositionsUpToRing(1), 1)
+        self.assertEqual(hexagon.totalPositionsUpToRing(2), 7)
+        self.assertEqual(hexagon.totalPositionsUpToRing(3), 19)
+
+        totalPositions = 19
+        for ring in range(4, 30):
+            posInThisRing = hexagon.numPositionsInRing(ring)
+            totalPositions += posInThisRing
+            self.assertEqual(
+                hexagon.totalPositionsUpToRing(ring), totalPositions, msg=f"{ring=}"
+            )

--- a/armi/utils/tests/test_hexagon.py
+++ b/armi/utils/tests/test_hexagon.py
@@ -20,6 +20,9 @@ from armi.utils import hexagon
 
 
 class TestHexagon(unittest.TestCase):
+    N_FUZZY_DRAWS: int = 10
+    """Number of random draws to use in some fuzzy testing"""
+
     def test_hexagon_area(self):
         """
         Area of a hexagon.
@@ -97,3 +100,37 @@ class TestHexagon(unittest.TestCase):
             self.assertEqual(
                 hexagon.totalPositionsUpToRing(ring), totalPositions, msg=f"{ring=}"
             )
+
+    def test_rotatedCellIndexErrors(self):
+        """Test errors for non-positive initial cell indices during rotation."""
+        self._testNonPosRotIndex(0)
+        for _ in range(self.N_FUZZY_DRAWS):
+            index = random.randint(-100, -1)
+            self._testNonPosRotIndex(index)
+
+    def _testNonPosRotIndex(self, index: int):
+        with self.assertRaisesRegex(ValueError, ".*must be positive", msg=f"{index=}"):
+            hexagon.getIndexOfRotatedCell(index, 0)
+
+    def test_rotatedCellOrientationErrors(self):
+        """ "Test errors for invalid orientation numbers during rotation."""
+        for _ in range(self.N_FUZZY_DRAWS):
+            upper = random.randint(6, 100)
+            self._testRotOrientation(upper)
+            lower = random.randint(-100, -1)
+            self._testRotOrientation(lower)
+
+    def _testRotOrientation(self, orientation: int):
+        with self.assertRaisesRegex(
+            ValueError, "Orientation number", msg=f"{orientation=}"
+        ):
+            hexagon.getIndexOfRotatedCell(
+                initialCellIndex=1, orientationNumber=orientation
+            )
+
+    def test_indexWithNoRotation(self):
+        """Test that the initial cell location is returned if not rotated."""
+        for _ in range(self.N_FUZZY_DRAWS):
+            ix = random.randint(1, 300)
+            postRotation = hexagon.getIndexOfRotatedCell(ix, orientationNumber=0)
+            self.assertEqual(postRotation, ix)

--- a/armi/utils/tests/test_hexagon.py
+++ b/armi/utils/tests/test_hexagon.py
@@ -46,8 +46,7 @@ class TestHexagon(unittest.TestCase):
         self.assertEqual(hexagon.numPositionsInRing(4), 18)
 
     def test_rotatedCellCenter(self):
-        # Cell one is always the center of the hexagon and its position
-        # is rotation invariant
+        """Test that location of the center cell is invariant through rotation."""
         for rot in range(6):
             self.assertTrue(hexagon.getIndexOfRotatedCell(1, rot), 1)
 

--- a/armi/utils/tests/test_iterables.py
+++ b/armi/utils/tests/test_iterables.py
@@ -16,6 +16,8 @@
 import time
 import unittest
 
+import numpy as np
+
 from armi.utils import iterables
 
 # CONSTANTS
@@ -174,3 +176,21 @@ class TestIterables(unittest.TestCase):
         self.assertEqual(vals[0], 0)
         self.assertEqual(vals[-1], 5)
         self.assertEqual(len(vals), 6)
+
+    def test_listPivot(self):
+        data = list(range(10))
+        loc = 4
+        actual = iterables.pivot(data, loc)
+        self.assertEqual(actual, data[loc:] + data[:loc])
+
+    def test_arrayPivot(self):
+        data = np.arange(10)
+        loc = -7
+        actual = iterables.pivot(data, loc)
+        expected = np.array(iterables.pivot(data.tolist(), loc))
+        self.assertTrue((actual == expected).all(), msg=f"{actual=} != {expected=}")
+        # Catch a silent failure case where pivot doesn't change the iterable
+        self.assertTrue(
+            (actual != data).all(),
+            msg=f"Pre-pivot {data=} should not equal post-pivot {actual=}",
+        )

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -11,6 +11,9 @@ New Features
 #. ARMI now supports Python 3.12. (`PR#1813 <https://github.com/terrapower/armi/pull/1813>`_)
 #. Removing the ``tabulate`` dependency by ingesting it to ``armi.utils.tabulate``. (`PR#1811 <https://github.com/terrapower/armi/pull/1811>`_)
 #. Adding ``--skip-inspection`` flag to ``CompareCases`` CLI. (`PR#1842 <https://github.com/terrapower/armi/pull/1842>`_)
+#. Provide utilities for determining location of a rotated object in a hexagonal lattice:
+   :func:`armi.utils.hexagon.getIndexOfRotatedCell`
+   (`PR#1846 <https://github.com/terrapower/armi/1846`)
 #. TBD
 
 API Changes

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -19,6 +19,9 @@ API Changes
 #. Removing deprecated method ``prepSearch``. (`PR#1845 <https://github.com/terrapower/armi/pull/1845>`_)
 #. Removing unused function ``SkippingXsGen_BuChangedLessThanTolerance``. (`PR#1845 <https://github.com/terrapower/armi/pull/1845>`_)
 #. Allow for unknown Flags when opening a DB. (`PR#1844 <https://github.com/terrapower/armi/pull/1835>`_)
+#. ``Assembly.rotatePins`` and ``Block.rotatePins`` have been removed. Prefer to use
+   :meth:`armi.reactor.assemblies.Assembly.rotate` and meth:`armi.reactor.block.Block.rotate`
+   (`PR#1846 <https://github.com/terrapower/armi/1846`)
 #. TBD
 
 Bug Fixes


### PR DESCRIPTION
## What is the change?

> 🚨 This change does *not* handle the rotation of all parameters that are tracked on pins and need to be rotated. That will come next after this cleanup because that will be a lot harder to manage and test and handle correctly 🚨 

As described in #1533, assembly rotation needed some love.

`Block.rotatePins` didn't do as much as people maybe would like (e.g., rotate parameters) so it is now private. `Block.rotate` should be preferred and will do (hopefully) everything people expect it to do

`Assembly.rotatePins` suffered from the same problem, and now is removed. `Assembly.rotate` should be preferred.

The `justCompute` flag in `Block._rotatePins` caught my eye and I found it was used when determining the new location of a pin with max burnup post-rotation. This means that in order to figure out where one pin would go, we would compute new locations for *every* pin in the block. And then maybe not use that as we rotate the assembly in all the possible orientations. This felt weird so I the "pin location post-rotate" functionality from that method and made it a new utility in `armi.utils.hexagon`. Now, when we are determining the optimal location of a pin during rotation, we just look at the proposed location of that pin.

`Block.rotate` did a lot (and it should!) but the method was very long. So I broke it up into a few private methods that are a bit more contained.

## Why is the change being made?

A large body of work is in progress to handle the parameter rotation. That work will be made easier after this cleanup.

## Other things to (maybe) do

- Remove `justCompute` switch in the now private `Block._rotatePins`? I can't find any usage of it now.
- Move the `Block.setOrientation` calls from `Block._rotatePins` to `Block.rotate`

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.