### PR TITLE
Improving the default value for Assembly.getArea()

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -280,15 +280,13 @@ class Assembly(composites.Composite):
         Return the area of the assembly by looking at its first block.
 
         The assumption is that all blocks in an assembly have the same area. Calculate the total
-        assembly volume in cm^3.
+        assembly volume in cm^3..
         """
         try:
             return self[0].getArea()
         except IndexError:
-            runLog.warning(
-                "{} has no blocks and therefore no area. Assuming 1.0".format(self)
-            )
-            return 1.0
+            runLog.warning(f"{self} has no blocks and therefore no area.")
+            return None
 
     def getVolume(self):
         """Calculate the total assembly volume in cm^3."""

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -262,15 +262,14 @@ class Assembly(composites.Composite):
         )
 
     def coords(self):
-        """Return the location of the assembly in the plane using cartesian global
-        coordinates.
+        """Return the location of the assembly in the plane using cartesian global coordinates.
 
         .. impl:: Assembly coordinates are retrievable.
             :id: I_ARMI_ASSEM_POSI1
             :implements: R_ARMI_ASSEM_POSI
 
-            In this method, the spatialLocator of an Assembly is leveraged to return
-            its physical (x,y) coordinates in cm.
+            In this method, the spatialLocator of an Assembly is leveraged to return its physical
+            (x,y) coordinates in cm.
         """
         x, y, _z = self.spatialLocator.getGlobalCoordinates()
         return (x, y)
@@ -280,7 +279,7 @@ class Assembly(composites.Composite):
         Return the area of the assembly by looking at its first block.
 
         The assumption is that all blocks in an assembly have the same area. Calculate the total
-        assembly volume in cm^3..
+        assembly volume in cm^3.
         """
         try:
             return self[0].getArea()
@@ -298,11 +297,11 @@ class Assembly(composites.Composite):
 
         Notes
         -----
-        If there is no plenum blocks in the assembly, a plenum volume of 0.0 is returned
+        If there is no plenum blocks in the assembly, a plenum volume of 0.0 is returned.
 
         Warning
         -------
-        This is a bit design-specific for pinned assemblies
+        This is a bit design-specific for pinned assemblies.
         """
         plenumVolume = 0.0
         for b in self.iterChildrenWithFlags(Flags.PLENUM):
@@ -347,8 +346,8 @@ class Assembly(composites.Composite):
                     "".format(b, b.getHeight(), refB, refB.getHeight())
                 )
             else:
-                # b is larger than refB. Split b up by splitting it into several smaller
-                # blocks of refBs
+                # b is larger than refB. Split b up by splitting it into several smaller blocks of
+                # refBs
                 heightToChop = b.getHeight()
                 heightChopped = 0.0
                 while (
@@ -362,16 +361,12 @@ class Assembly(composites.Composite):
                     heightChopped += refB.getHeight()
                     newBlocks += 1
                     runLog.important(
-                        "Added a new block {0} of height {1}".format(
-                            newB, newB.getHeight()
-                        )
+                        f"Added a new block {newB} of height {newB.getHeight()}"
                     )
-                    runLog.important(
-                        "Chopped {0} of {1}".format(heightChopped, heightToChop)
-                    )
-                newBlocks -= (
-                    1  # subtract one because we eliminated the original b completely.
-                )
+                    runLog.important(f"Chopped {heightChopped} of {heightToChop}")
+
+                # subtract one because we eliminated the original b completely.
+                newBlocks -= 1
 
         self.removeAll()
         self.spatialGrid = grids.AxialGrid.fromNCells(len(newBlockStack))
@@ -386,20 +381,19 @@ class Assembly(composites.Composite):
         Parameters
         ----------
         centers : bool, optional
-            Return centers instead of tops. If centers and zeroesAtFuel the zero point
-            will be center of first fuel.
+            Return centers instead of tops. If centers and zeroesAtFuel the zero point will be
+            center of first fuel.
 
         zeroAtFuel : bool, optional
-            If true will make the (bottom or center depending on centers) of the
-            first fuel block be the zero point instead of the bottom of the first block.
+            If true will make the (bottom or center depending on centers) of the first fuel block be
+            the zero point instead of the bottom of the first block.
 
         See Also
         --------
-        armi.reactor.assemblies.Assembly.makeAxialSnapList : makes index-based lookup of
-        axial mesh
+        armi.reactor.assemblies.Assembly.makeAxialSnapList : makes index-based lookup of axial mesh
 
-        armi.reactor.reactors.Reactor.findAllAxialMeshPoints : gets a global list of all
-        of these, plus finer res.
+        armi.reactor.reactors.Reactor.findAllAxialMeshPoints : gets a global list of all of these,
+        plus finer res.
         """
         bottom = 0.0
         meshVals = []

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -399,7 +399,7 @@ class Assembly_TestCase(unittest.TestCase):
         """Tests area calculation for hex assembly."""
         # Default case: for assemblies with no blocks
         a = HexAssembly("TestAssem", assemNum=10)
-        self.assertEqual(a.getArea(), 1)
+        self.assertEqual(a.getArea(), None)
 
         # more realistic case: a hex block/assembly
         cur = self.assembly.getArea()


### PR DESCRIPTION
## What is the change? Why is it being made?

ARMI had an insane default that I am worried could cause non-physical results downstream if people are not careful.

(As a side note, I ran ALL the downstream testing, and it all passed fine. So perhaps this PR is just paranoia. I still think it's worth doing; I don't want people HAVE to be extra careful to use ARMI safely.)

close #1682 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Improving the default value for Assembly.getArea()

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
