### PR TITLE
Reducing the warnings from Block.autoCreateSpatialGrids

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1252,7 +1252,7 @@ class Assembly(composites.Composite):
                 try:
                     b.autoCreateSpatialGrids(parentSpatialGrid)
                 except (ValueError, NotImplementedError) as e:
-                    runLog.warning(str(e), single=True)
+                    runLog.extra(str(e), single=True)
 
 
 class HexAssembly(Assembly):
@@ -1275,8 +1275,7 @@ class HexAssembly(Assembly):
         Parameters
         ----------
         rad : float
-            Counter clockwise rotation in radians. **MUST** be in increments of
-            60 degrees (PI / 3)
+            Counter clockwise rotation in radians. **MUST** be in increments of 60 degrees (PI / 3)
 
         Raises
         ------

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2186,7 +2186,7 @@ class HexBlock(Block):
 
         In this case, a simple block would be one that has either multiplicity of components equal
         to 1 or N but no other multiplicities. Also, this should only happen when N fits exactly
-        into a given number of hex rings.  Otherwise, do not create a grid for this block.
+        into a given number of hex rings. Otherwise, do not create a grid for this block.
 
         Parameters
         ----------
@@ -2211,12 +2211,21 @@ class HexBlock(Block):
         # Check multiplicities
         mults = {c.getDimension("mult") for c in self.iterComponents()}
 
-        if len(mults) != 2 or 1 not in mults:
-            raise ValueError(
-                "Could not create a spatialGrid for block {}, multiplicities are not 1 or N they are {}".format(
-                    self.p.type, mults
-                )
+        # Do some validation: Should we try to create a spatial grid?
+        multz = {float(m) for m in mults}
+        if len(multz) == 1 and list(multz)[0] == 1.0:
+            runLog.extra(
+                f"Will not create a spatialGrid for block {self.p.type}, multiplicities are are all 1.",
+                single=True,
             )
+            return
+        elif len(multz) != 2 or 1.0 not in multz:
+            runLog.extra(
+                f"Could not create a spatialGrid for block {self.p.type}, multiplicities are not 1 "
+                f"or N they are {mults}",
+                single=True,
+            )
+            return
 
         # build the grid, from pitch and orientation
         if isinstance(systemSpatialGrid, grids.HexGrid):


### PR DESCRIPTION
## What is the change? Why is it being made?

Reducing the number of warnings from `Block.autoCreateSpatialGrids()`. Essentially, I used a multi-pronged approach here:

1. I changed many of these from "warning" level to "extra" level
2. I fixed an issue where we were looking for "1", but not finding "1.0" in the list of multiplicities.
3. I isolated the case where all the multiplicities are 1 or 1.0.

I found this to be a particularly annoying thing to unit test, as I had to cover huge numbers of cases with realistic Blocks with various different collections of multiplicities. I was like 20 tests in and several hundred lines of code and... What do you say we just look at your log statements and see if I fixed the problem?  What do you think, is that crazy?


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Reducing the warnings from Block.autoCreateSpatialGrids

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
