### PR TITLE
Retooling single-warnings report as all warnings report

### DIFF
--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -155,8 +155,8 @@ class MainInterface(interfaces.Interface):
 
     def interactBOC(self, cycle=None):
         """Typically the first interface to interact beginning of cycle."""
-        runLog.important("Beginning of Cycle {0}".format(cycle))
-        runLog.LOG.clearSingleWarnings()
+        runLog.important(f"Beginning of Cycle {cycle}")
+        runLog.LOG.clearSinglLogs()
 
         if self.cs["reallySmallRun"]:
             self.cleanLastCycleFiles()

--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -156,7 +156,7 @@ class MainInterface(interfaces.Interface):
     def interactBOC(self, cycle=None):
         """Typically the first interface to interact beginning of cycle."""
         runLog.important(f"Beginning of Cycle {cycle}")
-        runLog.LOG.clearSinglLogs()
+        runLog.LOG.clearSingleLogs()
 
         if self.cs["reallySmallRun"]:
             self.cleanLastCycleFiles()

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -190,7 +190,7 @@ class _RunLog:
         return self.logger.getDuplicatesFilter()
 
     def clearSingleLogs(self):
-        """Reset the single warned list so we get messages again."""
+        """Reset the list of de-duplicated warnings, so users can see those warnings again."""
         dupsFilter = self.getDuplicatesFilter()
         if dupsFilter:
             dupsFilter.singleMessageCounts.clear()

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -114,7 +114,7 @@ class _RunLog:
             If this is zero, we are in the parent process, otherwise child process.
             This should not be adjusted after instantiation.
         """
-        rank = "" if mpiRank == 0 else "-{:>03d}".format(mpiRank)
+        rank = "" if mpiRank == 0 else f"-{mpiRank:>03d}"
 
         # NOTE: using ordereddict so we can get right order of options in GUI
         return collections.OrderedDict(
@@ -210,7 +210,7 @@ class _RunLog:
         except KeyError:
             log_strs = list(self.logLevels.keys())
             raise KeyError(
-                "{} is not a valid verbosity level: {}".format(level, log_strs)
+                f"{level} is not a valid verbosity level: {log_strs}"
             )
 
     def setVerbosity(self, level):
@@ -249,7 +249,7 @@ class _RunLog:
                         self._verbosity = self._logLevelNumbers[i]
                         break
         else:
-            raise TypeError("Invalid verbosity rank {}.".format(level))
+            raise TypeError(f"Invalid verbosity rank {level}.")
 
         # Finally, set the log level
         if self.logger is not None:
@@ -343,7 +343,7 @@ def concatenateLogs(logDir=None):
         info("No log files found to concatenate.")
         return
 
-    info("Concatenating {0} log files".format(len(stdoutFiles)))
+    info(f"Concatenating {len(stdoutFiles)} log files")
 
     # default worker log name if none is found
     caseTitle = "armi-workers"
@@ -356,7 +356,7 @@ def concatenateLogs(logDir=None):
                 caseTitle = candidate
                 break
 
-    combinedLogName = os.path.join(logDir, "{}-mpi.log".format(caseTitle))
+    combinedLogName = os.path.join(logDir, f"{caseTitle}-mpi.log")
     with open(combinedLogName, "w") as workerLog:
         workerLog.write(
             "\n{0} CONCATENATED WORKER LOG FILES {1}\n".format("-" * 10, "-" * 10)
@@ -670,7 +670,7 @@ class RunLogger(logging.Logger):
         for label, count in sorted(
             dupsFilter.warningCounts.items(), key=operator.itemgetter(1)
         ):
-            self.info("  {0:^10s}   {1:^25s}".format(str(count), str(label)))
+            self.info(f"  {str(count):^10s}   {str(label):^25s}")
         self.info("------------------------------------")
 
         # TODO: JOHN: Inject totals line
@@ -724,7 +724,7 @@ def createLogDir(logDir: str = None) -> None:
     while not os.path.exists(logDir):
         loopCounter += 1
         if loopCounter > (OS_SECONDS_TIMEOUT / secondsWait):
-            raise OSError("Was unable to create the log directory: {}".format(logDir))
+            raise OSError(f"Was unable to create the log directory: {logDir}")
 
         time.sleep(secondsWait)
 

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -183,16 +183,13 @@ class _RunLog:
         self.logger.log(msgLevel, msg, single=single, label=label)
 
     def getDuplicatesFilter(self):
-        """
-        The top-level ARMI logger should have a no duplicates filter.
-        If it exists, find it.
-        """
+        """If it exists, find the top-level ARMI logger 'should have a no duplicates' filter."""
         if not self.logger or not isinstance(self.logger, logging.Logger):
             return None
 
         return self.logger.getDuplicatesFilter()
 
-    def clearSingleWarnings(self):
+    def clearSinglLogs(self):
         """Reset the single warned list so we get messages again."""
         dupsFilter = self.getDuplicatesFilter()
         if dupsFilter:

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -647,13 +647,19 @@ class RunLogger(logging.Logger):
             return
 
         # sort by labcollections.defaultdict(lambda: 1)
+        total = 0
         for label, count in sorted(
             dupsFilter.warningCounts.items(), key=operator.itemgetter(1), reverse=True
         ):
             self.info(f"  {str(count):^10s}   {str(label):^25s}")
+            total += count
         self.info("------------------------------------")
 
-        # TODO: JOHN: Inject totals line
+        # add a totals line
+        self.info(
+            "  {0:^10s}   {1:^25s}".format(str(total), str("Total Number of Warnings"))
+        )
+        self.info("------------------------------------")
 
     def setVerbosity(self, intLevel):
         """A helper method to try to partially support the local, historical method of the same name."""

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -189,7 +189,7 @@ class _RunLog:
 
         return self.logger.getDuplicatesFilter()
 
-    def clearSinglLogs(self):
+    def clearSingleLogs(self):
         """Reset the single warned list so we get messages again."""
         dupsFilter = self.getDuplicatesFilter()
         if dupsFilter:

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -653,9 +653,7 @@ class RunLogger(logging.Logger):
         self.info("------------------------------------")
 
         # add a totals line
-        self.info(
-            "  {0:^10s}   {1:^25s}".format(str(total), str("Total Number of Warnings"))
-        )
+        self.info(f"  {str(total):^10s}   Total Number of Warnings")
         self.info("------------------------------------")
 
     def setVerbosity(self, intLevel):

--- a/armi/tests/mockRunLogs.py
+++ b/armi/tests/mockRunLogs.py
@@ -86,7 +86,7 @@ class BufferLog(runLog._RunLog):
                 return True
         return False
 
-    def clearSingleWarnings(self):
+    def clearSinglLogs(self):
         """Reset the single warned list so we get messages again."""
         self._singleMessageCounts.clear()
 

--- a/armi/tests/mockRunLogs.py
+++ b/armi/tests/mockRunLogs.py
@@ -86,7 +86,7 @@ class BufferLog(runLog._RunLog):
                 return True
         return False
 
-    def clearSinglLogs(self):
+    def clearSingleLogs(self):
         """Reset the single warned list so we get messages again."""
         self._singleMessageCounts.clear()
 

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -131,12 +131,13 @@ class TestRunLog(unittest.TestCase):
         log.log("warning", "test_warningReport", single=True, label=None)
         log.log("debug", "invisible due to log level", single=False, label=None)
         log.log("warning", "test_warningReport", single=True, label=None)
+        log.log("warning", "simple_warning", single=False, label=None)
         log.log("error", "high level something", single=False, label=None)
 
         # test that the logging found some duplicate outputs
         dupsFilter = log.getDuplicatesFilter()
         self.assertIsNotNone(dupsFilter)
-        warnings = dupsFilter.singleWarningMessageCounts
+        warnings = dupsFilter.warningCounts
         self.assertGreater(len(warnings), 0)
 
         # run the warning report
@@ -146,8 +147,10 @@ class TestRunLog(unittest.TestCase):
 
         # test what was logged
         streamVal = stream.getvalue()
-        self.assertIn("test_warningReport", streamVal, msg=streamVal)
         self.assertIn("Final Warning Count", streamVal, msg=streamVal)
+        self.assertIn("simple_warning", streamVal, msg=streamVal)
+        self.assertIn("test_warningReport", streamVal, msg=streamVal)
+        self.assertIn("Total Number of Warnings", streamVal, msg=streamVal)
         self.assertNotIn("invisible", streamVal, msg=streamVal)
         self.assertEqual(streamVal.count("test_warningReport"), 2, msg=streamVal)
 


### PR DESCRIPTION
## What is the change? Why is it being made?

ARMI provides a way to add a `single=True` parameter when logging, so that the logging statement is only printed once during the lifetime of the run.

That's a fine feature, but when I first added it there was a request to make a report of all the logging messages that were "de-duplicated" in this fashion, and show how many times they were printed.

Apparently, people downstream incorrectly interpreted that table as just a table of "ALL the warning messages during the run". And that is a feature they want.

So this PR retools the old de-duplicated-warnings-report with the new all-warnings-report that looks like:

```bash
[info] ----- Final Warning Count --------
[info]     COUNT                LABEL
[info]       1        Cannot get pin pitch in ...
[info]       1        Cannot get pin pitch in ...
...
[info]    11825745    None component returned ...
[info]    13825745    None component returned ...
[info]    22825745    None component returned instead of ...
[info]    42342342    Total Number of Warnings
```

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Retooling the old de-duplicated-warnings-report with a new all-warnings-report.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Trivial tweaks of I_ARMI_LOG_MPI for R_ARMI_LOG_MPI. Improving test T_ARMI_LOG2 for R_ARMI_LOG.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
