### PR TITLE
Update docstring for `Settings` class to reflect mutability

### DIFF
--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -61,7 +61,10 @@ class Settings:
 
     Notes
     -----
-    The actual settings in any instance of this class are immutable.
+    While it is possible to modify case settings during the course of a run, this
+    is highly discouraged because there will be no record of this happening in your
+    results or in the database produced from your run. There is no guarantee that
+    doing so will not cause unexpected problems with your calculation.
     """
 
     defaultCaseTitle = "armi"


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
The docstring for the `Settings` class had a note that was not technically true. This PR fixes the docstring but maintains the intent of the original in terms of discouraging users from changing settings mid-run.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Update the docstring for the `Settings` class to reflect their mutability

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: None


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
