### PR TITLE
Improving description of rateProdNet parameter

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -389,7 +389,7 @@ def _getNeutronicsBlockParams():
         pb.defParam(
             "rateProdNet",
             units=f"1/{units.CM}^3/{units.SECONDS}",
-            description="Net production rate of neutrons",
+            description="The total neutron production including (n,2n) source and fission source.",
         )
 
         pb.defParam(


### PR DESCRIPTION
## What is the change? Why is it being made?

The description for the `rateProdNet` parameter was insufficient, and people asked to improve it.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Improving descriptiion of rateProdNet parameter,

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
