### PR TITLE
Removing unused Parameters

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -180,7 +180,7 @@ class TestCompareDB3(unittest.TestCase):
                 dbs[1]._fullPath,
                 timestepCompare=[(0, 0), (0, 1)],
             )
-        self.assertEqual(len(diffs.diffs), 504)
+        self.assertEqual(len(diffs.diffs), 501)
         # Cycle length is only diff (x3)
         self.assertEqual(diffs.nDiffs(), 3)
 

--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -180,8 +180,18 @@ class TestCompareDB3(unittest.TestCase):
                 dbs[1]._fullPath,
                 timestepCompare=[(0, 0), (0, 1)],
             )
-        self.assertEqual(len(diffs.diffs), 501)
-        # Cycle length is only diff (x3)
+
+        # spot check the diffs
+        self.assertGreater(len(diffs.diffs), 200)
+        self.assertLess(len(diffs.diffs), 800)
+        self.assertIn("/c00n00", diffs._columns)
+        self.assertIn("/c00n01", diffs._columns)
+        self.assertIn(0, diffs._structureDiffs)
+        self.assertEqual(sum(diffs._structureDiffs), 0)
+        self.assertEqual(diffs.tolerance, 0)
+        self.assertIn("SpentFuelPool/flags max(abs(diff))", diffs.diffs)
+        self.assertIn("Circle/volume mean(diff)", diffs.diffs)
+        self.assertIn("Reactor/flags mean(diff)", diffs.diffs)
         self.assertEqual(diffs.nDiffs(), 3)
 
     def test_diffSpecialData(self):

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -550,14 +550,6 @@ def _getNeutronicsBlockParams():
             location=ParamLocation.MAX,
         )
 
-        pb.defParam(
-            "ppdensGamma",
-            units=f"{units.WATTS}/{units.CM}^3",
-            description="Peak gamma density",
-            categories=[parameters.Category.gamma],
-            location=ParamLocation.MAX,
-        )
-
     # rx rate params that are derived during mesh conversion.
     # We'd like all things that can be derived from flux and XS to be
     # in this category to minimize numerical diffusion but it is a WIP.

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -141,22 +141,6 @@ def _getNeutronicsBlockParams():
             default=0.0,
         )
 
-        pb.defParam(
-            "mgFluxSK",
-            units=f"n*{units.CM}/{units.SECONDS}",
-            description=(
-                "multigroup volume-integrated flux stored for multiple time steps in "
-                "spatial kinetics (2-D array)"
-            ),
-            location=ParamLocation.VOLUME_INTEGRATED,
-            saveToDB=False,
-            categories=[
-                parameters.Category.fluxQuantities,
-                parameters.Category.multiGroupQuantities,
-            ],
-            default=None,
-        )
-
         # Not anointing the pin fluxes as a MG quantity, since it has an extra dimension, which
         # could lead to issues, depending on how the multiGroupQuantities category gets used
         pb.defParam(

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -185,6 +185,26 @@ def _getNeutronicsBlockParams():
         )
 
         pb.defParam(
+            "axialPowerProfileNeutron",
+            units=f"{units.WATTS}/{units.CM}^3",
+            description="""For each reconstructed axial location, a tuple (z, neutron power density)
+            where with axial origin at the bottom of assembly in which the blocks are located.""",
+            location=ParamLocation.AVERAGE,
+            saveToDB=True,
+            default=None,
+        )
+
+        pb.defParam(
+            "axialPowerProfileGamma",
+            units=f"{units.WATTS}/{units.CM}^3",
+            description="""For each reconstructed axial location, a tuple (z, gamma power density)
+            where with axial origin at the bottom of assembly in which the blocks are located.""",
+            location=ParamLocation.AVERAGE,
+            saveToDB=True,
+            default=None,
+        )
+
+        pb.defParam(
             "betad",
             units=units.UNITLESS,
             description="Delayed neutron beta",

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -185,26 +185,6 @@ def _getNeutronicsBlockParams():
         )
 
         pb.defParam(
-            "axialPowerProfileNeutron",
-            units=f"{units.WATTS}/{units.CM}^3",
-            description="""For each reconstructed axial location, a tuple (z, neutron power density)
-            where with axial origin at the bottom of assembly in which the blocks are located.""",
-            location=ParamLocation.AVERAGE,
-            saveToDB=True,
-            default=None,
-        )
-
-        pb.defParam(
-            "axialPowerProfileGamma",
-            units=f"{units.WATTS}/{units.CM}^3",
-            description="""For each reconstructed axial location, a tuple (z, gamma power density)
-            where with axial origin at the bottom of assembly in which the blocks are located.""",
-            location=ParamLocation.AVERAGE,
-            saveToDB=True,
-            default=None,
-        )
-
-        pb.defParam(
             "betad",
             units=units.UNITLESS,
             description="Delayed neutron beta",

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -550,6 +550,14 @@ def _getNeutronicsBlockParams():
             location=ParamLocation.MAX,
         )
 
+        pb.defParam(
+            "ppdensGamma",
+            units=f"{units.WATTS}/{units.CM}^3",
+            description="Peak gamma density",
+            categories=[parameters.Category.gamma],
+            location=ParamLocation.MAX,
+        )
+
     # rx rate params that are derived during mesh conversion.
     # We'd like all things that can be derived from flux and XS to be
     # in this category to minimize numerical diffusion but it is a WIP.

--- a/armi/physics/thermalHydraulics/parameters.py
+++ b/armi/physics/thermalHydraulics/parameters.py
@@ -201,13 +201,6 @@ def _getBlockParams():
         )
 
         pb.defParam(
-            "THcoolantAverageT",
-            units=units.DEGC,
-            description="Flow-based average of the inlet and outlet coolant temperatures.",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "THcoolantInletT",
             units=units.DEGC,
             description="The nominal average bulk coolant inlet temperature into the block.",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -599,13 +599,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "intrinsicSourceDecayed",
-            units=units.UNITLESS,
-            description="Intrinsic source from spontaneous fissions after a decay period",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "kgFis",
             units=units.KG,
             description="Mass of fissile material in block",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -577,13 +577,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "crWastage",
-            units=units.MICRONS,
-            description="Combines ACCI and clad corrosion for control blocks",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "cyclicNErr",
             units=units.UNITLESS,
             description="Relative error of the block number density",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -441,12 +441,6 @@ def getBlockParameterDefinitions():
             description="Fuel density coefficient",
         )
 
-        pb.defParam(
-            "rxFuelVoidedTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG}",
-            description="Fuel voided-coolant temperature coefficient",
-        )
-
         # CLAD COEFFICIENTS
         pb.defParam(
             "rxCladDensityCoeffPerMass",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -568,12 +568,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "rxFuelTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel temperature coefficient",
-        )
-
-        pb.defParam(
             "rxFuelVoidedTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Fuel voided-coolant temperature coefficient",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -104,13 +104,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "percentBuMaxPinLocation",
-            units=units.UNITLESS,
-            description="Peak burnup pin location (integer)",
-            location=ParamLocation.MAX,
-        )
-
-        pb.defParam(
             "residence",
             units=units.DAYS,
             description=(

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -563,12 +563,6 @@ def getBlockParameterDefinitions():
 
         # STRUCTURE COEFFICIENTS
         pb.defParam(
-            "rxStructureDopplerCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Structure Doppler coefficient",
-        )
-
-        pb.defParam(
             "rxStructureTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Structure temperature coefficient",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -569,12 +569,6 @@ def getBlockParameterDefinitions():
 
         # CLAD COEFFICIENTS
         pb.defParam(
-            "rxCladDensityCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Clad density coefficient",
-        )
-
-        pb.defParam(
             "rxCladDopplerCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Clad Doppler coefficient",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -293,13 +293,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "powerRx",
-            units=f"{units.WATTS}/{units.CM}^3",
-            description="Power density of the reactor",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "timeToLimit",
             units=units.DAYS,
             description="Time unit block violates its burnup limit.",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -612,13 +612,6 @@ def getBlockParameterDefinitions():
             location=ParamLocation.VOLUME_INTEGRATED,
         )
 
-        pb.defParam(
-            "mreg",
-            units=units.UNITLESS,
-            description="SASSYS/DIF3D-K radial region index assignment",
-            location=ParamLocation.AVERAGE,
-        )
-
         pb.defParam("nPins", units=units.UNITLESS, description="Number of pins")
 
         pb.defParam(

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -561,13 +561,6 @@ def getBlockParameterDefinitions():
             description="Structure Doppler constant",
         )
 
-        # CLAD COEFFICIENTS
-        pb.defParam(
-            "rxCladTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Clad temperature coefficient",
-        )
-
         # STRUCTURE COEFFICIENTS
         pb.defParam(
             "rxStructureDensityCoeffPerTemp",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -74,15 +74,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "molesHmBOLByPin",
-            units=f"{units.MOLES}",
-            description="Total number of atoms of heavy metal at BOL",
-            default=None,
-            saveToDB=False,
-            location=ParamLocation.CHILDREN,
-        )
-
-        pb.defParam(
             "newDPA",
             units=units.DPA,
             description="Dose in DPA accrued during the current time step",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -569,12 +569,6 @@ def getBlockParameterDefinitions():
 
         # CLAD COEFFICIENTS
         pb.defParam(
-            "rxCladDopplerCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Clad Doppler coefficient",
-        )
-
-        pb.defParam(
             "rxCladTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Clad temperature coefficient",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -293,6 +293,13 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
+            "powerRx",
+            units=f"{units.WATTS}/{units.CM}^3",
+            description="Power density of the reactor",
+            location=ParamLocation.AVERAGE,
+        )
+
+        pb.defParam(
             "timeToLimit",
             units=units.DAYS,
             description="Time unit block violates its burnup limit.",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -448,12 +448,6 @@ def getBlockParameterDefinitions():
             description="Clad density coefficient",
         )
 
-        pb.defParam(
-            "rxCladTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG}",
-            description="Clad temperature coefficient",
-        )
-
         # STRUCTURE COEFFICIENTS
         pb.defParam(
             "rxStructureDensityCoeffPerMass",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -569,13 +569,6 @@ def getBlockParameterDefinitions():
         pb.defParam("buLimit", units=units.PERCENT_FIMA, description="Burnup limit")
 
         pb.defParam(
-            "cladACCI",
-            units=units.MICRONS,
-            description="The amount of cladding wastage due to absorber chemical clad interaction",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "convRatio",
             units=units.UNITLESS,
             description="Conversion ratio",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -455,12 +455,6 @@ def getBlockParameterDefinitions():
             description="Structure density coefficient",
         )
 
-        pb.defParam(
-            "rxStructureTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG}",
-            description="Structure temperature coefficient",
-        )
-
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerMass",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -555,13 +555,6 @@ def getBlockParameterDefinitions():
             description="Fuel voided-coolant Doppler constant",
         )
 
-        # STRUCTURE COEFFICIENTS
-        pb.defParam(
-            "rxStructureTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Structure temperature coefficient",
-        )
-
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerTemp",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -441,11 +441,29 @@ def getBlockParameterDefinitions():
             description="Fuel density coefficient",
         )
 
+        pb.defParam(
+            "rxFuelTemperatureCoeffPerMass",
+            units=f"{units.REACTIVITY}/{units.KG}",
+            description="Fuel temperature coefficient",
+        )
+
+        pb.defParam(
+            "rxFuelVoidedTemperatureCoeffPerMass",
+            units=f"{units.REACTIVITY}/{units.KG}",
+            description="Fuel voided-coolant temperature coefficient",
+        )
+
         # CLAD COEFFICIENTS
         pb.defParam(
             "rxCladDensityCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
             description="Clad density coefficient",
+        )
+
+        pb.defParam(
+            "rxCladTemperatureCoeffPerMass",
+            units=f"{units.REACTIVITY}/{units.KG}",
+            description="Clad temperature coefficient",
         )
 
         # STRUCTURE COEFFICIENTS
@@ -455,11 +473,23 @@ def getBlockParameterDefinitions():
             description="Structure density coefficient",
         )
 
+        pb.defParam(
+            "rxStructureTemperatureCoeffPerMass",
+            units=f"{units.REACTIVITY}/{units.KG}",
+            description="Structure temperature coefficient",
+        )
+
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
             description="Coolant density coefficient",
+        )
+
+        pb.defParam(
+            "rxCoolantTemperatureCoeffPerMass",
+            units=f"{units.REACTIVITY}/{units.KG}",
+            description="Coolant temperature coefficient",
         )
 
     with pDefs.createBuilder(
@@ -503,11 +533,79 @@ def getBlockParameterDefinitions():
             description="Fuel voided-coolant Doppler constant",
         )
 
+        pb.defParam(
+            "rxStructureDopplerConstant",
+            units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
+            description="Structure Doppler constant",
+        )
+
+        pb.defParam(
+            "rxCladDopplerConstant",
+            units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
+            description="Clad Doppler constant",
+        )
+
+        pb.defParam(
+            "rxFuelTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Fuel temperature coefficient",
+        )
+
+        pb.defParam(
+            "rxFuelVoidedTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Fuel voided-coolant temperature coefficient",
+        )
+
+        # CLAD COEFFICIENTS
+        pb.defParam(
+            "rxCladDensityCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Clad density coefficient",
+        )
+
+        pb.defParam(
+            "rxCladDopplerCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Clad Doppler coefficient",
+        )
+
+        pb.defParam(
+            "rxCladTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Clad temperature coefficient",
+        )
+
+        # STRUCTURE COEFFICIENTS
+        pb.defParam(
+            "rxStructureDensityCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Structure density coefficient",
+        )
+
+        pb.defParam(
+            "rxStructureDopplerCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Structure Doppler coefficient",
+        )
+
+        pb.defParam(
+            "rxStructureTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Structure temperature coefficient",
+        )
+
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Coolant density coefficient",
+        )
+
+        pb.defParam(
+            "rxCoolantTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Coolant temperature coefficient",
         )
 
     with pDefs.createBuilder(default=0.0) as pb:

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -524,14 +524,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "axExtenNodeHeight",
-            units=units.METERS,
-            description="Axial extension node height",
-            location=ParamLocation.AVERAGE,
-            default=0.0,
-        )
-
-        pb.defParam(
             "blockBeta",
             units=units.UNITLESS,
             description="Beta in each block",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -74,12 +74,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "fissileFraction",
-            units=units.UNITLESS,
-            description="Ratio of fissile mass to heavy metal mass at block-level",
-        )
-
-        pb.defParam(
             "molesHmBOLByPin",
             units=f"{units.MOLES}",
             description="Total number of atoms of heavy metal at BOL",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -555,12 +555,6 @@ def getBlockParameterDefinitions():
             description="Fuel voided-coolant Doppler constant",
         )
 
-        pb.defParam(
-            "rxStructureDopplerConstant",
-            units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
-            description="Structure Doppler constant",
-        )
-
         # STRUCTURE COEFFICIENTS
         pb.defParam(
             "rxStructureTemperatureCoeffPerTemp",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -561,12 +561,6 @@ def getBlockParameterDefinitions():
             description="Structure Doppler constant",
         )
 
-        pb.defParam(
-            "rxCladDopplerConstant",
-            units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
-            description="Clad Doppler constant",
-        )
-
         # CLAD COEFFICIENTS
         pb.defParam(
             "rxCladTemperatureCoeffPerTemp",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -462,12 +462,6 @@ def getBlockParameterDefinitions():
             description="Coolant density coefficient",
         )
 
-        pb.defParam(
-            "rxCoolantTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG}",
-            description="Coolant temperature coefficient",
-        )
-
     with pDefs.createBuilder(
         default=0.0,
         location=ParamLocation.VOLUME_INTEGRATED,

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -563,12 +563,6 @@ def getBlockParameterDefinitions():
 
         # STRUCTURE COEFFICIENTS
         pb.defParam(
-            "rxStructureDensityCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Structure density coefficient",
-        )
-
-        pb.defParam(
             "rxStructureDopplerCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Structure Doppler coefficient",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -442,12 +442,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "rxFuelTemperatureCoeffPerMass",
-            units=f"{units.REACTIVITY}/{units.KG}",
-            description="Fuel temperature coefficient",
-        )
-
-        pb.defParam(
             "rxFuelVoidedTemperatureCoeffPerMass",
             units=f"{units.REACTIVITY}/{units.KG}",
             description="Fuel voided-coolant temperature coefficient",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -613,13 +613,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "mchan",
-            units=units.UNITLESS,
-            description="SASSYS/DIF3D-K (external) channel index assignment",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "mreg",
             units=units.UNITLESS,
             description="SASSYS/DIF3D-K radial region index assignment",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -562,12 +562,6 @@ def getBlockParameterDefinitions():
             description="Coolant density coefficient",
         )
 
-        pb.defParam(
-            "rxCoolantTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Coolant temperature coefficient",
-        )
-
     with pDefs.createBuilder(default=0.0) as pb:
 
         pb.defParam(

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -567,12 +567,6 @@ def getBlockParameterDefinitions():
             description="Clad Doppler constant",
         )
 
-        pb.defParam(
-            "rxFuelVoidedTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel voided-coolant temperature coefficient",
-        )
-
         # CLAD COEFFICIENTS
         pb.defParam(
             "rxCladDensityCoeffPerTemp",

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -630,13 +630,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "powerShapeDelta",
-            units=units.WATTS,
-            description="Change in power shape when core temperature rises.",
-            location=ParamLocation.VOLUME_INTEGRATED,
-        )
-
-        pb.defParam(
             "puFrac",
             units=units.UNITLESS,
             description="Current Pu number density relative to HM at BOL",

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -116,7 +116,6 @@ class Block(composites.Composite):
             "fluxAdj",
             "buRate",
             "eqRegion",
-            "fissileFraction",
         ]:
             self.p[problemParam] = 0.0
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -533,12 +533,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "rxFuelTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel Temperature Coefficient",
-        )
-
-        pb.defParam(
             "rxFuelVoidedTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Fuel Voided-Coolant Temperature Coefficient",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -496,6 +496,18 @@ def defineCoreParameters():
         )
 
         pb.defParam(
+            "rxAclpRadialExpansionCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="ACLP Radial Expansion Coefficient",
+        )
+
+        pb.defParam(
+            "rxControlRodDrivelineExpansionCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="control rod driveline expansion coefficient",
+        )
+
+        pb.defParam(
             "rxCoreWideCoolantVoidWorth",
             units=f"{units.REACTIVITY}",
             description="Core-Wide Coolant Void Worth",
@@ -538,11 +550,79 @@ def defineCoreParameters():
             description="Fuel Voided-Coolant Doppler Constant",
         )
 
+        pb.defParam(
+            "rxFuelTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Fuel Temperature Coefficient",
+        )
+
+        pb.defParam(
+            "rxFuelVoidedTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Fuel Voided-Coolant Temperature Coefficient",
+        )
+
+        # CLAD COEFFICIENTS
+        pb.defParam(
+            "rxCladDensityCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Clad Density Coefficient",
+        )
+
+        pb.defParam(
+            "rxCladDopplerCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Clad Doppler Coefficient",
+        )
+
+        pb.defParam(
+            "rxCladDopplerConstant",
+            units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
+            description="Clad Doppler Constant",
+        )
+
+        pb.defParam(
+            "rxCladTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Clad Temperature Coefficient",
+        )
+
+        # STRUCTURE COEFFICIENTS
+        pb.defParam(
+            "rxStructureDensityCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Structure Density Coefficient",
+        )
+
+        pb.defParam(
+            "rxStructureDopplerCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Structure Doppler Coefficient",
+        )
+
+        pb.defParam(
+            "rxStructureDopplerConstant",
+            units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
+            description="Structure Doppler Constant",
+        )
+
+        pb.defParam(
+            "rxStructureTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Structure Temperature Coefficient",
+        )
+
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Coolant Density Coefficient",
+        )
+
+        pb.defParam(
+            "rxCoolantTemperatureCoeffPerTemp",
+            units=f"{units.REACTIVITY}/{units.DEGK}",
+            description="Coolant Temperature Coefficient",
         )
 
     with pDefs.createBuilder(

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -534,12 +534,6 @@ def defineCoreParameters():
 
         # STRUCTURE COEFFICIENTS
         pb.defParam(
-            "rxStructureDopplerCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Structure Doppler Coefficient",
-        )
-
-        pb.defParam(
             "rxStructureDopplerConstant",
             units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
             description="Structure Doppler Constant",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -74,22 +74,6 @@ def defineReactorParameters():
             default=0,
         )
 
-    with pDefs.createBuilder(
-        location=ParamLocation.AVERAGE, default=0.0, categories=["economics"]
-    ) as pb:
-
-        pb.defParam(
-            "eFeedMT",
-            units=units.MT,
-            description="Total feed material required in reactor economics",
-        )
-
-        pb.defParam(
-            "eSWU",
-            units=f"{units.KG}*SWU",
-            description="Separative work units in reactor economics",
-        )
-
     return pDefs
 
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -490,12 +490,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "rxControlRodDrivelineExpansionCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="control rod driveline expansion coefficient",
-        )
-
-        pb.defParam(
             "rxCoreWideCoolantVoidWorth",
             units=f"{units.REACTIVITY}",
             description="Core-Wide Coolant Void Worth",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -357,6 +357,12 @@ def defineCoreParameters():
             description="minimum axial location of the ACLP for 7 cycles at peak dose",
         )
 
+        pb.defParam(
+            "maxpercentBu",
+            units=units.PERCENT_FIMA,
+            description="Max percent burnup on any block in the problem",
+        )
+
         pb.defParam("rxSwing", units=units.PCM, description="Reactivity swing")
 
         pb.defParam(

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -534,12 +534,6 @@ def defineCoreParameters():
 
         # CLAD COEFFICIENTS
         pb.defParam(
-            "rxCladDopplerCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Clad Doppler Coefficient",
-        )
-
-        pb.defParam(
             "rxCladDopplerConstant",
             units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
             description="Clad Doppler Constant",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -85,12 +85,6 @@ def defineReactorParameters():
         )
 
         pb.defParam(
-            "eFissile",
-            units=units.MT,
-            description="Fissile mass required in reactor economics",
-        )
-
-        pb.defParam(
             "eSWU",
             units=f"{units.KG}*SWU",
             description="Separative work units in reactor economics",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -534,12 +534,6 @@ def defineCoreParameters():
 
         # STRUCTURE COEFFICIENTS
         pb.defParam(
-            "rxStructureDopplerConstant",
-            units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
-            description="Structure Doppler Constant",
-        )
-
-        pb.defParam(
             "rxStructureTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Structure Temperature Coefficient",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -544,10 +544,6 @@ def defineCoreParameters():
     ) as pb:
 
         pb.defParam(
-            "boecKeff", units=units.UNITLESS, description="BOEC Keff", default=0.0
-        )
-
-        pb.defParam(
             "cyclics",
             units=units.UNITLESS,
             description=(

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -532,13 +532,6 @@ def defineCoreParameters():
             description="Fuel Voided-Coolant Doppler Constant",
         )
 
-        # CLAD COEFFICIENTS
-        pb.defParam(
-            "rxCladTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Clad Temperature Coefficient",
-        )
-
         # STRUCTURE COEFFICIENTS
         pb.defParam(
             "rxStructureDensityCoeffPerTemp",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -532,13 +532,6 @@ def defineCoreParameters():
             description="Fuel Voided-Coolant Doppler Constant",
         )
 
-        # STRUCTURE COEFFICIENTS
-        pb.defParam(
-            "rxStructureTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Structure Temperature Coefficient",
-        )
-
         # COOLANT COEFFICIENTS
         pb.defParam(
             "rxCoolantDensityCoeffPerTemp",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -534,12 +534,6 @@ def defineCoreParameters():
 
         # STRUCTURE COEFFICIENTS
         pb.defParam(
-            "rxStructureDensityCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Structure Density Coefficient",
-        )
-
-        pb.defParam(
             "rxStructureDopplerCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Structure Doppler Coefficient",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -490,12 +490,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "rxAclpRadialExpansionCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="ACLP Radial Expansion Coefficient",
-        )
-
-        pb.defParam(
             "rxControlRodDrivelineExpansionCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="control rod driveline expansion coefficient",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -534,12 +534,6 @@ def defineCoreParameters():
 
         # CLAD COEFFICIENTS
         pb.defParam(
-            "rxCladDopplerConstant",
-            units=f"{units.REACTIVITY}*{units.DEGK}^(n-1)",
-            description="Clad Doppler Constant",
-        )
-
-        pb.defParam(
             "rxCladTemperatureCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Clad Temperature Coefficient",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -133,26 +133,6 @@ def defineCoreParameters():
             ),
         )
         pb.defParam(
-            "crWorthRequiredPrimary",
-            default=0.0,
-            units=units.PCM,
-            saveToDB=True,
-            description=(
-                "Worth requirement for the primary control rods in the reactor core to "
-                "achieve safe shutdown."
-            ),
-        )
-        pb.defParam(
-            "crWorthRequiredSecondary",
-            default=0.0,
-            units=units.PCM,
-            saveToDB=True,
-            description=(
-                "Worth requirement for the secondary control rods in the reactor core to "
-                "achieve safe shutdown."
-            ),
-        )
-        pb.defParam(
             "crTransientOverpowerWorth",
             default=0.0,
             units=units.PCM,

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -252,12 +252,6 @@ def defineCoreParameters():
             description="Full core intrinsic neutron source from spontaneous fissions before a decay period",
         )
 
-        pb.defParam(
-            "totalIntrinsicSourceDecayed",
-            units=f"n/{units.SECONDS}",
-            description="Full core intrinsic source from spontaneous fissions after a decay period",
-        )
-
     with pDefs.createBuilder(
         location=ParamLocation.AVERAGE, default=0.0, categories=["thermal hydraulics"]
     ) as pb:

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -534,12 +534,6 @@ def defineCoreParameters():
 
         # CLAD COEFFICIENTS
         pb.defParam(
-            "rxCladDensityCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Clad Density Coefficient",
-        )
-
-        pb.defParam(
             "rxCladDopplerCoeffPerTemp",
             units=f"{units.REACTIVITY}/{units.DEGK}",
             description="Clad Doppler Coefficient",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -539,12 +539,6 @@ def defineCoreParameters():
             description="Coolant Density Coefficient",
         )
 
-        pb.defParam(
-            "rxCoolantTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Coolant Temperature Coefficient",
-        )
-
     with pDefs.createBuilder(
         location=ParamLocation.AVERAGE, categories=["equilibrium"]
     ) as pb:

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -206,15 +206,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "maxcladFCCI",
-            units=units.MICRONS,
-            description="The core wide maximum amount of cladding wastage due to fuel chemical "
-            + "clad interaction calculated at the 0-sigma TH HCF temperatures and using the "
-            + "conservative FCCI model",
-            default=0.0,
-        )
-
-        pb.defParam(
             "maxDPA",
             units=units.DPA,
             description="Maximum DPA based on pin-level max if it exists, block level max otherwise",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -357,12 +357,6 @@ def defineCoreParameters():
             description="minimum axial location of the ACLP for 7 cycles at peak dose",
         )
 
-        pb.defParam(
-            "maxpercentBu",
-            units=units.PERCENT_FIMA,
-            description="Max percent burnup on any block in the problem",
-        )
-
         pb.defParam("rxSwing", units=units.PCM, description="Reactivity swing")
 
         pb.defParam(

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -57,12 +57,6 @@ def defineReactorParameters():
         )
 
         pb.defParam(
-            "lcoe",
-            units=f"{units.USD}/kWh",
-            description="Levelised cost of electricity",
-        )
-
-        pb.defParam(
             "time",
             units=units.YEARS,
             description="Time of reactor life from BOL to current time node",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -190,13 +190,6 @@ def defineCoreParameters():
         )
 
         pb.defParam(
-            "doublingTime",
-            units=units.YEARS,
-            description="""The time it takes to produce enough spent fuel to fuel a daughter 
-            reactor, in effective number of years at full power.""",
-        )
-
-        pb.defParam(
             "fissileMass", units=units.GRAMS, description="Fissile mass of the reactor"
         )
 

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -532,12 +532,6 @@ def defineCoreParameters():
             description="Fuel Voided-Coolant Doppler Constant",
         )
 
-        pb.defParam(
-            "rxFuelVoidedTemperatureCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel Voided-Coolant Temperature Coefficient",
-        )
-
         # CLAD COEFFICIENTS
         pb.defParam(
             "rxCladDensityCoeffPerTemp",

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -64,7 +64,7 @@ def plotReactorPerformance(reactor, dbi, buGroups, extension=None, history=None)
         The history tracker interface
     """
     try:
-        data = dbi.getHistory(reactor, params=["cycle", "time", "eFeedMT", "eSWU"])
+        data = dbi.getHistory(reactor, params=["cycle", "time"])
         data.update(
             dbi.getHistory(
                 reactor.core,
@@ -321,7 +321,6 @@ def plotCoreOverviewRadar(reactors, reactorNames=None):
         _getMechanicalVals,
         _getFuelVals,
         _getTHVals,
-        _getEconVals,
         _getPhysicalVals,
     ]
     firstReactorVals = {}  # for normalization
@@ -473,11 +472,6 @@ def _getTHVals(r):
         ]
     )
     return "T/H", labels, vals
-
-
-def _getEconVals(r):
-    labels, vals = zip(*[("Feed U", r.p.eFeedMT), ("SWU", r.p.eSWU)])
-    return "Economics", labels, vals
 
 
 def _radarFactory(numVars, frame="circle"):

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -476,9 +476,7 @@ def _getTHVals(r):
 
 
 def _getEconVals(r):
-    labels, vals = zip(
-        *[("Feed U", r.p.eFeedMT), ("SWU", r.p.eSWU), ("LCOE", r.p.lcoe)]
-    )
+    labels, vals = zip(*[("Feed U", r.p.eFeedMT), ("SWU", r.p.eSWU)])
     return "Economics", labels, vals
 
 

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -447,7 +447,6 @@ def _getFuelVals(r):
             numClad += 1
     tOverD /= numClad
     data = [
-        ("Max BU", r.core.p.maxpercentBu),
         (
             "Smear dens.",
             r.core.calcAvgParam("smearDensity", generationNum=2, typeSpec=Flags.FUEL),

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -447,7 +447,6 @@ def _getFuelVals(r):
             numClad += 1
     tOverD /= numClad
     data = [
-        ("Max FCCI", r.core.p.maxcladFCCI),
         ("Max BU", r.core.p.maxpercentBu),
         (
             "Smear dens.",

--- a/doc/tutorials/making_your_first_app.rst
+++ b/doc/tutorials/making_your_first_app.rst
@@ -369,7 +369,7 @@ you can run the ARMI ``vis-file`` entry point, like this::
 
 This creates several ``VTK`` files covering different time steps and levels of abstraction
 (assembly vs. block params). If you load up the block file and plot one of the output
-params (such as ``THcoolantAverageT`` you can see the outlet temperature going nicely
+params (such as ``THcoolantOutletT`` you can see the outlet temperature going nicely
 from 360 |deg|\ C  to 510 |deg|\ C (as expected given our simple TH solver).
 
 


### PR DESCRIPTION
## What is the change? Why is it being made?

I identified 22 unused parameters and ran substantial testing downstream to show they are unused. Then I removed those parameters.


### Unused Block Parameters

* axExtenNodeHeight
* cladACCI
* crWastage
* fissileFraction
* intrinsicSourceDecayed
* mchan
* molesHmBOLByPin
* mreg
* percentBuMaxPinLocation
* powerShapeDelta

### Unused Reactor Parameters

* boecKeff
* crWorthRequiredPrimary
* crWorthRequiredSecondary
* doublingTime
* eFeedMT
* eFissile
* eSWU
* lcoe
* maxcladFCCI
* totalIntrinsicSourceDecayed


### Unused Thermal Hydraulics Parameters

* THcoolantAverageT


### Unused Neutronics Parameters

* mgFluxSK


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: We identified several parameters which were totally unused, and removed them.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
