### PR TITLE
Cleaning up some casual docstrings

### DIFF
--- a/armi/apps.py
+++ b/armi/apps.py
@@ -18,15 +18,6 @@ The base ARMI App class.
 This module defines the :py:class:`App` class, which is used to configure the ARMI
 Framework for a specific application. An ``App`` implements a simple interface for
 customizing much of the Framework's behavior.
-
-Notes
------
-Historical Fun Fact
-
-This pattern is used by many frameworks as a way of encapsulating what would otherwise be global
-state. The ARMI Framework has historically made heavy use of global state (e.g.,
-:py:mod:`armi.nucDirectory.nuclideBases`), and it will take quite a bit of effort to refactor the
-code to access such things through an App object.
 """
 # ruff: noqa: E402
 import collections

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -469,7 +469,7 @@ class DistributionAction(MpiAction):
         actionResult = None
         try:
             action = mpiComm.scatter(self._actions, root=0)
-            # create a new communicator that only has these specific dudes running
+            # create a new communicator that only has these specific processes running
             hasAction = action is not None
             context.MPI_COMM = mpiComm.Split(int(hasAction))
             context.MPI_RANK = context.MPI_COMM.Get_rank()

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -753,8 +753,9 @@ class _IsotxsNuclideIO:
         """
         Get the scatter matrix for a particular blockNum.
 
-        Note: This is stupid and the logic should be combined with _setScatterMatrix.
-        Please recommend a better way to do it during code review.
+        Notes
+        -----
+        This logic could be combined with _setScatterMatrix.
         """
         if blockNumIndex == self._getElasticScatterBlockNumIndex():
             scatterMatrix = self._getMicros().elasticScatter

--- a/armi/physics/__init__.py
+++ b/armi/physics/__init__.py
@@ -69,13 +69,4 @@ and::
 And then the associated ARMI-based app could import both ``IAEA.physics.neutronics.superSourceTerm`` and
 ``IAEA.physics.economics.magwoodsbrain``. Having a consistency in namespace along these lines is
 quite nice.
-
-If you want to propose a new namespace root folder here, we recommend making a ticket to aid in the discussion.
-
-
-.. admonition:: Historical fun fact
-
-    **All** physics modules once actually lived in this package,
-    before the age of Plugins began. The current state is transient, and will
-    converge as the framework matures.
 """

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -278,12 +278,11 @@ class FuelHandler:
             multiplier. For example, if you wanted an assembly that had a bu close to half of
             assembly bob, you'd give param='percentBu', compareTo=(bob,0.5) If you want one with a
             bu close to 0.3, you'd do param='percentBu',compareTo=0.3. Yes, if you give a (float,
-            multiplier) tuple, the code will make fun of you for not doing your own math, but will
-            still operate as expected.
+            multiplier) tuple the code will still work as expected.
 
         forceSide : bool, optional
             requires the found assembly to have either 1: higher, -1: lower, None: any param than
-             compareTo
+            compareTo
 
         exclusions : list, optional
             List of assemblies that will be excluded from the search

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -51,8 +51,7 @@ as the first argument and the system will load up the associated grid, e.g.::
   between asemblies of different design, but the same flags.
 
 * No proper zoom support, and object sizes are fixed and don't accommodate long
-  specifiers. Adding zoom would make for a fun first task to a new developer interested
-  in computer graphics.
+  specifiers.
 """
 
 import colorsys


### PR DESCRIPTION
## What is the change?

I found one or two docstrings there were a bit too casual.  Or just defunct and unnecessary.

## Why is the change being made?

Just cleanup.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.