### PR TITLE
Removing SmartList & adding coverage

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -43,7 +43,7 @@ jobs:
           mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiFeatures.py || true
           mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiParameters.py || true
           mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiDirectoryChangers.py || true
-          coverage combine --rcfile=pyproject.toml --keep -a
+          coverage combine --rcfile=pyproject.toml --keep -a --fail-under=90
       - name: Publish to coveralls.io
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -43,7 +43,8 @@ jobs:
           mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiFeatures.py || true
           mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiParameters.py || true
           mpiexec -n 2 --use-hwthread-cpus coverage run --rcfile=pyproject.toml -m pytest --cov=armi --cov-config=pyproject.toml --cov-report=lcov --cov-append --ignore=venv armi/tests/test_mpiDirectoryChangers.py || true
-          coverage combine --rcfile=pyproject.toml --keep -a --fail-under=90
+          coverage combine --rcfile=pyproject.toml --keep -a
+          coverage report --rcfile=pyproject.toml -i --skip-empty --skip-covered --sort=cover --fail-under=90
       - name: Publish to coveralls.io
         uses: coverallsapp/github-action@v2
         with:

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -14,12 +14,9 @@
 
 """Tests the Interface."""
 import unittest
-import os
 
 from armi import interfaces
 from armi import settings
-from armi.tests import TEST_ROOT
-from armi.utils import textProcessors
 
 
 class DummyInterface(interfaces.Interface):
@@ -73,25 +70,6 @@ class TestCodeInterface(unittest.TestCase):
 
         self.assertEqual(type(i), type(iDup))
         self.assertEqual(i.enabled(), iDup.enabled())
-
-
-class TestTextProcessor(unittest.TestCase):
-    """Test Text processor."""
-
-    def setUp(self):
-        self.tp = textProcessors.TextProcessor(os.path.join(TEST_ROOT, "geom.xml"))
-
-    def test_fsearch(self):
-        """Test fsearch in re mode."""
-        line = self.tp.fsearch("xml")
-        self.assertIn("version", line)
-        self.assertEqual(self.tp.fsearch("xml"), "")
-
-    def test_fsearch_text(self):
-        """Test fsearch in text mode."""
-        line = self.tp.fsearch("xml", textFlag=True)
-        self.assertIn("version", line)
-        self.assertEqual(self.tp.fsearch("xml"), "")
 
 
 class TestTightCoupler(unittest.TestCase):

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -214,8 +214,8 @@ def keffVsTime(name, time, keff, keffUnc=None, ymin=None, extension=None):
 
 
 def buVsTime(name, scalars, extension=None):
-    r"""
-    produces a burnup and DPA vs. time plot for this case.
+    """
+    Produces a burnup and DPA vs time plot for this case.
 
     Will add a second axis containing DPA if the scalar column maxDPA exists.
 
@@ -235,8 +235,8 @@ def buVsTime(name, scalars, extension=None):
         plt.plot(scalars["time"], scalars["maxBuI"], ".-", label="Driver")
     except ValueError:
         runLog.warning(
-            "Incompatible axis length in burnup plot. Time has {0}, bu has {1}. Skipping"
-            "".format(len(scalars["time"]), len(scalars["maxBuI"]))
+            f"Incompatible axis length in burnup plot. Time has {len(scalars['time'])}, bu has "
+            f"{len(scalars['maxBuI'])}. Skipping"
         )
         plt.close(1)
         return
@@ -258,7 +258,7 @@ def buVsTime(name, scalars, extension=None):
 
     plt.title(title)
     plt.legend(loc="lower right")
-    figName = name + ".bu." + extension
+    figName = f"{name}.bu.{extension}"
     plt.savefig(figName)
     plt.close(1)
 
@@ -266,8 +266,8 @@ def buVsTime(name, scalars, extension=None):
 
 
 def xsHistoryVsTime(name, history, buGroups, extension=None):
-    r"""
-    Plot cross section history vs. time.
+    """
+    Plot cross section history vs time.
 
     Parameters
     ----------

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -214,8 +214,8 @@ def keffVsTime(name, time, keff, keffUnc=None, ymin=None, extension=None):
 
 
 def buVsTime(name, scalars, extension=None):
-    """
-    Produces a burnup and DPA vs time plot for this case.
+    r"""
+    produces a burnup and DPA vs. time plot for this case.
 
     Will add a second axis containing DPA if the scalar column maxDPA exists.
 
@@ -235,8 +235,8 @@ def buVsTime(name, scalars, extension=None):
         plt.plot(scalars["time"], scalars["maxBuI"], ".-", label="Driver")
     except ValueError:
         runLog.warning(
-            f"Incompatible axis length in burnup plot. Time has {len(scalars['time'])}, bu has "
-            f"{len(scalars['maxBuI'])}. Skipping"
+            "Incompatible axis length in burnup plot. Time has {0}, bu has {1}. Skipping"
+            "".format(len(scalars["time"]), len(scalars["maxBuI"]))
         )
         plt.close(1)
         return
@@ -258,7 +258,7 @@ def buVsTime(name, scalars, extension=None):
 
     plt.title(title)
     plt.legend(loc="lower right")
-    figName = f"{name}.bu.{extension}"
+    figName = name + ".bu." + extension
     plt.savefig(figName)
     plt.close(1)
 
@@ -266,8 +266,8 @@ def buVsTime(name, scalars, extension=None):
 
 
 def xsHistoryVsTime(name, history, buGroups, extension=None):
-    """
-    Plot cross section history vs time.
+    r"""
+    Plot cross section history vs. time.
 
     Parameters
     ----------

--- a/armi/utils/textProcessors.py
+++ b/armi/utils/textProcessors.py
@@ -304,7 +304,6 @@ class SequentialReader:
         ----------
         text : str
             text to find within the file
-
         warning : str
             An warning message to issue.
 
@@ -316,7 +315,8 @@ class SequentialReader:
         self._textWarnings.append((text, warning))
 
     def raiseErrorOnFindingText(self, text, error):
-        """Add a text search for every line of the file, if the text is found the specified error will be raised.
+        """Add a text search for every line of the file, if the text is found the specified error
+        will be raised.
 
         This is important for determining if errors occurred while searching for text.
 
@@ -335,7 +335,8 @@ class SequentialReader:
         self._textErrors.append((text, error))
 
     def raiseErrorOnFindingPattern(self, pattern, error):
-        """Add a pattern search for every line of the file, if the pattern is found the specified error will be raised.
+        """Add a pattern search for every line of the file, if the pattern is found the specified
+        error will be raised.
 
         This is important for determining if errors occurred while searching for text.
 
@@ -533,7 +534,7 @@ class TextProcessor:
     number = FLOATING_PATTERN
     decimal = DECIMAL_PATTERN
 
-    def __init__(self, fname, highMem=False):
+    def __init__(self, fname):
         self.eChecking = False
         # Preserve python 2-like behavior for unit tests that pass None and provide
         # their own text data (in py2, passing None to abspath yields cwd; py3 raises)
@@ -546,12 +547,7 @@ class TextProcessor:
                 # need this not to fail for detecting when RXSUM doesn't exist, etc.
                 # note: Could make it check before instantiating...
                 raise FileNotFoundError(f"{fname} does not exist.")
-        if not highMem:
-            # keep the file on disk, read as necessary
-            self.f = f
-        else:
-            # read all of f into memory and set up a list that remembers where it is.
-            self.f = SmartList(f)
+        self.f = f
 
     def reset(self):
         """Rewinds the file so you can search through it again."""
@@ -616,42 +612,3 @@ class TextProcessor:
                 result = ""
 
         return result
-
-
-class SmartList:
-    """A list that does stuff like files do i.e. remembers where it was, can seek, etc.
-    Actually this is pretty slow. so much for being smart. nice idea though.
-    """
-
-    def __init__(self, f):
-        self.lines = f.readlines()
-        self.position = 0
-        self.name = f.name
-        self.length = len(self.lines)
-
-    def __getitem__(self, index):
-        return self.lines[index]
-
-    def __setitem__(self, index, line):
-        self.lines[index] = line
-
-    def next(self):
-        if self.position >= self.length:
-            self.position = 0
-            raise StopIteration
-        else:
-            c = self.position
-            self.position += 1
-            return self.lines[c]
-
-    def __iter__(self):
-        return self
-
-    def __len__(self):
-        return len(self.lines)
-
-    def seek(self, line):
-        self.position = line
-
-    def close(self):
-        pass

--- a/armi/utils/textProcessors.py
+++ b/armi/utils/textProcessors.py
@@ -534,7 +534,7 @@ class TextProcessor:
     number = FLOATING_PATTERN
     decimal = DECIMAL_PATTERN
 
-    def __init__(self, fname):
+    def __init__(self, fname, highMem=False):
         self.eChecking = False
         # Preserve python 2-like behavior for unit tests that pass None and provide
         # their own text data (in py2, passing None to abspath yields cwd; py3 raises)

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -48,6 +48,7 @@ API Changes
 #. Removing ``globalFluxInterface.DoseResultsMapper`` class. (`PR#1952 <https://github.com/terrapower/armi/pull/1952>`_)
 #. Removing setting ``mpiTasksPerNode`` and renaming ``numProcessors`` to ``nTasks``. (`PR#1958 <https://github.com/terrapower/armi/pull/1958>`_)
 #. Changing ``synDbAfterWrite`` default to ``True``. (`PR#1968 <https://github.com/terrapower/armi/pull/1968>`_)
+#. Removing unused class ``SmartList``. (`PR#1992 <https://github.com/terrapower/armi/pull/1992>`_)
 #. TBD
 
 Bug Fixes


### PR DESCRIPTION
## What is the change?

1. Added a bunch of code coverage to `textProcessors.py`.
  * Moved unit tests for `textProcessors.py` from `test_interfaces.py`.
  * Removed `testProcessors.py::SmartList` from the API.
2. I added `--fail-under=90`.

## Why is the change being made?

Last night, I was trying to add code coverage to `textProcessors.py`, on general principles.

And I noticed two strange things:

1. Half the test for `textProcessors.py` were in `test_interface.py` for now reason. So I moved those into `textProcessors.py`.
2. The class `SmartList` in `textProcessors.py` was totally broken. I found multiple bugs in that class and it's usage while trying to write tests for it that prove it has not worked in at _least_ four years. So, it is unused and I removed it.

## Notes

* I tested the `--fail-under` flag in another branch and it [worked](https://github.com/terrapower/armi/actions/runs/11615347093/job/32345699811#step:6:731).
* @opotowsky I was able to show that this change does not affect downstream tests (jenkins 249)

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.