### PR TITLE
Closing the plot in plotConvertedBlock()

### DIFF
--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -490,6 +490,7 @@ class BlockAvgToCylConverter(BlockConverter):
             plt.savefig(fName)
         else:
             plt.show()
+        plt.close()
         return fName
 
 


### PR DESCRIPTION
## What is the change?

Here I simply added a `plt.close()` line inside a plotting function.

## Why is the change being made?

Leaving plots open can cause havoc with anyone else trying to use `matplotlib` elsewhere in the ecosystem.

close #1904

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.