### PR TITLE
Making output cache detection less specific

### DIFF
--- a/armi/utils/outputCache.py
+++ b/armi/utils/outputCache.py
@@ -175,10 +175,10 @@ def deleteCache(cachedFolder):
     """
     Remove this folder.
 
-    Requires safeword because this is potentially extremely destructive.
+    Requires keyword because this is potentially extremely destructive.
     """
-    if "Output_Cache" not in cachedFolder:
-        raise RuntimeError("Cache location must contain safeword: `Output_Cache`.")
+    if "cache" not in str(cachedFolder).lower():
+        raise RuntimeError("Cache location must contain keyword: `cache`.")
 
     cleanPath(cachedFolder)
 


### PR DESCRIPTION
## What is the change?

Before deleting a cache folder we used to look for the exact phrase "Output_Cache", but now I am just looking for "cache" in a case-insensitive way.

## Why is the change being made?

The old string was a bit too specific, I didn't love the pseudo-camel-case nature of it, and it bit someone recently.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.