### PR TITLE
First order deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
     "htmltree>=0.7.6", # Our reports have HTML output
     "matplotlib>=3.5.3,<3.8.0", # Important plotting library
-    "mpl_toolkits", # For adjusting matplotlib sub-plots
     "numpy>=1.21", # Important math library
     "ordered-set>=3.1.1", # A useful data structure
     "pluggy>=1.2.0", # Central tool behind the ARMI Plugin system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,17 +31,19 @@ authors = [
 ]
 dependencies = [
     "coverage>=7.2.0", # Code coverage tool. Sadly baked into every Case.
-    "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
+    "dateutil>=2.2", # To read a datetime string more easily.
     "h5py>=3.0,<=3.9 ; python_version < '3.11.0'",
+    "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
     "htmltree>=0.7.6", # Our reports have HTML output
     "matplotlib>=3.5.3,<3.8.0", # Important plotting library
+    "mpl_toolkits", # For adjusting matplotlib sub-plots
     "numpy>=1.21", # Important math library
     "ordered-set>=3.1.1", # A useful data structure
     "pluggy>=1.2.0", # Central tool behind the ARMI Plugin system
     "pyDOE>=0.3.8", # We import a Latin-hypercube algorithm to explore a phase space
     "pyevtk>=1.2.0", # Handles binary VTK visualization files
-    "ruamel.yaml.clib ; python_version >= '3.11.0'", # C-based core of ruamel below
     "ruamel.yaml ; python_version >= '3.11.0'", # Our foundational YAML library
+    "ruamel.yaml.clib ; python_version >= '3.11.0'", # C-based core of ruamel below
     "ruamel.yaml.clib<=0.2.7 ; python_version < '3.11.0'", # C-based core of ruamel below
     "ruamel.yaml<=0.17.21 ; python_version < '3.11.0'", # Our foundational YAML library
     "scipy>=1.7.0", # Used for curve-fitting and matrix math
@@ -81,9 +83,10 @@ test = [
     "ipykernel>=6.0.0", # IPython Kernel (We run test notebooks from the doc tutorials.)
     "jupyter_client>=7.0.0", # Reference implementation of the Jupyter protocol
     "nbconvert>=7.0.0", # Converting Jupyter Notebooks to other formats
-    "pytest>=7.0.0", # Our primary test tooling
+    "nbformat>=5.5.0", # Jupyter Notebook reader
     "pytest-cov>=4.0.0", # coverage plugin
     "pytest-xdist>=3.0.0", # To spread our tests over multiple CPUs
+    "pytest>=7.0.0", # Our primary test tooling
     "ruff==0.5.1", # Linting and code formatting (version-pinned)
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ authors = [
 ]
 dependencies = [
     "coverage>=7.2.0", # Code coverage tool. Sadly baked into every Case.
-    "dateutil>=2.2", # To read a datetime string more easily.
     "h5py>=3.0,<=3.9 ; python_version < '3.11.0'",
     "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
     "htmltree>=0.7.6", # Our reports have HTML output
@@ -42,6 +41,7 @@ dependencies = [
     "pluggy>=1.2.0", # Central tool behind the ARMI Plugin system
     "pyDOE>=0.3.8", # We import a Latin-hypercube algorithm to explore a phase space
     "pyevtk>=1.2.0", # Handles binary VTK visualization files
+    "python-dateutil>=2.2", # To read a datetime string more easily.
     "ruamel.yaml ; python_version >= '3.11.0'", # Our foundational YAML library
     "ruamel.yaml.clib ; python_version >= '3.11.0'", # C-based core of ruamel below
     "ruamel.yaml.clib<=0.2.7 ; python_version < '3.11.0'", # C-based core of ruamel below


### PR DESCRIPTION
## What is the change?

I added two first-order dependencies to the `pyproject.toml` file.

## Why is the change being made?

These are ALSO second-order dependencies. So ARMI builds fine with the `pyproject.toml` file as-is. But I consider this a failure of documentation. And Drew notes that we have less control as things stand.

Generally, I just want to declare all our first-order dependencies as such.

close #2038

(NOTE: I thought we had another first-order dep, mpl_toolkits, but it turns out that is just part of the matprops namespace.)

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary. (I don't believe this warrants a release note.)
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.