### PR TITLE
Removing defunct import

### DIFF
--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -37,12 +37,7 @@ DO_NOT_CLEAN_PATHS = [
 
 
 def armiAbsPath(*pathParts):
-    """
-    Convert a list of path components to an absolute path, without drive letters if possible.
-
-    This is mostly useful on Windows systems, where drive letters are not well defined for shared
-    drives. In these cases, it is useful to try to convert to a UNC path ifpossible.
-    """
+    """Convert a list of path components to an absolute path, without drive letters if possible."""
     return os.path.abspath(os.path.join(*pathParts))
 
 

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -40,18 +40,10 @@ def armiAbsPath(*pathParts):
     """
     Convert a list of path components to an absolute path, without drive letters if possible.
 
-    This is mostly useful on Windows systems, where drive letters are not well defined
-    across systems. In these cases, it is useful to try to convert to a UNC path if
-    possible.
+    This is mostly useful on Windows systems, where drive letters are not well defined for shared
+    drives. In these cases, it is useful to try to convert to a UNC path ifpossible.
     """
-    # imported here to prevent cluster failures, unsure why this causes an error
-    result = os.path.abspath(os.path.join(*pathParts))
-    try:
-        from ccl import common_operations
-
-        return common_operations.convert_to_unc_path(result)
-    except Exception:
-        return result
+    return os.path.abspath(os.path.join(*pathParts))
 
 
 def copyOrWarn(fileDescription, sourcePath, destinationPath):


### PR DESCRIPTION
## What is the change?

Here I remove a defunct import.

## Why is the change being made?

This import does not belong in ARMI.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.