### PR TITLE
Solving test warnings

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -14,6 +14,7 @@
 
 """Tests for the compareDB3 module."""
 import unittest
+import warnings
 
 import h5py
 import numpy as np
@@ -176,11 +177,13 @@ class TestCompareDB3(unittest.TestCase):
             dbs.append(db)
 
         # end-to-end validation that comparing a photocopy database works
-        diffs = compareDatabases(
-            dbs[0]._fullPath,
-            dbs[1]._fullPath,
-            timestepCompare=[(0, 0), (0, 1)],
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            diffs = compareDatabases(
+                dbs[0]._fullPath,
+                dbs[1]._fullPath,
+                timestepCompare=[(0, 0), (0, 1)],
+            )
         self.assertEqual(len(diffs.diffs), 504)
         # Cycle length is only diff (x3)
         self.assertEqual(diffs.nDiffs(), 3)
@@ -256,7 +259,7 @@ class TestCompareDB3(unittest.TestCase):
 
         # spin up one example H5 Dataset
         f1 = h5py.File("test_diffSimpleData1.hdf5", "w")
-        a1 = np.arange(100, dtype="<f8")
+        a1 = np.arange(1, 101, dtype="<f8")
         refData = f1.create_dataset("numberDensities", data=a1)
         refData.attrs["1"] = 1
         refData.attrs["2"] = 22
@@ -275,7 +278,7 @@ class TestCompareDB3(unittest.TestCase):
 
         # spin up a different size example H5 Dataset
         f3 = h5py.File("test_diffSimpleData3.hdf5", "w")
-        a2 = np.arange(90, dtype="<f8")
+        a2 = np.arange(1, 91, dtype="<f8")
         srcData3 = f3.create_dataset("numberDensities", data=a2)
         srcData3.attrs["1"] = 1
         srcData3.attrs["2"] = 22

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -451,8 +451,8 @@ class TestUniformMesh(unittest.TestCase):
 
         self.converter.convert(self.r)
         for ib, b in enumerate(self.converter.convReactor.core.getBlocks()):
-            b.p.mgFlux = list(range(33))
-            b.p.adjMgFlux = list(range(33))
+            b.p.mgFlux = list(range(1, 34))
+            b.p.adjMgFlux = list(range(1, 34))
             b.p.fastFlux = 2.0
             b.p.flux = 5.0
             b.p.power = 5.0

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -1232,7 +1232,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
             if rate["rateFis"] > 0.0:
                 fuelVolFrac = obj.getComponentAreaFrac(Flags.FUEL)
-                obj.p.fisDens = rate["rateFis"] / fuelVolFrac
+                obj.p.fisDens = (
+                    np.nan if fuelVolFrac == 0 else rate["rateFis"] / fuelVolFrac
+                )
                 obj.p.fisDensHom = rate["rateFis"]
             else:
                 obj.p.fisDens = 0.0

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -158,9 +158,9 @@ class TestGeneralUtils(unittest.TestCase):
         ytick = ([0, 1], ["1", "2"])
         fname = "test_plotMatrix_testfile"
         with directoryChangers.TemporaryDirectoryChanger():
-            utils.plotMatrix(matrix, fname, show=True, title="plot")
-            utils.plotMatrix(matrix, fname, minV=0, maxV=5, figsize=[3, 4])
-            utils.plotMatrix(matrix, fname, xticks=xtick, yticks=ytick)
+            utils.plotMatrix(matrix, fname, show=False, title="plot")
+            utils.plotMatrix(matrix, fname, show=False, minV=0, maxV=5, figsize=[3, 4])
+            utils.plotMatrix(matrix, fname, show=False, xticks=xtick, yticks=ytick)
 
     def test_classesInHierarchy(self):
         """Tests the classesInHierarchy utility."""

--- a/doc/.static/css/theme_fixes.css
+++ b/doc/.static/css/theme_fixes.css
@@ -21,3 +21,8 @@
 img {
    max-width: 100% !important;
 }
+
+/* get eq numbers to show on the side of the equation */
+span.eqno {
+    float: right;
+}


### PR DESCRIPTION
## What is the change?

Here I have made a bunch of random changes to unit tests necessary to remove the warnings we get during a run of our unit tests.

I should note that this solves ALL the warnings, except those from `jupyter` notebooks, because after some research I think we just have to wait for a new version of jupyter notebooks to be released to solve those. Sorry.


## Why is the change being made?

To close #2041

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.