### PR TITLE
Adding GH Action to close stale PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see: https://github.com/actions/stale
+name: Mark Stale PRs
+
+on:
+  schedule:
+  # once a day at 3:14 AM
+  - cron: '14 3 * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: "This pull request has been automatically marked as stale because it has not had any activity in the last 100 days. It will be closed in 7 days if no further activity occurs. Thank you for your contributions."
+          stale-pr-label: "stale"
+          days-before-pr-stale: 100
+          days-before-pr-close: 7
+          days-before-issue-stale: -1
+          operations-per-run: 100


### PR DESCRIPTION
## What is the change?

Here I add a GitHub Action to automatically warn people after 100 days of inactivity that their PR might be closed. And then 7 days later, the PR is marked "stale" and closed.

NOTE: I did _not_ add issues to this, because ARMI has a open tickets that I have not closed, and they form the backlog I use to plan ARMI work.

## Why is the change being made?

Managing an open source project is hard. And this will help me a tiny bit track my work.

close #1848 

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.