### PR TITLE
Ensuring reaction rate parameters are set after calc

### DIFF
--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -1231,8 +1231,8 @@ class UniformMeshGeometryConverter(GeometryConverter):
                     if nucRate[rx]:
                         rate[rx] += nucRate[rx]
 
-            for paramName, val in rate.items():
-                obj.p[paramName] = val  # put in #/cm^3/s
+            for paramName in RX_PARAM_NAMES:
+                obj.p[paramName] = rate[paramName]  # put in #/cm^3/s
 
             if rate["rateFis"] > 0.0:
                 fuelVolFrac = obj.getComponentAreaFrac(Flags.FUEL)


### PR DESCRIPTION
## What is the change?

Ensure that reaction rate parameters are set on all blocks during the reaction rate calculation.

## Why is the change being made?

PR #1887 introduced an alternate method for calculating reaction rates. This PR used a `defaultdict` to store and set reaction rate parameters. If a given reaction rate was not calculated in a block (e.g., fission reactions in a block without fissionable material) then the fission rate would not be set in the `defaultdict`, and as a result the parameter would not be set to 0.0. Instead of iterating over the `defaultdict` keys, we need to iterate over all of the reaction rate params in `RX_PARAM_NAMES`.

This error was not caught by unit tests but it was caught by downstream application testing.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `pyproject.toml`.