### PR TITLE
Removing 3 unused Settings

### DIFF
--- a/armi/physics/fuelCycle/settings.py
+++ b/armi/physics/fuelCycle/settings.py
@@ -18,7 +18,6 @@ CONF_ASSEM_ROTATION_STATIONARY = "assemblyRotationStationary"
 CONF_ASSEMBLY_ROTATION_ALG = "assemblyRotationAlgorithm"
 CONF_CIRCULAR_RING_MODE = "circularRingMode"
 CONF_CIRCULAR_RING_ORDER = "circularRingOrder"
-CONF_CUSTOM_FUEL_MANAGEMENT_INDEX = "customFuelManagementIndex"
 CONF_FUEL_HANDLER_NAME = "fuelHandlerName"
 CONF_JUMP_RING_NUM = "jumpRingNum"
 CONF_LEVELS_PER_CASCADE = "levelsPerCascade"
@@ -59,15 +58,6 @@ def getFuelCycleSettings():
             description="Order by which locations are sorted in circular rings for equilibrium shuffling",
             label="Eq. circular sort type",
             options=["angle", "distance", "distanceSmart"],
-        ),
-        setting.Setting(
-            CONF_CUSTOM_FUEL_MANAGEMENT_INDEX,
-            default=0,
-            description=(
-                "An index that determines which of various options is used in management. "
-                "Useful for optimization sweeps. "
-            ),
-            label="Custom Shuffling Index",
         ),
         setting.Setting(
             CONF_RUN_LATTICE_BEFORE_SHUFFLING,

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -68,7 +68,6 @@ CONF_OPT_DPA = [
 CONF_CLEAR_XS = "clearXS"
 CONF_MINIMUM_FISSILE_FRACTION = "minimumFissileFraction"
 CONF_MINIMUM_NUCLIDE_DENSITY = "minimumNuclideDensity"
-CONF_INFINITE_DILUTE_CUTOFF = "infiniteDiluteCutoff"
 CONF_TOLERATE_BURNUP_CHANGE = "tolerateBurnupChange"
 CONF_XS_BLOCK_REPRESENTATION = "xsBlockRepresentation"
 CONF_DISABLE_BLOCK_TYPE_EXCLUSION_IN_XS_GENERATION = (
@@ -295,13 +294,6 @@ def defineSettings():
             "dilution. This is also used as the minimum density considered for "
             "computing macroscopic cross sections. It can also be passed to physics "
             "plugins.",
-        ),
-        setting.Setting(
-            CONF_INFINITE_DILUTE_CUTOFF,
-            default=1e-10,
-            label="Infinite Dillute Cutoff",
-            description="Do not model nuclides with density less than this cutoff. "
-            "Used with PARTISN and SERPENT.",
         ),
         setting.Setting(
             CONF_TOLERATE_BURNUP_CHANGE,

--- a/armi/settings/fwSettings/databaseSettings.py
+++ b/armi/settings/fwSettings/databaseSettings.py
@@ -14,7 +14,6 @@
 
 """Settings related to the ARMI database."""
 
-import voluptuous as vol
 
 from armi.settings import setting
 

--- a/armi/settings/fwSettings/databaseSettings.py
+++ b/armi/settings/fwSettings/databaseSettings.py
@@ -23,7 +23,6 @@ CONF_DEBUG_DB = "debugDB"
 CONF_RELOAD_DB_NAME = "reloadDBName"
 CONF_LOAD_FROM_DB_EVERY_NODE = "loadFromDBEveryNode"
 CONF_DB_STORAGE_AFTER_CYCLE = "dbStorageAfterCycle"
-CONF_ZERO_OUT_NUCLIDES_NOT_IN_DB = "zeroOutNuclidesNotInDB"
 CONF_SYNC_AFTER_WRITE = "syncDbAfterWrite"
 CONF_FORCE_DB_PARAMS = "forceDbParams"
 
@@ -63,13 +62,6 @@ def defineSettings():
             description="Only store cycles after this cycle in the database (to "
             "save storage space)",
             schema=vol.All(vol.Coerce(int), vol.Range(min=0)),
-        ),
-        setting.Setting(
-            CONF_ZERO_OUT_NUCLIDES_NOT_IN_DB,
-            default=True,
-            label="Load Nuclides Not in Database",
-            description="If a nuclide was added to the problem after a previous case"
-            " was run, deactivate this to let it survive in a restart run",
         ),
         setting.Setting(
             CONF_SYNC_AFTER_WRITE,

--- a/armi/settings/fwSettings/databaseSettings.py
+++ b/armi/settings/fwSettings/databaseSettings.py
@@ -22,7 +22,6 @@ CONF_DB = "db"
 CONF_DEBUG_DB = "debugDB"
 CONF_RELOAD_DB_NAME = "reloadDBName"
 CONF_LOAD_FROM_DB_EVERY_NODE = "loadFromDBEveryNode"
-CONF_DB_STORAGE_AFTER_CYCLE = "dbStorageAfterCycle"
 CONF_SYNC_AFTER_WRITE = "syncDbAfterWrite"
 CONF_FORCE_DB_PARAMS = "forceDbParams"
 
@@ -54,14 +53,6 @@ def defineSettings():
             default=False,
             label="Load Database at EveryNode",
             description="Every node loaded from reference database",
-        ),
-        setting.Setting(
-            CONF_DB_STORAGE_AFTER_CYCLE,
-            default=0,
-            label="Database Storage After Cycle",
-            description="Only store cycles after this cycle in the database (to "
-            "save storage space)",
-            schema=vol.All(vol.Coerce(int), vol.Range(min=0)),
         ),
         setting.Setting(
             CONF_SYNC_AFTER_WRITE,

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -74,7 +74,6 @@ CONF_INITIALIZE_BURN_CHAIN = "initializeBurnChain"
 CONF_INPUT_HEIGHTS_HOT = "inputHeightsConsideredHot"
 CONF_LOAD_STYLE = "loadStyle"
 CONF_LOADING_FILE = "loadingFile"
-CONF_LOW_POWER_REGION_FRACTION = "lowPowerRegionFraction"  # reports
 CONF_MATERIAL_NAMESPACE_ORDER = "materialNamespaceOrder"
 CONF_MIN_MESH_SIZE_RATIO = "minMeshSizeRatio"
 CONF_MODULE_VERBOSITY = "moduleVerbosity"
@@ -585,13 +584,6 @@ def defineSettings() -> List[setting.Setting]:
             label="Load Style",
             description="Description of how the ARMI case will be initialized",
             options=["fromInput", "fromDB"],
-        ),
-        setting.Setting(
-            CONF_LOW_POWER_REGION_FRACTION,
-            default=0.05,
-            label="Low-power Region Fraction",
-            description="Description needed",
-            schema=vol.All(vol.Coerce(float), vol.Range(min=0, max=1)),
         ),
         setting.Setting(
             CONF_N_CYCLES,

--- a/armi/settings/fwSettings/tests/test_fwSettings.py
+++ b/armi/settings/fwSettings/tests/test_fwSettings.py
@@ -86,11 +86,6 @@ class TestSchema(unittest.TestCase):
                 "invalid": -1,
                 "error": vol.error.MultipleInvalid,
             },
-            "lowPowerRegionFraction": {
-                "valid": 0.5,
-                "invalid": 2,
-                "error": vol.error.MultipleInvalid,
-            },
             "nCycles": {"valid": 1, "invalid": -1, "error": vol.error.MultipleInvalid},
             "power": {"valid": 0, "invalid": -1, "error": vol.error.MultipleInvalid},
             "skipCycles": {

--- a/armi/settings/fwSettings/tests/test_fwSettings.py
+++ b/armi/settings/fwSettings/tests/test_fwSettings.py
@@ -105,11 +105,6 @@ class TestSchema(unittest.TestCase):
                 "invalid": -274,
                 "error": vol.error.MultipleInvalid,
             },
-            "dbStorageAfterCycle": {
-                "valid": 0,
-                "invalid": -1,
-                "error": vol.error.MultipleInvalid,
-            },
             "timelineInclusionCutoff": {
                 "valid": 1,
                 "invalid": 105,


### PR DESCRIPTION
## What is the change? Why is it being made?

I wrote a quick script that could find unused Settings in ARMI. As a result, I removed the unused Settings:

* `customFuelManagementIndex`
* `infiniteDiluteCutoff` (Thanks Tony!)
* `lowPowerRegionFraction`


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing 3 unused Settings

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
