### PR TITLE
Cylindrical Cross Section model updates

### DIFF
--- a/armi/nuclearDataIO/nuclearFileMetadata.py
+++ b/armi/nuclearDataIO/nuclearFileMetadata.py
@@ -110,9 +110,12 @@ class _Metadata:
             otherVal = other[key]
             mergedVal = None
             if not properties.numpyHackForEqual(selfVal, otherVal):
-                raise exceptionClass(
+                exceptionMsg = (
                     "{libType} {key} metadata differs between {lib1} and {lib2}; Cannot Merge\n"
-                    "{key} has values of {val1} and {val2}".format(
+                    "{key} has values of {val1} and {val2}"
+                )
+                raise exceptionClass(
+                    exceptionMsg.format(
                         libType=fileType,
                         lib1=selfContainer,
                         lib2=otherContainer,

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -570,7 +570,9 @@ class CylindricalComponentsAverageBlockCollection(AverageBlockCollection):
         repBlock.p.percentBu = self._calcWeightedBurnup()
         componentsInOrder = self._orderComponentsInGroup(repBlock)
 
-        for i, (c, allSimilarComponents) in enumerate(zip(sorted(repBlock), componentsInOrder)):
+        for i, (c, allSimilarComponents) in enumerate(
+            zip(sorted(repBlock), componentsInOrder)
+        ):
             allNucsNames, densities = self._getAverageComponentNucs(
                 allSimilarComponents, bWeights
             )

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -521,7 +521,7 @@ def getBlockNuclideTemperatureAvgTerms(block, allNucNames):
     return nvt, nv
 
 
-class CylindricalComponentsAverageBlockCollection(BlockCollection):
+class CylindricalComponentsAverageBlockCollection(AverageBlockCollection):
     """
     Creates a representative block for the purpose of cross section generation with a one-
     dimensional cylindrical model.
@@ -570,12 +570,13 @@ class CylindricalComponentsAverageBlockCollection(BlockCollection):
         repBlock.p.percentBu = self._calcWeightedBurnup()
         componentsInOrder = self._orderComponentsInGroup(repBlock)
 
-        for c, allSimilarComponents in zip(sorted(repBlock), componentsInOrder):
+        for i, (c, allSimilarComponents) in enumerate(zip(sorted(repBlock), componentsInOrder)):
             allNucsNames, densities = self._getAverageComponentNucs(
                 allSimilarComponents, bWeights
             )
             for nuc, aDensity in zip(allNucsNames, densities):
                 c.setNumberDensity(nuc, aDensity)
+            c.temperatureInC = self._getAverageComponentTemperature(i)
         repBlock.clearCache()
         self.calcAvgNuclideTemperatures()
         return repBlock

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -352,6 +352,7 @@ class AverageBlockCollection(BlockCollection):
             newBlock.setNumberDensities(self._getAverageNumberDensities())
 
         newBlock.p.percentBu = self._calcWeightedBurnup()
+        newBlock.clearCache()
         self.calcAvgNuclideTemperatures()
         return newBlock
 
@@ -575,6 +576,7 @@ class CylindricalComponentsAverageBlockCollection(BlockCollection):
             )
             for nuc, aDensity in zip(allNucsNames, densities):
                 c.setNumberDensity(nuc, aDensity)
+        repBlock.clearCache()
         self.calcAvgNuclideTemperatures()
         return repBlock
 

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1448,12 +1448,10 @@ class Component(composites.Composite, metaclass=ComponentType):
         density = composites.Composite.density(self)
 
         if not density and not isinstance(self.material, void.Void):
-            # possible that there are no nuclides in this component yet. In that case,
-            # defer to Material. Material.density is wrapped to warn if it's attached
-            # to a parent. Avoid that by calling the inner function directly
-            density = self.material.density.__wrapped__(
-                self.material, Tc=self.temperatureInC
-            )
+            # possible that there are no nuclides in this component yet. In that case, defer to
+            # Material. Material.density is wrapped to warn if it's attached to a parent. Avoid that
+            # by calling the inner function directly
+            density = self.material.density(Tc=self.temperatureInC)
 
         return density
 

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -90,6 +90,7 @@ class BlockConverter:
         # shape volume computations will fail
         newBlock.remove(solute, recomputeAreaFractions=False)
         self._sourceBlock = newBlock
+        solute.mergeNuclidesInto(solvent)
 
         # adjust new shape area.
         if solvent.__class__ is components.DerivedShape:
@@ -122,7 +123,6 @@ class BlockConverter:
             self._verifyExpansion(solute, solvent)
 
         solvent.changeNDensByFactor(oldArea / solvent.getArea())
-        solute.mergeNuclidesInto(solvent)
 
     def _checkInputs(self, soluteName, solventName, solute, solvent):
         if solute is None or solvent is None:
@@ -773,7 +773,9 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             od=outDiameter,
             mult=1,
         )
-        circle.setNumberDensities(baseComponent.getNumberDensities())
+        # set number densities directly to avoid material expansion
+        circle.p.nuclides = baseComponent.p.nuclides
+        circle.p.numberDensities = baseComponent.p.numberDensities
         circle.p.flags = baseComponent.p.flags
         return circle
 

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -642,9 +642,13 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
 
         pinComponentFlags = [
             Flags.FUEL,
+            Flags.ANNULAR | Flags.VOID,
             Flags.GAP,
+            Flags.BOND,
             Flags.LINER,
             Flags.CLAD,
+            Flags.WIRE,
+            Flags.CONTROL,
             Flags.REFLECTOR,
             Flags.SHIELD,
             Flags.SLUG,

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -640,6 +640,17 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
         """
         pinComponents, nonPins = [], []
 
+        pinComponentFlags = [
+            Flags.FUEL,
+            Flags.GAP,
+            Flags.LINER,
+            Flags.CLAD,
+            Flags.REFLECTOR,
+            Flags.SHIELD,
+            Flags.SLUG,
+            Flags.PIN,
+        ]
+
         for c in self._sourceBlock:
 
             # If the area of the component is negative than this component should be skipped
@@ -649,10 +660,7 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
             if c.getArea() < 0.0:
                 continue
 
-            if (
-                self._sourceBlock.getNumComponents(c.p.flags)
-                == self._sourceBlock.getNumPins()
-            ):
+            if any(c.hasFlags(f) for f in pinComponentFlags):
                 pinComponents.append(c)
             elif (
                 c.name != "coolant"


### PR DESCRIPTION
## What is the change? Why is it being made?

I have recently run into a few corner-case type issues when exercising the 1D cylindrical cross section model. This PR is intended to address those issues to make the 1D cylindrical model more robust and able to be used in more scenarios.

The problems and how they are being addressed are listed below:
 * The representative block for a `CylindricalComponentsAveageBlockCollection` has component temperatures that come from the selected candidate block. This PR changes the `_makeRepresentativeBlock` method to set component temperatures based on the average over the block collection.
 * `BlockConverter.dissolveComponentIntoComponent` loses the nuclides from the solute component when the solute is defined by linked dimensions that are linked to the solvent. This was an order of operations issue, which was resolved by moving up the `solute.mergeNuclidesInto(solvent)` within `dissolveComponentIntoComponent`.
 * The `HexComponentsToCylConverter` determines whether a component is associated with a pin based on the multiplicity of that component. This logic breaks down when a pin has multiple components that have the same flags. The implementation was changed to look through a hard-coded set of flags that are associated with pin-level components.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Updates to the CylindricalComponentsAverageBlockCollection representative block temperature treatment and the HexComponentsToCylConverter.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: The implementation of R_ARMI_BLOCKCONV_HEX_TO_CYL is being updated. The current functionality should be preserved, but it should be more robust across more situations and corner cases with these updates. The implementation of R_ARMI_XSGM_CREATE_REPR_BLOCKS for cylindrical XS models (I_ARMI_XSGM_CREATE_REPR_BLOCKS1) is also being updated to set the representative block's component temperatures based on the block collection average temperatures.
---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
