### PR TITLE
Handing empty string defaults better in copyInterfaceInputs

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -931,13 +931,16 @@ def copyInterfaceInputs(
             for f in files:
                 WILDCARD = False
                 RELATIVE = False
+                EMPTY = False
                 if "*" in f:
                     WILDCARD = True
                 if ".." in f:
                     RELATIVE = True
+                if not f:
+                    EMPTY = True
 
                 path = pathlib.Path(f)
-                if not WILDCARD and not RELATIVE:
+                if not WILDCARD and not RELATIVE and not EMPTY:
                     try:
                         if path.is_absolute() and path.exists():
                             # Path is absolute, no settings modification or filecopy needed

--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -930,27 +930,21 @@ def copyInterfaceInputs(
             newFiles = []
             for f in files:
                 WILDCARD = False
-                RELATIVE = False
                 EMPTY = False
+                ABSOLUTE = False
                 if "*" in f:
                     WILDCARD = True
-                if ".." in f:
-                    RELATIVE = True
                 if not f:
+                    # beware: pathlib.path("") returns "." which can be bad news, so we handle empty strings as
+                    # their own category
                     EMPTY = True
-
                 path = pathlib.Path(f)
-                if not WILDCARD and not RELATIVE and not EMPTY:
-                    try:
-                        if path.is_absolute() and path.exists():
-                            # Path is absolute, no settings modification or filecopy needed
-                            newFiles.append(path)
-                            continue
-                    except OSError:
-                        pass
+                if not EMPTY and path.is_absolute():
+                    ABSOLUTE = True
 
                 # Attempt to construct an absolute file path
                 sourceFullPath = os.path.join(sourceDirPath, f)
+                destFilePath = None
                 if WILDCARD:
                     globFilePaths = [
                         pathlib.Path(os.path.join(sourceDirPath, g))
@@ -965,7 +959,14 @@ def copyInterfaceInputs(
                                 label, gFile, destination, f
                             )
                             newFiles.append(str(destFilePath))
+                elif EMPTY:
+                    pass
+                elif ABSOLUTE:
+                    if path.exists():
+                        # Path is absolute, no settings modification or filecopy needed
+                        newFiles.append(path)
                 else:
+                    # treat as a relative path
                     destFilePath = _copyInputsHelper(
                         label, sourceFullPath, destination, f
                     )
@@ -979,7 +980,7 @@ def copyInterfaceInputs(
 
             # Some settings are a single filename. Others are lists of files. Make
             # sure we are returning what the setting expects
-            if isSetting:
+            if isSetting and len(newFiles):
                 if len(files) == 1 and not WILDCARD:
                     newSettings[label] = newFiles[0]
                 else:

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -641,7 +641,7 @@ class TestCopyInterfaceInputs(unittest.TestCase):
                 cs, destination=newDir.destination
             )
             with self.assertRaises(KeyError):
-                # shouldn't process this setting as anything to worry about
+                # shouldn't process this setting as anything to worry about, so it won't be added to the dict
                 _shuffleLogic = newSettings[testSetting]
 
     def test_failOnDuplicateSetting(self):

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -629,6 +629,21 @@ class TestCopyInterfaceInputs(unittest.TestCase):
             self.assertFalse(os.path.exists(newSettings[testSetting]))
             self.assertEqual(newSettings[testSetting], fakeShuffle)
 
+    def test_copyInterfaceInputs_emptyFilePath(self):
+        testSetting = CONF_SHUFFLE_LOGIC
+        cs = settings.Settings(ARMI_RUN_PATH)
+        fakeShuffle = ""
+        cs = cs.modified(newSettings={testSetting: fakeShuffle})
+
+        # ensure we are not in TEST_ROOT
+        with directoryChangers.TemporaryDirectoryChanger() as newDir:
+            newSettings = cases.case.copyInterfaceInputs(
+                cs, destination=newDir.destination
+            )
+            with self.assertRaises(KeyError):
+                # shouldn't process this setting as anything to worry about
+                _shuffleLogic = newSettings[testSetting]
+
     def test_failOnDuplicateSetting(self):
         """That that if a plugin attempts to add a duplicate setting, it raises an error."""
         # register the new Plugin


### PR DESCRIPTION
## What is the change? Why is it being made?

`copyInterfaceInputs` now handles the possibility that a file setting default could be an empty string. 

This scenario was not covered until this setting default was added downstream. The root of the issue is that `pathlib.Path("") = "."`. If that weren't the case, then I think this code would have just worked. Also, it seemed more robust to account for the absolute path scenario rather than relative path (which can include `..`, `.`, or nothing!) scenario. 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Adding logic to copyInterfaceInputs to properly handle a file setting default that is an empty string. 

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
