### PR TITLE
Some more fstring conversions

### DIFF
--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -237,7 +237,7 @@ class Component(composites.Composite, metaclass=ComponentType):
     ):
         if components and name in components:
             raise ValueError(
-                "Non-unique component name {} repeated in same block.".format(name)
+                f"Non-unique component name {name} repeated in same block."
             )
 
         composites.Composite.__init__(self, str(name))
@@ -292,10 +292,8 @@ class Component(composites.Composite, metaclass=ComponentType):
                 )
             else:
                 raise ValueError(
-                    "Components 1 ({} with OD {}) and 2 ({} and OD {}) cannot be ordered because their "
-                    "bounding circle outer diameters are not comparable.".format(
-                        self, thisOD, other, thatOD
-                    )
+                    f"Components 1 ({self} with OD {thisOD}) and 2 ({other} and OD {thatOD}) cannot be ordered because "
+                    "their bounding circle outer diameters are not comparable."
                 )
 
     def __setstate__(self, state):
@@ -340,15 +338,11 @@ class Component(composites.Composite, metaclass=ComponentType):
                 except Exception:
                     if value.count(".") > 1:
                         raise ValueError(
-                            "Component names should not have periods in them: `{}`".format(
-                                value
-                            )
+                            f"Component names should not have periods in them: `{value}`"
                         )
                     else:
                         raise KeyError(
-                            "Bad component link `{}` defined as `{}`".format(
-                                dimName, value
-                            )
+                            f"Bad component link `{dimName}` defined as `{value}`"
                         )
 
     def setLink(self, key, otherComp, otherCompKey):
@@ -503,7 +497,7 @@ class Component(composites.Composite, metaclass=ComponentType):
             elif arg == "add":
                 area += comp.getComponentArea(cold=cold, Tc=Tc)
             else:
-                raise ValueError("Option {} does not exist".format(arg))
+                raise ValueError(f"Option {arg} does not exist")
 
         self._checkNegativeArea(area, cold)
         return area
@@ -529,7 +523,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         if self.p.volume is None:
             self._updateVolume()
             if self.p.volume is None:
-                raise ValueError("{} has undefined volume.".format(self))
+                raise ValueError(f"{self} has undefined volume.")
         return self.p.volume
 
     def clearCache(self):
@@ -581,11 +575,8 @@ class Component(composites.Composite, metaclass=ComponentType):
                 cold and not self.containsVoidMaterial()
             ) or self.containsSolidMaterial():
                 negAreaFailure = (
-                    "Component {} with {} has cold negative area of {} cm^2. "
-                    "This can be caused by component "
-                    "overlap with component dimension linking or by invalid inputs.".format(
-                        self, self.material, area
-                    )
+                    f"Component {self} with {self.material} has cold negative area of {area} cm^2. "
+                    "This can be caused by component overlap with component dimension linking or by invalid inputs."
                 )
                 raise ArithmeticError(negAreaFailure)
 
@@ -601,11 +592,8 @@ class Component(composites.Composite, metaclass=ComponentType):
 
         if volume < 0.0 and self.containsSolidMaterial():
             negVolFailure = (
-                "Component {} with {} has cold negative volume of {} cm^3. "
-                "This can be caused by component "
-                "overlap with component dimension linking or by invalid inputs.".format(
-                    self, self.material, volume
-                )
+                f"Component {self} with {self.material} has cold negative volume of {volume} cm^3. "
+                "This can be caused by component overlap with component dimension linking or by invalid inputs."
             )
             raise ArithmeticError(negVolFailure)
 
@@ -856,8 +844,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         """
         if self.material.enrichedNuclide is None:
             raise ValueError(
-                "Cannot get enrichment of {} because `enrichedNuclide` is not defined."
-                "".format(self.material)
+                f"Cannot get enrichment of {self.material} because `enrichedNuclide` is not defined."
             )
         enrichedNuclide = nuclideBases.byName[self.material.enrichedNuclide]
         baselineNucNames = [nb.name for nb in enrichedNuclide.element.nuclides]
@@ -1080,17 +1067,14 @@ class Component(composites.Composite, metaclass=ComponentType):
         dLL = self.material.linearExpansionFactor(Tc=Tc, T0=T0)
         if not dLL and abs(Tc - T0) > self._TOLERANCE:
             runLog.error(
-                "Linear expansion percent may not be implemented in the {} material class.\n"
+                f"Linear expansion percent may not be implemented in the {self.material} material class.\n"
                 "This method needs to be implemented on the material to allow thermal expansion."
-                ".\nReference temperature: {}, Adjusted temperature: {}, Temperature difference: {}, "
-                "Specified tolerance: {}".format(
-                    self.material, T0, Tc, (Tc - T0), self._TOLERANCE
-                ),
+                f".\nReference temperature: {T0}, Adjusted temperature: {Tc}, Temperature difference: {(Tc - T0)}, "
+                f"Specified tolerance: {self._TOLERANCE}",
                 single=True,
             )
             raise RuntimeError(
-                "Linear expansion percent may not be implemented in the {} material "
-                "class.".format(self.material)
+                f"Linear expansion percent may not be implemented in the {self.material} material class."
             )
         return 1.0 + dLL
 
@@ -1100,9 +1084,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         runLog.important(self.setDimensionReport())
         if includeNuclides:
             for nuc in self.getNuclides():
-                runLog.important(
-                    "{0:10s} {1:.7e}".format(nuc, self.getNumberDensity(nuc))
-                )
+                runLog.important(f"{nuc:10s} {self.getNumberDensity(nuc):.7e}")
 
     def setDimensionReport(self):
         """Gives a report of the dimensions of this component."""
@@ -1112,11 +1094,11 @@ class Component(composites.Composite, metaclass=ComponentType):
                 reportGroup = componentReport
                 break
         if not reportGroup:
-            return "No report group designated for {} component.".format(self.getName())
+            return f"No report group designated for {self.getName()} component."
         reportGroup.header = [
             "",
-            "Tcold ({0})".format(self.inputTemperatureInC),
-            "Thot ({0})".format(self.temperatureInC),
+            f"Tcold ({self.inputTemperatureInC})",
+            f"Thot ({self.temperatureInC})",
         ]
 
         dimensions = {
@@ -1136,9 +1118,7 @@ class Component(composites.Composite, metaclass=ComponentType):
                 report.setData(niceName, [refVal, hotVal], reportGroup)
             except ValueError:
                 runLog.warning(
-                    "{0} has an invalid dimension for {1}. refVal: {2} hotVal: {3}".format(
-                        self, dimName, refVal, hotVal
-                    )
+                    f"{self} has an invalid dimension for {dimName}. refVal: {refVal} hotVal: {hotVal}"
                 )
 
         # calculate thickness if applicable.
@@ -1149,18 +1129,18 @@ class Component(composites.Composite, metaclass=ComponentType):
             suffix = "p"
 
         if suffix:
-            coldIn = self.getDimension("i{0}".format(suffix), cold=True)
-            hotIn = self.getDimension("i{0}".format(suffix))
-            coldOut = self.getDimension("o{0}".format(suffix), cold=True)
-            hotOut = self.getDimension("o{0}".format(suffix))
+            coldIn = self.getDimension(f"i{suffix}", cold=True)
+            hotIn = self.getDimension(f"i{suffix}")
+            coldOut = self.getDimension(f"o{suffix}", cold=True)
+            hotOut = self.getDimension(f"o{suffix}")
 
         if suffix and coldIn > 0.0:
             hotThick = (hotOut - hotIn) / 2.0
             coldThick = (coldOut - coldIn) / 2.0
             vals = (
                 "Thickness (cm)",
-                "{0:.7f}".format(coldThick),
-                "{0:.7f}".format(hotThick),
+                f"{coldThick:.7f}",
+                f"{hotThick:.7f}",
             )
             report.setData(vals[0], [vals[1], vals[2]], reportGroup)
 
@@ -1231,8 +1211,7 @@ class Component(composites.Composite, metaclass=ComponentType):
                 val = self.p[dimName]
             except Exception:
                 raise RuntimeError(
-                    "Could not find parameter {} defined for {}. Is the desired "
-                    "Component class?".format(dimName, self)
+                    f"Could not find parameter {dimName} defined for {self}. Is the desired Component class?"
                 )
             if isinstance(val, _DimensionLink):
                 linkedDims.append((self.p.paramDefs[dimName].fieldName, val))
@@ -1266,8 +1245,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         """
         if self.material.enrichedNuclide is None:
             raise ValueError(
-                "Cannot adjust enrichment of {} because `enrichedNuclide` is not defined."
-                "".format(self.material)
+                f"Cannot adjust enrichment of {self.material} because `enrichedNuclide` is not defined."
             )
         enrichedNuclide = nuclideBases.byName[self.material.enrichedNuclide]
         baselineNucNames = [nb.name for nb in enrichedNuclide.element.nuclides]


### PR DESCRIPTION
## What is the change? Why is it being made?

What: While doing some other work, I fell down a rabbit hole of swapping out easily swapped format-based strings with f-strings in composites.py.

Why: f-strings are preferred over .format()-based strings


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Swapping out old format-based strings with f-strings.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
