### PR TITLE
Removing a duplicate hex rotation impl tag

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2050,8 +2050,6 @@ class HexBlock(Block):
         Python list of length 6 in order to be eligible for rotation; all parameters that
         do not meet these two criteria are not rotated.
 
-        The pin indexing, as stored on the ``pinLocation`` parameter, is also updated.
-
         .. impl:: Rotating a hex block updates the orientation parameter.
             :id: I_ARMI_ROTATE_HEX_ORIENTATION
             :implements: R_ARMI_ROTATE_HEX_PARAMS

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2052,10 +2052,6 @@ class HexBlock(Block):
 
         The pin indexing, as stored on the ``pinLocation`` parameter, is also updated.
 
-        .. impl:: A hexagonal block shall be rotatable by 60 degree increments.
-            :id: I_ARMI_ROTATE_HEX
-            :implements: R_ARMI_ROTATE_HEX
-
         .. impl:: Rotating a hex block updates the orientation parameter.
             :id: I_ARMI_ROTATE_HEX_ORIENTATION
             :implements: R_ARMI_ROTATE_HEX_PARAMS


### PR DESCRIPTION
## What is the change?

The `I_ARMI_ROTATE_HEX` impl tag was added on both `HexBlock.rotate` and `HexAssembly.rotate`. The block tag was considered a duplicate and removed.

## Why is the change being made?

Docs are not buildable with the duplicate impl tags.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.