### PR TITLE
Finishing up the numProcessors -> nTasks conversion

### DIFF
--- a/armi/tests/ThRZSettings.yaml
+++ b/armi/tests/ThRZSettings.yaml
@@ -7,7 +7,7 @@ settings:
   comment: "Revised benchmark  "
   geomFile: ThRZGeom.xml
   loadingFile: ThRZloading.yaml
-  numProcessors: 12
+  nTasks: 12
   outputFileExtension: png
   power: 1000000.0
 

--- a/armi/tests/anl-afci-177/anl-afci-177.yaml
+++ b/armi/tests/anl-afci-177/anl-afci-177.yaml
@@ -19,6 +19,6 @@ settings:
     - 100
   comment: ANL-AFCI-177 CR 1.0 metal core but with HALEU instead of TRU
   genXS: Neutron
-  numProcessors: 1
+  nTasks: 1
   versions:
     armi: uncontrolled

--- a/armi/tests/c5g7/c5g7-settings.yaml
+++ b/armi/tests/c5g7/c5g7-settings.yaml
@@ -8,7 +8,7 @@ settings:
   cycleLength: 411.11
   loadingFile: c5g7-blueprints.yaml
   nCycles: 10
-  numProcessors: 1
+  nTasks: 1
   power: 1000000000.0
   versions:
     armi: uncontrolled

--- a/armi/tests/godiva/godiva.armi.unittest.yaml
+++ b/armi/tests/godiva/godiva.armi.unittest.yaml
@@ -16,7 +16,7 @@ settings:
   neutronicsKernel: DIF3D-FD
   neutronicsOutputsToSave: All
   neutronicsType: both
-  numProcessors: 36
+  nTasks: 36
   outers: 200
   power: 0.001
   verbosity: debug

--- a/armi/tests/zpprTest.yaml
+++ b/armi/tests/zpprTest.yaml
@@ -12,7 +12,7 @@ settings:
   geomFile: zpprTestGeom.xml
   loadingFile: 1DslabXSByCompTest.yaml
   mpiTasksPerNode: 6
-  numProcessors: 12
+  nTasks: 12
   outputFileExtension: pdf
   power: 75000000.0
   sortReactor: false # zpprs dont sor the right way. need better component sorting for slab...


### PR DESCRIPTION
## What is the change?

Renaming `numProcessors` to `nTasks` in test settings files.

## Why is the change being made?

#1958 renamed this setting, but there are some settings files in the `armi/tests` directory that continue to use it.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.