### PR TITLE
Organizing test settings files by category

### DIFF
--- a/armi/tests/ThRZSettings.yaml
+++ b/armi/tests/ThRZSettings.yaml
@@ -1,14 +1,19 @@
 metadata:
   version: uncontrolled
 settings:
+# global
   branchVerbosity: info
   burnSteps: 0
   comment: "Revised benchmark  "
-  db: false
-  genXS: Neutron
   geomFile: ThRZGeom.xml
-  groupStructure: ARMI45
   loadingFile: ThRZloading.yaml
   numProcessors: 12
   outputFileExtension: png
   power: 1000000.0
+
+# database
+  db: false
+
+# neutronics
+  genXS: Neutron
+  groupStructure: ARMI45

--- a/armi/tests/armiRun.yaml
+++ b/armi/tests/armiRun.yaml
@@ -1,4 +1,5 @@
 settings:
+# global
   availabilityFactor: 1
   beta: 0.003454
   branchVerbosity: debug
@@ -6,6 +7,47 @@ settings:
     - 100
   burnSteps: 2
   comment: Simple test input.
+  cycleLength: 2000.0
+  detailAssemLocationsBOL:
+    - 002-001
+  freshFeedType: igniter fuel
+  loadingFile: refSmallReactor.yaml
+  moduleVerbosity:
+    armi.reactor.reactors: info
+  nCycles: 6
+  outputFileExtension: png
+  power: 100000000.0
+  smallRun: true
+  startCycle: 1
+  startNode: 2
+  targetK: 1.002
+  verbosity: extra
+  versions:
+    armi: uncontrolled
+
+# database
+  db: false
+
+# equilibrium
+  eqRingSchedule:
+    - 13
+    - 1
+
+# fuel cycle
+  fuelHandlerName: EquilibriumShuffler
+  jumpRingNum: 9
+  shuffleLogic: refSmallReactorShuffleLogic.py
+
+# neutronics
+  epsFSAvg: 1e-06
+  epsFSPoint: 1e-06
+  loadPadElevation: 200.0
+
+# report
+  genReports: false
+  summarizeAssemDesign: false
+
+# unknown
   crossSectionControl:
     DA:
       geometry: 0D
@@ -31,33 +73,4 @@ settings:
         - gap
       numInternalRings: 1
       numExternalRings: 1
-  cycleLength: 2000.0
-  db: false
-  detailAssemLocationsBOL:
-    - 002-001
   epsBurnTime: 0.001
-  epsFSAvg: 1e-06
-  epsFSPoint: 1e-06
-  eqRingSchedule:
-    - 13
-    - 1
-  freshFeedType: igniter fuel
-  fuelHandlerName: EquilibriumShuffler
-  jumpRingNum: 9
-  loadingFile: refSmallReactor.yaml
-  startCycle: 1
-  startNode: 2
-  loadPadElevation: 200.0
-  genReports: false
-  moduleVerbosity:
-    armi.reactor.reactors: info
-  nCycles: 6
-  outputFileExtension: png
-  power: 100000000.0
-  shuffleLogic: refSmallReactorShuffleLogic.py
-  smallRun: true
-  summarizeAssemDesign: false
-  targetK: 1.002
-  verbosity: extra
-  versions:
-    armi: uncontrolled

--- a/armi/tests/armiRun.yaml
+++ b/armi/tests/armiRun.yaml
@@ -68,6 +68,3 @@ settings:
 # report
   genReports: false
   summarizeAssemDesign: false
-
-# unknown
-  epsBurnTime: 0.001

--- a/armi/tests/armiRun.yaml
+++ b/armi/tests/armiRun.yaml
@@ -25,29 +25,7 @@ settings:
   versions:
     armi: uncontrolled
 
-# database
-  db: false
-
-# equilibrium
-  eqRingSchedule:
-    - 13
-    - 1
-
-# fuel cycle
-  fuelHandlerName: EquilibriumShuffler
-  jumpRingNum: 9
-  shuffleLogic: refSmallReactorShuffleLogic.py
-
-# neutronics
-  epsFSAvg: 1e-06
-  epsFSPoint: 1e-06
-  loadPadElevation: 200.0
-
-# report
-  genReports: false
-  summarizeAssemDesign: false
-
-# unknown
+# cross section
   crossSectionControl:
     DA:
       geometry: 0D
@@ -73,4 +51,28 @@ settings:
         - gap
       numInternalRings: 1
       numExternalRings: 1
+
+# database
+  db: false
+
+# equilibrium
+  eqRingSchedule:
+    - 13
+    - 1
+
+# fuel cycle
+  fuelHandlerName: EquilibriumShuffler
+  jumpRingNum: 9
+  shuffleLogic: refSmallReactorShuffleLogic.py
+
+# neutronics
+  epsFSAvg: 1e-06
+  epsFSPoint: 1e-06
+  loadPadElevation: 200.0
+
+# report
+  genReports: false
+  summarizeAssemDesign: false
+
+# unknown
   epsBurnTime: 0.001

--- a/armi/tests/detailedAxialExpansion/armiRun.yaml
+++ b/armi/tests/detailedAxialExpansion/armiRun.yaml
@@ -1,12 +1,48 @@
 settings:
-  axialExpansion: true
-  detailedAxialExpansion: true
+# global
   beta: 0.003454
   branchVerbosity: debug
   buGroups:
     - 100
   burnSteps: 2
   comment: Simple test input with detailed axial expansion.
+  cycleLength: 2000.0
+  detailAssemLocationsBOL:
+    - 002-001
+  detailedAxialExpansion: true
+  freshFeedType: igniter fuel
+  loadingFile: refSmallReactor.yaml
+  moduleVerbosity:
+    armi.reactor.reactors: info
+  nCycles: 6
+  outputFileExtension: png
+  power: 100000000.0
+  startNode: 1
+  targetK: 1.002
+  verbosity: extra
+  versions:
+    armi: uncontrolled
+
+# database
+  db: false
+
+# fuel cycle
+  fuelHandlerName: EquilibriumShuffler
+  jumpRingNum: 9
+
+# fuel performance
+  axialExpansion: true
+
+# neutronics
+  epsFSAvg: 1e-06
+  epsFSPoint: 1e-06
+  loadPadElevation: 162.5
+
+# report
+  genReports: false
+  summarizeAssemDesign: false
+
+# unknown
   crossSectionControl:
     DA:
       geometry: 0D
@@ -19,26 +55,3 @@ settings:
     XA:
       xsFileLocation:
         - ISOXA
-  cycleLength: 2000.0
-  db: false
-  detailAssemLocationsBOL:
-    - 002-001
-  epsFSAvg: 1e-06
-  epsFSPoint: 1e-06
-  freshFeedType: igniter fuel
-  fuelHandlerName: EquilibriumShuffler
-  jumpRingNum: 9
-  loadingFile: refSmallReactor.yaml
-  startNode: 1
-  loadPadElevation: 162.5
-  genReports: false
-  moduleVerbosity:
-    armi.reactor.reactors: info
-  nCycles: 6
-  outputFileExtension: png
-  power: 100000000.0
-  summarizeAssemDesign: false
-  targetK: 1.002
-  verbosity: extra
-  versions:
-    armi: uncontrolled

--- a/armi/tests/detailedAxialExpansion/armiRun.yaml
+++ b/armi/tests/detailedAxialExpansion/armiRun.yaml
@@ -23,6 +23,20 @@ settings:
   versions:
     armi: uncontrolled
 
+# cross section
+  crossSectionControl:
+    DA:
+      geometry: 0D
+      blockRepresentation: Median
+      criticalBuckling: true
+      externalDriver: true
+      useHomogenizedBlockComposition: false
+      numInternalRings: 1
+      numExternalRings: 1
+    XA:
+      xsFileLocation:
+        - ISOXA
+
 # database
   db: false
 
@@ -41,17 +55,3 @@ settings:
 # report
   genReports: false
   summarizeAssemDesign: false
-
-# unknown
-  crossSectionControl:
-    DA:
-      geometry: 0D
-      blockRepresentation: Median
-      criticalBuckling: true
-      externalDriver: true
-      useHomogenizedBlockComposition: false
-      numInternalRings: 1
-      numExternalRings: 1
-    XA:
-      xsFileLocation:
-        - ISOXA

--- a/armi/tests/refTestCartesian.yaml
+++ b/armi/tests/refTestCartesian.yaml
@@ -25,6 +25,3 @@ settings:
 
 # report
   summarizeAssemDesign: false
-
-# unknown
-  epsBurnTime: 0.001

--- a/armi/tests/refTestCartesian.yaml
+++ b/armi/tests/refTestCartesian.yaml
@@ -1,24 +1,35 @@
 settings:
+# global
   beta: 0.003454
   buGroups:
     - 100
   burnSteps: 0
   comment: Full-core Cartesian input file with a 10x10 cm square pitch.
   cycleLength: 2000.0
-  epsBurnTime: 0.001
-  epsFSAvg: 1e-06
-  epsFSPoint: 1e-06
-  eqRingSchedule:
-    - 13
-    - 1
   freshFeedType: igniter fuel
-  jumpRingNum: 9
   loadingFile: refSmallCartesian.yaml
-  startNode: 1
-  loadPadElevation: 200.0
   outputFileExtension: png
   power: 400000000.0
-  summarizeAssemDesign: false
+  startNode: 1
   targetK: 1.002
   versions:
     armi: uncontrolled
+
+# equilibrium
+  eqRingSchedule:
+    - 13
+    - 1
+
+# fuel cycle
+  jumpRingNum: 9
+
+# neutronics
+  epsFSAvg: 1e-06
+  epsFSPoint: 1e-06
+  loadPadElevation: 200.0
+
+# report
+  summarizeAssemDesign: false
+
+# unknown
+  epsBurnTime: 0.001

--- a/armi/tests/smallestTestReactor/armiRunSmallest.yaml
+++ b/armi/tests/smallestTestReactor/armiRunSmallest.yaml
@@ -3,6 +3,7 @@
 # This is a single-hex-assembly reactor, with only one block.
 
 settings:
+# global
   availabilityFactor: 1
   beta: 0.003454
   branchVerbosity: debug
@@ -10,6 +11,41 @@ settings:
     - 100
   burnSteps: 2
   comment: Simple test input.
+  cycleLength: 2000.0
+  detailAssemLocationsBOL:
+    - 002-001
+  freshFeedType: igniter fuel
+  loadingFile: refSmallestReactor.yaml
+  moduleVerbosity:
+    armi.reactor.reactors: info
+  nCycles: 2
+  outputFileExtension: png
+  power: 1000000.0
+  smallRun: true
+  startCycle: 1
+  startNode: 2
+  targetK: 1.002
+  verbosity: extra
+  versions:
+    armi: uncontrolled
+
+# database
+  db: false
+
+# fuel cycle
+  fuelHandlerName: EquilibriumShuffler
+  jumpRingNum: 9
+
+# neutronics
+  epsFSAvg: 1e-06
+  epsFSPoint: 1e-06
+  loadPadElevation: 200.0
+
+# report
+  genReports: false
+  summarizeAssemDesign: false
+
+# unknown
   crossSectionControl:
     DA:
       geometry: 0D
@@ -35,28 +71,3 @@ settings:
         - gap
       numInternalRings: 1
       numExternalRings: 1
-  cycleLength: 2000.0
-  db: false
-  detailAssemLocationsBOL:
-    - 002-001
-  epsFSAvg: 1e-06
-  epsFSPoint: 1e-06
-  freshFeedType: igniter fuel
-  fuelHandlerName: EquilibriumShuffler
-  jumpRingNum: 9
-  loadingFile: refSmallestReactor.yaml
-  startCycle: 1
-  startNode: 2
-  loadPadElevation: 200.0
-  genReports: false
-  moduleVerbosity:
-    armi.reactor.reactors: info
-  nCycles: 2
-  outputFileExtension: png
-  power: 1000000.0
-  smallRun: true
-  summarizeAssemDesign: false
-  targetK: 1.002
-  verbosity: extra
-  versions:
-    armi: uncontrolled

--- a/armi/tests/smallestTestReactor/armiRunSmallest.yaml
+++ b/armi/tests/smallestTestReactor/armiRunSmallest.yaml
@@ -29,23 +29,7 @@ settings:
   versions:
     armi: uncontrolled
 
-# database
-  db: false
-
-# fuel cycle
-  fuelHandlerName: EquilibriumShuffler
-  jumpRingNum: 9
-
-# neutronics
-  epsFSAvg: 1e-06
-  epsFSPoint: 1e-06
-  loadPadElevation: 200.0
-
-# report
-  genReports: false
-  summarizeAssemDesign: false
-
-# unknown
+# cross section
   crossSectionControl:
     DA:
       geometry: 0D
@@ -71,3 +55,19 @@ settings:
         - gap
       numInternalRings: 1
       numExternalRings: 1
+
+# database
+  db: false
+
+# fuel cycle
+  fuelHandlerName: EquilibriumShuffler
+  jumpRingNum: 9
+
+# neutronics
+  epsFSAvg: 1e-06
+  epsFSPoint: 1e-06
+  loadPadElevation: 200.0
+
+# report
+  genReports: false
+  summarizeAssemDesign: false

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -63,7 +63,6 @@ class C5G7ReactorTests(unittest.TestCase):
             streamVal = mock.getStdout()
             self.assertIn("UraniumOxide", streamVal, msg=streamVal)
             self.assertIn("SaturatedWater", streamVal, msg=streamVal)
-            self.assertIn("invalid settings: fakeBad", streamVal, msg=streamVal)
 
             # test that there are 100 of each high, medium, and low MOX pins
             fuelPinsHigh = b.getComponent(Flags.HIGH | Flags.MOX)

--- a/armi/tests/tutorials/c5g7-settings.yaml
+++ b/armi/tests/tutorials/c5g7-settings.yaml
@@ -1,16 +1,23 @@
 settings:
+# global
   availabilityFactor: 0.9
-  fakeBad: 123456
-  power: 1000000000.0
+  buGroups:
+    - 100
+  burnSteps: 2
+  comment: C5G7 LWR Benchmark inputs
   cycleLength: 411.11
   loadingFile: c5g7-blueprints.yaml
   nCycles: 10
-  burnSteps: 2
-  buGroups:
-    - 100
-  comment: C5G7 LWR Benchmark inputs
-  genXS: Neutron
   numProcessors: 1
-  genReports: false
+  power: 1000000000.0
   versions:
     armi: uncontrolled
+
+# neutronics
+  genXS: Neutron
+
+# report
+  genReports: false
+
+# unknown
+  fakeBad: 123456

--- a/armi/tests/tutorials/c5g7-settings.yaml
+++ b/armi/tests/tutorials/c5g7-settings.yaml
@@ -18,6 +18,3 @@ settings:
 
 # report
   genReports: false
-
-# unknown
-  fakeBad: 123456

--- a/armi/tests/zpprTest.yaml
+++ b/armi/tests/zpprTest.yaml
@@ -18,12 +18,7 @@ settings:
   sortReactor: false # zpprs dont sor the right way. need better component sorting for slab...
   verbosity: extra
 
-# neutronics
-  epsEig: 1e-10
-  genXS: Neutron
-  xsBlockRepresentation: ComponentAverage1DSlab
-
-# unknown
+# cross section
   crossSectionControl:
     AA:
       geometry: 1D slab
@@ -46,3 +41,8 @@ settings:
       numInternalRings: 1
       numExternalRings: 1
       meshSubdivisionsPerCm: 10
+
+# neutronics
+  epsEig: 1e-10
+  genXS: Neutron
+  xsBlockRepresentation: ComponentAverage1DSlab

--- a/armi/tests/zpprTest.yaml
+++ b/armi/tests/zpprTest.yaml
@@ -1,10 +1,29 @@
 metadata:
   version: uncontrolled
 settings:
+# global
+  Tin: 20.0
+  Tout: 20.0
   buGroups:
     - 100
   burnSteps: 0
   comment: ZPPR test case
+  cycleLength: 365.25
+  geomFile: zpprTestGeom.xml
+  loadingFile: 1DslabXSByCompTest.yaml
+  mpiTasksPerNode: 6
+  numProcessors: 12
+  outputFileExtension: pdf
+  power: 75000000.0
+  sortReactor: false # zpprs dont sor the right way. need better component sorting for slab...
+  verbosity: extra
+
+# neutronics
+  epsEig: 1e-10
+  genXS: Neutron
+  xsBlockRepresentation: ComponentAverage1DSlab
+
+# unknown
   crossSectionControl:
     AA:
       geometry: 1D slab
@@ -27,17 +46,3 @@ settings:
       numInternalRings: 1
       numExternalRings: 1
       meshSubdivisionsPerCm: 10
-  cycleLength: 365.25
-  epsEig: 1e-10
-  genXS: Neutron
-  geomFile: zpprTestGeom.xml
-  loadingFile: 1DslabXSByCompTest.yaml
-  mpiTasksPerNode: 6
-  numProcessors: 12
-  outputFileExtension: pdf
-  power: 75000000.0
-  sortReactor: false # zpprs dont sor the right way. need better component sorting for slab...
-  Tin: 20.0
-  Tout: 20.0
-  verbosity: extra
-  xsBlockRepresentation: ComponentAverage1DSlab


### PR DESCRIPTION
## What is the change?

Organized the settings in the test settings files by category.

> Take a look and see what you think. I generated these files via scripting, so I can make tweaks if need be.

## Why is the change being made?

@albeanth [recently suggested](https://github.com/terrapower/armi/discussions/1083) that ARMI settings files could have categories to help us organize them. Now, that is a fun idea, but will be a very large API-breaking change. This PR gives us a lot of the benefits TODAY, as opposed to waiting a long time for ALL of the benefits.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.