### PR TITLE
Moving NeutronicsPlugin to its own file

### DIFF
--- a/armi/physics/neutronics/__init__.py
+++ b/armi/physics/neutronics/__init__.py
@@ -15,117 +15,11 @@
 """
 The neutronics physics package in the ARMI framework.
 
-Neutronics encompasses the modeling of nuclear chain reactions and their associated transmutation and decay.
-
-The ARMI Framework comes with a neutronics plugin that introduces two
-independent interfaces:
-
-:py:mod:`~armi.physics.neutronics.fissionProductModel`
-    Handles fission product modeling
-
-:py:mod:`~armi.physics.neutronics.crossSectionGroupManager`
-    Handles the management of different cross section "groups"
-
-.. warning:: There is also some legacy and question-raising code in this module that
-    is here temporarily while we finish untangling some of the neutronics
-    plugins outside of ARMI.
+Neutronics encompasses the modeling of nuclear chain reactions and their associated transmutation
+and decay.
 """
-# ruff: noqa: F401, E402
+# ruff: noqa: F401
 from enum import IntEnum
-
-import numpy as np
-
-from armi import plugins, runLog
-from armi.physics.neutronics.const import CONF_CROSS_SECTION
-from armi.utils import tabulate
-
-
-class NeutronicsPlugin(plugins.ArmiPlugin):
-    """The built-in neutronics plugin with a few capabilities and a lot of state parameter definitions."""
-
-    @staticmethod
-    @plugins.HOOKIMPL
-    def exposeInterfaces(cs):
-        """Collect and expose all of the interfaces that live under the built-in neutronics package."""
-        from armi.physics.neutronics import crossSectionGroupManager
-        from armi.physics.neutronics.fissionProductModel import fissionProductModel
-
-        interfaceInfo = []
-        for mod in (crossSectionGroupManager, fissionProductModel):
-            interfaceInfo += plugins.collectInterfaceDescriptions(mod, cs)
-
-        return interfaceInfo
-
-    @staticmethod
-    @plugins.HOOKIMPL
-    def defineParameters():
-        """Define parameters for the plugin."""
-        from armi.physics.neutronics import parameters as neutronicsParameters
-
-        return neutronicsParameters.getNeutronicsParameterDefinitions()
-
-    @staticmethod
-    @plugins.HOOKIMPL
-    def defineParameterRenames():
-        return {"buGroup": "envGroup", "buGroupNum": "envGroupNum"}
-
-    @staticmethod
-    @plugins.HOOKIMPL
-    def defineEntryPoints():
-        """Define entry points for the plugin."""
-        from armi.physics.neutronics import diffIsotxs
-
-        entryPoints = [diffIsotxs.CompareIsotxsLibraries]
-
-        return entryPoints
-
-    @staticmethod
-    @plugins.HOOKIMPL
-    def defineSettings():
-        """Define settings for the plugin."""
-        from armi.physics.neutronics import crossSectionSettings
-        from armi.physics.neutronics import settings as neutronicsSettings
-        from armi.physics.neutronics.fissionProductModel import (
-            fissionProductModelSettings,
-        )
-
-        settings = [
-            crossSectionSettings.XSSettingDef(
-                CONF_CROSS_SECTION,
-            )
-        ]
-        settings += neutronicsSettings.defineSettings()
-        settings += fissionProductModelSettings.defineSettings()
-
-        return settings
-
-    @staticmethod
-    @plugins.HOOKIMPL
-    def defineSettingsValidators(inspector):
-        """Implementation of settings inspections for neutronics settings."""
-        from armi.physics.neutronics.fissionProductModel.fissionProductModelSettings import (
-            getFissionProductModelSettingValidators,
-        )
-        from armi.physics.neutronics.settings import getNeutronicsSettingValidators
-
-        settingsValidators = getNeutronicsSettingValidators(inspector)
-        settingsValidators.extend(getFissionProductModelSettingValidators(inspector))
-        return settingsValidators
-
-    @staticmethod
-    @plugins.HOOKIMPL
-    def onProcessCoreLoading(core, cs, dbLoad):
-        """Called whenever a Core object is newly built."""
-        applyEffectiveDelayedNeutronFractionToCore(core, cs)
-
-    @staticmethod
-    @plugins.HOOKIMPL
-    def getReportContents(r, cs, report, stage, blueprint):
-        """Generates the Report Content for the Neutronics Report."""
-        from armi.physics.neutronics import reports
-
-        return reports.insertNeutronicsReport(r, cs, report, stage)
-
 
 from armi.physics.neutronics.const import (
     ALL,
@@ -136,6 +30,7 @@ from armi.physics.neutronics.const import (
     NEUTRONGAMMA,
     RESTARTFILES,
 )
+from armi.physics.neutronics.plugin import NeutronicsPlugin
 
 # ARC and CCCC cross section file format names
 COMPXS = "COMPXS"
@@ -175,6 +70,7 @@ GENERAL_BC = "Generalized"
 EXTRAPOLATED = "Extrapolated"
 ZEROFLUX = "ZeroSurfaceFlux"
 ZERO_INWARD_CURRENT = "ZeroInwardCurrent"
+
 
 # Common settings checks
 def gammaTransportIsRequested(cs):
@@ -229,57 +125,6 @@ def realCalculationRequested(cs):
     return cs[CONF_NEUTRONICS_TYPE] in ["real", "both"]
 
 
-def applyEffectiveDelayedNeutronFractionToCore(core, cs):
-    """Process the settings for the delayed neutron fraction and precursor decay constants."""
-    # Verify and set the core beta parameters based on the user-supplied settings
-    beta = cs["beta"]
-    decayConstants = cs["decayConstants"]
-
-    # If beta is interpreted as a float, then assign it to
-    # the total delayed neutron fraction parameter. Otherwise, setup the
-    # group-wise delayed neutron fractions and precursor decay constants.
-    reportTableData = []
-    if isinstance(beta, float):
-        core.p.beta = beta
-        reportTableData.append(("Total Delayed Neutron Fraction", core.p.beta))
-
-    elif isinstance(beta, list) and isinstance(decayConstants, list):
-        if len(beta) != len(decayConstants):
-            raise ValueError(
-                f"The values for `beta` ({beta}) and `decayConstants` "
-                f"({decayConstants}) are not consistent lengths."
-            )
-
-        core.p.beta = sum(beta)
-        core.p.betaComponents = np.array(beta)
-        core.p.betaDecayConstants = np.array(decayConstants)
-
-        reportTableData.append(("Total Delayed Neutron Fraction", core.p.beta))
-        for i, betaComponent in enumerate(core.p.betaComponents):
-            reportTableData.append(
-                (f"Group {i} Delayed Neutron Fractions", betaComponent)
-            )
-        for i, decayConstant in enumerate(core.p.betaDecayConstants):
-            reportTableData.append(
-                ("Group {i} Precursor Decay Constants", decayConstant)
-            )
-
-    # Report to the user the values were not applied.
-    if not reportTableData and (beta is not None or decayConstants is not None):
-        runLog.warning(
-            f"Delayed neutron fraction(s) - {beta} and decay constants"
-            f" - {decayConstants} have not been applied."
-        )
-    else:
-        runLog.extra(
-            tabulate.tabulate(
-                data=reportTableData,
-                headers=["Component", "Value"],
-                tableFmt="armi",
-            )
-        )
-
-
 class LatticePhysicsFrequency(IntEnum):
     """
     Enumeration for lattice physics update frequency options.
@@ -293,12 +138,12 @@ class LatticePhysicsFrequency(IntEnum):
 
     Notes
     -----
-    firstCoupledIteration only updates the cross sections during the first coupled iteration,
-    but not on any subsequent iterations. This may be an appropriate approximation in some cases
-    to save compute time, but each individual user should give careful consideration to whether
-    this is the behavior they want for a particular application. The main purpose of this setting
-    is to capture a large change in temperature distribution when running a snapshot at a different
-    power/flow condition than the original state being loaded from the database.
+    firstCoupledIteration only updates the cross sections during the first coupled iteration, but
+    not on any subsequent iterations. This may be an appropriate approximation in some cases to save
+    compute time, but each individual user should give careful consideration to whether this is the
+    behavior they want for a particular application. The main purpose of this setting is to capture
+    a large change in temperature distribution when running a snapshot at a different power/flow
+    condition than the original state being loaded from the database.
     """
 
     never = 0

--- a/armi/physics/neutronics/plugin.py
+++ b/armi/physics/neutronics/plugin.py
@@ -1,0 +1,169 @@
+# Copyright 2025 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A boilerplate entry for a neutronics physics plugin.
+
+The ARMI Framework comes with a neutronics plugin that introduces two independent interfaces:
+
+:py:mod:`~armi.physics.neutronics.fissionProductModel`
+    Handles fission product modeling
+
+:py:mod:`~armi.physics.neutronics.crossSectionGroupManager`
+    Handles the management of different cross section "groups"
+"""
+
+import numpy as np
+
+from armi import plugins, runLog
+from armi.physics.neutronics.const import CONF_CROSS_SECTION
+from armi.utils import tabulate
+
+
+class NeutronicsPlugin(plugins.ArmiPlugin):
+    """The built-in neutronics plugin with a few capabilities and a lot of state parameter definitions."""
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def exposeInterfaces(cs):
+        """Collect and expose all of the interfaces that live under the built-in neutronics package."""
+        from armi.physics.neutronics import crossSectionGroupManager
+        from armi.physics.neutronics.fissionProductModel import fissionProductModel
+
+        interfaceInfo = []
+        for mod in (crossSectionGroupManager, fissionProductModel):
+            interfaceInfo += plugins.collectInterfaceDescriptions(mod, cs)
+
+        return interfaceInfo
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineParameters():
+        """Define parameters for the plugin."""
+        from armi.physics.neutronics import parameters as neutronicsParameters
+
+        return neutronicsParameters.getNeutronicsParameterDefinitions()
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineParameterRenames():
+        return {"buGroup": "envGroup", "buGroupNum": "envGroupNum"}
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineEntryPoints():
+        """Define entry points for the plugin."""
+        from armi.physics.neutronics import diffIsotxs
+
+        entryPoints = [diffIsotxs.CompareIsotxsLibraries]
+
+        return entryPoints
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineSettings():
+        """Define settings for the plugin."""
+        from armi.physics.neutronics import crossSectionSettings
+        from armi.physics.neutronics import settings as neutronicsSettings
+        from armi.physics.neutronics.fissionProductModel import (
+            fissionProductModelSettings,
+        )
+
+        settings = [
+            crossSectionSettings.XSSettingDef(
+                CONF_CROSS_SECTION,
+            )
+        ]
+        settings += neutronicsSettings.defineSettings()
+        settings += fissionProductModelSettings.defineSettings()
+
+        return settings
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def defineSettingsValidators(inspector):
+        """Implementation of settings inspections for neutronics settings."""
+        from armi.physics.neutronics.fissionProductModel.fissionProductModelSettings import (
+            getFissionProductModelSettingValidators,
+        )
+        from armi.physics.neutronics.settings import getNeutronicsSettingValidators
+
+        settingsValidators = getNeutronicsSettingValidators(inspector)
+        settingsValidators.extend(getFissionProductModelSettingValidators(inspector))
+        return settingsValidators
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def onProcessCoreLoading(core, cs, dbLoad):
+        """Called whenever a Core object is newly built."""
+        applyEffectiveDelayedNeutronFractionToCore(core, cs)
+
+    @staticmethod
+    @plugins.HOOKIMPL
+    def getReportContents(r, cs, report, stage, blueprint):
+        """Generates the Report Content for the Neutronics Report."""
+        from armi.physics.neutronics import reports
+
+        return reports.insertNeutronicsReport(r, cs, report, stage)
+
+
+def applyEffectiveDelayedNeutronFractionToCore(core, cs):
+    """Process the settings for the delayed neutron fraction and precursor decay constants."""
+    # Verify and set the core beta parameters based on the user-supplied settings
+    beta = cs["beta"]
+    decayConstants = cs["decayConstants"]
+
+    # If beta is interpreted as a float, then assign it to the total delayed neutron fraction
+    # parameter. Otherwise, setup the group-wise delayed neutron fractions and precursor decay
+    # constants.
+    reportTableData = []
+    if isinstance(beta, float):
+        core.p.beta = beta
+        reportTableData.append(("Total Delayed Neutron Fraction", core.p.beta))
+
+    elif isinstance(beta, list) and isinstance(decayConstants, list):
+        if len(beta) != len(decayConstants):
+            raise ValueError(
+                f"The values for `beta` ({beta}) and `decayConstants` "
+                f"({decayConstants}) are not consistent lengths."
+            )
+
+        core.p.beta = sum(beta)
+        core.p.betaComponents = np.array(beta)
+        core.p.betaDecayConstants = np.array(decayConstants)
+
+        reportTableData.append(("Total Delayed Neutron Fraction", core.p.beta))
+        for i, betaComponent in enumerate(core.p.betaComponents):
+            reportTableData.append(
+                (f"Group {i} Delayed Neutron Fractions", betaComponent)
+            )
+        for i, decayConstant in enumerate(core.p.betaDecayConstants):
+            reportTableData.append(
+                ("Group {i} Precursor Decay Constants", decayConstant)
+            )
+
+    # Report to the user the values were not applied.
+    if not reportTableData and (beta is not None or decayConstants is not None):
+        runLog.warning(
+            f"Delayed neutron fraction(s) - {beta} and decay constants"
+            f" - {decayConstants} have not been applied."
+        )
+    else:
+        runLog.extra(
+            tabulate.tabulate(
+                data=reportTableData,
+                headers=["Component", "Value"],
+                tableFmt="armi",
+            )
+        )


### PR DESCRIPTION
## What is the change? Why is it being made?

Moving `NeutronicsPlugin` to its own file.

My goal here is to make a little progress on: https://github.com/terrapower/armi/issues/1452

This is the only change I could make from that ticket that wasn't API breaking.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Moving NeutronicsPlugin to its own file.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
