### PR TITLE
Remove silent overwrite of `shutil.copy`

### DIFF
--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -800,7 +800,7 @@ class MergeableDict(dict):
 
 
 def safeCopy(src: str, dst: str) -> None:
-    """This copy overwrites ``shutil.copy`` and checks that copy operation is truly completed before continuing."""
+    """Check that copy operation is truly completed before continuing."""
     # Convert files to OS-independence
     src = os.path.abspath(src)
     dst = os.path.abspath(dst)
@@ -882,8 +882,3 @@ def safeMove(src: str, dst: str) -> None:
 
     runLog.extra("Moved {} -> {}".format(src, dst))
     return dst
-
-
-# Allow us to check the copy operation is complete before continuing
-shutil_copy = shutil.copy
-shutil.copy = safeCopy

--- a/doc/release/0.5.rst
+++ b/doc/release/0.5.rst
@@ -33,7 +33,7 @@ Quality Work
 #. Significant revamp of the ARMI requirements. (`PR#2074 <https://github.com/terrapower/armi/pull/2074>`_)
 #. Adding PDF versions of the ARMI docs. (`PR#2072 <https://github.com/terrapower/armi/pull/2072>`_)
 #. Update docs build to occur with python 3.13 and updated docs dependencies. (`PR#2050 <https://github.com/terrapower/armi/pull/2050>`_)
-#. Remove silent overwriting of ``shutil.copy``. (`PR#2081 <https://github.com/terrapower/armi/pull/2081>`_)
+#. Removing silent overwrite of ``shutil.copy``. (`PR#2081 <https://github.com/terrapower/armi/pull/2081>`_)
 #. TBD
 
 

--- a/doc/release/0.5.rst
+++ b/doc/release/0.5.rst
@@ -33,6 +33,7 @@ Quality Work
 #. Significant revamp of the ARMI requirements. (`PR#2074 <https://github.com/terrapower/armi/pull/2074>`_)
 #. Adding PDF versions of the ARMI docs. (`PR#2072 <https://github.com/terrapower/armi/pull/2072>`_)
 #. Update docs build to occur with python 3.13 and updated docs dependencies. (`PR#2050 <https://github.com/terrapower/armi/pull/2050>`_)
+#. Remove silent overwriting of ``shutil.copy``. (`PR#2081 <https://github.com/terrapower/armi/pull/2081>`_)
 #. TBD
 
 


### PR DESCRIPTION
## What is the change?

Removing the silent overwriting of `shutil.copy`

## Why is the change being made?

This is just terrible practice. Let's not do it. 

Wags grandmotherly finger: "we should be ashamed of ourselves!"

close #1690

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] ~[Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.~ N/A

<!-- Check the code quality -->

- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.