### PR TITLE
Raise error in invalid xsTypeNum condition

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -109,8 +109,8 @@ def getXSTypeLabelFromNumber(xsTypeNumber: int) -> str:
             return chr(int(str(xsTypeNumber)[:2])) + chr(int(str(xsTypeNumber)[2:]))
         elif xsTypeNumber < ord("A"):
             raise ValueError(
-                f"Cannot convert invalid xsTypeNumber `{xsTypeNumber}` to char "
-                "The number must be >= 65 (corresponding to 'A')"
+                f"Cannot convert invalid xsTypeNumber `{xsTypeNumber}` to char. "
+                "The number must be >= 65 (corresponding to 'A')."
             )
         else:
             return chr(xsTypeNumber)

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -95,7 +95,7 @@ def getXSTypeNumberFromLabel(xsTypeLabel: str) -> int:
     return int("".join(["{:02d}".format(ord(si)) for si in xsTypeLabel]))
 
 
-def getXSTypeLabelFromNumber(xsTypeNumber: int) -> int:
+def getXSTypeLabelFromNumber(xsTypeNumber: int) -> str:
     """
     Convert a XSID label (e.g. 65) to an XS label (e.g. 'A').
 
@@ -107,6 +107,11 @@ def getXSTypeLabelFromNumber(xsTypeNumber: int) -> int:
         if xsTypeNumber > ord("Z"):
             # two digit. Parse
             return chr(int(str(xsTypeNumber)[:2])) + chr(int(str(xsTypeNumber)[2:]))
+        elif xsTypeNumber < ord("A"):
+            raise ValueError(
+                f"Cannot convert invalid xsTypeNumber `{xsTypeNumber}` to char "
+                "The number must be >= 65 (corresponding to 'A')"
+            )
         else:
             return chr(xsTypeNumber)
     except ValueError:

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -219,7 +219,7 @@ class Assembly_TestCase(unittest.TestCase):
             "residence": 4.0,
             "smearDensity": 0.6996721711791459,
             "timeToLimit": 2.7e5,
-            "xsTypeNum": 40,
+            "xsTypeNum": 65,
             "zbottom": 97.3521,
             "ztop": 111.80279999999999,
         }
@@ -776,9 +776,9 @@ class Assembly_TestCase(unittest.TestCase):
             # Set the 1st block to have higher params than the rest.
             self.blockParamsTemp = {}
             for key, val in self.blockParams.items():
-                b.p[key] = self.blockParamsTemp[key] = (
-                    val * i
-                )  # Iterate with i in self.assemNum, so higher assemNums get the high values.
+                # Iterate with i in self.assemNum, so higher assemNums get the high values.
+                if key != "xsTypeNum":  # must keep valid
+                    b.p[key] = self.blockParamsTemp[key] = val * i
 
             b.setHeight(self.height)
             b.setType("fuel")

--- a/armi/utils/tests/test_reportPlotting.py
+++ b/armi/utils/tests/test_reportPlotting.py
@@ -118,8 +118,8 @@ class TestRadar(unittest.TestCase):
         class HistTester:
             def __init__(self):
                 self.xsHistory = {
-                    1: [[0, 1], [0, 2], [0, 3]],
-                    2: [[0, 5], [0, 6], [0, 7]],
+                    65: [[0, 1], [0, 2], [0, 3]],
+                    66: [[0, 5], [0, 6], [0, 7]],
                 }
 
         history = HistTester()


### PR DESCRIPTION
## What is the change?

Add error and fix invalid test fixture data that was triggering a warning.



<!-- MANDATORY: Describe the change -->

## Why is the change being made?

It was mentioned in  #2041 as causing warnings during tests. Invalid input data should lead to errors. 

<!-- MANDATORY: Explain why the change is necessary -->
<!-- Optional: Link to any related GitHub Issues -->


---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.