### PR TITLE
Fixing _getParamMax for Volume-Integrated Assembly Params

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -216,15 +216,20 @@ class FuelHandler:
         multiplier = a.getSymmetryFactor()
         if multiplier != 1:
             # handle special case: volume-integrated parameters where symmetry factor is not 1
+            if blockLevelMax:
+                paramCollection = a.getBlocks()[0].p
+            else:
+                paramCollection = a.p
             isVolumeIntegrated = (
-                a.getBlocks()[0].p.paramDefs[paramName].location
+                paramCollection.paramDefs[paramName].location
                 == ParamLocation.VOLUME_INTEGRATED
             )
             multiplier = a.getSymmetryFactor() if isVolumeIntegrated else 1.0
+
         if blockLevelMax:
             return a.getChildParamValues(paramName).max() * multiplier
-
-        return a.p[paramName] * multiplier
+        else:
+            return a.p[paramName] * multiplier
 
     def findAssembly(
         self,

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -212,7 +212,7 @@ class FuelHandler:
 
     @staticmethod
     def _getParamMax(a, paramName, blockLevelMax=True):
-        """Get parameter with Block-level maximum."""
+        """Get assembly/block-level maximum parameter value in assembly."""
         multiplier = a.getSymmetryFactor()
         if multiplier != 1:
             # handle special case: volume-integrated parameters where symmetry factor is not 1


### PR DESCRIPTION
## What is the change?

Update `FuelHandler._getParamMax` to account for assembly parameters instead of only looking at block parameters.

## Why is the change being made?

https://github.com/terrapower/armi/pull/2017 introduced a bug where looking for the maximum parameter on an assembly would fail. This fixes that function to account for assembly parameters, while also allowing for future use of volume integrated assembly parameters with the function.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.