### PR TITLE
Stop checking for last node in Snapshots

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -33,7 +33,7 @@ from armi.reactor.converters import geometryConverters
 from armi.reactor.converters import uniformMesh
 from armi.reactor.flags import Flags
 from armi.settings.caseSettings import Settings
-from armi.utils import units, codeTiming, getMaxBurnSteps, getBurnSteps
+from armi.utils import units, codeTiming, getMaxBurnSteps
 
 ORDER = interfaces.STACK_ORDER.FLUX
 
@@ -112,17 +112,15 @@ class GlobalFluxInterface(interfaces.Interface):
             # track boc uncontrolled keff for rxSwing param.
             self._bocKeff = self.r.core.p.keffUnc or self.r.core.p.keff
 
-        # A 1 burnstep cycle would have 2 nodes, and the last node would be node index 1 (first is zero)
-        lastNodeInCycle = getBurnSteps(self.cs)[self.r.p.cycle]
-        if self.r.p.timeNode == lastNodeInCycle and self._bocKeff is not None:
+        if self._bocKeff is not None:
 
             eocKeff = self.r.core.p.keffUnc or self.r.core.p.keff
             swing = (eocKeff - self._bocKeff) / (eocKeff * self._bocKeff)
             self.r.core.p.rxSwing = swing * units.ABS_REACTIVITY_TO_PCM
             runLog.info(
                 f"BOC Uncontrolled keff: {self._bocKeff},  "
-                f"EOC Uncontrolled keff: {self.r.core.p.keffUnc}, "
-                f"Cycle Reactivity Swing: {self.r.core.p.rxSwing} pcm"
+                f"Current Uncontrolled keff: {self.r.core.p.keffUnc}, "
+                f"Cycle Reactivity Swing (so far): {self.r.core.p.rxSwing} pcm"
             )
 
     def checkEnergyBalance(self):

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -114,8 +114,8 @@ class GlobalFluxInterface(interfaces.Interface):
 
         if self._bocKeff is not None:
 
-            eocKeff = self.r.core.p.keffUnc or self.r.core.p.keff
-            swing = (eocKeff - self._bocKeff) / (eocKeff * self._bocKeff)
+            currentKeff = self.r.core.p.keffUnc or self.r.core.p.keff
+            swing = (currentKeff - self._bocKeff) / (currentKeff * self._bocKeff)
             self.r.core.p.rxSwing = swing * units.ABS_REACTIVITY_TO_PCM
             runLog.info(
                 f"BOC Uncontrolled keff: {self._bocKeff},  "

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -433,7 +433,11 @@ def defineCoreParameters():
             description="Max percent burnup on any block in the problem",
         )
 
-        pb.defParam("rxSwing", units=units.PCM, description="Reactivity swing")
+        pb.defParam(
+            "rxSwing",
+            units=units.PCM,
+            description="Current Reactivity swing from BOC reactivity",
+        )
 
         pb.defParam(
             "maxBuF",

--- a/doc/release/0.5.rst
+++ b/doc/release/0.5.rst
@@ -9,6 +9,7 @@ Release Date: TBD
 New Features
 ------------
 #. Move instead of copy files from TemporaryDirectoryChanger. (`PR#2022 <https://github.com/terrapower/armi/pull/2022>`_)
+#. `rXSwing`` is now calculated for all time nodes making snapshots less failure prone due to non-relevant  inputs. (`PR#2035 <https://github.com/terrapower/armi/pull/2035>`_)
 
 API Changes
 -----------

--- a/doc/release/0.5.rst
+++ b/doc/release/0.5.rst
@@ -9,7 +9,6 @@ Release Date: TBD
 New Features
 ------------
 #. Move instead of copy files from TemporaryDirectoryChanger. (`PR#2022 <https://github.com/terrapower/armi/pull/2022>`_)
-#. `rXSwing`` is now calculated for all time nodes making snapshots less failure prone due to non-relevant  inputs. (`PR#2035 <https://github.com/terrapower/armi/pull/2035>`_)
 
 API Changes
 -----------


### PR DESCRIPTION
## What is the change?

Stop checking if its the last node since this often breaks for snapshots and just calculate reactivity swing at all nodes.

## Why is the change being made?

If you do snapshot and don't have cycles and nodes consistent, you get an error.

Cycles and nodes don't have meaning for snapshots, so it is probably best to not force this and calculate partial cycle reactivity swing.

see #2034


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Stop checking if its the last node since this often breaks for snapshots and just calculate reactivity swing at all nodes.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.