### PR TITLE
Allowing the BOL orientations to be set in the blueprints

### DIFF
--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -192,8 +192,8 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
     _resolveFunctions = []
 
     def __new__(cls):
-        # yamlizable does not call __init__, so attributes that are not defined above
-        # need to be initialized here
+        # yamlizable does not call __init__, so attributes that are not defined above need to be
+        # initialized here
         self = yamlize.Object.__new__(cls)
         self.assemblies = {}
         self._prepped = False
@@ -208,9 +208,8 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
         return self
 
     def __init__(self):
-        # Yamlize does not call __init__, instead we use Blueprints.load which
-        # creates and instance of a Blueprints object and initializes it with values
-        # using setattr.
+        # Yamlize does not call __init__, instead we use Blueprints.load which creates and instance
+        # of a Blueprints object and initializes it with valuesconstructAssemusing setattr.
         self._assembliesBySpecifier = {}
         self._prepped = False
         self.systemDesigns = Systems()
@@ -221,9 +220,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
         self.elementsToExpand = []
 
     def __repr__(self):
-        return "<{} Assemblies:{} Blocks:{}>".format(
-            self.__class__.__name__, len(self.assemDesigns), len(self.blockDesigns)
-        )
+        return f"<{self.__class__.__name__} Assemblies:{len(self.assemDesigns)} Blocks:{len(self.blockDesigns)}>"
 
     def constructAssem(self, cs, name=None, specifier=None):
         """
@@ -235,12 +232,12 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             Used to apply various modeling options when constructing an assembly.
 
         name : str (optional, and should be exclusive with specifier)
-            Name of the assembly to construct. This should match the key that was used
-            to define the assembly in the Blueprints YAML file.
+            Name of the assembly to construct. This should match the key that was used to define the
+            assembly in the Blueprints YAML file.
 
         specifier : str (optional, and should be exclusive with name)
-            Identifier of the assembly to construct. This should match the identifier
-            that was used to define the assembly in the Blueprints YAML file.
+            Identifier of the assembly to construct. This should match the identifier that was used
+            to define the assembly in the Blueprints YAML file.
 
         Raises
         ------
@@ -249,14 +246,12 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
         Notes
         -----
-        There is some possibility for "compiling" the logic with closures to make
-        constructing an assembly / block / component faster. At this point is is pretty
-        much irrelevant because we are currently just deepcopying already constructed
-        assemblies.
+        There is some possibility for "compiling" the logic with closures to make constructing an
+        assembly / block / component faster. At this point is is pretty much irrelevant because we
+        are currently just deepcopying already constructed assemblies.
 
-        Currently, this method is backward compatible with other code in ARMI and
-        generates the `.assemblies` attribute (the BOL assemblies). Eventually, this
-        should be removed.
+        Currently, this method is backward compatible with other code in ARMI and generates the
+        `.assemblies` attribute (the BOL assemblies). Eventually, this should be removed.
         """
         self._prepConstruction(cs)
 
@@ -274,15 +269,15 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
     def _prepConstruction(self, cs):
         """
-        This method initializes a bunch of information within a Blueprints object such
-        as assigning assembly and block type numbers, resolving the nuclides in the
-        problem, and pre-populating assemblies.
+        This method initializes a bunch of information within a Blueprints object such as assigning
+        assembly and block type numbers, resolving the nuclides in the problem, and pre-populating
+        assemblies.
 
-        Ideally, it would not be necessary at all, but the ``cs`` currently contains a
-        bunch of information necessary to create the applicable model. If it were
-        possible, it would be terrific to override the Yamlizable.from_yaml method to
-        run this code after the instance has been created, but we need additional
-        information in order to build the assemblies that is not within the YAML file.
+        Ideally, it would not be necessary at all, but the ``cs`` currently contains a bunch of
+        information necessary to create the applicable model. If it were possible, it would be
+        terrific to override the Yamlizable.from_yaml method to run this code after the instance has
+        been created, but we need additional information in order to build the assemblies that is
+        not within the YAML file.
 
         This method should not be called directly, but it is used in testing.
         """
@@ -303,9 +298,8 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
             self._checkAssemblyAreaConsistency(cs)
 
             if not cs[CONF_DETAILED_AXIAL_EXPANSION]:
-                # this is required to set up assemblies so they know how to snap
-                # to the reference mesh. They won't know the mesh to conform to
-                # otherwise....
+                # this is required to set up assemblies so they know how to snap to the reference
+                # mesh. They won't know the mesh to conform to otherwise....
                 axialExpansionChanger.makeAssemsAbleToSnapToUniformMesh(
                     self.assemblies.values(), cs[CONF_NON_UNIFORM_ASSEM_FLAGS]
                 )
@@ -314,8 +308,8 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
                 runLog.header(
                     "=========== Axially expanding all assemblies from Tinput to Thot ==========="
                 )
-                # expand axial heights from cold to hot so dims and masses are consistent
-                # with specified component hot temperatures.
+                # expand axial heights from cold to hot so dims and masses are consistent with
+                # specified component hot temperatures.
                 assemsToSkip = [
                     Flags.fromStringIgnoreErrors(t)
                     for t in cs[CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP]
@@ -353,9 +347,8 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
         Also builds meta-data about which nuclides are in the problem.
 
-        This system works by building a dictionary in the
-        ``elementsToExpand`` attribute with ``Element`` keys
-        and list of ``NuclideBase`` values.
+        This system works by building a dictionary in the ``elementsToExpand`` attribute with
+        ``Element`` keys and list of ``NuclideBase`` values.
 
         The actual expansion of elementals to isotopics occurs during
         :py:meth:`Component construction <armi.reactor.blueprints.componentBlueprint.

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -105,8 +105,7 @@ class AssemblyBlueprint(yamlize.Object):
     """
     A data container for holding information needed to construct an ARMI assembly.
 
-    This class utilizes ``yamlize`` to enable serialization to and from the
-    blueprints YAML file.
+    This class utilizes ``yamlize`` to enable serialization to and from the blueprints YAML file.
 
     .. impl:: Create assembly from blueprint file.
         :id: I_ARMI_BP_ASSEM
@@ -328,8 +327,11 @@ class AssemblyKeyedList(yamlize.KeyedList):
     axialMeshPoints = yamlize.Attribute(
         key="axial mesh points", type=yamlize.IntList, default=None
     )
+    orientationBOL = yamlize.Attribute(
+        key="orientationBOL", type=yamlize.FloatList, default=0.0
+    )
 
-    # note: yamlize does not call an __init__ method, instead it uses __new__ and setattr
+    # NOTE: yamlize does not call an __init__ method, instead it uses __new__ and setattr
 
     @property
     def bySpecifier(self):

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -327,9 +327,6 @@ class AssemblyKeyedList(yamlize.KeyedList):
     axialMeshPoints = yamlize.Attribute(
         key="axial mesh points", type=yamlize.IntList, default=None
     )
-    orientationBOL = yamlize.Attribute(
-        key="orientationBOL", type=yamlize.FloatList, default=0.0
-    )
 
     # NOTE: yamlize does not call an __init__ method, instead it uses __new__ and setattr
 

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -297,8 +297,8 @@ class GridBlueprint(yamlize.Object):
         runLog.extra("Creating the spatial grid")
         if geom in (geometry.RZT, geometry.RZ):
             if self.gridBounds is None:
-                # This check is regrettably late. It would be nice if we could validate
-                # that bounds are provided if R-Theta mesh is being used.
+                # This check is regrettably late. It would be nice if we could validate that bounds
+                # are provided if R-Theta mesh is being used.
                 raise InputError(
                     f"Grid bounds must be provided for `{self.name}` to specify a grid with "
                     "r-theta components."
@@ -370,7 +370,6 @@ class GridBlueprint(yamlize.Object):
         else:
             return 6
 
-    # TODO: JOHN: does this need to be tweaked?
     def expandToFull(self):
         """
         Unfold the blueprints to represent full symmetry.
@@ -382,13 +381,14 @@ class GridBlueprint(yamlize.Object):
         for some scenarios, such as when expanding fuel shuffling paths or the like. Future work may
         make this more sophisticated.
         """
+        # if we are already full core, don't throw an error, just return passively
         if (
             geometry.SymmetryType.fromAny(self.symmetry).domain
             == geometry.DomainType.FULL_CORE
         ):
-            # No need!
             return
 
+        # fill the new grid contents
         grid = self.construct()
 
         newContents = copy.copy(self.gridContents)
@@ -398,6 +398,8 @@ class GridBlueprint(yamlize.Object):
                 newContents[idx2] = contents
 
         self.gridContents = newContents
+
+        # set the grid symmetry
         split = geometry.THROUGH_CENTER_ASSEMBLY in self.symmetry
         self.symmetry = str(
             geometry.SymmetryType(
@@ -424,15 +426,15 @@ class GridBlueprint(yamlize.Object):
             self._readGridContentsLattice()
 
         if self.gridContents is None:
-            # Make sure we have at least something; clients shouldn't have to worry
-            # about whether gridContents exist at all.
+            # Make sure we have at least something; clients shouldn't have to worry about whether
+            # gridContents exist at all.
             self.gridContents = dict()
 
     def _readGridContentsLattice(self):
         """Read an ascii map of grid contents.
 
         This update the gridContents attribute, which is a dict mapping grid i,j,k indices to
-        textual specifiers (e.g. ``IC``))
+        textual specifiers (e.g. ``IC``)).
         """
         self.readFromLatticeMap = True
         symmetry = geometry.SymmetryType.fromStr(self.symmetry)
@@ -448,12 +450,12 @@ class GridBlueprint(yamlize.Object):
             geom == geometry.GeomType.CARTESIAN
             and symmetry.domain == geometry.DomainType.FULL_CORE
         ):
-            # asciimaps is not smart about where the center should be, so we need to
-            # offset appropriately to get (0,0) in the middle
+            # asciimaps is not smart about where the center should be, so we need to offset
+            # appropriately to get (0,0) in the middle
             nx, ny = _getGridSize(asciimap.keys())
 
-            # turns out this works great for even and odd cases. love it when integer
-            # math works in your favor
+            # turns out this works great for even and odd cases. love it when integer math works in
+            # your favor
             iOffset = int(-nx / 2)
             jOffset = int(-ny / 2)
 
@@ -515,16 +517,15 @@ def _getGridSize(idx) -> Tuple[int, int]:
 def _filterOutsideDomain(gridBp):
     """Remove grid contents that lie outside the represented domain.
 
-    This removes extra objects; ARMI allows the user input specifiers in regions outside
-    of the represented domain, which is fine as long as the contained specifier is
-    consistent with the corresponding region in the represented domain given the
-    symmetry condition. For instance, if we have a 1/3-core hex model, it is typically
-    okay for an assembly to be specified outside of the first 1/3rd of the core, as long
-    as it is the same assembly as would be there when expanding the first 1/3rd into a
-    full-core model.
+    This removes extra objects; ARMI allows the user input specifiers in regions outside of the
+    represented domain, which is fine as long as the contained specifier is consistent with the
+    corresponding region in the represented domain given the symmetry condition. For instance, if we
+    have a 1/3-core hex model, it is typically okay for an assembly to be specified outside of the
+    first 1/3rd of the core, as long as it is the same assembly as would be there when expanding the
+    first 1/3rd into a full-core model.
 
-    However, we do not really want these hanging around, since editing the represented
-    1/Nth of the core will probably lead to consistency issues, so we remove them.
+    However, we do not really want these hanging around, since editing the represented 1/Nth of the
+    core will probably lead to consistency issues, so we remove them.
     """
     grid = gridBp.construct()
 
@@ -582,10 +583,10 @@ def saveToStream(stream, bluep, full=False, tryMap=False):
     tryMap : bool
         regardless of input form, attempt to output as a lattice map
     """
-    # To save, we want to try our best to output our grid blueprints in the lattice
-    # map style. However, we do not want to wreck the state that the current
-    # blueprints are in. So we make a copy and do some manipulations to try to
-    # canonicalize it and save that, leaving the original blueprints unmolested.
+    # To save, we want to try our best to output our grid blueprints in the lattice map style.
+    # However, we do not want to wreck the state that the current blueprints are in. So we make a
+    # copy and do some manipulations to try to canonicalize it and save that, leaving the original
+    # blueprints unmolested.
     bp = copy.deepcopy(bluep)
 
     if isinstance(bp, blueprints.Blueprints):
@@ -625,9 +626,9 @@ def saveToStream(stream, bluep, full=False, tryMap=False):
                 aMap = None
 
             if aMap is not None:
-                # If there is an ascii map available then use it to fill out
-                # the contents of the lattice map section of the grid design.
-                # This also clears out the grid contents so there is not duplicate data.
+                # If there is an ascii map available then use it to fill out the contents of the
+                # lattice map section of the grid design. This also clears out the grid contents so
+                # there is not duplicate data.
                 gridDesign.gridContents = None
                 mapString = StringIO()
                 aMap.writeAscii(mapString)

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -289,7 +289,9 @@ class GridBlueprint(yamlize.Object):
         If you do not enter ``latticeDimensions``, a unit grid will be produced which must be
         adjusted to the proper dimensions (often by inspection of children) at a later time.
         """
-        symmetry = geometry.SymmetryType.fromStr(self.symmetry) if self.symmetry else None
+        symmetry = (
+            geometry.SymmetryType.fromStr(self.symmetry) if self.symmetry else None
+        )
         geom = self.geom
         maxIndex = self._getMaxIndex()
         runLog.extra("Creating the spatial grid")

--- a/armi/reactor/blueprints/reactorBlueprint.py
+++ b/armi/reactor/blueprints/reactorBlueprint.py
@@ -106,8 +106,8 @@ class SystemBlueprint(yamlize.Object):
                 seen.add(key)
 
         raise ValueError(
-            "Could not determine an appropriate class for handling a "
-            "system of type `{}`. Supported types are {}.".format(typ, sorted(seen))
+            f"Could not determine an appropriate class for handling a system of type `{typ}`. "
+            f"Supported types are {seen}."
         )
 
     def construct(self, cs, bp, reactor, loadComps=True):
@@ -221,9 +221,7 @@ class SystemBlueprint(yamlize.Object):
     def _modifyGeometry(self, container, gridDesign):
         """Perform post-load geometry conversions like full core, edge assems."""
         # all cases should have no edge assemblies. They are added ephemerally when needed
-        from armi.reactor.converters import (
-            geometryConverters,
-        )
+        from armi.reactor.converters import geometryConverters
 
         runLog.header("=========== Applying Geometry Modifications ===========")
         converter = geometryConverters.EdgeAssemblyChanger()

--- a/armi/reactor/blueprints/tests/test_reactorBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_reactorBlueprints.py
@@ -55,6 +55,9 @@ core:
     grid contents:
       [0, 0]: IC
       [1, 1]: IC
+    orientationBOL:
+      [0, 0]: 56.7
+      [1, 1]: 123.4
 sfp:
     lattice pitch:
         x: 25.0
@@ -214,3 +217,11 @@ class TestReactorBlueprints(unittest.TestCase):
         self.assertEqual(len(sfp.getChildren()), 4)
         sfp.add(evst.getChildren()[0])
         self.assertEqual(len(sfp.getChildren()), 5)
+
+    def test_orientationBOL(self):
+        core, _sfp, _evst = self._setupReactor()
+
+        a0 = core.getAssembly(locationString="001-001")
+        self.assertEqual(a0.p.orientation, 56.7)
+        a1 = core.getAssembly(locationString="003-002")
+        self.assertEqual(a1.p.orientation, 123.4)

--- a/armi/reactor/grids/hexagonal.py
+++ b/armi/reactor/grids/hexagonal.py
@@ -394,9 +394,8 @@ class HexGrid(StructuredGrid):
         Returns
         -------
         None or int
-            None if not line of symmetry goes through the object at the
-            requested index. Otherwise, some grid constants like ``BOUNDARY_CENTER``
-            will be returned.
+            None if not line of symmetry goes through the object at the requested index. Otherwise,
+            some grid constants like ``BOUNDARY_CENTER`` will be returned.
 
         Notes
         -----
@@ -422,18 +421,17 @@ class HexGrid(StructuredGrid):
         return symmetryLine
 
     def getSymmetricEquivalents(self, indices: IJKType) -> List[IJType]:
-        """Retrieve the equivalent indices. If full core return nothing, if 1/3-core grid,
-        return the symmetric equivalents, if any other grid, raise an error.
+        """Retrieve the equivalent indices. If full core return nothing, if 1/3-core grid, return
+        the symmetric equivalents, if any other grid, raise an error.
 
         .. impl:: Equivalent contents in 1/3-core geometries are retrievable.
             :id: I_ARMI_GRID_EQUIVALENTS
             :implements: R_ARMI_GRID_EQUIVALENTS
 
-            This method takes in (I,J,K) indices, and if this ``HexGrid`` is full core,
-            it returns nothing. If this ``HexGrid`` is 1/3-core, this method will return
-            the 1/3-core symmetric equivalent of just (I,J). If this grid is any other kind,
-            this method will just return an error; a hexagonal grid with any other
-            symmetry is probably an error.
+            This method takes in (I,J,K) indices, and if this ``HexGrid`` is full core, it returns
+            nothing. If this ``HexGrid`` is 1/3-core, this method will return the 1/3-core symmetric
+            equivalent of just (I,J). If this grid is any other kind, this method will just return
+            an error; a hexagonal grid with any other symmetry is probably an error.
         """
         if (
             self.symmetry.domain == geometry.DomainType.THIRD_CORE
@@ -444,9 +442,7 @@ class HexGrid(StructuredGrid):
             return []
         else:
             raise NotImplementedError(
-                "Unhandled symmetry condition for HexGrid: {}".format(
-                    str(self.symmetry)
-                )
+                f"Unhandled symmetry condition for HexGrid: {self.symmetry}"
             )
 
     @staticmethod
@@ -455,13 +451,14 @@ class HexGrid(StructuredGrid):
         i, j = indices[:2]
         if i == 0 and j == 0:
             return []
+
         identicals = [(-i - j, i), (j, -i - j)]
         return identicals
 
     def triangleCoords(self, indices: IJKType) -> np.ndarray:
         """
-        Return 6 coordinate pairs representing the centers of the 6 triangles in a
-        hexagon centered here.
+        Return 6 coordinate pairs representing the centers of the 6 triangles in a hexagon centered
+        here.
 
         Ignores z-coordinate and only operates in 2D for now.
         """
@@ -507,8 +504,8 @@ class HexGrid(StructuredGrid):
         self._unitSteps = unitSteps[self._stepDims]
 
     def locatorInDomain(self, locator, symmetryOverlap: Optional[bool] = False) -> bool:
-        # This will include the "top" 120-degree symmetry lines. This is to support
-        # adding of edge assemblies.
+        # This will include the "top" 120-degree symmetry lines. This is to support adding of edge
+        # assemblies.
         if self.symmetry.domain == geometry.DomainType.THIRD_CORE:
             return self.isInFirstThird(locator, includeTopEdge=symmetryOverlap)
         else:
@@ -521,11 +518,10 @@ class HexGrid(StructuredGrid):
             :id: I_ARMI_GRID_SYMMETRY_LOC
             :implements: R_ARMI_GRID_SYMMETRY_LOC
 
-            This is a simple helper method to determine if a given locator (from an
-            ArmiObject) is in the first 1/3 of the ``HexGrid``. This method does not
-            attempt to check if this grid is full or 1/3-core. It just does the basic
-            math of dividing up a hex-assembly reactor core into thirds and testing if
-            the given location is in the first 1/3 or not.
+            This is a simple helper method to determine if a given locator (from an ArmiObject) is
+            in the first 1/3 of the ``HexGrid``. This method does not attempt to check if this grid
+            is full or 1/3-core. It just does the basic math of dividing up a hex-assembly reactor
+            core into thirds and testing if the given location is in the first 1/3 or not.
         """
         ring, pos = self.getRingPos(locator.indices)
         if ring == 1:
@@ -551,8 +547,8 @@ class HexGrid(StructuredGrid):
 
         IndexLocation are taken from a full core.
 
-        Ties between locations with the same distance (e.g. A3001 and A3003) are broken
-        by ring number then position number.
+        Ties between locations with the same distance (e.g. A3001 and A3003) are broken by ring
+        number then position number.
         """
         # first, roughly calculate how many rings need to be created to cover nLocs worth of assemblies
         nLocs = int(nLocs)
@@ -593,27 +589,27 @@ class HexGrid(StructuredGrid):
 
         Notes
         -----
-        Rotation uses a three-dimensional index in what can be known elsewhere
-        by the confusing name of "cubic" coordinate system for a hexagon. Cubic stems
-        from the notion of using three dimensions, ``(q, r, s)`` to describe a point in the
-        hexagonal grid. The conversion from the indexing used in the ARMI framework follows::
+        Rotation uses a three-dimensional index in what can be known elsewhere by the confusing name
+        of "cubic" coordinate system for a hexagon. Cubic stems from the notion of using three
+        dimensions, ``(q, r, s)`` to describe a point in the hexagonal grid. The conversion from the
+        indexing used in the ARMI framework follows::
 
             q = i
             r = j
             # s = - q - r = - (q + r)
             s = -(i + j)
 
-        The motivation for the cubic notation is rotation is far simpler: a clockwise
-        rotation by 60 degrees results in a shifting and negating of the coordinates. So
-        the first rotation of ``(q, r, s)`` would produce a new coordinate
-        ``(-r, -s, -q)``. Another rotation would produce ``(s, q, r)``, and so on.
+        The motivation for the cubic notation is rotation is far simpler: a clockwise rotation by 60
+        degrees results in a shifting and negating of the coordinates. So the first rotation of
+        ``(q, r, s)`` would produce a new coordinate ``(-r, -s, -q)``. Another rotation would
+        produce ``(s, q, r)``, and so on.
 
         Raises
         ------
         TypeError
-            If ``loc.grid`` is populated and not consistent with this grid. For example,
-            it doesn't make sense to rotate an index from a Cartesian grid in a hexagonal coordinate
-            system, nor hexagonal grid with different orientation (flats up vs. corners up)
+            If ``loc.grid`` is populated and not consistent with this grid. For example, it doesn't
+            make sense to rotate an index from a Cartesian grid in a hexagonal coordinate system,
+            nor hexagonal grid with different orientation (flats up vs. corners up)
         """
         if self._roughlyEqual(loc.grid) or loc.grid is None:
             i, j, k = loc[:3]

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -369,6 +369,16 @@ class TestValidateSFPSpatialGrids(unittest.TestCase):
         )
         self.assertIsNotNone(r.excore.sfp.spatialGrid)
 
+    def test_orientationBOL(self):
+        _o, r = loadTestReactor(
+            os.path.join(TEST_ROOT, "smallestTestReactor"),
+            inputFileName="armiRunSmallest.yaml",
+        )
+
+        # Test the null-case; these should all be zero.
+        for a in r.core.iterChildren():
+            self.assertEqual(a.p.orientation, 0.0)
+
 
 class Block_TestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

This was a new feature request. In the past, all orientations for high-level BP / Core children start with the same default, because all parameters do.

But there was a design request to be able to start the orientations of each Composite at the start of the run. So here I copy the `grid contents` parameter over to the `orientationBOL` parameter, so you can define the orientation parameter of any high-level Composite on any grid.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Allowing the BOL orientations to be set in the blueprints

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
