### PR TITLE
Fixing CLI syntax warnings at startup

### DIFF
--- a/armi/settings/settingsValidation.py
+++ b/armi/settings/settingsValidation.py
@@ -778,9 +778,9 @@ def validateVersion(versionThis: str, versionRequired: str) -> bool:
     bool
         Does this version match the version in the Settings file/object?
     """
-    fullV = "\d+\.\d+\.\d+"
-    medV = "\d+\.\d+"
-    minV = "\d+"
+    fullV = r"\d+\.\d+\.\d+"
+    medV = r"\d+\.\d+"
+    minV = r"\d+"
 
     if versionRequired == "uncontrolled":
         # This default flag means we don't want to check the version.


### PR DESCRIPTION
This fixes warnings when you run `armi` on the CLI (as run from Python 3.12):

```
(armi) :~/code/armi$ armi
/home/nick/code/armi/armi/settings/settingsValidation.py:781: SyntaxWarning: invalid escape sequence '\d'
  fullV = "\d+\.\d+\.\d+"
/home/nick/code/armi/armi/settings/settingsValidation.py:782: SyntaxWarning: invalid escape sequence '\d'
  medV = "\d+\.\d+"
/home/nick/code/armi/armi/settings/settingsValidation.py:783: SyntaxWarning: invalid escape sequence '\d'
  minV = "\d+"
```

## What is the change?

<!-- MANDATORY: Describe the change -->
Add proper backslashes to regular expression.  `\d` is an invalid escape sequence (where `\n` is a newline, `\d` means nothing).

## Why is the change being made?

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->

Because the code prints out 3 warnings on console as a first impression, and also:

> Changed in version 3.12: Unrecognized escape sequences produce a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). In a future Python version they will be eventually a [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError).

src: https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.