### PR TITLE
Streamlining GitHub CI, to be lighter during development

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,6 +13,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     # Deploying coverage to coveralls.io should not happen on forks

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     # Building and deploying docs is broken on forked repos

--- a/.github/workflows/mac_tests.yaml
+++ b/.github/workflows/mac_tests.yaml
@@ -5,11 +5,17 @@ permissions:
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'doc/**'
   pull_request:
     paths-ignore:
       - 'doc/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/.github/workflows/wintests.yaml
+++ b/.github/workflows/wintests.yaml
@@ -5,11 +5,17 @@ permissions:
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'doc/**'
   pull_request:
     paths-ignore:
       - 'doc/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## What is the change?

In this PR, I have made two changes:

* for non-PR commits, I have removed running unit tests on Windows and MacOS (only Linux remains)
* for all CI jobs that take longer than 2 minutes, I have added the hook to "stop current CI job if a new commit is added to that branch"

## Why is the change being made?

We hit a huge GitHub CI queue today, for the first time ever.

I am hopeful that these efficiency improvements will prevent this from happening in the future.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.