### PR TITLE
Cleaning up the codeTiming reports

### DIFF
--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -106,7 +106,7 @@ class ReportInterface(interfaces.Interface):
 
     def interactEOC(self, cycle=None):
         reportingUtils.writeCycleSummary(self.r.core)
-        runLog.info(self.o.timer.report(inclusion_cutoff=0.001))
+        runLog.info(self.o.timer.report(inclusionCutoff=0.001))
 
     def generateDesignReport(self, generateFullCoreMap, showBlockAxMesh):
         reportingUtils.makeCoreDesignReport(self.r.core, self.cs)
@@ -134,16 +134,14 @@ class ReportInterface(interfaces.Interface):
         reportingUtils.setNeutronBalancesReport(self.r.core)
         self.writeRunSummary()
         self.o.timer.stopAll()  # consider the run done
-        runLog.info(self.o.timer.report(inclusion_cutoff=0.001, total_time=True))
+        runLog.info(self.o.timer.report(inclusionCutoff=0.001, totalTime=True))
         _timelinePlot = self.o.timer.timeline(
-            self.cs.caseTitle, self.cs["timelineInclusionCutoff"], total_time=True
+            self.cs.caseTitle, self.cs["timelineInclusionCutoff"], totalTime=True
         )
         runLog.info(self.printReports())
 
-    # --------------------------------------------
-    #        Report Interface Specific
-    # --------------------------------------------
     def printReports(self):
+        """Report Interface Specific."""
         str_ = ""
         for report_ in self.reports:
             str_ += re.sub("\n", "\n\t", "{}".format(report_))
@@ -154,9 +152,6 @@ class ReportInterface(interfaces.Interface):
             + "\n----------- REPORTS END -----------"
         )
 
-    # --------------------------------------------
-    #        Ex-Core Summaries
-    # --------------------------------------------
     def writeRunSummary(self):
         """Make a summary of the run."""
         # spent fuel pool report

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -156,7 +156,7 @@ class Operator:
         self.r = None
         self.cs = cs
         runLog.LOG.startLog(self.cs.caseTitle)
-        self.timer = codeTiming.getMasterTimer()
+        self.timer = codeTiming.MasterTimer.getMasterTimer()
         self.interfaces = []
         self.restartData = []
         self.loadedRestartData = []

--- a/armi/utils/codeTiming.py
+++ b/armi/utils/codeTiming.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utilities related to profiling code."""
-
 import copy
 import functools
 import os
@@ -25,7 +24,7 @@ def timed(*args):
 
     Examples
     --------
-    ::
+    Here are some examples of using this method::
 
         @timed # your timer will be called the module+method name
         def mymethod(stuff):
@@ -63,24 +62,17 @@ def timed(*args):
         return time_decorator
     else:
         raise ValueError(
-            "The timed decorator has been misused. Input args were {}".format(args)
+            f"The timed decorator has been misused. Input args were {args}"
         )
 
 
-def getMasterTimer():
-    """Duplicate function to the MasterTimer.getMasterTimer method.
-
-    Provided for convenience and developer preference of which to use
-    """
-    return MasterTimer.getMasterTimer()
-
-
 class MasterTimer:
+    """A code timing interface, this class is designed to be a singleton."""
 
     _instance = None
 
     def __init__(self):
-        if MasterTimer._instance:
+        if MasterTimer._instance is not None:
             raise RuntimeError(
                 "{} is a pseudo singleton, do not attempt to make more than one.".format(
                     self.__class__.__name__
@@ -89,58 +81,62 @@ class MasterTimer:
         MasterTimer._instance = self
 
         self.timers = {}
-
         self.start_time = time.time()
         self.end_time = None
 
     @staticmethod
     def getMasterTimer():
-        if not MasterTimer._instance:
+        """Primary method that users need get access to the MasterTimer singleton."""
+        if MasterTimer._instance is None:
             MasterTimer()
+
         return MasterTimer._instance
 
     @staticmethod
-    def getTimer(event_name):
+    def getTimer(eventName):
         """Return a timer with no special action take.
 
         ``with timer: ...`` friendly!
         """
         master = MasterTimer.getMasterTimer()
 
-        if event_name in master.timers:
-            timer = master.timers[event_name]
+        if eventName in master.timers:
+            timer = master.timers[eventName]
         else:
-            timer = _Timer(event_name, False)
+            timer = _Timer(eventName, False)
+            master.timers[eventName] = timer
         return timer
 
     @staticmethod
-    def startTimer(event_name):
+    def startTimer(eventName):
         """Return a timer with a start call, or a newly made started timer.
 
         ``with timer: ...`` unfriendly!
         """
         master = MasterTimer.getMasterTimer()
 
-        if event_name in master.timers:
-            timer = master.timers[event_name]
+        if eventName in master.timers:
+            timer = master.timers[eventName]
             timer.start()
         else:
-            timer = _Timer(event_name, True)
+            timer = _Timer(eventName, True)
+            master.timers[eventName] = timer
         return timer
 
     @staticmethod
-    def endTimer(event_name):
+    def endTimer(eventName):
         """Return a timer with a stop call, or a newly made unstarted timer.
 
         ``with timer: ...`` unfriendly!
         """
         master = MasterTimer.getMasterTimer()
 
-        if event_name in master.timers:
-            timer = master.timers[event_name]
+        if eventName in master.timers:
+            timer = master.timers[eventName]
             timer.stop()
         else:
-            timer = _Timer(event_name, False)
+            timer = _Timer(eventName, False)
+            master.timers[eventName] = timer
         return timer
 
     @staticmethod
@@ -167,7 +163,7 @@ class MasterTimer:
         master = MasterTimer.getMasterTimer()
 
         for timer in master.timers.values():
-            timer.over_start = 0  # deal with what recursion may have caused
+            timer.overStart = 0  # deal with what recursion may have caused
             timer.stop()
 
         _Timer._frozen = True
@@ -176,109 +172,112 @@ class MasterTimer:
 
     @staticmethod
     def getActiveTimers():
+        """Get all the timers for processes that are still active."""
         master = MasterTimer.getMasterTimer()
 
         return [t for t in master.timers.values() if t.isActive]
 
     @staticmethod
-    def report(inclusion_cutoff=0.1, total_time=False):
+    def report(inclusionCutoff=0.1, totalTime=False):
         """
         Write a string report of the timers.
 
         Parameters
         ----------
-        inclusion_cutoff : float, optional
+        inclusionCutoff : float, optional
             Will not show results that have less than this fraction of the total time.
-        total_time : bool, optional
-            Use either the ratio of total time or time since last report for consideration against
-            the cutoff
+        totalTime : bool, optional
+            Use the ratio of total time or time since last report to compare against the cutoff.
 
         See Also
         --------
         armi.utils.codeTiming._Timer.__str__ : prints out the results for each individual line item
+
+        Returns
+        -------
+        str : Plain-text table report on the timers.
         """
         master = MasterTimer.getMasterTimer()
 
         table = [
-            "{:60s} {:^20} {:^20} {:^20} {:^8} {}\t".format(
+            "{:60s} {:^20} {:^20} {:^8}\t".format(
                 "TIMER REPORTS",
-                "SINCE LAST (s)",
                 "CUMULATIVE (s)",
                 "AVERAGE (s)",
-                "PAUSES",
-                "ACTIVE",
+                "NUM ITERS",
             )
         ]
 
         for timer in sorted(master.timers.values(), key=lambda x: x.time):
-            if total_time:
-                time_ratio = timer.time / master.time()
+            if totalTime:
+                timeRatio = timer.time / master.time()
             else:
-                time_ratio = timer.timeSinceReport / master.time()
-            if time_ratio < inclusion_cutoff:
+                timeRatio = timer.timeSinceReport / master.time()
+
+            if timeRatio < inclusionCutoff:
                 continue
             table.append(str(timer))
 
         return "\n".join(table)
 
     @staticmethod
-    def timeline(base_file_name, inclusion_cutoff=0.1, total_time=False):
-        r"""Produces a timeline graphic of the timers.
+    def timeline(baseFileName, inclusionCutoff=0.1, totalTime=False):
+        """Produces a timeline graphic of the timers.
 
         Parameters
         ----------
-        base_file_name : str
-            whatever the leading file path should be
-            this method generates the same file extension for every image to add to the base
-        inclusion_cutoff : float, optional
+        baseFileName : str
+            Whatever the leading file path should be.
+            This method generates the same file extension for every image to add to the base.
+        inclusionCutoff : float, optional
             Will not show results that have less than this fraction of the total time.
-        total_time : bool, optional
-            Use either the ratio of total time or time since last report for consideration against
-            the cutoff
+        totalTime : bool, optional
+            Use the ratio of total time or time since last report to compare against the cutoff.
+
+        Returns
+        -------
+        str : Path to the saved plot file.
         """
         import matplotlib.pyplot as plt
         import numpy as np
 
         # initial set up
         master = MasterTimer.getMasterTimer()
-        cur_time = master.time()
+        curTime = master.time()
 
         color_map = plt.cm.jet
 
-        y_values = []  # list of heights
-        y_level = 0  # height of the timelines
-        names = []
-        x_starts = []
-        x_stops = []
         colors = []
+        names = []
+        xStarts = []
+        xStops = []
+        yLevel = 0  # height of the timelines
+        yValues = []  # list of heights
 
         # plot content gather
         for timer in sorted(master.timers.values(), key=lambda x: x.name):
-            if total_time:
-                time_ratio = timer.time / master.time()
+            if totalTime:
+                timeRatio = timer.time / master.time()
             else:
-                time_ratio = timer.timeSinceReport / master.time()
-            if time_ratio < inclusion_cutoff:
+                timeRatio = timer.timeSinceReport / master.time()
+            if timeRatio < inclusionCutoff:
                 continue
 
-            y_level += 1
+            yLevel += 1
             names.append(timer.name)
-            for time_pair in timer.times:
-                y_values.append(y_level)
-                x_starts.append(time_pair[0])
-                x_stops.append(time_pair[1])
-                colors.append(color_map(time_ratio))
+            for timePair in timer.times:
+                colors.append(color_map(timeRatio))
+                xStarts.append(timePair[0])
+                xStops.append(timePair[1])
+                yValues.append(yLevel)
 
-        # plot set up
-        # might not be necessary to scale the width with the height like this
+        # plot set up: might not be necessary to scale the width with the height like this
         plt.figure(
             figsize=(3 + len(master.timers.values()), (3 + len(master.timers.values())))
         )
-        plt.axis([0.0, cur_time, 0.0, y_level + 1])
+        plt.axis([0.0, curTime, 0.0, yLevel + 1])
         plt.xlabel("Time (s)")
-        plt.yticks(
-            np.arange(y_level + 1), [""] + names
-        )  # offset needed for some reason
+        plt.yticks(np.arange(yLevel + 1), [""] + names)
         _loc, labels = plt.yticks()
         for tick in labels:
             tick.set_fontsize(40)
@@ -286,24 +285,23 @@ class MasterTimer:
         plt.tight_layout()
 
         # plot content draw
-        plt.hlines(y_values, x_starts, x_stops, colors)
+        plt.hlines(yValues, xStarts, xStops, colors)
 
-        def flatMerge(
-            l1, l2=None
-        ):  # duplicate a list flatly or merge them flatly (no tuples compared to zip)
+        def flatMerge(l1, l2=None):
+            # duplicate a list flatly or merge them flatly (no tuples compared to zip)
             return [item for sublist in zip(l1, l2 or l1) for item in sublist]
 
-        ymin = [y - 0.3 for y in y_values]
-        ymax = [y + 0.3 for y in y_values]
+        ymin = [y - 0.3 for y in yValues]
+        ymax = [y + 0.3 for y in yValues]
         plt.vlines(
-            flatMerge(x_starts, x_stops),
+            flatMerge(xStarts, xStops),
             flatMerge(ymin),
             flatMerge(ymax),
             flatMerge(colors),
         )
 
-        # done
-        filename = base_file_name + ".code-timeline.png"
+        # save and close
+        filename = baseFileName + ".code-timeline.png"
         plt.savefig(filename)
         plt.close()
         return os.path.join(os.getcwd(), filename)
@@ -320,11 +318,9 @@ class _Timer:
 
     def __init__(self, name, start):
         self.name = name
-        MasterTimer.getMasterTimer().timers[self.name] = self
-
         self._active = False
         self._times = []  # [(start, end), (start, end)...]
-        self.over_start = 0  # necessary for recursion tracking
+        self.overStart = 0  # necessary for recursion tracking
         self.reportedTotal = (
             0.0  # time elapsed since last asked to report time in __str__
         )
@@ -333,18 +329,16 @@ class _Timer:
             self.start()
 
     def __repr__(self):
-        return "<{} name:'{}' pauses:{} active:{} time:{}>".format(
-            self.__class__.__name__, self.name, self.pauses, self.isActive, self.time
+        return "<{} name:'{}' num iterations:{} time:{}>".format(
+            self.__class__.__name__, self.name, self.numIterations, self.time
         )
 
     def __str__(self):
-        str_ = "{:60s} {:>20.2f} {:>20.2f} {:>20.2f} {:^8} {}".format(
+        str_ = "{:60s} {:>20.2f} {:>20.2f} {:^8}".format(
             self.name[:60],
-            self.timeSinceReport,
             self.time,
-            self.time / (self.pauses + 1),
-            self.pauses,
-            self.isActive,
+            self.time / (self.numIterations + 1),
+            self.numIterations,
         )
         # needs to come after str generation because it resets the timeSinceReport
         self.reportedTotal = self.time
@@ -358,11 +352,12 @@ class _Timer:
 
     @property
     def isActive(self):
+        """Return True if the code for this timer still running."""
         return self._active
 
     @property
-    def pauses(self):
-        """If this number seems high remember .start() twice in a row adds a pause."""
+    def numIterations(self):
+        """If this number seems high remember .start() twice in a row adds a numIterations."""
         return len(self._times) - 1 if self._times else 0
 
     @property
@@ -385,38 +380,50 @@ class _Timer:
         else:
             return self._times
 
-    def _open_time_pair(self, cur_time):
-        self._times.append((cur_time, None))
+    def _openTimePair(self, curTime):
+        self._times.append((curTime, None))
 
-    def _close_time_pair(self, cur_time):
-        self._times[-1] = (self._times[-1][0], cur_time)
+    def _closeTimePair(self, curTime):
+        self._times[-1] = (self._times[-1][0], curTime)
 
     def start(self):
-        cur_time = MasterTimer.time()
+        """Start this Timer.
+
+        Returns
+        -------
+        float : Time stamp for the current time / start time.
+        """
+        curTime = MasterTimer.time()
 
         if self._frozen:
-            return cur_time
+            return curTime
         elif self.isActive:
             # call was made on an active timer, we're now over-started
-            self.over_start += 1
-            self._close_time_pair(cur_time)
+            self.overStart += 1
+            self._closeTimePair(curTime)
 
         self._active = True
-        self._open_time_pair(cur_time)
+        self._openTimePair(curTime)
 
-        return cur_time
+        return curTime
 
     def stop(self):
-        cur_time = MasterTimer.time()
+        """Stop this Timer.
+
+        Returns
+        -------
+        float : Time stamp for the current time / stop time.
+        """
+        curTime = MasterTimer.time()
 
         if self._frozen:
-            return cur_time
+            return curTime
 
-        if self.over_start:
+        if self.overStart:
             # can't end the timer as it's over-started
-            self.over_start -= 1
+            self.overStart -= 1
         elif self.isActive:
             self._active = False
-            self._close_time_pair(cur_time)
+            self._closeTimePair(curTime)
 
-        return cur_time
+        return curTime

--- a/armi/utils/tests/test_codeTiming.py
+++ b/armi/utils/tests/test_codeTiming.py
@@ -28,52 +28,92 @@ class CodeTimingTest(unittest.TestCase):
         codeTiming._Timer._frozen = False
         codeTiming.MasterTimer._instance = None
 
-    def test_method_definitions(self):
+    def test_methodDefinitions(self):
+        """Test that the timer decorators do not interupt the code being decorated."""
+
         @codeTiming.timed
-        def some_method(boop):
+        def someMethod(boop):
             return boop
 
         @codeTiming.timed("I have this name")
-        def some_other_method(boop):
+        def someOtherMethod(boop):
             return boop
 
-        x = some_method("dingdong")
-        y = some_other_method("bingbong")
+        x = someMethod("dingdong")
+        y = someOtherMethod("bingbong")
 
         self.assertEqual(x, "dingdong")
         self.assertEqual(y, "bingbong")
 
-    def test_alternate_usages(self):
-        master = codeTiming.getMasterTimer()
+    def test_countStartsStops(self):
+        """Test the start and stop counting logic."""
+        # test the start() and stop() methods, and their side effects
+        master = codeTiming.MasterTimer.getMasterTimer()
         timer = master.startTimer("bananananana")
-        timer.stop()
-        timer.start()
-        timer.start()
-        timer.stop()
-        timer.stop()
-        timer.stop()
-        timer.start()
+        t0 = timer.stop()
+        self.assertEqual(timer.overStart, 0)
+
+        t1 = timer.start()
+        self.assertGreater(t1, t0)
+        self.assertEqual(timer.overStart, 0)
+
+        t2 = timer.start()
+        self.assertGreater(t2, t1)
+        self.assertEqual(timer.overStart, 1)
+
+        t3 = timer.stop()
+        self.assertGreater(t3, t2)
+        self.assertEqual(timer.overStart, 0)
+
+        t4 = timer.stop()
+        self.assertGreater(t4, t3)
+        self.assertEqual(timer.overStart, 0)
+
+        t5 = timer.stop()
+        self.assertGreater(t5, t4)
+        self.assertEqual(timer.overStart, 0)
+
+        t6 = timer.start()
+        self.assertGreater(t6, t5)
+        self.assertEqual(timer.overStart, 0)
 
         timer2 = master.endTimer("wazzlewazllewazzzle")
-        timer2.start()
-        timer2.start()
+        t7 = timer2.start()
+        self.assertGreater(t7, t6)
+        self.assertEqual(timer2.overStart, 0)
 
+        t8 = timer2.start()
+        self.assertGreater(t8, t7)
+        self.assertEqual(timer2.overStart, 1)
+
+        # use the timers as context managers
         with timer2:
             with timer:
                 pass
 
-    def test_property_access(self):
-        # test property access is okay
-        master = codeTiming.getMasterTimer()
+        # There should be one start/stop each, leaving the over start count the same
+        self.assertEqual(timer.overStart, 0)
+        self.assertEqual(timer2.overStart, 1)
+
+    def test_propertyAccess(self):
+        """Test property access is okay."""
+        master = codeTiming.MasterTimer.getMasterTimer()
         timer = master.startTimer("sometimer")
 
-        _ = timer.times
-        _ = timer.time
-        _ = timer.name
-        _ = timer.isActive
+        t0 = timer.time
+        self.assertGreater(t0, 0)
+        ts = timer.times
+        self.assertEqual(len(ts), 1)
+        self.assertEqual(len(ts[0]), 2)
+        self.assertGreater(ts[0][0], 0)
+        self.assertGreater(ts[0][1], 0)
+        tName = timer.name
+        self.assertEqual(tName, "sometimer")
+        tActive = timer.isActive
+        self.assertTrue(tActive)
 
     def test_master(self):
-        master = codeTiming.getMasterTimer()
+        master = codeTiming.MasterTimer.getMasterTimer()
         _ = master.time
 
         master.startAll()
@@ -87,8 +127,8 @@ class CodeTimingTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             codeTiming.MasterTimer()
 
-    def test_messy_starts_and_stops(self):
-        master = codeTiming.getMasterTimer()
+    def test_messyStartsAndStops(self):
+        master = codeTiming.MasterTimer.getMasterTimer()
 
         name = "sometimerthatihaventmadeyet"
         larger_time_start = master.time()
@@ -124,11 +164,10 @@ class CodeTimingTest(unittest.TestCase):
         # even with all the starts and stops the total time needs to be between these two values.
         self.assertGreater(timer.time, lesser_time_end - lesser_time_start)
         self.assertLess(timer.time, larger_time_end - larger_time_start)
-        self.assertEqual(timer.pauses, 3)
+        self.assertEqual(timer.numIterations, 3)
 
         # test report
-        table = codeTiming.MasterTimer.report(inclusion_cutoff=0.01, total_time=True)
+        table = codeTiming.MasterTimer.report(inclusionCutoff=0.01, totalTime=True)
         self.assertIn("TIMER REPORTS", table)
         self.assertIn(name, table)
         self.assertIn("CUMULATIVE", table)
-        self.assertIn("ACTIVE", table)

--- a/armi/utils/tests/test_codeTiming.py
+++ b/armi/utils/tests/test_codeTiming.py
@@ -166,8 +166,22 @@ class CodeTimingTest(unittest.TestCase):
         self.assertLess(timer.time, larger_time_end - larger_time_start)
         self.assertEqual(timer.numIterations, 3)
 
-        # test report
+    def test_report(self):
+        master = codeTiming.MasterTimer.getMasterTimer()
+        name = "test_report"
+        timer = master.getTimer(name)
+        timer.start()
+        time.sleep(0.01)
+        timer.stop()
+
+        # basic validation of the reports
         table = codeTiming.MasterTimer.report(inclusionCutoff=0.01, totalTime=True)
-        self.assertIn("TIMER REPORTS", table)
+        self.assertIn("  AVERAGE ", table)
+        self.assertIn("  CUMULATIVE ", table)
+        self.assertIn("  NUM ITERS", table)
+        self.assertIn("TIMER REPORTS  ", table)
         self.assertIn(name, table)
-        self.assertIn("CUMULATIVE", table)
+
+        lines = table.strip().split("\n")
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(len(lines[1].strip().split()), 4)


### PR DESCRIPTION
## What is the change? Why is it being made?

This is a cleanup of the code timing reports.

In short, I removed the columns "is active" and "time since" and changed the name of one column from "pauses" to "num iterations".

I also did some basic code cleanup, added some docstrings, and added some unit tests.

### Note

Per Tony's request, this PR has a small API change that I will have to fix downstream.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Cleaning up the codeTiming reports.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
