### PR TITLE
swap out some fstrings.

### DIFF
--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -152,11 +152,9 @@ class FlagSerializer(parameters.Serializer):
 
         if version != cls.version:
             raise ValueError(
-                "The FlagSerializer version used to pack the data ({}) does not match "
-                "the current version ({})! This database either needs to be migrated, "
-                "or on-the-fly inter-version conversion needs to be implemented.".format(
-                    version, cls.version
-                )
+                f"The FlagSerializer version used to pack the data ({version}) does not match "
+                f"the current version ({cls.version})! This database either needs to be migrated, "
+                "or on-the-fly inter-version conversion needs to be implemented."
             )
 
         flagSetIn = set(flagOrderPassed)
@@ -362,8 +360,8 @@ class ArmiObject(metaclass=CompositeModelType):
             runLog.error(f"could not compare {self} and {other}")
             raise ValueError(
                 "Composite grids must be the same to compare:\n"
-                "This grid: {}\n"
-                "Other grid: {}".format(self.spatialGrid, other.spatialGrid)
+                f"This grid: {self.spatialGrid}\n"
+                f"Other grid: {other.spatialGrid}"
             )
         try:
             t1 = tuple(reversed(self.spatialLocator.getCompleteIndices()))
@@ -371,9 +369,7 @@ class ArmiObject(metaclass=CompositeModelType):
             return t1 < t2
         except ValueError:
             runLog.error(
-                "failed to compare {} and {}".format(
-                    self.spatialLocator, other.spatialLocator
-                )
+                f"failed to compare {self.spatialLocator} and {other.spatialLocator}"
             )
             raise
 
@@ -424,7 +420,7 @@ class ArmiObject(metaclass=CompositeModelType):
             c.parent = self
 
     def __repr__(self):
-        return "<{}: {}>".format(self.__class__.__name__, self.name)
+        return "f<{self.__class__.__name__}: {self.name}>"
 
     def __format__(self, spec):
         return format(str(self), spec)
@@ -971,8 +967,7 @@ class ArmiObject(metaclass=CompositeModelType):
                 nuclideNames.extend(self._getNuclidesFromSpecifier(ns))
         else:
             raise TypeError(
-                "nucSpec={0} is an invalid specifier. It is a {1}"
-                "".format(nucSpec, type(nucSpec))
+                f"nucSpec={nucSpec} is an invalid specifier. It is a {type(nucSpec)}"
             )
 
         # expand elementals if appropriate.
@@ -1053,9 +1048,7 @@ class ArmiObject(metaclass=CompositeModelType):
         rho = self.density()
         if not rho:
             raise ValueError(
-                "Cannot set mass fractions on {} because the mass density is zero.".format(
-                    self
-                )
+                f"Cannot set mass fractions on {self} because the mass density is zero."
             )
         oldMassFracs = self.getMassFracs()
         totalFracSet = 0.0
@@ -1149,9 +1142,7 @@ class ArmiObject(metaclass=CompositeModelType):
         self.clearCache()  # don't keep densities around or anything.
         if val > 1.0 or val < 0:
             raise ValueError(
-                "Invalid mass fraction {0} for {1}/{2} in {3}".format(
-                    val, nuclideToAdjust, elementToAdjust, self.getName()
-                )
+                f"Invalid mass fraction {val} for {nuclideToAdjust}/{elementToAdjust} in {self.getName()}"
             )
         if not nuclideToAdjust and not elementToAdjust:
             raise TypeError(
@@ -1218,9 +1209,7 @@ class ArmiObject(metaclass=CompositeModelType):
         # error checking.
         if abs(newA - val) > 1e-10:
             runLog.error(
-                "Adjust Mass fraction did not adjust {0} from {1} to {2}. It got to {3}".format(
-                    adjustNuclides, A, val, newA
-                )
+                f"Adjust Mass fraction did not adjust {adjustNuclides} from {A} to {val}. It got to {newA}"
             )
             raise RuntimeError("Failed to adjust mass fraction.")
 
@@ -1381,8 +1370,8 @@ class ArmiObject(metaclass=CompositeModelType):
             )
             if lfpMass:
                 raise RuntimeError(
-                    "Composite {} is attempting to expand lumped fission products, but does not have "
-                    "an lfpCollection.".format(self)
+                    f"Composite {self} is attempting to expand lumped fission products, but does not have "
+                    "an lfpCollection."
                 )
         return numberDensities
 
@@ -1489,10 +1478,8 @@ class ArmiObject(metaclass=CompositeModelType):
             activeVolumeFrac = 1.0
             if val:
                 raise ValueError(
-                    "The nuclide {} does not exist in any children of {}; "
-                    "cannot set its number density to {}. The nuclides here are: {}".format(
-                        nucName, self, val, self.getNuclides()
-                    )
+                    f"The nuclide {nucName} does not exist in any children of {self}; "
+                    f"cannot set its number density to {val}. The nuclides here are: {self.getNuclides()}"
                 )
         else:
             activeVolumeFrac = sum(
@@ -1713,7 +1700,7 @@ class ArmiObject(metaclass=CompositeModelType):
             except AttributeError:
                 coreMult = self.parent.powerMultiplier
             if not coreMult:
-                raise ValueError("powerMultiplier is equal to {}".format(coreMult))
+                raise ValueError(f"powerMultiplier is equal to {coreMult}")
         else:
             coreMult = 1.0
 
@@ -1791,9 +1778,7 @@ class ArmiObject(metaclass=CompositeModelType):
                     if weight < 0:
                         # Just for conservatism, do not allow negative weights.
                         raise ValueError(
-                            "Weighting value ({0},{1}) cannot be negative.".format(
-                                weightingParam, weight
-                            )
+                            f"Weighting value ({weightingParam},{weight}) cannot be negative."
                         )
                 else:
                     weight = 1.0
@@ -1808,9 +1793,8 @@ class ArmiObject(metaclass=CompositeModelType):
                     total += child.p[param] * weight
         if not weightSum:
             raise ValueError(
-                "Cannot calculate {0}-weighted average of {1} in {2}. "
-                "Weights sum to zero. typeSpec is {3}"
-                "".format(weightingParam, param, self, typeSpec)
+                f"Cannot calculate {weightingParam}-weighted average of {param} in {self}. "
+                f"Weights sum to zero. typeSpec is {typeSpec}"
             )
         return total / weightSum
 
@@ -2114,8 +2098,8 @@ class ArmiObject(metaclass=CompositeModelType):
         """
         if average:
             raise NotImplementedError(
-                "{} class has no method for producing average MG flux -- try"
-                "using blocks".format(self.__class__)
+                f"{self.__class__} class has no method for producing average MG flux -- try"
+                "using blocks"
             )
 
         volume = volume or self.getVolume()
@@ -2311,9 +2295,7 @@ class ArmiObject(metaclass=CompositeModelType):
         if nComp == 0:
             return None
         elif nComp > 1:
-            raise ValueError(
-                "More than one component named '{}' in {}".format(self, name)
-            )
+            raise ValueError(f"More than one component named '{self}' in {name}")
         else:
             return components[0]
 
@@ -2571,9 +2553,7 @@ class Composite(ArmiObject):
         """Add one new child."""
         if obj in self:
             raise RuntimeError(
-                "Cannot add {0} because it has already been added to {1}.".format(
-                    obj, self
-                )
+                f"Cannot add {obj} because it has already been added to {self}."
             )
         obj.parent = self
         self._children.append(obj)
@@ -2588,8 +2568,8 @@ class Composite(ArmiObject):
         """Move to specific location in parent. Often in a grid."""
         if locator.grid.armiObject is not self.parent:
             raise ValueError(
-                "Cannot move {} to a location in  {}, which is not its parent ({})."
-                "".format(self, locator.grid.armiObject, self.parent)
+                f"Cannot move {self} to a location in  {locator.grid.armiObject}"
+                ", which is not its parent ({self.parent})."
             )
         self.spatialLocator = locator
 
@@ -2597,9 +2577,7 @@ class Composite(ArmiObject):
         """Insert an object into the list of children at a particular index."""
         if obj in self._children:
             raise RuntimeError(
-                "Cannot insert {0} because it has already been added to {1}.".format(
-                    obj, self
-                )
+                f"Cannot insert {obj} because it has already been added to {self}."
             )
         obj.parent = self
         self._children.insert(index, obj)
@@ -2845,7 +2823,7 @@ class Composite(ArmiObject):
         )
         allComps = [c for c in genItems if hasattr(c, "p")]
         sendBuf = [c.p.getSyncData() for c in allComps]
-        runLog.debug("syncMpiState has {} comps".format(len(allComps)))
+        runLog.debug(f"syncMpiState has {len(allComps)} comps")
 
         try:
             context.MPI_COMM.barrier()  # sync up
@@ -2856,7 +2834,7 @@ class Composite(ArmiObject):
             msg = ["Failure while trying to allgather."]
             for ci, compData in enumerate(sendBuf):
                 if compData is not None:
-                    msg += ["sendBuf[{}]: {}".format(ci, compData)]
+                    msg += [f"sendBuf[{ci}]: {compData}"]
             runLog.error("\n".join(msg))
             raise
 
@@ -2867,9 +2845,7 @@ class Composite(ArmiObject):
 
         if len(compsPerNode) != 1:
             raise ValueError(
-                "The workers have different reactor sizes! comp lengths: {}".format(
-                    compsPerNode
-                )
+                f"The workers have different reactor sizes! comp lengths: {compsPerNode}"
             )
 
         for ci, comp in enumerate(allComps):
@@ -2903,10 +2879,8 @@ class Composite(ArmiObject):
 
         self._markSynchronized()
         runLog.extra(
-            "Synchronized reactor over MPI in {:.4f} seconds, {:.4f} seconds in MPI "
-            "allgather. count:{}".format(
-                timeit.default_timer() - startTime, allGatherTime, syncCount
-            )
+            f"Synchronized reactor over MPI in {timeit.default_timer() - startTime:.4f} seconds"
+            f", {allGatherTime:.4f} seconds in MPI allgather. count:{syncCount}"
         )
 
         return syncCount
@@ -3347,7 +3321,7 @@ def getReactionRateDict(nucName, lib, xsSuffix, mgFlux, nDens):
     Assume there is no n3n cross section in ISOTXS
     """
     nucLabel = nuclideBases.byName[nucName].label
-    key = "{}{}".format(nucLabel, xsSuffix)
+    key = f"{nucLabel}{xsSuffix}"
     libNuc = lib[key]
     rxnRates = {"n3n": 0}
     for rxName, mgXSs in [


### PR DESCRIPTION
## What is the change? Why is it being made?

What: While doing some other work, I fell down a rabbit hole of swapping out easily swapped `format`-based strings with f-strings. 

Why: f-strings > format-based strings


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Swap out old format-based strings with f-strings.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
