### PR TITLE
Fixing hex assembly rotation docs

### DIFF
--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -40,7 +40,7 @@ def getOptimalAssemblyOrientation(a: "HexAssembly", aPrev: "HexAssembly") -> int
     expected pin power. We evaluated "expected pin power" based on the power distribution in
     ``aPrev``, the previous assembly located where ``a`` is going. The algorithm goes as follows.
 
-    1. Get all the pin powers and ``IndexLocation``s from the block at the previous location/timenode.
+    1. Get all the pin powers and ``IndexLocation`` s from the block at the previous location/timenode.
     2. Obtain the ``IndexLocation`` of the pin with the highest burnup in the current assembly.
     3. For each possible rotation,
 

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -69,9 +69,11 @@ def getOptimalAssemblyOrientation(a: "HexAssembly", aPrev: "HexAssembly") -> int
     1. Get all the pin powers and ``IndexLocation``s from the block at the previous location/timenode.
     2. Obtain the ``IndexLocation`` of the pin with the highest burnup in the current assembly.
     3. For each possible rotation,
+
         - Find the new location with ``HexGrid.rotateIndex``
         - Find the index where that location occurs in previous locations
         - Find the previous power at that location
+
     4. Return the rotation with the lowest previous power
 
     This algorithm assumes a few things.

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -36,32 +36,6 @@ def getOptimalAssemblyOrientation(a: "HexAssembly", aPrev: "HexAssembly") -> int
     """
     Get optimal hex assembly orientation/rotation to minimize peak burnup.
 
-    .. impl:: Provide an algorithm for rotating hexagonal assemblies to equalize burnup
-        :id: I_ARMI_ROTATE_HEX_BURNUP
-        :implements: R_ARMI_ROTATE_HEX_BURNUP
-
-    Parameters
-    ----------
-    a : Assembly object
-        The assembly that is being rotated.
-    aPrev : Assembly object
-        The assembly that previously occupied this location (before the last shuffle).
-        If the assembly "a" was not shuffled, it's sufficient to pass ``a``.
-
-    Returns
-    -------
-    int
-        An integer from 0 to 5 representing the number of pi/3 (60 degree) counterclockwise
-        rotations from where ``a`` is currently oriented to the "optimal" orientation
-
-    Raises
-    ------
-    ValueError
-        If there is insufficient information to determine the rotation of ``a``. This could
-        be due to a lack of fuel blocks or parameters like ``linPowByPin``.
-
-    Notes
-    -----
     Works by placing the highest-burnup pin in the location (of 6 possible locations) with lowest
     expected pin power. We evaluated "expected pin power" based on the power distribution in
     ``aPrev``, the previous assembly located where ``a`` is going. The algorithm goes as follows.
@@ -88,6 +62,30 @@ def getOptimalAssemblyOrientation(a: "HexAssembly", aPrev: "HexAssembly") -> int
     3. Fuel pins in ``a`` have similar locations in ``aPrev``. This is mostly a safe
        assumption in that most fuel assemblies have similar layouts so it's plausible
        that if ``a`` has a fuel pin at ``(1, 0, 0)``, so does ``aPrev``.
+
+    .. impl:: Provide an algorithm for rotating hexagonal assemblies to equalize burnup
+        :id: I_ARMI_ROTATE_HEX_BURNUP
+        :implements: R_ARMI_ROTATE_HEX_BURNUP
+
+    Parameters
+    ----------
+    a : Assembly object
+        The assembly that is being rotated.
+    aPrev : Assembly object
+        The assembly that previously occupied this location (before the last shuffle).
+        If the assembly "a" was not shuffled, it's sufficient to pass ``a``.
+
+    Returns
+    -------
+    int
+        An integer from 0 to 5 representing the number of pi/3 (60 degree) counterclockwise
+        rotations from where ``a`` is currently oriented to the "optimal" orientation
+
+    Raises
+    ------
+    ValueError
+        If there is insufficient information to determine the rotation of ``a``. This could
+        be due to a lack of fuel blocks or parameters like ``linPowByPin``.
     """
     maxBuBlock = maxBurnupBlock(a)
     if maxBuBlock.spatialGrid is None:

--- a/doc/user/spatial_block_parameters.rst
+++ b/doc/user/spatial_block_parameters.rst
@@ -123,7 +123,7 @@ Note that we can assign the same component to multiple lattice sites with multip
 Also note that we do not need to assign a ``mult`` entry to these components. Their multiplicity will be determined
 based on the number of lattice sites they occupy!
 
-.. seelso::
+.. seealso::
 
     The :ref:`LWR tutorial <walkthrough-lwr>` contains additional examples for working with sub-block grids.
 


### PR DESCRIPTION
## What is the change?

Caught some typos and errors in docs that were previously introduced by me that made the docs render poorly.

## Why is the change being made?

Docs should be buildable and look nice.
### [Fix bad doc directive in block parameters](https://github.com/terrapower/armi/commit/0a88a8c908e4fbed992618f333c00fa5ed2243eb) 

Resolves the following error from doc
[builds](https://github.com/terrapower/armi/actions/runs/12128309602/job/33814420871)
```
/home/runner/work/armi/armi/doc/user/spatial_block_parameters.rst:126:
ERROR: Unknown directive type "seelso".

.. seelso::

    The :ref:`LWR tutorial <walkthrough-lwr>` contains additional
examples for working with sub-block grids.
```

### [Move discussion on getOptimalAssemblyRotation out of Notes section](https://github.com/terrapower/armi/commit/e261d9388b93734e02f1866e17d49a2625ecff7d) 

This doesn't seem to render well inside a note box. Not sure why it is not a unique section but its own admonition box

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.