### PR TITLE
thKernel data type fix

### DIFF
--- a/armi/physics/thermalHydraulics/settings.py
+++ b/armi/physics/thermalHydraulics/settings.py
@@ -34,7 +34,7 @@ def defineSettings():
         ),
         setting.Setting(
             CONF_TH_KERNEL,
-            default=False,
+            default="",
             label="Thermal Hydraulics Kernel",
             description="Name of primary T/H solver in this run",
         ),

--- a/armi/physics/thermalHydraulics/tests/__init__.py
+++ b/armi/physics/thermalHydraulics/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/armi/physics/thermalHydraulics/tests/test_thermalHydraulicsPlugin.py
+++ b/armi/physics/thermalHydraulics/tests/test_thermalHydraulicsPlugin.py
@@ -14,12 +14,10 @@
 
 """Unit tests for the thermal hydraulics plugin."""
 from armi.physics import thermalHydraulics
-from armi.physics.thermalHydraulics.settings import (
-    CONF_DO_TH,
-    CONF_TH_KERNEL
-)
+from armi.physics.thermalHydraulics.settings import CONF_DO_TH, CONF_TH_KERNEL
 from armi.settings import caseSettings
 from armi.tests.test_plugins import TestPlugin
+
 
 class TestThermalHydraulicsPlugin(TestPlugin):
     plugin = thermalHydraulics.ThermalHydraulicsPlugin

--- a/armi/physics/thermalHydraulics/tests/test_thermalHydraulicsPlugin.py
+++ b/armi/physics/thermalHydraulics/tests/test_thermalHydraulicsPlugin.py
@@ -1,0 +1,29 @@
+"""Unit tests for the thermal hydraulics plugin."""
+from armi.physics import thermalHydraulics
+from armi.physics.thermalHydraulics.settings import (
+    CONF_DO_TH,
+    CONF_TH_KERNEL
+)
+from armi.settings import caseSettings
+from armi.tests.test_plugins import TestPlugin
+
+class TestThermalHydraulicsPlugin(TestPlugin):
+    plugin = thermalHydraulics.ThermalHydraulicsPlugin
+
+    def test_thermalHydraulicsSettingsLoaded(self):
+        """Test that the thermal hydraulics case settings are loaded."""
+        cs = caseSettings.Settings()
+
+        self.assertIn(CONF_DO_TH, cs)
+        self.assertIn(CONF_TH_KERNEL, cs)
+
+    def test_thermalHydraulicsSettingsSet(self):
+        """Test that the thermal hydraulics case settings are applied correctly."""
+        cs = caseSettings.Settings()
+        thKernelName = "testKernel"
+
+        cs[CONF_DO_TH] = True
+        cs[CONF_TH_KERNEL] = thKernelName
+
+        self.assertTrue(cs[CONF_DO_TH])
+        self.assertEqual(cs[CONF_TH_KERNEL], thKernelName)

--- a/armi/physics/thermalHydraulics/tests/test_thermalHydraulicsPlugin.py
+++ b/armi/physics/thermalHydraulics/tests/test_thermalHydraulicsPlugin.py
@@ -1,3 +1,17 @@
+# Copyright 2024 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for the thermal hydraulics plugin."""
 from armi.physics import thermalHydraulics
 from armi.physics.thermalHydraulics.settings import (

--- a/armi/physics/thermalHydraulics/tests/test_thermalHydraulicsPlugin.py
+++ b/armi/physics/thermalHydraulics/tests/test_thermalHydraulicsPlugin.py
@@ -39,4 +39,3 @@ class TestThermalHydraulicsPlugin(TestPlugin):
 
         self.assertTrue(cs[CONF_DO_TH])
         self.assertEqual(cs[CONF_TH_KERNEL], thKernelName)
-

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -23,7 +23,7 @@ Bug Fixes
 ---------
 #. Fixed ``DerivedShape.getArea`` for ``cold=True``. (`PR#1831 <https://github.com/terrapower/armi/pull/1831>`_)
 #. Fixed error parsing command line integers in ``ReportsEntryPoint``. (`PR#1824 <https://github.com/terrapower/armi/pull/1824>`_)
-#. Changed data type of ``thKernel`` setting from ``bool`` to ``str`` in ``ThermalHydraulicsPlugin``.
+#. Changed data type of ``thKernel`` setting from ``bool`` to ``str`` in ``ThermalHydraulicsPlugin``. (`PR#1855 <https://github.com/terrapower/armi/pull/1855>`_)
 #. TBD
 
 Quality Work

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -23,6 +23,7 @@ Bug Fixes
 ---------
 #. Fixed ``DerivedShape.getArea`` for ``cold=True``. (`PR#1831 <https://github.com/terrapower/armi/pull/1831>`_)
 #. Fixed error parsing command line integers in ``ReportsEntryPoint``. (`PR#1824 <https://github.com/terrapower/armi/pull/1824>`_)
+#. Changed data type of ``thKernel`` setting from ``bool`` to ``str`` in ``ThermalHydraulicsPlugin``.
 #. TBD
 
 Quality Work


### PR DESCRIPTION
## What is the change?

The thKernel setting is meant to store the name of the primary thermal hydraulics solver for a run. The default value was False, causing the data type of thKernel to be bool. When a user set the value of thKernel to anything in the settings file, it would only be set to True. Changing the default value to an empty string changes its data type to str, allowing the setting to work as originally intended.

This change resolves issue #1854.

## Why is the change being made?

This change is necessary to allow the thKernel setting to work as intended. Without this change, the thKernel can only be set to boolean values. With this change, thKernel can be set to any string.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).
- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.