### PR TITLE
Trying to clean up pytest results table

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -44,6 +44,7 @@ jobs:
           python --version >> python_details.log
           pip freeze >> python_details.log
           pytest --junit-xml=test_results.xml -v -n 4 armi > pytest_verbose.log
+          python doc/.static/cleanup_test_results.py test_results.xml
           cd doc
           git submodule init
           git submodule update

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 
 |Build Status| |Code Coverage| |Commit Activity| |Good First Issues|
 
+#################
+ARMI Introduction
+#################
+
 The Advanced Reactor Modeling Interface (ARMI\ :sup:`®`) is an open-source tool that
 streamlines your nuclear reactor design/analysis needs by providing a
 software *reactor at your fingertips* and a rich ecosystem of utilities working in concert.
@@ -59,7 +63,7 @@ found in [#touranarmi]_.
      - armi-devs@terrapower.com
 
 Quick start
------------
+===========
 Before starting, you need to have `Python <https://www.python.org/downloads/>`_ 3.9+.
 
 Get the ARMI code, install the prerequisites, and fire up the launcher with the following
@@ -92,7 +96,7 @@ start touring the features and capabilities and then move on to the
 
 
 Background
-----------
+==========
 Nuclear reactor design requires, among other things, answers to the following questions:
 
 * Where are the neutrons? How fast are they moving? In which direction?
@@ -162,7 +166,7 @@ Because of ARMI's high-level nature, we believe we can collaborate effectively w
 ongoing reactor software developments.
 
 Communication and coupling
---------------------------
+==========================
 ARMI provides a central place for all physics kernels to interact: the Reactor Model.
 All modules read *state* information from this Reactor and write their output to it.
 This common interface allows seamless communication and coupling between different
@@ -178,7 +182,7 @@ perform basic data management and to help align efforts on external physics kern
 
 
 Automation
-----------
+==========
 
 ARMI can quickly and easily produce complex input files with high levels of detail in
 various approximations. This enables users to perform rapid high-fidelity analyses to
@@ -196,7 +200,7 @@ Carlo, subchannel vs. CFD, etc.).
 
 
 New analysis and physics capabilities
--------------------------------------
+=====================================
 The ARMI reactor model is fully accessible via a Python-based API, meaning that
 power-users and developers have full access to the details of the plant at all times.
 Developers adding new physics features can take advantage of the ARMI data management
@@ -229,7 +233,8 @@ Writing a module within ARMI automatically features access to the ARMI API, incl
 
 
 Use cases
----------
+=========
+
 Given input describing a reactor, a typical ARMI run loops over a set of plugins in a
 certain sequence. Some plugins trigger third-party simulation codes, producing input
 files for them, executing them, and translating the output back onto the reactor model
@@ -266,7 +271,7 @@ considering all important physics at the same time.
 Other interest may come from the following:
 
 The Research Scientist
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 A nuclear reactor research scientist, whether at a national lab or on a graduate or
 undergraduate university team, may benefit greatly from using ARMI. It's not uncommon
 for such people to spend significant fractions of effort on data management. ARMI will
@@ -286,7 +291,7 @@ ARMI ecosystem will be a great way to prove its true value (note that this requi
 rich ARMI physics ecosystem).
 
 The Nuclear Startup Engineer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------
 As various companies evaluate their ideas, they need tools for analysis. They
 can pick up ARMI and save 10 years of development and hit the ground running by
 plugging in their design-specific physics kernels and proprietary design
@@ -295,12 +300,12 @@ all come in handy immediately.
 
 
 Operating and Vendor Engineers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------
 People at well-established utilities or vendors can hook ARMI into their legacy
 systems and increase their overall productivity.
 
 The Enthusiast
-^^^^^^^^^^^^^^
+--------------
 If an enthusiast wants to try out a reactor idea they have, they can use ARMI
 (plus some physics kernels) to quickly get some performance metrics. They can
 see if their idea has wings, and if it does, they can then find a way to bring
@@ -308,7 +313,7 @@ it to engineering and commercial reality.
 
 
 History of ARMI
----------------
+===============
 ARMI was originally created by TerraPower, LLC near Seattle WA starting in 2009. Its
 founding mission was to determine the optimal fuel management operations required to
 transition a fresh Traveling Wave Reactor core from startup into an equilibrium state.
@@ -340,7 +345,7 @@ ideas, limited available funding can be spent more effectively.
 
 
 System Requirements
--------------------
+===================
 Being largely written in the Python programming language, the ARMI system works on
 basically any kind of computer. We have developed it predominantly within a Microsoft
 Windows environment, but have performed tests under various flavors of Linux as well. It
@@ -356,12 +361,12 @@ needed to support the more traditional Linux HPC environments.
 .. _getting-help:
 
 Getting help
-------------
+============
 You can get help with ARMI by either making issues on `our github page
 <https://github.com/terrapower/armi/issues>`_ or by e-mailing armi-devs@terrapower.com.
 
 Disclaimers
------------
+===========
 Due to TerraPower goals and priorities, many ARMI modules were developed with the
 sodium-cooled TWR as the target, and are not necessarily yet optimized for other plants.
 On the other hand, we have attempted to keep the framework general where possible, and
@@ -391,7 +396,7 @@ change it.
 
 
 License
--------
+=======
 TerraPower and ARMI are registered trademarks of TerraPower, LLC.
 Other trademarks and registered trademarks used in this Manual are the property of the
 respective trademark holders.
@@ -425,8 +430,6 @@ only use third-party Python libraries that have MIT or BSD licenses.
 
 .. [#touranarmi] Touran, Nicholas W., et al. "Computational tools for the integrated design of advanced nuclear reactors."
    Engineering 3.4 (2017): 518-526. https://doi.org/10.1016/J.ENG.2017.04.016
-
---------------
 
 .. |Build Status| image:: https://github.com/terrapower/armi/actions/workflows/unittests.yaml/badge.svg?branch=main
     :target: https://github.com/terrapower/armi/actions/workflows/unittests.yaml

--- a/armi/nucDirectory/tests/test_elements.py
+++ b/armi/nucDirectory/tests/test_elements.py
@@ -81,7 +81,7 @@ class TestElement(unittest.TestCase):
             with open(os.path.join(RES, "burn-chain.yaml"), "r") as burnChainStream:
                 nuclideBases.imposeBurnChain(burnChainStream)
 
-    def test_element_getNatrualIsotpicsOnlyRetrievesAbundaceGt0(self):
+    def test_elementGetNatrualIsotpicsOnlyRetrievesAbund(self):
         for ee in elements.byZ.values():
             if not ee.isNaturallyOccurring():
                 continue

--- a/armi/nucDirectory/tests/test_nucDirectory.py
+++ b/armi/nucDirectory/tests/test_nucDirectory.py
@@ -43,7 +43,7 @@ class TestNucDirectory(unittest.TestCase):
         for oldName in oldNames:
             self.assertIsNotNone(nucDir.getNuclideFromName(oldName))
 
-    def test_nucDir_getNuclideFromNuclidesNameReturnsNuclide(self):
+    def test_nucDir_getNucFromNucNameReturnsNuc(self):
         for nuc in nuclideBases.instances:
             self.assertEqual(nuc, nucDir.getNuclideFromName(nuc.name))
 

--- a/armi/nucDirectory/tests/test_nuclideBases.py
+++ b/armi/nucDirectory/tests/test_nuclideBases.py
@@ -94,7 +94,7 @@ class TestNuclide(unittest.TestCase):
             else:
                 self.assertIsInstance(lump, nuclideBases.NaturalNuclideBase)
 
-    def test_LumpNuclideBase_getNatrualIsotopicsDoesNotFail(self):
+    def test_LumpNucBaseGetNatIsotopDoesNotFail(self):
         for nuc in nuclideBases.where(
             lambda nn: isinstance(nn, nuclideBases.LumpNuclideBase) and nn.z == 0
         ):
@@ -120,7 +120,7 @@ class TestNuclide(unittest.TestCase):
         self.assertEqual(235, u235.a)
         self.assertEqual(92, u235.z)
 
-    def test_NaturalNuclide_atomicWeightIsAverageOfNaturallyOccuringIsotopes(self):
+    def test_natNucStomicWgtIsAvgOfNatIsotopes(self):
         for natNuk in nuclideBases.where(
             lambda nn: isinstance(nn, nuclideBases.NaturalNuclideBase)
         ):
@@ -129,7 +129,7 @@ class TestNuclide(unittest.TestCase):
                 atomicMass += natIso.abundance * natIso.weight
             self.assertAlmostEqual(atomicMass, natNuk.weight, delta=0.000001)
 
-    def test_nucBases_labelAndNameCollsionsAreForSameNuclide(self):
+    def test_nucBasesLabelAndNameCollsAreForSameNuc(self):
         """The name and labels for correct for nuclides.
 
         .. test:: Validate the name, label, and DB name are accessible for nuclides.
@@ -144,7 +144,7 @@ class TestNuclide(unittest.TestCase):
             self.assertEqual(nuc, nuclideBases.byLabel[nuc.label])
         self.assertGreater(count, 10)
 
-    def test_nucBases_imposeBurnChainDecayBulkStatistics(self):
+    def test_nucBases_imposeBurnChainDecayBulkStats(self):
         """Test must be updated manually when burn chain is modified."""
         decayers = list(nuclideBases.where(lambda nn: len(nn.decays) > 0))
         self.assertTrue(decayers)
@@ -162,7 +162,7 @@ class TestNuclide(unittest.TestCase):
                 continue
             self.assertAlmostEqual(1.0, sum(dd.branch for dd in nuc.decays))
 
-    def test_nucBases_imposeBurnChainTransmutationBulkStatistics(self):
+    def test_nucBasesImposeBurnChainTransmBulkStats(self):
         """
         Make sure all branches are equal to 1 for every transmutation type.
 

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -336,14 +336,14 @@ class AbstractTestXSlibraryMerging(TempFileMixin):
         with self.assertRaises(AttributeError):
             self.libCombined.merge(self.libAA)
 
-    def test_cannotMergeXSLibxWithDifferentGroupStructure(self):
+    def test_cannotMergeXSLibxWithDiffGroupStructure(self):
         dummyXsLib = xsLibraries.IsotxsLibrary()
         dummyXsLib.neutronEnergyUpperBounds = np.array([1, 2, 3])
         dummyXsLib.gammaEnergyUpperBounds = np.array([1, 2, 3])
         with self.assertRaises(properties.ImmutablePropertyError):
             dummyXsLib.merge(self.libCombined)
 
-    def test_mergeEmptyXSLibWithOtherEssentiallyClonesTheOther(self):
+    def test_mergeEmptyXSLibWithOtherClonesTheOther(self):
         emptyXSLib = xsLibraries.IsotxsLibrary()
         emptyXSLib.merge(self.libAA)
         self.libAA = None
@@ -419,7 +419,8 @@ class Pmatrx_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
         # this test does not work for PMATRX, MC**2-v3 does not currently
         pass
 
-    def test_cannotMergeXSLibsWithDifferentGammaGroupStructures(self):
+    def test_cannotMergeXSLibsWithDiffGammaGroups(self):
+        """Test that we cannot merge XS Libs with different Gamma Group Structures."""
         dummyXsLib = xsLibraries.IsotxsLibrary()
         dummyXsLib.gammaEnergyUpperBounds = np.array([1, 2, 3])
         with self.assertRaises(properties.ImmutablePropertyError):

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -25,13 +25,13 @@ class NuclideTests(unittest.TestCase):
     def setUpClass(cls):
         cls.lib = isotxs.readBinary(ISOAA_PATH)
 
-    def test_nuclide_createFromLabelFailsOnBadName(self):
+    def test_nucl_createFromLabelFailsOnBadName(self):
         nuc = xsNuclides.XSNuclide(None, "BACONAA")
         nuc.isotxsMetadata["nuclideId"] = "BACN87"
         with self.assertRaises(OSError):
             nuc.updateBaseNuclide()
 
-    def test_nuclide_creatingNuclidesDoesNotMessWithUnderlyingNuclideDict(self):
+    def test_nuc_creatingNucNotMessWithUnderlyingNucDict(self):
         nuc = nuclideBases.byName["U238"]
         self.assertFalse(hasattr(nuc, "xsId"))
         nrAA = xsNuclides.XSNuclide(None, "U238AA")
@@ -40,7 +40,7 @@ class NuclideTests(unittest.TestCase):
         self.assertEqual("AA", nrAA.xsId)
         self.assertFalse(hasattr(nuc, "xsId"))
 
-    def test_nuclide_modifyingNuclideAttributesUpdatesTheIsotxsNuclide(self):
+    def test_nucl_modifyingNucAttrUpdatesTheIsotxsNuc(self):
         lib = xsLibraries.IsotxsLibrary()
         nuc = nuclideBases.byName["FE"]
         nrAA = xsNuclides.XSNuclide(lib, "FEAA")

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -131,7 +131,7 @@ class TestLatticePhysicsWriter(unittest.TestCase):
         self.assertIn("AM241", names)
         self.assertIn("U238", names)
 
-    def test_getAllNuclidesByTemperatureInCExplicitFissionProducts(self):
+    def test_getAllNuclidesByTempInCExplicitFisProd(self):
         self.w.explicitFissionProducts = True
         c = self.r.core[0][0]
         nucsByTemp = self.w._getAllNuclidesByTemperatureInC(c)

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -987,7 +987,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
                 continue
             self.assertEqual(baSettingValue, aaSettings.__dict__[setting])
 
-    def test_createRepresentativeBlocksUsingExistingBlocks(self):
+    def test_createRepBlocksUsingExistingBlocks(self):
         """
         Demonstrates that a new representative block can be generated from an existing
         representative block.
@@ -999,7 +999,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
         """
         self._createRepresentativeBlocksUsingExistingBlocks(["fuel"])
 
-    def test_createRepresentativeBlocksUsingExistingBlocksDisableValidBlockTypes(self):
+    def test_createRepBlocksFromDisableValidBlockTypes(self):
         """
         Demonstrates that a new representative block can be generated from an existing
         representative block with the setting `disableBlockTypeExclusionInXsGeneration: true`.

--- a/armi/physics/neutronics/tests/test_crossSectionSettings.py
+++ b/armi/physics/neutronics/tests/test_crossSectionSettings.py
@@ -123,7 +123,7 @@ class TestCrossSectionSettings(unittest.TestCase):
         self.assertEqual(xsModel["YA"].ductHeterogeneous, False)
         self.assertEqual(xsModel["YA"].traceIsotopeThreshold, 0.0)
 
-    def test_setDefaultSettingsByLowestEnvGroupHomogeneous(self):
+    def test_setDefSettingsByLowestEnvGroupHomog(self):
         # Initialize some micro suffix in the cross sections
         cs = settings.Settings()
         xs = XSSettings()
@@ -149,7 +149,7 @@ class TestCrossSectionSettings(unittest.TestCase):
         self.assertNotIn("JB", xs)
         self.assertNotEqual(xs["JD"], xs["JB"])
 
-    def test_setDefaultSettingsByLowestEnvGroupOneDimensional(self):
+    def test_setDefSettingsByLowestEnvGroup1D(self):
         # Initialize some micro suffix in the cross sections
         cs = settings.Settings()
         xsModel = XSSettings()

--- a/armi/physics/neutronics/tests/test_energyGroups.py
+++ b/armi/physics/neutronics/tests/test_energyGroups.py
@@ -33,7 +33,7 @@ class TestEnergyGroups(unittest.TestCase):
             with self.assertRaises(ValueError):
                 energyGroups.getGroupStructureType(energyBounds)
 
-    def test_consistenciesBetweenGroupStructureAndGroupStructureType(self):
+    def test_consistenciesBetweenGSAndGSType(self):
         """Test that the reverse lookup of the energy group structures work.
 
         .. test:: Check the neutron energy group bounds for a given group structure.

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -45,7 +45,7 @@ assemblies:
         xs types: [A]
 """
 
-    def test_componentInitializationIncompleteBurnChain(self):
+    def test_componentInitIncompleteBurnChain(self):
         nuclideFlagsFuelWithBurn = (
             inspect.cleandoc(
                 r"""
@@ -65,7 +65,7 @@ assemblies:
         with self.assertRaises(ValueError):
             bp.constructAssem(cs, "assembly")
 
-    def test_componentInitializationControlCustomIsotopics(self):
+    def test_componentInitControlCustomIsotopics(self):
         nuclideFlags = (
             inspect.cleandoc(
                 """
@@ -157,7 +157,7 @@ assemblies:
         # More robust test, but worse unittest.py output when it fails
         self.assertTrue(c.hasFlags(Flags.FUEL | Flags.TEST))
 
-    def test_componentInitializationAmericiumCustomIsotopics(self):
+    def test_componentInitAmericiumCustomIsotopics(self):
         nuclideFlags = (
             inspect.cleandoc(
                 r"""
@@ -248,7 +248,7 @@ assemblies:
         for nuc in unexpectedNuclides:
             self.assertNotIn(nuc, a[0][0].getNuclides())
 
-    def test_componentInitializationThoriumBurnCustomIsotopics(self):
+    def test_componentInitThoriumBurnCustomIsotopics(self):
         nuclideFlags = (
             inspect.cleandoc(
                 r"""
@@ -307,7 +307,7 @@ assemblies:
         for nuc in expectedNuclides:
             self.assertIn(nuc, a[0][0].getNuclides())
 
-    def test_componentInitializationThoriumNoBurnCustomIsotopics(self):
+    def test_componentInitThoriumNoBurnCustomIsotopics(self):
         nuclideFlags = (
             inspect.cleandoc(
                 r"""

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -256,7 +256,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
             )
             self._getConservationMetrics(self.a)
 
-    def test_thermalExpansionContractionConservation_simple(self):
+    def test_thermExpansContractConserv_simple(self):
         """Thermally expand and then contract to ensure original state is recovered.
 
         .. test:: Thermally expand and then contract to ensure original assembly is recovered.
@@ -301,7 +301,7 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         self._checkNDens(origNDens, newNDens, 1.0)
         self._checkDetailedNDens(origDetailedNDens, newDetailedNDens, 1.0)
 
-    def test_thermalExpansionContractionConservation_complex(self):
+    def test_thermExpansContractionConserv_complex(self):
         """Thermally expand and then contract to ensure original state is recovered.
 
         Notes
@@ -720,7 +720,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
 
-    def test_updateComponentTempsBy1DTempFieldValueError(self):
+    def test_updateCompTempsBy1DTempFieldValError(self):
         tempGrid = [5.0, 15.0, 35.0]
         tempField = linspace(25.0, 310.0, 3)
         with self.assertRaises(ValueError) as cm:
@@ -730,7 +730,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
 
-    def test_updateComponentTempsBy1DTempFieldRuntimeError(self):
+    def test_updateCompTempsBy1DTempFieldError(self):
         tempGrid = [5.0, 15.0, 35.0]
         tempField = linspace(25.0, 310.0, 10)
         with self.assertRaises(RuntimeError) as cm:
@@ -838,7 +838,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
             msg=f"determineTargetComponent failed to recognize intended component: {expected}",
         )
 
-    def test_determineTargetComponentBlockWithMultipleFlags(self):
+    def test_determineTargetCompBlockWithMultiFlags(self):
         """Provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER with multiple flags."""
         # build a block that has two flags as well as a component matching each
         b = HexBlock("fuel poison", height=10.0)
@@ -851,7 +851,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         b.add(self.coolant)
         self._checkTarget(b, fuel)
 
-    def test_specifyTargetComponent_NotFound(self):
+    def test_specifyTargetComp_NotFound(self):
         """Ensure RuntimeError gets raised when no target component is found."""
         b = HexBlock("fuel", height=10.0)
         b.add(self.coolant)
@@ -865,7 +865,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
             the_exception = cm.exception
             self.assertEqual(the_exception.error_code, 3)
 
-    def test_specifyTargetComponent_singleSolid(self):
+    def test_specifyTargetComp_singleSolid(self):
         """Ensures that specifyTargetComponent is smart enough to set the only solid as the target component."""
         b = HexBlock("plenum", height=10.0)
         ductDims = {"Tinput": 25.0, "Thot": 25.0, "op": 17, "ip": 0.0, "mult": 1.0}
@@ -876,7 +876,7 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         b.setType("plenum")
         self._checkTarget(b, duct)
 
-    def test_specifyTargetComponet_MultipleFound(self):
+    def test_specifyTargetComp_MultiFound(self):
         """Ensure RuntimeError is hit when multiple target components are found.
 
         Notes

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -300,10 +300,10 @@ class TestBlockConverter(unittest.TestCase):
         # block went to 1 component
         self.assertEqual(1, len([c for c in convertedWithoutDriver]))
 
-    def test_convertHexWithFuelDriverOnNegativeComponentAreaBlock(self):
+    def test_convertHexWithFuelDrOnNegCompAreaBlock(self):
         """
-        Tests the conversion of a control block with linked components, where
-        a component contains a negative area due to thermal expansion.
+        Tests the conversion of a control block with linked components, where a component contains a
+        negative area due to thermal expansion.
         """
         driverBlock = (
             loadTestReactor(TEST_ROOT)[1]

--- a/armi/reactor/converters/tests/test_meshConverters.py
+++ b/armi/reactor/converters/tests/test_meshConverters.py
@@ -34,7 +34,7 @@ class TestRZReactorMeshConverter(unittest.TestCase):
             "axialSegsPerBin": 1,
         }
 
-    def test_meshByRingCompositionAxialBinsSmallCore(self):
+    def test_meshByRingCompAxialBinsSmallCore(self):
         expectedRadialMesh = [2, 3, 4, 4, 5, 5, 6, 6, 6, 7, 8, 8, 9, 10]
         expectedAxialMesh = [25.0, 50.0, 75.0, 100.0, 175.0]
         expectedThetaMesh = [2 * math.pi]
@@ -50,7 +50,7 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
         self.assertListEqual(meshConvert.thetaMesh, expectedThetaMesh)
 
-    def test_meshByRingCompositionAxialCoordinatesSmallCore(self):
+    def test_meshByRingCompoAxialCoordsSmallCore(self):
         expectedRadialMesh = [2, 3, 4, 4, 5, 5, 6, 6, 6, 7, 8, 8, 9, 10]
         expectedAxialMesh = [25.0, 50.0, 175.0]
         expectedThetaMesh = [2 * math.pi]
@@ -66,7 +66,7 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
         self.assertListEqual(meshConvert.thetaMesh, expectedThetaMesh)
 
-    def test_meshByRingCompositionAxialFlagsSmallCore(self):
+    def test_meshByRingCompAxialFlagsSmallCore(self):
         expectedRadialMesh = [2, 3, 4, 4, 5, 5, 6, 6, 6, 7, 8, 8, 9, 10]
         expectedAxialMesh = [25.0, 50.0, 75.0, 100.0, 175.0]
         expectedThetaMesh = [2 * math.pi]
@@ -95,7 +95,7 @@ class TestRZReactorMeshConverter(unittest.TestCase):
             "axialSegsPerBin": 2,
         }
 
-    def test_meshByRingCompositionAxialBinsLargeCore(self):
+    def test_meshByRingCompAxialBinsLargeCore(self):
         self._growReactor()
         expectedRadialMesh = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 13]
         expectedAxialMesh = [50.0, 100.0, 175.0]
@@ -112,7 +112,7 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
         self.assertListEqual(meshConvert.thetaMesh, expectedThetaMesh)
 
-    def test_meshByRingCompositionAxialCoordinatesLargeCore(self):
+    def test_meshByRingCompAxialCoordsLargeCore(self):
         self._growReactor()
         expectedRadialMesh = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 13]
         expectedAxialMesh = [25.0, 30.0, 60.0, 90.0, 105.2151, 152.0, 175.0]
@@ -129,7 +129,7 @@ class TestRZReactorMeshConverter(unittest.TestCase):
         self.assertListEqual(meshConvert.axialMesh, expectedAxialMesh)
         self.assertListEqual(meshConvert.thetaMesh, expectedThetaMesh)
 
-    def test_meshByRingCompositionAxialFlagsLargeCore(self):
+    def test_meshByRingCompAxialFlagsLargeCore(self):
         self._growReactor()
         expectedRadialMesh = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 13]
         expectedAxialMesh = [25.0, 100.0, 175.0]

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1136,7 +1136,7 @@ class AssemblyInReactor_TestCase(unittest.TestCase):
     def setUp(self):
         self.o, self.r = test_reactors.loadTestReactor(TEST_ROOT)
 
-    def test_snapAxialMeshToReferenceConservingMassBasedOnBlockIgniter(self):
+    def test_snapAxialMeshToRefConsMassBasedOnBlockIgn(self):
         originalMesh = [25.0, 50.0, 75.0, 100.0, 175.0]
         refMesh = [26.0, 52.0, 79.0, 108.0, 175.0]
 
@@ -1252,7 +1252,7 @@ class AssemblyInReactor_TestCase(unittest.TestCase):
         self.assertAlmostEqual(igniterCoolMass, igniterCoolMassAfterShrink, 7)
         self.assertAlmostEqual(igniterPlenumMass, igniterPlenumMassAfterShrink, 7)
 
-    def test_snapAxialMeshToReferenceConservingMassBasedOnBlockShield(self):
+    def test_snapAxialMesh2RefConsMassBasedOnBlockShield(self):
         originalMesh = [25.0, 50.0, 75.0, 100.0, 175.0]
         refMesh = [26.0, 52.0, 79.0, 108.0, 175.0]
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1698,7 +1698,7 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(sum(fracs.values()), sum([a for c, a in cur]))
 
     def test_expandElementalToIsotopics(self):
-        r"""Tests the expand to elementals capability."""
+        """Tests the expand to elementals capability."""
         initialN = {}
         initialM = {}
         elementals = [nuclideBases.byName[nn] for nn in ["FE", "CR", "SI", "V", "MO"]]
@@ -1730,7 +1730,7 @@ class Block_TestCase(unittest.TestCase):
             )
 
     def test_expandAllElementalsToIsotopics(self):
-        r"""Tests the expand all elementals simlutaneously capability."""
+        """Tests the expand all elementals simlutaneously capability."""
         initialN = {}
         initialM = {}
         elementals = [nuclideBases.byName[nn] for nn in ["FE", "CR", "SI", "V", "MO"]]
@@ -1763,7 +1763,7 @@ class Block_TestCase(unittest.TestCase):
             )
 
     def test_setPitch(self):
-        r"""
+        """
         Checks consistency after adjusting pitch.
 
         Needed to verify fix to Issue #165.
@@ -1809,7 +1809,7 @@ class Block_TestCase(unittest.TestCase):
         assert_allclose(235.0, mfpAbs, rtol=0.1)
         assert_allclose(17.0, diffusionLength, rtol=0.1)
 
-    def test_consistentMassDensityVolumeBetweenColdBlockAndColdComponents(self):
+    def test_consistentMassDensVolBetweenColdBlockAndComp(self):
         block = self.block
         expectedData = []
         actualData = []
@@ -1827,7 +1827,7 @@ class Block_TestCase(unittest.TestCase):
             for expectedVal, actualVal in zip(expected, actual):
                 self.assertAlmostEqual(expectedVal, actualVal, msg=msg)
 
-    def test_consistentMassDensityVolumeBetweenHotBlockAndHotComponents(self):
+    def test_consistentMassDensVolBetweenHotBlockAndComp(self):
         block = self._hotBlock
         expectedData = []
         actualData = []
@@ -1845,7 +1845,7 @@ class Block_TestCase(unittest.TestCase):
             for expectedVal, actualVal in zip(expected, actual):
                 self.assertAlmostEqual(expectedVal, actualVal, msg=msg)
 
-    def test_consistentAreaWithOverlappingComponents(self):
+    def test_consistentAreaWithOverlappingComp(self):
         """
         Test that negative gap areas correctly account for area overlapping upon thermal expansion.
 

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -648,7 +648,7 @@ class TestCircle(TestShapedComponent):
         "mult": 1.5,
     }
 
-    def test_getThermalExpansionFactorConservedMassByLinearExpansionPercent(self):
+    def test_getThermExpansFactorConsMassLinExpanPerc(self):
         """Test that when ARMI thermally expands a circle, mass is conserved.
 
         .. test:: Calculate thermal expansion.

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -788,7 +788,7 @@ class TestMiscMethods(unittest.TestCase):
                 self.obj.getNumberDensity(nuc), childDensities[nuc], 4, msg=nuc
             )
 
-    def test_getNumberDensitiesWithExpandedFissionProducts(self):
+    def test_getNumDensWithExpandedFissProds(self):
         """Get number densities from composite.
 
         .. test:: Get number densities.

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -380,7 +380,7 @@ class ParameterTests(unittest.TestCase):
             set(derA.paramDefs._paramDefs).issubset(set(derB.paramDefs._paramDefs))
         )
 
-    def test_cannotDefineParameterWithSameNameForCollectionSubclass(self):
+    def test_cannotDefineParamSameNameCollectionSubclass(self):
         class MockPCParent(parameters.ParameterCollection):
             pDefs = parameters.ParameterDefinitionCollection()
             with pDefs.createBuilder() as pb:

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -216,7 +216,7 @@ class SettingArgsTests(unittest.TestCase):
         ep.parse_args(["--nCycles", "5"])
         self.assertEqual(cs["nCycles"], 5)
 
-    def test_cannotLoadSettingsAfterParsingCommandLineSetting(self):
+    def test_cannotLoadSettingsAfterParsingCLI(self):
         self.test_commandLineSetting()
 
         with self.assertRaises(RuntimeError):

--- a/armi/utils/tests/test_properties.py
+++ b/armi/utils/tests/test_properties.py
@@ -43,7 +43,7 @@ class ImmutablePropertyTests(unittest.TestCase):
             ic.myNum = 2.2
         self.assertEqual(ic.myNum, 4.0)
 
-    def test_unlockDoesNotPermitsReassignmentOfAnImmutableProperty(self):
+    def test_unlockDoesntPermitReassignmentOfAnImmutProp(self):
         ic = ImmutableClass()
         ic.myNum = 7.7
         with self.assertRaises(properties.ImmutablePropertyError):

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -457,7 +457,7 @@ class TestTabulateInternal(unittest.TestCase):
         ]
         self.assertEqual(expected, output)
 
-    def test_alignColumnDecimalWithIncorrectThousandSeparators(self):
+    def test_alignColDecimalIncorrectThousandSeparators(self):
         """Internal: _align_column(..., 'decimal')."""
         column = ["12.345", "-1234.5", "1.23", "12,34.5", "1e+234", "1.0e234"]
         output = _alignColumn(column, "decimal")
@@ -498,32 +498,32 @@ class TestTabulateInternal(unittest.TestCase):
         expected = ["one line"]
         assert top == center == bottom == none == expected
 
-    def test_alignCellVeriticallyTopSingleTextMultiplePad(self):
+    def test_alignCellVertTopSingleTextMultiPad(self):
         """Internal: Align single cell text to top."""
         result = _alignCellVeritically(["one line"], 3, 8, "top")
         expected = ["one line", "        ", "        "]
         self.assertEqual(expected, result)
 
-    def test_alignCellVeriticallyCenterSingleTextMultiplePad(self):
+    def test_alignCellVertCenterSingleTextMultiPad(self):
         """Internal: Align single cell text to center."""
         result = _alignCellVeritically(["one line"], 3, 8, "center")
         expected = ["        ", "one line", "        "]
         self.assertEqual(expected, result)
 
-    def test_alignCellVeriticallyBottomSingleTextMultiplePad(self):
+    def test_alignCellVertBottomSingleTextMultiPad(self):
         """Internal: Align single cell text to bottom."""
         result = _alignCellVeritically(["one line"], 3, 8, "bottom")
         expected = ["        ", "        ", "one line"]
         self.assertEqual(expected, result)
 
-    def test_alignCellVeriticallyTopMultiTextMultiplePad(self):
+    def test_alignCellVertTopMultiTextMultiPad(self):
         """Internal: Align multiline celltext text to top."""
         text = ["just", "one ", "cell"]
         result = _alignCellVeritically(text, 6, 4, "top")
         expected = ["just", "one ", "cell", "    ", "    ", "    "]
         self.assertEqual(expected, result)
 
-    def test_alignCellVeriticallyCenterMultiTextMultiplePad(self):
+    def test_alignCellVertCenterMultiTextMultiPad(self):
         """Internal: Align multiline celltext text to center."""
         text = ["just", "one ", "cell"]
         result = _alignCellVeritically(text, 6, 4, "center")
@@ -533,7 +533,7 @@ class TestTabulateInternal(unittest.TestCase):
         expected = ["    ", "just", "one ", "cell", "    ", "    "]
         self.assertEqual(expected, result)
 
-    def test_alignCellVeriticallyBottomMultiTextMultiplePad(self):
+    def test_alignCellVertBottomMultiTextMultiPad(self):
         """Internal: Align multiline celltext text to bottom."""
         text = ["just", "one ", "cell"]
         result = _alignCellVeritically(text, 6, 4, "bottom")

--- a/doc/.static/cleanup_test_results.py
+++ b/doc/.static/cleanup_test_results.py
@@ -1,0 +1,52 @@
+# Copyright 2025 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Docs build helper script, used to clean up the test-results file so it is easier to read in HTML
+and PDF later.
+"""
+from sys import argv
+
+CLASS_NAME = 'classname="'
+
+
+def main():
+    assert len(argv) == 2, "No input file provided"
+    filePath = argv[1]
+    cleanup_test_results(filePath)
+
+
+def cleanup_test_results(filePath: str):
+    """Clean up the test-results file so it is easier to read in HTML and PDF later.
+
+    Parameters
+    ----------
+    filePath : str
+        Path to junit pytest test results XML file.
+    """
+    txt = open(filePath, "r").read()
+    bits = txt.split(CLASS_NAME)
+
+    newTxt = bits[0]
+    for i in range(1, len(bits)):
+        assert '"' in bits[i], f"Something is wrong with the file: {bits[i]}"
+        row = bits[i].split('"')
+        row[0] = row[0].split(".")[-1]
+        newTxt += CLASS_NAME + '"'.join(row)
+
+    with open(filePath, "w") as f:
+        f.write(newTxt)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/qa_docs/srsd/nucDirectory_reqs.rst
+++ b/doc/qa_docs/srsd/nucDirectory_reqs.rst
@@ -20,7 +20,7 @@ Functional Requirements
     :id: R_ARMI_ND_ISOTOPES
     :subtype: functional
     :basis: Isotope data is used to aid in construction of cross-section generation models, to convert between mass and number fractions, and other tasks.
-    :acceptance_criteria: Query isotopes and isomers by name, label, MC2-3 ID, MCNP ID, and AAAZZZS ID.  
+    :acceptance_criteria: Query isotopes and isomers by name, label, MC2-3 ID, MCNP ID, and AAAZZZS ID.
     :status: accepted
 
 .. req:: The nucDirectory package shall store data separately from code.

--- a/doc/qa_docs/srsd/reactors_reqs.rst
+++ b/doc/qa_docs/srsd/reactors_reqs.rst
@@ -250,7 +250,7 @@ Functional Requirements
     :id: R_ARMI_UMC_MIN_MESH
     :subtype: functional
     :basis: Regions with extremely small axial size can cause difficulties for the deterministic neutronics solvers.
-    :acceptance_criteria: Create a reactor with a mesh that is smaller than the minimum size. After the uniform mesh conversion the new mesh conforms to the user-specified value.    
+    :acceptance_criteria: Create a reactor with a mesh that is smaller than the minimum size. After the uniform mesh conversion the new mesh conforms to the user-specified value.
     :status: accepted
 
 .. ## blockConverters ######################

--- a/doc/qa_docs/str.rst
+++ b/doc/qa_docs/str.rst
@@ -91,7 +91,7 @@ Test Record Criteria
 
 The default values for the remaining 12 criteria pertaining to the test record are given in this
 section below. A test record will be produced after the test  is run which contains pertinent
-information about the execution of the test.  This test record will be saved as part of the software
+information about the execution of the test. This test record will be saved as part of the software
 test report (STR).
 
 Software Tested, Including System Software Used and All Versions


### PR DESCRIPTION
## What is the change? Why is it being made?

I am trying to clean up the pytest `test-results.xml` outputs, to make the final table more readable, particularly in PDF.

You will not that I had to add a custom script to hand-edit the PyTest `test-results.xml` table. And I had to shorten the names of dozens of tests.

BONUS: Also, you will notice that I changed the header levels in the main `README` file, which will make the outline of the final PDF much cleaner.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: I am trying to clean up the pytest `test-results.xml` outputs, to make the final table more readable, particularly in PDF.

<!-- MANDATORY: Describe any impact on the requirements -->
One-line Impact on Requirements: NA

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The [release notes](https://terrapower.github.io/armi/developer/tooling.html#add-release-notes) have been updated if necessary.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The dependencies are still up-to-date in `pyproject.toml`.