### PR TITLE
Removing unnecessary DB load try/except

### DIFF
--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -398,23 +398,14 @@ class Database:
         Notes
         -----
         There are no guarantees here. If the database was written from a different version of ARMI
-        than you are using, these results may not be usable. For instance, the database could have
-        been written from a vastly old or future version of ARMI from the code you are using.
+        than you are using, these results may not be usable. Or if the database was written using a
+        custom Application you do not have access to, the DB may not be usable.
         """
         cs = settings.Settings()
         cs.caseTitle = os.path.splitext(os.path.basename(self.fileName))[0]
-        try:
-            cs.loadFromString(
-                self.h5db["inputs/settings"].asstr()[()], handleInvalids=handleInvalids
-            )
-        except KeyError:
-            # not all paths to writing a database require inputs to be written to the database.
-            # Technically, settings do affect some of the behavior of database reading, so not
-            # having the settings that made the reactor that went into the database is not ideal.
-            # However, this isn't the right place to crash into it. Ideally, there would be not way
-            # to not have the settings in the database (force writing in writeToDB), or to make
-            # reading invariant to settings.
-            pass
+        cs.loadFromString(
+            self.h5db["inputs/settings"].asstr()[()], handleInvalids=handleInvalids
+        )
 
         return cs
 
@@ -424,8 +415,8 @@ class Database:
         Notes
         -----
         There are no guarantees here. If the database was written from a different version of ARMI
-        than you are using, these results may not be usable. For instance, the database could have
-        been written from a vastly old or future version of ARMI from the code you are using.
+        than you are using, these results may not be usable. Or if the database was written using a
+        custom Application you do not have access to, the DB may not be usable.
         """
         # Blueprints use the yamlize package, which uses class attributes to define much of the
         # class's behavior through metaclassing. Therefore, we need to be able to import all plugins


### PR DESCRIPTION
## What is the change? Why is it being made?

There is an unnecessary try/except in `DB.loadCS()`. It is a relic of a by-gone era. This is a small cleanup PR to remove that.

close #2054 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing unnecessary DB load try/except

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Hypothetically, this touches I_ARMI_DB_TIME1. However, all we are doing here is removing unused code. So there will be no noticeable effect.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
