### PR TITLE
 Making sure SFPs have spatial grids

### DIFF
--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -146,6 +146,8 @@ class SystemBlueprint(yamlize.Object):
 
         if geom is not None and self.name == "core":
             gridDesign = geom.toGridBlueprints("core")[0]
+        elif geom is not None and self.name == "Spent Fuel Pool":
+            gridDesign = geom.toGridBlueprints("Spent Fuel Pool")[0]
         else:
             if not bp.gridDesigns:
                 raise ValueError(

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -195,7 +195,9 @@ def factory(cs, bp, geom: Optional[SystemLayoutInput] = None) -> Reactor:
             )
 
         for structure in bp.systemDesigns:
-            bpGeom = geom if structure.name.lower() == "core" else None
+            bpGeom = (
+                geom if structure.name.lower() in ("core", "spent fuel pool") else None
+            )
             structure.construct(cs, bp, r, geom=bpGeom)
 
     runLog.debug(f"Reactor: {r}")

--- a/armi/reactor/spentFuelPool.py
+++ b/armi/reactor/spentFuelPool.py
@@ -85,8 +85,8 @@ class SpentFuelPool(ExcoreStructure):
 
     def _updateNumberOfColumns(self):
         """Determine the number of columns in the spatial grid."""
-        _locs = self.spatialGrid.items()
-        self.numColumns = len(set([ll[0][0] for ll in _locs]))
+        locs = self.spatialGrid.items()
+        self.numColumns = len(set([ll[0][0] for ll in locs]))
 
     def _getNextLocation(self):
         """Helper method to allow each discharged assembly to be easily dropped into the SFP.

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -336,8 +336,26 @@ class TestDetailedNDensUpdate(unittest.TestCase):
 
 
 class TestValidateSFPSpatialGrids(unittest.TestCase):
-    def test_validateSFPSpatialGrid(self):
-        """Validate the spatial grid for a new SFP is not None."""
+    def test_noSFPExists(self):
+        """Validate the spatial grid for a new SFP is None if it was not provided."""
+        # copy the inputs, so we can modify them
+        with TemporaryDirectoryChanger() as newDir:
+            oldDir = os.path.join(TEST_ROOT, "smallestTestReactor")
+            newDir2 = os.path.join(newDir.destination, "smallestTestReactor")
+            shutil.copytree(oldDir, newDir2)
+
+            # cut out the SFP grid in the input file
+            testFile = os.path.join(newDir2, "refSmallestReactor.yaml")
+            txt = open(testFile, "r").read()
+            txt = txt.split("symmetry: full")[0]
+            open(testFile, "w").write(txt)
+
+            # verify there is no spatial grid defined
+            _o, r = loadTestReactor(newDir2, inputFileName="armiRunSmallest.yaml")
+            self.assertIsNone(r.excore.sfp.spatialGrid)
+
+    def test_SFPSpatialGridExists(self):
+        """Validate the spatial grid for a new SFP is not None if it was provided."""
         _o, r = loadTestReactor(
             os.path.join(TEST_ROOT, "smallestTestReactor"),
             inputFileName="armiRunSmallest.yaml",

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -335,6 +335,16 @@ class TestDetailedNDensUpdate(unittest.TestCase):
         self.assertEqual(block.p.detailedNDens, np.array([0.5]))
 
 
+class TestValidateSFPSpatialGrids(unittest.TestCase):
+    def test_validateSFPSpatialGrid(self):
+        """Validate the spatial grid for a new SFP is not None."""
+        _o, r = loadTestReactor(
+            os.path.join(TEST_ROOT, "smallestTestReactor"),
+            inputFileName="armiRunSmallest.yaml",
+        )
+        self.assertIsNotNone(r.excore.sfp.spatialGrid)
+
+
 class Block_TestCase(unittest.TestCase):
     def setUp(self):
         self.block = loadTestBlock()

--- a/armi/tests/smallestTestReactor/refSmallestReactor.yaml
+++ b/armi/tests/smallestTestReactor/refSmallestReactor.yaml
@@ -19,3 +19,9 @@ grids:
       lattice map: |
         IC
       symmetry: full
+    sfp:
+      geom: cartesian
+      symmetry: full
+      lattice pitch:
+        x: 32.0
+        y: 32.0

--- a/doc/release/0.5.rst
+++ b/doc/release/0.5.rst
@@ -23,6 +23,7 @@ Bug Fixes
 ---------
 #. Fixing check for jagged arrays during ``_writeParams``. (`PR#2051 <https://github.com/terrapower/armi/pull/2051>`_)
 #. Fixing BP-section ignoring tool in ``PassiveDBLoadPlugin``. (`PR#2055 <https://github.com/terrapower/armi/pull/2055>`_)
+#. Making sure SFPs have spatial grids. (`PR#2082 <https://github.com/terrapower/armi/pull/2082>`_)
 #. Fixing number densities when custom isotopics are combined with Fluid components. (`PR#2071 <https://github.com/terrapower/armi/pull/2071>`_)
 #. Fixing scaling of volume-integrated parameters on edge assemblies. (`PR#2060 <https://github.com/terrapower/armi/pull/2060>`_)
 #. Fixing strictness of ``HexGrid`` rough equality check. (`PR#2058 <https://github.com/terrapower/armi/pull/2058>`_)


### PR DESCRIPTION
## What is the change?

 Making sure SFPs have spatial grids if the spatial grid is defined in the blueprints.

## Why is the change being made?

There was a bug reported where there was no spatial grid assigned to a Spent Fuel Pool, even if one was defined in the blueprints.

close #2066 

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.