### PR TITLE
Avoid closing plots that are meant to be interactive.

### DIFF
--- a/armi/nuclearDataIO/xsNuclides.py
+++ b/armi/nuclearDataIO/xsNuclides.py
@@ -240,10 +240,9 @@ def plotScatterMatrix(scatterMatrix, scatterTypeLabel="", fName=None):
     pyplot.colorbar()
     if fName:
         pyplot.savefig(fName)
+        pyplot.close()
     else:
         pyplot.show()
-
-    pyplot.close()
 
 
 def plotCompareScatterMatrix(scatterMatrix1, scatterMatrix2, fName=None):
@@ -260,7 +259,6 @@ def plotCompareScatterMatrix(scatterMatrix1, scatterMatrix2, fName=None):
     pyplot.colorbar()
     if fName:
         pyplot.savefig(fName)
+        pyplot.close()
     else:
         pyplot.show()
-
-    pyplot.close()

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -488,9 +488,9 @@ class BlockAvgToCylConverter(BlockConverter):
         fig.tight_layout()
         if fName:
             plt.savefig(fName)
+            plt.close()
         else:
             plt.show()
-        plt.close()
         return fName
 
 

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -178,10 +178,10 @@ def plotBlockDepthMap(
 
     if fName:
         plt.savefig(fName, dpi=150)
+        plt.close()
     else:
         plt.show()
 
-    plt.close()
     return fName
 
 
@@ -402,13 +402,16 @@ def plotFaceMap(
                 "Cannot update facemap at {0}: IOError. Is the file open?"
                 "".format(fName)
             )
+        plt.close(fig)
     elif referencesToKeep:
         # Don't show yet, since it will be updated.
         return fName
     else:
+        # Never close figures after a .show()
+        # because they're being used interactively e.g.
+        # in a live tutorial or by the doc gallery
         plt.show()
 
-    plt.close(fig)
     return fName
 
 
@@ -823,8 +826,8 @@ def plotAssemblyTypes(
     if fileName:
         fig.savefig(fileName)
         runLog.debug("Writing assem layout {} in {}".format(fileName, os.getcwd()))
+        plt.close(fig)
 
-    plt.close(fig)
     return fig
 
 
@@ -1092,10 +1095,10 @@ def plotBlockFlux(core, fName=None, bList=None, peak=False, adjoint=False, bList
             os.path.abspath(fName),
             report.FLUX_PLOT,
         )
+        plt.close()
     else:
+        # Never close interactive plots
         plt.show()
-
-    plt.close()
 
 
 def makeHistogram(x, y):
@@ -1503,7 +1506,6 @@ def plotNucXs(
 
     if fName:
         plt.savefig(fName)
+        plt.close()
     elif not noShow:
         plt.show()
-
-    plt.close()

--- a/doc/gallery-src/analysis/run_hexReactorToRZ.py
+++ b/doc/gallery-src/analysis/run_hexReactorToRZ.py
@@ -55,4 +55,3 @@ converter.convert(r)
 figs = converter.plotConvertedReactor()
 
 plt.show()
-plt.close()

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -30,7 +30,6 @@ demonstration purposes.
 # sphinx_gallery_thumbnail_number = 2
 import math
 
-import matplotlib.pyplot as plt
 
 from armi import configure
 from armi.physics.fuelCycle import fuelHandlers
@@ -73,4 +72,3 @@ for num in range(8):
 
 # show final burnup distribution
 plotting.plotFaceMap(reactor.core, param="percentBu")
-plt.close()

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -33,4 +33,3 @@ for b in reactor.core.getBlocks():
     b.p.pdens = x**2 + y**2 + z**2
 
 plotting.plotFaceMap(reactor.core, param="pdens", labelFmt="{0:.1e}")
-plotting.close()


### PR DESCRIPTION


## What is the change?


This change puts the close() only in the code branches that are expected to be run non-interactively, e.g. compute code. That allows the system to keep memory clear during big runs while still allowing interactive and gallery usage.

Fixes #1977

<!-- MANDATORY: Describe the change -->

## Why is the change being made?
The plt.show() options are intended for:

1. Interactive use on ipython or notebooks
2. Automated use during sphinx-gallery generation

Running plt.show() followed by plt.close() prevents at least the 2nd use case from working, as seen in #1977.

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.