### PR TITLE
Fixing wetted perimeter for hex inner ducts

### DIFF
--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -811,8 +811,7 @@ class Block_TestCase(unittest.TestCase):
         self.assertEqual(3, len(block))
         self.assertEqual(block.p.height, refHeight)
 
-    def test_getWettedPerimeterCircularInnerDuct(self):
-        """Calculate the wetted perimeter for a HexBlock with circular inner duct."""
+    def test_getWettedPerimeter(self):
         # calculate the reference value
         wire = self.block.getComponent(Flags.WIRE)
         correctionFactor = np.hypot(
@@ -830,6 +829,39 @@ class Block_TestCase(unittest.TestCase):
 
         # test getWettedPerimeter
         cur = self.block.getWettedPerimeter()
+        self.assertAlmostEqual(cur, ref)
+
+    def test_getWettedPerimeterCircularInnerDuct(self):
+        """Calculate the wetted perimeter for a HexBlock with circular inner duct."""
+        # build a test block with a Hex inner duct
+        fuelDims = {"Tinput": 400, "Thot": 400, "od": 0.76, "id": 0.00, "mult": 127.0}
+        cladDims = {"Tinput": 400, "Thot": 400, "od": 0.80, "id": 0.77, "mult": 127.0}
+        ductDims = {"Tinput": 400, "Thot": 400, "od": 16, "id": 15.3, "mult": 1.0}
+        intercoolantDims = {
+            "Tinput": 400,
+            "Thot": 400,
+            "od": 17.0,
+            "id": ductDims["od"],
+            "mult": 1.0,
+        }
+
+        fuel = components.Circle("fuel", "UZr", **fuelDims)
+        clad = components.Circle("clad", "HT9", **cladDims)
+        duct = components.Circle("inner duct", "HT9", **ductDims)
+        intercoolant = components.Circle("intercoolant", "Sodium", **intercoolantDims)
+
+        b = blocks.HexBlock("fuel", height=10.0)
+        b.add(fuel)
+        b.add(clad)
+        b.add(duct)
+        b.add(intercoolant)
+
+        # calculate the reference value
+        ref = (ductDims["id"] + ductDims["od"]) * math.pi
+        ref += b.getNumPins() * cladDims["od"] * math.pi
+
+        # test getWettedPerimeter
+        cur = b.getWettedPerimeter()
         self.assertAlmostEqual(cur, ref)
 
     def test_getWettedPerimeterHexInnerDuct(self):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -44,7 +44,7 @@ NUM_PINS_IN_TEST_BLOCK = 217
 
 
 def buildSimpleFuelBlock():
-    """Return a simple block containing fuel, clad, duct, and coolant."""
+    """Return a simple hex block containing fuel, clad, duct, and coolant."""
     b = blocks.HexBlock("fuel", height=10.0)
 
     fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
@@ -811,9 +811,9 @@ class Block_TestCase(unittest.TestCase):
         self.assertEqual(3, len(block))
         self.assertEqual(block.p.height, refHeight)
 
-    def test_getWettedPerimeter(self):
-        cur = self.block.getWettedPerimeter()
-
+    def test_getWettedPerimeterCircularInnerDuct(self):
+        """Calculate the wetted perimeter for a HexBlock with circular inner duct."""
+        # calculate the reference value
         wire = self.block.getComponent(Flags.WIRE)
         correctionFactor = np.hypot(
             1.0,
@@ -821,16 +821,48 @@ class Block_TestCase(unittest.TestCase):
             * wire.getDimension("helixDiameter")
             / wire.getDimension("axialPitch"),
         )
-        wireDiameter = wire.getDimension("od") * correctionFactor
+        wireDiam = wire.getDimension("od") * correctionFactor
 
-        ref = math.pi * (
-            self.block.getDim(Flags.CLAD, "od") + wireDiameter
-        ) * self.block.getDim(Flags.CLAD, "mult") + 6 * self.block.getDim(
-            Flags.DUCT, "ip"
-        ) / math.sqrt(
-            3
-        )
+        ipDim = self.block.getDim(Flags.DUCT, "ip")
+        odDim = self.block.getDim(Flags.CLAD, "od")
+        mult = self.block.getDim(Flags.CLAD, "mult")
+        ref = math.pi * (odDim + wireDiam) * mult + 6 * ipDim / math.sqrt(3)
 
+        # test getWettedPerimeter
+        cur = self.block.getWettedPerimeter()
+        self.assertAlmostEqual(cur, ref)
+
+    def test_getWettedPerimeterHexInnerDuct(self):
+        """Calculate the wetted perimeter for a HexBlock with hexagonal inner duct."""
+        # build a test block with a Hex inner duct
+        fuelDims = {"Tinput": 400, "Thot": 400, "od": 0.76, "id": 0.00, "mult": 127.0}
+        cladDims = {"Tinput": 400, "Thot": 400, "od": 0.80, "id": 0.77, "mult": 127.0}
+        ductDims = {"Tinput": 400, "Thot": 400, "op": 16, "ip": 15.3, "mult": 1.0}
+        intercoolantDims = {
+            "Tinput": 400,
+            "Thot": 400,
+            "op": 17.0,
+            "ip": ductDims["op"],
+            "mult": 1.0,
+        }
+
+        fuel = components.Circle("fuel", "UZr", **fuelDims)
+        clad = components.Circle("clad", "HT9", **cladDims)
+        duct = components.Hexagon("inner duct", "HT9", **ductDims)
+        intercoolant = components.Hexagon("intercoolant", "Sodium", **intercoolantDims)
+
+        b = blocks.HexBlock("fuel", height=10.0)
+        b.add(fuel)
+        b.add(clad)
+        b.add(duct)
+        b.add(intercoolant)
+
+        # calculate the reference value
+        ref = 6 * (ductDims["ip"] + ductDims["op"]) / math.sqrt(3)
+        ref += b.getNumPins() * cladDims["od"] * math.pi
+
+        # test getWettedPerimeter
+        cur = b.getWettedPerimeter()
         self.assertAlmostEqual(cur, ref)
 
     def test_getFlowAreaPerPin(self):

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -60,6 +60,7 @@ Bug Fixes
 #. Material theoretical density is serialized to and read from database. (`PR#1852 <https://github.com/terrapower/armi/pull/1852>`_)
 #. Removed broken and unused column in ``summarizeMaterialData``. (`PR#1925 <https://github.com/terrapower/armi/pull/1925>`_)
 #. Fixed edge case in ``assemblyBlueprint._checkParamConsistency()``. (`PR#1928 <https://github.com/terrapower/armi/pull/1928>`_)
+#. Fixed wetted perimeter for hex inner ducts. (`PR#1985 <https://github.com/terrapower/armi/pull/1985>`_)
 #. TBD
 
 Quality Work


### PR DESCRIPTION
## What is the change?

Fixing wetted perimeter on `HexBlock` for hexagnal inner ducts.

## Why is the change being made?

To close #1983

The `HexBlock` currently assumes all inner ducts are circular.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.