### PR TITLE
Clarifying setting disableBlockTypeExclusionInXsGeneration

### DIFF
--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -280,22 +280,18 @@ class XSSettings(dict):
         """
         Set defaults for current and future xsIDs based user settings.
 
-        This must be delayed past read-time since the settings that effect this
-        may not be loaded yet and could still be at their own defaults when
-        this input is being processed. Thus, defaults are set at a later time.
+        This must be delayed after read-time since the settings affecting this may not be loaded yet and could still be
+        at their own defaults when this input is being processed. Thus, defaults are set at a later time.
 
         Parameters
         ----------
         blockRepresentation : str
             Valid options are provided in ``CrossSectionGroupManager.BLOCK_COLLECTIONS``
-
         validBlockTypes : list of str or bool
-           This configures which blocks (by their type) that the cross section
-           group manager will merge together to create a representative block. If
-           set to ``None`` or ``True`` then all block types in the XS ID will be
-           considered. If this is set to ``False`` then a default of ["fuel"] will
-           be used. If this is set to a list of strings then the specific list will
-           be used. A typical input may be ["fuel"] to just consider the fuel blocks.
+           This configures which blocks (by their type) the cross section group manager will merge together to create a
+           representative block. If set to ``None`` or ``True`` then all block types in the XS ID will be considered. If
+           set to ``False`` then a default of ["fuel"] will be used. If set to a list of strings then the specific list
+           will be used. A typical input may be ["fuel"] to just consider the fuel blocks.
 
         See Also
         --------
@@ -304,10 +300,7 @@ class XSSettings(dict):
         self._blockRepresentation = blockRepresentation
         self._validBlockTypes = validBlockTypes
         for _xsId, xsOpt in self.items():
-            xsOpt.setDefaults(
-                blockRepresentation,
-                validBlockTypes,
-            )
+            xsOpt.setDefaults(blockRepresentation, validBlockTypes)
             xsOpt.validate()
 
     def _getDefault(self, xsID):
@@ -638,18 +631,16 @@ class XSModelingOptions:
         blockRepresentation : str
             Valid options are provided in ``CrossSectionGroupManager.BLOCK_COLLECTIONS``
         validBlockTypes : list of str or bool
-           This configures which blocks (by their type) that the cross section
-           group manager will merge together to create a representative block. If
-           set to ``None`` or ``True`` then all block types in the XS ID will be
-           considered. If this is set to ``False`` then a default of ["fuel"] will
-           be used. If this is set to a list of strings then the specific list will
-           be used. A typical input may be ["fuel"] to just consider the fuel blocks.
+           This configures which blocks (by their type) the cross section group manager will merge together to create a
+           representative block. If set to ``None`` or ``True`` then all block types in the XS ID will be considered. If
+           set to ``False`` then a default of ["fuel"] will be used. If set to a list of strings then the specific list
+           will be used. A typical input may be ["fuel"] to just consider the fuel blocks.
 
         Notes
         -----
-        These defaults are application-specific and design specific. They are included to provide an
-        example and are tuned to fit the internal needs of TerraPower. Consider a separate
-        implementation/subclass if you would like different behavior.
+        These defaults are application-specific and design specific. They are included to provide an example and are
+        tuned to fit the internal needs of TerraPower. Consider a separate implementation/subclass if you would like
+        different behavior.
         """
         if type(validBlockTypes) is bool:
             validBlockTypes = None if validBlockTypes else ["fuel"]

--- a/armi/physics/neutronics/settings.py
+++ b/armi/physics/neutronics/settings.py
@@ -307,10 +307,10 @@ def defineSettings():
         setting.Setting(
             CONF_DISABLE_BLOCK_TYPE_EXCLUSION_IN_XS_GENERATION,
             default=False,
-            label="Include All Block Types in XS Generation",
-            description="Use all blocks in a cross section group when generating a "
-            "representative block. When this is disabled only `fuel` blocks will be "
-            "considered",
+            label="Which Block types to merge together in XS Generation",
+            description="Control which blocks get merged together by the XSGM. If set to ``None`` or ``True`` then all "
+            "block types in the XS ID will be considered. If set to ``False`` then a default of ['fuel'] will be used. "
+            "Can also be set to an exact list of strings for types to consider.",
         ),
         setting.Setting(
             CONF_XS_KERNEL,


### PR DESCRIPTION
## What is the change? Why is it being made?

Clarifying the setting `disableBlockTypeExclusionInXsGeneration`. It was only previously documented in the `XSModelingOptions` and `XSSettings` `.setDefaults()` methods. I am hoping extending the description field makes it more clear.

close #2108

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Clarifying the setting disableBlockTypeExclusionInXsGeneration.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
