### PR TITLE
Removing Composite.getNumberDensities()

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1100,7 +1100,7 @@ class Block(composites.Composite):
                 nucName, 0.0
             ) + fraction * otherBlockDensities.get(nucName, 0.0)
 
-        self.setNumberDensities(newDensities)
+        self.updateNumberDensities(newDensities)
 
     def getComponentAreaFrac(self, typeSpec):
         """

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -55,10 +55,9 @@ class FlagSerializer(parameters.Serializer):
     """
     Serializer implementation for Flags.
 
-    This operates by converting each set of Flags (too large to fit in a uint64) into a
-    sequence of enough uint8 elements to represent all flags. These constitute a
-    dimension of a 2-D numpy array containing all Flags for all objects provided to the
-    ``pack()`` function.
+    This operates by converting each set of Flags (too large to fit in a uint64) into a sequence of
+    enough uint8 elements to represent all flags. These constitute a dimension of a 2-D numpy array
+    containing all Flags for all objects provided to the ``pack()`` function.
     """
 
     version = "1"
@@ -66,10 +65,10 @@ class FlagSerializer(parameters.Serializer):
     @staticmethod
     def pack(data):
         """
-        Flags are represented as a 2D numpy array of uint8 (single-byte, unsigned
-        integers), where each row contains the bytes representing a single Flags
-        instance. We also store the list of field names so that we can verify that the
-        reader and the writer can agree on the meaning of each bit.
+        Flags are represented as a 2D numpy array of uint8 (single-byte, unsigned integers), where
+        each row contains the bytes representing a single Flags instance. We also store the list of
+        field names so that we can verify that the reader and the writer can agree on the meaning of
+        each bit.
 
         Under the hood, this calls the private implementation providing the
         :py:class:`armi.reactor.flags.Flags` class as the target output class.
@@ -81,9 +80,8 @@ class FlagSerializer(parameters.Serializer):
         """
         Implement the pack operation given a target output Flag class.
 
-        This is kept separate from the public interface to permit testing of the
-        functionality without having to do unholy things to ARMI's actual set of
-        ``reactor.flags.Flags``.
+        This is kept separate from the public interface to permit testing of the functionality
+        without having to do unholy things to ARMI's actual set of ``reactor.flags.Flags``.
         """
         npa = np.array([b for f in data for b in f.to_bytes()], dtype=np.uint8).reshape(
             (len(data), flagCls.width())
@@ -94,8 +92,8 @@ class FlagSerializer(parameters.Serializer):
     @staticmethod
     def _remapBits(inp: int, mapping: Dict[int, int]):
         """
-        Given an input bitfield, map each bit to the appropriate new bit position based
-        on the passed mapping.
+        Given an input bitfield, map each bit to the appropriate new bit position based on the
+        passed mapping.
 
         Parameters
         ----------
@@ -118,9 +116,8 @@ class FlagSerializer(parameters.Serializer):
         """
         Reverse the pack operation.
 
-        This will allow for some degree of conversion from old flags to a new set of
-        flags, as long as all of the source flags still exist in the current set of
-        flags.
+        This will allow for some degree of conversion from old flags to a new set of flags, as long
+        as all of the source flags still exist in the current set of flags.
 
         Under the hood, this calls the private implementation providing the
         :py:class:`armi.reactor.flags.Flags` class as the target output class.
@@ -196,14 +193,13 @@ def _defineBaseParameters():
     """
     Return parameter definitions that all ArmiObjects must have to function properly.
 
-    For now, this pretty much just includes ``flags``, since these are used throughout
-    the composite model to filter which objects are considered when traversing the
-    reactor model.
+    For now, this pretty much just includes ``flags``, since these are used throughout the composite
+    model to filter which objects are considered when traversing the reactor model.
 
-    Note also that the base ParameterCollection class also has a ``serialNum``
-    parameter. These are defined in different locations, since serialNum is a guaranteed
-    feature of a ParameterCollection (for serialization to the database and history
-    tracking), while the ``flags`` parameter is more a feature of the composite model.
+    Note also that the base ParameterCollection class also has a ``serialNum`` parameter. These are
+    defined in different locations, since serialNum is a guaranteed feature of a ParameterCollection
+    (for serialization to the database and history tracking), while the ``flags`` parameter is more
+    a feature of the composite model.
 
     .. important::
         Notice that the ``flags`` parameter is not written to the database. This is for
@@ -298,13 +294,12 @@ class ArmiObject(metaclass=CompositeModelType):
         :id: I_ARMI_PARAM1
         :implements: R_ARMI_PARAM
 
-        An ARMI reactor model is composed of collections of ARMIObject objects. These
-        objects are combined in a hierarchical manner. Each level of the composite tree
-        is able to be assigned parameters which define it, such as temperature, flux,
-        or keff values. This class defines an attribute of type ``ParameterCollection``,
-        which contains all the functionality of an ARMI ``Parameter`` object. Because
-        the entire model is composed of ARMIObjects at the most basic level, each level
-        of the Composite tree contains this parameter attribute and can thus be queried.
+        An ARMI reactor model is composed of collections of ARMIObject objects. These objects are
+        combined in a hierarchical manner. Each level of the composite tree is able to be assigned
+        parameters which define it, such as temperature, flux, or keff values. This class defines an
+        attribute of type ``ParameterCollection``, which contains all the functionality of an ARMI
+        ``Parameter`` object. Because the entire model is composed of ARMIObjects, each level of the
+        Composite tree contains this parameter attribute and can be queried.
 
     Attributes
     ----------
@@ -335,10 +330,9 @@ class ArmiObject(metaclass=CompositeModelType):
         self.cached = {}
         self._backupCache = None
         self.p = self.paramCollectionType()
-        # TODO: These are not serialized to the database, and will therefore
-        # lead to surprising behavior when using databases. We need to devise a
-        # way to either represent them in parameters, or otherwise reliably
-        # recover them.
+        # TODO: These are not serialized to the database, and will therefore lead to surprising
+        # behavior when using databases. We need to devise a way to either represent them in
+        # parameters, or otherwise reliably recover them.
         self._lumpedFissionProducts = None
         self.spatialGrid = None
         self.spatialLocator = grids.CoordinateLocation(0.0, 0.0, 0.0, None)
@@ -347,16 +341,15 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         Implement the less-than operator.
 
-        Implementing this on the ArmiObject allows most objects, under most
-        circumstances to be sorted. This is useful from the context of the Database
-        classes, so that they can produce a stable layout of the serialized composite
-        structure.
+        Implementing this on the ArmiObject allows most objects, under most circumstances to be
+        sorted. This is useful from the context of the Database classes, so that they can produce a
+        stable layout of the serialized composite structure.
 
-        By default, this sorts using the spatial locator, in K, J, I order, which should
-        give a relatively intuitive order. For safety, it makes sure that the objects
-        being sorted live in the same grid, since it probably doesn't make
-        sense to sort things across containers or scopes. If this ends up being too
-        restrictive, it can probably be relaxed or overridden on specific classes.
+        By default, this sorts using the spatial locator, in K, J, I order, which should give a
+        relatively intuitive order. For safety, it makes sure that the objects being sorted live in
+        the same grid, since it probably doesn't make sense to sort things across containers or
+        scopes. If this ends up being too restrictive, it can probably be relaxed or overridden on
+        specific classes.
         """
         if self.spatialLocator is None or other.spatialLocator is None:
             runLog.error("could not compare {} and {}".format(self, other))
@@ -387,15 +380,15 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         Python method for reducing data before pickling.
 
-        This removes links to parent objects, which allows one to, for example, pickle
-        an assembly without pickling the entire reactor. Likewise, one could
-        MPI_COMM.bcast an assembly without broadcasting the entire reactor.
+        This removes links to parent objects, which allows one to, for example, pickle an assembly
+        without pickling the entire reactor. Likewise, one could MPI_COMM.bcast an assembly without
+        broadcasting the entire reactor.
 
         Notes
         -----
-        Special treatment of ``parent`` is not enough, since the spatialGrid also
-        contains a reference back to the armiObject. Consequently, the ``spatialGrid``
-        needs to be reassigned in ``__setstate__``.
+        Special treatment of ``parent`` is not enough, since the spatialGrid also contains a
+        reference back to the armiObject. Consequently, the ``spatialGrid`` needs to be reassigned
+        in ``__setstate__``.
         """
         state = self.__dict__.copy()
         state["parent"] = None
@@ -411,10 +404,10 @@ class ArmiObject(metaclass=CompositeModelType):
 
         Notes
         -----
-        This ArmiObject may have lost a reference to its parent. If the parent was also
-        pickled (serialized), then the parent should update the ``.parent`` attribute
-        during its own ``__setstate__``. That means within the context of
-        ``__setstate__`` one should not rely upon ``self.parent``.
+        This ArmiObject may have lost a reference to its parent. If the parent was also pickled
+        (serialized), then the parent should update the ``.parent`` attribute during its own
+        ``__setstate__``. That means within the context of ``__setstate__`` one should not rely upon
+        ``self.parent``.
         """
         self.__dict__.update(state)
 
@@ -457,11 +450,11 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         Make a clean copy of this object.
 
-        .. warning:: Be careful with inter-object dependencies. If one object contains a
-            reference to another object which contains links to the entire hierarchical
-            tree, memory can fill up rather rapidly. Weak references are designed to help
-            with this problem.
-
+        Warning
+        -------
+        Be careful with inter-object dependencies. If one object contains a reference to another
+        object which contains links to the entire hierarchical tree, memory can fill up rather
+        rapidly. Weak references are designed to help with this problem.
         """
         raise NotImplementedError
 
@@ -475,11 +468,9 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         Obtain a value from the cache.
 
-        Cached values can be used to temporarily store frequently read but
-        long-to-compute values.  The practice is generally discouraged because it's
-        challenging to make sure to properly invalidate the cache when the state
-        changes.
-
+        Cached values can be used to temporarily store frequently read but long-to-compute values.
+        The practice is generally discouraged because it's challenging to make sure to properly
+        invalidate the cache when the state changes.
         """
         return self.cached.get(name, None)
 
@@ -1472,9 +1463,8 @@ class ArmiObject(metaclass=CompositeModelType):
         nTot : float
             Total ndens of all nuclides in atoms/bn-cm. Not homogenized.
         """
-        nFPsPerLFP = (
-            fissionProductModel.NUM_FISSION_PRODUCTS_PER_LFP
-        )  # LFPs count as two! Big deal in non BOL cases.
+        # LFPs count as two! Big deal in non BOL cases.
+        nFPsPerLFP = fissionProductModel.NUM_FISSION_PRODUCTS_PER_LFP
         return sum(
             dens * (nFPsPerLFP if "LFP" in name else 1.0)
             for name, dens in self.getNumberDensities().items()
@@ -1484,11 +1474,10 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         Set the number density of this nuclide to this value.
 
-        This distributes atom density evenly across all children that contain nucName.
-        If the nuclide doesn't exist in any of the children, then that's actually an
-        error. This would only happen if some unnatural nuclide like Pu239 built up in
-        fresh UZr. That should be anticipated and dealt with elsewhere.
-
+        This distributes atom density evenly across all children that contain nucName. If the
+        nuclide doesn't exist in any of the children, then that's actually an error. This would only
+        happen if some unnatural nuclide like Pu239 built up in fresh UZr. That should be
+        anticipated and dealt with elsewhere.
         """
         activeChildren = self.getChildrenWithNuclides({nucName})
         if not activeChildren:
@@ -1504,26 +1493,25 @@ class ArmiObject(metaclass=CompositeModelType):
             activeVolumeFrac = sum(
                 vf for ci, vf in self.getVolumeFractions() if ci in activeChildren
             )
-        dehomogenizedNdens = (
-            val / activeVolumeFrac
-        )  # scale up to dehomogenize on children.
+
+        # scale up to dehomogenize on children
+        dehomogenizedNdens = val / activeVolumeFrac
         for child in activeChildren:
             child.setNumberDensity(nucName, dehomogenizedNdens)
 
-    def setNumberDensities(self, numberDensities):
+    def setNumberDensitiesTODOJOHN(self, numberDensities):  # TODO: JOHN
         """
         Set one or more multiple number densities. Reset any non-listed nuclides to 0.0.
 
         Parameters
         ----------
         numberDensities : dict
-            nucName: ndens pairs.
+            nucName: ndens pairs
 
         Notes
         -----
-        We'd like to not have to call setNumberDensity for each nuclide because we don't
-        want to call ``getVolumeFractions`` for each nuclide (it's inefficient).
-
+        We'd like to not have to call setNumberDensity for each nuclide because we do not want to
+        call ``getVolumeFractions`` for each nuclide (it's inefficient).
         """
         numberDensities.update(
             {nuc: 0.0 for nuc in self.getNuclides() if nuc not in numberDensities}
@@ -1534,27 +1522,25 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         Set one or more multiple number densities. Leaves unlisted number densities alone.
 
-        This changes a nuclide number density only on children that already have that
-        nuclide, thereby allowing, for example, actinides to stay in the fuel component
-        when setting block-level values.
+        This changes a nuclide number density only on children that already have that nuclide,
+        thereby allowing, for example, actinides to stay in the fuel component when setting block-
+        level values.
 
-        The complication is that various number densities are distributed among various
-        components. This sets the number density for each nuclide evenly across all
-        components that contain it.
+        The complication is that various number densities are distributed among various components.
+        This sets the number density for each nuclide evenly across all components that contain it.
 
         Parameters
         ----------
         numberDensities : dict
-            nucName: ndens pairs.
-
+            nucName: ndens pairs
         """
         children, volFracs = zip(*self.getVolumeFractions())
         childNucs = tuple(set(child.getNuclides()) for child in children)
 
         allDehomogenizedNDens = collections.defaultdict(dict)
 
-        # compute potentially-different homogenization factors for each child.  evenly
-        # distribute entire number density over the subset of active children.
+        # Compute potentially-different homogenization factors for each child. Evenly distribute
+        # entire number density over the subset of active children.
         for nuc, dens in numberDensities.items():
             # get "active" indices, i.e., indices of children containing nuc
             # NOTE: this is one of the rare instances in which (imo), using explicit
@@ -1590,7 +1576,13 @@ class ArmiObject(metaclass=CompositeModelType):
         densitiesScaled = {
             nuc: val * factor for nuc, val in self.getNumberDensities().items()
         }
-        self.setNumberDensities(densitiesScaled)
+
+        densitiesScaled.update(
+            {nuc: 0.0 for nuc in self.getNuclides() if nuc not in densitiesScaled}
+        )
+        self.updateNumberDensities(densitiesScaled)
+
+        # self.setNumberDensities(densitiesScaled)  # TODO: JOHN
         # Update detailedNDens
         if self.p.detailedNDens is not None:
             self.p.detailedNDens *= factor
@@ -1604,8 +1596,13 @@ class ArmiObject(metaclass=CompositeModelType):
 
         Set to almost zero, so components remember which nuclides are where.
         """
-        ndens = {nuc: units.TRACE_NUMBER_DENSITY for nuc in self.getNuclides()}
-        self.setNumberDensities(ndens)
+        # ndens = {nuc: units.TRACE_NUMBER_DENSITY for nuc in self.getNuclides()}
+        # self.setNumberDensities(ndens) # TODO: JOHN
+
+        numberDensities = {
+            nuc: units.TRACE_NUMBER_DENSITY for nuc in self.getNuclides()
+        }
+        self.updateNumberDensities(numberDensities)
 
     def density(self):
         """Returns the mass density of the object in g/cc."""
@@ -1694,15 +1691,14 @@ class ArmiObject(metaclass=CompositeModelType):
             object types to restrict to
 
         generationNum : int, optional
-            Which generation to consider. 1 means direct children, 2 means children of
-            children. Default: Just return direct children.
+            Which generation to consider. 1 means direct children, 2 means children of children.
+            Default: Just return direct children.
 
         calcBasedOnFullObj : bool, optional
-            Some assemblies or blocks, such as the center assembly in a third core
-            model, are not modeled as full assemblies or blocks. In the third core model
-            objects at these positions are modeled as having 1/3 the volume and thus 1/3
-            the power. Setting this argument to True will apply the full value of the
-            parameter as if it was a full block or assembly.
+            Some assemblies or blocks, such as the center assembly in a third core model, are not
+            modeled as full assemblies or blocks. In the third core model objects at these positions
+            are modeled as having 1/3 the volume and thus 1/3 the power. Setting this argument to
+            True will apply the full value of the parameter as if it was a full block or assembly.
         """
         tot = 0.0
         if objs is None:
@@ -1768,20 +1764,19 @@ class ArmiObject(metaclass=CompositeModelType):
         generationNum : int, optional
             Which generation to average over (1 for children, 2 for grandchildren)
 
-
         The weighted sum is:
 
         .. math::
 
             \left<\text{x}\right> = \frac{\sum_{i} x_i w_i}{\sum_i w_i}
 
-        where :math:`i` is each child, :math:`x_i` is the param value of the i-th child,
-        and :math:`w_i` is the weighting param value of the i-th child.
+        where :math:`i` is each child, :math:`x_i` is the param value of the i-th child, and
+        :math:`w_i` is the weighting param value of the i-th child.
 
         Warning
         -------
-        If a param is unset/zero on any of the children, this will be included in the
-        average and may significantly perturb results.
+        If a param is unset/zero on any of the children, this will be included in the average and
+        may significantly perturb results.
 
         Returns
         -------
@@ -1902,10 +1897,9 @@ class ArmiObject(metaclass=CompositeModelType):
                 try:
                     val = b.p[param]
                 except parameters.UnknownParameterError:
-                    # No worries; not all Composite types are guaranteed to have the
-                    # relevant parameter. It might be a good idea to more strongly
-                    # type-check this, perhaps by passing the paramDef,
-                    # rather than its name?
+                    # No worries; not all Composite types are guaranteed to have the relevant
+                    # parameter. It might be a good idea to more strongly type-check this, perhaps
+                    # by passing the paramDef, rather than its name?
                     continue
                 if val is None:
                     # Neither bigger or smaller than anything (also illegal in Python3)
@@ -1967,9 +1961,9 @@ class ArmiObject(metaclass=CompositeModelType):
 
         Notes
         -----
-        If an object is on a symmetry line, the volume reported by getVolume
-        is reduced to reflect that the block is not wholly within the reactor. This
-        reduction in volume reduces the reported HM moles.
+        If an object is on a symmetry line, the volume reported by getVolume is reduced to reflect
+        that the block is not wholly within the reactor. This reduction in volume reduces the
+        reported HM moles.
         """
         return (
             self.getHMDens()
@@ -2048,14 +2042,15 @@ class ArmiObject(metaclass=CompositeModelType):
         r"""
         Calculate the atomic weight of this object in g/mole of atoms.
 
-        .. warning:: This is not the molecular weight, which is grams per mole of
-            molecules (grams/gram-molecule). That requires knowledge of the chemical
-            formula. Don't be surprised when you run this on UO2 and find it to be 90;
-            there are a lot of Oxygen atoms in UO2.
-
         .. math::
 
             A =  \frac{\sum_i N_i A_i }{\sum_i N_i}
+
+        Warning
+        -------
+        This is not the molecular weight, which is grams per mole of molecules
+        (grams/gram-molecule). That requires knowledge of the chemical formula. Don't be surprised
+        when you run this on UO2 and find it to be 90; there are a lot of Oxygen atoms in UO2.
         """
         numerator = 0.0
         denominator = 0.0
@@ -2074,8 +2069,8 @@ class ArmiObject(metaclass=CompositeModelType):
 
         Notes
         -----
-        Implemented to get number densities and then convert to mass
-        because getMass is too slow on a large tree.
+        Implemented to get number densities and then convert to mass because getMass is too slow on
+        a large tree.
         """
         numDensities = self.getNumberDensities()
         vol = self.getVolume()
@@ -2091,8 +2086,8 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         Return the multigroup neutron flux in [n/cm^2/s].
 
-        The first entry is the first energy group (fastest neutrons). Each additional
-        group is the next energy group, as set in the ISOTXS library.
+        The first entry is the first energy group (fastest neutrons). Each additional group is the
+        next energy group, as set in the ISOTXS library.
 
         On blocks, it is stored integrated over volume on <block>.p.mgFlux
 
@@ -2106,9 +2101,8 @@ class ArmiObject(metaclass=CompositeModelType):
             for pin detailed yet
 
         volume: float, optional
-            The volume-integrated flux is divided by volume before being
-            returned. The user may specify a volume here, or the function will
-            obtain the block volume directly.
+            The volume-integrated flux is divided by volume before being returned. The user may
+            specify a volume here, or the function will obtain the block volume directly.
 
         gamma : bool, optional
             Whether to return the neutron flux or the gamma flux.
@@ -2120,8 +2114,8 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         if average:
             raise NotImplementedError(
-                "{} class has no method for producing average MG flux -- try"
-                "using blocks".format(self.__class__)
+                f"{self.__class__} class has no method for producing average MG flux -- try using "
+                "blocks"
             )
 
         volume = volume or self.getVolume()
@@ -2229,7 +2223,7 @@ class ArmiObject(metaclass=CompositeModelType):
         return ((minI, maxI), (minJ, maxJ), (minK, maxK))
 
     def getComponentNames(self):
-        r"""
+        """
         Get all unique component names of this Composite.
 
         Returns
@@ -2271,7 +2265,6 @@ class ArmiObject(metaclass=CompositeModelType):
         Returns
         -------
         componentsWithThisMat : list
-
         """
         if materialName is None:
             materialName = material.getName()
@@ -2468,58 +2461,50 @@ class Composite(ArmiObject):
     """
     An ArmiObject that has children.
 
-    This is a fundamental ARMI state object that generally represents some piece of the
-    nuclear reactor that is made up of other smaller pieces. This object can cache
-    information about its children to help performance.
+    This is a fundamental ARMI state object that generally represents some piece of the nuclear
+    reactor that is made up of other smaller pieces. This object can cache information about its
+    children to help performance.
 
     **Details about spatial representation**
 
     Spatial representation of a ``Composite`` is handled through a combination of the
-    ``spatialLocator`` and ``spatialGrid`` parameters. The ``spatialLocator`` is a numpy
-    triple representing either:
+    ``spatialLocator`` and ``spatialGrid`` parameters. The ``spatialLocator`` is a numpy triple
+    representing either:
 
-    1. Indices in the parent's ``spatialGrid`` (for lattices, etc.), used when the dtype
-    is int.
-
+    1. Indices in the parent's ``spatialGrid`` (for lattices, etc.), used when the dtype is int.
     2. Coordinates in the parent's universe in cm, used when the dtype is float.
 
-    The top parent of any composite must have a coordinate-based ``spatialLocator``. For
-    example, a Reactor an a Pump should both have coordinates based on how far apart
-    they are.
+    The top parent of any composite must have a coordinate-based ``spatialLocator``. For example, a
+    Reactor an a Pump should both have coordinates based on how far apart they are.
 
-    The traversal of indices and grids is recursive. The Reactor/Core/Assembly/Block
-    model is handled by putting a 2-D grid (either Theta-R, Hex, or Cartesian) on the
-    Core and individual 1-D Z-meshes on the assemblies. Then, Assemblies have 2-D
-    spatialLocators (i,j,0) and Blocks have 1-D spatiaLocators (0,0,k). These get added
-    to form the global indices. This way, if an assembly is moved, all the blocks
-    immediately and naturally move with it. Individual children may have
-    coordinate-based spatialLocators mixed with siblings in a grid. This allows mixing
-    grid-representation with explicit representation, often useful in advanced
-    assemblies and thermal reactors.
+    The traversal of indices and grids is recursive. The Reactor/Core/Assembly/Block model is
+    handled by putting a 2-D grid (either Theta-R, Hex, or Cartesian) on the Core and individual 1-D
+    Z-meshes on the assemblies. Then, Assemblies have 2-D spatialLocators (i,j,0) and Blocks have
+    1-D spatiaLocators (0,0,k). These get added to form the global indices. This way, if an assembly
+    is moved, all the blocks immediately and naturally move with it. Individual children may have
+    coordinate-based spatialLocators mixed with siblings in a grid. This allows mixing grid-
+    representation with explicit representation, often useful in advanced assemblies and thermal
+    reactors.
 
-    The traversal of indices and grids is recursive. The
-    Reactor/Core/Assembly/Block model is handled by putting a 2-D grid (either
-    Theta-R, Hex, or Cartesian) on the Core and individual 1-D Z-meshes on the
-    assemblies. Then, Assemblies have 2-D spatialLocators (i,j,0) and Blocks
-    have 1-D spatiaLocators (0,0,k). These get added to form the global indices.
-    This way, if an assembly is moved, all the blocks immediately and naturally
-    move with it. Individual children may have coordinate-based spatialLocators
-    mixed with siblings in a grid. This allows mixing grid-representation with
-    explicit representation, often useful in advanced assemblies and thermal
+    The traversal of indices and grids is recursive. The Reactor/Core/Assembly/Block model is
+    handled by putting a 2-D grid (either Theta-R, Hex, or Cartesian) on the Core and individual 1-D
+    Z-meshes on the assemblies. Then, Assemblies have 2-D spatialLocators (i,j,0) and Blocks have
+    1-D spatiaLocators (0,0,k). These get added to form the global indices. This way, if an assembly
+    is moved, all the blocks immediately and naturally move with it. Individual children may have
+    coordinate-based spatialLocators mixed with siblings in a grid. This allows mixing grid-
+    representation with explicit representation, often useful in advanced assemblies and thermal
     reactors.
 
     .. impl:: Composites are a physical part of the reactor in a hierarchical data model.
         :id: I_ARMI_CMP0
         :implements: R_ARMI_CMP
 
-        An ARMI reactor model is composed of collections of ARMIObject objects. This
-        class is a child-class of the ARMIObject class and provides a structure
-        allowing a reactor model to be composed of Composites.
+        An ARMI reactor model is composed of collections of ARMIObject objects. This class is a
+        child-class of the ARMIObject class and provides a structure allowing a reactor model to be
+        composed of Composites.
 
-        This class provides various methods to query and modify the hierarchical ARMI
-        reactor model, including but not limited to, iterating, sorting, and adding or
-        removing child Composites.
-
+        This class provides various methods to query and modify the hierarchical ARMI reactor model,
+        including but not limited to, iterating, sorting, and adding or removing child Composites.
     """
 
     _children: list["Composite"]
@@ -2545,9 +2530,8 @@ class Composite(ArmiObject):
         """
         Membership check.
 
-        This does not use quality checks for membership checking because equality
-        operations can be fairly heavy. Rather, this only checks direct identity
-        matches.
+        This does not use quality checks for membership checking because equality operations can be
+        fairly heavy. Rather, this only checks direct identity matches.
         """
         return id(item) in set(id(c) for c in self._children)
 
@@ -2637,8 +2621,8 @@ class Composite(ArmiObject):
             Produce composites at this depth. A depth of ``1`` includes children of ``self``, ``2``
             is children of children, and so on.
         predicate: f(Composite) -> bool, optional
-            Function to check on a composite before producing it. All items in the iteration
-            will pass this check.
+            Function to check on a composite before producing it. All items in the iteration will
+            pass this check.
 
         Returns
         -------
@@ -2660,8 +2644,8 @@ class Composite(ArmiObject):
 
         If you do not need any depth-traversal, natural iteration should be sufficient.
 
-        The :func:`filter` command may be sufficient if you do not wish to pass a predicate. The following
-        are identical::
+        The :func:`filter` command may be sufficient if you do not wish to pass a predicate. The
+        following are identical::
             >>> checker = lambda c: len(c.name) % 3
             >>> for child in c.getChildren(predicate=checker):
             ...     pass
@@ -2671,7 +2655,6 @@ class Composite(ArmiObject):
             ...     pass
 
         If you're going to be doing traversal beyond the first generation, this method will help you.
-
         """
         if deep and generationNum > 1:
             raise RuntimeError(
@@ -2695,12 +2678,11 @@ class Composite(ArmiObject):
     def iterChildrenWithMaterials(self, *args, **kwargs) -> Iterator:
         """Produce an iterator that also includes any materials found on descendants.
 
-        Arguments are forwarded to :meth:`iterChildren` and control the depth of traversal
-        and filtering of objects.
+        Arguments are forwarded to :meth:`iterChildren` and control the depth of traversal and
+        filtering of objects.
 
-        This is useful for sending state across MPI tasks where you need a more full
-        representation of the composite tree. Which includes the materials attached
-        to components.
+        This is useful for sending state across MPI tasks where you need a more full representation
+        of the composite tree. Which includes the materials attached to components.
         """
         children = self.iterChildren(*args, **kwargs)
         # Each entry is either (c, ) or (c, c.material) if the child has a material attribute
@@ -2710,8 +2692,8 @@ class Composite(ArmiObject):
             ),
             children,
         )
-        # Iterator that iterates over each "sub" iterator. If we have ((c0, ), (c1, m1)), this produces a single
-        # iterator of (c0, c1, m1)
+        # Iterator that iterates over each "sub" iterator. If we have ((c0, ), (c1, m1)), this
+        # produces a single iterator of (c0, c1, m1)
         return itertools.chain.from_iterable(stitched)
 
     def getChildren(
@@ -2728,17 +2710,16 @@ class Composite(ArmiObject):
             :id: I_ARMI_CMP1
             :implements: R_ARMI_CMP
 
-            This method retrieves all children within a given Composite object. Children
-            of any generation can be retrieved. This is achieved by visiting all
-            children and calling this method recursively for each generation requested.
+            This method retrieves all children within a given Composite object. Children of any
+            generation can be retrieved. This is achieved by visiting all children and calling this
+            method recursively for each generation requested.
 
-            If the method is called with ``includeMaterials``, it will additionally
-            include information about the material for each child. If a function is
-            supplied as the ``predicate`` argument, then this method will be used
-            to evaluate all children as a filter to include or not. For example, if the
-            caller of this method only desires children with a certain flag, or children
-            which only contain a certain material, then the ``predicate`` function
-            can be used to perform this filtering.
+            If the method is called with ``includeMaterials``, it will additionally include
+            information about the material for each child. If a function is supplied as the
+            ``predicate`` argument, then this method will be used to evaluate all children as a
+            filter to include or not. For example, if the caller of this method only desires
+            children with a certain flag, or children which only contain a certain material, then
+            the ``predicate`` function can be used to perform this filtering.
 
         Parameters
         ----------
@@ -2746,26 +2727,25 @@ class Composite(ArmiObject):
             Return all children of all levels.
 
         generationNum : int, optional
-            Which generation to return. 1 means direct children, 2 means children of
-            children. Setting this parameter will only return children of this
-            generation, not their parents. Default: Just return direct children.
+            Which generation to return. 1 means direct children, 2 means children of children.
+            Setting this parameter will only return children of this generation, not their parents.
+            Default: Just return direct children.
 
         includeMaterials : bool, optional
             Include the material properties
 
         predicate : callable, optional
-            An optional unary predicate to use for filtering results. This can be used
-            to request children of specific types, or with desired attributes. Not all
-            ArmiObjects have the same methods and members, so care should be taken to
-            make sure that the predicate executes gracefully in all cases (e.g., use
-            ``getattr(obj, "attribute", None)`` to access instance attributes). Failure
-            to meet the predicate only affects the object in question; children will
-            still be considered.
+            An optional unary predicate to use for filtering results. This can be used to request
+            children of specific types, or with desired attributes. Not all ArmiObjects have the
+            same methods and members, so care should be taken to make sure that the predicate
+            executes gracefully in all cases (e.g., use ``getattr(obj, "attribute", None)`` to
+            access instance attributes). Failure to meet the predicate only affects the object in
+            question; children will still be considered.
 
         See Also
         --------
-        :meth:`iterChildren` if you do not need to produce a full list, e.g., just iterating
-        over objects.
+        :meth:`iterChildren` if you do not need to produce a full list, e.g., just iterating over
+        objects.
 
         Examples
         --------
@@ -2818,22 +2798,21 @@ class Composite(ArmiObject):
 
     def syncMpiState(self):
         """
-        Synchronize all parameters of this object and all children to all worker nodes
-        over the network using MPI.
+        Synchronize all parameters of this object and all children to all worker nodes over the
+        network using MPI.
 
-        In parallelized runs, if each process has its own copy of the entire reactor
-        hierarchy, this method synchronizes the state of all parameters on all objects.
+        In parallelized runs, if each process has its own copy of the entire reactor hierarchy, this
+        method synchronizes the state of all parameters on all objects.
 
         .. impl:: Composites can be synchronized across MPI threads.
             :id: I_ARMI_CMP_MPI
             :implements: R_ARMI_CMP_MPI
 
-            Parameters need to be handled properly during parallel code execution.This
-            method synchronizes all parameters of the composite object across all
-            processes by cycling through all the children of the Composite and ensuring
-            that their parameters are properly synchronized. If it fails to synchronize,
-            an error message is displayed which alerts the user to which Composite has
-            inconsistent data across the processes.
+            Parameters need to be handled properly during parallel code execution. This method
+            synchronizes all parameters of the composite object across all processes by cycling
+            through all the children of the Composite and ensuring that their parameters are
+            properly synchronized. If it fails to synchronize, an error message is displayed which
+            alerts the user to which Composite has inconsistent data across the processes.
 
         Returns
         -------
@@ -2926,10 +2905,9 @@ class Composite(ArmiObject):
             # nodeSyncData is a list of tuples
             for key, val in nodeSyncData.items():
                 if key in syncedKeys:
-                    # TODO: this requires further investigation and should be avoidable.
-                    # this situation results when a composite object is flagged as being
-                    # out of sync, and this parameter was also globally modified and
-                    # readjusted to the original value.
+                    # TODO: this requires further investigation and should be avoidable. This
+                    # situation results when a composite object is flagged as being out of sync, and
+                    # this parameter was also globally modified and readjusted to the original value
                     curVal = self.p[key]
                     if isinstance(val, np.ndarray) or isinstance(curVal, np.ndarray):
                         if (val != curVal).any():
@@ -2949,8 +2927,8 @@ class Composite(ArmiObject):
         """
         Mark the composite and child parameters as synchronized across MPI.
 
-        We clear SINCE_LAST_DISTRIBUTE_STATE so that anything after this point will set
-        the SINCE_LAST_DISTRIBUTE_STATE flag, indicating it has been modified
+        We clear SINCE_LAST_DISTRIBUTE_STATE so that anything after this point will set the
+        SINCE_LAST_DISTRIBUTE_STATE flag, indicating it has been modified
         SINCE_LAST_DISTRIBUTE_STATE.
         """
         paramDefs = set()
@@ -2975,8 +2953,8 @@ class Composite(ArmiObject):
         Parameters
         ----------
         paramsToApply : iterable
-            Parameters that should be applied to the state after existing the state
-            retainer. All others will be reverted to their values upon entering.
+            Parameters that should be applied to the state after existing the state retainer. All
+            others will be reverted to their values upon entering.
 
         Notes
         -----
@@ -2988,8 +2966,8 @@ class Composite(ArmiObject):
         """
         Create and store a backup of the state.
 
-        This needed to be overridden due to linked components which actually have a
-        parameter value of another ARMI component.
+        This needed to be overridden due to linked components which actually have a parameter value
+        of another ARMI component.
         """
         self._backupCache = (self.cached, self._backupCache)
         self.cached = {}  # don't .clear(), using reference above!
@@ -3012,7 +2990,7 @@ class Composite(ArmiObject):
             self.spatialGrid.restoreBackup()
 
     def getLumpedFissionProductsIfNecessary(self, nuclides=None):
-        """Return Lumped Fission Product objects that belong to this object or any of its children."""
+        """Return Lumped Fission Product objects that belong to this object or its children."""
         if self.requiresLumpedFissionProducts(nuclides=nuclides):
             lfps = self.getLumpedFissionProductCollection()
             if lfps is None:
@@ -3020,8 +2998,9 @@ class Composite(ArmiObject):
                     return c.getLumpedFissionProductsIfNecessary(nuclides=nuclides)
             else:
                 return lfps
-        # There are no lumped fission products in the batch so if you use a
-        # dictionary no one will know the difference
+
+        # There are no lumped fission products in the batch so if you use a dictionary no one will
+        # know the difference
         return {}
 
     def getLumpedFissionProductCollection(self):
@@ -3035,7 +3014,7 @@ class Composite(ArmiObject):
 
         See Also
         --------
-        armi.physics.neutronics.fissionProductModel.lumpedFissionProduct.LumpedFissionProduct : LFP object
+        armi.physics.neutronics.fissionProductModel.lumpedFissionProduct.LumpedFissionProduct
         """
         lfps = ArmiObject.getLumpedFissionProductCollection(self)
         if lfps is None:
@@ -3062,8 +3041,8 @@ class Composite(ArmiObject):
         """
         Returns the multigroup neutron tracklength in [n-cm/s].
 
-        The first entry is the first energy group (fastest neutrons). Each additional
-        group is the next energy group, as set in the ISOTXS library.
+        The first entry is the first energy group (fastest neutrons). Each additional group is the
+        next energy group, as set in the ISOTXS library.
 
         Parameters
         ----------
@@ -3215,12 +3194,11 @@ class StateRetainer:
       reads; however, it does use more memory.
 
     * This can be used on any object within the composite pattern via with
-      ``[rabc].retainState([list], [of], [parameters], [to], [retain]):``.
-      Use on an object up in the hierarchy applies to all objects below as well.
+      ``[rabc].retainState([list], [of], [parameters], [to], [retain]):``. Use on an object up in
+      the hierarchy applies to all objects below as well.
 
     * This is intended to work across MPI, so that if you were to broadcast the reactor the state
       would be correct; however the exact implication on ``parameters`` may be unclear.
-
     """
 
     def __init__(self, composite: Composite, paramsToApply=None):
@@ -3288,9 +3266,11 @@ def gatherMaterialsByVolume(
     filter both by container type (e.g. Block type) with one set of flags, and Components with
     another set of flags.
 
-    .. warning:: This is a **composition** related helper method that will likely be filed into
-        classes/modules that deal specifically with the composition of things in the data model.
-        Thus clients that use it from here should expect to need updates soon.
+    Warning
+    -------
+    This is a **composition** related helper method that will likely be filed into classes/modules
+    that deal specifically with the composition of things in the data model. Thus clients that use
+    it from here should expect to need updates soon.
     """
     volumes = {}
     samples = {}

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -848,20 +848,18 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 continue
             elif not sourceBlocksInfo:
                 raise ValueError(
-                    "An error occurred when attempting to map to the "
-                    f"results from {sourceAssembly} to {destinationAssembly}. "
-                    f"No blocks in {sourceAssembly} exist between the axial "
-                    f"elevations of {zLower:<12.5f} cm and {zUpper:<12.5f} cm. "
-                    "This a major bug in the uniform mesh converter that should "
-                    "be reported to the developers."
+                    f"An error occurred when attempting to map to the results from "
+                    f"{sourceAssembly} to {destinationAssembly}. No blocks in {sourceAssembly} "
+                    f"exist between the axial elevations of {zLower:<12.5f} cm and {zUpper:<12.5f} "
+                    "cm. This a major bug in the uniform mesh converter that should be reported."
                 )
 
             if mapNumberDensities:
                 setNumberDensitiesFromOverlaps(destBlock, sourceBlocksInfo)
 
-            # Iterate over each of the blocks that were found in the uniform mesh
-            # source assembly within the lower and upper bounds of the destination
-            # block and perform the parameter mapping.
+            # Iterate over each of the blocks that were found in the uniform mesh source assembly
+            # within the lower and upper bounds of the destination block and perform the parameter
+            # mapping.
             if paramMapper is not None:
                 updatedDestVals = collections.defaultdict(float)
                 for sourceBlock, sourceBlockOverlapHeight in sourceBlocksInfo:
@@ -894,14 +892,14 @@ class UniformMeshGeometryConverter(GeometryConverter):
                     destBlock, updatedDestVals.values(), updatedDestVals.keys()
                 )
 
-        # If requested, the reaction rates will be calculated based on the
-        # mapped neutron flux and the XS library.
+        # If requested, the reaction rates will be calculated based on the mapped neutron flux and
+        # the XS library.
         if calcReactionRates:
             if paramMapper is None:
                 runLog.warning(
-                    f"Reaction rates requested for {destinationAssembly}, but no ParamMapper "
-                    "was provided to setAssemblyStateFromOverlaps(). Reaction rates calculated "
-                    "will reflect the intended result without new parameter values being mapped in."
+                    f"Reaction rates requested for {destinationAssembly}, but no ParamMapper was "
+                    "provided to setAssemblyStateFromOverlaps(). Reaction rates calculated will "
+                    "reflect the intended result without new parameter values being mapped in."
                 )
             core = sourceAssembly.getAncestor(lambda c: isinstance(c, Core))
             if core is not None:
@@ -961,16 +959,16 @@ class UniformMeshGeometryConverter(GeometryConverter):
                 continue
             assemsToPlot.append(coreAssems[0])
 
-        # Obtain the plot numbering based on the existing files so that existing plots
-        # are not overwritten.
+        # Obtain the plot numbering based on the existing files so that existing plots are not
+        # overwritten.
         start = 0
         existingFiles = glob.glob(
             f"{self.convReactor.core.name}AssemblyTypes" + "*" + ".png"
         )
-        # This loops over the existing files for the assembly types outputs
-        # and makes a unique integer value so that plots are not overwritten. The
-        # regular expression here captures the first integer as AssemblyTypesX and
-        # then ensures that the numbering in the next enumeration below is 1 above that.
+        # This loops over the existing files for the assembly types outputs and makes a unique
+        # integer value so that plots are not overwritten. The regular expression here captures the
+        # first integer as AssemblyTypesX and then ensures that the numbering in the next
+        # enumeration below is 1 above that.
         for f in existingFiles:
             newStart = int(re.search(r"\d+", f).group())
             if newStart > start:
@@ -998,11 +996,11 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         Notes
         -----
-        The parameters mapped into and out of the uniform mesh will vary depending on
-        the physics kernel using the uniform mesh. The parameters to be mapped in each
-        direction are defined as a class attribute. New options can be created by extending
-        the base class with different class attributes for parameters to map, and applying
-        special modifications to these categorized lists with the `_setParamsToUpdate` method.
+        The parameters mapped into and out of the uniform mesh will vary depending on the physics
+        kernel using the uniform mesh. The parameters to be mapped in each direction are defined as
+        a class attribute. New options can be created by extending the base class with different
+        class attributes for parameters to map, and applying special modifications to these
+        categorized lists with the `_setParamsToUpdate` method.
 
         This base class `_setParamsToUpdate()` method should not be called, so this raises a
         NotImplementedError.
@@ -1010,12 +1008,8 @@ class UniformMeshGeometryConverter(GeometryConverter):
         Parameters
         ----------
         direction : str
-            "in" or "out". The direction of mapping; "in" to the uniform mesh assembly, or "out" of it.
-            Different parameters are mapped in each direction.
-
-        Raises
-        ------
-        NotImplementedError
+            "in" or "out". The direction of mapping; "in" to the uniform mesh assembly, or "out" of
+            it. Different parameters are mapped in each direction.
         """
         raise NotImplementedError
 
@@ -1032,10 +1026,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
     def _buildAllUniformAssemblies(self):
         """
-        Loop through each new block for each mesh point and apply conservation of atoms.
-        We use the submesh and allow blocks to be as small as the smallest submesh to
-        avoid unnecessarily diffusing small blocks into huge ones (e.g. control blocks
-        into plenum).
+        Loop through each new block for each mesh point and apply conservation of atoms. We use the
+        submesh and allow blocks to be as small as the smallest submesh to avoid unnecessarily
+        diffusing small blocks into huge ones (e.g. control blocks into plenum).
         """
         runLog.debug(
             f"Creating new assemblies from {self._sourceReactor.core} "
@@ -1072,14 +1065,13 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         Notes
         -----
-        This is a basic parameter mapping routine that can be used by most sub-classes.
-        If special mapping logic is required, this method can be defined on sub-classes as necessary.
+        This is a basic parameter mapping routine that can be used by most sub-classes. If special
+        mapping logic is required, this method can be defined on sub-classes as necessary.
         """
         # Map reactor core parameters
         for paramName in self.paramMapper.reactorParamNames:
-            # Check if the source reactor has a value assigned for this
-            # parameter and if so, then apply it. Otherwise, revert back to
-            # the original value.
+            # Check if the source reactor has a value assigned for this parameter and if so, then
+            # apply it. Otherwise, revert back to the original value.
             if (
                 sourceReactor.core.p[paramName]
                 or paramName not in self._cachedReactorCoreParamData
@@ -1101,23 +1093,25 @@ class UniformMeshGeometryConverter(GeometryConverter):
                     calcReactionRates=False,
                 )
 
-            # If requested, the reaction rates will be calculated based on the
-            # mapped neutron flux and the XS library.
+            # If requested, the reaction rates will be calculated based on the mapped neutron flux
+            # and the XS library.
             if self.calcReactionRates:
                 self._calculateReactionRatesEfficient(
                     destReactor.core, sourceReactor.core.p.keff
                 )
 
-        # Clear the cached data after it has been mapped to prevent issues with
-        # holding on to block data long-term.
+        # Clear the cached data after it has been mapped to prevent issues with holding on to block
+        # data long-term.
         self._cachedReactorCoreParamData = {}
 
     @staticmethod
     def _calculateReactionRatesEfficient(core, keff):
         """
-        First, sort blocks into groups by XS type. Then, we just need to grab micros for each XS type once.
+        First, sort blocks into groups by XS type. Then, we just need to grab micros for each XS
+        type once.
 
-        Iterate over list of blocks with the given XS type; calculate reaction rates for these blocks
+        Iterate over list of blocks with the given XS type; calculate reaction rates for these
+        blocks.
         """
         xsTypeGroups = collections.defaultdict(list)
         for b in core.iterBlocks():
@@ -1141,16 +1135,15 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         Notes
         -----
-        If a block in the assembly does not contain any multi-group flux
-        than the reaction rate calculation for this block will be skipped.
+        If a block in the assembly does not contain any multi-group flux than the reaction rate
+        calculation for this block will be skipped.
         """
         from armi.physics.neutronics.globalFlux import globalFluxInterface
 
         for b in assem:
-            # Checks if the block has a multi-group flux defined and if it
-            # does not then this will skip the reaction rate calculation. This
-            # is captured by the TypeError, due to a `NoneType` divide by float
-            # error.
+            # Checks if the block has a multi-group flux defined and if it does not then this will
+            # skip the reaction rate calculation. This is captured by the TypeError, due to a
+            # `NoneType` divide by float error.
             try:
                 b.getMgFlux()
             except TypeError:
@@ -1168,9 +1161,9 @@ class UniformMeshGeometryConverter(GeometryConverter):
             :id: I_ARMI_FLUX_RX_RATES_BY_XS_ID
             :implements: R_ARMI_FLUX_RX_RATES
 
-            This is an alternative implementation of :need:`I_ARMI_FLUX_RX_RATES` that
-            is more efficient when computing reaction rates for a large set of blocks
-            that share a common set of microscopic cross sections.
+            This is an alternative implementation of :need:`I_ARMI_FLUX_RX_RATES` that is more
+            efficient when computing reaction rates for a large set of blocks that share a common
+            set of microscopic cross sections.
 
             For more detail on the reation rate calculations, see :need:`I_ARMI_FLUX_RX_RATES`.
 
@@ -1182,14 +1175,14 @@ class UniformMeshGeometryConverter(GeometryConverter):
             implemented for a block.
 
         keff : float
-            The keff of the core. This is required to get the neutron production rate correct
-            via the neutron balance statement (since nuSigF has a 1/keff term).
+            The keff of the core. This is required to get the neutron production rate correct via
+            the neutron balance statement (since nuSigF has a 1/keff term).
 
         xsNucDict: Dict[str, XSNuclide]
-            Microscopic cross sections to use in computing the reaction rates. Keys are
-            nuclide names (e.g., "U235") and values are the associated XSNuclide objects
-            from the cross section library, which contain the microscopic cross section
-            data for a given nuclide in the current cross section group.
+            Microscopic cross sections to use in computing the reaction rates. Keys are nuclide
+            names (e.g., "U235") and values are the associated XSNuclide objects from the cross
+            section library, which contain the microscopic cross section data for a given nuclide in
+            the current cross section group.
         """
         for obj in objList:
             rate = collections.defaultdict(float)
@@ -1246,10 +1239,10 @@ class UniformMeshGeometryConverter(GeometryConverter):
 
         Notes
         -----
-        In some cases, we may want to read flux into a converted reactor from a
-        pre-existing physics output instead of mapping it in from the pre-conversion
-        source reactor. This method can be called after reading that flux in to
-        calculate updated reaction rates derived from that flux.
+        In some cases, we may want to read flux into a converted reactor from a pre-existing physics
+        output instead of mapping it in from the pre-conversion source reactor. This method can be
+        called after reading that flux in to calculate updated reaction rates derived from that
+        flux.
         """
         if self._hasNonUniformAssems:
             for assem in self.convReactor.core.getAssemblies(self._nonUniformMeshFlags):
@@ -1268,21 +1261,20 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
 
     Notes
     -----
-    This uniform mesh converter is intended for setting up an eigenvalue
-    (fission-source) neutronics solve. There are no block parameters that need
-    to be mapped in for a basic eigenvalue calculation, just number densities.
-    The results of the calculation are mapped out (i.e., back to the non-uniform
-    mesh). The results mapped out include things like flux, power, and reaction
+    This uniform mesh converter is intended for setting up an eigenvalue (fission-source) neutronics
+    solve. There are no block parameters that need to be mapped in for a basic eigenvalue
+    calculation, just number densities. The results of the calculation are mapped out (i.e., back to
+    the non-uniform mesh). The results mapped out include things like flux, power, and reaction
     rates.
 
-    .. warning::
-        If a parameter is calculated by a physics solver while the reactor is in its
-        converted (uniform mesh) state, that parameter *must* be included in the list
-        of `reactorParamNames` or `blockParamNames` to be mapped back to the non-uniform
-        reactor; otherwise, it will be lost. These lists are defined through the
-        `_setParamsToUpdate` method, which uses the `reactorParamMappingCategories` and
-        `blockParamMappingCategories` attributes and applies custom logic to create a list of
-        parameters to be mapped in each direction.
+    Warning
+    -------
+    If a parameter is calculated by a physics solver while the reactor is in its converted (uniform
+    mesh) state, that parameter *must* be included in the list of `reactorParamNames` or
+    `blockParamNames` to be mapped back to the non-uniform reactor; otherwise, it will be lost.
+    These lists are defined through the `_setParamsToUpdate` method, which uses the
+    `reactorParamMappingCategories` and `blockParamMappingCategories` attributes and applies custom
+    logic to create a list of parameters to be mapped in each direction.
     """
 
     reactorParamMappingCategories = {
@@ -1306,9 +1298,8 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
             Case settings object.
 
         calcReactionRates : bool, optional
-            Set to True by default, but if set to False the reaction
-            rate calculation after the neutron flux is remapped will
-            not be calculated.
+            Set to True by default, but if set to False the reaction rate calculation after the
+            neutron flux is remapped will not be calculated.
         """
         UniformMeshGeometryConverter.__init__(self, cs)
         self.calcReactionRates = calcReactionRates
@@ -1319,19 +1310,18 @@ class NeutronicsUniformMeshConverter(UniformMeshGeometryConverter):
 
         Notes
         -----
-        For the fission-source neutronics calculation, there are no block parameters
-        that need to be mapped in. This function applies additional filters to the
-        list of categories defined in `blockParamMappingCategories[out]` to avoid mapping
-        out cumulative parameters like DPA or burnup. These parameters should not
-        exist on the neutronics uniform mesh assembly anyway, but this filtering
-        provides an added layer of safety to prevent data from being inadvertently
-        overwritten.
+        For the fission-source neutronics calculation, there are no block parameters that need to be
+        mapped in. This function applies additional filters to the list of categories defined in
+        `blockParamMappingCategories[out]` to avoid mapping out cumulative parameters like DPA or
+        burnup. These parameters should not exist on the neutronics uniform mesh assembly anyway,
+        but this filtering provides an added layer of safety to prevent data from being
+        inadvertently overwritten.
 
         Parameters
         ----------
         direction : str
-            "in" or "out". The direction of mapping; "in" to the uniform mesh assembly, or "out" of it.
-            Different parameters are mapped in each direction.
+            "in" or "out". The direction of mapping; "in" to the uniform mesh assembly, or "out" of
+            it. Different parameters are mapped in each direction.
         """
         reactorParamNames = []
         blockParamNames = []
@@ -1374,18 +1364,18 @@ class GammaUniformMeshConverter(UniformMeshGeometryConverter):
     This uniform mesh converter is intended for setting up a fixed-source gamma transport solve.
     Some block parameters from the neutronics solve, such as `b.p.mgFlux`, may need to be mapped
     into the uniform mesh reactor so that the gamma source can be calculated by the ARMI plugin
-    performing gamma transport. Parameters that are updated with gamma transport results, such
-    as `powerGenerated`, `powerNeutron`, and `powerGamma`, need to be mapped back to the
-    non-uniform reactor.
+    performing gamma transport. Parameters that are updated with gamma transport results, such as
+    `powerGenerated`, `powerNeutron`, and `powerGamma`, need to be mapped back to the non-uniform
+    reactor.
 
-    .. warning::
-        If a parameter is calculated by a physics solver while the reactor is in its
-        converted (uniform mesh) state, that parameter *must* be included in the list
-        of `reactorParamNames` or `blockParamNames` to be mapped back to the non-uniform
-        reactor; otherwise, it will be lost. These lists are defined through the
-        `_setParamsToUpdate` method, which uses the `reactorParamMappingCategories` and
-        `blockParamMappingCategories` attributes and applies custom logic to create a list of
-        parameters to be mapped in each direction.
+    Warning
+    -------
+    If a parameter is calculated by a physics solver while the reactor is in its converted (uniform
+    mesh) state, that parameter *must* be included in the list of `reactorParamNames` or
+    `blockParamNames` to be mapped back to the non-uniform reactor; otherwise, it will be lost.
+    These lists are defined through the `_setParamsToUpdate` method, which uses the
+    `reactorParamMappingCategories` and `blockParamMappingCategories` attributes and applies custom
+    logic to create a list of parameters to be mapped in each direction.
     """
 
     reactorParamMappingCategories = {
@@ -1408,18 +1398,18 @@ class GammaUniformMeshConverter(UniformMeshGeometryConverter):
 
         Notes
         -----
-        For gamma transport, only a small subset of neutronics parameters need to be
-        mapped out. The set is defined in this method. There are conditions on the
-        output blockParamMappingCategories: only non-cumulative, gamma parameters are mapped out.
-        This avoids numerical diffusion of cumulative parameters or those created by the
-        initial eigenvalue neutronics solve from being mapped in both directions by the
-        mesh converter for the fixed-source gamma run.
+        For gamma transport, only a small subset of neutronics parameters need to be mapped out. The
+        set is defined in this method. There are conditions on the output
+        blockParamMappingCategories: only non-cumulative, gamma parameters are mapped out. This
+        avoids numerical diffusion of cumulative parameters or those created by the initial
+        eigenvalue neutronics solve from being mapped in both directions by the mesh converter for
+        the fixed-source gamma run.
 
         Parameters
         ----------
         direction : str
-            "in" or "out". The direction of mapping; "in" to the uniform mesh assembly, or "out" of it.
-            Different parameters are mapped in each direction.
+            "in" or "out". The direction of mapping; "in" to the uniform mesh assembly, or "out" of
+            it. Different parameters are mapped in each direction.
         """
         reactorParamNames = []
         blockParamNames = []
@@ -1438,6 +1428,7 @@ class GammaUniformMeshConverter(UniformMeshGeometryConverter):
             )
         else:
             excludeList = b.p.paramDefs.inCategory(parameters.Category.gamma).names
+
         for category in self.blockParamMappingCategories[direction]:
             blockParamNames.extend(
                 [
@@ -1454,19 +1445,17 @@ class GammaUniformMeshConverter(UniformMeshGeometryConverter):
 
 class ParamMapper:
     """
-    Utility for parameter setters/getters that can be used when
-    transferring data from one assembly to another during the mesh
-    conversion process. Stores some data like parameter defaults and
-    properties to save effort of accessing paramDefs many times for
-    the same data.
+    Utility for parameter setters/getters that can be used when transferring data from one assembly
+    to another during the mesh conversion process. Stores some data like parameter defaults and
+    properties to save effort of accessing paramDefs many times for the same data.
     """
 
     def __init__(self, reactorParamNames, blockParamNames, b):
         """
         Initialize the list of parameter defaults.
 
-        The ParameterDefinitionCollection lookup is very slow, so this we do it once
-        and store it as a hashed list.
+        The ParameterDefinitionCollection lookup is very slow, so this we do it once and store it as
+        a hashed list.
         """
         self.paramDefaults = {
             paramName: b.p.pDefs[paramName].default for paramName in blockParamNames
@@ -1479,12 +1468,11 @@ class ParamMapper:
             )
             for paramName in blockParamNames
         }
-        # determine which parameters are peak/max
-        # Unfortunately, these parameters don't tell you WHERE in the block the peak
-        # value occurs. So when mapping block parameters in setAssemblyStateFromOverlaps(),
-        # we will just grab the maximum value over all of the source blocks. This effectively
-        # assumes that all of the source blocks overlap 100% with the destination block,
-        # although this is rarely actually the case.
+        # Determine which parameters are peak/max. Unfortunately, these parameters don't tell you
+        # WHERE in the block the peak value occurs. So when mapping block parameters in
+        # setAssemblyStateFromOverlaps(), we will just grab the maximum value over all of the source
+        # blocks. This effectively assumes that all of the source blocks overlap 100% with the
+        # destination block, although this is rarely actually the case.
         self.isPeak = {
             paramName: b.p.paramDefs[paramName].atLocation(parameters.ParamLocation.MAX)
             for paramName in blockParamNames
@@ -1538,10 +1526,10 @@ def setNumberDensitiesFromOverlaps(block, overlappingBlockInfo):
     r"""
     Set number densities on a block based on overlapping blocks.
 
-    A conservation of number of atoms technique is used to map the non-uniform number densities onto the uniform
-    neutronics mesh. When the number density of a height :math:`H` neutronics mesh block :math:`N^{\prime}` is
-    being computed from one or more blocks in the ARMI mesh with number densities :math:`N_i` and
-    heights :math:`h_i`, the following formula is used:
+    A conservation of number of atoms technique is used to map the non-uniform number densities onto
+    the uniform neutronics mesh. When the number density of a height :math:`H` neutronics mesh block
+    :math:`N^{\prime}` is being computed from one or more blocks in the ARMI mesh with number
+    densities :math:`N_i` and heights :math:`h_i`, the following formula is used:
 
     .. math::
 
@@ -1554,8 +1542,13 @@ def setNumberDensitiesFromOverlaps(block, overlappingBlockInfo):
         heightScaling = overlappingHeightInCm / blockHeightInCm
         for nucName, numberDensity in overlappingBlock.getNumberDensities().items():
             totalDensities[nucName] += numberDensity * heightScaling
-    block.setNumberDensities(dict(totalDensities))
-    # Set the volume of each component in the block to `None` so that the
-    # volume of each component is recomputed.
+
+    totalDensities.update(
+        {nuc: 0.0 for nuc in block.getNuclides() if nuc not in totalDensities}
+    )
+    block.updateNumberDensities(totalDensities)
+    # block.setNumberDensities(dict(totalDensities)) # TODO: JOHN
+    # Set the volume of each component in the block to `None` so that the volume of each component
+    # is recomputed.
     for c in block:
         c.p.volume = None

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -383,8 +383,7 @@ class Block_TestCase(unittest.TestCase):
             self.block.getDim(Flags.FUEL, "od") ** 2
             - self.block.getDim(Flags.FUEL, "id") ** 2
         ) / self.block.getDim(Flags.LINER, "id") ** 2
-        places = 10
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=10)
 
         # test with liner instead of clad
         ref = (
@@ -395,13 +394,13 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(
             cur,
             ref,
-            places=places,
+            places=10,
             msg="Incorrect getSmearDensity with liner. Got {0}. Should be {1}".format(
                 cur, ref
             ),
         )
 
-        # test with annular fuel.
+        # test with annular fuel
         fuelDims = {
             "Tinput": 273.0,
             "Thot": 273.0,
@@ -419,7 +418,7 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(
             cur,
             ref,
-            places=places,
+            places=10,
             msg="Incorrect getSmearDensity with annular fuel. Got {0}. Should be {1}".format(
                 cur, ref
             ),
@@ -514,18 +513,15 @@ class Block_TestCase(unittest.TestCase):
 
         ref = self.block.getMass()
         cur = Block2.getMass()
-        places = 6
-        self.assertAlmostEqual(ref, cur, places=places)
+        self.assertAlmostEqual(ref, cur, places=6)
 
         ref = self.block.getArea()
         cur = Block2.getArea()
-        places = 6
-        self.assertAlmostEqual(ref, cur, places=places)
+        self.assertAlmostEqual(ref, cur, places=6)
 
         ref = self.block.getHeight()
         cur = Block2.getHeight()
-        places = 6
-        self.assertAlmostEqual(ref, cur, places=places)
+        self.assertAlmostEqual(ref, cur, places=6)
 
         self.assertEqual(self.block.p.flags, Block2.p.flags)
 
@@ -576,13 +572,11 @@ class Block_TestCase(unittest.TestCase):
 
             ref = self.block.getArea()
             cur = homogBlock.getArea()
-            places = 6
-            self.assertAlmostEqual(ref, cur, places=places)
+            self.assertAlmostEqual(ref, cur, places=6)
 
             ref = self.block.getHeight()
             cur = homogBlock.getHeight()
-            places = 6
-            self.assertAlmostEqual(ref, cur, places=places)
+            self.assertAlmostEqual(ref, cur, places=6)
 
     def test_getXsType(self):
         self.cs = settings.Settings()
@@ -724,8 +718,7 @@ class Block_TestCase(unittest.TestCase):
         for nuc in self.block.getNuclides():
             cur = self.block.getNumberDensity(nuc)
             ref = 0.0
-            places = 5
-            self.assertAlmostEqual(cur, ref, places=places)
+            self.assertAlmostEqual(cur, ref, places=5)
 
     def test_getNumberDensity(self):
         refDict = {
@@ -738,13 +731,12 @@ class Block_TestCase(unittest.TestCase):
             "ZR": 0.00709003962772,
         }
 
-        self.block.setNumberDensities(refDict)
+        self.block.updateNumberDensities(refDict)
 
         for nucKey, nucItem in refDict.items():
             cur = self.block.getNumberDensity(nucKey)
             ref = nucItem
-            places = 6
-            self.assertAlmostEqual(ref, cur, places=places)
+            self.assertAlmostEqual(ref, cur, places=6)
 
     def test_getMasses(self):
         masses = sorted(self.block.getMasses())
@@ -764,37 +756,7 @@ class Block_TestCase(unittest.TestCase):
         self.block.setNumberDensity("U235", ref)
 
         cur = self.block.getNumberDensity("U235")
-        places = 5
-        self.assertAlmostEqual(cur, ref, places=places)
-
-    def test_setNumberDensities(self):
-        """Make sure we can set multiple number densities at once."""
-        b = self.block
-        b.setNumberDensity("NA", 0.5)
-        refDict = {
-            "U235": 0.00275173784234,
-            "U238": 0.0217358415457,
-            "W": 1.09115150103e-05,
-            "ZR": 0.00709003962772,
-        }
-
-        b.setNumberDensities(refDict)
-
-        for nucKey, nucItem in refDict.items():
-            cur = self.block.getNumberDensity(nucKey)
-            ref = nucItem
-            places = 6
-            self.assertAlmostEqual(cur, ref, places=places)
-
-        # make sure U235 stayed fully contained in the fuel component
-        fuelC = b.getComponent(Flags.FUEL)
-        self.assertAlmostEqual(
-            b.getNumberDensity("U235"),
-            fuelC.getNumberDensity("U235") * fuelC.getVolumeFraction(),
-        )
-
-        # make sure other vals were zeroed out
-        self.assertAlmostEqual(b.getNumberDensity("NA23"), 0.0)
+        self.assertAlmostEqual(cur, ref, places=5)
 
     def test_getMass(self):
         self.block.setHeight(100.0)
@@ -807,8 +769,7 @@ class Block_TestCase(unittest.TestCase):
         ref = d * v * A / MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
         cur = self.block.getMass(nucName)
 
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
     def test_setMass(self):
         self.block.setHeight(100.0)
@@ -819,16 +780,14 @@ class Block_TestCase(unittest.TestCase):
 
         cur = self.block.getMass(nuc)
         ref = mass
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
         cur = self.block.getNumberDensity(nuc)
         v = self.block.getVolume()
         A = nucDir.getAtomicWeight(nuc)
         ref = MOLES_PER_CC_TO_ATOMS_PER_BARN_CM * mass / (v * A)
 
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
     def test_getTotalMass(self):
         self.block.setHeight(100.0)
@@ -843,7 +802,7 @@ class Block_TestCase(unittest.TestCase):
             "W186": 1.17057432664e-05,
             "ZR": 0.00709003962772,
         }
-        self.block.setNumberDensities(refDict)
+        self.block.updateNumberDensities(refDict)
 
         cur = self.block.getMass()
 
@@ -856,8 +815,7 @@ class Block_TestCase(unittest.TestCase):
         v = self.block.getVolume()
         ref = tot * v / MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
 
-        places = 9
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=9)
 
     def test_replaceBlockWithBlock(self):
         """Tests conservation of mass flag in replaceBlockWithBlock."""
@@ -1013,8 +971,7 @@ class Block_TestCase(unittest.TestCase):
         self.block.adjustUEnrich(ref)
 
         cur = self.block.getComponent(Flags.FUEL).getEnrichment()
-        places = 5
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=5)
 
     def test_setLocation(self):
         """
@@ -1077,7 +1034,7 @@ class Block_TestCase(unittest.TestCase):
             "W186": 1.17057432664e-05,
             "ZR": 0.00709003962772,
         }
-        self.block.setNumberDensities(refDict)
+        self.block.updateNumberDensities(refDict)
 
         cur = self.block.getTotalNDens()
 
@@ -1087,8 +1044,7 @@ class Block_TestCase(unittest.TestCase):
             tot += ndens
 
         ref = tot
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
     def test_getHMDens(self):
         self.block.setType("fuel")
@@ -1102,7 +1058,7 @@ class Block_TestCase(unittest.TestCase):
             "W186": 1.17057432664e-05,
             "ZR": 0.00709003962772,
         }
-        self.block.setNumberDensities(refDict)
+        self.block.updateNumberDensities(refDict)
 
         cur = self.block.getHMDens()
 
@@ -1114,8 +1070,7 @@ class Block_TestCase(unittest.TestCase):
 
         ref = hmDens
 
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
     def test_getFissileMassEnrich(self):
         fuelDims = {"Tinput": 273.0, "Thot": 273.0, "od": 0.76, "id": 0.0, "mult": 1.0}
@@ -1133,13 +1088,12 @@ class Block_TestCase(unittest.TestCase):
             "W186": 1.17057432664e-05,
             "ZR": 0.00709003962772,
         }
-        self.block.setNumberDensities(refDict)
+        self.block.updateNumberDensities(refDict)
 
         cur = self.block.getFissileMassEnrich()
 
         ref = self.block.getFissileMass() / self.block.getHMMass()
-        places = 4
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=4)
         self.block.remove(self.fuelComponent)
 
     def test_getMicroSuffix(self):
@@ -1160,12 +1114,10 @@ class Block_TestCase(unittest.TestCase):
         self.block.adjustUEnrich(0.25)
 
         ref = 0.25
-
         self.block.adjustUEnrich(ref)
         cur = self.block.getUraniumMassEnrich()
 
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
     def test_getUraniumNumEnrich(self):
         self.block.adjustUEnrich(0.25)
@@ -1194,7 +1146,7 @@ class Block_TestCase(unittest.TestCase):
             "W186": 1.17057432664e-05,
             "ZR": 0.00709003962772,
         }
-        self.block.setNumberDensities(refDict)
+        self.block.updateNumberDensities(refDict)
 
         nucName = "U238"
         moles = (
@@ -1221,7 +1173,7 @@ class Block_TestCase(unittest.TestCase):
             "PU241": 0.00011209296581262849,
             "PU242": 2.3078961257395204e-05,
         }
-        fuel.setNumberDensities({nuc: v / vFrac for nuc, v in refDict.items()})
+        fuel.updateNumberDensities({nuc: v / vFrac for nuc, v in refDict.items()})
 
         # test moles
         cur = self.block.getPuMoles()
@@ -1317,11 +1269,12 @@ class Block_TestCase(unittest.TestCase):
 
         Notes
         -----
-        - When checking component-level BOL params, puFrac is skipped due to 1) there's no Pu in the block, and 2)
-          getPuMoles is functionally identical to getHMMoles (just limits nuclides from heavy metal to just Pu).
-        - getSymmetryFactor is mocked to return 3. This indicates that the block is in the center-most assembly.
-          Providing this mock ensures that symmetry factors are tested as well (otherwise it's just a factor of 1
-          and it is a less robust test).
+        - When checking component-level BOL params, puFrac is skipped due to 1) there's no Pu in the
+          block, and 2) getPuMoles is functionally identical to getHMMoles (just limits nuclides
+          from heavy metal to just Pu).
+        - getSymmetryFactor is mocked to return 3. This indicates that the block is in the center-
+          most assembly. Providing this mock ensures that symmetry factors are tested as well
+          (otherwise it's just a factor of 1 and it is a less robust test).
         """
         mock_sf.return_value = 3
         area = self.block.getArea()
@@ -1329,7 +1282,7 @@ class Block_TestCase(unittest.TestCase):
         self.block.setHeight(height)
 
         self.block.clearNumberDensities()
-        self.block.setNumberDensities(
+        self.block.updateNumberDensities(
             {
                 "U238": 0.018518936996911595,
                 "ZR": 0.006040713762820692,
@@ -1636,8 +1589,7 @@ class Block_TestCase(unittest.TestCase):
         fracs = self.block.getVolumeFractions()
 
         ref = calcFracManually(("bond", "coolant"))
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
         # allow inexact for things like fuel1, fuel2 or clad vs. cladding
         val = self.block.getComponentAreaFrac([Flags.COOLANT, Flags.INTERCOOLANT])
@@ -1651,8 +1603,7 @@ class Block_TestCase(unittest.TestCase):
     def test_100_getPinPitch(self):
         cur = self.block.getPinPitch()
         ref = self.block.getDim(Flags.CLAD, "od") + self.block.getDim(Flags.WIRE, "od")
-        places = 6
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=6)
 
     def test_101_getPitch(self):
         cur = self.block.getPitch(returnComp=True)
@@ -1687,13 +1638,13 @@ class Block_TestCase(unittest.TestCase):
             a = c.getArea()
             tot += a
             areas.append((c, a))
+
         fracs = {}
         for c, a in areas:
             fracs[c.getName()] = a / tot
 
-        places = 6
         for c, a in cur:
-            self.assertAlmostEqual(a, fracs[c.getName()], places=places)
+            self.assertAlmostEqual(a, fracs[c.getName()], places=6)
 
         self.assertAlmostEqual(sum(fracs.values()), sum([a for c, a in cur]))
 

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -605,7 +605,8 @@ class TestCompositeTree(unittest.TestCase):
             "NA23": 2e-2,
             "ZR": 0.00709003962772,
         }
-        self.block.setNumberDensities(self.refDict)
+        self.block.clearNumberDensities()
+        self.block.updateNumberDensities(self.refDict)
 
     def test_ordering(self):
         a = assemblies.Assembly("dummy")
@@ -681,7 +682,6 @@ class TestCompositeTree(unittest.TestCase):
         self.fuelComponent = components.Circle("fuel", "UZr", **fuelDims)
         self.block.add(self.fuelComponent)
 
-        self.block.clearNumberDensities()
         self.refDict = {
             "U235": 0.00275173784234,
             "U238": 0.0217358415457,
@@ -693,7 +693,8 @@ class TestCompositeTree(unittest.TestCase):
             "NA23": 2e-2,
             "ZR": 0.00709003962772,
         }
-        self.block.setNumberDensities(self.refDict)
+        self.block.clearNumberDensities()
+        self.block.updateNumberDensities(self.refDict)
 
         cur = self.block.getHMMass()
 


### PR DESCRIPTION
## What is the change? Why is it being made?

Here I remove the method `Composite.getNumberDensities()` at the request of the user base. It leads to too many complicated concerns about number densities in, say, a `Block` which contains multiple `Components` with differing number densities. So now the method `getNumberDensities()` only exists on `Components`, which by definition have no children.

close #1374 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing Composite.getNumberDensities to simplify concerns about auto-homogenizing materials.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
