### PR TITLE
Removing unnecessary column in print-out

### DIFF
--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -144,7 +144,7 @@ class SystemBlueprint(yamlize.Object):
         """
         from armi.reactor import reactors  # avoid circular import
 
-        runLog.info("Constructing the `{}`".format(self.name))
+        runLog.info(f"Constructing the `{self.name}`")
 
         if geom is not None and self.name == "core":
             gridDesign = geom.toGridBlueprints("core")[0]
@@ -196,9 +196,7 @@ class SystemBlueprint(yamlize.Object):
         return system
 
     def _loadAssemblies(self, cs, container, gridContents, bp):
-        runLog.header(
-            "=========== Adding Assemblies to {} ===========".format(container)
-        )
+        runLog.header(f"=========== Adding Assemblies to {container} ===========")
         badLocations = set()
         for locationInfo, aTypeID in gridContents.items():
             newAssembly = bp.constructAssem(cs, specifier=aTypeID)
@@ -232,9 +230,7 @@ class SystemBlueprint(yamlize.Object):
         # (unless specified on input)
         if not gridDesign.latticeDimensions:
             runLog.info(
-                "Updating spatial grid pitch data for {} geometry".format(
-                    container.geomType
-                )
+                f"Updating spatial grid pitch data for {container.geomType} geometry"
             )
             if container.geomType == geometry.GeomType.HEX:
                 container.spatialGrid.changePitch(container[0][0].getPitch())
@@ -258,26 +254,21 @@ def summarizeMaterialData(container):
         Any Core object with Blocks and Components defined.
     """
     runLog.header(
-        "=========== Summarizing Source of Material Data for {} ===========".format(
-            container
-        )
+        f"=========== Summarizing Source of Material Data for {container} ==========="
     )
     materialNames = set()
     materialData = []
     for c in container.iterComponents():
         if c.material.name in materialNames:
             continue
-        materialData.append((c.material.name, c.material.DATA_SOURCE, False))
+        materialData.append((c.material.name, c.material.DATA_SOURCE))
         materialNames.add(c.material.name)
+
     materialData = sorted(materialData)
     runLog.info(
         tabulate.tabulate(
             data=materialData,
-            headers=[
-                "Material Name",
-                "Source Location",
-                "Property Data was Modified\nfrom the Source?",
-            ],
+            headers=["Material Name", "Source Location"],
             tableFmt="armi",
         )
     )

--- a/armi/reactor/blueprints/tests/test_reactorBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_reactorBlueprints.py
@@ -122,11 +122,7 @@ class TestReactorBlueprints(unittest.TestCase):
 
     def test_materialDataSummary(self):
         """Test that the material data summary for the core is valid as a printout to the stdout."""
-        expectedMaterialData = [
-            ("Custom", "ARMI", False),
-            ("HT9", "ARMI", False),
-            ("UZr", "ARMI", False),
-        ]
+        expectedMaterialData = [("Custom", "ARMI"), ("HT9", "ARMI"), ("UZr", "ARMI")]
         core, _sfp = self._setupReactor()
         materialData = reactorBlueprint.summarizeMaterialData(core)
         for actual, expected in zip(materialData, expectedMaterialData):

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -41,6 +41,7 @@ Bug Fixes
 #. Rotate hexagonal assembly patches correctly on facemap plots. (`PR#1883 <https://github.com/terrapower/armi/pull/1883>`_)
 #. Update height of fluid components after axial expansion (`PR#1828 <https://github.com/terrapower/armi/pull/1828>`_)
 #. Material theoretical density is serialized to and read from database. (`PR#1852 <https://github.com/terrapower/armi/pull/1852>`_)
+#. Removed broken and unused column in ``summarizeMaterialData``. (`PR#1925 <https://github.com/terrapower/armi/pull/1925>`_)
 #. TBD
 
 Quality Work


### PR DESCRIPTION
## What is the change?

There is an incorrect and unused column in a summary table in the reactor blueprints, and this PR fixes it.

## Why is the change being made?

I could have fixed the column to be correct, but since no one but Chris has EVER noticed it was broken, I infer the column is unused.

close #1192

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.