### PR TITLE
Removing dependence on six

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -28,6 +28,7 @@ from typing import Dict, Optional, Sequence, Set, Union
 import ast
 import cProfile
 import glob
+import io
 import os
 import pathlib
 import pstats
@@ -38,7 +39,6 @@ import time
 import trace
 
 import coverage
-import six
 
 from armi import context
 from armi import getPluginManager
@@ -492,7 +492,7 @@ class Case:
 
         profiler.disable()
         profiler.dump_stats("profiler.{:0>3}.stats".format(context.MPI_RANK))
-        statsStream = six.StringIO()
+        statsStream = io.StringIO()
         summary = pstats.Stats(profiler, stream=statsStream).sort_stats("cumulative")
         summary.print_stats()
         if context.MPI_SIZE > 0 and context.MPI_COMM is not None:

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -20,8 +20,6 @@ See :doc:`/developer/entrypoints`.
 import argparse
 from typing import Optional, Union
 
-import six
-
 from armi import context, runLog, settings
 
 
@@ -46,8 +44,7 @@ class _EntryPointEnforcer(type):
         return type.__new__(mcs, name, bases, attrs)
 
 
-@six.add_metaclass(_EntryPointEnforcer)
-class EntryPoint:
+class EntryPoint(metaclass=_EntryPointEnforcer):
     """
     Generic command line entry point.
 

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -56,9 +56,8 @@ and override the :py:meth:`~armi.mpiActions.MpiAction.invokeHook` method.
 import collections
 import gc
 import math
+import pickle
 import timeit
-
-from six.moves import cPickle
 
 from armi import context
 from armi import interfaces
@@ -138,7 +137,7 @@ class MpiAction:
             self.o = self.r = self.cs = None
         try:
             return mpiFunction(obj, root=0)
-        except cPickle.PicklingError as error:
+        except pickle.PicklingError as error:
             runLog.error("Failed to {} {}.".format(mpiFunction.__name__, obj))
             runLog.error(error)
             raise
@@ -539,7 +538,7 @@ class DistributeStateAction(MpiAction):
             # or how the interfaces are distributed.
             self.r._markSynchronized()
 
-        except (cPickle.PicklingError, TypeError) as error:
+        except (pickle.PicklingError, TypeError) as error:
             runLog.error("Failed to transmit on distribute state root MPI bcast")
             runLog.error(error)
             # workers are still waiting for a reactor object

--- a/armi/nuclearDataIO/cccc/tests/test_cccc.py
+++ b/armi/nuclearDataIO/cccc/tests/test_cccc.py
@@ -15,8 +15,6 @@
 import io
 import unittest
 
-import six
-
 from armi.nuclearDataIO import cccc
 
 
@@ -104,4 +102,4 @@ class CcccAsciiRecordTests(CcccBinaryRecordTests):
         cls.readerClass = cccc.AsciiRecordReader
 
     def setUp(self):
-        self.streamCls = six.StringIO
+        self.streamCls = io.StringIO

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -15,11 +15,11 @@
 import copy
 import filecmp
 import os
+import pickle
 import traceback
 import unittest
 
 import numpy as np
-from six.moves import cPickle
 
 from armi.nucDirectory import nuclideBases
 from armi.nuclearDataIO import xsLibraries
@@ -87,15 +87,15 @@ class TestXSLibrary(TempFileMixin, unittest.TestCase):
             cls.xsLibGenerationErrorStack = traceback.format_exc()
 
     def test_canPickleAndUnpickleISOTXS(self):
-        pikAA = cPickle.loads(cPickle.dumps(self.isotxsAA))
+        pikAA = pickle.loads(pickle.dumps(self.isotxsAA))
         self.assertTrue(xsLibraries.compare(pikAA, self.isotxsAA))
 
     def test_canPickleAndUnpickleGAMISO(self):
-        pikAA = cPickle.loads(cPickle.dumps(self.gamisoAA))
+        pikAA = pickle.loads(pickle.dumps(self.gamisoAA))
         self.assertTrue(xsLibraries.compare(pikAA, self.gamisoAA))
 
     def test_canPickleAndUnpicklePMATRX(self):
-        pikAA = cPickle.loads(cPickle.dumps(self.pmatrxAA))
+        pikAA = pickle.loads(pickle.dumps(self.pmatrxAA))
         self.assertTrue(xsLibraries.compare(pikAA, self.pmatrxAA))
 
     def test_compareWorks(self):

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -19,11 +19,10 @@ Test the cross section manager.
 """
 import copy
 import os
+import pickle
 import unittest
 from io import BytesIO
 from unittest.mock import MagicMock
-
-from six.moves import cPickle
 
 from armi import settings
 from armi.physics.neutronics import crossSectionGroupManager
@@ -73,9 +72,9 @@ class TestBlockCollection(unittest.TestCase):
     def test_is_pickleable(self):
         self.bc.weightingParam = "test"
         buf = BytesIO()
-        cPickle.dump(self.bc, buf)
+        pickle.dump(self.bc, buf)
         buf.seek(0)
-        newBc = cPickle.load(buf)
+        newBc = pickle.load(buf)
         self.assertEqual(self.bc.weightingParam, newBc.weightingParam)
 
 
@@ -85,6 +84,7 @@ class TestBlockCollectionMedian(unittest.TestCase):
         for bi, b in enumerate(self.blockList):
             b.setType("fuel")
             b.p.percentBu = bi / 4.0 * 100
+
         self.blockList[0], self.blockList[2] = self.blockList[2], self.blockList[0]
         self.bc = MedianBlockCollection(
             self.blockList[0].core.r.blueprints.allNuclidesInProblem

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 """Parameter definitions for Blocks."""
-import six
-
 from armi import runLog
 from armi.physics.neutronics import crossSectionGroupManager
 from armi.reactor import parameters
@@ -207,7 +205,7 @@ def getBlockParameterDefinitions():
                 )
                 self.envGroupNum = intValue
                 return
-            elif not isinstance(envGroupChar, six.string_types):
+            elif not isinstance(envGroupChar, str):
                 raise Exception(
                     f"Wrong type for envGroupChar {envGroupChar}: {type(envGroupChar)}"
                 )

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -39,7 +39,6 @@ import timeit
 from typing import Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
-import six
 
 from armi import context, runLog, utils
 from armi.nucDirectory import elements, nucDir, nuclideBases
@@ -759,10 +758,9 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         if not typeID:
             return not exact
-        if isinstance(typeID, six.string_types):
+        if isinstance(typeID, str):
             raise TypeError(
-                "Must pass Flags, or an iterable of Flags; Strings are no longer "
-                "supported"
+                "Must pass Flags, or an iterable of Flags; Strings are no longer supported"
             )
 
         elif not isinstance(typeID, Flags):

--- a/armi/reactor/parameters/parameterCollections.py
+++ b/armi/reactor/parameters/parameterCollections.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Optional, List, Set, Iterator, Callable
 import copy
 import pickle
-from typing import Any, Optional, List, Set, Iterator, Callable
 import sys
 
 import numpy as np
-import six
 
 from armi import runLog
 from armi.reactor.parameters import parameterDefinitions, exceptions
@@ -38,10 +37,10 @@ The serial number for all ParameterCollections
 This is a counter of the number of instances of all types. They are useful for tracking items
 through the history of a database.
 
-.. warning::
-
-    This is not MPI safe. We also have not done anything to make it thread safe,
-    except that the GIL exists.
+Warning
+-------
+This is not MPI safe. We also have not done anything to make it thread safe, except that the GIL
+exists.
 """
 
 
@@ -365,7 +364,7 @@ class ParameterCollection(metaclass=_ParameterCollectionType):
             )
 
     def __delitem__(self, name):
-        if isinstance(name, six.string_types):
+        if isinstance(name, str):
             pd = self.paramDefs[name]
             if hasattr(self, pd.fieldName):
                 pd.assigned = SINCE_ANYTHING
@@ -374,7 +373,7 @@ class ParameterCollection(metaclass=_ParameterCollectionType):
             del self._hist[name]
 
     def __contains__(self, name):
-        if isinstance(name, six.string_types):
+        if isinstance(name, str):
             return hasattr(self, "_p_" + name)
         else:
             return name in self._hist

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -15,12 +15,12 @@
 import copy
 import logging
 import os
+import pickle
 import unittest
 from math import sqrt
 from unittest.mock import patch
 
 from numpy.testing import assert_allclose, assert_equal
-from six.moves import cPickle
 
 from armi import operators
 from armi import runLog
@@ -170,7 +170,7 @@ def loadTestReactor(
 
     if isPickeledReactor and TEST_REACTOR:
         # return test reactor only if no custom settings are needed.
-        o, r, assemNum = cPickle.loads(TEST_REACTOR)
+        o, r, assemNum = pickle.loads(TEST_REACTOR)
         o.reattach(r, o.cs)
         return o, r
 
@@ -196,7 +196,7 @@ def loadTestReactor(
     if isPickeledReactor:
         # cache it for fast load for other future tests
         # protocol=2 allows for classes with __slots__ but not __getstate__ to be pickled
-        TEST_REACTOR = cPickle.dumps((o, o.r, o.r.p.maxAssemNum), protocol=2)
+        TEST_REACTOR = pickle.dumps((o, o.r, o.r.p.maxAssemNum), protocol=2)
 
     return o, o.r
 
@@ -934,7 +934,7 @@ class HexReactorTests(ReactorTests):
         assert_allclose(mass1, mass2)
 
     def test_isPickleable(self):
-        loaded = cPickle.loads(cPickle.dumps(self.r))
+        loaded = pickle.loads(pickle.dumps(self.r))
 
         # ensure we didn't break the current reactor
         self.assertIs(self.r.core.spatialGrid.armiObject, self.r.core)

--- a/armi/tests/mockRunLogs.py
+++ b/armi/tests/mockRunLogs.py
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This module contains subclasses of the armi.runLog._RunLog class that can be used to determine whether or not
-one of the specific methods were called. These should only be used in testing.
+This module contains subclasses of the armi.runLog._RunLog class that can be used to determine
+whether or not one of the specific methods were called. These should only be used in testing.
 """
-import six
+import io
 import sys
 
 from armi import runLog
 
 
 class BufferLog(runLog._RunLog):
-    r"""Log which captures the output in attributes instead of emitting them.
+    """Log which captures the output in attributes instead of emitting them.
 
-    Used mostly in testing to ensure certain things get output, or to prevent any output
-    from showing.
+    Used mostly in testing to ensure certain things get output, or to prevent any output from
+    showing.
     """
 
     def __init__(self, *args, **kwargs):
@@ -34,7 +34,7 @@ class BufferLog(runLog._RunLog):
         self._outputStream = ""
         self._singleMessageCounts = {}
         self._singleWarningMessageCounts = {}
-        self._errStream = six.StringIO()
+        self._errStream = io.StringIO()
         sys.stderr = self._errStream
         self.setVerbosity(0)
 

--- a/armi/utils/iterables.py
+++ b/armi/utils/iterables.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 """Module of utilities to help dealing with iterable objects in Python."""
-from itertools import tee, chain
+from itertools import chain, filterfalse, tee
 import struct
-
-from six.moves import filterfalse, map, xrange, filter
 
 import numpy as np
 
@@ -43,7 +41,7 @@ def chunk(lst, n):
     >>> list(chunk([1,2,3,4,5,6,7,8,9,10], 4))
      [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10]]
     """
-    for i in xrange(0, len(lst), n):
+    for i in range(0, len(lst), n):
         yield lst[i : i + n]
 
 
@@ -84,7 +82,7 @@ def split(a, n, padWith=()):
 
     k, m = divmod(N, n)
     chunked = [
-        a[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] or padWith for i in xrange(n)
+        a[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] or padWith for i in range(n)
     ]
     return chunked
 


### PR DESCRIPTION
## What is the change?

Removing ARMI's direct dependence on `six`.

However, you will notice I didn't remove `six` from `pyproject.toml`, because it is not in there. One of ARMI's secondary dependencies is `six`, apparently. (I haven't bothered to figure out which one.)


## Why is the change being made?

ARMI doesn't support Python 2 any more, so we don't need this dependence.

close #2036

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary. (This doesn't require a release note.)
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.