### PR TITLE
Handling checking for OSs better

### DIFF
--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -377,28 +377,28 @@ def _getSystemInfoLinux():
 
 
 def getSystemInfo():
-    """Get system information, assuming the system is Windows or Linux.
+    """Get system information, assuming the system is Linux, MacOS, and Windows.
 
     Notes
     -----
-    The format of the system information will be different on Windows vs Linux.
+    The format of the system information will be different on Linux, MacOS, and Windows.
 
     Returns
     -------
     str
         Basic system information: OS name, OS version, basic processor information
     """
-    # Get basic system information (on Windows and Linux)
-    if "win" in sys.platform:
+    # Get basic system information (on Linux, MacOS, and Windows)
+    if "darwin" in sys.platform:
+        return _getSystemInfoMac()
+    elif "win" in sys.platform:
         return _getSystemInfoWindows()
     elif "linux" in sys.platform:
         return _getSystemInfoLinux()
-    elif "darwin" in sys.platform:
-        return _getSystemInfoMac()
     else:
         runLog.warning(
             f"Cannot get system information for {sys.platform} because ARMI only "
-            + "supports Linux, Windows, and MacOS."
+            + "supports Linux, MacOS, and Windows."
         )
         return ""
 

--- a/armi/context.py
+++ b/armi/context.py
@@ -82,7 +82,8 @@ START_TIME = time.ctime()
 # Set batch mode if not a TTY, which means you're on a cluster writing to a stdout file. In this
 # mode you cannot respond to prompts. (This does not work reliably for both Windows and Linux so an
 # os-specific solution is applied.)
-isatty = sys.stdout.isatty() if "win" in sys.platform else sys.stdin.isatty()
+IS_WINDOWS = ("win" in sys.platform) and ("darwin" not in sys.platform)
+isatty = sys.stdout.isatty() if IS_WINDOWS else sys.stdin.isatty()
 CURRENT_MODE = Mode.INTERACTIVE if isatty else Mode.BATCH
 Mode.setMode(CURRENT_MODE)
 

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -806,8 +806,10 @@ def safeCopy(src: str, dst: str) -> None:
     dst = os.path.abspath(dst)
     if os.path.isdir(dst):
         dst = os.path.join(dst, os.path.basename(src))
+
     srcSize = os.path.getsize(src)
     if "win" in sys.platform:
+        # this covers Windows ("win32") and MacOS ("darwin")
         shutil.copyfile(src, dst)
         shutil.copymode(src, dst)
     elif "linux" in sys.platform:
@@ -816,8 +818,9 @@ def safeCopy(src: str, dst: str) -> None:
     else:
         raise OSError(
             "Cannot perform ``safeCopy`` on files because ARMI only supports "
-            + "Linux and Windows."
+            + "Linux, MacOs, and Windows."
         )
+
     waitTime = 0.01  # 10 ms
     maxWaitTime = 300  # 5 min
     totalWaitTime = 0
@@ -832,7 +835,7 @@ def safeCopy(src: str, dst: str) -> None:
                 f"File copy from {dst} to {src} has failed due to exceeding "
                 + f"a maximum wait time of {maxWaitTime/60} minutes."
             )
-            break
+            Return
 
     runLog.extra("Copied {} -> {}".format(src, dst))
 


### PR DESCRIPTION
## What is the change?

I went through all instance of `sys.platform` in ARMI to check that we were handling it correcty.

## Why is the change being made?

The problem I found was people were doing this to test if the current OS is Windows:

```python
"win" in sys.platform
```

This is because `sys.platform` returns `"win32"` for Windows, but it also returns `"darwin"` for MacOS.

Here is a helpful table:

```
┍━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━┑
│ System              │ Value               │
┝━━━━━━━━━━━━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━┥
│ Linux               │ linux or linux2     │
│ Windows             │ win32               │
│ Windows/Cygwin      │ cygwin              │
│ Windows/MSYS2       │ msys                │
│ MacOS               │ darwin              │
│ OS/2                │ os2                 │
│ OS/2 EMX            │ os2emx              │
│ RiscOS              │ riscos              │
│ AtheOS              │ atheos              │
│ FreeBSD 7           │ freebsd7            │
│ FreeBSD 8           │ freebsd8            │
│ FreeBSD N           │ freebsdN            │
│ OpenBSD 6           │ openbsd6            │
│ AIX                 │ aix                 │
┕━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━┙
```

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.