### PR TITLE
Ignoring Fluid density warning for Component Fluids

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -759,7 +759,7 @@ class Fluid(Material):
 
     def __init_subclass__(cls):
         # Undo the parent-aware density wrapping. Fluids do not expand in the same way solids, so
-        # Fluid.density(T) is correct. This does not hold for solids because they thermalaly expand.
+        # Fluid.density(T) is correct. This does not hold for solids because they thermally expand.
         if hasattr(cls.density, "__wrapped__"):
             cls.density = cls.density.__wrapped__
 

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -758,11 +758,8 @@ class Fluid(Material):
     """A material that fills its container. Could also be a gas."""
 
     def __init_subclass__(cls):
-        # Undo the parent-aware density wrapping
-        # Justification: fluids do not expand in the same way solids expand so
-        # fluid.density(T) is an appropriate representation of the density of
-        # the fluid. This does not hold for solids because of the thermal expansion
-        # mechanics imposed by the rest of the framework
+        # Undo the parent-aware density wrapping. Fluids do not expand in the same way solids, so
+        # Fluid.density(T) is correct. This does not hold for solids because they thermalaly expand.
         if hasattr(cls.density, "__wrapped__"):
             cls.density = cls.density.__wrapped__
 

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -757,6 +757,15 @@ class Material:
 class Fluid(Material):
     """A material that fills its container. Could also be a gas."""
 
+    def __init_subclass__(cls):
+        # Undo the parent-aware density wrapping
+        # Justification: fluids do not expand in the same way solids expand so
+        # fluid.density(T) is an appropriate representation of the density of
+        # the fluid. This does not hold for solids because of the thermal expansion
+        # mechanics imposed by the rest of the framework
+        if hasattr(cls.density, "__wrapped__"):
+            cls.density = cls.density.__wrapped__
+
     def getThermalExpansionDensityReduction(self, prevTempInC, newTempInC):
         """Return the factor required to update thermal expansion going from one temperature (in
         Celcius) to a new temperature.

--- a/armi/materials/tests/test_fluids.py
+++ b/armi/materials/tests/test_fluids.py
@@ -1,0 +1,64 @@
+# Copyright 2025 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for fluid-specific behaviors.
+
+The ARMI framework has a lot of thermal expansion machinery that applies to all components
+but doesn't make sense for fluids. The tests here help show fluid materials still
+play nice with the rest of the framework.
+"""
+
+from unittest import TestCase
+
+from armi.materials.material import Fluid, Material
+from armi.reactor.components import Circle
+from armi.tests import mockRunLogs
+
+
+class TestFluids(TestCase):
+    class MyFluid(Fluid):
+        """Stand-in fluid that doesn't provide lots of functionality."""
+
+    class MySolid(Material):
+        """Stand-in solid that doesn't provide lots of functionality."""
+
+    def test_fluidDensityWrapperNoWarning(self):
+        """Test that Component.material.density does not raise a warning for fluids.
+
+        The ARMI Framework contains a mechanism to warn users if they as for the density
+        of a material when that material is attached to a component, e.g., ``comp.material.density()``.
+        The problem here is the component is the source of truth for volume and composition. It stores
+        dimensions, which can be thermally expanded according to the material, and number densities, which
+        may be updated through operation. Much of the framework operates on ``component.density`` and
+        other ``Component`` methods for mass accounting. However, ``comp.material.density`` does
+        not know about the new composition or volumes and can diverge from ``component.density``.
+
+        Additionally, the framework does not do any thermal expansion on fluids. So the above calls to
+        ``component.material.density`` are warranted if the material is a fluid.
+        """
+        self._checkCompDensityLogs(
+            mat=self.MySolid(),
+            nExpectedWarnings=1,
+            msg="Solids should have the density warning logged.",
+        )
+        self._checkCompDensityLogs(
+            mat=self.MyFluid(),
+            nExpectedWarnings=0,
+            msg="Fluids should not have the density warning logged.",
+        )
+
+    def _checkCompDensityLogs(self, mat: Material, nExpectedWarnings: int, msg: str):
+        comp = Circle(name="test", material=mat, Tinput=20, Thot=20, id=0, od=1, mult=1)
+        with mockRunLogs.LogCounter() as logs:
+            comp.material.density(Tc=comp.temperatureInC)
+        self.assertEqual(logs.messageCounts["warning"], nExpectedWarnings, msg=msg)

--- a/armi/materials/tests/test_fluids.py
+++ b/armi/materials/tests/test_fluids.py
@@ -36,15 +36,14 @@ class TestFluids(TestCase):
         """Test that Component.material.density does not raise a warning for fluids.
 
         The ARMI Framework contains a mechanism to warn users if they ask for the density of a
-        material attached to a component, e.g., ``comp.material.density()``. The problem is the
-        component is the source of truth for volume and composition. It stores dimensions, which can
-        be thermally expanded according to the material and number densities, which may be updated
-        during operation. Much of the framework operates on ``Component.density`` and other
-        ``Component`` methods for mass accounting. However, ``comp.material.density`` does not know
-        about the new composition or volumes and can diverge from ``component.density``.
+        material attached to a component. But the component is the source of truth for volume and
+        composition. And can be thermally expanded during operation. Much of the framework operates
+        on ``Component.density`` and other ``Component`` methods for mass accounting. However,
+        ``comp.material.density`` does not know about the new composition or volumes and can diverge
+        from ``component.density``.
 
-        Additionally, the framework does not do any thermal expansion on fluids. So the above calls to
-        ``component.material.density`` are warranted if the material is a fluid.
+        Additionally, the framework does not do any thermal expansion on fluids. So the above calls
+        to ``component.material.density`` are warranted for fluids.
         """
         self._checkCompDensityLogs(
             mat=self.MySolid(),

--- a/armi/materials/tests/test_fluids.py
+++ b/armi/materials/tests/test_fluids.py
@@ -35,13 +35,13 @@ class TestFluids(TestCase):
     def test_fluidDensityWrapperNoWarning(self):
         """Test that Component.material.density does not raise a warning for fluids.
 
-        The ARMI Framework contains a mechanism to warn users if they as for the density
-        of a material when that material is attached to a component, e.g., ``comp.material.density()``.
-        The problem here is the component is the source of truth for volume and composition. It stores
-        dimensions, which can be thermally expanded according to the material, and number densities, which
-        may be updated through operation. Much of the framework operates on ``component.density`` and
-        other ``Component`` methods for mass accounting. However, ``comp.material.density`` does
-        not know about the new composition or volumes and can diverge from ``component.density``.
+        The ARMI Framework contains a mechanism to warn users if they ask for the density of a
+        material attached to a component, e.g., ``comp.material.density()``. The problem is the
+        component is the source of truth for volume and composition. It stores dimensions, which can
+        be thermally expanded according to the material and number densities, which may be updated
+        during operation. Much of the framework operates on ``Component.density`` and other
+        ``Component`` methods for mass accounting. However, ``comp.material.density`` does not know
+        about the new composition or volumes and can diverge from ``component.density``.
 
         Additionally, the framework does not do any thermal expansion on fluids. So the above calls to
         ``component.material.density`` are warranted if the material is a fluid.

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -96,8 +96,12 @@ class _Material_Test:
         self.assertEqual(dens * 1000.0, densKgM3)
 
     def test_wrappedDensity(self):
-        """Test that the density decorator is applied."""
-        self.assertTrue(hasattr(self.mat.density, "__wrapped__"))
+        """Test that the density decorator is applied to non-fluids."""
+        self.assertEqual(
+            hasattr(self.mat.density, "__wrapped__"),
+            not isinstance(self.mat, materials.Fluid),
+            msg=self.mat,
+        )
 
 
 class MaterialConstructionTests(unittest.TestCase):

--- a/doc/release/0.5.rst
+++ b/doc/release/0.5.rst
@@ -10,6 +10,8 @@ New Features
 ------------
 #. Move instead of copy files from TemporaryDirectoryChanger. (`PR#2022 <https://github.com/terrapower/armi/pull/2022>`_)
 #. Creating the ``armi.testing`` module, to share ARMI testing tools. (`PR#2028 <https://github.com/terrapower/armi/pull/2028>`_)
+#. Invoking ``component.material.density()``  does not log an expensive stack trace if the material
+   is a fluid. (`PR#2075 <https://github.com/terrapower/armi/pull/2075>`_)
 #. TBD
 
 API Changes


### PR DESCRIPTION
## What is the change?

Calling `Component.material.density` does not log a warning with a traceback if the material is a subclass of `Fluid`

## Why is the change being made?

TH applications need fluid densities and the traceback invocation is kind of a bottleneck.

https://github.com/terrapower/armi/pull/1852 introduced a warning when `Component.material.density(...)` was invoked. The rationale is the `Component` is the source of truth for volume, density, mass, etc. And components are the things that are thermally expanded.

However, fluids are not thermally expanded and so the density of a fluid material is appropriate.

This change undoes the density wrapper applied by the base `Material` when creating a `Fluid` subclass.

A test is added to show that any non-`Fluid` subclass still logs the warning, but a `Fluid` subclass does not.

I attempted to use a "real" material like `Sodium` but lots of other warnings can be logged depending on appropriate bounds of temperatures. So a fake Fluid is used to have more control over what warnings are logged.

I contend that the stack trace should still be used in this message. This is a message meant for application developers to root out problematic parts of their codebase. And it helped us pinpoint very specific call locations with ease.

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.