### PR TITLE
Improving calculation for total job memory

### DIFF
--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -181,7 +181,7 @@ class TestMemoryProfiler(unittest.TestCase):
             self.assertIn("Currently using 6.0 GB of memory.", stdOut)
             self.assertIn("There is 44.0 GB of memory left.", stdOut)
             self.assertIn("There is a total allocation of 50.0 GB", stdOut)
-            # Try another for funzies
+            # Try another for funzies where we only use half the available resources on the node
             mockLogs.emptyStdout()
             self.memPro.cs = {"cpusPerTask": 5, "nTasks": 1}
             self.memPro.printCurrentMemoryState()

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -139,9 +139,18 @@ class TestMemoryProfiler(unittest.TestCase):
         vMem.total = (1024**3) * 50
         mockVMem.return_value = vMem
 
-        expectedArrangement = {0: 50, 1: 50, 2: 50, 3: 45, 4: 40, 5: 50}
-        for nTasksPerNode, jobMemory in expectedArrangement.items():
-            self.assertEqual(getTotalJobMemory(nTasksPerNode), jobMemory)
+        expectedArrangement = {
+            (10, 1): 50,
+            (1, 10): 50,
+            (2, 5): 50,
+            (3, 3): 45,
+            (4, 1): 20,
+            (2, 4): 40,
+            (5, 2): 50,
+        }
+        for compReq, jobMemory in expectedArrangement.items():
+            # compReq[0] is nTasks and compReq[1] is cpusPerTask
+            self.assertEqual(getTotalJobMemory(compReq[0], compReq[1]), jobMemory)
 
     @patch("armi.bookkeeping.memoryProfiler.PrintSystemMemoryUsageAction")
     @patch("armi.bookkeeping.memoryProfiler.SystemAndProcessMemoryUsage")
@@ -166,20 +175,26 @@ class TestMemoryProfiler(unittest.TestCase):
         mockVMem.return_value = vMem
         self._setMemUseMock(mockPrintSysMemUseAction)
         with mockRunLogs.BufferLog() as mockLogs:
-            csMock = MagicMock()
-            csMock.__getitem__.return_value = 2
-            self.memPro.cs = csMock
+            self.memPro.cs = {"cpusPerTask": 1, "nTasks": 10}
             self.memPro.printCurrentMemoryState()
             stdOut = mockLogs.getStdout()
             self.assertIn("Currently using 6.0 GB of memory.", stdOut)
             self.assertIn("There is 44.0 GB of memory left.", stdOut)
             self.assertIn("There is a total allocation of 50.0 GB", stdOut)
+            # Try another for funzies
+            mockLogs.emptyStdout()
+            self.memPro.cs = {"cpusPerTask": 5, "nTasks": 1}
+            self.memPro.printCurrentMemoryState()
+            stdOut = mockLogs.getStdout()
+            self.assertIn("Currently using 6.0 GB of memory.", stdOut)
+            self.assertIn("There is 19.0 GB of memory left.", stdOut)
+            self.assertIn("There is a total allocation of 25.0 GB", stdOut)
 
     def test_printCurrentMemoryState_noSetting(self):
         """Test that the try/except works as it should."""
         expectedStr = (
             "To view memory consumed, remaining available, and total allocated for a case, "
-            "add the setting 'nTasksPerNode' to your application."
+            "add the setting 'cpusPerTask' to your application."
         )
         with mockRunLogs.BufferLog() as mockLogs:
             self.memPro.printCurrentMemoryState()


### PR DESCRIPTION
## What is the change?

This swaps the calculation for total job memory to use a more straightforward cluster resource request parameter. Some edits and additions to the tests flow from the update.

## Why is the change being made?

This makes the math simpler!

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] ~The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.~ too small to matter
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.