### PR TITLE
fix side effects from tests

### DIFF
--- a/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
+++ b/armi/bookkeeping/db/tests/test_passiveDBLoadPlugin.py
@@ -36,6 +36,10 @@ class TestPassiveDBLoadPlugin(unittest.TestCase):
         """
         self.app = getApp()
         self._backupApp = deepcopy(self.app)
+        self._cacheBPSections = PassiveDBLoadPlugin.SKIP_BP_SECTIONS
+        self._cacheUnkownParams = PassiveDBLoadPlugin.UNKNOWN_PARAMS
+        PassiveDBLoadPlugin.SKIP_BP_SECTIONS = []
+        PassiveDBLoadPlugin.UNKNOWN_PARAMS = {}
 
     def tearDown(self):
         """Restore the App to its original state."""
@@ -43,6 +47,8 @@ class TestPassiveDBLoadPlugin(unittest.TestCase):
 
         armi._app = self._backupApp
         context.APP_NAME = "armi"
+        PassiveDBLoadPlugin.SKIP_BP_SECTIONS = self._cacheBPSections
+        PassiveDBLoadPlugin.UNKNOWN_PARAMS = self._cacheUnkownParams
 
     def test_passiveDBLoadPlugin(self):
         plug = PassiveDBLoadPlugin()

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -133,15 +133,15 @@ class TestAddingOptions(unittest.TestCase):
     def setUp(self):
         self.dc = directoryChangers.TemporaryDirectoryChanger()
         self.dc.__enter__()
+        # load in the plugin with extra, added options
+        self.pm = getPluginManagerOrFail()
+        self.pm.register(PluginAddsOptions)
 
     def tearDown(self):
         self.dc.__exit__(None, None, None)
+        self.pm.unregister(PluginAddsOptions)
 
     def test_addingOptions(self):
-        # load in the plugin with extra, added options
-        pm = getPluginManagerOrFail()
-        pm.register(PluginAddsOptions)
-
         # modify the default/text settings YAML file to include neutronicsKernel
         fin = os.path.join(TEST_ROOT, "armiRun.yaml")
         txt = open(fin, "r").read()


### PR DESCRIPTION
## What is the change? Why is it being made?

Two armi tests have unintended side effects for other tests because they modify things about the App without putting things back to how they were after the test finishes. This PR adds some setUp/tearDown methods that cache the state before and after the test. 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Fix unintended unit test side effects.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
