### PR TITLE
Fixing misleading comment in FuelHandler.swapCascade()

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -885,6 +885,11 @@ class FuelHandler:
         """
         Perform swaps on a list of assemblies.
 
+        Parameters
+        ----------
+        assemList: list
+            A list of assemblies to be shuffled.
+
         Notes
         -----
         [goingOut,inter1,inter2,goingIn]  will go to
@@ -899,16 +904,15 @@ class FuelHandler:
         # first check for duplicates
         for assem in assemList:
             if assemList.count(assem) != 1:
-                runLog.extra("Warning: %s is in the cascade more than once!" % assem)
+                runLog.warning(f"{assem} is in the cascade more than once.")
 
-        # now swap.
+        # now swap
         levels = len(assemList)
         for level in range(levels - 1):
             if not assemList[level + 1]:
-                # If None in the cascade, just skip it. this will lead to slightly unintended shuffling if
-                # the user wasn't careful enough. Their problem.
-                runLog.extra(
-                    "Skipping level %d in the cascade because it is none" % (level + 1)
+                runLog.info(
+                    f"Skipping level {level + 1} in the cascade because it is None. Be careful, "
+                    "this might cause an unexpected shuffling order."
                 )
                 continue
             self.swapAssemblies(assemList[0], assemList[level + 1])


### PR DESCRIPTION
## What is the change?

Fixed a confusing and misleading comment in `FuelHandler.swapCascade()`.

## Why is the change being made?

Just cleanup

The comment was too casual, but also didn't adequately explain the issue. And it wasn't reflected in the log statement on the next line.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.