### PR TITLE
Update the way that block grids are built in HexBlocks

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1239,21 +1239,6 @@ class Assembly(composites.Composite):
         grid = self.parent.spatialGrid
         return grid.overlapsWhichSymmetryLine(self.spatialLocator.getCompleteIndices())
 
-    def orientBlocks(self, parentSpatialGrid):
-        """Add special grids to the blocks inside this Assembly, respecting their orientation.
-
-        Parameters
-        ----------
-        parentSpatialGrid : Grid
-            Spatial Grid of the parent of this Assembly (probably a system-level grid).
-        """
-        for b in self:
-            if b.spatialGrid is None:
-                try:
-                    b.autoCreateSpatialGrids(parentSpatialGrid)
-                except (ValueError, NotImplementedError) as e:
-                    runLog.extra(str(e), single=True)
-
 
 class HexAssembly(Assembly):
     """An assembly that is hexagonal in cross-section."""

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2177,7 +2177,7 @@ class HexBlock(Block):
             return
 
         grid = grids.HexGrid.fromPitch(
-            self.inferPinPitch(cold=True),
+            self.getPinPitch(cold=True),
             numRings=0,
             armiObject=self,
             cornersUp=cornersUp,
@@ -2220,7 +2220,13 @@ class HexBlock(Block):
         pinCenterFlatToFlat = math.sqrt(3.0) / 2.0 * pinCenterCornerToCorner
         return pinCenterFlatToFlat
 
-    def inferPinPitch(self, cold=False):
+    def hasPinPitch(self):
+        """Return True if the block has enough information to calculate pin pitch."""
+        return (self.getComponent(Flags.CLAD, quiet=True) is not None) and (
+            self.getComponent(Flags.WIRE, quiet=True) is not None
+        )
+
+    def getPinPitch(self, cold=False):
         """
         For a "simple" HexBlock, infer the pin pitch in cm.
 

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2243,6 +2243,11 @@ class HexBlock(Block):
         -------
         pinPitch : float
             pin pitch in cm
+
+        Notes
+        -----
+        This method assumes a close-packed bundle. If the blueprints specify a grid
+        for this block, the value returned will not necessarily align with that pitch.
         """
         try:
             clad = self.getComponent(

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2187,7 +2187,7 @@ class HexBlock(Block):
             cornersUp = False
 
         grid = grids.HexGrid.fromPitch(
-            self.getPinPitch(cold=True),
+            self.inferPinPitch(cold=True),
             numRings=0,
             armiObject=self,
             cornersUp=cornersUp,
@@ -2230,18 +2230,19 @@ class HexBlock(Block):
         pinCenterFlatToFlat = math.sqrt(3.0) / 2.0 * pinCenterCornerToCorner
         return pinCenterFlatToFlat
 
-    def hasPinPitch(self):
-        """Return True if the block has enough information to calculate pin pitch."""
-        return (self.getComponent(Flags.CLAD) is not None) and (
-            self.getComponent(Flags.WIRE) is not None
-        )
+    # def hasPinPitch(self):
+    #     """Return True if the block has enough information to calculate pin pitch."""
+    #     return (self.getComponent(Flags.CLAD) is not None) and (
+    #         self.getComponent(Flags.WIRE) is not None
+    #     )
 
-    def getPinPitch(self, cold=False):
+    def inferPinPitch(self, cold=False):
         """
-        Get the pin pitch in cm.
+        For a "simple" HexBlock, infer the pin pitch in cm.
 
         Assumes that the pin pitch is defined entirely by contacting cladding tubes and wire wraps.
-        Grid spacers not yet supported.
+        Grid spacers not yet supported. Will only work if the block has a single
+        clad and a single wire component.
 
         Parameters
         ----------

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -269,7 +269,7 @@ class Block(composites.Composite):
 
         return smearDensity
 
-    def autoCreateSpatialGrids(self, systemSpatialGrid=None):
+    def autoCreateSpatialGrids(self, *args, **kwargs):
         """
         Creates a spatialGrid for a Block.
 
@@ -277,20 +277,8 @@ class Block(composites.Composite):
         spatialGrids inferred based on the multiplicity of their components. This would add the
         ability to create a spatialGrid for a Block and give its children the corresponding
         spatialLocators if certain conditions are met.
-
-        Parameters
-        ----------
-        systemSpatialGrid : Grid, optional
-            Spatial Grid of the system-level parent of this Assembly that contains this Block.
-
-        Raises
-        ------
-        ValueError
-            If the multiplicities of the block are not only 1 or N or if generated ringNumber leads
-            to more positions than necessary.
         """
-        if self.spatialGrid is None:
-            self.spatialGrid = systemSpatialGrid
+        pass
 
     def getMgFlux(self, adjoint=False, average=False, volume=None, gamma=False):
         """
@@ -2128,7 +2116,7 @@ class HexBlock(Block):
                     return 2.0
         return 1.0
 
-    def autoCreateSpatialGrids(self, systemSpatialGrid=None):
+    def autoCreateSpatialGrids(self, cornersUp=False, *args, **kwargs):
         """
         Given a block without a spatialGrid, create a spatialGrid and give its children the
         corresponding spatialLocators (if it is a simple block).
@@ -2139,8 +2127,11 @@ class HexBlock(Block):
 
         Parameters
         ----------
-        systemSpatialGrid : Grid, optional
-            Spatial Grid of the system-level parent of this Assembly that contains this Block.
+        cornersUp : bool, optional
+            Whether the block's grid should be corners-up or not. This should be
+            the opposite of the core grid (i.e. if the core is flats-up, then the
+            grid for the pins within each assembly should be corners-up). If not
+            given, flats-up is assumed.
 
         Notes
         -----
@@ -2179,12 +2170,6 @@ class HexBlock(Block):
                 single=True,
             )
             return
-
-        # build the grid, from pitch and orientation
-        if isinstance(systemSpatialGrid, grids.HexGrid):
-            cornersUp = not systemSpatialGrid.cornersUp
-        else:
-            cornersUp = False
 
         grid = grids.HexGrid.fromPitch(
             self.inferPinPitch(cold=True),

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -265,8 +265,16 @@ class BlockBlueprint(yamlize.KeyedList):
         b.p.xsType = xsType
         b.setBuLimitInfo()
         b = self._mergeComponents(b)
+
+        if spatialGrid:
+            b.spatialGrid = spatialGrid
+        else:
+            try:
+                b.autoCreateSpatialGrids()
+            except (ValueError, NotImplementedError) as e:
+                runLog.extra(str(e), single=True)
+
         b.verifyBlockDims()
-        b.spatialGrid = spatialGrid
 
         return b
 

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -269,13 +269,13 @@ class BlockBlueprint(yamlize.KeyedList):
         if spatialGrid:
             b.spatialGrid = spatialGrid
         else:
-            cornersUpCore = (
-                blueprint.gridDesigns[blueprint.systemDesigns["core"].gridName].geom
-                == geometry.HEX_CORNERS_UP
-            )
             try:
+                cornersUpCore = (
+                    blueprint.gridDesigns[blueprint.systemDesigns["core"].gridName].geom
+                    == geometry.HEX_CORNERS_UP
+                )
                 b.autoCreateSpatialGrids(cornersUp=not cornersUpCore)
-            except (ValueError, NotImplementedError) as e:
+            except (TypeError, ValueError, NotImplementedError) as e:
                 runLog.extra(str(e), single=True)
 
         b.verifyBlockDims()

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -21,7 +21,7 @@ import yamlize
 
 from armi import getPluginManagerOrFail, runLog
 from armi.materials.material import Material
-from armi.reactor import blocks, parameters, geometry
+from armi.reactor import blocks, geometry, parameters
 from armi.reactor.blueprints import componentBlueprint
 from armi.reactor.components.component import Component
 from armi.reactor.composites import Composite
@@ -270,8 +270,8 @@ class BlockBlueprint(yamlize.KeyedList):
             b.spatialGrid = spatialGrid
         else:
             cornersUpCore = (
-                geometry.HEX_CORNERS_UP
-                == blueprint.gridDesigns[blueprint.systemDesigns["core"].gridName].geom
+                blueprint.gridDesigns[blueprint.systemDesigns["core"].gridName].geom
+                == geometry.HEX_CORNERS_UP
             )
             try:
                 b.autoCreateSpatialGrids(cornersUp=not cornersUpCore)

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -21,7 +21,7 @@ import yamlize
 
 from armi import getPluginManagerOrFail, runLog
 from armi.materials.material import Material
-from armi.reactor import blocks, parameters
+from armi.reactor import blocks, parameters, geometry
 from armi.reactor.blueprints import componentBlueprint
 from armi.reactor.components.component import Component
 from armi.reactor.composites import Composite
@@ -269,8 +269,12 @@ class BlockBlueprint(yamlize.KeyedList):
         if spatialGrid:
             b.spatialGrid = spatialGrid
         else:
+            cornersUpCore = (
+                geometry.HEX_CORNERS_UP
+                == blueprint.gridDesigns[blueprint.systemDesigns["core"].gridName].geom
+            )
             try:
-                b.autoCreateSpatialGrids()
+                b.autoCreateSpatialGrids(cornersUp=not cornersUpCore)
             except (ValueError, NotImplementedError) as e:
                 runLog.extra(str(e), single=True)
 

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -211,7 +211,6 @@ class TestBlockConverter(unittest.TestCase):
             .core.getAssemblies(Flags.FUEL)[2]
             .getFirstBlock(Flags.FUEL)
         )
-        block.spatialGrid = grids.HexGrid.fromPitch(1.0)
 
         converter = blockConverters.HexComponentsToCylConverter(block)
         converter.convert()
@@ -254,9 +253,6 @@ class TestBlockConverter(unittest.TestCase):
 
         # add depletable flag to see if it is carried
         control.p.flags |= Flags.DEPLETABLE
-
-        driverBlock.spatialGrid = None
-        block.spatialGrid = grids.HexGrid.fromPitch(1.0)
 
         convertedWithoutDriver = self._testConvertWithDriverRings(
             block,

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -552,7 +552,6 @@ class Core(composites.Composite):
         for b in a:
             self.blocksByName[b.getName()] = b
 
-        a.orientBlocks(parentSpatialGrid=self.spatialGrid)
         if self.geomType == geometry.GeomType.HEX:
             ring, _loc = self.spatialGrid.getRingPos(
                 a.spatialLocator.getCompleteIndices()

--- a/armi/reactor/spentFuelPool.py
+++ b/armi/reactor/spentFuelPool.py
@@ -70,9 +70,6 @@ class SpentFuelPool(ExcoreStructure):
         else:
             loc = self._getNextLocation()
 
-        # orient the blocks to match this grid
-        assem.orientBlocks(parentSpatialGrid=self.spatialGrid)
-
         super().add(assem, loc)
 
     def getAssembly(self, name):

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -997,7 +997,7 @@ class Assembly_TestCase(unittest.TestCase):
         """Test the volume of a pin in the assembly's plenum."""
         pinPlenumVolume = 5.951978000285659e-05
 
-        self._setup_blueprints("refSmallReactorBase.yaml")
+        self._setup_blueprints("refSmallReactor.yaml")
         assembly = self.r.blueprints.assemblies.get("igniter fuel")
         self.assertEqual(pinPlenumVolume, assembly.getPinPlenumVolumeInCubicMeters())
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2262,7 +2262,7 @@ class HexBlock_TestCase(unittest.TestCase):
         self.assertEqual(70.6, self.hexBlock.getDuctOP())
 
         self.assertAlmostEqual(34.273, self.hexBlock.getPinToDuctGap(), 3)
-        self.assertEqual(0.11, self.hexBlock.getPinPitch())
+        self.assertAlmostEqual(0.11, self.hexBlock.getPinPitch(), 10)
         self.assertAlmostEqual(300.889, self.hexBlock.getWettedPerimeter(), 3)
         self.assertAlmostEqual(4242.184, self.hexBlock.getFlowArea(), 3)
         self.assertAlmostEqual(56.395, self.hexBlock.getHydraulicDiameter(), 3)
@@ -2715,8 +2715,6 @@ class ThRZBlock_TestCase(unittest.TestCase):
         """Since not applicable to ThetaRZ Grids."""
         b = self.ThRZBlock
         self.assertIsNone(b.spatialGrid)
-        b.autoCreateSpatialGrids("FakeSpatilGrid")
-        self.assertIsNotNone(b.spatialGrid)
 
     def test_getWettedPerimeter(self):
         with self.assertRaises(NotImplementedError):
@@ -2820,8 +2818,6 @@ class CartesianBlock_TestCase(unittest.TestCase):
         """Since not applicable to Cartesian Grids."""
         b = self.cartesianBlock
         self.assertIsNone(b.spatialGrid)
-        b.autoCreateSpatialGrids("FakeSpatialGrid")
-        self.assertIsNotNone(b.spatialGrid)
 
     def test_getWettedPerimeter(self):
         with self.assertRaises(NotImplementedError):

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -41,6 +41,9 @@ class MockBP:
     inactiveNuclides = set()
     elementsToExpand = set()
     customIsotopics = {}
+    gridDesigns = unittest.mock.MagicMock()
+
+    systemDesigns = unittest.mock.MagicMock()
 
 
 def getDummyParamDefs():


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: 

This change updates the reactor building process such that grids are assigned to blocks earlier in the process.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: 

Requirements are not impacted.


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
