### PR TITLE
Renaming Reactor.moveList to Reactor.moves

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -142,7 +142,7 @@ class FuelHandlerInterface(interfaces.Interface):
 
         This can be used to export shuffling to an external code or to
         perform explicit repeat shuffling in a restart.
-        It creates a ``*SHUFFLES.txt`` file based on the Reactor.moveList structure
+        It creates a ``*SHUFFLES.txt`` file based on the Reactor.moves structure
 
         See Also
         --------
@@ -155,7 +155,7 @@ class FuelHandlerInterface(interfaces.Interface):
             # remember, we put cycle 0 in so we could do BOL branch searches.
             # This also syncs cycles up with external physics kernel cycles.
             out.write("Before cycle {0}:\n".format(cycle + 1))
-            movesThisCycle = self.r.core.moveList.get(cycle)
+            movesThisCycle = self.r.core.moves.get(cycle)
             if movesThisCycle is not None:
                 for (
                     fromLoc,

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -293,7 +293,7 @@ class Core(composites.Composite):
         self.timeOfStart = time.time()
         self.zones = zones.Zones()  # initialize with empty Zones object
         # initialize the list that holds all shuffles
-        self.moveList = {}
+        self.moves = {}
         self.scalarVals = {}
         self._nuclideCategories = {}
         self.typeList = []  # list of block types to convert name - to -number.
@@ -1886,13 +1886,12 @@ class Core(composites.Composite):
     def setMoveList(self, cycle, oldLoc, newLoc, enrichList, assemblyType, assemName):
         """Tracks the movements in terms of locations and enrichments."""
         data = (oldLoc, newLoc, enrichList, assemblyType, assemName)
-        # NOTE: moveList is actually a moveDict (misnomer)
-        if self.moveList.get(cycle) is None:
-            self.moveList[cycle] = []
-        if data in self.moveList[cycle]:
+        if self.moves.get(cycle) is None:
+            self.moves[cycle] = []
+        if data in self.moves[cycle]:
             # remove the old version and throw the new on at the end.
-            self.moveList[cycle].remove(data)
-        self.moveList[cycle].append(data)
+            self.moves[cycle].remove(data)
+        self.moves[cycle].append(data)
 
     def createFreshFeed(self, cs=None):
         """

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -11,10 +11,8 @@ New Features
 #. ARMI now supports Python 3.12. (`PR#1813 <https://github.com/terrapower/armi/pull/1813>`_)
 #. Removing the ``tabulate`` dependency by ingesting it to ``armi.utils.tabulate``. (`PR#1811 <https://github.com/terrapower/armi/pull/1811>`_)
 #. Adding ``--skip-inspection`` flag to ``CompareCases`` CLI. (`PR#1842 <https://github.com/terrapower/armi/pull/1842>`_)
-#. Provide utilities for determining location of a rotated object in a hexagonal lattice:
-   :func:`armi.utils.hexagon.getIndexOfRotatedCell`
-   (`PR#1846 <https://github.com/terrapower/armi/1846`)
-#. Allow merging a component with zero area into another component (`PR#1858 <https://github.com/terrapower/armi/pull/1858>`_)
+#. Provide utilities for determining location of a rotated object in a hexagonal lattice (``getIndexOfRotatedCell``). (`PR#1846 <https://github.com/terrapower/armi/1846`)
+#. Allow merging a component with zero area into another component. (`PR#1858 <https://github.com/terrapower/armi/pull/1858>`_)
 #. TBD
 
 API Changes
@@ -23,9 +21,8 @@ API Changes
 #. Removing deprecated method ``prepSearch``. (`PR#1845 <https://github.com/terrapower/armi/pull/1845>`_)
 #. Removing unused function ``SkippingXsGen_BuChangedLessThanTolerance``. (`PR#1845 <https://github.com/terrapower/armi/pull/1845>`_)
 #. Allow for unknown Flags when opening a DB. (`PR#1844 <https://github.com/terrapower/armi/pull/1835>`_)
-#. ``Assembly.rotatePins`` and ``Block.rotatePins`` have been removed. Prefer to use
-   :meth:`armi.reactor.assemblies.Assembly.rotate` and meth:`armi.reactor.block.Block.rotate`
-   (`PR#1846 <https://github.com/terrapower/armi/1846`)
+#. ``Assembly.rotatePins`` and ``Block.rotatePins`` have been removed. Prefer to use ``Assembly.rotate`` and ``Block.rotate``. (`PR#1846 <https://github.com/terrapower/armi/1846`)
+#. Renaming ``Reactor.moveList`` to ``Reactor.moves``. (`PR#1881 <https://github.com/terrapower/armi/pull/1881>`_)
 #. TBD
 
 Bug Fixes
@@ -39,8 +36,8 @@ Bug Fixes
 
 Quality Work
 ------------
-#. Removing deprecated code (``axialUnitGrid``) (`PR#1809 <https://github.com/terrapower/armi/pull/1809>`_)
-#. Refactoring (``axialExpansionChanger``) (`PR#1861 <https://github.com/terrapower/armi/pull/1861>`_)
+#. Removing deprecated code ``axialUnitGrid``. (`PR#1809 <https://github.com/terrapower/armi/pull/1809>`_)
+#. Refactoring ``axialExpansionChanger``. (`PR#1861 <https://github.com/terrapower/armi/pull/1861>`_)
 #. TBD
 
 Changes that Affect Requirements


### PR DESCRIPTION
## What is the change?

I am renaming `Reactor.moveList` to `Reactor.moves`. 

(There is only one downstream project that I can find that might be affected by this change.)

## Why is the change being made?

The attribute is actually a `dict` and not a `list`. And this is one of the main reasons we don't inject the variable type into the variable name when we write code.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.