### PR TITLE
Adding GitHub content protection rule to CI

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -2,17 +2,20 @@ name: black
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 # use workaround due to: https://github.com/psf/black/issues/2079#issuecomment-812359146
 jobs:
-    check-formatting:
-        runs-on: ubuntu-24.04
-        steps:
-            - uses: actions/checkout@v2
-            - name: Set up Python 3.11
-              uses: actions/setup-python@v2
-              with:
-                python-version: '3.11'
-            - name: Install Black
-              run: pip install 'black==22.6.0'
-            - name: Run black --check .
-              run: black --check .
+  check-formatting:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
+      - name: Install Black
+        run: pip install 'black==22.6.0'
+      - name: Run black --check .
+        run: black --check .

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,5 +1,8 @@
 name: Coverage
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/licensechecker.yaml
+++ b/.github/workflows/licensechecker.yaml
@@ -1,5 +1,10 @@
 name: Check License Lines
+
+permissions:
+  contents: read
+
 on: [push, pull_request]
+
 jobs:
   check-license-lines:
     runs-on: ubuntu-24.04

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,5 +1,8 @@
 name: Linting
 
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/mac_tests.yaml
+++ b/.github/workflows/mac_tests.yaml
@@ -1,5 +1,8 @@
 name: ARMI MacOS Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,5 +1,8 @@
 name: ARMI unit tests
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:

--- a/.github/workflows/validatemanifest.yaml
+++ b/.github/workflows/validatemanifest.yaml
@@ -1,5 +1,8 @@
 name: Validate Manifest
 
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -1,5 +1,8 @@
 name: ARMI Windows tests
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
## What is the change?

I have set our CI workflows to only have "read"-level access to the repository by default. That is, when CI runs, it can clone the repo and build a venv or run tests, but the CI does not have the power to write to the GitHub repository (which it could have with the GitHub auth token you can inject into a GitHub Action).

## Why is the change being made?

GitHub added [this security feature](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions) in 2021. It is not a complete solution onto itself. Anyone on our GitHub "team" could commit code directly to our repo, of course. But we have our repo set such that when someone who isn't on our "team" opens a PR, the CI will not run until the repo Owner approves the workflows. This gives us a chance to review the changes they made.

So it would be a Big Red Flag if someone we don't know opened a PR into our repo, and they had to visibly change this repo setting from "read" to "write", or they just removed the permissions entirely. 

Thus, human intervention is still part of our security system. But this PR provides us another safeguard and a stopgap against security concerns.

For more information [this blog post](https://dev.to/azu/how-to-set-github-actions-s-permissions-hln) was quick and helpful.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.