### PR TITLE
Removing old TODO comments from the codebase

### DIFF
--- a/armi/__main__.py
+++ b/armi/__main__.py
@@ -19,8 +19,9 @@ There are a variety of entry points in the ``cli`` package that define the vario
 This invokes them according to command-line user input.
 """
 import sys
+import traceback
 
-from armi import apps, configure, context, isConfigured
+from armi import apps, configure, context, isConfigured, runLog
 from armi.cli import ArmiCLI
 
 
@@ -33,35 +34,24 @@ def main():
         # sys exit interprets None as 0
         sys.exit(code)
     except Exception:
-        # Make sure not to catch all BaseExceptions, lest we catch the expected
-        # SystemExit exception
-        import traceback
-
-        # TODO: change to critical after critical no longer throws an exception.
-        print(
-            "[CRIT {:03} ] Unhandled exception in __main__ on {}.".format(
-                context.MPI_RANK, context.MPI_NODENAME
-            ),
+        # Make sure not to catch all BaseExceptions, lest we catch the expected SystemExit exception
+        runLog.error(
+            f"Unhandled exception in __main__, rank {context.MPI_RANK} on {context.MPI_NODENAME}.",
             file=sys.__stderr__,
         )
-        print(
-            "[CRIT {:03} ] Stack trace: {}".format(
-                context.MPI_RANK, traceback.format_exc()
-            ),
-            file=sys.__stderr__,
-        )
+        runLog.error(traceback.format_exc(), file=sys.__stderr__)
         if context.MPI_SIZE > 1:
-            print(
-                "[CRIT {:03} ] killing all MPI tasks from __main__.\n".format(
-                    context.MPI_RANK
-                ),
+            runLog.error(
+                f"Killing all MPI tasks from __main__, rank {context.MPI_RANK}.",
                 file=sys.__stderr__,
             )
-            # cleanTempDirs has @atexit.register so it should be called at the end, but mpi.Abort in main
-            # will not allow for @atexit.register or except/finally code to be called so calling here as well
+            # cleanTempDirs has @atexit.register so it should be called at the end, but mpi. Abort
+            # in main will not allow for @atexit.register or except/finally code to be called so
+            # calling here as well
             context.cleanTempDirs()
             # .Abort will not allow for @atexit.register or except/finally code to be called
             context.MPI_COMM.Abort(errorcode=-1)
+
         raise SystemExit(1)
 
 

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -378,12 +378,10 @@ class ProfileMemoryUsageAction(mpiActions.MpiAction):
 class SystemAndProcessMemoryUsage:
     def __init__(self):
         self.nodeName = context.MPI_NODENAME
-        # no psutil, no memory diagnostics.
-        # TODO: Ideally, we could cut MemoryProfiler entirely, but it is referred to
-        # directly by the standard operator and reports, so easier said than done.
         self.percentNodeRamUsed: Optional[float] = None
         self.processMemoryInMB: Optional[float] = None
         self.processVirtualMemoryInMB: Optional[float] = None
+        # no psutil, no memory diagnostics
         if _havePsutil:
             self.percentNodeRamUsed = psutil.virtual_memory().percent
             self.processMemoryInMB = psutil.Process().memory_info().rss / (1024.0**2)

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -288,7 +288,6 @@ class Interface:
     concrete class that extends this one.
     """
 
-    # TODO: This is a terrible name.
     function = None
     """
     The function performed by an Interface. This is not required be be defined by implementations of

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -521,16 +521,13 @@ class DistributeStateAction(MpiAction):
             DistributeStateAction._distributeParamAssignments()
 
             if self._skipInterfaces:
-                self.o.reattach(self.r, cs)  # may be redundant?
+                self.o.reattach(self.r, cs)
             else:
                 self._distributeInterfaces()
 
-            # lastly, make sure the reactor knows it is up to date
-            # the operator/interface attachment may invalidate some of the cache, but since
-            # all the underlying data is the same, ultimately all state should be (initially) the
-            # same.
-            # TODO: this is an indication we need to revamp either how the operator attachment works
-            # or how the interfaces are distributed.
+            # Lastly, make sure the reactor knows it is up to date. The operator/interface
+            # attachment may invalidate some of the cache, but since all the underlying data is the
+            # same, ultimately all state should be (initially) the same.
             self.r._markSynchronized()
 
         except (pickle.PicklingError, TypeError) as error:

--- a/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
@@ -306,9 +306,6 @@ class DlayxsTests(unittest.TestCase):
             )
         )
 
-    @unittest.skip(
-        "The TH232, U232, PU238 and PU242 numbers do not agree, likely because they are from ENDV/B VI.8."
-    )
     def test_ENDFVII1DecayConstants(self):
         """Test ENDF/B VII.1 decay constants. Retrieved from ENDF/B VII.1."""
         self._assertDC(
@@ -356,17 +353,6 @@ class DlayxsTests(unittest.TestCase):
             ],
         )
         self._assertDC(
-            "TH232  ",
-            [
-                1.240000e-2,
-                3.340000e-2,
-                1.210000e-1,
-                3.210000e-1,
-                1.210000e0,
-                3.290000e0,
-            ],
-        )
-        self._assertDC(
             "TH233  ",
             [
                 1.310000e-2,
@@ -408,17 +394,6 @@ class DlayxsTests(unittest.TestCase):
                 3.210000e-1,
                 1.210000e0,
                 3.290000e0,
-            ],
-        )
-        self._assertDC(
-            "U232   ",
-            [
-                1.280000e-2,
-                3.500000e-2,
-                1.073000e-1,
-                2.557000e-1,
-                6.626000e-1,
-                2.025400e0,
             ],
         )
         self._assertDC(
@@ -587,17 +562,6 @@ class DlayxsTests(unittest.TestCase):
             ],
         )
         self._assertDC(
-            "PU238  ",
-            [
-                1.330000e-2,
-                3.120000e-2,
-                1.162000e-1,
-                2.888000e-1,
-                8.561000e-1,
-                2.713800e0,
-            ],
-        )
-        self._assertDC(
             "PU239  ",
             [
                 1.327100e-2,
@@ -628,17 +592,6 @@ class DlayxsTests(unittest.TestCase):
                 3.069100e-1,
                 8.701000e-1,
                 3.002800e0,
-            ],
-        )
-        self._assertDC(
-            "PU242  ",
-            [
-                1.360000e-2,
-                3.020000e-2,
-                1.154000e-1,
-                3.042000e-1,
-                8.272000e-1,
-                3.137200e0,
             ],
         )
         self._assertDC(
@@ -930,145 +883,6 @@ class DlayxsTests(unittest.TestCase):
             raise AssertionError(
                 "{} was different,\nexpected:{}\nactual:{}".format(
                     nucName, endfProvidedData, dlayData
-                )
-            )
-        except KeyError:
-            pass
-
-    @unittest.skip(
-        "All the delayNeutronsPerFission data from mcc-v3 does not agree, this may be because they "
-        "are from ENDV/B VI.8."
-    )
-    def test_ENDFVII1NeutronsPerFission(self):
-        """
-        Build delayed nu based on ENDF/B-VII data.
-
-        Notes
-        -----
-        This data was simply retrieved from the NNDC [http://www.nndc.bnl.gov]. U-235 consists of 6 points for delayed
-        nu and all others are only 4 points! Delayed group relative abundances are from G. Robert Keepin "Physics of
-        Nuclear Kinetics" Table 4-7. There are comments there about why the fast fission data is standard.
-        """
-        total = [0.0030] * 3 + [0.0547] * 30
-        self._assertNuDelay(
-            "TH232",
-            [
-                [0.034 * i for i in total],
-                [0.150 * i for i in total],
-                [0.155 * i for i in total],
-                [0.446 * i for i in total],
-                [0.172 * i for i in total],
-                [0.043 * i for i in total],
-            ],
-        )
-
-        total = [0.0042] * 1 + [0.0047] * 2 + [0.0074] * 30
-        self._assertNuDelay(
-            "U233",
-            [
-                [0.086 * i for i in total],
-                [0.274 * i for i in total],
-                [0.227 * i for i in total],
-                [0.317 * i for i in total],
-                [0.073 * i for i in total],
-                [0.023 * i for i in total],
-            ],
-        )
-
-        total = [0.0090] * 3 + [0.0167] * 30
-        self._assertNuDelay(
-            "U235",
-            [
-                [0.038 * i for i in total],
-                [0.213 * i for i in total],
-                [0.188 * i for i in total],
-                [0.407 * i for i in total],
-                [0.128 * i for i in total],
-                [0.026 * i for i in total],
-            ],
-        )
-
-        total = [0.026] * 3 + [0.044] * 30
-        self._assertNuDelay(
-            "U238",
-            [
-                [0.013 * i for i in total],
-                [0.137 * i for i in total],
-                [0.162 * i for i in total],
-                [0.388 * i for i in total],
-                [0.225 * i for i in total],
-                [0.075 * i for i in total],
-            ],
-        )
-
-        total = [0.0043] * 3 + [0.00645] * 30
-        self._assertNuDelay(
-            "PU239",
-            [
-                [0.038 * i for i in total],
-                [0.280 * i for i in total],
-                [0.216 * i for i in total],
-                [0.328 * i for i in total],
-                [0.103 * i for i in total],
-                [0.035 * i for i in total],
-            ],
-        )
-
-        total = [0.00615] * 3 + [0.0090] * 30
-        self._assertNuDelay(
-            "PU240",
-            [
-                [0.028 * i for i in total],
-                [0.273 * i for i in total],
-                [0.192 * i for i in total],
-                [0.350 * i for i in total],
-                [0.128 * i for i in total],
-                [0.029 * i for i in total],
-            ],
-        )
-
-        # Keepin doesn't have any data on relative delayed group abundances for
-        # Pu-241 and Pu-242, and it looks like A.DELAY doesn't either! Let's
-        # assume that the abundances are the same as Pu-240.
-        total = [0.0084] * 3 + [0.0162] * 30
-        self._assertNuDelay(
-            "PU241",
-            [
-                [0.028 * i for i in total],
-                [0.273 * i for i in total],
-                [0.192 * i for i in total],
-                [0.350 * i for i in total],
-                [0.128 * i for i in total],
-                [0.029 * i for i in total],
-            ],
-        )
-
-        total = [0.0115] + [0.0129] + [0.0133] + [0.0153] * 30
-        self._assertNuDelay(
-            "PU242",
-            [
-                [0.028 * i for i in total],
-                [0.273 * i for i in total],
-                [0.192 * i for i in total],
-                [0.350 * i for i in total],
-                [0.128 * i for i in total],
-                [0.029 * i for i in total],
-            ],
-        )
-
-    def _assertNuDelay(self, nucName, endfProvidedData):
-        try:
-            dlayData = self.dlayxs3[
-                nuclideBases.byName[nucName.strip()]
-            ].delayNeutronsPerFission
-            npData = np.array(endfProvidedData)
-            self.assertTrue(np.allclose(dlayData, npData, 1e-3))
-        except AssertionError:
-            # this is reraised because generating the message might take some time to format all the
-            # data from the arrays
-            raise AssertionError(
-                "{} was different,\nexpected:{}\nactual:{}".format(
-                    nucName, npData, dlayData
                 )
             )
         except KeyError:

--- a/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
@@ -306,6 +306,9 @@ class DlayxsTests(unittest.TestCase):
             )
         )
 
+    @unittest.skip(
+        "The TH232, U232, PU238 and PU242 numbers do not agree, likely because they are from ENDV/B VI.8."
+    )
     def test_ENDFVII1DecayConstants(self):
         """Test ENDF/B VII.1 decay constants. Retrieved from ENDF/B VII.1."""
         self._assertDC(
@@ -353,6 +356,17 @@ class DlayxsTests(unittest.TestCase):
             ],
         )
         self._assertDC(
+            "TH232  ",
+            [
+                1.240000e-2,
+                3.340000e-2,
+                1.210000e-1,
+                3.210000e-1,
+                1.210000e0,
+                3.290000e0,
+            ],
+        )
+        self._assertDC(
             "TH233  ",
             [
                 1.310000e-2,
@@ -394,6 +408,17 @@ class DlayxsTests(unittest.TestCase):
                 3.210000e-1,
                 1.210000e0,
                 3.290000e0,
+            ],
+        )
+        self._assertDC(
+            "U232   ",
+            [
+                1.280000e-2,
+                3.500000e-2,
+                1.073000e-1,
+                2.557000e-1,
+                6.626000e-1,
+                2.025400e0,
             ],
         )
         self._assertDC(
@@ -562,6 +587,17 @@ class DlayxsTests(unittest.TestCase):
             ],
         )
         self._assertDC(
+            "PU238  ",
+            [
+                1.330000e-2,
+                3.120000e-2,
+                1.162000e-1,
+                2.888000e-1,
+                8.561000e-1,
+                2.713800e0,
+            ],
+        )
+        self._assertDC(
             "PU239  ",
             [
                 1.327100e-2,
@@ -592,6 +628,17 @@ class DlayxsTests(unittest.TestCase):
                 3.069100e-1,
                 8.701000e-1,
                 3.002800e0,
+            ],
+        )
+        self._assertDC(
+            "PU242  ",
+            [
+                1.360000e-2,
+                3.020000e-2,
+                1.154000e-1,
+                3.042000e-1,
+                8.272000e-1,
+                3.137200e0,
             ],
         )
         self._assertDC(
@@ -883,6 +930,145 @@ class DlayxsTests(unittest.TestCase):
             raise AssertionError(
                 "{} was different,\nexpected:{}\nactual:{}".format(
                     nucName, endfProvidedData, dlayData
+                )
+            )
+        except KeyError:
+            pass
+
+    @unittest.skip(
+        "All the delayNeutronsPerFission data from mcc-v3 does not agree, this may be because they "
+        "are from ENDV/B VI.8."
+    )
+    def test_ENDFVII1NeutronsPerFission(self):
+        """
+        Build delayed nu based on ENDF/B-VII data.
+
+        Notes
+        -----
+        This data was simply retrieved from the NNDC [http://www.nndc.bnl.gov]. U-235 consists of 6 points for delayed
+        nu and all others are only 4 points! Delayed group relative abundances are from G. Robert Keepin "Physics of
+        Nuclear Kinetics" Table 4-7. There are comments there about why the fast fission data is standard.
+        """
+        total = [0.0030] * 3 + [0.0547] * 30
+        self._assertNuDelay(
+            "TH232",
+            [
+                [0.034 * i for i in total],
+                [0.150 * i for i in total],
+                [0.155 * i for i in total],
+                [0.446 * i for i in total],
+                [0.172 * i for i in total],
+                [0.043 * i for i in total],
+            ],
+        )
+
+        total = [0.0042] * 1 + [0.0047] * 2 + [0.0074] * 30
+        self._assertNuDelay(
+            "U233",
+            [
+                [0.086 * i for i in total],
+                [0.274 * i for i in total],
+                [0.227 * i for i in total],
+                [0.317 * i for i in total],
+                [0.073 * i for i in total],
+                [0.023 * i for i in total],
+            ],
+        )
+
+        total = [0.0090] * 3 + [0.0167] * 30
+        self._assertNuDelay(
+            "U235",
+            [
+                [0.038 * i for i in total],
+                [0.213 * i for i in total],
+                [0.188 * i for i in total],
+                [0.407 * i for i in total],
+                [0.128 * i for i in total],
+                [0.026 * i for i in total],
+            ],
+        )
+
+        total = [0.026] * 3 + [0.044] * 30
+        self._assertNuDelay(
+            "U238",
+            [
+                [0.013 * i for i in total],
+                [0.137 * i for i in total],
+                [0.162 * i for i in total],
+                [0.388 * i for i in total],
+                [0.225 * i for i in total],
+                [0.075 * i for i in total],
+            ],
+        )
+
+        total = [0.0043] * 3 + [0.00645] * 30
+        self._assertNuDelay(
+            "PU239",
+            [
+                [0.038 * i for i in total],
+                [0.280 * i for i in total],
+                [0.216 * i for i in total],
+                [0.328 * i for i in total],
+                [0.103 * i for i in total],
+                [0.035 * i for i in total],
+            ],
+        )
+
+        total = [0.00615] * 3 + [0.0090] * 30
+        self._assertNuDelay(
+            "PU240",
+            [
+                [0.028 * i for i in total],
+                [0.273 * i for i in total],
+                [0.192 * i for i in total],
+                [0.350 * i for i in total],
+                [0.128 * i for i in total],
+                [0.029 * i for i in total],
+            ],
+        )
+
+        # Keepin doesn't have any data on relative delayed group abundances for
+        # Pu-241 and Pu-242, and it looks like A.DELAY doesn't either! Let's
+        # assume that the abundances are the same as Pu-240.
+        total = [0.0084] * 3 + [0.0162] * 30
+        self._assertNuDelay(
+            "PU241",
+            [
+                [0.028 * i for i in total],
+                [0.273 * i for i in total],
+                [0.192 * i for i in total],
+                [0.350 * i for i in total],
+                [0.128 * i for i in total],
+                [0.029 * i for i in total],
+            ],
+        )
+
+        total = [0.0115] + [0.0129] + [0.0133] + [0.0153] * 30
+        self._assertNuDelay(
+            "PU242",
+            [
+                [0.028 * i for i in total],
+                [0.273 * i for i in total],
+                [0.192 * i for i in total],
+                [0.350 * i for i in total],
+                [0.128 * i for i in total],
+                [0.029 * i for i in total],
+            ],
+        )
+
+    def _assertNuDelay(self, nucName, endfProvidedData):
+        try:
+            dlayData = self.dlayxs3[
+                nuclideBases.byName[nucName.strip()]
+            ].delayNeutronsPerFission
+            npData = np.array(endfProvidedData)
+            self.assertTrue(np.allclose(dlayData, npData, 1e-3))
+        except AssertionError:
+            # this is reraised because generating the message might take some time to format all the
+            # data from the arrays
+            raise AssertionError(
+                "{} was different,\nexpected:{}\nactual:{}".format(
+                    nucName, npData, dlayData
                 )
             )
         except KeyError:

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -279,8 +279,8 @@ class TestGetISOTXSFilesInWorkingDirectory(unittest.TestCase):
         """
         Utility method for saying what things contain.
 
-        This could just check the contents and the length, but the error produced when you pass shouldNotBeThere
-        is much nicer.
+        This could just check the contents and the length, but the error produced when you pass
+        shouldNotBeThere is much nicer.
         """
         container = set(container)
         self.assertEqual(container, set(shouldBeThere))
@@ -363,34 +363,6 @@ class AbstractTestXSlibraryMerging(TempFileMixin):
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibAA_ABPath(), self.testFileName))
 
-    def test_canRemoveIsotopes(self):
-        emptyXSLib = xsLibraries.IsotxsLibrary()
-        emptyXSLib.merge(self.libAA)
-        self.libAA = None
-        emptyXSLib.merge(self.libAB)
-        self.libAB = None
-        for nucId in [
-            "ZR93_7",
-            "ZR95_7",
-            "XE1287",
-            "XE1297",
-            "XE1307",
-            "XE1317",
-            "XE1327",
-            "XE1337",
-            "XE1347",
-            "XE1357",
-            "XE1367",
-        ]:
-            nucLabel = nuclideBases.byMcc3Id[nucId].label
-            del emptyXSLib[nucLabel + "AA"]
-            del emptyXSLib[nucLabel + "AB"]
-        self.assertEqual(
-            set(self.libLumped.nuclideLabels), set(emptyXSLib.nuclideLabels)
-        )
-        self.getWriteFunc()(emptyXSLib, self.testFileName)
-        self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
-
 
 class Pmatrx_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
     def getErrorType(self):
@@ -413,11 +385,6 @@ class Pmatrx_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
 
     def getLibLumpedPath(self):
         return PMATRX_LUMPED
-
-    @unittest.skip("Do not have data for comparing merged and purged PMATRX")
-    def test_canRemoveIsotopes(self):
-        # this test does not work for PMATRX, MC**2-v3 does not currently
-        pass
 
     def test_cannotMergeXSLibsWithDiffGammaGroups(self):
         """Test that we cannot merge XS Libs with different Gamma Group Structures."""
@@ -449,6 +416,34 @@ class Isotxs_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
     def getLibLumpedPath(self):
         return ISOTXS_LUMPED
 
+    def test_canRemoveIsotopes(self):
+        emptyXSLib = xsLibraries.IsotxsLibrary()
+        emptyXSLib.merge(self.libAA)
+        self.libAA = None
+        emptyXSLib.merge(self.libAB)
+        self.libAB = None
+        for nucId in [
+            "ZR93_7",
+            "ZR95_7",
+            "XE1287",
+            "XE1297",
+            "XE1307",
+            "XE1317",
+            "XE1327",
+            "XE1337",
+            "XE1347",
+            "XE1357",
+            "XE1367",
+        ]:
+            nucLabel = nuclideBases.byMcc3Id[nucId].label
+            del emptyXSLib[nucLabel + "AA"]
+            del emptyXSLib[nucLabel + "AB"]
+        self.assertEqual(
+            set(self.libLumped.nuclideLabels), set(emptyXSLib.nuclideLabels)
+        )
+        self.getWriteFunc()(emptyXSLib, self.testFileName)
+        self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
+
 
 class Gamiso_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
     def getErrorType(self):
@@ -471,6 +466,34 @@ class Gamiso_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
 
     def getLibLumpedPath(self):
         return GAMISO_LUMPED
+
+    def test_canRemoveIsotopes(self):
+        emptyXSLib = xsLibraries.IsotxsLibrary()
+        emptyXSLib.merge(self.libAA)
+        self.libAA = None
+        emptyXSLib.merge(self.libAB)
+        self.libAB = None
+        for nucId in [
+            "ZR93_7",
+            "ZR95_7",
+            "XE1287",
+            "XE1297",
+            "XE1307",
+            "XE1317",
+            "XE1327",
+            "XE1337",
+            "XE1347",
+            "XE1357",
+            "XE1367",
+        ]:
+            nucLabel = nuclideBases.byMcc3Id[nucId].label
+            del emptyXSLib[nucLabel + "AA"]
+            del emptyXSLib[nucLabel + "AB"]
+        self.assertEqual(
+            set(self.libLumped.nuclideLabels), set(emptyXSLib.nuclideLabels)
+        )
+        self.getWriteFunc()(emptyXSLib, self.testFileName)
+        self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
 
 
 class Combined_Merge_Tests(unittest.TestCase):

--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -279,8 +279,8 @@ class TestGetISOTXSFilesInWorkingDirectory(unittest.TestCase):
         """
         Utility method for saying what things contain.
 
-        This could just check the contents and the length, but the error produced when you pass
-        shouldNotBeThere is much nicer.
+        This could just check the contents and the length, but the error produced when you pass shouldNotBeThere
+        is much nicer.
         """
         container = set(container)
         self.assertEqual(container, set(shouldBeThere))
@@ -363,6 +363,34 @@ class AbstractTestXSlibraryMerging(TempFileMixin):
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibAA_ABPath(), self.testFileName))
 
+    def test_canRemoveIsotopes(self):
+        emptyXSLib = xsLibraries.IsotxsLibrary()
+        emptyXSLib.merge(self.libAA)
+        self.libAA = None
+        emptyXSLib.merge(self.libAB)
+        self.libAB = None
+        for nucId in [
+            "ZR93_7",
+            "ZR95_7",
+            "XE1287",
+            "XE1297",
+            "XE1307",
+            "XE1317",
+            "XE1327",
+            "XE1337",
+            "XE1347",
+            "XE1357",
+            "XE1367",
+        ]:
+            nucLabel = nuclideBases.byMcc3Id[nucId].label
+            del emptyXSLib[nucLabel + "AA"]
+            del emptyXSLib[nucLabel + "AB"]
+        self.assertEqual(
+            set(self.libLumped.nuclideLabels), set(emptyXSLib.nuclideLabels)
+        )
+        self.getWriteFunc()(emptyXSLib, self.testFileName)
+        self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
+
 
 class Pmatrx_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
     def getErrorType(self):
@@ -385,6 +413,11 @@ class Pmatrx_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
 
     def getLibLumpedPath(self):
         return PMATRX_LUMPED
+
+    @unittest.skip("Do not have data for comparing merged and purged PMATRX")
+    def test_canRemoveIsotopes(self):
+        # this test does not work for PMATRX, MC**2-v3 does not currently
+        pass
 
     def test_cannotMergeXSLibsWithDiffGammaGroups(self):
         """Test that we cannot merge XS Libs with different Gamma Group Structures."""
@@ -416,34 +449,6 @@ class Isotxs_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
     def getLibLumpedPath(self):
         return ISOTXS_LUMPED
 
-    def test_canRemoveIsotopes(self):
-        emptyXSLib = xsLibraries.IsotxsLibrary()
-        emptyXSLib.merge(self.libAA)
-        self.libAA = None
-        emptyXSLib.merge(self.libAB)
-        self.libAB = None
-        for nucId in [
-            "ZR93_7",
-            "ZR95_7",
-            "XE1287",
-            "XE1297",
-            "XE1307",
-            "XE1317",
-            "XE1327",
-            "XE1337",
-            "XE1347",
-            "XE1357",
-            "XE1367",
-        ]:
-            nucLabel = nuclideBases.byMcc3Id[nucId].label
-            del emptyXSLib[nucLabel + "AA"]
-            del emptyXSLib[nucLabel + "AB"]
-        self.assertEqual(
-            set(self.libLumped.nuclideLabels), set(emptyXSLib.nuclideLabels)
-        )
-        self.getWriteFunc()(emptyXSLib, self.testFileName)
-        self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
-
 
 class Gamiso_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
     def getErrorType(self):
@@ -466,34 +471,6 @@ class Gamiso_Merge_Tests(AbstractTestXSlibraryMerging, unittest.TestCase):
 
     def getLibLumpedPath(self):
         return GAMISO_LUMPED
-
-    def test_canRemoveIsotopes(self):
-        emptyXSLib = xsLibraries.IsotxsLibrary()
-        emptyXSLib.merge(self.libAA)
-        self.libAA = None
-        emptyXSLib.merge(self.libAB)
-        self.libAB = None
-        for nucId in [
-            "ZR93_7",
-            "ZR95_7",
-            "XE1287",
-            "XE1297",
-            "XE1307",
-            "XE1317",
-            "XE1327",
-            "XE1337",
-            "XE1347",
-            "XE1357",
-            "XE1367",
-        ]:
-            nucLabel = nuclideBases.byMcc3Id[nucId].label
-            del emptyXSLib[nucLabel + "AA"]
-            del emptyXSLib[nucLabel + "AB"]
-        self.assertEqual(
-            set(self.libLumped.nuclideLabels), set(emptyXSLib.nuclideLabels)
-        )
-        self.getWriteFunc()(emptyXSLib, self.testFileName)
-        self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))
 
 
 class Combined_Merge_Tests(unittest.TestCase):

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -363,21 +363,16 @@ class MacroscopicCrossSectionCreator:
     """
     Create macroscopic cross sections from micros and number density.
 
-    Object encapsulating all high-level methods related to the creation of
-    macroscopic cross sections.
+    Object encapsulating all high-level methods related to the creation of macroscopic cross
+    sections.
     """
 
-    def __init__(
-        self, buildScatterMatrix=True, buildOnlyCoolant=False, minimumNuclideDensity=0.0
-    ):
+    def __init__(self, buildScatterMatrix=True, minimumNuclideDensity=0.0):
         self.densities = None
         self.macros = None
         self.micros = None
         self.minimumNuclideDensity = minimumNuclideDensity
         self.buildScatterMatrix = buildScatterMatrix
-        self.buildOnlyCoolant = (
-            buildOnlyCoolant  # TODO: this is not implemented yet. is it needed?
-        )
         self.block = None
 
     def createMacrosOnBlocklist(
@@ -388,6 +383,7 @@ class MacroscopicCrossSectionCreator:
             block.macros = self.createMacrosFromMicros(
                 microLibrary, block, nucNames, libType=libType
             )
+
         return blockList
 
     def createMacrosFromMicros(

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -314,9 +314,8 @@ class Operator:
         """
         Return whether we are approaching EOL.
 
-        For the standard operator, this will return true when the current cycle
-        is the last cycle (cs["nCycles"] - 1). Other operators may need to
-        impose different logic.
+        For the standard operator, this will return true when the current cycle is the last cycle
+        (cs["nCycles"] - 1). Other operators may need to impose different logic.
         """
         return self.r.p.cycle == self.cs["nCycles"] - 1
 
@@ -333,7 +332,7 @@ class Operator:
             The Reactor object to attach to this Operator.
         """
         self.r = r
-        r.o = self  # TODO: this is only necessary for fuel-handler hacking
+        r.o = self
         with self.timer.getTimer("Interface Creation"):
             self.createInterfaces()
             self._processInterfaceDependencies()
@@ -587,7 +586,8 @@ class Operator:
 
         Notes
         -----
-        Used within _interactAll to write details between each physics interaction when cs['debugDB'] is enabled.
+        Used within _interactAll to write details between each physics interaction when
+        cs['debugDB'] is enabled.
 
         Parameters
         ----------
@@ -596,8 +596,8 @@ class Operator:
         interfaceName : str
             name of the interface that is interacting (e.g. globalflux, lattice, th)
         statePointIndex : int (optional)
-            used as a counter to make labels that increment throughout an _interactAll call. The result should be fed
-            into the next call to ensure labels increment.
+            used as a counter to make labels that increment throughout an _interactAll call. The
+            result should be fed into the next call to ensure labels increment.
         """
         dbiForDetailedWrite = self.getInterface("database")
         db = dbiForDetailedWrite.database if dbiForDetailedWrite is not None else None
@@ -661,10 +661,9 @@ class Operator:
 
         Notes
         -----
-        If the interfaces are flagged to be reversed at EOL, they are
-        separated from the main stack and appended at the end in reverse
-        order. This allows, for example, an interface that must run
-        first to also run last.
+        If the interfaces are flagged to be reversed at EOL, they are separated from the main stack
+        and appended at the end in reverse order. This allows, for example, an interface that must
+        run first to also run last.
         """
         activeInterfaces = self.getActiveInterfaces("EOL", excludedInterfaceNames)
         self._interactAll("EOL", activeInterfaces)
@@ -716,7 +715,7 @@ class Operator:
 
         Notes
         -----
-        This is split off from self.interactAllCoupled to accommodate testing
+        This is split off from self.interactAllCoupled to accommodate testing.
         """
         # Summarize the coupled results and the convergence status.
         converged = []

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -338,7 +338,7 @@ class AverageBlockCollection(BlockCollection):
     def _makeRepresentativeBlock(self):
         """Generate a block that best represents all blocks in group."""
         newBlock = self._getNewBlock()
-        lfpCollection = self._getAverageFuelLFP()
+        lfpCollection = self._getLFP()
         newBlock.setLumpedFissionProducts(lfpCollection)
         # check if components are similar
         if self._performAverageByComponent():
@@ -371,9 +371,8 @@ class AverageBlockCollection(BlockCollection):
         ndens = weights.dot([b.getNuclideNumberDensities(nuclides) for b in blocks])
         return dict(zip(nuclides, ndens))
 
-    def _getAverageFuelLFP(self):
-        """Compute the average lumped fission products."""
-        # TODO: make do actual average of LFPs
+    def _getLFP(self):
+        """Find lumped fission product collection."""
         b = self.getCandidateBlocks()[0]
         return b.getLumpedFissionProductCollection()
 
@@ -388,6 +387,7 @@ class AverageBlockCollection(BlockCollection):
             )
             nvt += nvtBlock * wt
             nv += nvBlock * wt
+
         return nvt, nv
 
     def _getAverageComponentNumberDensities(self, compIndex):

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -604,8 +604,8 @@ class CylindricalComponentsAverageBlockCollection(BlockCollection):
                 "homogenized"
             )
 
-        # TODO: Using Fe-56 as a proxy for structure and Na-23 as proxy for coolant is undesirably
-        # SFR-centric. This should be generalized in the future, if possible.
+        # NOTE: We are using Fe-56 as a proxy for structure and Na-23 as proxy for coolant is
+        # undesirably SFR-centric. This should be generalized in the future, if possible.
         consistentNucs = {"PU239", "U238", "U235", "U234", "FE56", "NA23", "O16"}
         for c, repC in zip(sorted(b), sorted(repBlock)):
             compString = (
@@ -613,8 +613,8 @@ class CylindricalComponentsAverageBlockCollection(BlockCollection):
             )
             if c.p.mult != repC.p.mult:
                 raise ValueError(
-                    f"{compString} must have the same multiplicity, but they have."
-                    f"{repC.p.mult} and {c.p.mult}, respectively."
+                    f"{compString} must have the same multiplicity, but they have. {repC.p.mult} "
+                    f"and {c.p.mult}, respectively."
                 )
 
             theseNucs = set(c.getNuclides())
@@ -638,10 +638,12 @@ class CylindricalComponentsAverageBlockCollection(BlockCollection):
             weight = bWeight * c.getArea()
             totalWeight += weight
             densities += weight * np.array(c.getNuclideNumberDensities(allNucNames))
+
         if totalWeight > 0.0:
             weightedDensities = densities / totalWeight
         else:
             weightedDensities = np.zeros_like(densities)
+
         return allNucNames, weightedDensities
 
     def _orderComponentsInGroup(self, repBlock):
@@ -691,9 +693,9 @@ class CylindricalComponentsDuctHetAverageBlockCollection(
 
     Notes
     -----
-    The representative block for this collection is the same as the parent. The only difference between
-    the two collection types is that this collection calculates average nuclide temperatures based only
-    on the components that are inside of the duct.
+    The representative block for this collection is the same as the parent. The only difference
+    between the two collection types is that this collection calculates average nuclide temperatures
+    based only on the components that are inside of the duct.
     """
 
     def _getNewBlock(self):

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -693,9 +693,9 @@ class CylindricalComponentsDuctHetAverageBlockCollection(
 
     Notes
     -----
-    The representative block for this collection is the same as the parent. The only difference
-    between the two collection types is that this collection calculates average nuclide temperatures
-    based only on the components that are inside of the duct.
+    The representative block for this collection is the same as the parent. The only difference between
+    the two collection types is that this collection calculates average nuclide temperatures based only
+    on the components that are inside of the duct.
     """
 
     def _getNewBlock(self):

--- a/armi/physics/neutronics/macroXSGenerationInterface.py
+++ b/armi/physics/neutronics/macroXSGenerationInterface.py
@@ -34,54 +34,47 @@ class MacroXSGenerator(mpiActions.MpiAction):
         blocks,
         lib,
         buildScatterMatrix,
-        buildOnlyCoolant,
         libType,
         minimumNuclideDensity=0.0,
     ):
         mpiActions.MpiAction.__init__(self)
         self.buildScatterMatrix = buildScatterMatrix
-        self.buildOnlyCoolant = buildOnlyCoolant
         self.libType = libType
         self.lib = lib
         self.blocks = blocks
         self.minimumNuclideDensity = minimumNuclideDensity
 
     def __reduce__(self):
-        # Prevent blocks and lib from being broadcast by passing None to ctor.
-        # Although lib must be broadcast, we need to do it explicitly to
-        # correctly deal with the default lib=None argument in buildMacros(),
-        # which utilizes this action. Default arguments make things more complicated.
+        # Prevent blocks and lib from being broadcast by passing None to ctor. Although lib must be
+        # broadcast, we need to do it explicitly to correctly deal with the default lib=None
+        # argument in buildMacros(), which utilizes this action. Default arguments make things more
+        # complicated.
         return (
             MacroXSGenerator,
             (
                 None,
                 None,
                 self.buildScatterMatrix,
-                self.buildOnlyCoolant,
                 self.libType,
                 self.minimumNuclideDensity,
             ),
         )
 
     def invokeHook(self):
-        # logic here gets messy due to all the default arguments in the calling
-        # method. There exists a large number of permutations to be handled.
-
+        # logic here gets messy due to all the default arguments in the calling method. There exists
+        # a large number of permutations to be handled.
         if context.MPI_RANK == 0:
             allBlocks = self.blocks
             if allBlocks is None:
                 allBlocks = self.r.core.getBlocks()
 
             lib = self.lib or self.r.core.lib
-
         else:
             allBlocks = []
             lib = None
 
         mc = xsCollections.MacroscopicCrossSectionCreator(
-            self.buildScatterMatrix,
-            self.buildOnlyCoolant,
-            self.minimumNuclideDensity,
+            self.buildScatterMatrix, self.minimumNuclideDensity
         )
 
         if context.MPI_SIZE > 1:
@@ -129,7 +122,6 @@ class MacroXSGenerationInterface(interfaces.Interface):
         lib=None,
         bListSome=None,
         buildScatterMatrix=True,
-        buildOnlyCoolant=False,
         libType="micros",
     ):
         """
@@ -175,10 +167,6 @@ class MacroXSGenerationInterface(interfaces.Interface):
             as 'scatter' or 'chi') will be built. Essentially, this option saves
             huge runtime for the fluxRecon module.
 
-        buildOnlyCoolant : Boolean, optional
-            If True, homogenized macro XS will be built only for NA-23. If
-            False, the function runs normally.
-
         libType : str, optional
             The block attribute containing the desired microscopic XS for this
             block: either "micros" for neutron XS or "gammaXS" for gamma XS.
@@ -194,7 +182,6 @@ class MacroXSGenerationInterface(interfaces.Interface):
             bListSome,
             lib,
             buildScatterMatrix,
-            buildOnlyCoolant,
             libType,
             self.minimumNuclideDensity,
         )

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -40,21 +40,19 @@ CONF_GLOBAL_FLUX_ACTIVE = "globalFluxActive"
 CONF_GROUP_STRUCTURE = "groupStructure"
 CONF_INNERS_ = "inners"
 CONF_LOADING_FILE = "loadingFile"
-CONF_NEUTRONICS_KERNEL = "neutronicsKernel"
 CONF_MCNP_LIB_BASE = "mcnpLibraryVersion"
+CONF_NEUTRONICS_KERNEL = "neutronicsKernel"
 CONF_NEUTRONICS_TYPE = "neutronicsType"
 CONF_NUMBER_MESH_PER_EDGE = "numberMeshPerEdge"
 CONF_OUTERS_ = "outers"
 CONF_RESTART_NEUTRONICS = "restartNeutronics"
 
-# Used for dpa/dose analysis.
-# TODO: These should be relocated to more design-specific places
+# used by global flux interface
 CONF_ACLP_DOSE_LIMIT = "aclpDoseLimit"
 CONF_DPA_XS_SET = "dpaXsSet"
 CONF_GRID_PLATE_DPA_XS_SET = "gridPlateDpaXsSet"
 CONF_LOAD_PAD_ELEVATION = "loadPadElevation"
 CONF_LOAD_PAD_LENGTH = "loadPadLength"
-
 CONF_OPT_DPA = [
     "",
     "dpa_EBRII_INC600",
@@ -66,19 +64,19 @@ CONF_OPT_DPA = [
 
 # moved from xsSettings
 CONF_CLEAR_XS = "clearXS"
-CONF_MINIMUM_FISSILE_FRACTION = "minimumFissileFraction"
-CONF_MINIMUM_NUCLIDE_DENSITY = "minimumNuclideDensity"
-CONF_INFINITE_DILUTE_CUTOFF = "infiniteDiluteCutoff"
-CONF_TOLERATE_BURNUP_CHANGE = "tolerateBurnupChange"
-CONF_XS_BLOCK_REPRESENTATION = "xsBlockRepresentation"
 CONF_DISABLE_BLOCK_TYPE_EXCLUSION_IN_XS_GENERATION = (
     "disableBlockTypeExclusionInXsGeneration"
 )
-CONF_XS_KERNEL = "xsKernel"
-CONF_XS_SCATTERING_ORDER = "xsScatteringOrder"
+CONF_INFINITE_DILUTE_CUTOFF = "infiniteDiluteCutoff"
+CONF_LATTICE_PHYSICS_FREQUENCY = "latticePhysicsFrequency"
+CONF_MINIMUM_FISSILE_FRACTION = "minimumFissileFraction"
+CONF_MINIMUM_NUCLIDE_DENSITY = "minimumNuclideDensity"
+CONF_TOLERATE_BURNUP_CHANGE = "tolerateBurnupChange"
+CONF_XS_BLOCK_REPRESENTATION = "xsBlockRepresentation"
 CONF_XS_BUCKLING_CONVERGENCE = "xsBucklingConvergence"
 CONF_XS_EIGENVALUE_CONVERGENCE = "xsEigenvalueConvergence"
-CONF_LATTICE_PHYSICS_FREQUENCY = "latticePhysicsFrequency"
+CONF_XS_KERNEL = "xsKernel"
+CONF_XS_SCATTERING_ORDER = "xsScatteringOrder"
 
 
 def defineSettings():
@@ -107,9 +105,8 @@ def defineSettings():
             CONF_GLOBAL_FLUX_ACTIVE,
             default="Neutron",
             label="Global Flux Calculation",
-            description="Calculate the global flux at each timestep for the selected "
-            "particle type(s) using the specified neutronics kernel (see Global Flux "
-            "tab).",
+            description="Calculate the global flux at each timestep for the selected particle "
+            "type(s) using the specified neutronics kernel (see Global Flux tab).",
             options=["", "Neutron", "Neutron and Gamma"],
         ),
         setting.Setting(
@@ -291,10 +288,9 @@ def defineSettings():
             CONF_MINIMUM_NUCLIDE_DENSITY,
             default=1e-15,
             label="Minimum nuclide density",
-            description="Density to use for nuclides and fission products at infinite "
-            "dilution. This is also used as the minimum density considered for "
-            "computing macroscopic cross sections. It can also be passed to physics "
-            "plugins.",
+            description="Density to use for nuclides and fission products at infinite dilution. "
+            "This is also used as the minimum density considered for computing macroscopic cross "
+            "sections. It can also be passed to physics plugins.",
         ),
         setting.Setting(
             CONF_INFINITE_DILUTE_CUTOFF,

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -106,7 +106,7 @@ def defineSettings():
             default="Neutron",
             label="Global Flux Calculation",
             description="Calculate the global flux at each timestep for the selected particle "
-            "type(s) using the specified neutronics kernel (see Global Flux tab).",
+            "type(s) using the specified neutronics kernel.",
             options=["", "Neutron", "Neutron and Gamma"],
         ),
         setting.Setting(
@@ -290,7 +290,7 @@ def defineSettings():
             label="Minimum nuclide density",
             description="Density to use for nuclides and fission products at infinite dilution. "
             "This is also used as the minimum density considered for computing macroscopic cross "
-            "sections. It can also be passed to physics plugins.",
+            "sections.",
         ),
         setting.Setting(
             CONF_INFINITE_DILUTE_CUTOFF,

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -101,7 +101,7 @@ class Block(composites.Composite):
         # which component to use to determine block pitch, along with its 'op'
         self._pitchDefiningComponent = (None, 0.0)
 
-        # TODO: what's causing these to have wrong values at BOL?
+        # Manually set some parameters at BOL
         for problemParam in ["THcornTemp", "THedgeTemp"]:
             self.p[problemParam] = []
 

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -260,7 +260,6 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
         """
         self._prepConstruction(cs)
 
-        # TODO: this should be migrated assembly designs instead of assemblies
         if name is not None:
             assem = self.assemblies[name]
         elif specifier is not None:

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -426,15 +426,8 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             elif elemental in eleExpand and elemental.element.symbol in nuclideFlags:
                 # code-specific expansion required based on code and ENDF
                 newNuclides = eleExpand[elemental]
-                # overlay code details onto nuclideFlags for other parts of the code
-                # that will use them.
-                # TODO: would be better if nuclideFlags did this upon reading s.t.
-                # order didn't matter. On the other hand, this is the only place in
-                # the code where NuclideFlags get built and have user settings around
-                # (hence "resolve").
-                # This must be updated because the operative expansion code just uses the flags
-                #
-                # Also, if this element is not in nuclideFlags at all, we just don't add it
+                # Overlay code details onto nuclideFlags for other parts of the code that use them.
+                # Also, if this element is not in nuclideFlags at all, we just don't add it.
                 nuclideFlags[elemental.element.symbol].expandTo = [
                     nb.name for nb in newNuclides
                 ]

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -205,15 +205,13 @@ class AssemblyBlueprint(yamlize.Object):
         a.spatialGrid = grids.AxialGrid.fromNCells(len(blocks))
         a.spatialGrid.armiObject = a
 
-        # TODO: Remove mesh points from blueprints entirely. Submeshing should be
-        # handled by specific physics interfaces
+        # init submeshes
         radMeshPoints = self.radialMeshPoints or 1
         a.p.RadMesh = radMeshPoints
         aziMeshPoints = self.azimuthalMeshPoints or 1
         a.p.AziMesh = aziMeshPoints
 
-        # loop a second time because we needed all the blocks before choosing the
-        # assembly class.
+        # Loop a second time because we needed all the blocks before choosing the assembly class.
         for axialIndex, b in enumerate(blocks):
             b.name = b.makeName(a.p.assemNum, axialIndex)
             a.add(b)

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -204,7 +204,6 @@ class SystemBlueprint(yamlize.Object):
         runLog.header(f"=========== Adding Composites to {container} ===========")
         badLocations = set()
         for locationInfo, aTypeID in gridContents.items():
-
             # TODO: We should allow for non-Assembly objects/geometries to be loaded into the grid.
             #       For instance, an ex-core grid may define ducts, not just Assemblies.
             newAssembly = bp.constructAssem(cs, specifier=aTypeID)

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -204,8 +204,6 @@ class SystemBlueprint(yamlize.Object):
         runLog.header(f"=========== Adding Composites to {container} ===========")
         badLocations = set()
         for locationInfo, aTypeID in gridContents.items():
-            # TODO: We should allow for non-Assembly objects/geometries to be loaded into the grid.
-            #       For instance, an ex-core grid may define ducts, not just Assemblies.
             newAssembly = bp.constructAssem(cs, specifier=aTypeID)
 
             i, j = locationInfo

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2918,30 +2918,27 @@ class Composite(ArmiObject):
         return syncCount
 
     def _syncParameters(self, allSyncData, errors):
-        # ensure no overlap with syncedKeys, use errors to report overlapping data
+        """Ensure no overlap with syncedKeys, use errors to report overlapping data."""
         syncedKeys = set()
         for nodeRank, nodeSyncData in enumerate(allSyncData):
             if nodeSyncData is None:
                 continue
-            # nodeSyncData is a list of tuples
+
             for key, val in nodeSyncData.items():
                 if key in syncedKeys:
-                    # TODO: this requires further investigation and should be avoidable.
-                    # this situation results when a composite object is flagged as being
-                    # out of sync, and this parameter was also globally modified and
-                    # readjusted to the original value.
+                    # Edge Case: a Composite object is flagged as out of sync, and this parameter
+                    # was also globally modified and readjusted to the original value.
                     curVal = self.p[key]
                     if isinstance(val, np.ndarray) or isinstance(curVal, np.ndarray):
                         if (val != curVal).any():
                             errors[self, key].append(nodeRank)
                     elif curVal != val:
                         errors[self, key].append(nodeRank)
-                        runLog.error(
-                            "in {}, {} differ ({} != {})".format(self, key, curVal, val)
-                        )
+                        runLog.error(f"in {self}, {key} differ ({curVal} != {val})")
                     continue
                 syncedKeys.add(key)
                 self.p[key] = val
+
         self.clearCache()
         return len(syncedKeys)
 

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -348,11 +348,9 @@ class ArmiObject(metaclass=CompositeModelType):
         sorted. This is useful from the context of the Database classes, so that they can produce a
         stable layout of the serialized composite structure.
 
-        By default, this sorts using the spatial locator, in K, J, I order, which should give a
-        relatively intuitive order. For safety, it makes sure that the objects being sorted live in
-        the same grid, since it probably doesn't make sense to sort things across containers or
-        scopes. If this ends up being too restrictive, it can probably be relaxed or overridden on
-        specific classes.
+        By default, this sorts using the spatial locator in K, J, I order, which should give a
+        relatively intuitive order. It also makes sure that the objects being sorted live in the
+        same grid.
         """
         if self.spatialLocator is None or other.spatialLocator is None:
             runLog.error(f"could not compare {self} and {other}")

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -335,10 +335,7 @@ class ArmiObject(metaclass=CompositeModelType):
         self.cached = {}
         self._backupCache = None
         self.p = self.paramCollectionType()
-        # TODO: These are not serialized to the database, and will therefore
-        # lead to surprising behavior when using databases. We need to devise a
-        # way to either represent them in parameters, or otherwise reliably
-        # recover them.
+        # NOTE: LFPs are not serialized to the database, which could matter when loading an old DB.
         self._lumpedFissionProducts = None
         self.spatialGrid = None
         self.spatialLocator = grids.CoordinateLocation(0.0, 0.0, 0.0, None)
@@ -347,25 +344,24 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         Implement the less-than operator.
 
-        Implementing this on the ArmiObject allows most objects, under most
-        circumstances to be sorted. This is useful from the context of the Database
-        classes, so that they can produce a stable layout of the serialized composite
-        structure.
+        Implementing this on the ArmiObject allows most objects, under most circumstances to be
+        sorted. This is useful from the context of the Database classes, so that they can produce a
+        stable layout of the serialized composite structure.
 
-        By default, this sorts using the spatial locator, in K, J, I order, which should
-        give a relatively intuitive order. For safety, it makes sure that the objects
-        being sorted live in the same grid, since it probably doesn't make
-        sense to sort things across containers or scopes. If this ends up being too
-        restrictive, it can probably be relaxed or overridden on specific classes.
+        By default, this sorts using the spatial locator, in K, J, I order, which should give a
+        relatively intuitive order. For safety, it makes sure that the objects being sorted live in
+        the same grid, since it probably doesn't make sense to sort things across containers or
+        scopes. If this ends up being too restrictive, it can probably be relaxed or overridden on
+        specific classes.
         """
         if self.spatialLocator is None or other.spatialLocator is None:
-            runLog.error("could not compare {} and {}".format(self, other))
+            runLog.error(f"could not compare {self} and {other}")
             raise ValueError(
                 "One or more of the compared objects have no spatialLocator"
             )
 
         if self.spatialLocator.grid is not other.spatialLocator.grid:
-            runLog.error("could not compare {} and {}".format(self, other))
+            runLog.error(f"could not compare {self} and {other}")
             raise ValueError(
                 "Composite grids must be the same to compare:\n"
                 "This grid: {}\n"

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -471,7 +471,7 @@ class ArmiObject(metaclass=CompositeModelType):
         for child in self:
             child.clearCache()
 
-    def _getCached(self, name):  # TODO: stop the "returns None" nonsense?
+    def _getCached(self, name):
         """
         Obtain a value from the cache.
 
@@ -483,7 +483,7 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         return self.cached.get(name, None)
 
-    def _setCache(self, name, val):  # TODO: remove me
+    def _setCache(self, name, val):
         """
         Set a value in the cache.
 

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -854,7 +854,6 @@ class Core(composites.Composite):
             )
 
         # determine if the circularRingList has been generated
-        # TODO: make circularRingList a property that is generated on request
         if not self.circularRingList:
             self.circularRingList = self.buildCircularRingDictionary(
                 self._circularRingPitch
@@ -1085,9 +1084,8 @@ class Core(composites.Composite):
             block.getName(): block for block in self.getBlocks(includeAll=True)
         }
 
-    # TODO: (Idea) wrap this in an "if not self.blocksByLocName:"
-    # This will likely fail, but it will help diagnose why property approach
-    # wasn't working correctly
+    # This will likely fail, but it will help diagnose why property approach wasn't working
+    # correctly
     def genBlocksByLocName(self):
         """If self.blocksByLocName is deleted, then this will regenerate it or update it if things change."""
         self.blocksByLocName = {
@@ -1337,7 +1335,6 @@ class Core(composites.Composite):
         else:
             return {b.getLocation(): b for a in self for b in a}
 
-    # TODO: Can be cleaned up, but need test case to guard agains breakage
     def getFluxVector(
         self, energyOrder=0, adjoint=False, extSrc=False, volumeIntegrated=True
     ):
@@ -1349,12 +1346,11 @@ class Core(composites.Composite):
         Parameters
         ----------
         energyOrder : int, optional
-            A value of 0 implies that the flux will have all energy groups for
-            the first mesh point, and then all energy groups for the next mesh point, etc.
+            A value of 0 implies that the flux will have all energy groups for the first mesh point,
+            and then all energy groups for the next mesh point, etc.
 
-            A value of 1 implies that the flux will have values for all mesh points
-            of the first energy group first, followed by all mesh points for the second energy
-            group, etc.
+            A value of 1 implies that the flux will have values for all mesh points of the first
+            energy group first, followed by all mesh points for the second energy group, etc.
 
         adjoint : bool, optional
             If True, will return adjoint flux instead of real flux.
@@ -1389,7 +1385,7 @@ class Core(composites.Composite):
             flux.extend(vals)
 
         if energyOrder == 1:
-            # swap order.
+            # swap order
             newFlux = []
             for g in groups:
                 oneGroup = [flux[i] for i in range(g, len(flux), len(groups))]

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -2012,8 +2012,8 @@ class Core(composites.Composite):
         Parameters
         ----------
         target : float
-            This is the fraction of the total reactor fuel flux compared to the flux in a
-            specific assembly in a ring
+            This is the fraction of the total reactor fuel flux compared to the flux in a specific
+            assembly in a ring
 
         Returns
         -------
@@ -2031,17 +2031,15 @@ class Core(composites.Composite):
 
         # loop there all of the rings
         for ringNumber in range(numRings, 0, -1):
-            # compare to outer most ring
-            # flatten list into one list of all blocks
+            # Compare to outer most ring. flatten list into one list of all blocks
             blocksInRing = list(
-                itertools.chain(
-                    *[
+                itertools.chain.from_iterable(
+                    [
                         a.iterBlocks(Flags.FUEL)
                         for a in self.getAssembliesInRing(ringNumber)
                     ]
                 )
             )
-            # TODO: itertools.chain.from_iterable(...)
 
             totalPower = self.getTotalBlockParam("flux", objs=allFuelBlocks)
             ringPower = self.getTotalBlockParam("flux", objs=blocksInRing)

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -2251,8 +2251,6 @@ class Core(composites.Composite):
                 applySubMesh=True,
             )
 
-        # self.numRings = self.getNumRings()  # TODO: why needed?
-
         self.getNuclideCategories()
 
         # Generate list of flags that are to be stationary during assembly shuffling
@@ -2262,9 +2260,7 @@ class Core(composites.Composite):
             stationaryBlockFlags.append(Flags.fromString(stationaryBlockFlagString))
 
         self.stationaryBlockFlagsList = stationaryBlockFlags
-
         self.setBlockMassParams()
-
         self.p.maxAssemNum = self.getMaxParam("assemNum")
 
         getPluginManagerOrFail().hook.onProcessCoreLoading(
@@ -2273,8 +2269,8 @@ class Core(composites.Composite):
 
     def buildManualZones(self, cs):
         """
-        Build the Zones that are defined manually in the given Settings file,
-        in the `zoneDefinitions` setting.
+        Build the Zones that are defined manually in the given Settings file, in the
+        `zoneDefinitions` setting.
 
         Parameters
         ----------
@@ -2292,9 +2288,8 @@ class Core(composites.Composite):
 
         Notes
         -----
-        This function will just define the Zones it sees in the settings, it does
-        not do any validation against a Core object to ensure those manual zones
-        make sense.
+        This function will just define the Zones it sees in the settings, it does not do any
+        validation against a Core object to ensure those manual zones make sense.
         """
         runLog.debug(
             "Building Zones by manual definitions in `zoneDefinitions` setting"
@@ -2321,8 +2316,8 @@ class Core(composites.Composite):
     ) -> Iterator[blocks.Block]:
         """Iterate over the blocks in the core.
 
-        Useful for operations that just want to find all the blocks in the core
-        with light filtering.
+        Useful for operations that just want to find all the blocks in the core with light
+        filtering.
 
         Parameters
         ----------
@@ -2331,8 +2326,8 @@ class Core(composites.Composite):
         exact: bool, optional
             Strictness on the usage of ``typeSpec`` used in :meth:`armi.reactor.composites.hasFlags`
         predicate: f(block) -> bool, optional
-            Limit the traversal to blocks that pass this predicate. Can be used in addition to ``typeSpec``
-            to perform more advanced filtering.
+            Limit the traversal to blocks that pass this predicate. Can be used in addition to
+            ``typeSpec`` to perform more advanced filtering.
 
         Returns
         -------

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -2203,7 +2203,7 @@ class Core(composites.Composite):
          * It process boosters,
          * sets axial snap lists,
          * checks the geometry,
-         * sets up location tables ( tracks where the initial feeds were (for moderation or something)
+         * sets up location tables (tracks where the initial feeds were (for moderation or something)
 
         See Also
         --------
@@ -2226,9 +2226,8 @@ class Core(composites.Composite):
             )
 
         if dbLoad:
-            # reactor.blueprints.assemblies need to be populated
-            # this normally happens during armi/reactor/blueprints/__init__.py::constructAssem
-            # but for DB load, this is not called so it must be here.
+            # reactor.blueprints.assemblies need to be populated this normally happens during
+            # blueprint constructAssem. But for DB load, this is not called so it must be here.
             self.parent.blueprints._prepConstruction(cs)
         else:
             # set reactor level meshing params
@@ -2236,8 +2235,8 @@ class Core(composites.Composite):
                 Flags.fromStringIgnoreErrors(t)
                 for t in cs[CONF_NON_UNIFORM_ASSEM_FLAGS]
             ]
-            # some assemblies, like control assemblies, have a non-conforming mesh
-            # and should not be included in self.p.referenceBlockAxialMesh and self.p.axialMesh
+            # Some assemblies, like control assemblies, have a non-conforming mesh and should not be
+            # included in self.p.referenceBlockAxialMesh and self.p.axialMesh
             uniformAssems = [
                 a
                 for a in self.getAssemblies()
@@ -2252,7 +2251,7 @@ class Core(composites.Composite):
                 applySubMesh=True,
             )
 
-        self.numRings = self.getNumRings()  # TODO: why needed?
+        # self.numRings = self.getNumRings()  # TODO: why needed?
 
         self.getNuclideCategories()
 

--- a/armi/reactor/grids/locations.py
+++ b/armi/reactor/grids/locations.py
@@ -176,21 +176,15 @@ class IndexLocation(LocationBase):
     """
     An immutable location representing one cell in a grid.
 
-    The locator is intimately tied to a grid and together, they represent
-    a grid cell somewhere in the coordinate system of the grid.
+    The locator is intimately tied to a grid and together, they represent a grid cell somewhere in
+    the coordinate system of the grid.
 
-    ``grid`` is not in the constructor (must be added after construction ) because
-    the extra argument (grid) gives an inconsistency between __init__ and __new__.
-    Unfortunately this decision makes whipping up IndexLocations on the fly awkward.
-    But perhaps that's ok because they should only be created by their grids.
-
-    TODO Is the above correct still? The constructor has an optional ``Grid``
-
+    ``grid`` is not in the constructor (must be added after construction ) because the extra
+    argument (grid) gives an inconsistency between __init__ and __new__. Unfortunately this decision
+    makes whipping up IndexLocations on the fly awkward. But perhaps that's ok because they should
+    only be created by their grids.
     """
 
-    # TODO Maybe __slots__ = LocationBase.__slots__ + ("parentLocation", )
-    # But parentLocation is a property...
-    # Maybe other parts of ARMI set attributes?
     __slots__ = ()
 
     def __add__(self, that: Union[IJKType, "IndexLocation"]) -> "IndexLocation":

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -162,23 +162,20 @@ class Settings:
 
         Notes
         -----
-        Checking the validity of grabbing specific settings at this point,
-        as is done for the SIMPLE_CYCLES_INPUT's, feels
-        a bit intrusive and out of place. In particular, the fact that the check
-        is done every time that a setting is reached for, no matter if it is the
-        setting in question, is quite clunky. In the future, it would be desirable
-        if the settings system were more flexible to control this type of thing
-        at a deeper level.
+        Checking the validity of grabbing specific settings at this point, as is done for the
+        SIMPLE_CYCLES_INPUT's, feels a bit intrusive and out of place. In particular, the fact that
+        the check is done every time that a setting is reached for, no matter if it is the setting
+        in question, is quite clunky. In the future, it would be desirable if the settings system
+        were more flexible to control this type of thing at a deeper level.
         """
         if key not in self.__settings:
             return False, NonexistentSetting(key)
 
         if key in SIMPLE_CYCLES_INPUTS and self.__settings["cycles"].value != []:
             err = ValueError(
-                "Cannot grab simple cycles information from the case settings "
-                "when detailed cycles information is also entered. In general "
-                "cycles information should be pulled off the operator or parsed "
-                "using the appropriate getter in the utils."
+                "Cannot grab simple cycles information from the case settings when detailed cycles "
+                "information is also entered. In general cycles information should be pulled off "
+                "the operator or parsed using the appropriate getter in the utils."
             )
 
             return False, err
@@ -222,8 +219,8 @@ class Settings:
         """
         Rebuild schema upon unpickling since schema is unpickleable.
 
-        Pickling happens during mpi broadcasts and also
-        during testing where the test reactor is cached.
+        Pickling happens during mpi broadcasts and also during testing where the test reactor is
+        cached.
 
         See Also
         --------
@@ -260,8 +257,8 @@ class Settings:
         """Return a duplicate copy of this settings object."""
         cs = deepcopy(self)
         cs._failOnLoad = False
-        # it's not really protected access since it is a new Settings object.
-        # _failOnLoad is set to false, because this new settings object should be independent of the command line
+        # It's not really protected access since it is a new Settings object. _failOnLoad is set to
+        # false, because this new settings object should be independent of the command line
         return cs
 
     def revertToDefaults(self):
@@ -303,12 +300,9 @@ class Settings:
     def _prepToRead(self, fName):
         if self._failOnLoad:
             raise RuntimeError(
-                "Cannot load settings file after processing of command "
-                "line options begins.\nYou may be able to fix this by "
-                "reordering the command line arguments, and making sure "
-                "the settings file `{}` comes before any modified settings.".format(
-                    fName
-                )
+                "Cannot load settings file after processing of command line options begins.\nYou "
+                "may be able to fix this by reordering the command line arguments, and making sure "
+                f"the settings file `{fName}` comes before any modified settings."
             )
         path = pathTools.armiAbsPath(fName)
         return settingsIO.SettingsReader(self), path
@@ -316,21 +310,17 @@ class Settings:
     def loadFromString(self, string, handleInvalids=True):
         """Read in settings from a YAML string.
 
-        Passes the reader back out in case you want to know something about how the
-        reading went like for knowing if a file contained deprecated settings, etc.
+        Passes the reader back out in case you want to know something about how the reading went
+        like for knowing if a file contained deprecated settings, etc.
         """
         if self._failOnLoad:
             raise RuntimeError(
-                "Cannot load settings after processing of command "
-                "line options begins.\nYou may be able to fix this by "
-                "reordering the command line arguments."
+                "Cannot load settings after processing of command line options begins.\nYou may be "
+                "able to fix this by reordering the command line arguments."
             )
 
         reader = settingsIO.SettingsReader(self)
-        fmt = reader.SettingsInputFormat.YAML
-        reader.readFromStream(
-            io.StringIO(string), handleInvalids=handleInvalids, fmt=fmt
-        )
+        reader.readFromStream(io.StringIO(string), handleInvalids=handleInvalids)
 
         self.initLogVerbosity()
 
@@ -348,8 +338,8 @@ class Settings:
 
         Notes
         -----
-        This means that creating a Settings object sets the global logging
-        level of the entire code base.
+        This means that creating a Settings object sets the global logging level of the entire code
+        base.
         """
         if context.MPI_RANK == 0:
             runLog.setVerbosity(self["verbosity"])
@@ -371,11 +361,11 @@ class Settings:
         fName : str
             the file to write to
         style : str (optional)
-            the method of output to be used when creating the file for the current
-            state of settings (short, medium, or full)
+            the method of output to be used when creating the file for the current state of settings
+            (short, medium, or full)
         fromFile : str (optional)
-            if the source file and destination file are different (i.e. for cloning)
-            and the style argument is ``medium``, then this arg is used
+            if the source file and destination file are different (i.e. for cloning) and the style
+            argument is ``medium``, then this arg is used
         """
         self.path = pathTools.armiAbsPath(fName)
         if style == "medium":
@@ -392,8 +382,8 @@ class Settings:
 
     def getSettingsSetByUser(self, fPath):
         """
-        Grabs the list of settings in the user-defined input file so that the settings
-        can be tracked outside of a Settings object.
+        Grabs the list of settings in the user-defined input file so that the settings can be
+        tracked outside of a Settings object.
 
         Parameters
         ----------
@@ -405,8 +395,8 @@ class Settings:
         userSettingsNames : list
             The settings names read in from a yaml settings file
         """
-        # We do not want to load these as settings, but just grab the dictionary straight
-        # from the settings file to know which settings are user-defined
+        # We do not want to load these as settings, but just grab the dictionary straight from the
+        # settings file to know which settings are user-defined.
         with open(fPath, "r") as stream:
             yaml = YAML()
             yaml.allow_duplicate_keys = False
@@ -440,8 +430,8 @@ class Settings:
         return writer
 
     def updateEnvironmentSettingsFrom(self, otherCs):
-        """Updates the environment settings in this object based on some other cs
-        (from the GUI, most likely).
+        """Updates the environment settings in this object based on some other cs (from the GUI,
+        most likely).
 
         Parameters
         ----------

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -390,7 +390,7 @@ def prompt(statement, question, *options):
         # Use the logger tools to handle user prompts (runLog supports this).
         while response not in responses:
             runLog.LOG.log("prompt", statement)
-            runLog.LOG.log("prompt", f"{question} ({", ".join(responses)}): ")
+            runLog.LOG.log("prompt", "{} ({}): ".format(question, ", ".join(responses)))
             response = sys.stdin.readline().strip().upper()
 
         if response == "CANCEL":

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -18,7 +18,6 @@
 """
 import collections
 import datetime
-import enum
 import os
 import sys
 from typing import Dict, Set, Tuple
@@ -52,10 +51,10 @@ class SettingRenamer:
     """
     Utility class to help with setting rename migrations.
 
-    This class stores a cache of renaming maps, derived from the ``Setting.oldNames``
-    values of the passed ``settings``. Expired renames are retained, so that meaningful
-    warning messages can be generated if one attempts to use one of them. The renaming
-    logic follows the rules described in :py:meth:`renameSetting`.
+    This class stores a cache of renaming maps, derived from the ``Setting.oldNames`` values of the
+    passed ``settings``. Expired renames are retained, so that meaningful warning messages can be
+    generated if one attempts to use one of them. The renaming logic follows the rules described in
+    :py:meth:`renameSetting`.
     """
 
     def __init__(self, settings: Dict[str, Setting]):
@@ -89,12 +88,11 @@ class SettingRenamer:
         Attempt to rename a candidate setting.
 
         Renaming follows these rules:
-         - If the ``name`` corresponds to a current setting name, do not attempt to
-           rename it.
-         - If the ``name`` does not correspond to a current setting name, but is one of
-           the active renames, return the corresponding active rename.
-         - If the ``name`` does not correspond to a current setting name, but is one of
-           the expired renames, produce a warning and do not rename it.
+         - If the ``name`` corresponds to a current setting name, do not attempt to rename it.
+         - If the ``name`` does not correspond to a current setting name, but is one of the active
+           renames, return the corresponding active rename.
+         - If the ``name`` does not correspond to a current setting name, but is one of the expired
+           renames, produce a warning and do not rename it.
 
         Parameters
         ----------
@@ -113,9 +111,7 @@ class SettingRenamer:
 
         activeRename = self._activeRenames.get(name, None)
         if activeRename is not None:
-            runLog.warning(
-                "Invalid setting {} found. Renaming to {}.".format(name, activeRename)
-            )
+            runLog.warning(f"Invalid setting {name} found. Renaming to {activeRename}.")
             return activeRename, True
 
         expiredCandidates = {
@@ -130,8 +126,8 @@ class SettingRenamer:
                 ]
             )
             runLog.warning(
-                "Encountered an invalid setting `{}`. There are expired "
-                "renames to newer setting names:\n{}".format(name, msg)
+                f"Encountered an invalid setting `{name}`. There are expired renames to newer "
+                f"setting names:\n{msg}"
             )
 
         return name, False
@@ -144,9 +140,9 @@ class SettingsReader:
         :id: I_ARMI_SETTINGS_IO_TXT
         :implements: R_ARMI_SETTINGS_IO_TXT
 
-        ARMI uses the YAML standard for settings files. ARMI uses industry-standard
-        ``ruamel.yaml`` Python library to read these files. ARMI does not bend or
-        change the YAML file format standard in any way.
+        ARMI uses the YAML standard for settings files. ARMI uses industry-standard ``ruamel.yaml``
+        Python library to read these files. ARMI does not bend or change the YAML file format
+        standard in any way.
 
     Parameters
     ----------
@@ -154,29 +150,17 @@ class SettingsReader:
         The settings object to read into
     """
 
-    class SettingsInputFormat(enum.Enum):
-        YAML = enum.auto()
-
-        # TODO: Is this method still necessary?
-        @classmethod
-        def fromExt(cls, ext):
-            return {".yaml": cls.YAML}[ext]
-
     def __init__(self, cs):
         self.cs = cs
-        self.format = self.SettingsInputFormat.YAML
         self.inputPath = "<stream>"
-
         self.invalidSettings = set()
         self.settingsAlreadyRead = set()
-        self.liveVersion = version
-        self.inputVersion = version
-
         self._renamer = SettingRenamer(dict(self.cs.items()))
 
-        # The input version will be overwritten if explicitly stated in input file.
-        # otherwise, it's assumed to precede the version inclusion change and should be
-        # treated as alright.
+        # The input version will be overwritten if explicitly stated in input file. Otherwise, it's
+        # assumed to precede the version inclusion change and should be treated as alright.
+        self.inputVersion = version
+        self.liveVersion = version
 
     def __getitem__(self, key):
         return self.cs[key]
@@ -185,27 +169,22 @@ class SettingsReader:
         return getattr(self.cs, attr)
 
     def __repr__(self):
-        return "<{} {}>".format(self.__class__.__name__, self.inputPath)
+        return f"<{self.__class__.__name__} {self.inputPath}>"
 
     def readFromFile(self, path, handleInvalids=True):
         """Load file and read it."""
         with open(path, "r") as f:
-            # make sure that we can actually open the file before trying to guess its
-            # format. This will yield better error messages when things go awry.
             ext = os.path.splitext(path)[1].lower()
-            self.format = self.SettingsInputFormat.fromExt(ext)
+            assert ext.lower() in (".yaml", ".yml"), f"{ext} is the wrong extension"
             self.inputPath = path
             try:
-                self.readFromStream(f, handleInvalids, self.format)
+                self.readFromStream(f, handleInvalids)
             except Exception as ee:
                 raise InvalidSettingsFileError(path, str(ee))
 
-    def readFromStream(self, stream, handleInvalids=True, fmt=SettingsInputFormat.YAML):
+    def readFromStream(self, stream, handleInvalids=True):
         """Read from a file-like stream."""
-        self.format = fmt
-        if self.format == self.SettingsInputFormat.YAML:
-            self._readYaml(stream)
-
+        self._readYaml(stream)
         if handleInvalids:
             self._checkInvalidSettings()
 
@@ -259,7 +238,7 @@ class SettingsReader:
         if not proceed:
             raise InvalidSettingsStopProcess(self)
         else:
-            runLog.warning("Ignoring invalid settings: {}".format(invalidNames))
+            runLog.warning(f"Ignoring invalid settings: {invalidNames}")
 
     def _applySettings(self, name, val):
         """Add a setting, if it is valid. Capture invalid settings."""
@@ -271,8 +250,8 @@ class SettingsReader:
             # apply validations
             _settingObj = self.cs.getSetting(name)
 
-            # The val is automatically coerced into the expected type
-            # when set using either the default or user-defined schema
+            # The val is automatically coerced into the expected type when set using either the
+            # default or user-defined schema
             self.cs[name] = val
 
 
@@ -293,9 +272,9 @@ class SettingsWriter:
         self.cs = settings_instance
         self.style = style
         if style not in {WRITE_SHORT, WRITE_MEDIUM, WRITE_FULL}:
-            raise ValueError("Invalid supplied setting writing style {}".format(style))
-        # The writer should know about the old settings it is overwriting,
-        # but only sometimes (when the style is medium)
+            raise ValueError(f"Invalid supplied setting writing style {style}")
+        # The writer should know about the old settings it is overwriting, but only sometimes (when
+        # the style is medium)
         self.settingsSetByUser = settingsSetByUser
 
     @staticmethod
@@ -400,7 +379,7 @@ def prompt(statement, question, *options):
             responses.insert(index, "YES")
 
         if not any(responses):
-            raise RuntimeError("No suitable responses in {}".format(responses))
+            raise RuntimeError(f"No suitable responses in {responses}")
 
         # highly requested shorthand responses
         if "YES" in responses:
@@ -411,7 +390,7 @@ def prompt(statement, question, *options):
         # Use the logger tools to handle user prompts (runLog supports this).
         while response not in responses:
             runLog.LOG.log("prompt", statement)
-            runLog.LOG.log("prompt", "{} ({}): ".format(question, ", ".join(responses)))
+            runLog.LOG.log("prompt", f"{question} ({", ".join(responses)}): ")
             response = sys.stdin.readline().strip().upper()
 
         if response == "CANCEL":
@@ -421,7 +400,7 @@ def prompt(statement, question, *options):
 
     else:
         raise RunLogPromptUnresolvable(
-            "Incorrect CURRENT_MODE for prompting user: {}".format(context.CURRENT_MODE)
+            f"Incorrect CURRENT_MODE for prompting user: {context.CURRENT_MODE}"
         )
 
 
@@ -433,8 +412,8 @@ class RunLogPromptCancel(Exception):
 
 class RunLogPromptUnresolvable(Exception):
     """
-    An error that occurs when the current mode enum in armi.__init__ suggests the user cannot be communicated with from
-    the current process.
+    An error that occurs when the current mode enum in armi.__init__ suggests the user cannot be
+    communicated with from the current process.
     """
 
     pass

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -48,10 +48,7 @@ class SettingsFailureTests(unittest.TestCase):
         with self.assertRaises(InvalidSettingsFileError):
             cs = settings.caseSettings.Settings()
             reader = settingsIO.SettingsReader(cs)
-            reader.readFromStream(
-                io.StringIO("useless:\n    should_fail"),
-                fmt=settingsIO.SettingsReader.SettingsInputFormat.YAML,
-            )
+            reader.readFromStream(io.StringIO("useless:\n    should_fail"))
 
 
 class SettingsReaderTests(unittest.TestCase):

--- a/armi/utils/asciimaps.py
+++ b/armi/utils/asciimaps.py
@@ -438,9 +438,8 @@ class AsciiMapHexThirdFlatsUp(AsciiMap):
 
         Used before writing the asciimap from data.
 
-        Add flat-hex specific corner truncation detection that allows
-        some positions to be empty near the corners of the full hex,
-        as is typical for hexagonal core maps.
+        Add flat-hex specific corner truncation detection that allows some positions to be empty
+        near the corners of the full hex, as is typical for hexagonal core maps.
 
         For 1/3 hex, _ijMax represents the outer outline
         """
@@ -453,8 +452,7 @@ class AsciiMapHexThirdFlatsUp(AsciiMap):
         maxIWithData = max(iWithData) if iWithData else -1
         self._asciiLinesOffCorner = (self._ijMax - maxIWithData) * 2 - 1
 
-        # in jagged systems we have to also check the neighbor.
-        # TODO: maybe even more corner positions could be left out in very large maps.
+        # in jagged systems we have to also check the neighbor
         nextIWithData = [i for i, j in self.asciiLabelByIndices if j == 1]
         nextMaxIWithData = max(nextIWithData) if nextIWithData else -1
         if nextMaxIWithData == maxIWithData - 1:
@@ -478,8 +476,7 @@ class AsciiMapHexFullFlatsUp(AsciiMapHexThirdFlatsUp):
     number of placeholders on the left. This makes this one's
     base computation more complex.
 
-    We also allow all corners to be cut off on these, further
-    complicating things.
+    We also allow all corners to be cut off on these, further complicating things.
     """
 
     def _getIJBaseByAsciiLine(self, asciiLineNum):

--- a/armi/utils/gridEditor.py
+++ b/armi/utils/gridEditor.py
@@ -1572,19 +1572,9 @@ type, domain, and boundary conditions.
 
 
 class NewGridBlueprintDialog(wx.Dialog):
-    """
-    Dialog box for configuring a new grid blueprint.
+    """Dialog box for configuring a new grid blueprint."""
 
-    TODO
-    ----
-    This can be a closer match to the stuff in geometry.py once that is implemented with
-    enums instead of string constants. Right now, we are sort of shadowing the logic
-    behind ``geometry.VALID_SYMMETRY``, rather that whipping up the logic from
-    ``VALID_SYMMETRY``, which would be `slick`.
-    """
-
-    # these provide stable mappings from the wx.Choice control indices to the respective
-    # geom types
+    # these provide stable mappings from the wx.Choice control indices to the respective geom types
     _geomFromIdx = {
         i: geomType
         for i, geomType in enumerate(

--- a/doc/developer/standards_and_practices.rst
+++ b/doc/developer/standards_and_practices.rst
@@ -310,9 +310,8 @@ General do's and don'ts
 Do not use ``print``
     ARMI code should not use the ``print`` function; use one of the methods within ``armi.runLog``.
 
-Do not add new ``TODO`` statements in your commits and PRs.
-    If your new ``TODO`` statement is important, it should be a GitHub Issue. Yes, we have existing
-    ``TODO`` statements in the code, those are relic and need to be removed. Similarly, never mark
+Do not add new ``TODO`` statements to the repo.
+    If your new ``TODO`` statement is important, it should be a GitHub Issue. Similarly, never mark
     the code with ``FIXME`` or ``XXX```; open a ticket.
 
 Do not link GitHub tickets or PRs in code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,6 @@ exclude = [
 # N801 - Class name should use CapWords convention
 # SIM - code simplification rules
 # TID - tidy imports
-# TODO: We want to support PLW0603 - don't use the global keyword
 select = ["D", "E", "F", "I", "N801", "SIM", "TID"]
 
 # Ruff rules we ignore (for now) because they are not 100% automatable


### PR DESCRIPTION
## What is the change? Why is it being made?

A few years ago ARMI had ~185 `TODO`s sprinkled liberally throughout the code. I found this morning that there were only about 30 left.

In this PR I have gone through and removed all the old TODOs. You might have to look at this commit-by-commit, because there were several approaches used:

1. Just remove the `TODO` comment if it is defunct, or I disagree with it.
2. Do the cleanup the `TODO` recommends.
3. Remove the `TODO` by opening a ticket.

For (3), I opened two new tickets:

* https://github.com/terrapower/armi/issues/2124
* https://github.com/terrapower/armi/issues/2125

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing old TODO comments from the codebase

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
