### PR TITLE
Allow merging a solute with zero area

### DIFF
--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -16,17 +16,15 @@
 import copy
 import math
 
-import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.patches import Wedge
+import numpy as np
 from matplotlib.collections import PatchCollection
+from matplotlib.patches import Wedge
 
-from armi.reactor import blocks
-from armi.reactor import grids
-from armi.reactor import components
-from armi.reactor.flags import Flags
 from armi import runLog
+from armi.reactor import blocks, components, grids
+from armi.reactor.flags import Flags
 
 SIN60 = math.sin(math.radians(60.0))
 
@@ -141,12 +139,15 @@ class BlockConverter:
                 "Components are not of compatible shape to be merged "
                 "solute: {}, solvent: {}".format(solute, solvent)
             )
-        if solute.getArea() <= 0 or solvent.getArea() <= 0:
+        if solute.getArea() < 0:
             raise ValueError(
-                "Cannot merge components if either have negative area. "
-                "{} area: {}, {} area : {}".format(
-                    solute, solvent, solute.getArea(), solvent.getArea()
-                )
+                "Cannot merge solute with negative area into a solvent. "
+                "{} area: {}".format(solute, solute.getArea())
+            )
+        if solvent.getArea() <= 0:
+            raise ValueError(
+                "Cannot merge into a solvent with negative or 0 area. "
+                "{} area: {}".format(solvent, solvent.getArea())
             )
 
     def restablishLinks(self, solute, solvent, soluteLinks):

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -72,7 +72,7 @@ def buildSimpleFuelBlockNegativeArea():
     b.add(coolant)
     b.add(intercoolant)
 
-    b.getVolumeFractions()  # TODO: remove, should be no-op when removed self.cached
+    b.getVolumeFractions()
 
     return b
 

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -53,12 +53,13 @@ def buildSimpleFuelBlockNegativeArea():
     fuel = components.Circle("fuel", "UZr", **fuelDims)
     clad = components.Circle("clad", "HT9", **cladDims)
     gapDims = {
-        "Tinput": coldTemp,
-        "Thot": hotTempFuel,
-        "od": clad.id,
-        "id": fuel.od,
-        "mult": 127,
+        "Tinput": 25,
+        "Thot": 600,
+        "od": "clad.id",
+        "id": "fuel.od",
+        "mult": 127.0,
     }
+    gapDims["components"] = {"fuel": fuel, "clad": clad}
     gap = components.Circle("gap", "Void", **gapDims)
     duct = components.Hexagon("duct", "HT9", **ductDims)
     coolant = components.DerivedShape("coolant", "Sodium", **coolDims)

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -18,18 +18,16 @@ import unittest
 
 import numpy as np
 
-from armi.reactor.converters import blockConverters
-from armi.reactor import blocks
-from armi.reactor import components
-from armi.reactor.flags import Flags
-from armi.reactor.tests.test_blocks import loadTestBlock
-from armi.reactor.tests.test_reactors import loadTestReactor, TEST_ROOT
-from armi.utils import hexagon
-from armi.reactor import grids
-from armi.utils.directoryChangers import TemporaryDirectoryChanger
 from armi.physics.neutronics.isotopicDepletion.isotopicDepletionInterface import (
     isDepletable,
 )
+from armi.reactor import blocks, components, grids
+from armi.reactor.converters import blockConverters
+from armi.reactor.flags import Flags
+from armi.reactor.tests.test_blocks import loadTestBlock
+from armi.reactor.tests.test_reactors import TEST_ROOT, loadTestReactor
+from armi.utils import hexagon
+from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class TestBlockConverter(unittest.TestCase):
@@ -87,6 +85,25 @@ class TestBlockConverter(unittest.TestCase):
         self._test_dissolve_multi(
             loadTestBlock(), ["inner liner", "outer liner"], "clad"
         )
+
+    def test_dissolveZeroArea(self):
+        """Test dissolving a zero-area component into another."""
+        self._test_dissolve(loadTestBlock(), "gap2", "outer liner")
+
+    def test_dissolveIntoZeroArea(self):
+        """Test dissolving a component into a zero-area solvent (raises ValueError)."""
+        with self.assertRaises(ValueError):
+            self._test_dissolve(loadTestBlock(), "outer liner", "gap2")
+
+    def test_dissolveNegativeArea(self):
+        """Test dissolving a zero-area component into another."""
+        with self.assertRaises(ValueError):
+            self._test_dissolve(loadTestBlock(cold=False), "gap3", "clad")
+
+    def test_dissolveIntoNegativeArea(self):
+        """Test dissolving a zero-area component into another."""
+        with self.assertRaises(ValueError):
+            self._test_dissolve(loadTestBlock(cold=False), "clad", "gap3")
 
     def _test_dissolve_multi(self, block, soluteNames, solventName):
         converter = blockConverters.MultipleComponentMerger(

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -13,32 +13,31 @@
 # limitations under the License.
 """Tests blocks.py."""
 import copy
+import io
 import math
 import os
 import unittest
 from unittest.mock import MagicMock, patch
-import io
 
 import numpy as np
 from numpy.testing import assert_allclose
 
 from armi import materials, runLog, settings, tests
-from armi.reactor import blueprints
-from armi.reactor.components import basicShapes, complexShapes
 from armi.nucDirectory import nucDir, nuclideBases
+from armi.nuclearDataIO import xsCollections
 from armi.nuclearDataIO.cccc import isotxs
-from armi.physics.neutronics import NEUTRON, GAMMA
+from armi.physics.neutronics import GAMMA, NEUTRON
 from armi.physics.neutronics.settings import (
     CONF_LOADING_FILE,
     CONF_XS_KERNEL,
 )
-from armi.reactor import blocks, components, geometry, grids
+from armi.reactor import blocks, blueprints, components, geometry, grids
+from armi.reactor.components import basicShapes, complexShapes
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_assemblies import makeTestAssembly
 from armi.tests import ISOAA_PATH, TEST_ROOT
 from armi.utils import hexagon, units
 from armi.utils.units import MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
-from armi.nuclearDataIO import xsCollections
 
 NUM_PINS_IN_TEST_BLOCK = 217
 
@@ -151,7 +150,7 @@ def loadTestBlock(cold=True):
         "id": 0.90,
         "mult": NUM_PINS_IN_TEST_BLOCK,
     }
-    outerLiner = components.Circle("outer liner", "HT9", **outerLinerDims)
+    outerLiner = components.Circle("outer liner", "Inconel800", **outerLinerDims)
 
     linerLinerGapDims = {
         "Tinput": hotTempStructure,

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -150,7 +150,7 @@ def loadTestBlock(cold=True):
         "id": 0.90,
         "mult": NUM_PINS_IN_TEST_BLOCK,
     }
-    outerLiner = components.Circle("outer liner", "Inconel800", **outerLinerDims)
+    outerLiner = components.Circle("outer liner", "HT9", **outerLinerDims)
 
     linerLinerGapDims = {
         "Tinput": hotTempStructure,

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -11,6 +11,7 @@ New Features
 #. ARMI now supports Python 3.12. (`PR#1813 <https://github.com/terrapower/armi/pull/1813>`_)
 #. Removing the ``tabulate`` dependency by ingesting it to ``armi.utils.tabulate``. (`PR#1811 <https://github.com/terrapower/armi/pull/1811>`_)
 #. Adding ``--skip-inspection`` flag to ``CompareCases`` CLI. (`PR#1842 <https://github.com/terrapower/armi/pull/1842>`_)
+#. Allow merging a component with zero area into another component (`PR#1858 <https://github.com/terrapower/armi/pull/1858>`_)
 #. TBD
 
 API Changes


### PR DESCRIPTION
## What is the change?

The block converter `mergeComponents` was implemented to not allow merging any components that had zero area. This should be loosened to allow for merging a zero area solute into a non-zero area solvent. 

## Why is the change being made?

There are many situations where we don't care about modeling zero-area components (for example, a gap that has completely closed) and it is helpful to be able to merge these components into another component so that they don't appear on the block.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.