### PR TITLE
Adding unit tests for `CylindricalComponentsDuctHetAverageBlockCollection`

### DIFF
--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -536,6 +536,68 @@ class TestBlockCollectionComponentAverage1DCylinder(unittest.TestCase):
                     f"{nuc} temperature does not match expected value of {compTemp}",
                 )
 
+    def test_ComponentAverageDuctHet1DCylinder(self):
+        """
+        Tests that the cross-section group manager calculates the expected component atom density,
+        component area, and average nuclide temperature correctly for a duct heterogeneous cylindrical 
+        block collection.
+        """
+        self.o.cs[CONF_CROSS_SECTION]["ZA"].ductHeterogeneous = True
+        xsgm = self.o.getInterface("xsGroups")
+
+        xsgm.interactBOL()
+
+        # Check that the correct defaults are propagated after the interactBOL
+        # from the cross section group manager is called.
+        xsOpt = self.o.cs[CONF_CROSS_SECTION]["ZA"]
+        self.assertEqual(xsOpt.blockRepresentation, "ComponentAverage1DCylinder")
+
+        xsgm.createRepresentativeBlocks()
+        xsgm.updateNuclideTemperatures()
+
+        representativeBlockList = list(xsgm.representativeBlocks.values())
+        representativeBlockList.sort(key=lambda repB: repB.getMass() / repB.getVolume())
+        reprBlock = xsgm.representativeBlocks["ZA"]
+        self.assertEqual(reprBlock.name, "1D_CYL_DUCT_HET_AVG_ZA")
+        self.assertEqual(reprBlock.p.percentBu, 0.0)
+
+        refTemps = {"fuel": 600.0, "coolant": 450.0, "structure": 462.4565}
+
+        for c, compDensity, compArea in zip(
+            reprBlock, self.expectedComponentDensities, self.expectedComponentAreas
+        ):
+            self.assertEqual(compArea, c.getArea())
+            cNucs = c.getNuclides()
+            for nuc in cNucs:
+                self.assertAlmostEqual(
+                    c.getNumberDensity(nuc), compDensity.get(nuc, 0.0)
+                )
+                if "fuel" in c.getType():
+                    compTemp = refTemps["fuel"]
+                elif any(sodium in c.getType() for sodium in ["bond", "coolant"]):
+                    compTemp = refTemps["coolant"]
+                else:
+                    compTemp = refTemps["structure"]
+
+                if any(comp in c.getType() for comp in ["fuel", "bond", "coolant"]):
+                    # only 1 fuel component, and bond and coolant are both at same temperature
+                    # the component temp should match the avg nuc temp
+                    self.assertAlmostEqual(
+                        compTemp,
+                        xsgm.avgNucTemperatures["ZA"][nuc],
+                        2,
+                        f"{nuc} temperature does not match expected value of {compTemp} for component {c}",
+                    )
+                else:
+                    # steel components are at different temperatures
+                    # the temperatures should be different
+                    diff = abs(compTemp - xsgm.avgNucTemperatures["ZA"][nuc])
+                    self.assertGreater(
+                        diff,
+                        1.0,
+                        f"{nuc} temperature matches expected value of {compTemp} for component {c} but they should be different",
+                    )
+
     def test_checkComponentConsistency(self):
         xsgm = self.o.getInterface("xsGroups")
         xsgm.interactBOL()

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -539,7 +539,7 @@ class TestBlockCollectionComponentAverage1DCylinder(unittest.TestCase):
     def test_ComponentAverageDuctHet1DCylinder(self):
         """
         Tests that the cross-section group manager calculates the expected component atom density,
-        component area, and average nuclide temperature correctly for a duct heterogeneous cylindrical 
+        component area, and average nuclide temperature correctly for a duct heterogeneous cylindrical
         block collection.
         """
         self.o.cs[CONF_CROSS_SECTION]["ZA"].ductHeterogeneous = True
@@ -595,7 +595,7 @@ class TestBlockCollectionComponentAverage1DCylinder(unittest.TestCase):
                     self.assertGreater(
                         diff,
                         1.0,
-                        f"{nuc} temperature matches expected value of {compTemp} for component {c} but they should be different",
+                        f"{nuc} temperature should be different from {compTemp} for component {c}",
                     )
 
     def test_checkComponentConsistency(self):

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -197,7 +197,7 @@ class TestBlockConverter(unittest.TestCase):
         coolantMass = block.getComponent(Flags.COOLANT).getMass("NA")
         self.assertAlmostEqual(insideBlock.getMass("U235"), block.getMass("U235"))
         self.assertAlmostEqual(insideBlock.getMass("NA"), bondMass + coolantMass)
-        self.assertAlmostEqual(insideBlock.getArea(), ductIP ** 2 * math.sqrt(3)/2)
+        self.assertAlmostEqual(insideBlock.getArea(), ductIP**2 * math.sqrt(3) / 2)
 
     def test_convert(self):
         """Test conversion with no fuel driver.


### PR DESCRIPTION
## What is the change?

Adding unit tests to cover `CylindricalComponentsDuctHetAverageBlockCollection `.

## Why is the change being made?

Because a previous PR dropped the code coverage.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.