### PR TITLE
Skip XS generation when calculation uses tight coupling

### DIFF
--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -217,14 +217,17 @@ class LatticePhysicsInterface(interfaces.Interface):
         Generate new cross sections based off the case settings and the current state
         of the reactor if the lattice physics frequency is at least everyNode.
 
-        If this is not a coupled calculation, then we want to regenerate
-        all cross sections at each time node. If it _is_ a coupled calculation,
-        then keep the existing XS lib for the interactEveryNode calculation,
-        adding in any XS groups as necessary to ensure that all XS groups are
-        covered.
+        If this is not a coupled calculation, or if cross sections are only being
+        generated at everyNode, then we want to regenerate all cross sections here.
+        If it _is_ a coupled calculation, and we are generating cross sections at
+        coupled iterations, then keep the existing XS lib for now, adding
+        any XS groups as necessary to ensure that all XS groups are covered.
         """
         if self._latticePhysicsFrequency >= LatticePhysicsFrequency.everyNode:
-            if not self.o.couplingIsActive():
+            if (
+                not self.o.couplingIsActive()
+                or self._latticePhysicsFrequency == LatticePhysicsFrequency.everyNode
+            ):
                 self.r.core.lib = None
             self.updateXSLibrary(self.r.p.cycle, self.r.p.timeNode)
 

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -216,9 +216,16 @@ class LatticePhysicsInterface(interfaces.Interface):
 
         Generate new cross sections based off the case settings and the current state
         of the reactor if the lattice physics frequency is at least everyNode.
+
+        If this is not a coupled calculation, then we want to regenerate
+        all cross sections at each time node. If it _is_ a coupled calculation,
+        then keep the existing XS lib for the interactEveryNode calculation,
+        adding in any XS groups as necessary to ensure that all XS groups are
+        covered.
         """
         if self._latticePhysicsFrequency >= LatticePhysicsFrequency.everyNode:
-            self.r.core.lib = None
+            if not self.o.couplingIsActive():
+                self.r.core.lib = None
             self.updateXSLibrary(self.r.p.cycle, self.r.p.timeNode)
 
     def interactCoupled(self, iteration):

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -183,6 +183,24 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         self.latticeInterface.interactEveryNode()
         self.assertIsNone(self.o.r.core.lib)
 
+    def test_interactEveryNodeWhenCoupledButNot(self):
+        """
+        Test that the XS lib is cleared when coupled iterations are turned on
+        but the lattice physics frequency is not high enough.
+        """
+        self.o.couplingIsActive = lambda: True
+        self.latticeInterface._latticePhysicsFrequency = (
+            LatticePhysicsFrequency.firstCoupledIteration
+        )
+        self.latticeInterface.interactEveryNode()
+        self.assertEqual(self.o.r.core.lib, "Nonsense")
+
+        self.latticeInterface._latticePhysicsFrequency = (
+            LatticePhysicsFrequency.everyNode
+        )
+        self.latticeInterface.interactEveryNode()
+        self.assertIsNone(self.o.r.core.lib)
+
     def test_interactEveryNodeFirstCoupled(self):
         """Test interactEveryNode() with LatticePhysicsFrequency.firstCoupledIteration."""
         self.latticeInterface._latticePhysicsFrequency = (

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -171,6 +171,18 @@ class TestLatticePhysicsInterface(TestLatticePhysicsInterfaceBase):
         self.latticeInterface.interactEveryNode()
         self.assertIsNone(self.o.r.core.lib)
 
+    def test_interactEveryNodeWhenCoupled(self):
+        """
+        Test that the XS lib is not cleared when coupled iterations are turned on.
+        """
+        self.o.couplingIsActive = lambda: True
+        self.latticeInterface.interactEveryNode()
+        self.assertEqual(self.o.r.core.lib, "Nonsense")
+
+        self.o.couplingIsActive = lambda: False
+        self.latticeInterface.interactEveryNode()
+        self.assertIsNone(self.o.r.core.lib)
+
     def test_interactEveryNodeFirstCoupled(self):
         """Test interactEveryNode() with LatticePhysicsFrequency.firstCoupledIteration."""
         self.latticeInterface._latticePhysicsFrequency = (


### PR DESCRIPTION
## What is the change?

When tight coupling is on, the regeneration of cross sections at the `interactEveryNode()` step might not be that useful because the cross sections are guaranteed to change during coupled iterations (assuming that `LatticePhysicsFrequency` is high enough to trigger during coupled iterations). Since the results from the `interactEveryNode()` step in this case are just an initial guess, it might not be very important to have super precise cross sections. Therefore if some cross sections already exist at `interactEveryNode()`, this PR skips their regeneration.

## Why is the change being made?

Cross section generation is expensive. This change is being made primarily for performance reasons.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.