### PR TITLE
Mostly parameters related updates to docs

### DIFF
--- a/armi/reactor/parameters/__init__.py
+++ b/armi/reactor/parameters/__init__.py
@@ -71,6 +71,17 @@ of any such types. The type within a given array should be homogeneous. Examples
     >>> b.p.fuelTemp = numpy.array(range(217), dtype=float)
     >>> b.p.fuelTemp[58] = 600
 
+The parameter attributes can be access via the ``paramDefs`` property. Perhaps a user is
+curious about the units of a block parameter:
+
+    >>> defs = b.p.paramDefs
+    >>> defs["heightBOL"]
+    <ParamDef name:heightBOL collectionType:BlockParameterCollection units:cm assigned:29>
+
+    # Or, more simply:
+    >>> defs["heightBOL"].units
+    'cm'
+
 .. note::
 
     There have been many discussions on what the specific name of this module/system

--- a/armi/reactor/parameters/parameterCollections.py
+++ b/armi/reactor/parameters/parameterCollections.py
@@ -431,7 +431,7 @@ class ParameterCollection(metaclass=_ParameterCollectionType):
         Get the :py:class:`ParameterDefinitionCollection` associated with this instance.
 
         This serves as both an alias for the pDefs class attribute, and as a read-only
-        accessor for them. Most non-paramter-system related interactions with an
+        accessor for them. Most non-parameter-system related interactions with an
         object's ``ParameterCollection`` should go through this. In the future, it
         probably makes sense to make the ``pDefs`` that the ``applyDefinitions`` and
         ``ResolveParametersMeta`` things are sensitive to more hidden from outside the

--- a/doc/user/assembly_parameters_report.rst
+++ b/doc/user/assembly_parameters_report.rst
@@ -4,7 +4,8 @@
 Assembly Parameters
 *******************
 
-This document lists all of the Assembly Parameters that are provided by the ARMI Framework.
+This document lists all of the :py:mod:`Assembly Parameters <armi.reactor.assemblyParameters>` that are provided by the
+ARMI Framework. See :py:mod:`armi.reactor.parameters` for use.
 
 .. exec::
    from armi.reactor import assemblies

--- a/doc/user/block_parameters_report.rst
+++ b/doc/user/block_parameters_report.rst
@@ -4,7 +4,8 @@
 Block Parameters
 ****************
 
-This document lists all of the Block Parameters that are provided by the ARMI Framework.
+This document lists all of the :py:mod:`Block Parameters <armi.reactor.blockParameters>` that are provided by the ARMI
+Framework. See :py:mod:`armi.reactor.parameters` for use.
 
 .. exec::
    from armi.reactor import blocks

--- a/doc/user/component_parameters_report.rst
+++ b/doc/user/component_parameters_report.rst
@@ -4,7 +4,8 @@
 Component Parameters
 ********************
 
-This document lists all of the Component Parameters that are provided by the ARMI Framework.
+This document lists all of the :py:mod:`Component Parameters <armi.reactor.components.componentParameters>` that are
+provided by the ARMI Framework. See :py:mod:`armi.reactor.parameters` for use.
 
 .. exec::
    from armi.reactor.components import Component

--- a/doc/user/core_parameters_report.rst
+++ b/doc/user/core_parameters_report.rst
@@ -4,7 +4,8 @@
 Core Parameters
 ***************
 
-This document lists all of the Core Parameters that are provided by the ARMI Framework.
+This document lists all of the Core Parameters that are provided by the ARMI Framework. See
+:py:mod:`armi.reactor.parameters` for use.
 
 .. exec::
    from armi.reactor import reactors

--- a/doc/user/manual_data_access.rst
+++ b/doc/user/manual_data_access.rst
@@ -25,7 +25,8 @@ Accessing Some Interesting Info
 Often times, you may be interested in the geometric dimensions of various blocks. These are stored on the
 :py:mod:`components <armi.reactor.components>`, and may be accessed as follows::
 
-    b = r.core.getFirstBlock(Flags.FUEL) # Depending on how the reactor was loaded, this may need to be ``o.r``.
+    b = r.core.getFirstBlock(Flags.FUEL)
+    # Depending on how the reactor was loaded, this may need to be ``o.r``.
     fuel = b.getComponent(Flags.FUEL)
     od = fuel.getDimension('od',cold=True)  # fuel outer diameter in cm
     odHot = fuel.getDimension('od')  # hot dimension

--- a/doc/user/manual_data_access.rst
+++ b/doc/user/manual_data_access.rst
@@ -25,7 +25,7 @@ Accessing Some Interesting Info
 Often times, you may be interested in the geometric dimensions of various blocks. These are stored on the
 :py:mod:`components <armi.reactor.components>`, and may be accessed as follows::
 
-    b = o.r.core.getFirstBlock(Flags.FUEL)
+    b = r.core.getFirstBlock(Flags.FUEL) # Depending on how the reactor was loaded, this may need to be ``o.r``.
     fuel = b.getComponent(Flags.FUEL)
     od = fuel.getDimension('od',cold=True)  # fuel outer diameter in cm
     odHot = fuel.getDimension('od')  # hot dimension

--- a/doc/user/reactor_parameters_report.rst
+++ b/doc/user/reactor_parameters_report.rst
@@ -4,7 +4,8 @@
 Reactor Parameters
 ******************
 
-This document lists all of the Reactor Parameters that are provided by the ARMI Framework.
+This document lists all of the :py:mod:`Reactor Parameters <armi.reactor.reactorParameters>` that are provided by the
+ARMI Framework. See :py:mod:`armi.reactor.parameters` for use.
 
 .. exec::
    from armi.reactor import reactors


### PR DESCRIPTION
## What is the change?

Some docs/docstring edits!

Giving more links to the parameter module intro as well as adding info about how to get units of a parameter. 

Also added a little clarification based on a stumble they had while walking through the user manual (the UM leads you to have `r`, not `o.r`, but there's plenty of ways you end up with one or the other)

## Why is the change being made?

A user was asking me some questions, and it exposed some potential docs improvements. 

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.