### PR TITLE
Hiding sphinx-needs warnings during doc build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -44,4 +44,3 @@ jobs:
           branch: main
           folder: doc/_build/html
           target-folder: armi
-

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,8 +2,8 @@ name: Documentation
 
 on:
   push:
-#    branches:
-#      - main
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,12 +36,12 @@ jobs:
           git submodule init
           git submodule update
           make html
-#      - name: deploy
-#        uses: JamesIves/github-pages-deploy-action@v4.6.1
-#        with:
-#          token: ${{ secrets.ACCESS_TOKEN }}
-#          repository-name: ${{ github.repository_owner }}/terrapower.github.io
-#          branch: main
-#          folder: doc/_build/html
-#          target-folder: armi
+      - name: deploy
+        uses: JamesIves/github-pages-deploy-action@v4.6.1
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          repository-name: ${{ github.repository_owner }}/terrapower.github.io
+          branch: main
+          folder: doc/_build/html
+          target-folder: armi
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,8 +2,8 @@ name: Documentation
 
 on:
   push:
-    branches:
-      - main
+#    branches:
+#      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,11 +36,12 @@ jobs:
           git submodule init
           git submodule update
           make html
-      - name: deploy
-        uses: JamesIves/github-pages-deploy-action@v4.6.1
-        with:
-          token: ${{ secrets.ACCESS_TOKEN }}
-          repository-name: ${{ github.repository_owner }}/terrapower.github.io
-          branch: main
-          folder: doc/_build/html
-          target-folder: armi
+#      - name: deploy
+#        uses: JamesIves/github-pages-deploy-action@v4.6.1
+#        with:
+#          token: ${{ secrets.ACCESS_TOKEN }}
+#          repository-name: ${{ github.repository_owner }}/terrapower.github.io
+#          branch: main
+#          folder: doc/_build/html
+#          target-folder: armi
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -218,6 +218,7 @@ class SkipNeedsDirective(Directive):
 
     Temporary patch until we figure out a different/better way to maintain formal QA docs.
     """
+
     has_content = True
     required_arguments = 1
     optional_arguments = 0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -213,6 +213,11 @@ class PyReverse(Directive):
 
 
 class SkipNeedsDirective(Directive):
+    """
+    A no-op directive that filters out any sphinx-need directives from docs.
+
+    Temporary patch until we figure out a different/better way to maintain formal QA docs.
+    """
     has_content = True
     required_arguments = 1
     optional_arguments = 0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -212,6 +212,20 @@ class PyReverse(Directive):
             )
 
 
+class SkipNeedsDirective(Directive):
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+
+    def run(self):
+        _delete_opt = self.options.get("delete")
+        _collapse = self.options.get("collapse")
+        _jinja_content = self.options.get("jinja_content")
+        _hide = "hide" in self.options
+        return []
+
+
 def autodoc_skip_member_handler(app, what, name, obj, skip, options):
     """Manually exclude certain methods/functions from docs."""
     # exclude special methods from unittest
@@ -234,8 +248,8 @@ def setup(app):
     app.add_domain(PatchedPythonDomain, override=True)
     app.add_directive("exec", ExecDirective)
     app.add_directive("pyreverse", PyReverse)
-    app.add_directive("impl", directives.admonitions.Note)
-    app.add_directive("test", directives.admonitions.Note)
+    app.add_directive("impl", SkipNeedsDirective)
+    app.add_directive("test", SkipNeedsDirective)
 
     # making tutorial data dir
     dataDir = pathlib.Path("user") / ".." / "anl-afci-177"


### PR DESCRIPTION
## What is the change?

Skipping Sphinx-Needs warnings on public doc build.

## Why is the change being made?

There were 500 of these warnings, and they were obscuring the rest of the doc build.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.