### PR TITLE
Removing broken plot buVsTime

### DIFF
--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -24,7 +24,6 @@ for instance, plot some sequence of objects in a loop at every time node. If you
 to see your memory usage grow inexplicably, you should question any plots that you are
 generating.
 """
-
 import itertools
 import math
 import os
@@ -111,12 +110,8 @@ def plotReactorPerformance(reactor, dbi, buGroups, extension=None, history=None)
         ymin=1.0,
         extension=extension,
     )
-    buVsTime(reactor.name, scalars, extension=extension)
     xsHistoryVsTime(reactor.name, history, buGroups, extension=extension)
     movesVsCycle(reactor.name, scalars, extension=extension)
-
-
-# --------------------------
 
 
 def valueVsTime(name, x, y, key, yaxis, title, ymin=None, extension=None):
@@ -211,58 +206,6 @@ def keffVsTime(name, time, keff, keffUnc=None, ymin=None, extension=None):
     plt.close(1)
 
     report.setData("K-Eff", os.path.abspath(figName), report.KEFF_PLOT)
-
-
-def buVsTime(name, scalars, extension=None):
-    r"""
-    produces a burnup and DPA vs. time plot for this case.
-
-    Will add a second axis containing DPA if the scalar column maxDPA exists.
-
-    Parameters
-    ----------
-    name : str
-        reactor.name
-    scalars : dict
-        Scalar values for this case
-    extension : str, optional
-        The file extension for saving the figure
-    """
-    extension = extension or settings.Settings()["outputFileExtension"]
-
-    plt.figure()
-    try:
-        plt.plot(scalars["time"], scalars["maxBuI"], ".-", label="Driver")
-    except ValueError:
-        runLog.warning(
-            "Incompatible axis length in burnup plot. Time has {0}, bu has {1}. Skipping"
-            "".format(len(scalars["time"]), len(scalars["maxBuI"]))
-        )
-        plt.close(1)
-        return
-
-    plt.plot(scalars["time"], scalars["maxBuF"], ".-", label="Feed")
-    plt.xlabel("Time (yr)")
-    plt.ylabel("BU (%FIMA)")
-    plt.grid(color="0.70")
-    plt.legend(loc="lower left")
-    title = "Maximum burnup"
-    if scalars["maxDPA"]:
-        plt.twinx()
-        plt.plot(scalars["time"], scalars["maxDPA"], "r--", label="dpa")
-        plt.legend(loc="lower right")
-        plt.ylabel("dpa")
-        title += " and DPA"
-
-    title += " for " + name
-
-    plt.title(title)
-    plt.legend(loc="lower right")
-    figName = name + ".bu." + extension
-    plt.savefig(figName)
-    plt.close(1)
-
-    report.setData("Burnup Plot", os.path.abspath(figName), report.BURNUP_PLOT)
 
 
 def xsHistoryVsTime(name, history, buGroups, extension=None):
@@ -675,7 +618,6 @@ def createPlotMetaData(
     -------
     metadata : dict
         Dictionary with all plot metadata information
-
     """
     metadata = {}
 

--- a/armi/utils/tests/test_reportPlotting.py
+++ b/armi/utils/tests/test_reportPlotting.py
@@ -22,7 +22,6 @@ from armi.reactor.tests import test_reactors
 from armi.tests import TEST_ROOT
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 from armi.utils.reportPlotting import (
-    buVsTime,
     createPlotMetaData,
     keffVsTime,
     movesVsCycle,
@@ -97,19 +96,6 @@ class TestRadar(unittest.TestCase):
         valueVsTime(self.r.name, t, t, "val", "yaxis", "title", extension=ext)
         self.assertTrue(os.path.exists("R-armiRunSmallest.val.png"))
         self.assertGreater(os.path.getsize("R-armiRunSmallest.val.png"), 0)
-
-    def test_buVsTime(self):
-        name = "buvstime"
-        scalars = {
-            "time": [1, 2, 3, 4],
-            "maxBuI": [6, 7, 8, 9],
-            "maxBuF": [6, 7, 8, 9],
-            "maxDPA": [6, 7, 8, 9],
-        }
-        figName = name + ".bu.png"
-        buVsTime(name, scalars, "png")
-        self.assertTrue(os.path.exists(figName))
-        self.assertGreater(os.path.getsize(figName), 0)
 
     def test_movesVsCycle(self):
         name = "movesVsCycle"

--- a/doc/release/0.4.rst
+++ b/doc/release/0.4.rst
@@ -38,6 +38,7 @@ API Changes
 #. Renaming ``Reactor.moveList`` to ``Reactor.moves``. (`PR#1881 <https://github.com/terrapower/armi/pull/1881>`_)
 #. ``copyInterfaceInputs`` no longer requires a valid setting object. (`PR#1934 <https://github.com/terrapower/armi/pull/1934>`_)
 #. Removing ``buildEqRingSchedule``. (`PR#1928 <https://github.com/terrapower/armi/pull/1928>`_)
+#. Removing broken plot ``buVsTime``. (`PR#1994 <https://github.com/terrapower/armi/pull/1994>`_)
 #. Allowing for unknown Flags when opening a DB. (`PR#1844 <https://github.com/terrapower/armi/pull/1835>`_)
 #. Removing ``Assembly.doubleResolution()``. (`PR#1951 <https://github.com/terrapower/armi/pull/1951>`_)
 #. Removing ``assemblyLists.py`` and the ``AssemblyList`` class. (`PR#1891 <https://github.com/terrapower/armi/pull/1891>`_)


### PR DESCRIPTION
## What is the change?

Removing broken plot `buVsTime`.

## Why is the change being made?

This plot has been broken for a few years, so I know it has been unused for that time.

I spoke with analysts that you might expect to want it, and they do not.

close #1902

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.