### PR TITLE
Fixing broken requirement crumbs

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1254,7 +1254,7 @@ class HexAssembly(Assembly):
         """Rotate an assembly and its children.
 
         .. impl:: A hexagonal assembly shall support rotating around the z-axis in 60 degree increments.
-            :id: I_ARMI_ROTATE_HEX
+            :id: I_ARMI_ROTATE_HEX_ASSEM
             :implements: R_ARMI_ROTATE_HEX
 
             This method loops through every ``Block`` in this ``HexAssembly`` and rotates

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2051,32 +2051,23 @@ class HexBlock(Block):
 
     def rotate(self, rad: float):
         """
-        Rotates a block's spatially varying parameters by a specified angle in the
-        counter-clockwise direction.
+        Rotates a block's spatially-varying parameters by a specified angle in the counter-clockwise
+        direction.
 
-        The parameters must have a ParamLocation of either CORNERS or EDGES and must be a
-        Python list of length 6 in order to be eligible for rotation; all parameters that
-        do not meet these two criteria are not rotated.
+        The parameters must have a ParamLocation of either CORNERS or EDGES and must be a list of
+        length 6 in order to be eligible for rotation; all parameters that do not meet these two
+        criteria are not rotated.
 
-        .. impl:: Rotating a hex block updates the orientation parameter.
-            :id: I_ARMI_ROTATE_HEX_ORIENTATION
-            :implements: R_ARMI_ROTATE_HEX_PARAMS
-
-        .. impl:: Rotating a hex block updates parameters on the boundary of the hexagon.
-            :id: I_ARMI_ROTATE_HEX_BOUNDARY
-            :tests: R_ARMI_ROTATE_HEX_PARAMS
-
-        .. impl:: Rotating a hex block updates the spatial coordinates on contained objects.
-            :id: I_ARMI_ROTATE_HEX_PIN
-            :tests: R_ARMI_ROTATE_HEX
+        .. impl:: Rotating a hex block updates parameters on the boundary, the orientation
+            parameter, and the spatial coordinates on contained objects.
+            :id: I_ARMI_ROTATE_HEX_BLOCK
+            :implements: R_ARMI_ROTATE_HEX
 
         Parameters
         ----------
-        rad: float, required
-            Angle of counter-clockwise rotation in units of radians. Rotations must be
-            in 60-degree increments (i.e., PI/6, PI/3, PI, 2 * PI/3, 5 * PI/6,
-            and 2 * PI)
-
+        rad: float
+            Angle of counter-clockwise rotation in units of radians. Rotations must be in 60-degree
+            increments (i.e., PI/6, PI/3, PI, 2 * PI/3, 5 * PI/6, and 2 * PI).
         """
         rotNum = round((rad % (2 * math.pi)) / math.radians(60))
         self._rotateChildLocations(rad, rotNum)

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1015,7 +1015,7 @@ class Assembly_TestCase(unittest.TestCase):
         """Test rotation of an assembly spatial objects.
 
         .. test:: An assembly can be rotated about its z-axis.
-            :id: T_ARMI_ROTATE_HEX
+            :id: T_ARMI_ROTATE_HEX_ASSEM
             :tests: R_ARMI_ROTATE_HEX
         """
         a = makeTestAssembly(1, 1)

--- a/armi/reactor/tests/test_hexBlockRotate.py
+++ b/armi/reactor/tests/test_hexBlockRotate.py
@@ -72,13 +72,10 @@ class HexBlockRotateTests(unittest.TestCase):
     def test_orientationVector(self):
         """Test the z-value in the orientation vector matches rotation.
 
-        .. test:: Demonstrate that a HexBlock can be rotated in 60 degree increments.
+        .. test:: Demonstrate that a HexBlock can be rotated in 60 degree increments, and the
+            resultant orientation parameter reflects the current rotation.
             :id: T_ARMI_ROTATE_HEX_BLOCK
             :tests: R_ARMI_ROTATE_HEX
-
-        .. test:: After rotating a block, the orientation parameter reflects the current rotation.
-            :id: T_ARMI_ROTATE_HEX_ORIENTATION
-            :tests: R_ARMI_ROTATE_HEX_PARAMS
         """
         for nRotations in range(-10, 10):
             rotationAmount = 60 * nRotations
@@ -100,7 +97,7 @@ class HexBlockRotateTests(unittest.TestCase):
 
         .. test:: Rotating a hex block updates parameters on the boundary of the hexagon.
             :id: T_ARMI_ROTATE_HEX_BOUNDARY
-            :tests: R_ARMI_ROTATE_HEX_PARAMS
+            :tests: R_ARMI_ROTATE_HEX
         """
         # No rotation == no changes to data
         self._rotateAndCompareBoundaryParams(0, self.BOUNDARY_DATA)


### PR DESCRIPTION
## What is the change?

Removing references to requirement `R_ARMI_ROTATE_HEX_PARMS` in favor of `R_ARMI_ROTATE_HEX`

## Why is the change being made?

The tentative new requirement `R_ARMI_ROTATE_HEX_PARAMS` was removed.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.