### PR TITLE
Update number densities for the effect of `puFrac` on axial expansion

### DIFF
--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -660,9 +660,9 @@ class Component(composites.Composite, metaclass=ComponentType):
         self.changeNDensByFactor(f)
         self.clearLinkedCache()
 
-    def setPuFrac(self, prevPuFrac):
+    def expandForPuFrac(self, prevPuFrac):
         r"""
-        Adjust puFrac of this component.
+        Adjust density of this component according to expansion from puFrac changes.
 
         This will cause effective expansion or contraction of solid components similar to thermal 
         expansion but at a constant temperature. If the thermal expansion coefficient is dependent 
@@ -694,7 +694,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         dLLprev = prevMaterial.linearExpansionPercent(Tc=self.temperatureInC) / 100.0
         dLLnew = self.material.linearExpansionPercent(Tc=self.temperatureInC) / 100.0
         expansionRatio = (1.0 + dLLnew) / (1.0 + dLLprev)
-        f = 1.0 / expansionRatio ** 2
+        f = 1.0 / expansionRatio**2
         self.changeNDensByFactor(f)
         self.clearLinkedCache()
 


### PR DESCRIPTION
## What is the change?

Implement a new component function that adjusts the number density of the component to account for the effective change in thermal expansion resulting from change in composition (which affects material properties) at a constant temperature.

## Why is the change being made?

We have fuel materials where the thermal expansion coefficient is dependent on the composition of the material. As a UZr metal fuel alloy depletes, it accumulates Pu, which affects material properties. Since the `puFrac` affects the thermal expansion coefficient, a change in the `puFrac` causes a change in dimensions just like a change in temperature would, and the number densities need to be adjusted accordingly to conserve mass.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `pyproject.toml`.