### PR TITLE
Relaxing copyInterfaceInputs to not require a valid Setting

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -882,6 +882,7 @@ def copyInterfaceInputs(
     enables developers to add new inputs in a plugin-dependent/ modular way.
 
     This function should now be able to handle the updating of:
+
       - a single file (relative or absolute)
       - a list of files (relative or absolute), and
       - a file entry that has a wildcard processing into multiple files.
@@ -900,12 +901,12 @@ def copyInterfaceInputs(
         The source case settings to find input files
     destination : str
         The target directory to copy input files to
-    sourceDir : str (optional)
+    sourceDir : str, optional
         The directory from which to copy files. Defaults to cs.inputDirectory
 
     Returns
     -------
-    newSettings : dict
+    dict
         A new settings object that contains settings for the keys and values that are
         either an absolute file path, a list of absolute file paths, or the original
         file path if absolute paths could not be resolved
@@ -931,12 +932,10 @@ def copyInterfaceInputs(
             if not isinstance(key, settings.Setting):
                 try:
                     key = cs.getSetting(key)
+                    label = key.name
                 except NonexistentSetting(key):
-                    raise ValueError(
-                        f"{key} is not a valid setting. Ensure the relevant specifyInputs "
-                        "method uses a correct setting name."
-                    )
-            label = key.name
+                    runLog.debug(f"{key} is not a valid setting; continuing on anyway.")
+                    label = key
 
             newFiles = []
             for f in files:
@@ -981,8 +980,8 @@ def copyInterfaceInputs(
 
                 if destFilePath == f:
                     runLog.debug(
-                        f"No input files for `{label}` setting could be resolved with "
-                        f"the following path: `{sourceFullPath}`. Will not update `{label}`."
+                        f"No input files for `{label}` could be resolved with the "
+                        f"following path: `{sourceFullPath}`. Will not update `{label}`."
                     )
 
             # Some settings are a single filename. Others are lists of files. Make


### PR DESCRIPTION
## What is the change?

Relaxing the case method `copyInterfaceInputs()` to not require a valid Setting.

## Why is the change being made?

There are multiple open requests to allow a case to copy inputs for things that are not mapped to "valid" settings.

close #772
close #825

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.