### PR TITLE
Removing an unhelpful comment

### DIFF
--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -476,8 +476,8 @@ def writeAssemblyMassSummary(r):
             blockType = b.getType()
             if blockType not in types:
                 types.append(blockType)
-        # if the BOL fuel assem is in the center of the core, its area is 1/3 of the full area b/c it's a sliced assem.
-        # bug: mass came out way high for a case once. 265 MT vs. 92 MT hm.
+        # If the BOL fuel assem is in the center of the core, its area is 1/3 of the full area b/c
+        # its a sliced assem.
 
         # count assemblies
         core = r.core


### PR DESCRIPTION
## What is the change?

Removing a comment.

## Why is the change being made?

This comment line is so conversational and anecdotal, I don't think it has ever been useful to anyone.

This was pointed out to me by Chris here: https://github.com/terrapower/armi/issues/2006#issuecomment-2509396885

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.