### PR TITLE
Adding DeprecationWarning for HistoryTrackerInterface

### DIFF
--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -139,6 +139,9 @@ class HistoryTrackerInterface(interfaces.Interface):
         self.xsHistory = {}
         self._preloadedBlockHistory = None
 
+        msg = "The HistoryTrackerInterface is deprecated, and will be removed."
+        runLog.warning(msg)
+
     def interactBOL(self):
         self.addDetailAssembliesBOL()
 


### PR DESCRIPTION
## What is the change?

Adding a `DeprecationWarning` for `HistoryTrackerInterface`.

## Why is the change being made?

This has been scheduled in ARMI since 2018, when the armi `Database` was invented. There has been a ticket open for a couple of years: https://github.com/terrapower/armi/issues/792

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.