### PR TITLE
Improving error testing

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -228,15 +228,17 @@ class TestCompareDB3(unittest.TestCase):
             refData4 = f4.create_dataset("numberDensities", data=a2)
             refData4.attrs["shapes"] = "2"
             refData4.attrs["numDens"] = a2
+            refData4.attrs["specialFormatting"] = True
             f5 = h5py.File("test_diffSpecialData5.hdf5", "w")
             srcData5 = f5.create_dataset("numberDensities", data=a2)
             srcData5.attrs["shapes"] = "2"
             srcData5.attrs["numDens"] = a2
+            srcData5.attrs["specialFormatting"] = True
 
-            # there should an exception
-            with self.assertRaises(Exception) as e:
+            # there should a log message
+            with mockRunLogs.BufferLog() as mock:
                 _diffSpecialData(refData4, srcData5, out, dr)
-                self.assertIn("Unable to unpack special data for paramName", e)
+                self.assertIn("Unable to unpack special data for", mock.getStdout())
 
             # make an H5 datasets that will add a np.inf diff because keys don't match
             f6 = h5py.File("test_diffSpecialData6.hdf5", "w")

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -41,9 +41,6 @@ class PathToolsTests(unittest.TestCase):
             with mockRunLogs.BufferLog() as mock:
                 pathTools.copyOrWarn("Test File", "FileDoesntExist.txt", pathCopy)
                 self.assertIn("Could not copy", mock.getStdout())
-                self.assertIn(
-                    "The system cannot find the file specified", mock.getStdout()
-                )
 
     def test_copyOrWarnDir(self):
         with TemporaryDirectoryChanger():
@@ -62,9 +59,6 @@ class PathToolsTests(unittest.TestCase):
             with mockRunLogs.BufferLog() as mock:
                 pathTools.copyOrWarn("Test File", "DirDoesntExist", pathDirCopy)
                 self.assertIn("Could not copy", mock.getStdout())
-                self.assertIn(
-                    "The system cannot find the file specified", mock.getStdout()
-                )
 
     def test_separateModuleAndAttribute(self):
         self.assertRaises(

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -19,6 +19,7 @@ import types
 import unittest
 
 from armi import context
+from armi.tests import mockRunLogs
 from armi.utils import pathTools
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
@@ -36,11 +37,13 @@ class PathToolsTests(unittest.TestCase):
             pathTools.copyOrWarn("Test File", path, pathCopy)
             self.assertTrue(os.path.exists(pathCopy))
 
-            # Test an exception
-            with self.assertRaises(Exception) as e:
+            # Test a non-existant file
+            with mockRunLogs.BufferLog() as mock:
                 pathTools.copyOrWarn("Test File", "FileDoesntExist.txt", pathCopy)
-                self.assertIn("Could not copy", e)
-                self.assertIn("No such file or directory", e)
+                self.assertIn("Could not copy", mock.getStdout())
+                self.assertIn(
+                    "The system cannot find the file specified", mock.getStdout()
+                )
 
     def test_copyOrWarnDir(self):
         with TemporaryDirectoryChanger():
@@ -55,11 +58,13 @@ class PathToolsTests(unittest.TestCase):
             self.assertTrue(os.path.exists(pathDirCopy))
             self.assertTrue(os.path.exists(os.path.join(pathDirCopy, "test.txt")))
 
-            # Test an exception
-            with self.assertRaises(Exception) as e:
+            # Test a non-existant file
+            with mockRunLogs.BufferLog() as mock:
                 pathTools.copyOrWarn("Test File", "DirDoesntExist", pathDirCopy)
-                self.assertIn("Could not copy", e)
-                self.assertIn("No such file or directory", e)
+                self.assertIn("Could not copy", mock.getStdout())
+                self.assertIn(
+                    "The system cannot find the file specified", mock.getStdout()
+                )
 
     def test_separateModuleAndAttribute(self):
         self.assertRaises(


### PR DESCRIPTION
## What is the change?

Improving some of our tests that were using `unittest.TestCase.assertRaises()` incorrectly.

## Why is the change being made?

In #2001 I identify 3 tests in ARMI that were incorrectly using `assertRaises()`. When I got in there to look at them, I found that all three tests were essentially broken. And I had to slightly re-write those tests. 

close #2001 

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.