### PR TITLE
OperatorMPI doesn't need to bcast quits if there no other workers

### DIFF
--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -81,21 +81,19 @@ class OperatorMPI(Operator):
                 )
                 raise
             finally:
-                if context.MPI_SIZE > 0:
+                # If there are other processes, tell them to stop
+                if context.MPI_SIZE > 1:
                     runLog.important(
                         "Stopping all MPI worker nodes and cleaning temps."
                     )
-                    context.MPI_COMM.bcast(
-                        "quit", root=0
-                    )  # send the quit command to the workers.
+                    # send the quit command to the workers.
+                    context.MPI_COMM.bcast("quit", root=0)
                     runLog.debug("Waiting for all nodes to close down")
-                    context.MPI_COMM.bcast(
-                        "finished", root=0
-                    )  # wait until they're done cleaning up.
+                    # wait until they're done cleaning up.
+                    context.MPI_COMM.bcast("finished", root=0)
                     runLog.important("All worker nodes stopped.")
-                time.sleep(
-                    1
-                )  # even though we waited, still need more time to close stdout.
+                # even though we waited, still need more time to close stdout.
+                time.sleep(1)
                 runLog.debug("Main operate finished")
                 runLog.close()  # concatenate all logs.
         else:


### PR DESCRIPTION
## What is the change? Why is it being made?

If `MPI_SIZE == 1`, we are either

1. Running in MPI with one worker, or
2. Running w/o MPI with one worker (e.g., no `mpi4py` installed)

So there are no other workers to be shut down. This also allows the snapshot operator to call `operate` in cases where `mpi4py` is not installed. Like my local development station.

Otherwise, `OperatorSnapshots` cannot run w/o `mpi4py` installed. And `mpi4py` is optional, and the connection to `OperatorSnapshots` is not evidenced from the user docs.

A couple things are at play here

The `OperatorSnapshots` class inherits from the MPI operator.
https://github.com/terrapower/armi/blob/ffb740eb4c7b39c0cd4816fcb73ee07eed441a38/armi/operators/snapshots.py#L21

If `mpi4py` is not installed, we set `armi.context.MPI_SIZE = 1` (makes sense, you can't use more than one worker w/o MPI) and `armi.context.MPI_COMM = None`
https://github.com/terrapower/armi/blob/ffb740eb4c7b39c0cd4816fcb73ee07eed441a38/armi/context.py#L88-L93

When `OperatorMPI.operate` finishes, successfully or in error, the `finally` block communicates a quit to workers if `MPI_SIZE > 0`

https://github.com/terrapower/armi/blob/ffb740eb4c7b39c0cd4816fcb73ee07eed441a38/armi/operators/operatorMPI.py#L83-L90

Since there will almost surely never be a case where `MPI_SIZE == 0`, `OperatorMPI` and `SnapshotsOperator` will hit the `MPI_COMM.bcast` lines in the `finally` block. But, if you don't have `mpi4py` installed, `MPI_SIZE = 1` and `MPI_COMM = None` so you see errors like
```
  File "C:\Users\anjohnson\codes\armi\armi\cli\run.py", line 33, in invoke
    inputCase.run()
    ~~~~~~~~~~~~~^^
  File "C:\Users\anjohnson\codes\armi\armi\cases\case.py", line 330, in run
    o.operate()
    ~~~~~~~~~^^
  File "C:\Users\anjohnson\codes\armi\armi\operators\operatorMPI.py", line 88, in operate
    context.MPI_COMM.bcast(
    ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'bcast'
```

Our documentation only says you need to install `mpi4py` if you'll be running ARMI in parallel w/ MPI

https://github.com/terrapower/armi/blob/ffb740eb4c7b39c0cd4816fcb73ee07eed441a38/doc/user/user_install.rst?plain=1#L56

You could intuit a connection by looking at the source code or the API docs which describe the inheritance to `OperatorMPI`.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Allow `OperatorSnaphots.operate` work with without optional `mpi4py` dependency.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
