### PR TITLE
Provide better composite iteration methods

### DIFF
--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -829,11 +829,11 @@ class Database:
         return r
 
     @staticmethod
-    def _setParamsBeforeFreezing(r):
+    def _setParamsBeforeFreezing(r: Reactor):
         """Set some special case parameters before they are made read-only."""
-        for child in r.getChildren(deep=True):
-            if not isinstance(child, Component):
-                continue
+        for child in r.iterChildren(
+            deep=True, predicate=lambda c: isinstance(c, Component)
+        ):
             # calling Component.getVolume() sets the volume parameter
             child.getVolume()
 

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -208,13 +208,13 @@ class ReportInterface(interfaces.Interface):
     @staticmethod
     def countAssembliesSFP(sfp):
         """Report on the count of assemblies in the SFP at each timestep."""
-        if not sfp.getChildren():
+        if not len(sfp):
             return
 
         runLog.important("Count:")
         totCount = 0
         thisTimeCount = 0
-        a = sfp.getChildren()[0]
+        a = sfp[0]
         lastTime = a.getAge() / units.DAYS_PER_YEAR + a.p.chargeTime
 
         for a in sfp:

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -184,7 +184,7 @@ class ReportInterface(interfaces.Interface):
         runLog.important(title)
         runLog.important("-" * len(title))
         totFis = 0.0
-        for a in sfp.getChildren():
+        for a in sfp:
             runLog.important(
                 "{assembly:15s} discharged at t={dTime:10f} after {residence:10f} yrs. It entered at cycle: {cycle}. "
                 "It has {fiss:10f} kg (x {mult}) fissile and peak BU={bu:.2f} %.".format(
@@ -217,7 +217,7 @@ class ReportInterface(interfaces.Interface):
         a = sfp.getChildren()[0]
         lastTime = a.getAge() / units.DAYS_PER_YEAR + a.p.chargeTime
 
-        for a in sfp.getChildren():
+        for a in sfp:
             thisTime = a.getAge() / units.DAYS_PER_YEAR + a.p.chargeTime
 
             if thisTime != lastTime:

--- a/armi/bookkeeping/visualization/utils.py
+++ b/armi/bookkeeping/visualization/utils.py
@@ -121,7 +121,7 @@ class VtkMesh:
 
 def createReactorBlockMesh(r: reactors.Reactor) -> VtkMesh:
     mesh = VtkMesh.empty()
-    blks = r.getChildren(deep=True, predicate=lambda o: isinstance(o, blocks.Block))
+    blks = r.iterChildren(deep=True, predicate=lambda o: isinstance(o, blocks.Block))
     for b in blks:
         mesh.append(createBlockMesh(b))
 
@@ -130,7 +130,7 @@ def createReactorBlockMesh(r: reactors.Reactor) -> VtkMesh:
 
 def createReactorAssemMesh(r: reactors.Reactor) -> VtkMesh:
     mesh = VtkMesh.empty()
-    assems = r.getChildren(
+    assems = r.iterChildren(
         deep=True, predicate=lambda o: isinstance(o, assemblies.Assembly)
     )
     for a in assems:

--- a/armi/bookkeeping/visualization/vtk.py
+++ b/armi/bookkeeping/visualization/vtk.py
@@ -95,17 +95,10 @@ class VtkDumper(dumper.VisFileDumper):
                 "includeParams and excludeParams can not both be used at the same time"
             )
 
-        blks = r.getChildren(deep=True, predicate=lambda o: isinstance(o, blocks.Block))
-        assems = r.getChildren(
-            deep=True, predicate=lambda o: isinstance(o, assemblies.Assembly)
-        )
-
         blockMesh = utils.createReactorBlockMesh(r)
-        assemMesh = utils.createReactorAssemMesh(r)
-
-        # collect param data
+        # Use r.getChildren here because we need to iterate over the blocks twice
+        blks = r.getChildren(deep=True, predicate=lambda o: isinstance(o, blocks.Block))
         blockData = _collectObjectData(blks, includeParams, excludeParams)
-        assemData = _collectObjectData(assems, includeParams, excludeParams)
         # block number densities are special, since they arent stored as params
         blockNdens = database.collectBlockNumberDensities(blks)
         # we need to copy the number density vectors to guarantee unit stride, which
@@ -116,6 +109,11 @@ class VtkDumper(dumper.VisFileDumper):
         fullPath = blockMesh.write(blockPath, blockData)
         self._blockFiles.append((fullPath, r.p.time))
 
+        assems = r.iterChildren(
+            deep=True, predicate=lambda o: isinstance(o, assemblies.Assembly)
+        )
+        assemMesh = utils.createReactorAssemMesh(r)
+        assemData = _collectObjectData(assems, includeParams, excludeParams)
         fullPath = assemMesh.write(assemPath, assemData)
         self._assemFiles.append((fullPath, r.p.time))
 

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -640,7 +640,7 @@ class FuelHandler:
                 f"or otherwise instantiate a SpentFuelPool object as r.excore['sfp']"
             )
         else:
-            sfpAssems = self.r.excore["sfp"].getChildren()
+            sfpAssems = list(self.r.excore["sfp"])
 
         assemblyList = [[] for _i in range(len(ringList))]  # empty lists for each ring
         if exclusions is None:

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -448,7 +448,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
             self.r.p.cycle = cycle
             fh.cycle = cycle
             fh.manageFuel(cycle)
-            for a in self.r.excore["sfp"].getChildren():
+            for a in self.r.excore["sfp"]:
                 self.assertEqual(a.getLocation(), "SFP")
             for b in self.r.core.getBlocks(Flags.FUEL):
                 self.assertGreater(b.p.kgHM, 0.0, "b.p.kgHM not populated!")
@@ -478,7 +478,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         ensure repeatability.
         """
         # check labels before shuffling:
-        for a in self.r.excore["sfp"].getChildren():
+        for a in self.r.excore["sfp"]:
             self.assertEqual(a.getLocation(), "SFP")
 
         # do some shuffles
@@ -512,7 +512,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         # make sure the shuffle was repeated perfectly.
         for a in self.r.core.getAssemblies():
             self.assertEqual(a.getName(), firstPassResults[a.getLocation()])
-        for a in self.r.excore["sfp"].getChildren():
+        for a in self.r.excore["sfp"]:
             self.assertEqual(a.getLocation(), "SFP")
 
         # Do some cleanup, since the fuelHandler Interface has code that gets

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -791,7 +791,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
 
         # grab an arbitrary fuel assembly from the core and from the SFP
         a1 = self.r.core.getAssemblies(Flags.FUEL)[0]
-        a2 = self.r.excore["sfp"].getChildren(Flags.FUEL)[0]
+        a2 = self.r.excore["sfp"].getChildrenWithFlags(Flags.FUEL)[0]
 
         # grab the stationary blocks pre swap
         a1PreSwapStationaryBlocks = [

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -277,7 +277,7 @@ class GlobalFluxInterfaceUsingExecuters(GlobalFluxInterface):
             return self.r.core.p.keff
         if self.coupler.parameter == "power":
             scaledCorePowerDistribution = []
-            for a in self.r.core.getChildren():
+            for a in self.r.core:
                 scaledPower = []
                 assemPower = sum(b.p.power for b in a)
                 for b in a:

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -286,7 +286,7 @@ class TestGlobalFluxInterfaceWithExecuters(unittest.TestCase):
         self._setTightCouplingTrue()
         self.assertEqual(self.gfi.getTightCouplingValue(), 1.0)  # set in setUp
         self.gfi.coupler.parameter = "power"
-        for a in self.r.core.getChildren():
+        for a in self.r.core:
             for b in a:
                 b.p.power = 10.0
         self.assertEqual(

--- a/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
+++ b/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
@@ -223,7 +223,7 @@ def makeReactionRateTable(obj, nuclides: List = None):
         for nucName in nuclides
     }
 
-    for armiObject in obj.getChildren():
+    for armiObject in obj:
         for nucName in nuclides:
             rxnRates = armiObject.getReactionRates(nucName, nDensity=1.0)
             for rxName, rxRate in rxnRates.items():

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -879,9 +879,7 @@ class Assembly(composites.Composite):
         return zip(blocks, zCoords)
 
     def hasContinuousCoolantChannel(self):
-        return all(
-            b.containsAtLeastOneChildWithFlags(Flags.COOLANT) for b in self.getBlocks()
-        )
+        return all(b.containsAtLeastOneChildWithFlags(Flags.COOLANT) for b in self)
 
     def getFirstBlock(self, typeSpec=None, exact=False):
         bs = self.getBlocks(typeSpec, exact=exact)

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -304,10 +304,8 @@ class Assembly(composites.Composite):
         -------
         This is a bit design-specific for pinned assemblies
         """
-        plenumBlocks = self.getBlocks(Flags.PLENUM)
-
         plenumVolume = 0.0
-        for b in plenumBlocks:
+        for b in self.iterBlocks(Flags.PLENUM):
             cladId = b.getComponent(Flags.CLAD).getDimension("id")
             length = b.getHeight()
             plenumVolume += (
@@ -317,7 +315,7 @@ class Assembly(composites.Composite):
 
     def getAveragePlenumTemperature(self):
         """Return the average of the plenum block outlet temperatures."""
-        plenumBlocks = self.getBlocks(Flags.PLENUM)
+        plenumBlocks = self.iterBlocks(Flags.PLENUM)
         plenumTemps = [b.p.THcoolantOutletT for b in plenumBlocks]
 
         # no plenum blocks, use the top block of the assembly for plenum temperature
@@ -792,6 +790,31 @@ class Assembly(composites.Composite):
         with open(fName, "w") as pkl:
             pickle.dump(self, pkl)
 
+    def iterBlocks(self, typeSpec=None, exact=False):
+        """Produce an iterator over all blocks in this assembly from bottom to top.
+
+        Parameters
+        ----------
+        typeSpec : Flags or list of Flags, optional
+            Restrict returned blocks to have these flags.
+        exact : bool, optional
+            If true, only produce blocks that have those exact flags.
+
+        Returns
+        -------
+        iterable of Block
+
+        See also
+        --------
+        * :meth:`__iter__` - if no type spec provided, assemblies can be
+          naturally iterated upon.
+        * :meth:`iterChildrenWithFlags` - alternative if you know you have
+           a type spec that isn't ``None``.
+        """
+        if typeSpec is None:
+            return iter(self)
+        return self.iterChildrenWithFlags(typeSpec, exact)
+
     def getBlocks(self, typeSpec=None, exact=False):
         """
         Get blocks in an assembly from bottom to top.
@@ -808,10 +831,7 @@ class Assembly(composites.Composite):
         blocks : list
             List of blocks.
         """
-        if typeSpec is None:
-            return self.getChildren()
-        else:
-            return self.getChildrenWithFlags(typeSpec, exactMatch=exact)
+        return list(self.iterBlocks(typeSpec, exact))
 
     def getBlocksAndZ(self, typeSpec=None, returnBottomZ=False, returnTopZ=False):
         """
@@ -1169,7 +1189,7 @@ class Assembly(composites.Composite):
         blockCounter : int
             number of blocks of this type
         """
-        return len(self.getBlocks(blockTypeSpec))
+        return sum(1 for _ in self.iterBlocks(blockTypeSpec))
 
     def getDim(self, typeSpec, dimName):
         """

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -904,14 +904,11 @@ class Assembly(composites.Composite):
             return None
 
     def getFirstBlockByType(self, typeName):
-        bs = [
-            b
-            for b in self.getChildren(deep=False)
-            if isinstance(b, blocks.Block) and b.getType() == typeName
-        ]
-        if bs:
-            return bs[0]
-        return None
+        blocks = filter(lambda b: b.getType() == typeName, self)
+        try:
+            return next(blocks)
+        except StopIteration:
+            return None
 
     def getBlockAtElevation(self, elevation):
         """

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -882,10 +882,25 @@ class Assembly(composites.Composite):
         return all(b.containsAtLeastOneChildWithFlags(Flags.COOLANT) for b in self)
 
     def getFirstBlock(self, typeSpec=None, exact=False):
-        bs = self.getBlocks(typeSpec, exact=exact)
-        if bs:
-            return bs[0]
-        else:
+        """Find the first block that matches the spec.
+
+        Parameters
+        ----------
+        typeSpec : flag or list of flags, optional
+            Specification to require on the returned block.
+        exact : bool, optional
+            Require block to exactly match ``typeSpec``
+
+        Returns
+        -------
+        Block or None
+            First block that matches if such a block could be found.
+        """
+        try:
+            # Create an iterator and attempt to advance it to the first value.
+            return next(self.iterBlocks(typeSpec, exact))
+        except StopIteration:
+            # No items found in the iteration -> no blocks match the request
             return None
 
     def getFirstBlockByType(self, typeName):

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -935,7 +935,7 @@ class Block(composites.Composite):
         self._updatePitchComponent(c)
 
     def removeAll(self, recomputeAreaFractions=True):
-        for c in self.getChildren():
+        for c in list(self):
             self.remove(c, recomputeAreaFractions=False)
         if recomputeAreaFractions:  # only do this once
             self.getVolumeFractions()

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1537,7 +1537,7 @@ class Block(composites.Composite):
         :meth:`getPinCoordinates` - companion for this method.
         """
         items = []
-        for clad in self.getChildrenWithFlags(Flags.CLAD):
+        for clad in self.iterChildrenWithFlags(Flags.CLAD):
             if isinstance(clad.spatialLocator, grids.MultiIndexLocation):
                 items.extend(clad.spatialLocator)
             else:

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -627,7 +627,7 @@ class Block(composites.Composite):
             return area
 
         a = 0.0
-        for c in self.getChildren():
+        for c in self:
             myArea = c.getArea(cold=cold)
             a += myArea
         fullArea = a
@@ -1288,7 +1288,7 @@ class Block(composites.Composite):
     def getDimensions(self, dimension):
         """Return dimensional values of the specified dimension."""
         dimVals = set()
-        for c in self.getChildren():
+        for c in self:
             try:
                 dimVal = c.getDimension(dimension)
             except parameters.ParameterError:

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -519,7 +519,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
                     runLog.error("CURRENT COMPARISON BLOCK:")
                     b.printContents(includeNuclides=False)
 
-                    for c in b.getChildren():
+                    for c in b:
                         runLog.error(
                             "{0} area {1} effective area {2}"
                             "".format(c, c.getArea(), c.getVolume() / b.getHeight())

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -383,7 +383,7 @@ class DerivedShape(UnshapedComponent):
         # Determine the volume/areas of the non-derived shape components within the parent.
         siblingVolume = 0.0
         siblingArea = 0.0
-        for sibling in self.parent.getChildren():
+        for sibling in self.parent:
             if sibling is self:
                 continue
             elif not self and isinstance(sibling, DerivedShape):

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -964,7 +964,7 @@ class Component(composites.Composite, metaclass=ComponentType):
     def getLinkedComponents(self):
         """Find other components that are linked to this component."""
         dependents = []
-        for child in self.parent.getChildren():
+        for child in self.parent:
             for dimName in child.DIMENSION_NAMES:
                 isLinked = child.dimensionIsLinked(dimName)
                 if isLinked and child.p[dimName].getLinkedComponent() is self:

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -898,7 +898,7 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         raise NotImplementedError()
 
-    def getMass(self, nuclideNames=None):
+    def getMass(self, nuclideNames=None) -> float:
         """
         Determine the mass in grams of nuclide(s) and/or elements in this object.
 
@@ -921,7 +921,7 @@ class ArmiObject(metaclass=CompositeModelType):
         mass : float
             The mass in grams.
         """
-        return sum([c.getMass(nuclideNames=nuclideNames) for c in self])
+        return sum(c.getMass(nuclideNames=nuclideNames) for c in self)
 
     def getMassFrac(self, nucName):
         """

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2701,6 +2701,28 @@ class Composite(ArmiObject):
             for c in self:
                 yield from c._iterChildren(deep, generationNum - 1, checker)
 
+    def iterChildrenWithMaterials(self, *args, **kwargs) -> Iterator:
+        """Produce an iterator that also includes any materials found on descendants.
+
+        Arguments are forwarded to :meth:`iterChildren` and control the depth of traversal
+        and filtering of objects.
+
+        This is useful for sending state across MPI tasks where you need a more full
+        representation of the composite tree. Which includes the materials attached
+        to components.
+        """
+        children = self.iterChildren(*args, **kwargs)
+        # Each entry is either (c, ) or (c, c.material) if the child has a material attribute
+        stitched = map(
+            lambda c: (
+                (c,) if getattr(c, "material", None) is None else (c, c.material)
+            ),
+            children,
+        )
+        # Iterator that iterates over each "sub" iterator. If we have ((c0, ), (c1, m1)), this produces a single
+        # iterator of (c0, c1, m1)
+        return itertools.chain.from_iterable(stitched)
+
     def getChildren(
         self,
         deep=False,
@@ -2770,22 +2792,15 @@ class Composite(ArmiObject):
         [grandchild1, grandchild3]
 
         """
-        children = self.iterChildren(
-            deep=deep, generationNum=generationNum, predicate=predicate
-        )
         if not includeMaterials:
-            return list(children)
-        # Each entry is either (c, ) or (c, c.material) if the child has a material attribute
-        stitched = map(
-            lambda c: (
-                (c, ) if getattr(c, "material", None) is None else (c, c.material)
-            ),
-            children,
-        )
-        # Iterator that iterates over each "sub" iterator. If we have ((c0, ), (c1, m1)), this produces a single
-        # iterator of (c0, c1, m1)
-        flattened = itertools.chain.from_iterable(stitched)
-        return list(flattened)
+            items = self.iterChildren(
+                deep=deep, generationNum=generationNum, predicate=predicate
+            )
+        else:
+            items = self.iterChildrenWithMaterials(
+                deep=deep, generationNum=generationNum, predicate=predicate
+            )
+        return list(items)
 
     def iterChildrenWithFlags(self, typeSpec: TypeSpec, exactMatch=False):
         """Produce an iterator over all children of a specific type."""
@@ -2856,8 +2871,11 @@ class Composite(ArmiObject):
 
         startTime = timeit.default_timer()
         # sync parameters...
-        allComps = [self] + self.getChildren(deep=True, includeMaterials=True)
-        allComps = [c for c in allComps if hasattr(c, "p")]
+        genItems = itertools.chain(
+            [self],
+            self.iterChildrenWithMaterials(deep=True),
+        )
+        allComps = [c for c in genItems if hasattr(c, "p")]
         sendBuf = [c.p.getSyncData() for c in allComps]
         runLog.debug("syncMpiState has {} comps".format(len(allComps)))
 
@@ -2962,7 +2980,11 @@ class Composite(ArmiObject):
         SINCE_LAST_DISTRIBUTE_STATE.
         """
         paramDefs = set()
-        for child in [self] + self.getChildren(deep=True, includeMaterials=True):
+        items = itertools.chain(
+            [self],
+            self.iterChildrenWithMaterials(deep=True),
+        )
+        for child in items:
             # Materials don't have a "p" / Parameter attribute to sync
             if hasattr(child, "p"):
                 # below reads as: assigned & everything_but(SINCE_LAST_DISTRIBUTE_STATE)
@@ -3232,7 +3254,7 @@ class StateRetainer:
 
     """
 
-    def __init__(self, composite, paramsToApply=None):
+    def __init__(self, composite: Composite, paramsToApply=None):
         """
         Create an instance of a StateRetainer.
 
@@ -3260,9 +3282,11 @@ class StateRetainer:
         ``backUp()`` or ``restoreBackup()``.
         """
         paramDefs = set()
-        for child in [self.composite] + self.composite.getChildren(
-            deep=True, includeMaterials=True
-        ):
+        items = itertools.chain(
+            (self.composite,),
+            self.composite.iterChildrenWithMaterials(deep=True),
+        )
+        for child in items:
             if hasattr(child, "p"):
                 # materials don't have Parameters
                 paramDefs.update(child.p.paramDefs)

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2697,8 +2697,12 @@ class Composite(ArmiObject):
                 yield from c._iterChildren(deep, generationNum - 1, checker)
 
     def getChildren(
-        self, deep=False, generationNum=1, includeMaterials=False, predicate=None
-    ):
+        self,
+        deep=False,
+        generationNum=1,
+        includeMaterials=False,
+        predicate: Optional[Callable[["Composite"], bool]] = None,
+    ) -> list["Composite"]:
         """
         Return the children objects of this composite.
 
@@ -2740,6 +2744,11 @@ class Composite(ArmiObject):
             to meet the predicate only affects the object in question; children will
             still be considered.
 
+        See Also
+        --------
+        :meth:`iterChildren` if you do not need to produce a full list, e.g., just iterating
+        over objects.
+
         Examples
         --------
         >>> obj.getChildren()
@@ -2756,33 +2765,22 @@ class Composite(ArmiObject):
         [grandchild1, grandchild3]
 
         """
-        _pred = predicate or (lambda x: True)
-        if deep and generationNum > 1:
-            raise RuntimeError(
-                "Cannot get children with a generation number set and the deep flag set"
-            )
-
-        children = []
-        for child in self._children:
-            if generationNum == 1 or deep:
-                if _pred(child):
-                    children.append(child)
-
-            if generationNum > 1 or deep:
-                children.extend(
-                    child.getChildren(
-                        deep=deep,
-                        generationNum=generationNum - 1,
-                        includeMaterials=includeMaterials,
-                        predicate=predicate,
-                    )
-                )
-        if includeMaterials:
-            material = getattr(self, "material", None)
-            if material:
-                children.append(material)
-
-        return children
+        children = self.iterChildren(
+            deep=deep, generationNum=generationNum, predicate=predicate
+        )
+        if not includeMaterials:
+            return list(children)
+        # Each entry is either (c, ) or (c, c.material) if the child has a material attribute
+        stitched = map(
+            lambda c: (
+                (c, ) if getattr(c, "material", None) is None else (c, c.material)
+            ),
+            children,
+        )
+        # Iterator that iterates over each "sub" iterator. If we have ((c0, ), (c1, m1)), this produces a single
+        # iterator of (c0, c1, m1)
+        flattened = itertools.chain.from_iterable(stitched)
+        return list(flattened)
 
     def iterChildrenWithFlags(self, typeSpec: TypeSpec, exactMatch=False):
         """Produce an iterator over all children of a specific type."""

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2725,13 +2725,13 @@ class Composite(ArmiObject):
         """Get all children of a specific type."""
         return list(self.iterChildrenWithFlags(typeSpec, exactMatch))
 
-    def getChildrenOfType(self, typeName):
+    def iterChildrenOfType(self, typeName: str):
+        """Produce an iterator over all children with a specific input type name"""
+        return filter(lambda c: c.getType() == typeName, self)
+
+    def getChildrenOfType(self, typeName: str):
         """Get children that have a specific input type name."""
-        children = []
-        for child in self:
-            if child.getType() == typeName:
-                children.append(child)
-        return children
+        return list(self.iterChildrenOfType(typeName))
 
     def getComponents(self, typeSpec: TypeSpec = None, exact=False):
         return list(self.iterComponents(typeSpec, exact))

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2637,22 +2637,27 @@ class Composite(ArmiObject):
         predicate: Optional[Callable[["Composite"], bool]] = None,
     ) -> Iterator["Composite"]:
         """Iterate over children objects of this composite.
-        
+
         Parameters
         ----------
         deep : bool, optional
+            If true, traverse the entire composite tree. Otherwise, go as far as ``generationNum``.
         generationNum: int, optional
-        predicate: f(Composite) -> bool, optional,
-        
+            Produce composites at this depth. A depth of ``1`` includes children of ``self``, ``2``
+            is children of children, and so on.
+        predicate: f(Composite) -> bool, optional
+            Function to check on a composite before producing it. All items in the iteration
+            will pass this check.
+
         Returns
         -------
         iterator of Composite
-        
+
         See Also
         --------
         :meth:`getChildren` produces a list for situations where you need to perform
         multiple iterations or do list operations (append, indexing, sorting, containment, etc.)
-        
+
         Composites are naturally iterable. The following are identical::
 
             >>> for child in c.getChildren():
@@ -2663,7 +2668,7 @@ class Composite(ArmiObject):
             ...     pass
 
         If you do not need any depth-traversal, natural iteration should be sufficient.
-        
+
         The :func:`filter` command may be sufficient if you do not wish to pass a predicate. The following
         are identical::
             >>> checker = lambda c: len(c.name) % 3
@@ -2675,7 +2680,7 @@ class Composite(ArmiObject):
             ...     pass
 
         If you're going to be doing traversal beyond the first generation, this method will help you.
-        
+
         """
         if deep and generationNum > 1:
             raise RuntimeError(

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -471,7 +471,7 @@ class ArmiObject(metaclass=CompositeModelType):
     def clearCache(self):
         """Clear the cache so all new values are recomputed."""
         self.cached = {}
-        for child in self.getChildren():
+        for child in self:
             child.clearCache()
 
     def _getCached(self, name):  # TODO: stop the "returns None" nonsense?
@@ -617,7 +617,7 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         for paramName in paramNames:
             myVal = self.p[paramName]
-            for c in self.getChildren():
+            for c in self:
                 c.p[paramName] = myVal
 
     @classmethod
@@ -1631,7 +1631,7 @@ class ArmiObject(metaclass=CompositeModelType):
         self._lumpedFissionProducts = lfpCollection
 
     def setChildrenLumpedFissionProducts(self, lfpCollection):
-        for c in self.getChildren():
+        for c in self:
             c.setLumpedFissionProducts(lfpCollection)
 
     def getFissileMassEnrich(self):
@@ -1932,7 +1932,7 @@ class ArmiObject(metaclass=CompositeModelType):
             List of nuclide names that exist in this
         """
         nucs = set()
-        for child in self.getChildren():
+        for child in self:
             nucs.update(child.getNuclides())
         return nucs
 
@@ -3038,7 +3038,7 @@ class Composite(ArmiObject):
         """
         lfps = ArmiObject.getLumpedFissionProductCollection(self)
         if lfps is None:
-            for c in self.getChildren():
+            for c in self:
                 lfps = c.getLumpedFissionProductCollection()
                 if lfps is not None:
                     break
@@ -3176,7 +3176,7 @@ class Composite(ArmiObject):
     def printContents(self, includeNuclides=True):
         """Display information about all the comprising children in this object."""
         runLog.important(self)
-        for c in self.getChildren():
+        for c in self:
             c.printContents(includeNuclides=includeNuclides)
 
     def _genChildByLocationLookupTable(self):

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -36,7 +36,7 @@ import collections
 import itertools
 import operator
 import timeit
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Dict, List, Optional, Tuple, Type, Union, Iterator, Callable
 
 import numpy as np
 import six
@@ -2531,6 +2531,8 @@ class Composite(ArmiObject):
 
     """
 
+    _children: list["Composite"]
+
     def __init__(self, name):
         ArmiObject.__init__(self, name)
         self.childrenByLocator = {}
@@ -2627,6 +2629,72 @@ class Composite(ArmiObject):
         self.removeAll()
         for c in items:
             self.add(c)
+
+    def iterChildren(
+        self,
+        deep=False,
+        generationNum=1,
+        predicate: Optional[Callable[["Composite"], bool]] = None,
+    ) -> Iterator["Composite"]:
+        """Iterate over children objects of this composite.
+        
+        Parameters
+        ----------
+        deep : bool, optional
+        generationNum: int, optional
+        predicate: f(Composite) -> bool, optional,
+        
+        Returns
+        -------
+        iterator of Composite
+        
+        See Also
+        --------
+        :meth:`getChildren` produces a list for situations where you need to perform
+        multiple iterations or do list operations (append, indexing, sorting, containment, etc.)
+        
+        Composites are naturally iterable. The following are identical::
+
+            >>> for child in c.getChildren():
+            ...     pass
+            >>> for child in c.iterChildren():
+            ...     pass
+            >>> for child in c:
+            ...     pass
+
+        If you do not need any depth-traversal, natural iteration should be sufficient.
+        
+        The :func:`filter` command may be sufficient if you do not wish to pass a predicate. The following
+        are identical::
+            >>> checker = lambda c: len(c.name) % 3
+            >>> for child in c.getChildren(predicate=checker):
+            ...     pass
+            >>> for child in c.iterChildren(predicate=checker):
+            ...     pass
+            >>> for child in filter(checker, c):
+            ...     pass
+
+        If you're going to be doing traversal beyond the first generation, this method will help you.
+        
+        """
+        if deep and generationNum > 1:
+            raise RuntimeError(
+                "Cannot get children with a generation number set and the deep flag set"
+            )
+        if predicate is None:
+            checker = lambda _: True
+        else:
+            checker = predicate
+        yield from self._iterChildren(deep, generationNum, checker)
+
+    def _iterChildren(
+        self, deep: bool, generationNum: int, checker: Callable[["Composite"], bool]
+    ) -> Iterator["Composite"]:
+        if deep or generationNum == 1:
+            yield from filter(checker, self)
+        if deep or generationNum > 1:
+            for c in self:
+                yield from c._iterChildren(deep, generationNum - 1, checker)
 
     def getChildren(
         self, deep=False, generationNum=1, includeMaterials=False, predicate=None

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -525,6 +525,10 @@ class ArmiObject(metaclass=CompositeModelType):
         """Return the children of this object."""
         raise NotImplementedError
 
+    def iterChildrenWithFlags(self, typeSpec: TypeSpec, exactMatch=True):
+        """Produce an iterator of children that have given flags."""
+        raise NotImplementedError()
+
     def getChildrenWithFlags(self, typeSpec: TypeSpec, exactMatch=True):
         """Get all children that have given flags."""
         raise NotImplementedError
@@ -2712,13 +2716,14 @@ class Composite(ArmiObject):
 
         return children
 
+    def iterChildrenWithFlags(self, typeSpec: TypeSpec, exactMatch=False):
+        """Produce an iterator over all children of a specific type."""
+        checker = operator.methodcaller("hasFlags", typeSpec, exactMatch)
+        return filter(checker, self)
+
     def getChildrenWithFlags(self, typeSpec: TypeSpec, exactMatch=False):
         """Get all children of a specific type."""
-        children = []
-        for child in self:
-            if child.hasFlags(typeSpec, exact=exactMatch):
-                children.append(child)
-        return children
+        return list(self.iterChildrenWithFlags(typeSpec, exactMatch))
 
     def getChildrenOfType(self, typeName):
         """Get children that have a specific input type name."""

--- a/armi/reactor/converters/axialExpansionChanger/expansionData.py
+++ b/armi/reactor/converters/axialExpansionChanger/expansionData.py
@@ -288,19 +288,17 @@ class ExpansionData:
         if flagOfInterest is None:
             # Follow expansion of most neutronically important component, fuel then control/poison
             for targetFlag in TARGET_FLAGS_IN_PREFERRED_ORDER:
-                candidates = [c for c in b.getChildren() if c.hasFlags(targetFlag)]
+                candidates = b.getChildrenWithFlags(targetFlag)
                 if candidates:
                     break
             # some blocks/components are not included in the above list but should still be found
             if not candidates:
                 candidates = [c for c in b.getChildren() if c.p.flags in b.p.flags]
         else:
-            candidates = [c for c in b.getChildren() if c.hasFlags(flagOfInterest)]
+            candidates = b.getChildrenWithFlags(flagOfInterest)
         if len(candidates) == 0:
             # if only 1 solid, be smart enought to snag it
-            solidMaterials = list(
-                c for c in b if not isinstance(c.material, material.Fluid)
-            )
+            solidMaterials = getSolidComponents(b)
             if len(solidMaterials) == 1:
                 candidates = solidMaterials
         if len(candidates) == 0:

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -789,5 +789,5 @@ def makeParametersReadOnly(r):
     Once you make one Reactor read-only, you cannot make it writeable again.
     """
     r.p.readOnly = True
-    for child in r.getChildren(deep=True):
+    for child in r.iterChildren(deep=True):
         child.p.readOnly = True

--- a/armi/reactor/spentFuelPool.py
+++ b/armi/reactor/spentFuelPool.py
@@ -77,7 +77,7 @@ class SpentFuelPool(ExcoreStructure):
 
     def getAssembly(self, name):
         """Get a specific assembly by name."""
-        for a in self.getChildren():
+        for a in self:
             if a.getName() == name:
                 return a
 
@@ -123,7 +123,7 @@ class SpentFuelPool(ExcoreStructure):
             The new max Assembly number.
         """
         ind = startIndex
-        for a in self.getChildren():
+        for a in self:
             oldName = a.getName()
             newName = a.makeNameFromAssemNum(ind)
             if oldName == newName:

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -165,8 +165,9 @@ class TestGeneralComponents(unittest.TestCase):
             def clearCache(self):
                 pass
 
-            def getChildren(self):
-                return []
+            def __iter__(self):
+                """Act like an iterator but don't actually iterate."""
+                return iter(())
 
             derivedMustUpdate = False
 

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -467,6 +467,17 @@ class TestCompositePattern(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(clads)
 
+    def test_removeAll(self):
+        """Test the ability to remove all children of a composite."""
+        self.container.removeAll()
+        self.assertEqual(len(self.container), 0)
+        # Nothing to iterate over
+        items = iter(self.container)
+        with self.assertRaises(StopIteration):
+            next(items)
+        for child in self.tree[1]:
+            self.assertIsNone(child.parent)
+
 
 class TestCompositeTree(unittest.TestCase):
     blueprintYaml = """

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -247,26 +247,26 @@ class TestCompositePattern(unittest.TestCase):
 
     def test_sort(self):
         # in this case, the children should start sorted
-        c0 = [c.name for c in self.container.getChildren()]
+        c0 = [c.name for c in self.container]
         self.container.sort()
-        c1 = [c.name for c in self.container.getChildren()]
+        c1 = [c.name for c in self.container]
         self.assertNotEqual(c0, c1)
 
         # verify repeated sortings behave
         for _ in range(3):
             self.container.sort()
-            ci = [c.name for c in self.container.getChildren()]
+            ci = [c.name for c in self.container]
             self.assertEqual(c1, ci)
 
         # break the order
         children = self.container.getChildren()
         self.container._children = children[2:] + children[:2]
-        c2 = [c.name for c in self.container.getChildren()]
+        c2 = [c.name for c in self.container]
         self.assertNotEqual(c1, c2)
 
         # verify the sort order
         self.container.sort()
-        c3 = [c.name for c in self.container.getChildren()]
+        c3 = [c.name for c in self.container]
         self.assertEqual(c1, c3)
 
     def test_areChildernOfType(self):
@@ -397,12 +397,12 @@ class TestCompositePattern(unittest.TestCase):
 
         # validate that the LFP collection is None
         self.container.setChildrenLumpedFissionProducts(None)
-        for c in self.container.getChildren():
+        for c in self.container:
             self.assertIsNone(c._lumpedFissionProducts)
 
         # validate that the LFP collection is not None
         self.container.setChildrenLumpedFissionProducts(lfps)
-        for c in self.container.getChildren():
+        for c in self.container:
             self.assertIsNotNone(c._lumpedFissionProducts)
 
     def test_requiresLumpedFissionProducts(self):
@@ -900,7 +900,7 @@ class TestMiscMethods(unittest.TestCase):
         # sum nuc densities from children components
         totalVolume = self.obj.getVolume()
         childDensities = {}
-        for o in self.obj.getChildren():
+        for o in self.obj:
             m = o.getVolume()
             d = o.getNumberDensities()
             for nuc, val in d.items():
@@ -938,7 +938,7 @@ class TestMiscMethods(unittest.TestCase):
         # sum nuc densities from children components
         totalVolume = self.obj.getVolume()
         childDensities = {}
-        for o in self.obj.getChildren():
+        for o in self.obj:
             # get the number densities with and without fission products
             d0 = o.getNumberDensities(expandFissionProducts=False)
             d = o.getNumberDensities(expandFissionProducts=True)

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -106,6 +106,7 @@ class TestCompositePattern(unittest.TestCase):
             container.add(leaf)
         nested = DummyComposite("clad", 98)
         nested.setType("clad")
+        self.cladChild = nested
         self.secondGen = DummyComposite("liner", 97)
         self.thirdGen = DummyLeaf("pin 77", 33)
         self.secondGen.add(self.thirdGen)
@@ -424,6 +425,13 @@ class TestCompositePattern(unittest.TestCase):
             self.assertIn(c, expectedChildren)
             found.add(c)
         self.assertSetEqual(found, expectedChildren)
+
+    def test_iterChildrenOfType(self):
+        clads = self.container.iterChildrenOfType("clad")
+        first = next(clads)
+        self.assertIs(first, self.cladChild)
+        with self.assertRaises(StopIteration):
+            next(clads)
 
 
 class TestCompositeTree(unittest.TestCase):

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -77,6 +77,8 @@ class DummyLeaf(composites.Composite):
         composites.Composite.__init__(self, name)
         self.p.type = name
         self.spatialLocator = grids.IndexLocation(i, i, i, _testGrid)
+        # Some special material attribute for testing getChildren(includeMaterials=True)
+        self.material = ("hello", "world")
 
     def getChildren(
         self, deep=False, generationNum=1, includeMaterials=False, predicate=None
@@ -172,6 +174,22 @@ class TestCompositePattern(unittest.TestCase):
         )
         self.assertEqual(len(onlyLiner), 1)
         self.assertIs(onlyLiner[0], self.secondGen)
+
+    def test_getChildrenWithMaterials(self):
+        """Test the ability for getChildren to place the material after the object."""
+        withMaterials = self.container.getChildren(deep=True, includeMaterials=True)
+        # Grab the iterable so we can control the progression
+        items = iter(withMaterials)
+        for item in items:
+            expectedMat = getattr(item, "material", None)
+            if expectedMat is None:
+                continue
+            # Material should be the next item in the list
+            actualMat = next(items)
+            self.assertIs(actualMat, expectedMat)
+            break
+        else:
+            raise RuntimeError("No materials found with includeMaterials=True")
 
     def test_getName(self):
         """Test the getName method.

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -478,6 +478,17 @@ class TestCompositePattern(unittest.TestCase):
         for child in self.tree[1]:
             self.assertIsNone(child.parent)
 
+    def test_setChildren(self):
+        """Test the ability to override children on a composite."""
+        newChildren = self.tree[2] + self.tree[3]
+        oldChildren = list(self.container)
+        self.container.setChildren(newChildren)
+        self.assertEqual(len(self.container), len(newChildren))
+        for old in oldChildren:
+            self.assertIsNone(old.parent)
+        for actualNew, expectedNew in zip(newChildren, self.container):
+            self.assertIs(actualNew, expectedNew)
+
 
 class TestCompositeTree(unittest.TestCase):
     blueprintYaml = """

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -417,6 +417,14 @@ class TestCompositePattern(unittest.TestCase):
         numSynced = self.container._syncParameters(data, {})
         self.assertEqual(numSynced, 2)
 
+    def test_iterChildrenWithFlags(self):
+        expectedChildren = {c for c in self.container if c.hasFlags(Flags.DUCT)}
+        found = set()
+        for c in self.container.iterChildrenWithFlags(Flags.DUCT):
+            self.assertIn(c, expectedChildren)
+            found.add(c)
+        self.assertSetEqual(found, expectedChildren)
+
 
 class TestCompositeTree(unittest.TestCase):
     blueprintYaml = """

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -360,7 +360,7 @@ class HexReactorTests(ReactorTests):
         self.assertFalse(self.r.core.isFullCore)
         self.r.core.growToFullCore(self.o.cs)
         aNums = []
-        for a in self.r.core.getChildren():
+        for a in self.r.core:
             self.assertNotIn(a.getNum(), aNums)
             aNums.append(a.getNum())
 


### PR DESCRIPTION
## What is the change?

The high-level idea is to provide ways for users and developers to traverse the composite tree without using lists. For example, calling
```python
for c in r.getChildren(deep=True):
```
first traverses the entire tree and populates a list of all composites in the reactor tree. Then, it returns that list to the caller for iteration. 

This PR adds the following `Composite` methods:

- `iterChildren`
- `iterChildrenWithFlags`
- `iterChildrenOfType`
- `iterChildrenWithMaterials`
  - I hate this one because it's so specific I don't see end users using it often.
  - But it's vital for MPI distribution that we should have a robust mechanism for it.
  - But it's only used in a few places that I don't think it justifies being a `Composite` method, but I can't easily think of a better place for it to live
  - :shrug:

This PR adds the following specific methods

- `Assembly.iterBlocks`

The various `get*` methods still return lists of things for backwards compatibility, but rely on the `iter*` methods. Ideally `Composite.getChildren` would just be `list(self.getChildren(...))` but we need to support `Composite.getChildren(..., includeMaterials=True)` so that's some additional complexity.

In a few places where we use the `get*` methods for once-through iteration, those are replaced with `iter*`. So our example above would instead look lik
```python
for c in r.iterChildren(deep=True):
```

There are still some use cases for making a list, especially if you want to iterate through the thing twice. Something like
```python
objs = r.iterChildren(deep=True)
for o in objs:
    # do something on the first pass
second = list(objs)
```
produces an empty list for `second` because the iterator `objs` is exhausted in the loop.

## Why is the change being made?

Efficiency, both time (remove redundant traversal over tree) and space (remove list of children)

Closes #1915 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.