### PR TITLE
Fixing HexBlock docstrings

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2054,7 +2054,7 @@ class HexBlock(Block):
             :id: I_ARMI_ROTATE_HEX_ORIENTATION
             :implements: R_ARMI_ROTATE_HEX_PARAMS
 
-        .. imp:: Rotating a hex block updates parameters on the boundary of the hexagon.
+        .. impl:: Rotating a hex block updates parameters on the boundary of the hexagon.
             :id: I_ARMI_ROTATE_HEX_BOUNDARY
             :tests: R_ARMI_ROTATE_HEX_PARAMS
 

--- a/armi/reactor/tests/test_hexBlockRotate.py
+++ b/armi/reactor/tests/test_hexBlockRotate.py
@@ -73,7 +73,7 @@ class HexBlockRotateTests(unittest.TestCase):
         """Test the z-value in the orientation vector matches rotation.
 
         .. test:: Demonstrate that a HexBlock can be rotated in 60 degree increments.
-            :id: T_ARMI_ROTATE_HEX
+            :id: T_ARMI_ROTATE_HEX_BLOCK
             :tests: R_ARMI_ROTATE_HEX
 
         .. test:: After rotating a block, the orientation parameter reflects the current rotation.


### PR DESCRIPTION
## What is the change?

Squashing the last of the sphinx-needs bugs I introduced 🤦 

## Why is the change being made?

Building docs with the sphinx needs info was broken

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.