### PR TITLE
Adding description of EOL time node in DB

### DIFF
--- a/doc/user/outputs.rst
+++ b/doc/user/outputs.rst
@@ -181,6 +181,11 @@ documentation of the database modules.
 
        Also, it is important to note that all components are flattened and then grouped
        by type.
+   * - ``/c{CC}n{NN}EOL/``
+     - H5Group
+     - A special time node, like the one above, where {CC} is the last cycle and {NN} is the last
+       node. If this exists, it is meant to represent the EOL, which is perhaps a few days after the
+       end of the last cycle, where fuel is decaying non-operationally.
    * - ``/c{CC}n{NN}/layout/``
      - H5Group
      - A group that contains  a description of the ARMI model within this timenode


### PR DESCRIPTION
## What is the change?

Adding description of the new EOL time node in DB.

## Why is the change being made?

This should have been added when the EOL change was made. But it's just a documentation change.

close #1782 

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.