### PR TITLE
Move files from temporary directory changer

### DIFF
--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -78,6 +78,7 @@ from armi.reactor.reactorParameters import makeParametersReadOnly
 from armi.reactor.reactors import Core, Reactor
 from armi.settings.fwSettings.globalSettings import CONF_SORT_REACTOR
 from armi.utils import getNodesPerCycle
+from armi.utils import safeMove
 from armi.utils.textProcessors import resolveMarkupInclusions
 
 # CONSTANTS
@@ -312,7 +313,7 @@ class Database:
 
         if self._permission == "w":
             # move out of the FAST_PATH and into the working directory
-            newPath = shutil.move(self._fullPath, self._fileName)
+            newPath = safeMove(self._fullPath, self._fileName)
             self._fullPath = os.path.abspath(newPath)
 
     def splitDatabase(
@@ -351,7 +352,7 @@ class Database:
         backupDBPath = os.path.abspath(label.join(os.path.splitext(self._fileName)))
         runLog.info("Retaining full database history in {}".format(backupDBPath))
         if self._fullPath is not None:
-            shutil.move(self._fullPath, backupDBPath)
+            safeMove(self._fullPath, backupDBPath)
 
         self.h5db = h5py.File(self._fullPath, self._permission)
         dbOut = self.h5db

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -836,6 +836,7 @@ def safeCopy(src: str, dst: str) -> None:
 
     runLog.extra("Copied {} -> {}".format(src, dst))
 
+
 def safeMove(src: str, dst: str) -> None:
     """This copy overwrites ``shutil.move`` and checks that move operation is truly completed before continuing."""
     # Convert files to OS-independence

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -844,6 +844,7 @@ def safeMove(src: str, dst: str) -> None:
     dst = os.path.abspath(dst)
     if os.path.isdir(dst):
         dst = os.path.join(dst, os.path.basename(src))
+
     srcSize = os.path.getsize(src)
     if "win" in sys.platform:
         shutil.move(src, dst)
@@ -853,7 +854,7 @@ def safeMove(src: str, dst: str) -> None:
     else:
         raise OSError(
             "Cannot perform ``safeMove`` on files because ARMI only supports "
-            + "Linux and Windows."
+            + "Linux, MacOS, and Windows."
         )
     waitTime = 0.01  # 10 ms
     maxWaitTime = 6000  # 1 min

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -846,8 +846,7 @@ def safeMove(src: str, dst: str) -> None:
         dst = os.path.join(dst, os.path.basename(src))
     srcSize = os.path.getsize(src)
     if "win" in sys.platform:
-        shutil.copyfile(src, dst)
-        shutil.copymode(src, dst)
+        os.replace(src, dst)
     elif "linux" in sys.platform:
         cmd = f'mv "{src}" "{dst}"'
         os.system(cmd)

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -872,6 +872,7 @@ def safeMove(src: str, dst: str) -> None:
             break
 
     runLog.extra("Moved {} -> {}".format(src, dst))
+    return dst
 
 
 # Allow us to check the copy operation is complete before continuing

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -848,7 +848,7 @@ def safeMove(src: str, dst: str) -> None:
     if "win" in sys.platform:
         shutil.move(src, dst)
     elif "linux" in sys.platform:
-        cmd = f'cp "{src}" "{dst}"'
+        cmd = f'mv "{src}" "{dst}"'
         os.system(cmd)
     else:
         raise OSError(
@@ -856,7 +856,7 @@ def safeMove(src: str, dst: str) -> None:
             + "Linux and Windows."
         )
     waitTime = 0.01  # 10 ms
-    maxWaitTime = 60  # 1 min
+    maxWaitTime = 6000  # 1 min
     totalWaitTime = 0
     while True:
         try:

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -859,9 +859,12 @@ def safeMove(src: str, dst: str) -> None:
     maxWaitTime = 60  # 1 min
     totalWaitTime = 0
     while True:
-        dstSize = os.path.getsize(dst)
-        if srcSize == dstSize:
-            break
+        try:
+            dstSize = os.path.getsize(dst)
+            if srcSize == dstSize:
+                break
+        except FileNotFoundError:
+            pass
         time.sleep(waitTime)
         totalWaitTime += waitTime
         if totalWaitTime > maxWaitTime:

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -846,7 +846,8 @@ def safeMove(src: str, dst: str) -> None:
         dst = os.path.join(dst, os.path.basename(src))
     srcSize = os.path.getsize(src)
     if "win" in sys.platform:
-        shutil.move(src, dst)
+        shutil.copyfile(src, dst)
+        shutil.copymode(src, dst)
     elif "linux" in sys.platform:
         cmd = f'mv "{src}" "{dst}"'
         os.system(cmd)

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -836,7 +836,45 @@ def safeCopy(src: str, dst: str) -> None:
 
     runLog.extra("Copied {} -> {}".format(src, dst))
 
+def safeMove(src: str, dst: str) -> None:
+    """This copy overwrites ``shutil.move`` and checks that move operation is truly completed before continuing."""
+    # Convert files to OS-independence
+    src = os.path.abspath(src)
+    dst = os.path.abspath(dst)
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src))
+    srcSize = os.path.getsize(src)
+    if "win" in sys.platform:
+        shutil.move(src, dst)
+    elif "linux" in sys.platform:
+        cmd = f'cp "{src}" "{dst}"'
+        os.system(cmd)
+    else:
+        raise OSError(
+            "Cannot perform ``safeMove`` on files because ARMI only supports "
+            + "Linux and Windows."
+        )
+    waitTime = 0.01  # 10 ms
+    maxWaitTime = 60  # 1 min
+    totalWaitTime = 0
+    while True:
+        dstSize = os.path.getsize(dst)
+        if srcSize == dstSize:
+            break
+        time.sleep(waitTime)
+        totalWaitTime += waitTime
+        if totalWaitTime > maxWaitTime:
+            runLog.warning(
+                f"File move from {dst} to {src} has failed due to exceeding "
+                + f"a maximum wait time of {maxWaitTime/60} minutes."
+            )
+            break
+
+    runLog.extra("Moved {} -> {}".format(src, dst))
+
 
 # Allow us to check the copy operation is complete before continuing
 shutil_copy = shutil.copy
+shutil_move = shutil.move
 shutil.copy = safeCopy
+shutil.move = safeMove

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -847,6 +847,7 @@ def safeMove(src: str, dst: str) -> None:
 
     srcSize = os.path.getsize(src)
     if "win" in sys.platform:
+        # this covers Windows ("win32") and MacOS ("darwin")
         shutil.move(src, dst)
     elif "linux" in sys.platform:
         cmd = f'mv "{src}" "{dst}"'
@@ -856,6 +857,7 @@ def safeMove(src: str, dst: str) -> None:
             "Cannot perform ``safeMove`` on files because ARMI only supports "
             + "Linux, MacOS, and Windows."
         )
+
     waitTime = 0.01  # 10 ms
     maxWaitTime = 6000  # 1 min
     totalWaitTime = 0
@@ -873,7 +875,7 @@ def safeMove(src: str, dst: str) -> None:
                 f"File move from {dst} to {src} has failed due to exceeding "
                 + f"a maximum wait time of {maxWaitTime/60} minutes."
             )
-            break
+            return
 
     runLog.extra("Moved {} -> {}".format(src, dst))
     return dst

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -838,7 +838,7 @@ def safeCopy(src: str, dst: str) -> None:
 
 
 def safeMove(src: str, dst: str) -> None:
-    """This copy overwrites ``shutil.move`` and checks that move operation is truly completed before continuing."""
+    """Check that a file has been successfully moved before continuing."""
     # Convert files to OS-independence
     src = os.path.abspath(src)
     dst = os.path.abspath(dst)
@@ -846,7 +846,7 @@ def safeMove(src: str, dst: str) -> None:
         dst = os.path.join(dst, os.path.basename(src))
     srcSize = os.path.getsize(src)
     if "win" in sys.platform:
-        os.replace(src, dst)
+        shutil.move(src, dst)
     elif "linux" in sys.platform:
         cmd = f'mv "{src}" "{dst}"'
         os.system(cmd)
@@ -880,6 +880,4 @@ def safeMove(src: str, dst: str) -> None:
 
 # Allow us to check the copy operation is complete before continuing
 shutil_copy = shutil.copy
-shutil_move = shutil.move
 shutil.copy = safeCopy
-shutil.move = safeMove

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -22,6 +22,7 @@ import string
 from armi import context
 from armi import runLog
 from armi.utils import pathTools
+from armi.utils import safeMove
 
 
 def _changeDirectory(destination):
@@ -160,7 +161,7 @@ class DirectoryChanger:
         """
         folderName = os.path.split(self.destination)[1]
         recoveryPath = os.path.join(self.initial, f"dump-{folderName}")
-        shutil.move(self.destination, recoveryPath)
+        safeMove(self.destination, recoveryPath)
 
     def _createOutputDirectory(self):
         if self.outputPath == self.initial:
@@ -235,7 +236,7 @@ class DirectoryChanger:
                 toPath = os.path.join(destinationPath, destName)
                 if moveFiles:
                     runLog.extra("Moving {} to {}".format(fromPath, toPath))
-                    shutil.move(fromPath, toPath)
+                    safeMove(fromPath, toPath)
                 else:
                     runLog.extra("Copying {} to {}".format(fromPath, toPath))
                     shutil.copy(fromPath, toPath)

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -161,7 +161,7 @@ class DirectoryChanger:
         """
         folderName = os.path.split(self.destination)[1]
         recoveryPath = os.path.join(self.initial, f"dump-{folderName}")
-        safeMove(self.destination, recoveryPath)
+        shutil.copytree(self.destination, recoveryPath)
 
     def _createOutputDirectory(self):
         if self.outputPath == self.initial:

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -128,10 +128,14 @@ class DirectoryChanger:
         """Copy ``filesToMove`` into the destination directory on entry."""
         initialPath = self.initial
         destinationPath = self.destination
-        self._transferFiles(initialPath, destinationPath, self._filesToMove)
+        self._transferFiles(
+            initialPath, destinationPath, self._filesToMove, moveFiles=False
+        )
         if self.outputPath != self.initial:
             destinationPath = self.outputPath
-            self._transferFiles(initialPath, destinationPath, self._filesToMove)
+            self._transferFiles(
+                initialPath, destinationPath, self._filesToMove, moveFiles=False
+            )
 
     def retrieveFiles(self):
         """Copy ``filesToRetrieve`` back into the initial directory on exit."""

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -136,8 +136,15 @@ class DirectoryChanger:
     def retrieveFiles(self):
         """Copy ``filesToRetrieve`` back into the initial directory on exit."""
         if self.outputPath != self.initial:
-            self._transferFiles(self.destination, self.outputPath, self._filesToRetrieve, moveFiles=False)
-        self._transferFiles(self.destination, self.initial, self._filesToRetrieve, moveFiles=True)
+            self._transferFiles(
+                self.destination,
+                self.outputPath,
+                self._filesToRetrieve,
+                moveFiles=False,
+            )
+        self._transferFiles(
+            self.destination, self.initial, self._filesToRetrieve, moveFiles=True
+        )
 
     def _retrieveEntireFolder(self):
         """

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -220,7 +220,6 @@ class TestGeneralUtils(unittest.TestCase):
                 self.assertIn("file2", mock.getStdout())
                 self.assertIn("->", mock.getStdout())
             self.assertTrue(os.path.exists(os.path.join("dir2", "file1.txt")))
-            self.assertTrue(os.path.exists(os.path.join("dir2", "file2.txt")))
 
     def test_safeMove(self):
         with directoryChangers.TemporaryDirectoryChanger():
@@ -249,7 +248,6 @@ class TestGeneralUtils(unittest.TestCase):
                 self.assertIn("file2", mock.getStdout())
                 self.assertIn("->", mock.getStdout())
             self.assertTrue(os.path.exists(os.path.join("dir2", "file1.txt")))
-            self.assertTrue(os.path.exists(os.path.join("dir2", "file2.txt")))
 
     def test_safeMoveDir(self):
         with directoryChangers.TemporaryDirectoryChanger():
@@ -267,9 +265,7 @@ class TestGeneralUtils(unittest.TestCase):
                 self.assertIn("Moved", mock.getStdout())
                 self.assertIn("dir1", mock.getStdout())
                 self.assertIn("dir2", mock.getStdout())
-
             self.assertTrue(os.path.exists(os.path.join("dir2", "file1.txt")))
-            self.assertTrue(os.path.exists(os.path.join("dir2", "file2.txt")))
 
 
 class CyclesSettingsTests(unittest.TestCase):

--- a/doc/release/0.5.rst
+++ b/doc/release/0.5.rst
@@ -8,7 +8,7 @@ Release Date: TBD
 
 New Features
 ------------
-#. TBD
+#. Move instead of copy files from TemporaryDirectoryChanger. (`PR#2022 <https://github.com/terrapower/armi/pull/2022>`_)
 
 API Changes
 -----------


### PR DESCRIPTION
## What is the change?

Use `shutil.move` / `mv` instead of `shutil.copy` / `cp` to move files from temporary directory back to the original working directory on `__exit__`.

## Why is the change being made?

Copying files from one location to another keeps the original file intact, but the original files in a temporary directory do not need to be kept around after the `__exit__` from the `TemporaryDirectoryChanger`. These files are immediately deleted after the copy operation is completed.

Using `shutil.move()` is significantly faster than `shutil.copy()` when the source and destination locations are on the same drive, since the data doesn't have to physically be copied to a new place in memory.

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.