### PR TITLE
Removing Assembly.doubleResolution

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -315,38 +315,6 @@ class Assembly(composites.Composite):
 
         return sum(plenumTemps) / len(plenumTemps)
 
-    def doubleResolution(self):
-        """
-        Turns each block into two half-size blocks.
-
-        Notes
-        -----
-        Used for mesh sensitivity studies.
-
-        Warning
-        -------
-        This is likely destined for a geometry converter rather than this instance method.
-        """
-        newBlockStack = []
-        topIndex = -1
-        for b in self:
-            b0 = b
-            b1 = copy.deepcopy(b)
-            for bx in [b0, b1]:
-                newHeight = bx.getHeight() / 2.0
-                bx.p.height = newHeight
-                bx.p.heightBOL = newHeight
-                topIndex += 1
-                bx.p.topIndex = topIndex
-                newBlockStack.append(bx)
-                bx.clearCache()
-
-        self.removeAll()
-        self.spatialGrid = grids.AxialGrid.fromNCells(len(newBlockStack))
-        for b in newBlockStack:
-            self.add(b)
-        self.reestablishBlockOrder()
-
     def adjustResolution(self, refA):
         """Split the blocks in this assembly to have the same mesh structure as refA."""
         newBlockStack = []

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -392,20 +392,6 @@ class Assembly_TestCase(unittest.TestCase):
         places = 6
         self.assertAlmostEqual(cur, ref, places=places)
 
-    def test_doubleResolution(self):
-        b = self.assembly[0]
-        initialHeight = b.p.heightBOL
-        self.assembly.doubleResolution()
-        cur = len(self.assembly.getBlocks())
-        ref = 2 * len(self.blockList)
-        self.assertEqual(cur, ref)
-
-        cur = self.assembly.getBlocks()[0].getHeight()
-        ref = self.height / 2.0
-        places = 6
-        self.assertNotEqual(initialHeight, b.p.heightBOL)
-        self.assertAlmostEqual(cur, ref, places=places)
-
     def test_adjustResolution(self):
         # Make a second assembly with 4 times the resolution
         assemNum2 = self.assemNum * 4

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -32,6 +32,7 @@ API Changes
 #. ``copyInterfaceInputs`` no longer requires a valid setting object. (`PR#1934 <https://github.com/terrapower/armi/pull/1934>`_)
 #. Removing ``buildEqRingSchedule``. (`PR#1928 <https://github.com/terrapower/armi/pull/1928>`_)
 #. Allowing for unknown Flags when opening a DB. (`PR#1844 <https://github.com/terrapower/armi/pull/1835>`_)
+#. Removing ``Assembly.doubleResolution()``. (`PR#1951 <https://github.com/terrapower/armi/pull/1951>`_)
 #. Removing ``assemblyLists.py`` and the ``AssemblyList`` class. (`PR#1891 <https://github.com/terrapower/armi/pull/1891>`_)
 #. Removing ``Assembly.rotatePins`` and ``Block.rotatePins``. Prefer ``Assembly.rotate`` and ``Block.rotate``. (`PR#1846 <https://github.com/terrapower/armi/1846`_)
 #. Transposing ``pinMgFluxes`` parameters so that leading dimension is pin index (`PR#1937 <https://github.com/terrapower/armi/pull/1937>`)


### PR DESCRIPTION
## What is the change?

Removing the method `Assembly.doubleResolution()`.

## Why is the change being made?

Two reasons:

1. The method is not used ANYWHERE.
2. The method should probably be in some converter logic, not in the base `Assembly` class.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.