### PR TITLE
Moving test Godiva blueprints to own dir

### DIFF
--- a/armi/reactor/tests/test_rz_reactors.py
+++ b/armi/reactor/tests/test_rz_reactors.py
@@ -18,8 +18,8 @@ import os
 import unittest
 
 from armi import settings
-from armi.tests import TEST_ROOT
 from armi.reactor import reactors
+from armi.tests import TEST_ROOT
 
 
 class TestRZTReactor(unittest.TestCase):
@@ -48,12 +48,11 @@ class TestRZTReactorModern(unittest.TestCase):
         """
         The Godiva benchmark model is a HEU sphere with a radius of 8.74 cm.
 
-        This unit tests loading and verifies the reactor is loaded correctly by
-        comparing volumes against expected volumes for full core (including
-        void boundary conditions) and just the fuel.
+        This tests loading and verifies the reactor is loaded correctly by comparing volumes against
+        expected volumes for full core (including void boundary conditions) and just the fuel.
         """
         cs = settings.Settings(
-            fName=os.path.join(TEST_ROOT, "Godiva.armi.unittest.yaml")
+            fName=os.path.join(TEST_ROOT, "godiva", "godiva.armi.unittest.yaml")
         )
         r = reactors.loadFromCs(cs)
 
@@ -69,7 +68,7 @@ class TestRZTReactorModern(unittest.TestCase):
         for b in r.core.getBlocks():
             reactorVolumes.append(b.getVolume())
             for c in b:
-                if "Godiva" in c.name:
+                if "godiva" in c.name:
                     fuelVolumes.append(c.getVolume())
         # verify the total reactor volume is as expected
         tolerance = 1e-3

--- a/armi/tests/godiva/godiva-blueprints.yaml
+++ b/armi/tests/godiva/godiva-blueprints.yaml
@@ -62,7 +62,7 @@ assemblies:
     specifier: assembly1_1
     blocks:
       - name: block1_1_1
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -85,7 +85,7 @@ assemblies:
           inner_radius: 0.0
           mult: 0.0773080587387085
       - name: block1_1_2
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -97,7 +97,7 @@ assemblies:
           inner_radius: 0.0
           mult: 1.0
       - name: block1_1_3
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -109,7 +109,7 @@ assemblies:
           inner_radius: 0.0
           mult: 1.0
       - name: block1_1_4
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -121,7 +121,7 @@ assemblies:
           inner_radius: 0.0
           mult: 1.0
       - name: block1_1_5
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -180,7 +180,7 @@ assemblies:
     specifier: assembly2_1
     blocks:
       - name: block2_1_1
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -203,7 +203,7 @@ assemblies:
           inner_radius: 3.001
           mult: 0.4045467972755432
       - name: block2_1_2
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -215,7 +215,7 @@ assemblies:
           inner_radius: 3.001
           mult: 1.0
       - name: block2_1_3
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -227,7 +227,7 @@ assemblies:
           inner_radius: 3.001
           mult: 1.0
       - name: block2_1_4
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -239,7 +239,7 @@ assemblies:
           inner_radius: 3.001
           mult: 1.0
       - name: block2_1_5
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -298,7 +298,7 @@ assemblies:
     specifier: assembly3_1
     blocks:
       - name: block3_1_1
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -321,7 +321,7 @@ assemblies:
           inner_radius: 6.002
           mult: 0.9538451991975307
       - name: block3_1_2
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -344,7 +344,7 @@ assemblies:
           inner_radius: 6.002
           mult: 0.3964693546295166
       - name: block3_1_3
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -367,7 +367,7 @@ assemblies:
           inner_radius: 6.002
           mult: 0.12437152862548828
       - name: block3_1_4
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85
@@ -390,7 +390,7 @@ assemblies:
           inner_radius: 6.002
           mult: 0.4006919860839844
       - name: block3_1_5
-        Godiva:
+        godiva:
           shape: RadialSegment
           material: UZr
           Tinput: 26.85

--- a/armi/tests/godiva/godiva.armi.unittest.yaml
+++ b/armi/tests/godiva/godiva.armi.unittest.yaml
@@ -12,7 +12,7 @@ settings:
   genReports: false
   genXS: Neutron
   groupStructure: ARMI45
-  loadingFile: Godiva-blueprints.yaml
+  loadingFile: godiva-blueprints.yaml
   neutronicsKernel: DIF3D-FD
   neutronicsOutputsToSave: All
   neutronicsType: both


### PR DESCRIPTION
## What is the change?

Here I move the test Godiva reactor blueprints to their own directory.

## Why is the change being made?

1. The test directory is always messy and hard to find things in, so I am trying to clean up the area.
2. I expect to have more test reactors in the future, so I am doing a little pre-emptory cleanup.

I note that the Godiva blueprints are _not_ in ARMI's `pyproject.toml` file, so they are not used by anyone outside of ARMI. (They can't be, because they don't come packaged with ARMI.) So this is an extremely safe change.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.