### PR TITLE
Stopping deploy Docs and Coverage in forked repos

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   build:
+    # Deploying coverage to coveralls.io should not happen on forks
+    if: github.repository == 'terrapower/armi'
     runs-on: ubuntu-24.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   build:
-
+    # Building and deploying docs is broken on forked repos
+    if: github.repository == 'terrapower/armi'
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
## What is the change?

Forked repos have a real problem with ARMI CI right now, because they can't build and deploy the ARMI docs, or coverage, even though those are CI steps.

This PR makes it so forked repos are free from having to deal with "deploying" their own ARMI docs or coverage to coveralls.io.

## Why is the change being made?

I am just trying to support our supporters.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.