### PR TITLE
Unpin the max `matplotlib` version, which upgrades numpy

### DIFF
--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -1394,8 +1394,9 @@ class Database:
                 # current time step and something has created the group to store aux data
                 continue
 
-            cycle = h5TimeNodeGroup.attrs["cycle"]
-            timeNode = h5TimeNodeGroup.attrs["timeNode"]
+            # might save as int or np.int64, so forcing int keeps things predictable
+            cycle = int(h5TimeNodeGroup.attrs["cycle"])
+            timeNode = int(h5TimeNodeGroup.attrs["timeNode"])
             layout = Layout(
                 (self.versionMajor, self.versionMinor), h5group=h5TimeNodeGroup
             )

--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -1097,7 +1097,7 @@ class Database:
                     )
                 )
 
-            if data.dtype.type is np.string_:
+            if data.dtype.type is np.bytes_:
                 data = np.char.decode(data)
 
             if attrs.get("specialFormatting", False):
@@ -1291,7 +1291,7 @@ class Database:
                         )
                         raise
 
-                    if data.dtype.type is np.string_:
+                    if data.dtype.type is np.bytes_:
                         data = np.char.decode(data)
 
                     if dataSet.attrs.get("specialFormatting", False):
@@ -1450,7 +1450,7 @@ class Database:
                             )
                             raise
 
-                        if data.dtype.type is np.string_:
+                        if data.dtype.type is np.bytes_:
                             data = np.char.decode(data)
 
                         if dataSet.attrs.get("specialFormatting", False):

--- a/armi/bookkeeping/db/databaseInterface.py
+++ b/armi/bookkeeping/db/databaseInterface.py
@@ -390,7 +390,8 @@ class DatabaseInterface(interfaces.Interface):
         if nowRequested:
             for param in params or history.keys():
                 if param == "location":
-                    history[param][now] = tuple(comp.spatialLocator.indices)
+                    # might save as int or np.int64, so forcing int keeps things predictable
+                    history[param][now] = tuple(int(i) for i in comp.spatialLocator.indices)
                 else:
                     history[param][now] = comp.p[param]
 

--- a/armi/bookkeeping/db/databaseInterface.py
+++ b/armi/bookkeeping/db/databaseInterface.py
@@ -391,7 +391,9 @@ class DatabaseInterface(interfaces.Interface):
             for param in params or history.keys():
                 if param == "location":
                     # might save as int or np.int64, so forcing int keeps things predictable
-                    history[param][now] = tuple(int(i) for i in comp.spatialLocator.indices)
+                    history[param][now] = tuple(
+                        int(i) for i in comp.spatialLocator.indices
+                    )
                 else:
                     history[param][now] = comp.p[param]
 

--- a/armi/bookkeeping/tests/armiRun-A0032-aHist-ref.txt
+++ b/armi/bookkeeping/tests/armiRun-A0032-aHist-ref.txt
@@ -1,5 +1,5 @@
-  (np.int64(0),np.int64(0))        (0,1)
-                0.00000E+00  0.00000E+00
+      (0,0)        (0,1)
+0.00000E+00  0.00000E+00
 
 
 key: residence
@@ -33,7 +33,7 @@ key: ztop
 
 
 key: location
-(7,-1,0)  (np.int64(0),np.int64(0),np.int64(0))
+(7,-1,0)  (0,0,0)
 
 
 EOL        bottom         top      center

--- a/armi/bookkeeping/tests/armiRun-A0032-aHist-ref.txt
+++ b/armi/bookkeeping/tests/armiRun-A0032-aHist-ref.txt
@@ -1,5 +1,5 @@
-      (0,0)        (0,1)
-0.00000E+00  0.00000E+00
+  (np.int64(0),np.int64(0))        (0,1)
+                0.00000E+00  0.00000E+00
 
 
 key: residence
@@ -33,7 +33,7 @@ key: ztop
 
 
 key: location
-(7,-1,0)  (0,0,0)
+(7,-1,0)  (np.int64(0),np.int64(0),np.int64(0))
 
 
 EOL        bottom         top      center

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1021,7 +1021,7 @@ class Assembly(composites.Composite):
         return blocksHere
 
     def getParamValuesAtZ(
-        self, param, elevations, interpType="linear", fillValue=np.NaN
+        self, param, elevations, interpType="linear", fillValue=np.nan
     ):
         """
         Interpolates a param axially to find it at any value of elevation z.
@@ -1070,7 +1070,7 @@ class Assembly(composites.Composite):
         )
         return interpolator(elevations)
 
-    def getParamOfZFunction(self, param, interpType="linear", fillValue=np.NaN):
+    def getParamOfZFunction(self, param, interpType="linear", fillValue=np.nan):
         """
         Interpolates a param axially to find it at any value of elevation z.
 

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -132,7 +132,7 @@ class UnshapedComponent(Component):
         material,
         Tinput,
         Thot,
-        area=np.NaN,
+        area=np.nan,
         modArea=None,
         isotopics=None,
         mergeWith=None,
@@ -224,12 +224,12 @@ class UnshapedVolumetricComponent(UnshapedComponent):
         material,
         Tinput,
         Thot,
-        area=np.NaN,
+        area=np.nan,
         op=None,
         isotopics=None,
         mergeWith=None,
         components=None,
-        volume=np.NaN,
+        volume=np.nan,
     ):
         Component.__init__(
             self,

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -411,7 +411,8 @@ def minimizeScalarFunc(
         tol=tol,
         options={"maxiter": maxIterations},
     )
-    ans = float(X["x"])
+
+    ans = float(X["x"][0])
     if positiveGuesses is True:
         ans = abs(ans)
 
@@ -515,7 +516,7 @@ def parabolaFromPoints(p1, p2, p3):
         print("Error in parabola {} {}".format(A, b))
         raise
 
-    return float(x[0]), float(x[1]), float(x[2])
+    return float(x[0][0]), float(x[1][0]), float(x[2][0])
 
 
 def parabolicInterpolation(ap, bp, cp, targetY):

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -412,6 +412,7 @@ def minimizeScalarFunc(
         options={"maxiter": maxIterations},
     )
 
+    # X returns `[num]` instead of `num`, so we have to grab the first/only element in that list
     ans = float(X["x"][0])
     if positiveGuesses is True:
         ans = abs(ans)
@@ -516,6 +517,7 @@ def parabolaFromPoints(p1, p2, p3):
         print("Error in parabola {} {}".format(A, b))
         raise
 
+    # x[#] returns `[num]` instead of `num`, so we have to grab the first/only element in that list
     return float(x[0][0]), float(x[1][0]), float(x[2][0])
 
 

--- a/armi/utils/tests/test_iterables.py
+++ b/armi/utils/tests/test_iterables.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Unittests for iterables.py."""
-import time
 import unittest
 
 import numpy as np
@@ -69,20 +68,14 @@ class TestIterables(unittest.TestCase):
         self.assertEqual(unchu, data)
 
     def test_packingAndUnpackingBinaryStrings(self):
-        start = time.perf_counter()
         packed = iterables.packBinaryStrings(_TEST_DATA)
         unpacked = iterables.unpackBinaryStrings(packed["turtle"][0])
-        timeDelta = time.perf_counter() - start
         self.assertEqual(_TEST_DATA["turtle"], unpacked)
-        return timeDelta
 
     def test_packingAndUnpackingHexStrings(self):
-        start = time.perf_counter()
         packed = iterables.packHexStrings(_TEST_DATA)
         unpacked = iterables.unpackHexStrings(packed["turtle"][0])
-        timeDelta = time.perf_counter() - start
         self.assertEqual(_TEST_DATA["turtle"], unpacked)
-        return timeDelta
 
     def test_sequenceInit(self):
         # init an empty sequence

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -213,7 +213,7 @@ class TestTabulateInputs(unittest.TestCase):
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
             dtype={
                 "names": ["name", "age", "height"],
-                "formats": ["a32", "uint8", "float32"],
+                "formats": ["S", "uint8", "float32"],
             },
         )
         expected = "\n".join(
@@ -233,7 +233,7 @@ class TestTabulateInputs(unittest.TestCase):
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
             dtype={
                 "names": ["name", "age", "height"],
-                "formats": ["a32", "uint8", "float32"],
+                "formats": ["S", "uint8", "float32"],
             },
         )
         expected = "\n".join(
@@ -253,7 +253,7 @@ class TestTabulateInputs(unittest.TestCase):
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
             dtype={
                 "names": ["name", "age", "height"],
-                "formats": ["a32", "uint8", "float32"],
+                "formats": ["S", "uint8", "float32"],
             },
         )
         expected = "\n".join(

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -213,7 +213,7 @@ class TestTabulateInputs(unittest.TestCase):
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
             dtype={
                 "names": ["name", "age", "height"],
-                "formats": ["S", "uint8", "float32"],
+                "formats": ["S32", "uint8", "float32"],
             },
         )
         expected = "\n".join(
@@ -233,7 +233,7 @@ class TestTabulateInputs(unittest.TestCase):
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
             dtype={
                 "names": ["name", "age", "height"],
-                "formats": ["S", "uint8", "float32"],
+                "formats": ["S32", "uint8", "float32"],
             },
         )
         expected = "\n".join(
@@ -253,7 +253,7 @@ class TestTabulateInputs(unittest.TestCase):
             [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
             dtype={
                 "names": ["name", "age", "height"],
-                "formats": ["S", "uint8", "float32"],
+                "formats": ["S32", "uint8", "float32"],
             },
         )
         expected = "\n".join(

--- a/armi/utils/tests/test_textProcessors.py
+++ b/armi/utils/tests/test_textProcessors.py
@@ -145,7 +145,7 @@ X  Y  0.0"""
 
     def test_readFileWithPattern(self):
         with textProcessors.SequentialReader(self._DUMMY_FILE_NAME) as sr:
-            self.assertTrue(sr.searchForPattern("(X\s+Y\s+\d+\.\d+)"))
+            self.assertTrue(sr.searchForPattern(r"(X\s+Y\s+\d+\.\d+)"))
             self.assertEqual(float(sr.line.split()[2]), 3.5)
 
     def test_issueWarningOnFindingText(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
     "ruamel.yaml.clib ; python_version >= '3.11.0'", # C-based core of ruamel below
     "ruamel.yaml.clib<=0.2.7 ; python_version < '3.11.0'", # C-based core of ruamel below
     "ruamel.yaml<=0.17.21 ; python_version < '3.11.0'", # Our foundational YAML library
-    "scipy>=1.7.0", # Used for curve-fitting and matrix math
+    "scipy<1.14.0 ; python_version <= '3.10.0'",
+    "scipy>=1.7.0 ; python_version > '3.10.0'", # Used for curve-fitting and matrix math
     "toml>0.9.5", # Needed to parse the pyproject.toml file
     "voluptuous>=0.12.1", # Used to validate YAML data files
     "yamlize==0.7.1", # Custom YAML-to-object library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,11 @@ authors = [
 ]
 dependencies = [
     "coverage>=7.2.0", # Code coverage tool. Sadly baked into every Case.
-    "h5py>=3.0,<=3.9 ; python_version < '3.11.0'",
-    "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
+    "h5py>=3.0,<=3.9 ; python_version < '3.10.0'",
+    "h5py>=3.9 ; python_version >= '3.10.0'", # Needed because our database files are H5 format
     "htmltree>=0.7.6", # Our reports have HTML output
-    "matplotlib>=3.5.3", # Important plotting library
+    "matplotlib>=3.5.3,<=3.8.0 ; python_version < '3.11.0'",
+    "matplotlib>=3.5.3 ; python_version >= '3.11.0'", # Important plotting library
     "numpy>=1.21", # Important math library
     "ordered-set>=3.1.1", # A useful data structure
     "pluggy>=1.2.0", # Central tool behind the ARMI Plugin system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "h5py>=3.0,<=3.9 ; python_version < '3.11.0'",
     "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
     "htmltree>=0.7.6", # Our reports have HTML output
-    "matplotlib>=3.5.3,<3.8.0", # Important plotting library
+    "matplotlib>=3.5.3", # Important plotting library
     "numpy>=1.21", # Important math library
     "ordered-set>=3.1.1", # A useful data structure
     "pluggy>=1.2.0", # Central tool behind the ARMI Plugin system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ authors = [
 ]
 dependencies = [
     "coverage>=7.2.0", # Code coverage tool. Sadly baked into every Case.
-    "h5py>=3.0,<=3.9 ; python_version < '3.10.0'",
-    "h5py>=3.9 ; python_version >= '3.10.0'", # Needed because our database files are H5 format
+    "h5py>=3.0,<=3.9 ; python_version < '3.11.0'",
+    "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
     "htmltree>=0.7.6", # Our reports have HTML output
     "matplotlib>=3.5.3,<=3.8.0 ; python_version < '3.11.0'",
     "matplotlib>=3.5.3 ; python_version >= '3.11.0'", # Important plotting library
@@ -46,8 +46,7 @@ dependencies = [
     "ruamel.yaml.clib ; python_version >= '3.11.0'", # C-based core of ruamel below
     "ruamel.yaml.clib<=0.2.7 ; python_version < '3.11.0'", # C-based core of ruamel below
     "ruamel.yaml<=0.17.21 ; python_version < '3.11.0'", # Our foundational YAML library
-    "scipy<1.14.0 ; python_version <= '3.10.0'",
-    "scipy>=1.7.0 ; python_version > '3.10.0'", # Used for curve-fitting and matrix math
+    "scipy>=1.7.0", # Used for curve-fitting and matrix math
     "toml>0.9.5", # Needed to parse the pyproject.toml file
     "voluptuous>=0.12.1", # Used to validate YAML data files
     "yamlize==0.7.1", # Custom YAML-to-object library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "h5py>=3.0,<=3.9 ; python_version < '3.11.0'",
     "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
     "htmltree>=0.7.6", # Our reports have HTML output
-    "matplotlib>=3.5.3", # Important plotting library
+    "matplotlib>=3.5.3,<3.8.0 ; python_version < '3.11.0'",
+    "matplotlib>=3.5.3 ; python_version >= '3.11.0'", # Important plotting library
     "numpy>=1.21", # Important math library
     "ordered-set>=3.1.1", # A useful data structure
     "pluggy>=1.2.0", # Central tool behind the ARMI Plugin system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,7 @@ dependencies = [
     "h5py>=3.0,<=3.9 ; python_version < '3.11.0'",
     "h5py>=3.9 ; python_version >= '3.11.0'", # Needed because our database files are H5 format
     "htmltree>=0.7.6", # Our reports have HTML output
-    "matplotlib>=3.5.3,<3.8.0 ; python_version < '3.11.0'",
-    "matplotlib>=3.5.3 ; python_version >= '3.11.0'", # Important plotting library
+    "matplotlib>=3.5.3", # Important plotting library
     "numpy>=1.21", # Important math library
     "ordered-set>=3.1.1", # A useful data structure
     "pluggy>=1.2.0", # Central tool behind the ARMI Plugin system


### PR DESCRIPTION
## What is the change?

tl;dr: fixed some numpy and python deprecation issues, and deleted the max matplotlib pin for py311 and up.

Unpinning the max `matplotlib` pin in ARMI opened some floodgates for other upgrades, specifically `numpy`. I ended up with one test failing in `test_historyTracker.py` because some zeroes were being saved as `np.int64` in the database and that was getting processed into strings when using `getHistory`. So that's where those forced `int()` pieces came from. The rest is self explanatory numpy deprecation warnings. 

## Why is the change being made?

`matplotlib` v3.8 being the max version doesn't always work with higher python versions. The pip resolution in github actions  is not behaving the same elsewhere. So let's just fix root cause of the max pin instead. 

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.