### PR TITLE
Cleanup out defunct to do comments

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -135,7 +135,7 @@ class TestCompareDB3(unittest.TestCase):
             inputFileName="smallestTestReactor/armiRunSmallest.yaml",
         )
 
-        # create two DBs, identical but for file names
+        # create two DBs, identical but for file names and cycle lengths
         dbs = []
         for lenCycle in range(1, 3):
             # build some test data

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -315,7 +315,6 @@ class TestDatabase3Smaller(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.db.genAuxiliaryData((-1, -1))
 
-    # TODO: This should be expanded.
     def test_replaceNones(self):
         """Super basic test that we handle Nones correctly in database read/writes."""
         data3 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -332,7 +332,6 @@ class TestGriddedBlock(unittest.TestCase):
         self.assertTrue(a1.hasFlags(Flags.FUEL, exact=True))
         self.assertTrue(a2.hasFlags(Flags.FUEL | Flags.TEST, exact=True))
 
-    # TODO: This test passes, but shouldn't.
     def test_densityConsistentWithComponentConstructor(self):
         a1 = self.blueprints.assemDesigns.bySpecifier["IC"].construct(
             self.cs, self.blueprints

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -35,19 +35,10 @@ from armi.reactor.blueprints.gridBlueprint import saveToStream
 
 
 class TestBlueprints(unittest.TestCase):
-    """Test that the basic functionality of faithfully receiving user input to construct
-    ARMI data model objects works as expected.
+    """Test that the basic functionality of faithfully receiving user input to construct ARMI data
+    model objects works as expected.
 
-    Values are hopefully not hardcoded in here, just sanity checks that nothing messed
-    up as this is code has VERY high incidental coverage from other tests.
-
-    NOTE: as it stands it seems a little hard to test more granularity with the
-    blueprints file as each initialization is intended to be a complete load from the
-    input file, and each load also
-    makes calls out to the reactor for some assembly initialization steps.
-
-    TODO: see the above note, and try to test blueprints on a wider range of input
-    files, touching on each failure case.
+    Try to ensure you test for ideas and not exact matches here, to make the tests more robust.
     """
 
     @classmethod

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -504,7 +504,6 @@ class ArmiObject(metaclass=CompositeModelType):
         ----------
         other : ArmiObject
             The object to copy params from
-
         """
         self.p = other.p.__class__()
         for p, val in other.p.items():

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1450,33 +1450,33 @@ class Block_TestCase(unittest.TestCase):
     def test_rotatePins(self):
         b = self.block
         b.setRotationNum(0)
-        index = b.rotatePins(0, justCompute=True)
+        index = b._rotatePins(0, justCompute=True)
         self.assertEqual(b.getRotationNum(), 0)
         self.assertEqual(index[5], 5)
         self.assertEqual(index[2], 2)  # pin 1 is center and never rotates.
 
-        index = b.rotatePins(1)
+        index = b._rotatePins(1)
         self.assertEqual(b.getRotationNum(), 1)
         self.assertEqual(index[2], 3)
         self.assertEqual(b.p.pinLocation[1], 3)
 
-        index = b.rotatePins(1)
+        index = b._rotatePins(1)
         self.assertEqual(b.getRotationNum(), 2)
         self.assertEqual(index[2], 4)
         self.assertEqual(b.p.pinLocation[1], 4)
 
-        index = b.rotatePins(2)
-        index = b.rotatePins(4)  # over-rotate to check modulus
+        index = b._rotatePins(2)
+        index = b._rotatePins(4)  # over-rotate to check modulus
         self.assertEqual(b.getRotationNum(), 2)
         self.assertEqual(index[2], 4)
         self.assertEqual(index[6], 2)
         self.assertEqual(b.p.pinLocation[1], 4)
         self.assertEqual(b.p.pinLocation[5], 2)
 
-        self.assertRaises(ValueError, b.rotatePins, -1)
-        self.assertRaises(ValueError, b.rotatePins, 10)
-        self.assertRaises((ValueError, TypeError), b.rotatePins, None)
-        self.assertRaises((ValueError, TypeError), b.rotatePins, "a")
+        self.assertRaises(ValueError, b._rotatePins, -1)
+        self.assertRaises(ValueError, b._rotatePins, 10)
+        self.assertRaises((ValueError, TypeError), b._rotatePins, None)
+        self.assertRaises((ValueError, TypeError), b._rotatePins, "a")
 
     def test_expandElementalToIsotopics(self):
         r"""Tests the expand to elementals capability."""
@@ -2623,3 +2623,23 @@ class MassConservationTests(unittest.TestCase):
             10,
             "Sum of component mass {0} != total block mass {1}. ".format(tMass, bMass),
         )
+
+
+class EmptyBlockRotateTest(unittest.TestCase):
+    """Rotation tests on an empty hexagonal block.
+
+    Useful for enforcing rotation works on blocks without pins.
+
+    """
+
+    def setUp(self):
+        self.block = blocks.HexBlock("empty")
+
+    def test_orientation(self):
+        """Test the orientation parameter is updated on a rotated empty block."""
+        rotDegrees = 60
+        preRotateOrientation = self.block.p.orientation[2]
+        self.block.rotate(math.radians(rotDegrees))
+        postRotationOrientation = self.block.p.orientation[2]
+        self.assertNotEqual(preRotateOrientation, postRotationOrientation)
+        self.assertEqual(postRotationOrientation, rotDegrees)

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -70,8 +70,6 @@ def buildSimpleFuelBlock():
     b.add(coolant)
     b.add(intercoolant)
 
-    b.getVolumeFractions()  # TODO: remove, should be no-op when removed self.cached
-
     return b
 
 
@@ -231,8 +229,6 @@ def loadTestBlock(cold=True):
     block.add(coolant)
     block.add(duct)
     block.add(interSodium)
-
-    block.getVolumeFractions()  # TODO: remove, should be no-op when removed self.cached
 
     block.setHeight(16.0)
 
@@ -1454,33 +1450,33 @@ class Block_TestCase(unittest.TestCase):
     def test_rotatePins(self):
         b = self.block
         b.setRotationNum(0)
-        index = b._rotatePins(0, justCompute=True)
+        index = b.rotatePins(0, justCompute=True)
         self.assertEqual(b.getRotationNum(), 0)
         self.assertEqual(index[5], 5)
         self.assertEqual(index[2], 2)  # pin 1 is center and never rotates.
 
-        index = b._rotatePins(1)
+        index = b.rotatePins(1)
         self.assertEqual(b.getRotationNum(), 1)
         self.assertEqual(index[2], 3)
         self.assertEqual(b.p.pinLocation[1], 3)
 
-        index = b._rotatePins(1)
+        index = b.rotatePins(1)
         self.assertEqual(b.getRotationNum(), 2)
         self.assertEqual(index[2], 4)
         self.assertEqual(b.p.pinLocation[1], 4)
 
-        index = b._rotatePins(2)
-        index = b._rotatePins(4)  # over-rotate to check modulus
+        index = b.rotatePins(2)
+        index = b.rotatePins(4)  # over-rotate to check modulus
         self.assertEqual(b.getRotationNum(), 2)
         self.assertEqual(index[2], 4)
         self.assertEqual(index[6], 2)
         self.assertEqual(b.p.pinLocation[1], 4)
         self.assertEqual(b.p.pinLocation[5], 2)
 
-        self.assertRaises(ValueError, b._rotatePins, -1)
-        self.assertRaises(ValueError, b._rotatePins, 10)
-        self.assertRaises((ValueError, TypeError), b._rotatePins, None)
-        self.assertRaises((ValueError, TypeError), b._rotatePins, "a")
+        self.assertRaises(ValueError, b.rotatePins, -1)
+        self.assertRaises(ValueError, b.rotatePins, 10)
+        self.assertRaises((ValueError, TypeError), b.rotatePins, None)
+        self.assertRaises((ValueError, TypeError), b.rotatePins, "a")
 
     def test_expandElementalToIsotopics(self):
         r"""Tests the expand to elementals capability."""
@@ -2627,23 +2623,3 @@ class MassConservationTests(unittest.TestCase):
             10,
             "Sum of component mass {0} != total block mass {1}. ".format(tMass, bMass),
         )
-
-
-class EmptyBlockRotateTest(unittest.TestCase):
-    """Rotation tests on an empty hexagonal block.
-
-    Useful for enforcing rotation works on blocks without pins.
-
-    """
-
-    def setUp(self):
-        self.block = blocks.HexBlock("empty")
-
-    def test_orientation(self):
-        """Test the orientation parameter is updated on a rotated empty block."""
-        rotDegrees = 60
-        preRotateOrientation = self.block.p.orientation[2]
-        self.block.rotate(math.radians(rotDegrees))
-        postRotationOrientation = self.block.p.orientation[2]
-        self.assertNotEqual(preRotateOrientation, postRotationOrientation)
-        self.assertEqual(postRotationOrientation, rotDegrees)


### PR DESCRIPTION
## What is the change?

The repo has a ton of `TODO` comments in it. I went through the ones in the test files and found most of them were defunct. (Or I just opened a ticket to cover them later.)

## Why is the change being made?

This is the beginning of me finally doing the work to purge ARMI of all `TODO` statements. I will see if they are still relevant. If they are, I will fix them or make them a ticket.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.