### PR TITLE
Ignore code coverage on type checking

### DIFF
--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -125,10 +125,7 @@ import pluggy
 from armi import pluginManager
 from armi.utils import flags
 
-# Not used during runtime so we could have a coverage drop here. Add the
-# pragma line to tell coverage.py to skip this
-# https://coverage.readthedocs.io/en/stable/excluding.html
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from armi.reactor.composites import Composite
 
 

--- a/armi/reactor/__init__.py
+++ b/armi/reactor/__init__.py
@@ -55,11 +55,7 @@ from typing import Dict, Callable, Union, TYPE_CHECKING
 
 from armi import plugins
 
-# Provide type checking but avoid circular imports
-# Not used during runtime so we could have a coverage drop here. Add the
-# pragma line to tell coverage.py to skip this
-# https://coverage.readthedocs.io/en/stable/excluding.html
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from armi.reactor.reactors import Core
     from armi.reactor.assemblyLists import SpentFuelPool
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,9 @@ exclude_also = [
     "def __repr__",
     "if self\\.debug",
 
+    # Don't complain about missing type checking-only code:
+    "if TYPE_CHECKING",
+
     # Don't complain if tests don't hit defensive assertion code:
     "raise AssertionError",
     "raise KeyboardInterrupt",


### PR DESCRIPTION
## What is the change?

Changed how we ignore this hideous type-checking lines.

## Why is the change being made?

If we add more of this ugly type-checking-only import lines, I don't want to have to track the code coverage with special in-line comments on all of them.

Using the automated tooling in the `pyproject.toml` seems much easier, and will lead to a more consistent result.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.