### PR TITLE
Removing upper bound pin on HDF5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ authors = [
 ]
 dependencies = [
     "coverage>=7.2.0", # Code coverage tool. Sadly baked into every Case.
-    "h5py>=3.9,<3.12 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
+    "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
     "h5py>=3.0,<=3.9 ; python_version < '3.11.0'",
     "htmltree>=0.7.6", # Our reports have HTML output
     "matplotlib>=3.5.3,<3.8.0", # Important plotting library


### PR DESCRIPTION
## What is the change?

Removing the upper bound pin on the HDF5 library.

## Why is the change being made?

We [recently](https://github.com/terrapower/armi/pull/1907) had to put a temporary stop-gap in place for the HDF5 library, because its latest release was bugged on Windows. Their team [now says](https://github.com/h5py/h5py/issues/2505) this problem is resolved, so I thought it was time to remove this version upper bound on their tool.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.