### PR TITLE
Provide Parameter.hasCategory

### DIFF
--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -421,6 +421,10 @@ class Parameter:
         """True if parameter is defined at location."""
         return self.location and self.location & loc
 
+    def hasCategory(self, category: str) -> bool:
+        """True if a parameter has a specific category."""
+        return category in self.categories
+
 
 class ParameterDefinitionCollection:
     """

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -456,9 +456,17 @@ class ParameterTests(unittest.TestCase):
         self.assertEqual(p2.categories, set(["awesome", "stuff", "bacon"]))
         self.assertEqual(p3.categories, set(["bacon"]))
 
+        for p in [p1, p2, p3]:
+            self._testCategoryConsistency(p)
+
         self.assertEqual(set(pc.paramDefs.inCategory("awesome")), set([p1, p2]))
         self.assertEqual(set(pc.paramDefs.inCategory("stuff")), set([p1, p2]))
         self.assertEqual(set(pc.paramDefs.inCategory("bacon")), set([p2, p3]))
+
+    def _testCategoryConsistency(self, p: parameters.Parameter):
+        for category in p.categories:
+            self.assertTrue(p.hasCategory(category))
+        self.assertFalse(p.hasCategory("this_shouldnot_exist"))
 
     def test_parameterCollectionsHave__slots__(self):
         """Tests we prevent accidental creation of attributes."""

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -15,6 +15,8 @@ New Features
    :func:`armi.utils.hexagon.getIndexOfRotatedCell`
    (`PR#1846 <https://github.com/terrapower/armi/1846`)
 #. Allow merging a component with zero area into another component (`PR#1858 <https://github.com/terrapower/armi/pull/1858>`_)
+#. Provide :meth:`armi.reactor.parameters.Parameter.hasCategory`
+   (`PR#1886 <https://github.com/terrapower/armi/pull/1886>`_)
 #. TBD
 
 API Changes

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -15,7 +15,7 @@ New Features
    :func:`armi.utils.hexagon.getIndexOfRotatedCell`
    (`PR#1846 <https://github.com/terrapower/armi/1846`)
 #. Allow merging a component with zero area into another component (`PR#1858 <https://github.com/terrapower/armi/pull/1858>`_)
-#. Provide :meth:`armi.reactor.parameters.Parameter.hasCategory`
+#. Provide :meth:`armi.reactor.parameters.Parameter.hasCategory`.
    (`PR#1886 <https://github.com/terrapower/armi/pull/1886>`_)
 #. TBD
 


### PR DESCRIPTION
## What is the change?

Provides `Parameter.hasCategory` to check if a parameter has a given category.

## Why is the change being made?

Closes #1884 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.