### PR TITLE
Corrrectly ignoring BP sections in PassiveDBLoadPlugin

### DIFF
--- a/armi/bookkeeping/db/passiveDBLoadPlugin.py
+++ b/armi/bookkeeping/db/passiveDBLoadPlugin.py
@@ -33,6 +33,7 @@ class PassThroughYamlize(yamlize.Object):
 
     @classmethod
     def from_yaml(cls, loader, node, round_trip_data=None):
+        node.value = []
         return yamlize.Object.from_yaml.__func__(
             PassThroughYamlize, loader, node, round_trip_data
         )

--- a/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
+++ b/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
@@ -1,0 +1,151 @@
+# Copyright 2025 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides functionality for testing the PassiveDBLoadPlugin."""
+import unittest
+from copy import deepcopy
+from io import StringIO
+
+from ruamel.yaml.cyaml import CLoader
+from ruamel.yaml.nodes import MappingNode, ScalarNode, SequenceNode
+
+from armi import getApp
+from armi.bookkeeping.db.passiveDBLoadPlugin import (
+    PassiveDBLoadPlugin,
+    PassThroughYamlize,
+)
+from armi.reactor.blocks import Block
+
+_TEST_BP_YAML = """
+grids:
+    !include path/to/fake/grid.yaml
+reactivity coefficients:
+    core-wide:
+        fuel axial expansion: False
+        grid plate radial expansion: False
+        fuel:
+            coefficients: Doppler,Voided Doppler
+            assembly flags: Fuel
+"""
+
+_TEST_NODE = [
+    (
+        ScalarNode(tag="tag:yaml.org,2002:str", value="core-wide"),
+        MappingNode(
+            tag="tag:yaml.org,2002:map",
+            value=[
+                (
+                    ScalarNode(
+                        tag="tag:yaml.org,2002:str", value="fuel axial expansion"
+                    ),
+                    ScalarNode(tag="tag:yaml.org,2002:bool", value="False"),
+                ),
+                (
+                    ScalarNode(
+                        tag="tag:yaml.org,2002:str", value="grid plate radial expansion"
+                    ),
+                    ScalarNode(tag="tag:yaml.org,2002:bool", value="True"),
+                ),
+                (
+                    ScalarNode(tag="tag:yaml.org,2002:str", value="fuel"),
+                    MappingNode(
+                        tag="tag:yaml.org,2002:map",
+                        value=[
+                            (
+                                ScalarNode(
+                                    tag="tag:yaml.org,2002:str", value="coefficients"
+                                ),
+                                SequenceNode(
+                                    tag="tag:yaml.org,2002:seq",
+                                    value=[
+                                        ScalarNode(
+                                            tag="tag:yaml.org,2002:str", value="Doppler"
+                                        ),
+                                        ScalarNode(
+                                            tag="tag:yaml.org,2002:str",
+                                            value="Voided Doppler",
+                                        ),
+                                    ],
+                                ),
+                            ),
+                            (
+                                ScalarNode(
+                                    tag="tag:yaml.org,2002:str", value="assembly flags"
+                                ),
+                                SequenceNode(
+                                    tag="tag:yaml.org,2002:seq",
+                                    value=[
+                                        ScalarNode(
+                                            tag="tag:yaml.org,2002:str", value="Fuel"
+                                        )
+                                    ],
+                                ),
+                            ),
+                        ],
+                    ),
+                ),
+            ],
+        ),
+    ),
+]
+
+
+class TestPassiveDBLoadPlugin(unittest.TestCase):
+    def setUp(self):
+        """
+        Manipulate the standard App. We can't just configure our own, since the
+        pytest environment bleeds between tests.
+        """
+        self.app = getApp()
+        self._backupApp = deepcopy(self.app)
+
+    def test_passiveDBLoadPlugin(self):
+        plug = PassiveDBLoadPlugin()
+
+        # default case
+        bpSections = plug.defineBlueprintsSections()
+        self.assertEqual(len(bpSections), 0)
+        params = plug.defineParameters()
+        self.assertEqual(len(params), 0)
+
+        # non-empty cases
+        PassiveDBLoadPlugin.SKIP_BP_SECTIONS = ["hi", "mom"]
+        PassiveDBLoadPlugin.UNKNOWN_PARAMS = {Block: ["fake1", "fake2"]}
+        bpSections = plug.defineBlueprintsSections()
+        self.assertEqual(len(bpSections), 2)
+        self.assertTrue(type(bpSections[0]), tuple)
+        self.assertEqual(bpSections[0][0], "hi")
+        self.assertTrue(type(bpSections[1]), tuple)
+        self.assertEqual(bpSections[1][0], "mom")
+        params = plug.defineParameters()
+        self.assertEqual(len(params), 1)
+        self.assertIn(Block, params)
+
+
+class TestPassThroughYamlize(unittest.TestCase):
+    def test_passThroughYamlizeExample1(self):
+        # create node from known BP-style YAML object
+        node = MappingNode("test1", _TEST_NODE)
+
+        # test that node is non-zero and has the "core-wide" section
+        self.assertEqual(node.value[0][0].value, "core-wide")
+        self.assertGreater(len(node.value), 0)
+
+        # pass the YAML string through the known YAML
+        pty = PassThroughYamlize()
+        loader = CLoader(StringIO(_TEST_BP_YAML))
+        _p = pty.from_yaml(loader, node)
+
+        # prove the section has been cleared
+        self.assertEqual(len(node.value), 0)

--- a/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
+++ b/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
@@ -136,15 +136,32 @@ class TestPassiveDBLoadPlugin(unittest.TestCase):
 class TestPassThroughYamlize(unittest.TestCase):
     def test_passThroughYamlizeExample1(self):
         # create node from known BP-style YAML object
+        node = MappingNode(
+            "test1", ScalarNode(tag="tag:yaml.org,2002:str", value="core-wide")
+        )
+        # node = MappingNode("test1", _TEST_BP_YAML)
+
+        # test that node is non-zero and has the "core-wide" section
+        self.assertEqual(node.value.value, "core-wide")
+
+        # pass the YAML string through the known YAML
+        pty = PassThroughYamlize()
+        loader = CLoader(StringIO(""))
+        _p = pty.from_yaml(loader, node)
+
+        # prove the section has been cleared
+        self.assertEqual(len(node.value), 0)
+
+    def test_passThroughYamlizeExample2(self):
+        # create node from known BP-style YAML object
         node = MappingNode("test1", _TEST_NODE)
 
         # test that node is non-zero and has the "core-wide" section
         self.assertEqual(node.value[0][0].value, "core-wide")
-        self.assertGreater(len(node.value), 0)
 
         # pass the YAML string through the known YAML
         pty = PassThroughYamlize()
-        loader = CLoader(StringIO(_TEST_BP_YAML))
+        loader = CLoader(StringIO(""))
         _p = pty.from_yaml(loader, node)
 
         # prove the section has been cleared

--- a/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
+++ b/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
@@ -28,15 +28,12 @@ from armi.bookkeeping.db.passiveDBLoadPlugin import (
 from armi.reactor.blocks import Block
 
 _TEST_BP_YAML = """
-grids:
-    !include path/to/fake/grid.yaml
-reactivity coefficients:
-    core-wide:
-        fuel axial expansion: False
-        grid plate radial expansion: False
-        fuel:
-            coefficients: Doppler,Voided Doppler
-            assembly flags: Fuel
+core-wide:
+    fuel axial expansion: False
+    grid plate radial expansion: False
+    fuel:
+        coefficients: Doppler,Voided Doppler
+        assembly flags: Fuel
 """
 
 _TEST_NODE = [
@@ -139,7 +136,6 @@ class TestPassThroughYamlize(unittest.TestCase):
         node = MappingNode(
             "test1", ScalarNode(tag="tag:yaml.org,2002:str", value="core-wide")
         )
-        # node = MappingNode("test1", _TEST_BP_YAML)
 
         # test that node is non-zero and has the "core-wide" section
         self.assertEqual(node.value.value, "core-wide")
@@ -154,7 +150,11 @@ class TestPassThroughYamlize(unittest.TestCase):
 
     def test_passThroughYamlizeExample2(self):
         # create node from known BP-style YAML object
-        node = MappingNode("test1", _TEST_NODE)
+        #node = MappingNode("test1", _TEST_NODE)
+        from ruaml.yaml import YAML
+        y = YAML()
+        node = y.load(_TEST_BP_YAML)
+        print(node)
 
         # test that node is non-zero and has the "core-wide" section
         self.assertEqual(node.value[0][0].value, "core-wide")

--- a/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
+++ b/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 from io import StringIO
 
 from ruamel.yaml.cyaml import CLoader
-from ruamel.yaml.nodes import MappingNode, ScalarNode, SequenceNode
+from ruamel.yaml.nodes import MappingNode, ScalarNode
 
 from armi import getApp
 from armi.bookkeeping.db.passiveDBLoadPlugin import (
@@ -26,76 +26,6 @@ from armi.bookkeeping.db.passiveDBLoadPlugin import (
     PassThroughYamlize,
 )
 from armi.reactor.blocks import Block
-
-_TEST_BP_YAML = """
-core-wide:
-    fuel axial expansion: False
-    grid plate radial expansion: False
-    fuel:
-        coefficients: Doppler,Voided Doppler
-        assembly flags: Fuel
-"""
-
-_TEST_NODE = [
-    (
-        ScalarNode(tag="tag:yaml.org,2002:str", value="core-wide"),
-        MappingNode(
-            tag="tag:yaml.org,2002:map",
-            value=[
-                (
-                    ScalarNode(
-                        tag="tag:yaml.org,2002:str", value="fuel axial expansion"
-                    ),
-                    ScalarNode(tag="tag:yaml.org,2002:bool", value="False"),
-                ),
-                (
-                    ScalarNode(
-                        tag="tag:yaml.org,2002:str", value="grid plate radial expansion"
-                    ),
-                    ScalarNode(tag="tag:yaml.org,2002:bool", value="True"),
-                ),
-                (
-                    ScalarNode(tag="tag:yaml.org,2002:str", value="fuel"),
-                    MappingNode(
-                        tag="tag:yaml.org,2002:map",
-                        value=[
-                            (
-                                ScalarNode(
-                                    tag="tag:yaml.org,2002:str", value="coefficients"
-                                ),
-                                SequenceNode(
-                                    tag="tag:yaml.org,2002:seq",
-                                    value=[
-                                        ScalarNode(
-                                            tag="tag:yaml.org,2002:str", value="Doppler"
-                                        ),
-                                        ScalarNode(
-                                            tag="tag:yaml.org,2002:str",
-                                            value="Voided Doppler",
-                                        ),
-                                    ],
-                                ),
-                            ),
-                            (
-                                ScalarNode(
-                                    tag="tag:yaml.org,2002:str", value="assembly flags"
-                                ),
-                                SequenceNode(
-                                    tag="tag:yaml.org,2002:seq",
-                                    value=[
-                                        ScalarNode(
-                                            tag="tag:yaml.org,2002:str", value="Fuel"
-                                        )
-                                    ],
-                                ),
-                            ),
-                        ],
-                    ),
-                ),
-            ],
-        ),
-    ),
-]
 
 
 class TestPassiveDBLoadPlugin(unittest.TestCase):
@@ -134,27 +64,32 @@ class TestPassThroughYamlize(unittest.TestCase):
     def test_passThroughYamlizeExample1(self):
         # create node from known BP-style YAML object
         node = MappingNode(
-            "test1", ScalarNode(tag="tag:yaml.org,2002:str", value="core-wide")
+            "test_passThroughYamlizeExample1",
+            [
+                (
+                    ScalarNode(tag="tag:yaml.org,2002:str", value="core-wide"),
+                    MappingNode(
+                        tag="tag:yaml.org,2002:map",
+                        value=[
+                            (
+                                ScalarNode(
+                                    tag="tag:yaml.org,2002:str",
+                                    value="fuel axial expansion",
+                                ),
+                                ScalarNode(tag="tag:yaml.org,2002:bool", value="False"),
+                            ),
+                            (
+                                ScalarNode(
+                                    tag="tag:yaml.org,2002:str",
+                                    value="grid plate radial expansion",
+                                ),
+                                ScalarNode(tag="tag:yaml.org,2002:bool", value="True"),
+                            ),
+                        ],
+                    ),
+                )
+            ],
         )
-
-        # test that node is non-zero and has the "core-wide" section
-        self.assertEqual(node.value.value, "core-wide")
-
-        # pass the YAML string through the known YAML
-        pty = PassThroughYamlize()
-        loader = CLoader(StringIO(""))
-        _p = pty.from_yaml(loader, node)
-
-        # prove the section has been cleared
-        self.assertEqual(len(node.value), 0)
-
-    def test_passThroughYamlizeExample2(self):
-        # create node from known BP-style YAML object
-        #node = MappingNode("test1", _TEST_NODE)
-        from ruaml.yaml import YAML
-        y = YAML()
-        node = y.load(_TEST_BP_YAML)
-        print(node)
 
         # test that node is non-zero and has the "core-wide" section
         self.assertEqual(node.value[0][0].value, "core-wide")

--- a/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
+++ b/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
@@ -20,7 +20,7 @@ from io import StringIO
 from ruamel.yaml.cyaml import CLoader
 from ruamel.yaml.nodes import MappingNode, ScalarNode
 
-from armi import getApp
+from armi import context, getApp
 from armi.bookkeeping.db.passiveDBLoadPlugin import (
     PassiveDBLoadPlugin,
     PassThroughYamlize,
@@ -36,6 +36,13 @@ class TestPassiveDBLoadPlugin(unittest.TestCase):
         """
         self.app = getApp()
         self._backupApp = deepcopy(self.app)
+
+    def tearDown(self):
+        """Restore the App to its original state."""
+        import armi
+
+        armi._app = self._backupApp
+        context.APP_NAME = "armi"
 
     def test_passiveDBLoadPlugin(self):
         plug = PassiveDBLoadPlugin()

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -28,7 +28,6 @@ from armi import (
     settings,
     utils,
 )
-from armi.bookkeeping.db.passiveDBLoadPlugin import PassiveDBLoadPlugin
 from armi.physics.neutronics import NeutronicsPlugin
 from armi.reactor.blocks import Block
 from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
@@ -130,28 +129,6 @@ class TestPluginRegistration(unittest.TestCase):
         second = pm.hook.getAxialExpansionChanger()
         # Registering a plugin that implements the hook means we get that plugin's axial expander
         self.assertIs(second, SillyAxialExpansionChanger)
-
-    def test_passiveDBLoadPlugin(self):
-        plug = PassiveDBLoadPlugin()
-
-        # default case
-        bpSections = plug.defineBlueprintsSections()
-        self.assertEqual(len(bpSections), 0)
-        params = plug.defineParameters()
-        self.assertEqual(len(params), 0)
-
-        # non-empty cases
-        PassiveDBLoadPlugin.SKIP_BP_SECTIONS = ["hi", "mom"]
-        PassiveDBLoadPlugin.UNKNOWN_PARAMS = {Block: ["fake1", "fake2"]}
-        bpSections = plug.defineBlueprintsSections()
-        self.assertEqual(len(bpSections), 2)
-        self.assertTrue(type(bpSections[0]), tuple)
-        self.assertEqual(bpSections[0][0], "hi")
-        self.assertTrue(type(bpSections[1]), tuple)
-        self.assertEqual(bpSections[1][0], "mom")
-        params = plug.defineParameters()
-        self.assertEqual(len(params), 1)
-        self.assertIn(Block, params)
 
     def test_beforeReactorConstructionHook(self):
         """Test that plugin hook successfully injects code before reactor initialization.

--- a/doc/release/0.5.rst
+++ b/doc/release/0.5.rst
@@ -15,9 +15,11 @@ New Features
 API Changes
 -----------
 #. Removing ``Database3`` from the API, use ``Database``. (`PR#2052 <https://github.com/terrapower/armi/pull/2052>`_)
+#. TBD
 
 Bug Fixes
 ---------
+#. Fixing BP-section ignoring tool in ``PassiveDBLoadPlugin``. (`PR#2055 <https://github.com/terrapower/armi/pull/2055>`_)
 #. TBD
 
 Quality Work


### PR DESCRIPTION
## What is the change?

I am wiping out the YAML contents of a YAML section we want to ignore when using the `PassiveDBLoadPlugin`.

I also had to add a unit test, and moved a unit test from one file to the new one.

## Why is the change being made?

There is currently a big present where the YAML section is only _partially_ deleted.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.