### PR TITLE
Making the xsLibrary tests more thread safe

### DIFF
--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -53,8 +53,8 @@ DLAYXS_MCC3 = os.path.join(FIXTURE_DIR_CCCC, "mc2v3.dlayxs")
 UFG_FLUX_EDIT = os.path.join(FIXTURE_DIR, "mc2v3-AA.flux_ufg")
 
 
-class TempFileMixin(unittest.TestCase):
-    """really a test case."""
+class TempFileMixin:
+    """Not a test; just helpful test tooling."""
 
     def setUp(self):
         self.td = TemporaryDirectoryChanger()
@@ -71,7 +71,7 @@ class TempFileMixin(unittest.TestCase):
         )
 
 
-class TestXSLibrary(TempFileMixin):
+class TestXSLibrary(TempFileMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.isotxsAA = isotxs.readBinary(ISOTXS_AA)
@@ -228,7 +228,7 @@ class TestXSLibrary(TempFileMixin):
     def _canWritefromCombined(self, writer, refFile):
         if self.xsLibGenerationErrorStack is not None:
             print(self.xsLibGenerationErrorStack)
-            raise Exception("see stdout for stack trace")
+            raise Exception("See stdout for stack trace")
         # check to make sure they labels overlap... or are actually the same
         writer.writeBinary(self.xsLib, self.testFileName)
         self.assertTrue(filecmp.cmp(refFile, self.testFileName))
@@ -293,13 +293,13 @@ class AbstractTestXSlibraryMerging(TempFileMixin):
 
     Notes
     -----
-    This is just a base class, so it isn't run directly.
+    This is just a base class, it isn't run directly.
     """
 
     def setUp(self):
         TempFileMixin.setUp(self)
-        # load a library that is in the ARMI tree. This should
-        # be a small library with LFPs, Actinides, structure, and coolant
+        # Load a library that is in the ARMI tree. This should be a small library with LFPs,
+        # Actinides, structure, and coolant
         self.libAA = self.getReadFunc()(self.getLibAAPath())
         self.libAB = self.getReadFunc()(self.getLibABPath())
         self.libCombined = self.getReadFunc()(self.getLibAA_ABPath())
@@ -392,7 +392,7 @@ class AbstractTestXSlibraryMerging(TempFileMixin):
         self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
 
 
-class Pmatrx_merge_Tests(AbstractTestXSlibraryMerging):
+class Pmatrx_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
     def getErrorType(self):
         return OSError
 
@@ -426,7 +426,7 @@ class Pmatrx_merge_Tests(AbstractTestXSlibraryMerging):
             dummyXsLib.merge(self.libCombined)
 
 
-class Isotxs_merge_Tests(AbstractTestXSlibraryMerging):
+class Isotxs_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
     def getErrorType(self):
         return OSError
 
@@ -449,7 +449,7 @@ class Isotxs_merge_Tests(AbstractTestXSlibraryMerging):
         return ISOTXS_LUMPED
 
 
-class Gamiso_merge_Tests(AbstractTestXSlibraryMerging):
+class Gamiso_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
     def getErrorType(self):
         return OSError
 
@@ -472,10 +472,10 @@ class Gamiso_merge_Tests(AbstractTestXSlibraryMerging):
         return GAMISO_LUMPED
 
 
-class Combined_merge_Tests(unittest.TestCase):
+class Combined_Merge_Tests(unittest.TestCase):
     def setUp(self):
-        # load a library that is in the ARMI tree. This should
-        # be a small library with LFPs, Actinides, structure, and coolant
+        # Load a library that is in the ARMI tree. This should be a small library with LFPs,
+        # Actinides, structure, and coolant
         self.isotxsAA = isotxs.readBinary(ISOTXS_AA)
         self.gamisoAA = gamiso.readBinary(GAMISO_AA)
         self.pmatrxAA = pmatrx.readBinary(PMATRX_AA)
@@ -490,7 +490,3 @@ class Combined_merge_Tests(unittest.TestCase):
             lib, xsLibrarySuffix="", mergeGammaLibs=True, alternateDirectory=FIXTURE_DIR
         )
         self.assertEqual(set(lib.nuclideLabels), set(self.libCombined.nuclideLabels))
-
-
-# Remove the abstract class, so that it does not run (all tests would fail)
-del AbstractTestXSlibraryMerging

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -287,7 +287,7 @@ class TestGetISOTXSFilesInWorkingDirectory(unittest.TestCase):
         self.assertEqual(set(), container & set(shouldNotBeThere))
 
 
-class TestXSlibraryMerging(TempFileMixin):
+class AbstractTestXSlibraryMerging(TempFileMixin):
     """
     A shared class that defines tests that should be true for all IsotxsLibrary merging.
 
@@ -296,36 +296,14 @@ class TestXSlibraryMerging(TempFileMixin):
     This is just a base class, so it isn't run directly.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.libAA = None
-        cls.libAB = None
-        cls.libCombined = None
-        cls.libLumped = None
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.libAA = None
-        cls.libAB = None
-        cls.libCombined = None
-        cls.libLumped = None
-        del cls.libAA
-        del cls.libAB
-        del cls.libCombined
-        del cls.libLumped
-
     def setUp(self):
         TempFileMixin.setUp(self)
         # load a library that is in the ARMI tree. This should
         # be a small library with LFPs, Actinides, structure, and coolant
-        for attrName, path in [
-            ("libAA", self.getLibAAPath),
-            ("libAB", self.getLibABPath),
-            ("libCombined", self.getLibAA_ABPath),
-            ("libLumped", self.getLibLumpedPath),
-        ]:
-            if getattr(self.__class__, attrName) is None:
-                setattr(self.__class__, attrName, self.getReadFunc()(path()))
+        self.libAA = self.getReadFunc()(self.getLibAAPath())
+        self.libAB = self.getReadFunc()(self.getLibABPath())
+        self.libCombined = self.getReadFunc()(self.getLibAA_ABPath())
+        self.libLumped = self.getReadFunc()(self.getLibLumpedPath())
 
     def getErrorType(self):
         raise NotImplementedError()
@@ -368,16 +346,16 @@ class TestXSlibraryMerging(TempFileMixin):
     def test_mergeEmptyXSLibWithOtherEssentiallyClonesTheOther(self):
         emptyXSLib = xsLibraries.IsotxsLibrary()
         emptyXSLib.merge(self.libAA)
-        self.__class__.libAA = None
+        self.libAA = None
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibAAPath(), self.testFileName))
 
     def test_mergeTwoXSLibFiles(self):
         emptyXSLib = xsLibraries.IsotxsLibrary()
         emptyXSLib.merge(self.libAA)
-        self.__class__.libAA = None
+        self.libAA = None
         emptyXSLib.merge(self.libAB)
-        self.__class__.libAB = None
+        self.libAB = None
         self.assertEqual(
             set(self.libCombined.nuclideLabels), set(emptyXSLib.nuclideLabels)
         )
@@ -388,9 +366,9 @@ class TestXSlibraryMerging(TempFileMixin):
     def test_canRemoveIsotopes(self):
         emptyXSLib = xsLibraries.IsotxsLibrary()
         emptyXSLib.merge(self.libAA)
-        self.__class__.libAA = None
+        self.libAA = None
         emptyXSLib.merge(self.libAB)
-        self.__class__.libAB = None
+        self.libAB = None
         for nucId in [
             "ZR93_7",
             "ZR95_7",
@@ -414,7 +392,7 @@ class TestXSlibraryMerging(TempFileMixin):
         self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
 
 
-class Pmatrx_merge_Tests(TestXSlibraryMerging):
+class Pmatrx_merge_Tests(AbstractTestXSlibraryMerging):
     def getErrorType(self):
         return OSError
 
@@ -448,7 +426,7 @@ class Pmatrx_merge_Tests(TestXSlibraryMerging):
             dummyXsLib.merge(self.libCombined)
 
 
-class Isotxs_merge_Tests(TestXSlibraryMerging):
+class Isotxs_merge_Tests(AbstractTestXSlibraryMerging):
     def getErrorType(self):
         return OSError
 
@@ -471,7 +449,7 @@ class Isotxs_merge_Tests(TestXSlibraryMerging):
         return ISOTXS_LUMPED
 
 
-class Gamiso_merge_Tests(TestXSlibraryMerging):
+class Gamiso_merge_Tests(AbstractTestXSlibraryMerging):
     def getErrorType(self):
         return OSError
 
@@ -495,47 +473,16 @@ class Gamiso_merge_Tests(TestXSlibraryMerging):
 
 
 class Combined_merge_Tests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.isotxsAA = None
-        cls.isotxsAB = None
-        cls.gamisoAA = None
-        cls.gamisoAB = None
-        cls.pmatrxAA = None
-        cls.pmatrxAB = None
-        cls.libCombined = None
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.isotxsAA = None
-        cls.isotxsAB = None
-        cls.gamisoAA = None
-        cls.gamisoAB = None
-        cls.pmatrxAA = None
-        cls.pmatrxAB = None
-        cls.libCombined = None
-        del cls.isotxsAA
-        del cls.isotxsAB
-        del cls.gamisoAA
-        del cls.gamisoAB
-        del cls.pmatrxAA
-        del cls.pmatrxAB
-        del cls.libCombined
-
     def setUp(self):
         # load a library that is in the ARMI tree. This should
         # be a small library with LFPs, Actinides, structure, and coolant
-        for attrName, path, readFunc in [
-            ("isotxsAA", ISOTXS_AA, isotxs.readBinary),
-            ("gamisoAA", GAMISO_AA, gamiso.readBinary),
-            ("pmatrxAA", PMATRX_AA, pmatrx.readBinary),
-            ("isotxsAB", ISOTXS_AB, isotxs.readBinary),
-            ("gamisoAB", GAMISO_AB, gamiso.readBinary),
-            ("pmatrxAB", PMATRX_AB, pmatrx.readBinary),
-            ("libCombined", ISOTXS_AA_AB, isotxs.readBinary),
-        ]:
-            if getattr(self.__class__, attrName) is None:
-                setattr(self.__class__, attrName, readFunc(path))
+        self.isotxsAA = isotxs.readBinary(ISOTXS_AA)
+        self.gamisoAA = gamiso.readBinary(GAMISO_AA)
+        self.pmatrxAA = pmatrx.readBinary(PMATRX_AA)
+        self.isotxsAB = isotxs.readBinary(ISOTXS_AB)
+        self.gamisoAB = gamiso.readBinary(GAMISO_AB)
+        self.pmatrxAB = pmatrx.readBinary(PMATRX_AB)
+        self.libCombined = isotxs.readBinary(ISOTXS_AA_AB)
 
     def test_mergeAllXSLibFiles(self):
         lib = xsLibraries.IsotxsLibrary()
@@ -546,4 +493,4 @@ class Combined_merge_Tests(unittest.TestCase):
 
 
 # Remove the abstract class, so that it does not run (all tests would fail)
-del TestXSlibraryMerging
+del AbstractTestXSlibraryMerging


### PR DESCRIPTION
## What is the change?

I have changed some tests to read in some data files by thread, rather than by class.

## Why is the change being made?

We believe this will make these tests more thread safe.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.