### PR TITLE
Fixing Block docstring

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -65,9 +65,10 @@ _PitchDefiningComponent = Optional[Tuple[Type[components.Component], ...]]
 
 class Block(composites.Composite):
     """
-    A homogenized axial slab of material.
+    An axial slice of an assembly.
 
-    Blocks are stacked together to form assemblies.
+    Blocks are Composite objects with extra parameter bindings, utility functions, and other
+    details that let them play nicely with their containing Assembly.
     """
 
     uniqID = 0
@@ -86,14 +87,12 @@ class Block(composites.Composite):
 
         name : str
             The name of this block
-
         height : float, optional
             The height of the block in cm. Defaults to 1.0 so that ``getVolume`` assumes unit height.
         """
         composites.Composite.__init__(self, name)
         self.p.height = height
         self.p.heightBOL = height
-
         self.p.orientation = np.array((0.0, 0.0, 0.0))
 
         self.points = []

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -67,8 +67,8 @@ class Block(composites.Composite):
     """
     An axial slice of an assembly.
 
-    Blocks are Composite objects with extra parameter bindings, utility functions, and other
-    details that let them play nicely with their containing Assembly.
+    Blocks are Composite objects with extra parameter bindings, and utility methods that let them
+    play nicely with their containing Assembly.
     """
 
     uniqID = 0


### PR DESCRIPTION
## What is the change?

Fixing the docstring for the `Block` class.

## Why is the change being made?

This docstring was tremendously old.

close #2020

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.