### PR TITLE
Remove `eqRingSchedule` from test yaml files

### DIFF
--- a/armi/tests/armiRun.yaml
+++ b/armi/tests/armiRun.yaml
@@ -38,9 +38,6 @@ settings:
   epsBurnTime: 0.001
   epsFSAvg: 1e-06
   epsFSPoint: 1e-06
-  eqRingSchedule:
-    - 13
-    - 1
   freshFeedType: igniter fuel
   fuelHandlerName: EquilibriumShuffler
   jumpRingNum: 9

--- a/armi/tests/refTestCartesian.yaml
+++ b/armi/tests/refTestCartesian.yaml
@@ -8,9 +8,6 @@ settings:
   epsBurnTime: 0.001
   epsFSAvg: 1e-06
   epsFSPoint: 1e-06
-  eqRingSchedule:
-    - 13
-    - 1
   freshFeedType: igniter fuel
   jumpRingNum: 9
   loadingFile: refSmallCartesian.yaml


### PR DESCRIPTION
## What is the change?

Remove the `eqRingSchedule` setting from test reactor yaml file.

## Why is the change being made?

This setting is only used by a downstream application and is not defined in the ARMI framework.

<!-- Optional: Link to any related GitHub Issues -->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.