### PR TITLE
Fixing typo in new settingsValidation imports

### DIFF
--- a/armi/operators/settingsValidation.py
+++ b/armi/operators/settingsValidation.py
@@ -24,6 +24,6 @@ DeprecationWarning: This file will disappear in early 2025.
 """
 # ruff: noqa: F401
 
-from armi.settings.settingsValidations import createQueryRevertBadPathToDefault
-from armi.settings.settingsValidations import Inspector
-from armi.settings.settingsValidations import Query
+from armi.settings.settingsValidation import createQueryRevertBadPathToDefault
+from armi.settings.settingsValidation import Inspector
+from armi.settings.settingsValidation import Query


### PR DESCRIPTION
## What is the change?

Fixing typo in new settingsValidation imports

## Why is the change being made?

There was a typo in a recent PR. Fixing it.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.