### PR TITLE
Update rotation requirement impl, tag links: Hex specific

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1261,7 +1261,7 @@ class HexAssembly(Assembly):
             :id: I_ARMI_ROTATE_HEX
             :implements: R_ARMI_ROTATE_HEX
 
-            This method loops through every ``Block`` in this ``Assembly`` and rotates
+            This method loops through every ``Block`` in this ``HexAssembly`` and rotates
             it by a given angle (in radians). The rotation angle is positive in the
             counter-clockwise direction. To perform the ``Block`` rotation, the
             :meth:`armi.reactor.blocks.HexBlock.rotate` method is called.

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1237,15 +1237,6 @@ class Assembly(composites.Composite):
 
         Each Block on the Assembly is rotated in turn.
 
-        .. impl:: An assembly can be rotated about its z-axis.
-            :id: I_ARMI_SHUFFLE_ROTATE
-            :implements: R_ARMI_SHUFFLE_ROTATE
-
-            This method loops through every ``Block`` in this ``Assembly`` and rotates
-            it by a given angle (in radians). The rotation angle is positive in the
-            counter-clockwise direction. To perform the ``Block`` rotation, the
-            :py:meth:`armi.reactor.blocks.Block.rotate` method is called.
-
         Parameters
         ----------
         rad: float
@@ -1265,6 +1256,15 @@ class HexAssembly(Assembly):
 
     def rotate(self, rad: float):
         """Rotate an assembly and its children.
+
+        .. impl:: A hexagonal assembly shall support rotating around the z-axis in 60 degree increments.
+            :id: I_ARMI_ROTATE_HEX
+            :implements: R_ARMI_ROTATE_HEX
+
+            This method loops through every ``Block`` in this ``Assembly`` and rotates
+            it by a given angle (in radians). The rotation angle is positive in the
+            counter-clockwise direction. To perform the ``Block`` rotation, the
+            :meth:`armi.reactor.blocks.HexBlock.rotate` method is called.
 
         Parameters
         ----------

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1026,8 +1026,8 @@ class Assembly_TestCase(unittest.TestCase):
         """Test rotation of an assembly spatial objects.
 
         .. test:: An assembly can be rotated about its z-axis.
-            :id: T_ARMI_SHUFFLE_ROTATE
-            :tests: R_ARMI_SHUFFLE_ROTATE
+            :id: T_ARMI_ROTATE_HEX
+            :tests: R_ARMI_ROTATE_HEX
         """
         a = makeTestAssembly(1, 1)
         b = blocks.HexBlock("TestBlock")


### PR DESCRIPTION
## What is the change?

New and updated requirements on rotation are scoped to hexagonal assemblies.

## Why is the change being made?

Updating to match requirements.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.