### PR TITLE
Extensibility improvements to axial expansion classes

### DIFF
--- a/armi/reactor/converters/axialExpansionChanger/__init__.py
+++ b/armi/reactor/converters/axialExpansionChanger/__init__.py
@@ -26,4 +26,5 @@ from armi.reactor.converters.axialExpansionChanger.axialExpansionChanger import 
 from armi.reactor.converters.axialExpansionChanger.expansionData import ExpansionData
 from armi.reactor.converters.axialExpansionChanger.expansionData import (
     getSolidComponents,
+    iterSolidComponents,
 )

--- a/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
+++ b/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
@@ -75,9 +75,7 @@ def areAxiallyLinked(componentA: Component, componentB: Component) -> bool:
         odB = componentB.getBoundingCircleOuterDiameter(cold=True)
         biggerID = max(idA, idB)
         smallerOD = min(odA, odB)
-        if biggerID >= smallerOD:
-            return False
-        return True
+        return biggerID < smallerOD
     return False
 
 

--- a/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
+++ b/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
@@ -268,7 +268,7 @@ class AssemblyAxialLinkage:
         for ib, linkdBlk in enumerate(self.linkedBlocks[b]):
             if linkdBlk is not None:
                 for otherC in iterSolidComponents(linkdBlk.getChildren()):
-                    if areAxiallyLinked(c, otherC):
+                    if self.areAxiallyLinked(c, otherC):
                         if lstLinkedC[ib] is not None:
                             errMsg = (
                                 "Multiple component axial linkages have been found for "
@@ -292,3 +292,34 @@ class AssemblyAxialLinkage:
                 f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
                 single=True,
             )
+
+    @staticmethod
+    def areAxiallyLinked(componentA: Component, componentB: Component) -> bool:
+        """Check if two components are axially linked.
+
+        Components are considered linked if the following are found to be true:
+
+        1. Both contain solid materials.
+        2. They have compatible types (e.g., ``Circle`` and ``Circle``).
+        3. Their multiplicities are the same.
+        4. The smallest inner bounding diameter of the two is less than the largest outer
+        bounding diameter of the two.
+
+        Parameters
+        ----------
+        componentA : :py:class:`Component <armi.reactor.components.component.Component>`
+            component of interest
+        componentB : :py:class:`Component <armi.reactor.components.component.Component>`
+            component to compare and see if is linked to componentA
+
+        Returns
+        -------
+        bool
+            Status of linkage check
+
+        See Also
+        --------
+        :func:`areAxiallyLinked` for more details. This method is provided to allow
+        subclasses the ability to override the linkage check.
+        """
+        return areAxiallyLinked(componentA, componentB)

--- a/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
+++ b/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
@@ -284,12 +284,12 @@ class AssemblyAxialLinkage:
 
         self.linkedComponents[c] = lstLinkedC
 
-        if lstLinkedC[0] is None:
+        if self.linkedBlocks[b].lower is None and lstLinkedC.lower is None:
             runLog.debug(
                 f"Assembly {self.a}, Block {b}, Component {c} has nothing linked below it!",
                 single=True,
             )
-        if lstLinkedC[1] is None:
+        if self.linkedBlocks[b].upper is None and lstLinkedC.upper is None:
             runLog.debug(
                 f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
                 single=True,

--- a/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
+++ b/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
@@ -19,7 +19,7 @@ from armi import runLog
 from armi.reactor.blocks import Block
 from armi.reactor.components import Component, UnshapedComponent
 from armi.reactor.converters.axialExpansionChanger.expansionData import (
-    getSolidComponents,
+    iterSolidComponents,
 )
 
 
@@ -191,7 +191,7 @@ class AssemblyAxialLinkage:
         """Gets the block and component based linkage."""
         for b in self.a:
             self._getLinkedBlocks(b)
-            for c in getSolidComponents(b):
+            for c in iterSolidComponents(b):
                 self._getLinkedComponents(b, c)
 
     def _getLinkedBlocks(self, b: Block):
@@ -267,7 +267,7 @@ class AssemblyAxialLinkage:
         lstLinkedC = AxialLink(None, None)
         for ib, linkdBlk in enumerate(self.linkedBlocks[b]):
             if linkdBlk is not None:
-                for otherC in getSolidComponents(linkdBlk.getChildren()):
+                for otherC in iterSolidComponents(linkdBlk.getChildren()):
                     if areAxiallyLinked(c, otherC):
                         if lstLinkedC[ib] is not None:
                             errMsg = (

--- a/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
@@ -154,7 +154,7 @@ class AxialExpansionChanger:
                 b.completeInitialLoading()
 
     def performPrescribedAxialExpansion(
-        self, a: Assembly, componentLst: list, percents: list, setFuel=True
+        self, a: Assembly, components: list, percents: list, setFuel=True
     ):
         """Perform axial expansion/contraction of an assembly given prescribed expansion percentages.
 
@@ -173,10 +173,10 @@ class AxialExpansionChanger:
         ----------
         a : :py:class:`Assembly <armi.reactor.assemblies.Assembly>`
             ARMI assembly to be changed
-        componentLst : list[:py:class:`Component <armi.reactor.components.component.Component>`]
+        components : list[:py:class:`Component <armi.reactor.components.component.Component>`]
             list of Components to be expanded
         percents : list[float]
-            list of expansion percentages for each component listed in componentList
+            list of expansion percentages for each component listed in components
         setFuel : boolean, optional
             Boolean to determine whether or not fuel blocks should have their target components set
             This is useful when target components within a fuel block need to be determined on-the-fly.
@@ -186,7 +186,7 @@ class AxialExpansionChanger:
         - percents may be positive (expansion) or negative (contraction)
         """
         self.setAssembly(a, setFuel)
-        self.expansionData.setExpansionFactors(componentLst, percents)
+        self.expansionData.setExpansionFactors(components, percents)
         self.axiallyExpandAssembly()
 
     def performThermalAxialExpansion(

--- a/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
@@ -21,7 +21,7 @@ from armi.reactor.converters.axialExpansionChanger.assemblyAxialLinkage import (
 )
 from armi.reactor.converters.axialExpansionChanger.expansionData import (
     ExpansionData,
-    getSolidComponents,
+    iterSolidComponents,
 )
 from armi.reactor.flags import Flags
 
@@ -325,7 +325,7 @@ class AxialExpansionChanger:
                 b.p.zbottom = self.linked.linkedBlocks[b][0].p.ztop
             isDummyBlock = ib == (numOfBlocks - 1)
             if not isDummyBlock:
-                for c in getSolidComponents(b):
+                for c in iterSolidComponents(b):
                     growFrac = self.expansionData.getExpansionFactor(c)
                     runLog.debug(msg=f"      Component {c}, growFrac = {growFrac:.4e}")
                     c.height = growFrac * blockHeight

--- a/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Enable component-wise axial expansion for assemblies and/or a reactor."""
+import typing
 
 from numpy import array
 
 from armi import runLog
+from armi.reactor.assemblies import Assembly
 from armi.reactor.converters.axialExpansionChanger.assemblyAxialLinkage import (
     AssemblyAxialLinkage,
 )
@@ -69,6 +71,9 @@ class AxialExpansionChanger:
       for any other assembly type.
     - Useful for fuel performance, thermal expansion, reactivity coefficients, etc.
     """
+
+    linked: typing.Optional[AssemblyAxialLinkage]
+    expansionData: typing.Optional[ExpansionData]
 
     def __init__(self, detailedAxialExpansion: bool = False):
         """
@@ -149,7 +154,7 @@ class AxialExpansionChanger:
                 b.completeInitialLoading()
 
     def performPrescribedAxialExpansion(
-        self, a, componentLst: list, percents: list, setFuel=True
+        self, a: Assembly, componentLst: list, percents: list, setFuel=True
     ):
         """Perform axial expansion/contraction of an assembly given prescribed expansion percentages.
 
@@ -186,7 +191,7 @@ class AxialExpansionChanger:
 
     def performThermalAxialExpansion(
         self,
-        a,
+        a: Assembly,
         tempGrid: list,
         tempField: list,
         setFuel: bool = True,
@@ -233,7 +238,7 @@ class AxialExpansionChanger:
         self.linked = None
         self.expansionData = None
 
-    def setAssembly(self, a, setFuel=True, expandFromTinputToThot=False):
+    def setAssembly(self, a: Assembly, setFuel=True, expandFromTinputToThot=False):
         """Set the armi assembly to be changed and init expansion data class for assembly.
 
         Parameters

--- a/armi/reactor/converters/axialExpansionChanger/expansionData.py
+++ b/armi/reactor/converters/axialExpansionChanger/expansionData.py
@@ -57,26 +57,36 @@ def getSolidComponents(b: "Block") -> list["Component"]:
 
 
 class ExpansionData:
-    """Data container for axial expansion."""
+    r"""Data container for axial expansion.
+
+    The primary responsibility of this class is to determine the axial expansion factors
+    for each component in the assembly. Expansion factors can be compute from the component
+    temperatures in :meth:`computeThermalExpansionFactors` or provided directly to the class
+    via :meth:`setExpansionFactors`.
+
+    This class relies on the concept of a "target" expansion component for each block. While
+    components will expand at different rates, the final height of the block must be determined.
+    The target component, determined by :meth:`determineTargetComponents`\, will drive the total
+    height of the block post-expansion.
+
+    Parameters
+    ----------
+    a: :py:class:`Assembly <armi.reactor.assemblies.Assembly>`
+        Assembly to assign component-wise expansion data to
+    setFuel: bool
+        used to determine if fuel component should be set as
+        axial expansion target component during initialization.
+        see self._isFuelLocked
+    expandFromTinputToThot: bool
+        Determines if thermal expansion factors should be caculated from
+            - ``c.inputTemperatureInC`` to ``c.temperatureInC`` when ``True``, or
+            - some other reference temperature and ``c.temperatureInC`` when ``False``
+    """
 
     _expansionFactors: dict["Component", float]
     componentReferenceTemperature: dict["Component", float]
 
     def __init__(self, a: "Assembly", setFuel: bool, expandFromTinputToThot: bool):
-        """
-        Parameters
-        ----------
-        a: :py:class:`Assembly <armi.reactor.assemblies.Assembly>`
-            Assembly to assign component-wise expansion data to
-        setFuel: bool
-            used to determine if fuel component should be set as
-            axial expansion target component during initialization.
-            see self._isFuelLocked
-        expandFromTinputToThot: bool
-            determines if thermal expansion factors should be calculated
-            from c.inputTemperatureInC to c.temperatureInC (True) or some other
-            reference temperature and c.temperatureInC (False)
-        """
         self._a = a
         self.componentReferenceTemperature = {}
         self._expansionFactors = {}

--- a/armi/reactor/converters/axialExpansionChanger/expansionData.py
+++ b/armi/reactor/converters/axialExpansionChanger/expansionData.py
@@ -341,8 +341,7 @@ class ExpansionData:
         c = b.getComponent(Flags.FUEL)
         if c is None:
             raise RuntimeError(f"No fuel component within {b}!")
-        self._componentDeterminesBlockHeight[c] = True
-        b.p.axialExpTargetComponent = c.name
+        self._setExpansionTarget(b, c)
 
     def isTargetComponent(self, c: "Component") -> bool:
         """Returns bool if c is a target component.

--- a/armi/reactor/converters/axialExpansionChanger/expansionData.py
+++ b/armi/reactor/converters/axialExpansionChanger/expansionData.py
@@ -14,7 +14,7 @@
 """Data container for axial expansion."""
 
 from statistics import mean
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Iterable
 
 from armi import runLog
 from armi.materials import material
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
     from armi.reactor.assemblies import Assembly
 
 
+def iterSolidComponents(b: "Block") -> Iterable["Component"]:
+    """Iterate over all solid components in the block."""
+    return filter(lambda c: not isinstance(c.material, material.Fluid), b)
+
+
 def getSolidComponents(b: "Block") -> list["Component"]:
     """
     Return list of components in the block that have solid material.
@@ -42,8 +47,13 @@ def getSolidComponents(b: "Block") -> list["Component"]:
     -----
     Axial expansion only needs to be applied to solid materials. We should not update
     number densities on fluid materials to account for changes in block height.
+
+    See Also
+    --------
+    :func:`iterSolidComponents` produces an iterable rather than a list and may be better
+    suited if you simply want to iterate over solids in a block.
     """
-    return [c for c in b if not isinstance(c.material, material.Fluid)]
+    return list(iterSolidComponents(b))
 
 
 class ExpansionData:
@@ -179,7 +189,7 @@ class ExpansionData:
 
     def _setComponentThermalExpansionFactors(self, b: "Block"):
         """For each component in the block, set the thermal expansion factors."""
-        for c in getSolidComponents(b):
+        for c in iterSolidComponents(b):
             self._perComponentThermalExpansionFactors(c)
 
     def _perComponentThermalExpansionFactors(self, c: "Component"):

--- a/armi/reactor/converters/axialExpansionChanger/expansionData.py
+++ b/armi/reactor/converters/axialExpansionChanger/expansionData.py
@@ -246,7 +246,9 @@ class ExpansionData:
             elif b.hasFlags(Flags.PLENUM) or b.hasFlags(Flags.ACLP):
                 self.determineTargetComponent(b, Flags.CLAD)
             elif b.hasFlags(Flags.DUMMY):
-                self.determineTargetComponent(b, Flags.COOLANT)
+                # Dummy blocks are not real and not used. Therefore we don't need to assign anything
+                # special for them
+                pass
             elif setFuel and b.hasFlags(Flags.FUEL):
                 self._isFuelLocked(b)
             else:

--- a/armi/reactor/converters/axialExpansionChanger/expansionData.py
+++ b/armi/reactor/converters/axialExpansionChanger/expansionData.py
@@ -95,17 +95,10 @@ class ExpansionData:
                 f"        len(expFrac) = {len(expFrac)}"
             )
             raise RuntimeError
-        if 0.0 in expFrac:
-            msg = (
-                "An expansion fraction, L1/L0, equal to 0.0, is not physical. Expansion fractions "
-                "should be greater than 0.0."
-            )
-            runLog.error(msg)
-            raise RuntimeError(msg)
         for exp in expFrac:
-            if exp < 0.0:
+            if exp <= 0.0:
                 msg = (
-                    "A negative expansion fraction, L1/L0, is not physical. Expansion fractions "
+                    f"Expansion factor {exp}, L1/L0, is not physical. Expansion fractions "
                     "should be greater than 0.0."
                 )
                 runLog.error(msg)

--- a/armi/reactor/converters/axialExpansionChanger/expansionData.py
+++ b/armi/reactor/converters/axialExpansionChanger/expansionData.py
@@ -99,15 +99,15 @@ class ExpansionData:
 
         Parameters
         ----------
-        componentLst : List[:py:class:`Component <armi.reactor.components.component.Component>`]
+        components : List[:py:class:`Component <armi.reactor.components.component.Component>`]
             list of Components to have their heights changed
         expFrac : List[float]
-            list of L1/L0 height changes that are to be applied to componentLst
+            list of L1/L0 height changes that are to be applied to components
 
         Raises
         ------
         RuntimeError
-            If componentLst and expFrac are different lengths
+            If components and expFrac are different lengths
         """
         if len(components) != len(expFrac):
             runLog.error(

--- a/armi/reactor/converters/axialExpansionChanger/expansionData.py
+++ b/armi/reactor/converters/axialExpansionChanger/expansionData.py
@@ -257,8 +257,10 @@ class ExpansionData:
     def determineTargetComponent(
         self, b: "Block", flagOfInterest: Optional[Flags] = None
     ) -> "Component":
-        """Determines target component, stores it on the block, and appends it to
-        self._componentDeterminesBlockHeight.
+        """Determines target component, or the component who's expansion will determine block height.
+
+        This information is also stored on the block at ``Block.p.axialExpTargetComponent`` for faster
+        retrieval later.
 
         Parameters
         ----------

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -34,6 +34,7 @@ from armi.reactor.converters.axialExpansionChanger import (
 )
 from armi.reactor.converters.axialExpansionChanger.assemblyAxialLinkage import (
     areAxiallyLinked,
+    AxialLink,
 )
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_reactors import loadTestReactor, reduceTestReactorRings
@@ -1266,3 +1267,46 @@ class FakeMatException(materials.ht9.HT9):
         """A fake linear expansion percent."""
         Tc = units.getTc(Tc, Tk)
         return 0.08 * Tc
+
+
+class TestAxialLinkHelper(unittest.TestCase):
+    """Tests for the AxialLink dataclass / namedtuple like class."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.LOWER_BLOCK = _buildDummySodium(20, 10)
+        cls.UPPER_BLOCK = _buildDummySodium(300, 50)
+
+    def setUp(self):
+        self.link = AxialLink(self.LOWER_BLOCK, self.UPPER_BLOCK)
+
+    def test_positionGet(self):
+        """Test the getitem accessor."""
+        self.assertIs(self.link[0], self.link.lower)
+        self.assertIs(self.link[1], self.link.upper)
+        with self.assertRaises(AttributeError):
+            self.link[3]
+
+    def test_positionSet(self):
+        """Test the setitem setter."""
+        self.link[0] = None
+        self.assertIsNone(self.link.lower)
+        self.link[0] = self.LOWER_BLOCK
+        self.assertIs(self.link.lower, self.LOWER_BLOCK)
+        self.link[1] = None
+        self.assertIsNone(self.link.upper)
+        self.link[1] = self.UPPER_BLOCK
+        self.assertIs(self.link.upper, self.UPPER_BLOCK)
+        with self.assertRaises(AttributeError):
+            self.link[-1] = None
+
+    def test_iteration(self):
+        """Test the ability to iterate over the items in the link."""
+        genItems = iter(self.link)
+        first = next(genItems)
+        self.assertIs(first, self.link.lower)
+        second = next(genItems)
+        self.assertIs(second, self.link.upper)
+        # No items left
+        with self.assertRaises(StopIteration):
+            next(genItems)

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -33,7 +33,7 @@ from armi.reactor.converters.axialExpansionChanger import (
     getSolidComponents,
 )
 from armi.reactor.converters.axialExpansionChanger.assemblyAxialLinkage import (
-    _determineLinked,
+    areAxiallyLinked,
 )
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_reactors import loadTestReactor, reduceTestReactorRings
@@ -697,7 +697,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
         compDims = {"Tinput": 25.0, "Thot": 25.0}
         compA = UnshapedComponent("unshaped_1", "FakeMat", **compDims)
         compB = UnshapedComponent("unshaped_2", "FakeMat", **compDims)
-        self.assertFalse(_determineLinked(compA, compB))
+        self.assertFalse(areAxiallyLinked(compA, compB))
 
     def test_getLinkedComponents(self):
         """Test for multiple component axial linkage."""
@@ -1027,26 +1027,26 @@ class TestLinkage(AxialExpansionTestBase, unittest.TestCase):
             typeB = method(*common, **dims[1])
             if assertionBool:
                 self.assertTrue(
-                    _determineLinked(typeA, typeB),
+                    areAxiallyLinked(typeA, typeB),
                     msg="Test {0:s} failed for component type {1:s}!".format(
                         name, str(method)
                     ),
                 )
                 self.assertTrue(
-                    _determineLinked(typeB, typeA),
+                    areAxiallyLinked(typeB, typeA),
                     msg="Test {0:s} failed for component type {1:s}!".format(
                         name, str(method)
                     ),
                 )
             else:
                 self.assertFalse(
-                    _determineLinked(typeA, typeB),
+                    areAxiallyLinked(typeA, typeB),
                     msg="Test {0:s} failed for component type {1:s}!".format(
                         name, str(method)
                     ),
                 )
                 self.assertFalse(
-                    _determineLinked(typeB, typeA),
+                    areAxiallyLinked(typeB, typeA),
                     msg="Test {0:s} failed for component type {1:s}!".format(
                         name, str(method)
                     ),
@@ -1145,7 +1145,7 @@ class TestLinkage(AxialExpansionTestBase, unittest.TestCase):
     def test_unshapedComponentAndCircle(self):
         comp1 = Circle(*self.common, od=1.0, id=0.0)
         comp2 = UnshapedComponent(*self.common, area=1.0)
-        self.assertFalse(_determineLinked(comp1, comp2))
+        self.assertFalse(areAxiallyLinked(comp1, comp2))
 
 
 def buildTestAssemblyWithFakeMaterial(name: str, hot: bool = False):

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -20,6 +20,7 @@ New Features
    matches a given condition. (`PR#1899 <https://github.com/terrapower/armi/pull/1899>`_)
 #. Plugins can provide the ``getAxialExpansionChanger`` hook to customize axial expansion.
    (`PR#1870 <https://github.com/terrapower/armi/pull/1870`_)
+#. Provide ``axialExpansionChanger.iterSolidComponents`` for iterating over solid components in a block.
 #. TBD
 
 API Changes


### PR DESCRIPTION
## What is the change?

A handful of improvements to allow subclasses of axial expansion things more control. A general theme was to take large methods and break them up so subclasses can override at their discretion.

Some documentation has been added to axial expansion related classes. It's by no means complete, nor to the level of #935. But as I fumbled through the code and got helped from @albeanth, I added what I could to the docstrings.
 
## Why is the change being made?

I am working on features internally that need more control over performing axial expansion that require these changes.

Closes #1453 

Closes #1918 
---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.