### PR TITLE
Account for symmetry factor in `getMgFlux`

### DIFF
--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1221,6 +1221,46 @@ class Component(composites.Composite, metaclass=ComponentType):
             )
         self.setMassFracs(adjustedMassFracs)
 
+    def getMgFlux(self, adjoint=False, average=False, volume=None, gamma=False):
+        """
+        Return the multigroup neutron flux in [n/cm^2/s].
+
+        The first entry is the first energy group (fastest neutrons). Each additional
+        group is the next energy group, as set in the ISOTXS library.
+
+        On blocks, it is stored integrated over volume on <block>.p.mgFlux
+
+        Parameters
+        ----------
+        adjoint : bool, optional
+            Return adjoint flux instead of real
+
+        average : bool, optional
+            If true, will return average flux between latest and previous. Doesn't work
+            for pin detailed yet
+
+        volume: float, optional
+            If average=True, the volume-integrated flux is divided by volume before
+            being returned. The user may specify a volume here, or the function will
+            obtain the block volume directly.
+
+        gamma : bool, optional
+            Whether to return the neutron flux or the gamma flux.
+
+        Returns
+        -------
+        flux : np.ndarray
+            multigroup neutron flux in [n/cm^2/s]
+        """
+        if average:
+            raise NotImplementedError(
+                "{} class has no method for producing average MG flux -- try"
+                "using blocks".format(self.__class__)
+            )
+
+        volume = volume or self.getVolume() / self.parent.getSymmetryFactor()
+        return self.getIntegratedMgFlux(adjoint=adjoint, gamma=gamma) / volume
+
     def getIntegratedMgFlux(self, adjoint=False, gamma=False):
         """
         Return the multigroup neutron tracklength in [n-cm/s].

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1228,8 +1228,6 @@ class Component(composites.Composite, metaclass=ComponentType):
         The first entry is the first energy group (fastest neutrons). Each additional
         group is the next energy group, as set in the ISOTXS library.
 
-        On blocks, it is stored integrated over volume on <block>.p.mgFlux
-
         Parameters
         ----------
         adjoint : bool, optional
@@ -1240,9 +1238,9 @@ class Component(composites.Composite, metaclass=ComponentType):
             for pin detailed yet
 
         volume: float, optional
-            If average=True, the volume-integrated flux is divided by volume before
-            being returned. The user may specify a volume here, or the function will
-            obtain the block volume directly.
+            The volume-integrated flux is divided by volume before
+            being returned. The user may specify a volume here, or the function
+            will obtain the block volume directly.
 
         gamma : bool, optional
             Whether to return the neutron flux or the gamma flux.
@@ -1254,8 +1252,8 @@ class Component(composites.Composite, metaclass=ComponentType):
         """
         if average:
             raise NotImplementedError(
-                "{} class has no method for producing average MG flux -- try"
-                "using blocks".format(self.__class__)
+                "Component has no method for producing average MG flux -- try"
+                "using blocks"
             )
 
         volume = volume or self.getVolume() / self.parent.getSymmetryFactor()

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1232,16 +1232,13 @@ class Component(composites.Composite, metaclass=ComponentType):
         ----------
         adjoint : bool, optional
             Return adjoint flux instead of real
-
         average : bool, optional
-            If true, will return average flux between latest and previous. Doesn't work
-            for pin detailed yet
-
+            If True, will return average flux between latest and previous. Doesn't work
+            for pin detailed.
         volume: float, optional
             The volume-integrated flux is divided by volume before
             being returned. The user may specify a volume here, or the function
             will obtain the block volume directly.
-
         gamma : bool, optional
             Whether to return the neutron flux or the gamma flux.
 

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2079,8 +2079,8 @@ class ArmiObject(metaclass=CompositeModelType):
             for pin detailed yet
 
         volume: float, optional
-            If average=True, the volume-integrated flux is divided by volume before
-            being returned. The user may specify a volume here, or the function will
+            The volume-integrated flux is divided by volume before being
+            returned. The user may specify a volume here, or the function will
             obtain the block volume directly.
 
         gamma : bool, optional

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1298,7 +1298,6 @@ class Block_TestCase(unittest.TestCase):
         np.testing.assert_almost_equal(neutronFlux, np.ones(5) * normalization)
         np.testing.assert_almost_equal(gammaFlux, np.ones(4) * normalization * 2.0)
 
-
     @patch.object(blocks.HexBlock, "getSymmetryFactor")
     def test_completeInitialLoading(self, mock_sf):
         """Ensure that some BOL block and component params are populated properly.

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1274,13 +1274,17 @@ class Block_TestCase(unittest.TestCase):
         neutronFluxInt = fuel.getIntegratedMgFlux()
         gammaFluxInt = fuel.getIntegratedMgFlux(gamma=True)
         # getIntegratedMgFlux should be scaled by the component volume fraction
-        np.testing.assert_almost_equal(neutronFluxInt, np.full(5, neutronFlux * volFrac))
+        np.testing.assert_almost_equal(
+            neutronFluxInt, np.full(5, neutronFlux * volFrac)
+        )
         np.testing.assert_almost_equal(gammaFluxInt, np.full(4, gammaFlux * volFrac))
 
         # getMgFlux should return regular, non-integrated flux
         neutronMgFlux = fuel.getMgFlux()
         gammaMgFlux = fuel.getMgFlux(gamma=True)
-        np.testing.assert_almost_equal(neutronMgFlux, np.full(5, neutronFlux / blockVol))
+        np.testing.assert_almost_equal(
+            neutronMgFlux, np.full(5, neutronFlux / blockVol)
+        )
         np.testing.assert_almost_equal(gammaMgFlux, np.full(4, gammaFlux / blockVol))
 
         # calculate Mg Flux with a Symmetry Factor of 1
@@ -1294,13 +1298,17 @@ class Block_TestCase(unittest.TestCase):
         neutronFluxInt = fuel.getIntegratedMgFlux()
         gammaFluxInt = fuel.getIntegratedMgFlux(gamma=True)
         # getIntegratedMgFlux should be scaled by the component volume fraction
-        np.testing.assert_almost_equal(neutronFluxInt, np.full(5, neutronFlux * volFrac))
+        np.testing.assert_almost_equal(
+            neutronFluxInt, np.full(5, neutronFlux * volFrac)
+        )
         np.testing.assert_almost_equal(gammaFluxInt, np.full(4, gammaFlux * volFrac))
 
         # getMgFlux should return regular, non-integrated flux
         neutronMgFlux = fuel.getMgFlux()
         gammaMgFlux = fuel.getMgFlux(gamma=True)
-        np.testing.assert_almost_equal(neutronMgFlux, np.full(5, neutronFlux / blockVol))
+        np.testing.assert_almost_equal(
+            neutronMgFlux, np.full(5, neutronFlux / blockVol)
+        )
         np.testing.assert_almost_equal(gammaMgFlux, np.full(4, gammaFlux / blockVol))
 
     @patch.object(blocks.HexBlock, "getSymmetryFactor")

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1262,41 +1262,46 @@ class Block_TestCase(unittest.TestCase):
     def test_getMgFlux(self, mock_sf):
         # calculate Mg Flux with a Symmetry Factor of 3
         mock_sf.return_value = 3
-        self.block.p.mgFlux = np.array([1, 1, 1, 1, 1])
-        self.block.p.mgFluxGamma = np.array([2, 2, 2, 2])
+        neutronFlux = 1.0
+        gammaFlux = 2.0
+        self.block.p.mgFlux = np.full(5, neutronFlux)
+        self.block.p.mgFluxGamma = np.full(4, gammaFlux)
         fuel = self.block.getComponent(Flags.FUEL)
         blockVol = self.block.getVolume()
         fuelVol = fuel.getVolume()
+        # compute volume fraction of component; need symmetry factor
         volFrac = fuelVol / blockVol / self.block.getSymmetryFactor()
         neutronFluxInt = fuel.getIntegratedMgFlux()
         gammaFluxInt = fuel.getIntegratedMgFlux(gamma=True)
-        np.testing.assert_almost_equal(neutronFluxInt, np.ones(5) * volFrac)
-        np.testing.assert_almost_equal(gammaFluxInt, np.ones(4) * volFrac * 2.0)
+        # getIntegratedMgFlux should be scaled by the component volume fraction
+        np.testing.assert_almost_equal(neutronFluxInt, np.full(5, neutronFlux * volFrac))
+        np.testing.assert_almost_equal(gammaFluxInt, np.full(4, gammaFlux * volFrac))
 
-        neutronFlux = fuel.getMgFlux()
-        gammaFlux = fuel.getMgFlux(gamma=True)
-        normalization = volFrac / fuelVol * self.block.getSymmetryFactor()
-        np.testing.assert_almost_equal(neutronFlux, np.ones(5) * normalization)
-        np.testing.assert_almost_equal(gammaFlux, np.ones(4) * normalization * 2.0)
+        # getMgFlux should return regular, non-integrated flux
+        neutronMgFlux = fuel.getMgFlux()
+        gammaMgFlux = fuel.getMgFlux(gamma=True)
+        np.testing.assert_almost_equal(neutronMgFlux, np.full(5, neutronFlux / blockVol))
+        np.testing.assert_almost_equal(gammaMgFlux, np.full(4, gammaFlux / blockVol))
 
         # calculate Mg Flux with a Symmetry Factor of 1
         mock_sf.return_value = 1
-        self.block.p.mgFlux = np.array([1, 1, 1, 1, 1])
-        self.block.p.mgFluxGamma = np.array([2, 2, 2, 2])
+        self.block.p.mgFlux = np.full(5, neutronFlux)
+        self.block.p.mgFluxGamma = np.full(4, gammaFlux)
         fuel = self.block.getComponent(Flags.FUEL)
         blockVol = self.block.getVolume()
         fuelVol = fuel.getVolume()
         volFrac = fuelVol / blockVol / self.block.getSymmetryFactor()
         neutronFluxInt = fuel.getIntegratedMgFlux()
         gammaFluxInt = fuel.getIntegratedMgFlux(gamma=True)
-        np.testing.assert_almost_equal(neutronFluxInt, np.ones(5) * volFrac)
-        np.testing.assert_almost_equal(gammaFluxInt, np.ones(4) * volFrac * 2.0)
+        # getIntegratedMgFlux should be scaled by the component volume fraction
+        np.testing.assert_almost_equal(neutronFluxInt, np.full(5, neutronFlux * volFrac))
+        np.testing.assert_almost_equal(gammaFluxInt, np.full(4, gammaFlux * volFrac))
 
-        neutronFlux = fuel.getMgFlux()
-        gammaFlux = fuel.getMgFlux(gamma=True)
-        normalization = volFrac / fuelVol * self.block.getSymmetryFactor()
-        np.testing.assert_almost_equal(neutronFlux, np.ones(5) * normalization)
-        np.testing.assert_almost_equal(gammaFlux, np.ones(4) * normalization * 2.0)
+        # getMgFlux should return regular, non-integrated flux
+        neutronMgFlux = fuel.getMgFlux()
+        gammaMgFlux = fuel.getMgFlux(gamma=True)
+        np.testing.assert_almost_equal(neutronMgFlux, np.full(5, neutronFlux / blockVol))
+        np.testing.assert_almost_equal(gammaMgFlux, np.full(4, gammaFlux / blockVol))
 
     @patch.object(blocks.HexBlock, "getSymmetryFactor")
     def test_completeInitialLoading(self, mock_sf):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1268,10 +1268,16 @@ class Block_TestCase(unittest.TestCase):
         blockVol = self.block.getVolume()
         fuelVol = fuel.getVolume()
         volFrac = fuelVol / blockVol / self.block.getSymmetryFactor()
-        neutronFlux = fuel.getIntegratedMgFlux()
-        gammaFlux = fuel.getIntegratedMgFlux(gamma=True)
-        np.testing.assert_almost_equal(neutronFlux, np.ones(5) * volFrac)
-        np.testing.assert_almost_equal(gammaFlux, np.ones(4) * volFrac * 2.0)
+        neutronFluxInt = fuel.getIntegratedMgFlux()
+        gammaFluxInt = fuel.getIntegratedMgFlux(gamma=True)
+        np.testing.assert_almost_equal(neutronFluxInt, np.ones(5) * volFrac)
+        np.testing.assert_almost_equal(gammaFluxInt, np.ones(4) * volFrac * 2.0)
+
+        neutronFlux = fuel.getMgFlux()
+        gammaFlux = fuel.getMgFlux(gamma=True)
+        normalization = volFrac / fuelVol * self.block.getSymmetryFactor()
+        np.testing.assert_almost_equal(neutronFlux, np.ones(5) * normalization)
+        np.testing.assert_almost_equal(gammaFlux, np.ones(4) * normalization * 2.0)
 
         # calculate Mg Flux with a Symmetry Factor of 1
         mock_sf.return_value = 1
@@ -1281,10 +1287,17 @@ class Block_TestCase(unittest.TestCase):
         blockVol = self.block.getVolume()
         fuelVol = fuel.getVolume()
         volFrac = fuelVol / blockVol / self.block.getSymmetryFactor()
-        neutronFlux = fuel.getIntegratedMgFlux()
-        gammaFlux = fuel.getIntegratedMgFlux(gamma=True)
-        np.testing.assert_almost_equal(neutronFlux, np.ones(5) * volFrac)
-        np.testing.assert_almost_equal(gammaFlux, np.ones(4) * volFrac * 2.0)
+        neutronFluxInt = fuel.getIntegratedMgFlux()
+        gammaFluxInt = fuel.getIntegratedMgFlux(gamma=True)
+        np.testing.assert_almost_equal(neutronFluxInt, np.ones(5) * volFrac)
+        np.testing.assert_almost_equal(gammaFluxInt, np.ones(4) * volFrac * 2.0)
+
+        neutronFlux = fuel.getMgFlux()
+        gammaFlux = fuel.getMgFlux(gamma=True)
+        normalization = volFrac / fuelVol * self.block.getSymmetryFactor()
+        np.testing.assert_almost_equal(neutronFlux, np.ones(5) * normalization)
+        np.testing.assert_almost_equal(gammaFlux, np.ones(4) * normalization * 2.0)
+
 
     @patch.object(blocks.HexBlock, "getSymmetryFactor")
     def test_completeInitialLoading(self, mock_sf):

--- a/doc/release/0.5.rst
+++ b/doc/release/0.5.rst
@@ -27,7 +27,7 @@ Bug Fixes
 #. Fixing number densities when custom isotopics are combined with Fluid components. (`PR#2071 <https://github.com/terrapower/armi/pull/2071>`_)
 #. Fixing scaling of volume-integrated parameters on edge assemblies. (`PR#2060 <https://github.com/terrapower/armi/pull/2060>`_)
 #. Fixing strictness of ``HexGrid`` rough equality check. (`PR#2058 <https://github.com/terrapower/armi/pull/2058>`_)
-#  Fixing treatment of symmetry factors when calculating component flux and reaction rates. (`PR#2068 <https://github.com/terrapower/armi/pull/2068>`_)
+#  Fixing treatment of symmetry factors when calculating component flux and reaction rates. (`PR#2068 <https://github.com/terrapower/armi/pull/2068>`_, `PR#2086 <https://github.com/terrapower/armi/pull/2086>`_))
 #. TBD
 
 Quality Work


### PR DESCRIPTION
## What is the change?

Implement a `getMgFlux` method for `Component` instead of inheriting from the `Composite` class.

## Why is the change being made?

The component volume does not account for the parent symmetry factor (see #2006), so we need a special `getMgFlux` that incorporates the symmetry factor here.

This should have been included in #2068 , which addressed #2059 , but this was missed. `getMgFlux` uses `getIntegratedMgFlux`, which was updated to incorporate the symmetry factor. `getMgFlux` needs to also incoporate the `symmetryFactor` to stay consistent.


---

## Checklist

<!--
    You (the pull requester) should put an `x` if the condition is met.

    (If a checkbox doesn't apply to your PR, check it anyway.)
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.