### PR TITLE
Add Core.iterBlocks and Assembly.iterBlocks

### DIFF
--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -344,7 +344,7 @@ class TestDatabaseWriter(unittest.TestCase):
         expectedFluxes7 = {}
 
         def setFluxAwesome(cycle, node):
-            for bi, b in enumerate(self.r.core.getBlocks()):
+            for bi, b in enumerate(self.r.core.iterBlocks()):
                 b.p.flux = 1e6 * bi + 1e3 * cycle + node
                 if bi == 0:
                     expectedFluxes0[cycle, node] = b.p.flux
@@ -358,8 +358,7 @@ class TestDatabaseWriter(unittest.TestCase):
             if cycle != 0 or node != 2:
                 return
 
-            blocks = self.r.core.getBlocks()
-            b0 = blocks[0]
+            b0 = next(self.r.core.iterBlocks())
 
             db = self.o.getInterface("database")._db
 
@@ -378,15 +377,14 @@ class TestDatabaseWriter(unittest.TestCase):
 
     def test_getHistoryByLocation(self):
         def setFluxAwesome(cycle, node):
-            for bi, b in enumerate(self.r.core.getBlocks()):
+            for bi, b in enumerate(self.r.core.iterBlocks()):
                 b.p.flux = 1e6 * bi + 1e3 * cycle + node
 
         def getFluxAwesome(cycle, node):
             if cycle != 1 or node != 2:
                 return
 
-            blocks = self.r.core.getBlocks()
-            b = blocks[0]
+            b = next(self.r.core.iterBlocks())
 
             db = self.o.getInterface("database").database
 
@@ -426,7 +424,7 @@ class TestDatabaseReading(unittest.TestCase):
 
         # update a few parameters
         def writeFlux(cycle, node):
-            for bi, b in enumerate(o.r.core.getBlocks()):
+            for bi, b in enumerate(o.r.core.iterBlocks()):
                 b.p.flux = 1e6 * bi + cycle * 100 + node
                 b.p.mgFlux = np.repeat(b.p.flux / 33, 33)
 
@@ -555,11 +553,11 @@ class TestDatabaseReading(unittest.TestCase):
         with Database(self.dbName, "r") as db:
             r2 = db.load(0, 0)
 
-        for b1, b2 in zip(self.r.core.getBlocks(), r2.core.getBlocks()):
+        for b1, b2 in zip(self.r.core.iterBlocks(), r2.core.iterBlocks()):
             for c1, c2 in zip(sorted(b1), sorted(b2)):
                 self.assertEqual(c1.name, c2.name)
 
-        for bi, b in enumerate(r2.core.getBlocks()):
+        for bi, b in enumerate(r2.core.iterBlocks()):
             assert_allclose(b.p.flux, 1e6 * bi)
 
     def test_variousTypesWork(self):

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -672,7 +672,7 @@ def summarizePinDesign(core):
     designInfo = collections.defaultdict(list)
 
     try:
-        for b in core.getBlocks(Flags.FUEL):
+        for b in core.iterBlocks(Flags.FUEL):
             fuel = b.getComponent(Flags.FUEL)
             duct = b.getComponent(Flags.DUCT)
             clad = b.getComponent(Flags.CLAD)

--- a/armi/bookkeeping/visualization/tests/test_vis.py
+++ b/armi/bookkeeping/visualization/tests/test_vis.py
@@ -68,7 +68,7 @@ class TestVisDump(unittest.TestCase):
             inputFileName="smallestTestReactor/armiRunSmallest.yaml"
         )
 
-        cls.hexBlock = cls.r.core.getBlocks()[0]
+        cls.hexBlock = next(cls.r.core.iterBlocks())
 
         cls.cartesianBlock = blocks.CartesianBlock("TestCartesianBlock", caseSetting)
         cartesianComponent = components.HoledSquare(

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -217,7 +217,7 @@ class FuelHandler:
         if multiplier != 1:
             # handle special case: volume-integrated parameters where symmetry factor is not 1
             if blockLevelMax:
-                paramCollection = a.getBlocks()[0].p
+                paramCollection = a[0].p
             else:
                 paramCollection = a.p
             isVolumeIntegrated = (

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -595,7 +595,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         newSettings = {CONF_ASSEM_ROTATION_STATIONARY: True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
-        b = assem.getBlocks(Flags.FUEL)[0]
+        b = next(assem.iterBlocks(Flags.FUEL))
 
         b.p.linPowByPin = [1, 2, 3]
         self.assertEqual(type(b.p.linPowByPin), np.ndarray)
@@ -609,7 +609,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         newSettings = {CONF_ASSEM_ROTATION_STATIONARY: True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
-        b = assem.getBlocks(Flags.FUEL)[0]
+        b = next(assem.iterBlocks(Flags.FUEL))
 
         b.p.linPowByPinNeutron = [1, 2, 3]
         self.assertEqual(type(b.p.linPowByPinNeutron), np.ndarray)
@@ -623,7 +623,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         newSettings = {CONF_ASSEM_ROTATION_STATIONARY: True}
         self.o.cs = self.o.cs.modified(newSettings=newSettings)
         assem = self.o.r.core.getFirstAssembly(Flags.FUEL)
-        b = assem.getBlocks(Flags.FUEL)[0]
+        b = next(assem.iterBlocks(Flags.FUEL))
 
         b.p.linPowByPinGamma = [1, 2, 3]
         self.assertEqual(type(b.p.linPowByPinGamma), np.ndarray)

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -175,7 +175,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         # symmetry factor == 3
         mockGetSymmetry.return_value = 3
         a.p.paramDefs["kInf"].location = ParamLocation.VOLUME_INTEGRATED
-        a.getBlocks()[0].p.paramDefs["kInf"].location = ParamLocation.VOLUME_INTEGRATED
+        a[0].p.paramDefs["kInf"].location = ParamLocation.VOLUME_INTEGRATED
         res = fuelHandlers.FuelHandler._getParamMax(a, "kInf", True)
         self.assertAlmostEqual(res, expectedValue * 3)
 

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -71,11 +71,12 @@ class FuelHandlerTestHelper(ArmiTestHelper):
             customSettings={"nCycles": 3, "trackAssems": True},
         )
 
-        blockList = self.r.core.getBlocks()
-        for bi, b in enumerate(blockList):
+        allBlocks = self.r.core.getBlocks()
+        fakeBu = 30.0 / len(allBlocks)
+        for bi, b in enumerate(allBlocks):
             b.p.flux = 5e10
             if b.isFuel():
-                b.p.percentBu = 30.0 * bi / len(blockList)
+                b.p.percentBu = fakeBu * bi
         self.nfeed = len(self.r.core.getAssemblies(Flags.FEED))
         self.nigniter = len(self.r.core.getAssemblies(Flags.IGNITER))
         self.nSfp = len(self.r.excore["sfp"])

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -437,9 +437,8 @@ class TestFuelHandler(FuelHandlerTestHelper):
         # the burnup should be the maximum bu within
         # up to a burnup of 20%, which by the simple
         # dummy data layout should be the 2/3rd block in the blocklist
-        bs = self.r.core.getBlocks(Flags.FUEL)
         lastB = None
-        for b in bs:
+        for b in self.r.core.iterBlocks(Flags.FUEL):
             if b.p.percentBu > 20:
                 break
             lastB = b
@@ -470,7 +469,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
             fh.manageFuel(cycle)
             for a in self.r.excore["sfp"]:
                 self.assertEqual(a.getLocation(), "SFP")
-            for b in self.r.core.getBlocks(Flags.FUEL):
+            for b in self.r.core.iterBlocks(Flags.FUEL):
                 self.assertGreater(b.p.kgHM, 0.0, "b.p.kgHM not populated!")
                 self.assertGreater(b.p.kgFis, 0.0, "b.p.kgFis not populated!")
 

--- a/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_fissionProductModel.py
@@ -72,7 +72,7 @@ class TestFissionProductModelLumpedFissionProducts(unittest.TestCase):
         # Set up the global LFPs and check that they are setup.
         self.assertTrue(fpModel._useGlobalLFPs)
         fpModel.interactBOL()
-        for b in r.core.getBlocks():
+        for b in r.core.iterBlocks():
             if b.isFuel():
                 self.assertTrue(b._lumpedFissionProducts is not None)
             else:
@@ -82,7 +82,7 @@ class TestFissionProductModelLumpedFissionProducts(unittest.TestCase):
         fpModel.allBlocksNeedAllNucs = False
         fpModel.interactBOL()
         allNucsInProblem = set(r.blueprints.allNuclidesInProblem)
-        for b in r.core.getBlocks():
+        for b in r.core.iterBlocks():
             if isDepletable(b):
                 if len(allNucsInProblem - set(b.getNuclides())) > 0:
                     break
@@ -193,7 +193,7 @@ class TestFissionProductModelExplicitMC2LibrarySlower(unittest.TestCase):
 
         # Check that the depletable blocks have all explicit
         # fission products in them.
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             nuclideList = b.getNuclides()
             if isDepletable(b):
                 for nb in nuclideBases.byMcc3Id.values():

--- a/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
+++ b/armi/physics/neutronics/fissionProductModel/tests/test_lumpedFissionProduct.py
@@ -171,9 +171,7 @@ class TestLumpedFissionProductCollection(unittest.TestCase):
 
     def test_getNumberDensities(self):
         o = buildOperatorOfEmptyHexBlocks()
-        assems = o.r.core.getAssemblies(Flags.FUEL)
-        blocks = assems[0].getBlocks(Flags.FUEL)
-        b = blocks[0]
+        b = next(o.r.core.iterBlocks(Flags.FUEL))
         fpDensities = self.lfps.getNumberDensities(objectWithParentDensities=b)
         for fp in ["GE73", "GE74", "GE76", "AS75", "KR85", "MO99", "SM150", "XE135"]:
             self.assertEqual(fpDensities[fp], 0.0)

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -82,7 +82,7 @@ class GlobalFluxInterface(interfaces.Interface):
         self.r.core.p.dpaFullWidthHalfMax = 0.0
         self.r.core.p.elevationOfACLP3Cycles = 0.0
         self.r.core.p.elevationOfACLP7Cycles = 0.0
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             b.p.detailedDpaThisCycle = 0.0
             b.p.newDPA = 0.0
 
@@ -681,7 +681,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
 
     def clearFlux(self):
         """Delete flux on all blocks. Needed to prevent stale flux when partially reloading."""
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             b.p.mgFlux = []
             b.p.adjMgFlux = []
             b.p.mgFluxGamma = []
@@ -704,7 +704,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
         # update the block power param here as well so
         # the ratio/multiplications below are consistent
         currentCorePower = 0.0
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             # The multi-group flux is volume integrated, so J/cm * n-cm/s gives units of Watts
             b.p.power = np.dot(
                 b.getTotalEnergyGenerationConstants(), b.getIntegratedMgFlux()
@@ -720,7 +720,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
                 self.r.core, powerRatio, currentCorePower, renormalizationCorePower
             )
         )
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             b.p.mgFlux *= powerRatio
             b.p.flux *= powerRatio
             b.p.fluxPeak *= powerRatio
@@ -816,7 +816,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
         updateFluenceAndDpa : uses values computed here to update cumulative dpa
         """
         if blockList is None:
-            blockList = self.r.core.getBlocks()
+            blockList = self.r.core.iterBlocks()
 
         hasDPA = False
         for b in blockList:

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -449,6 +449,6 @@ class TestGlobalFluxUtils(unittest.TestCase):
 
 def applyDummyFlux(r, ng=33):
     """Set arbitrary flux distribution on a Reactor."""
-    for b in r.core.getBlocks():
+    for b in r.core.iterBlocks():
         b.p.power = 1.0
         b.p.mgFlux = np.arange(ng, dtype=np.float64)

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -52,7 +52,7 @@ def setBlockNeutronVelocities(r, neutronVelocities):
     ValueError
         Multi-group neutron velocities was not computed during the cross section calculation.
     """
-    for b in r.core.getBlocks():
+    for b in r.core.iterBlocks():
         xsID = b.getMicroSuffix()
         if xsID not in neutronVelocities:
             raise ValueError(

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -73,7 +73,7 @@ class TestLatticePhysicsWriter(unittest.TestCase):
         d = defaultdict(float)
         d["AA"] = 10.0
         setBlockNeutronVelocities(self.r, d)
-        tot = sum([b.p.mgNeutronVelocity for b in self.r.core.getBlocks()])
+        tot = sum([b.p.mgNeutronVelocity for b in self.r.core.iterBlocks()])
         self.assertGreater(tot, 3000.0)
 
     def test_latticePhysicsWriter(self):

--- a/armi/physics/neutronics/tests/test_macroXSGenerationInterface.py
+++ b/armi/physics/neutronics/tests/test_macroXSGenerationInterface.py
@@ -39,7 +39,7 @@ class TestMacroXSGenerationInterface(unittest.TestCase):
         )
 
         # Before: verify there are no macro XS on each block
-        for b in r.core.getBlocks():
+        for b in r.core.iterBlocks():
             self.assertIsNone(b.macros)
 
         # create the macro XS interface
@@ -59,6 +59,6 @@ class TestMacroXSGenerationInterface(unittest.TestCase):
         self.assertEqual(i.macrosLastBuiltAt, 0)
 
         # After: verify there are macro XS on each block
-        for b in r.core.getBlocks():
+        for b in r.core.iterBlocks():
             self.assertIsNotNone(b.macros)
             self.assertTrue(isinstance(b.macros, XSCollection))

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -219,7 +219,7 @@ class Assembly(composites.Composite):
         if scalingFactor == 1:
             return
 
-        volIntegratedParamsToScale = self.getBlocks()[0].p.paramDefs.atLocation(
+        volIntegratedParamsToScale = self[0].p.paramDefs.atLocation(
             ParamLocation.VOLUME_INTEGRATED
         )
         for b in self:

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -222,7 +222,7 @@ class Assembly(composites.Composite):
         volIntegratedParamsToScale = self.getBlocks()[0].p.paramDefs.atLocation(
             ParamLocation.VOLUME_INTEGRATED
         )
-        for b in self.getBlocks():
+        for b in self:
             for param in volIntegratedParamsToScale:
                 name = param.name
                 if b.p[name] is None or isinstance(b.p[name], str):

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -784,7 +784,32 @@ class Assembly(composites.Composite):
         with open(fName, "w") as pkl:
             pickle.dump(self, pkl)
 
-    def getBlocks(self, typeSpec=None, exact=False) -> list[blocks.Block]:
+    def iterBlocks(self, typeSpec=None, exact=False):
+        """Produce an iterator over all blocks in this assembly from bottom to top.
+
+        Parameters
+        ----------
+        typeSpec : Flags or list of Flags, optional
+            Restrict returned blocks to have these flags.
+        exact : bool, optional
+            If true, only produce blocks that have those exact flags.
+
+        Returns
+        -------
+        iterable of Block
+
+        See also
+        --------
+        * :meth:`__iter__` - if no type spec provided, assemblies can be
+          naturally iterated upon.
+        * :meth:`iterChildrenWithFlags` - alternative if you know you have
+           a type spec that isn't ``None``.
+        """
+        if typeSpec is None:
+            return iter(self)
+        return self.iterChildrenWithFlags(typeSpec, exact)
+
+    def getBlocks(self, typeSpec=None, exact=False):
         """
         Get blocks in an assembly from bottom to top.
 
@@ -800,11 +825,7 @@ class Assembly(composites.Composite):
         blocks : list
             List of blocks.
         """
-        if typeSpec is None:
-            items = iter(self)
-        else:
-            items = self.iterChildrenWithFlags(typeSpec, exact)
-        return list(items)
+        return list(self.iterBlocks(typeSpec, exact))
 
     def getBlocksAndZ(self, typeSpec=None, returnBottomZ=False, returnTopZ=False):
         """
@@ -1174,11 +1195,7 @@ class Assembly(composites.Composite):
         blockCounter : int
             number of blocks of this type
         """
-        if blockTypeSpec is None:
-            items = iter(self)
-        else:
-            items = self.iterChildrenWithFlags(blockTypeSpec)
-        return sum(1 for _ in items)
+        return sum(1 for _ in self.iterBlocks(blockTypeSpec))
 
     def getDim(self, typeSpec, dimName):
         """

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -798,7 +798,7 @@ class Assembly(composites.Composite):
         -------
         iterable of Block
 
-        See also
+        See Also
         --------
         * :meth:`__iter__` - if no type spec provided, assemblies can be
           naturally iterated upon.

--- a/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
@@ -291,8 +291,8 @@ class AxialExpansionChanger:
         - If false, the top most block in the assembly is artificially chopped
           to preserve the assembly height. A runLog.Warning also issued.
         """
-        blkLst = self.linked.a.getBlocks()
-        if not blkLst[-1].hasFlags(Flags.DUMMY):
+        top = self.linked.a[-1]
+        if not top.hasFlags(Flags.DUMMY):
             runLog.warning(
                 f"No dummy block present at the top of {self.linked.a}! "
                 "Top most block will be artificially chopped "

--- a/armi/reactor/converters/geometryConverters.py
+++ b/armi/reactor/converters/geometryConverters.py
@@ -1163,7 +1163,7 @@ class HexToRZThetaConverter(GeometryConverter):
     def _getBlockAtMeshPoint(
         self, innerTheta, outerTheta, innerRadius, outerRadius, innerAxial, outerAxial
     ):
-        for b in self.convReactor.core.getBlocks():
+        for b in self.convReactor.core.iterBlocks():
             blockMidTh, blockMidR, blockMidZ = b.spatialLocator.getGlobalCoordinates(
                 nativeCoords=True
             )

--- a/armi/reactor/converters/meshConverters.py
+++ b/armi/reactor/converters/meshConverters.py
@@ -275,7 +275,7 @@ class _RZThetaReactorMeshConverterByAxialFlags(RZThetaReactorMeshConverter):
             blockFlags = set([(b.p.flags, b.getMicroSuffix()) for b in a])
             for flags, xsID in blockFlags:
                 meshes = []
-                for b in a.getBlocks(flags):
+                for b in a.iterBlocks(flags):
                     # Skip this block if it has a different XS ID than the
                     # current target.
                     if b.getMicroSuffix() != xsID:

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -213,7 +213,7 @@ class TestHexToRZConverter(unittest.TestCase):
         return expectedMassDict, expectedNuclideList
 
     def _checkBlockComponents(self, newR):
-        for b in newR.core.getBlocks():
+        for b in newR.core.iterBlocks():
             if len(b) != 1:
                 raise ValueError(
                     "Block {} has {} components and should only have 1".format(
@@ -315,7 +315,7 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
             self.assertTrue(numAssemsWithEdgeAssem, len(self.r.core.getAssemblies()))
 
         # must be added after geom transform
-        for b in self.o.r.core.getBlocks():
+        for b in self.o.r.core.iterBlocks():
             b.p.power = 1.0
         converter.scaleParamsRelatedToSymmetry(self.r.core)
         a = self.r.core.getAssembliesOnSymmetryLine(grids.BOUNDARY_0_DEGREES)[0]

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -84,7 +84,7 @@ class TestAssemblyUniformMesh(unittest.TestCase):
         )
 
         prevB = None
-        for newB, sourceB in zip(newAssem.getBlocks(), sourceAssem.getBlocks()):
+        for newB, sourceB in zip(newAssem, sourceAssem):
             if newB.isFuel() and sourceB.isFuel():
                 self.assertEqual(newB.p["xsType"], sourceB.p["xsType"])
             elif not newB.isFuel() and not sourceB.isFuel():

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -449,7 +449,7 @@ class TestUniformMesh(unittest.TestCase):
         applyNonUniformHeightDistribution(self.r)  # note: this perturbs the ref mass
 
         self.converter.convert(self.r)
-        for ib, b in enumerate(self.converter.convReactor.core.getBlocks()):
+        for ib, b in enumerate(self.converter.convReactor.core.iterBlocks()):
             b.p.mgFlux = list(range(1, 34))
             b.p.adjMgFlux = list(range(1, 34))
             b.p.fastFlux = 2.0
@@ -471,7 +471,7 @@ class TestUniformMesh(unittest.TestCase):
 
         self.converter.applyStateToOriginal()
 
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             self.assertAlmostEqual(b.p.fastFlux, 2.0)
             self.assertAlmostEqual(b.p.flux, 5.0)
             self.assertAlmostEqual(b.p.pdens, 0.5)
@@ -573,7 +573,7 @@ class TestGammaUniformMesh(unittest.TestCase):
         applyNonUniformHeightDistribution(self.r)  # note: this perturbs the ref. mass
 
         # set original parameters on pre-mapped core with non-uniform assemblies
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             b.p.mgFlux = list(range(33))
             b.p.adjMgFlux = list(range(33))
             b.p.fastFlux = 2.0
@@ -583,7 +583,7 @@ class TestGammaUniformMesh(unittest.TestCase):
 
         # set new parameters on core with uniform assemblies (emulate a physics kernel)
         self.converter.convert(self.r)
-        for b in self.converter.convReactor.core.getBlocks():
+        for b in self.converter.convReactor.core.iterBlocks():
             b.p.powerGamma = 0.5
             b.p.powerNeutron = 0.5
             b.p.linPow = 10.0
@@ -605,7 +605,7 @@ class TestGammaUniformMesh(unittest.TestCase):
 
         self.converter.applyStateToOriginal()
 
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             # equal to original value because these were never mapped
             self.assertEqual(b.p.fastFlux, 2.0)
             self.assertEqual(b.p.flux, 5.0)

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -940,7 +940,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         blocks = []
         for a in assems:
-            blocks.extend(a.getBlocks())
+            blocks.extend(a)
         firstBlock = blocks[0]
         for paramName in blockParamNames:
             defaultValue = firstBlock.p.pDefs[paramName].default

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -1120,7 +1120,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         Iterate over list of blocks with the given XS type; calculate reaction rates for these blocks
         """
         xsTypeGroups = collections.defaultdict(list)
-        for b in core.getBlocks():
+        for b in core.iterBlocks():
             xsTypeGroups[b.getMicroSuffix()].append(b)
 
         for xsID, blockList in xsTypeGroups.items():

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -23,7 +23,7 @@ import copy
 import itertools
 import os
 import time
-from typing import Optional, Callable, Iterator
+from typing import Callable, Iterator, Optional
 
 import numpy as np
 

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -2027,7 +2027,7 @@ class Core(composites.Composite):
         fluxFraction = 0
         targetRing = numRings
 
-        allFuelBlocks = list(self.getBlocks(Flags.FUEL))
+        allFuelBlocks = self.getBlocks(Flags.FUEL)
 
         # loop there all of the rings
         for ringNumber in range(numRings, 0, -1):
@@ -2036,7 +2036,7 @@ class Core(composites.Composite):
             blocksInRing = list(
                 itertools.chain(
                     *[
-                        a.getBlocks(Flags.FUEL)
+                        a.iterBlocks(Flags.FUEL)
                         for a in self.getAssembliesInRing(ringNumber)
                     ]
                 )

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -1108,7 +1108,7 @@ class Core(composites.Composite):
             assemblies will be returned as well as the ones in the reactor.
 
         kwargs : dict
-            Any keyword argument from R.getAssemblies()
+            Any keyword argument from :meth:`getAssemblies`
 
         Returns
         -------

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -30,6 +30,8 @@ import numpy as np
 from armi import getPluginManagerOrFail, nuclearDataIO, runLog
 from armi.nuclearDataIO import xsLibraries
 from armi.reactor import (
+    assemblies,
+    blocks,
     composites,
     geometry,
     grids,
@@ -705,7 +707,7 @@ class Core(composites.Composite):
         exactType=False,
         exclusions=None,
         overrideCircularRingMode=False,
-    ):
+    ) -> list[assemblies.Assembly]:
         """
         Returns the assemblies in a specified ring. Definitions of rings can change
         with problem parameters.
@@ -771,7 +773,7 @@ class Core(composites.Composite):
 
     def getAssembliesInSquareOrHexRing(
         self, ring, typeSpec=None, exactType=False, exclusions=None
-    ):
+    ) -> list[assemblies.Assembly]:
         """
         Returns the assemblies in a specified ring. Definitions of rings can change with problem
         parameters.
@@ -819,7 +821,7 @@ class Core(composites.Composite):
 
     def getAssembliesInCircularRing(
         self, ring, typeSpec=None, exactType=False, exclusions=None
-    ):
+    ) -> list[assemblies.Assembly]:
         """
         Gets an assemblies within a circular range of the center of the core. This function allows
         for more circular styled assembly shuffling instead of the current hex approach.
@@ -926,7 +928,7 @@ class Core(composites.Composite):
 
             assymap[aName] = assem
 
-    def getAssemblyByName(self, name):
+    def getAssemblyByName(self, name: str) -> assemblies.Assembly:
         """
         Find the assembly that has this name.
 
@@ -962,7 +964,7 @@ class Core(composites.Composite):
         includeAll=False,
         zones=None,
         exact=False,
-    ):
+    ) -> list[assemblies.Assembly]:
         """
         Return a list of all the assemblies in the reactor.
 
@@ -1044,7 +1046,7 @@ class Core(composites.Composite):
         )
         return {nozzleType: i for i, nozzleType in enumerate(sorted(nozzleList))}
 
-    def getBlockByName(self, name):
+    def getBlockByName(self, name: str) -> blocks.Block:
         """
         Finds a block based on its name.
 
@@ -1067,7 +1069,7 @@ class Core(composites.Composite):
             self._genBlocksByName()
             return self.blocksByName[name]
 
-    def getBlocksByIndices(self, indices):
+    def getBlocksByIndices(self, indices) -> list[blocks.Block]:
         """Get blocks in assemblies by block indices."""
         blocks = []
         for i, j, k in indices:
@@ -1090,7 +1092,7 @@ class Core(composites.Composite):
             block.getLocation(): block for block in self.getBlocks(includeAll=True)
         }
 
-    def getBlocks(self, bType=None, **kwargs):
+    def getBlocks(self, bType=None, **kwargs) -> list[blocks.Block]:
         """
         Returns an iterator over all blocks in the reactor in order.
 
@@ -1114,14 +1116,15 @@ class Core(composites.Composite):
 
         See Also
         --------
-        getAssemblies : locates the assemblies in the search
+        * :meth:`traverseBlocks`: iterator over blocks with limited filtering.
+        * :meth:`getAssemblies` : locates the assemblies in the search
         """
         blocks = [b for a in self.getAssemblies(**kwargs) for b in a]
         if bType:
             blocks = [b for b in blocks if b.hasFlags(bType)]
         return blocks
 
-    def getFirstBlock(self, blockType=None, exact=False):
+    def getFirstBlock(self, blockType=None, exact=False) -> blocks.Block:
         """
         Return the first block of the requested type in the reactor, or return first block.
         exact=True will only match fuel, not testfuel, for example.
@@ -1145,7 +1148,7 @@ class Core(composites.Composite):
 
         return None
 
-    def getFirstAssembly(self, typeSpec=None, exact=False):
+    def getFirstAssembly(self, typeSpec=None, exact=False) -> assemblies.Assembly:
         """
         Gets the first assembly in the reactor.
 

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -274,12 +274,13 @@ class Core(composites.Composite):
         fissileMass = 0.0
         heavyMetalMass = 0.0
         totalVolume = 0.0
-        numBlocks = len(self.getBlocks())
-        for block in self.getBlocks():
+        numBlocks = 0
+        for block in self.iterBlocks():
             totalMass += block.getMass()
             fissileMass += block.getFissileMass()
             heavyMetalMass += block.getHMMass()
             totalVolume += block.getVolume()
+            numBlocks += 1
         totalMass = totalMass * self.powerMultiplier / 1000.0
         fissileMass = fissileMass * self.powerMultiplier / 1000.0
         heavyMetalMass = heavyMetalMass * self.powerMultiplier / 1000.0
@@ -313,7 +314,7 @@ class Core(composites.Composite):
 
     def setBlockMassParams(self):
         """Set the parameters kgHM and kgFis for each block and calculate Pu fraction."""
-        for b in self.getBlocks():
+        for b in self.iterBlocks():
             b.p.kgHM = b.getHMMass() / units.G_PER_KG
             b.p.kgFis = b.getFissileMass() / units.G_PER_KG
             b.p.puFrac = (
@@ -1187,7 +1188,7 @@ class Core(composites.Composite):
 
     def getAllXsSuffixes(self):
         """Return all XS suffices (e.g. AA, AB, etc.) in the core."""
-        return sorted(set(b.getMicroSuffix() for b in self.getBlocks()))
+        return sorted(set(b.getMicroSuffix() for b in self.iterBlocks()))
 
     def getNuclideCategories(self):
         """
@@ -1370,11 +1371,10 @@ class Core(composites.Composite):
             The values you requested. length is NxG.
         """
         flux = []
-        blocks = list(self.getBlocks())
         groups = range(self.lib.numGroups)
 
         # build in order 0
-        for b in blocks:
+        for b in self.iterBlocks():
             if adjoint:
                 vals = b.p.adjMgFlux
             elif extSrc:
@@ -1739,10 +1739,9 @@ class Core(composites.Composite):
 
     def saveAllFlux(self, fName="allFlux.txt"):
         """Dump all flux to file for debugging purposes."""
-        blocks = list(self.getBlocks())
         groups = range(self.lib.numGroups)
         with open(fName, "w") as f:
-            for block in blocks:
+            for block in self.iterBlocks():
                 for gi in groups:
                     f.write(
                         "{:10s} {:10d} {:12.5E} {:12.5E} {:12.5E}\n"
@@ -2003,7 +2002,7 @@ class Core(composites.Composite):
 
     def getMaxNumPins(self):
         """Find max number of pins of any block in the reactor."""
-        return max(b.getNumPins() for b in self.getBlocks())
+        return max(b.getNumPins() for b in self.iterBlocks())
 
     def getMinimumPercentFluxInFuel(self, target=0.005):
         """
@@ -2087,7 +2086,7 @@ class Core(composites.Composite):
         num = 0.0
         denom = 0.0
         if not blockList:
-            blockList = list(self.getBlocks())
+            blockList = self.getBlocks()
 
         for b in blockList:
             if flux2Weight:
@@ -2123,7 +2122,7 @@ class Core(composites.Composite):
 
     def setPitchUniform(self, pitchInCm):
         """Set the pitch in all blocks."""
-        for b in self.getBlocks():
+        for b in self.iterBlocks():
             b.setPitch(pitchInCm)
 
         # have to update the 2-D reactor mesh too.
@@ -2217,7 +2216,7 @@ class Core(composites.Composite):
             "=========== Initializing Mesh, Assembly Zones, and Nuclide Categories =========== "
         )
 
-        for b in self.getBlocks():
+        for b in self.iterBlocks():
             if b.p.molesHmBOL > 0.0:
                 break
         else:

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -353,7 +353,7 @@ class Assembly_TestCase(unittest.TestCase):
             "adjMgFlux": [1, 2, 3],  # Should normally be an ndarray, list for testing
             "lastMgFlux": "foo",  # Should normally be an ndarray, str for testing
         }
-        for b in self.assembly.getBlocks(Flags.FUEL):
+        for b in self.assembly.iterBlocks(Flags.FUEL):
             b.p.update(blockParams)
 
         i, j = grids.HexGrid.getIndicesFromRingAndPos(1, 1)
@@ -361,7 +361,7 @@ class Assembly_TestCase(unittest.TestCase):
         self.assertEqual(self.assembly.getSymmetryFactor(), 1)
         self.assembly.moveTo(locator)
         self.assertEqual(self.assembly.getSymmetryFactor(), 3)
-        for b in self.assembly.getBlocks(Flags.FUEL):
+        for b in self.assembly.iterBlocks(Flags.FUEL):
             # float
             assert_allclose(b.p["massHmBOL"] / blockParams["massHmBOL"], 1 / 3)
             # np.ndarray
@@ -496,7 +496,7 @@ class Assembly_TestCase(unittest.TestCase):
         mass1 = sum(bi.getMass("U235") for bi in self.assembly)
         self.assertAlmostEqual(mass0, mass1)
 
-        fuelBlock = self.assembly.getBlocks(Flags.FUEL)[0]
+        fuelBlock = next(self.assembly.iterBlocks(Flags.FUEL))
         blockU35Mass = fuelBlock.getMass("U235")
         fuelBlock.setMass("U235", 2 * blockU35Mass)
         self.assertAlmostEqual(fuelBlock.getMass("U235"), blockU35Mass * 2)

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1096,7 +1096,7 @@ class Assembly_TestCase(unittest.TestCase):
             :tests: R_ARMI_ASSEM_BLOCKS
         """
         coords = []
-        for b in self.assembly.getBlocks():
+        for b in self.assembly.iterBlocks():
             # Confirm children are blocks
             self.assertIsInstance(b, blocks.Block)
 

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -799,7 +799,7 @@ class Assembly_TestCase(unittest.TestCase):
     def test_reattach(self):
         # Remake original assembly
         self.assembly = makeTestAssembly(self.assemNum, self.assemNum)
-        self.assertEqual(0, len(self.assembly.getBlocks()))
+        self.assertEqual(0, len(self.assembly))
 
         # add some blocks with a component
         for i in range(self.assemNum):
@@ -827,8 +827,8 @@ class Assembly_TestCase(unittest.TestCase):
 
             self.assembly.add(b)
 
-        self.assertEqual(self.assemNum, len(self.assembly.getBlocks()))
-        for b in self.assembly.getBlocks():
+        self.assertEqual(self.assemNum, len(self.assembly))
+        for b in self.assembly:
             self.assertEqual("fuel", b.getType())
 
     def test_reestablishBlockOrder(self):
@@ -1035,24 +1035,25 @@ class Assembly_TestCase(unittest.TestCase):
         a.add(b)
         a.rotate(math.radians(120))
         # test list rotation
-        self.assertEqual(a.getBlocks()[0].p.THcornTemp, rotTemp)
-        self.assertAlmostEqual(a.getBlocks()[0].p.displacementX, rotX)
-        self.assertAlmostEqual(a.getBlocks()[0].p.displacementY, rotY)
+        b = a[0]
+        self.assertEqual(b.p.THcornTemp, rotTemp)
+        self.assertAlmostEqual(b.p.displacementX, rotX)
+        self.assertAlmostEqual(b.p.displacementY, rotY)
 
         b.p.THcornTemp = np.array([400, 450, 500, 550, 600, 650])
         rotTemp = np.array([600, 650, 400, 450, 500, 550])
         a.rotate(math.radians(120))
         # test np.ndarray rotation
         for i in range(len(b.p.THcornTemp)):
-            self.assertEqual(a.getBlocks()[0].p.THcornTemp[i], rotTemp[i])
+            self.assertEqual(b.p.THcornTemp[i], rotTemp[i])
 
         # test that floats and ints are left alone
         b.p.THcornTemp = 3
         a.rotate(math.radians(120))
-        self.assertEqual(a.getBlocks()[0].p.THcornTemp, 3)
+        self.assertEqual(b.p.THcornTemp, 3)
         b.p.THcornTemp = 4.0
         a.rotate(math.radians(120))
-        self.assertEqual(a.getBlocks()[0].p.THcornTemp, 4.0)
+        self.assertEqual(b.p.THcornTemp, 4.0)
 
         # check that TypeError is raised for unexpected data type
         b.p.THcornTemp = "bad data"
@@ -1112,7 +1113,7 @@ class Assembly_TestCase(unittest.TestCase):
 
     def test_assem_hex_type(self):
         """Test that all children of a hex assembly are hexagons."""
-        for b in self.assembly.getBlocks():
+        for b in self.assembly:
 
             # For a hex assem, confirm they are of type "Hexagon"
             pitch_comp_type = b.PITCH_COMPONENT_TYPE[0]
@@ -1146,7 +1147,7 @@ class AssemblyInReactor_TestCase(unittest.TestCase):
 
         igniterFuel = self.r.core.childrenByLocator[grid[0, 0, 0]]
         # gridplate, fuel, fuel, fuel, plenum
-        for b in igniterFuel.getBlocks(Flags.FUEL):
+        for b in igniterFuel.iterBlocks(Flags.FUEL):
             fuelComp = b.getComponent(Flags.FUEL)
             # add isotopes from clad and coolant to fuel component to test mass conservation
             # mass should only be conserved within fuel component, not over the whole block

--- a/armi/reactor/tests/test_cores.py
+++ b/armi/reactor/tests/test_cores.py
@@ -78,3 +78,19 @@ class HexCoreTests(unittest.TestCase):
             actuals = self.core.getAssemblies(zones=fakeZones)
         for a in actuals:
             self.assertIn(a.getLocation(), locations, msg=str(a))
+
+    def test_getBlocks(self):
+        """Test the ability to get all blocks in the core."""
+        blocks = []
+        for a in self.core:
+            blocks.extend(a)
+        actual = self.core.getBlocks()
+        self.assertAllIs(actual, blocks)
+
+    def test_getBlocksWithFlag(self):
+        """Test the ability to get all blocks with a flag in the core."""
+        blocks = []
+        for a in self.core:
+            blocks.extend(filter(lambda b: b.hasFlags(Flags.FUEL), a))
+        actual = self.core.getBlocks(Flags.FUEL)
+        self.assertAllIs(actual, blocks)

--- a/armi/reactor/tests/test_cores.py
+++ b/armi/reactor/tests/test_cores.py
@@ -1,0 +1,80 @@
+# Copyright 2024 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import itertools
+import random
+import typing
+import unittest
+from unittest import mock
+
+from armi.reactor.assemblies import HexAssembly
+from armi.reactor.cores import Core
+from armi.reactor.flags import Flags
+from armi.reactor.tests.test_reactors import loadTestReactor, TEST_ROOT
+from armi.utils import directoryChangers
+
+
+class HexCoreTests(unittest.TestCase):
+    """Tests on a hex reactor core."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.directoryChanger = directoryChangers.DirectoryChanger(TEST_ROOT)
+        cls.directoryChanger.open()
+        r = loadTestReactor(TEST_ROOT)[1]
+        cls.core: Core = r.core
+
+    def assertAllIs(
+        self,
+        actuals: typing.Iterable[typing.Any],
+        expecteds: typing.Iterable[typing.Any],
+        fill=None,
+    ):
+        """Assert that all items in two iterables are the same objects."""
+        for actual, expected in itertools.zip_longest(
+            actuals, expecteds, fillvalue=fill
+        ):
+            self.assertIs(actual, expected)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.directoryChanger.close()
+
+    def test_getAllAssem(self):
+        """Test the ability to produce all assemblies."""
+        expectedAll = list(self.core)
+        actualAll = self.core.getAssemblies()
+        self.assertAllIs(actualAll, expectedAll)
+
+    def test_getAllAssemWithFlag(self):
+        """Test the ability to produce assemblies with a flag."""
+        for spec in (Flags.FUEL, Flags.CONTROL):
+            expected = self.core.getChildrenWithFlags(spec)
+            actual = self.core.getAssemblies(typeSpec=spec)
+            for a in actual:
+                self.assertIsInstance(a, HexAssembly)
+                self.assertTrue(a.hasFlags(spec))
+            self.assertAllIs(actual, expected)
+
+    def test_getAssemsInZones(self):
+        """Test the ability to produce assemblies in a zone."""
+        # Grab a few assemblies and add their locations to those in the zones
+        selection = random.choices(self.core.getAssemblies(), k=5)
+        locations = [a.getLocation() for a in selection]
+        fakeZones = ["hot", "cold"]
+        with mock.patch.object(
+            self.core.zones, "getZoneLocations", mock.Mock(return_value=locations)
+        ):
+            actuals = self.core.getAssemblies(zones=fakeZones)
+        for a in actuals:
+            self.assertIn(a.getLocation(), locations, msg=str(a))

--- a/armi/reactor/tests/test_cores.py
+++ b/armi/reactor/tests/test_cores.py
@@ -21,7 +21,7 @@ from armi.reactor.assemblies import HexAssembly
 from armi.reactor.blocks import Block
 from armi.reactor.cores import Core
 from armi.reactor.flags import Flags
-from armi.reactor.tests.test_reactors import loadTestReactor, TEST_ROOT
+from armi.reactor.tests.test_reactors import TEST_ROOT, loadTestReactor
 from armi.utils import directoryChangers
 
 

--- a/armi/reactor/tests/test_cores.py
+++ b/armi/reactor/tests/test_cores.py
@@ -1,4 +1,4 @@
-# Copyright 2024 TerraPower, LLC
+# Copyright 2025 TerraPower, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/armi/reactor/tests/test_cores.py
+++ b/armi/reactor/tests/test_cores.py
@@ -85,7 +85,7 @@ class HexCoreTests(unittest.TestCase):
         blocks = []
         for a in self.core:
             blocks.extend(a)
-        actual = self.core.getBlocks()
+        actual = self.core.iterBlocks()
         self.assertAllIs(actual, blocks)
 
     def test_getBlocksWithFlag(self):

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -264,7 +264,7 @@ class HexReactorTests(ReactorTests):
             self.assertNotIn(a.getNum(), aNums)
             aNums.append(a.getNum())
 
-        bNames = [b.getName() for b in self.r.core.getBlocks()]
+        bNames = [b.getName() for b in self.r.core.iterBlocks()]
         for bName in bNames:
             self.assertEqual(bNames.count(bName), 1)
         self.assertEqual(self.r.core.powerMultiplier, 1.0)
@@ -291,7 +291,7 @@ class HexReactorTests(ReactorTests):
 
     def test_setPitchUniform(self):
         self.r.core.setPitchUniform(0.0)
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             self.assertEqual(b.getPitch(), 0.0)
 
     def test_countBlocksOfType(self):
@@ -328,7 +328,7 @@ class HexReactorTests(ReactorTests):
 
     def test_setB10VolOnCreation(self):
         """Test the setting of b.p.initialB10ComponentVol."""
-        for controlBlock in self.r.core.getBlocks(Flags.CONTROL):
+        for controlBlock in self.r.core.iterBlocks(Flags.CONTROL):
             controlComps = [c for c in controlBlock if c.getNumberDensity("B10") > 0]
             self.assertEqual(len(controlComps), 1)
             controlComp = controlComps[0]
@@ -714,7 +714,7 @@ class HexReactorTests(ReactorTests):
             set(self.r.blueprints.elementsToExpand), set(r2.blueprints.elementsToExpand)
         )
 
-        for b2, b3 in zip(r2.core.getBlocks(), self.r.core.getBlocks()):
+        for b2, b3 in zip(r2.core.iterBlocks(), self.r.core.iterBlocks()):
             for element in self.r.blueprints.elementsToExpand:
                 # nucspec allows elemental mass to be computed
                 mass2 = b2.getMass(element.symbol)
@@ -742,7 +742,7 @@ class HexReactorTests(ReactorTests):
             :id: T_ARMI_R_SYMM
             :tests: R_ARMI_R_SYMM
         """
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             sym = b.getSymmetryFactor()
             i, j, _ = b.spatialLocator.getCompleteIndices()
             if i == 0 and j == 0:
@@ -764,7 +764,7 @@ class HexReactorTests(ReactorTests):
             numGroups = 5
 
         self.r.core.lib = MockLib()
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             b.p.mgFlux = range(5)
             b.p.adjMgFlux = range(5)
 
@@ -776,7 +776,7 @@ class HexReactorTests(ReactorTests):
             numGroups = 5
 
         self.r.core.lib = MockLib()
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             b.p.mgFlux = range(5)
             b.p.adjMgFlux = [i + 0.1 for i in range(5)]
             b.p.extSrc = [i + 0.2 for i in range(5)]
@@ -784,10 +784,11 @@ class HexReactorTests(ReactorTests):
         adjFlux = self.r.core.getFluxVector(adjoint=True)
         srcVec = self.r.core.getFluxVector(extSrc=True)
         fluxVol = self.r.core.getFluxVector(volumeIntegrated=True)
-        expFlux = [i for i in range(5) for b in self.r.core.getBlocks()]
-        expAdjFlux = [i + 0.1 for b in self.r.core.getBlocks() for i in range(5)]
-        expSrcVec = [i + 0.2 for b in self.r.core.getBlocks() for i in range(5)]
-        expFluxVol = list(range(5)) * len(self.r.core.getBlocks())
+        blocks = self.r.core.getBlocks()
+        expFlux = [i for i in range(5) for _ in blocks]
+        expAdjFlux = [i + 0.1 for _ in blocks for i in range(5)]
+        expSrcVec = [i + 0.2 for _ in blocks for i in range(5)]
+        expFluxVol = list(range(5)) * len(blocks)
         assert_allclose(expFlux, mgFlux)
         assert_allclose(expAdjFlux, adjFlux)
         assert_allclose(expSrcVec, srcVec)
@@ -831,7 +832,7 @@ class HexReactorTests(ReactorTests):
     def test_getMass(self):
         # If these are not in agreement check on block symmetry factor being applied to volumes
         mass1 = self.r.core.getMass()
-        mass2 = sum([b.getMass() for b in self.r.core.getBlocks()])
+        mass2 = sum([b.getMass() for b in self.r.core.iterBlocks()])
         assert_allclose(mass1, mass2)
 
     def test_isPickleable(self):
@@ -1047,7 +1048,7 @@ class HexReactorTests(ReactorTests):
 
     def test_pinCoordsAllBlocks(self):
         """Make sure all blocks can get pin coords."""
-        for b in self.r.core.getBlocks():
+        for b in self.r.core.iterBlocks():
             coords = b.getPinCoordinates()
             self.assertGreater(len(coords), -1)
 

--- a/armi/reactor/tests/test_rz_reactors.py
+++ b/armi/reactor/tests/test_rz_reactors.py
@@ -65,7 +65,7 @@ class TestRZTReactorModern(unittest.TestCase):
 
         reactorVolumes = []
         fuelVolumes = []
-        for b in r.core.getBlocks():
+        for b in r.core.iterBlocks():
             reactorVolumes.append(b.getVolume())
             for c in b:
                 if "godiva" in c.name:

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -416,7 +416,7 @@ def _getPhysicalVals(r):
     avgHeight = 0.0
     fuelA = r.core.getAssemblies(Flags.FUEL)
     avgHeight = sum(
-        b.getHeight() for a in fuelA for b in a.getBlocks(Flags.FUEL)
+        b.getHeight() for a in fuelA for b in a.iterBlocks(Flags.FUEL)
     ) / len(fuelA)
     radius = r.core.getCoreRadius()
 
@@ -439,7 +439,7 @@ def _getPhysicalVals(r):
 def _getFuelVals(r):
     tOverD = 0.0
     numClad = 0.0
-    for b in r.core.getBlocks(Flags.FUEL):
+    for b in r.core.iterBlocks(Flags.FUEL):
         clad = b.getComponent(Flags.CLAD)
         if clad:
             cladOD = clad.getDimension("od")

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -48,7 +48,7 @@ class TestPlotting(unittest.TestCase):
     def test_plotDepthMap(self):  # indirectly tests plot face map
         with TemporaryDirectoryChanger():
             # set some params to visualize
-            for i, b in enumerate(self.o.r.core.getBlocks()):
+            for i, b in enumerate(self.o.r.core.iterBlocks()):
                 b.p.percentBu = i / 100
             fName = plotting.plotBlockDepthMap(
                 self.r.core, param="percentBu", fName="depthMapPlot.png", depthIndex=2

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -87,21 +87,21 @@ class TestPlotting(unittest.TestCase):
             xslib = isotxs.readBinary(ISOAA_PATH)
             self.r.core.lib = xslib
 
-            blockList = self.r.core.getBlocks()
-            for _, b in enumerate(blockList):
+            blocks = self.r.core.getBlocks()
+            for b in blocks:
                 b.p.mgFlux = range(33)
 
-            plotting.plotBlockFlux(self.r.core, fName="flux.png", bList=blockList)
+            plotting.plotBlockFlux(self.r.core, fName="flux.png", bList=blocks)
             self.assertTrue(os.path.exists("flux.png"))
             plotting.plotBlockFlux(
-                self.r.core, fName="peak.png", bList=blockList, peak=True
+                self.r.core, fName="peak.png", bList=blocks, peak=True
             )
             self._checkFileExists("peak.png")
             plotting.plotBlockFlux(
                 self.r.core,
                 fName="bList2.png",
-                bList=blockList,
-                bList2=blockList,
+                bList=blocks,
+                bList2=blocks,
             )
             self._checkFileExists("bList2.png")
 


### PR DESCRIPTION
## What is the change? Why is it being made?

Introduce mechanisms for iterating over `Blocks` in the `Reactor` that do not involve making intermediate lists.

`Core.iterBlocks()` assumes you have a `Core` with `Assemblies` with `Blocks`. This is not limited to hex `Reactors` but may not work in all cases. 

It is not as powerful as `Core.getBlocks` because that:

1. Looks to the spent fuel pool,
2. Looks to assemblies that may not exist _right now_

Instead, it just finds all `Blocks` that are grandchildren of the `Core`.

- `Core.iterBlocks` supports filtering by flags and/or filtering with a conditional function. 

- `Assembly.iterBlocks` is really a shortcut for iterating over an `Assembly` with some filtering. You could just as easily do `Assembly.iterChildren` or `Assembly.iterChildrenWithFlags`. Both of those are sensible if we want to keep the API small and composable. But we have `Assembly.getBlocks` so this felt like a good idea. At the very least, some occurrences like `assembly.getBlocks()[0]` were changed to `assembly[0]`


## SCR Information

Change Type: features

One-Sentence Description: Adding Core.iterBlocks and Asssembly.iterBlocks for traversing grandchildren of a Core.

One-line Impact on Requirements: A trivial implementation change to switch from getBlocks to iterBlocks in the tests for T_ARMI_MACRO_XS, T_ARMI_UMC_PARAM_BACKWARD0, T_ARMI_UMC_PARAM_BACKWARD1, T_ARMI_ROTATE_HEX_ASSEM, T_ARMI_ASSEM_BLOCKS, T_ARMI_R_SYMM, and T_ARMI_ADD_EDGE_ASSEMS.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
