### PR TITLE
Adding SQA for the SFP and cycles setting

### DIFF
--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -436,22 +436,6 @@ settings:
   runType: Standard
 """
 
-    powerFractionsSolution = [
-        [0.1, 0.2, 0.3],
-        [0.2, 0.2, 0.2, 0.2, 0],
-        [0.3, 0.3, 0.3, 0.3, 0.3],
-    ]
-    cycleNamesSolution = ["startup sequence", None, "prepare for shutdown"]
-    availabilityFactorsSolution = [0.1, 0.5, 1]
-    stepLengthsSolution = [
-        [1, 1, 1],
-        [10 / 5 * 0.5, 10 / 5 * 0.5, 10 / 5 * 0.5, 10 / 5 * 0.5, 10 / 5 * 0.5],
-        [3, 3, 3, 3, 3],
-    ]
-    cycleLengthsSolution = [30, 10, 15]
-    burnStepsSolution = [3, 5, 5]
-    maxBurnStepsSolution = 5
-
     def setUp(self):
         self.standaloneDetailedCS = Settings()
         self.standaloneDetailedCS.loadFromString(self.detailedCyclesSettings)
@@ -464,28 +448,35 @@ settings:
             :id: T_ARMI_SETTINGS_POWER1
             :tests: R_ARMI_SETTINGS_POWER
         """
-        self.assertEqual(self.detailedOperator.powerFractions, self.powerFractionsSolution)
+        powerFractionsSolution = [
+            [0.1, 0.2, 0.3],
+            [0.2, 0.2, 0.2, 0.2, 0],
+            [0.3, 0.3, 0.3, 0.3, 0.3],
+        ]
 
+        self.assertEqual(self.detailedOperator.powerFractions, powerFractionsSolution)
         self.detailedOperator._powerFractions = None
-        self.assertEqual(self.detailedOperator.powerFractions, self.powerFractionsSolution)
+        self.assertEqual(self.detailedOperator.powerFractions, powerFractionsSolution)
 
     def test_getCycleNames(self):
-        self.assertEqual(self.detailedOperator.cycleNames, self.cycleNamesSolution)
+        cycleNamesSolution = ["startup sequence", None, "prepare for shutdown"]
+        self.assertEqual(self.detailedOperator.cycleNames, cycleNamesSolution)
 
         self.detailedOperator._cycleNames = None
-        self.assertEqual(self.detailedOperator.cycleNames, self.cycleNamesSolution)
+        self.assertEqual(self.detailedOperator.cycleNames, cycleNamesSolution)
 
     def test_getAvailabilityFactors(self):
-        self.assertEqual(
-            self.detailedOperator.availabilityFactors,
-            self.availabilityFactorsSolution,
-        )
+        """Check that the "availability factor" is correctly set from the "cycles" setting.
+
+        .. test:: Users can manually control time discretization of the simulation.
+            :id: R_ARMI_FW_HISTORY3
+            :tests: R_ARMI_FW_HISTORY
+        """
+        availabilityFactorsSolution = [0.1, 0.5, 1]
+        self.assertEqual(self.detailedOperator.availabilityFactors, availabilityFactorsSolution)
 
         self.detailedOperator._availabilityFactors = None
-        self.assertEqual(
-            self.detailedOperator.availabilityFactors,
-            self.availabilityFactorsSolution,
-        )
+        self.assertEqual(self.detailedOperator.availabilityFactors, availabilityFactorsSolution)
 
     def test_getStepLengths(self):
         """Test that the manually-set, detailed time steps are retrievable.
@@ -494,10 +485,16 @@ settings:
             :id: T_ARMI_FW_HISTORY1
             :tests: R_ARMI_FW_HISTORY
         """
+        stepLengthsSolution = [
+            [1, 1, 1],
+            [10 / 5 * 0.5, 10 / 5 * 0.5, 10 / 5 * 0.5, 10 / 5 * 0.5, 10 / 5 * 0.5],
+            [3, 3, 3, 3, 3],
+        ]
+
         # detailed step lengths can be set manually
-        self.assertEqual(self.detailedOperator.stepLengths, self.stepLengthsSolution)
+        self.assertEqual(self.detailedOperator.stepLengths, stepLengthsSolution)
         self.detailedOperator._stepLength = None
-        self.assertEqual(self.detailedOperator.stepLengths, self.stepLengthsSolution)
+        self.assertEqual(self.detailedOperator.stepLengths, stepLengthsSolution)
 
         # when doing detailed step information, we don't get step information from settings
         cs = self.detailedOperator.cs
@@ -508,22 +505,43 @@ settings:
             cs["burnSteps"]
 
     def test_getCycleLengths(self):
-        self.assertEqual(self.detailedOperator.cycleLengths, self.cycleLengthsSolution)
+        """Check that the "cycle length" is correctly set from the "cycles" setting.
+
+        .. test:: Users can manually control time discretization of the simulation.
+            :id: R_ARMI_FW_HISTORY4
+            :tests: R_ARMI_FW_HISTORY
+        """
+        cycleLengthsSolution = [30, 10, 15]
+        self.assertEqual(self.detailedOperator.cycleLengths, cycleLengthsSolution)
 
         self.detailedOperator._cycleLengths = None
-        self.assertEqual(self.detailedOperator.cycleLengths, self.cycleLengthsSolution)
+        self.assertEqual(self.detailedOperator.cycleLengths, cycleLengthsSolution)
 
     def test_getBurnSteps(self):
-        self.assertEqual(self.detailedOperator.burnSteps, self.burnStepsSolution)
+        """Check that the "burn steps" is correctly set from the "cycles" setting.
+
+        .. test:: Users can manually control time discretization of the simulation.
+            :id: R_ARMI_FW_HISTORY5
+            :tests: R_ARMI_FW_HISTORY
+        """
+        burnStepsSolution = [3, 5, 5]
+        self.assertEqual(self.detailedOperator.burnSteps, burnStepsSolution)
 
         self.detailedOperator._burnSteps = None
-        self.assertEqual(self.detailedOperator.burnSteps, self.burnStepsSolution)
+        self.assertEqual(self.detailedOperator.burnSteps, burnStepsSolution)
 
     def test_getMaxBurnSteps(self):
-        self.assertEqual(self.detailedOperator.maxBurnSteps, self.maxBurnStepsSolution)
+        """Check that the max of the "burn steps" is correctly set from the "cycles" setting.
+
+        .. test:: Users can manually control time discretization of the simulation.
+            :id: R_ARMI_FW_HISTORY6
+            :tests: R_ARMI_FW_HISTORY
+        """
+        maxBurnStepsSolution = 5
+        self.assertEqual(self.detailedOperator.maxBurnSteps, maxBurnStepsSolution)
 
         self.detailedOperator._maxBurnSteps = None
-        self.assertEqual(self.detailedOperator.maxBurnSteps, self.maxBurnStepsSolution)
+        self.assertEqual(self.detailedOperator.maxBurnSteps, maxBurnStepsSolution)
 
 
 class TestInterfaceAndEventHeaders(unittest.TestCase):

--- a/armi/reactor/spentFuelPool.py
+++ b/armi/reactor/spentFuelPool.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """A nuclear reactor frequently has storage pools (or 'ponds') for spent fuel.
 
-This file implements a simple/default representation of such as an ARMI "system". ARMI systems, like
-the core are grids filled with ArmiObjects. This module also includes some helper tools to aid
-transferring spent fuel assemblies from the core to the SFP.
+This file implements a simple/default representation of such as an ARMI "system". ARMI systems, like the core are grids
+filled with ArmiObjects. This module also includes some helper tools to aid transferring spent fuel assemblies from the
+core to the SFP.
 """
 
 import itertools
@@ -24,9 +24,18 @@ from armi.reactor.excoreStructure import ExcoreStructure
 
 
 class SpentFuelPool(ExcoreStructure):
-    """A place to put assemblies when they've been discharged.
+    """The Spent Fuel Pool (SFP) is a place to store discharged assemblies.
 
     This class is a core-like system object, so it has a spatial grid that Assemblies can fit in.
+
+    .. impl:: The user-specified reactor.
+        :id: I_ARMI_SFP
+        :implements: R_ARMI_SFP
+
+        The SpentFuelPool is a composite structure meant to represent storage ponds for used fuel
+        assemblies. As a data structure, it is little more than a container for ``Assembly``
+        objects. It should be able to easily support adding or removing ``Assembly`` objects. And at
+        every time node the current state of the SFP will be written to the database.
     """
 
     def __init__(self, name, parent=None):
@@ -89,9 +98,9 @@ class SpentFuelPool(ExcoreStructure):
     def _getNextLocation(self):
         """Helper method to allow each discharged assembly to be easily dropped into the SFP.
 
-        The logic here is that we assume that the SFP is a rectangular-ish grid, with a set number
-        of columns per row. So when you add an Assembly here, if you don't provide a location, the
-        grid is filled in a col/row order with whatever grid cell is found open first.
+        The logic here is that we assume that the SFP is a rectangular-ish grid, with a set number of columns per row.
+        So when you add an Assembly here, if you don't provide a location, the grid is filled in a col/row order with
+        whatever grid cell is found open first.
         """
         filledLocations = {a.spatialLocator for a in self}
         grid = self.spatialGrid
@@ -112,8 +121,8 @@ class SpentFuelPool(ExcoreStructure):
         Parameters
         ----------
         startIndex : int, optional
-            The default is to start counting at zero. But if you are renumbering assemblies across
-            the entire Reactor, you may want to start at a different number.
+            The default is to start counting at zero. But if you are renumbering assemblies across the entire Reactor,
+            you may want to start at a different number.
 
         Returns
         -------

--- a/armi/reactor/tests/test_excoreStructures.py
+++ b/armi/reactor/tests/test_excoreStructures.py
@@ -77,9 +77,17 @@ class TestSpentFuelPool(TestCase):
         self.sfp.spatialGrid = grids.CartesianGrid.fromRectangle(1.0, 1.0)
 
     def test_constructor(self):
+        """Show that the spent fuel pool is a composite.
+
+        .. test:: The spent fuel pool is a Composite structure.
+            :id: T_ARMI_SFP0
+            :tests: R_ARMI_SFP
+        """
         self.assertEqual(self.sfp.name, "sfp")
         self.assertIsNone(self.sfp.parent)
         self.assertIsNone(self.sfp.numColumns)
+        self.assertTrue(isinstance(self.sfp, Composite))
+        self.assertTrue(isinstance(self.sfp, ExcoreStructure))
         self.assertTrue(isinstance(self.sfp.spatialGrid, grids.CartesianGrid))
 
     def test_representation(self):
@@ -88,7 +96,13 @@ class TestSpentFuelPool(TestCase):
         self.assertIn("sfp", rep)
         self.assertIn("id:", rep)
 
-    def test_add(self):
+    def test_addRemove(self):
+        """Show that we can add and remove Assemblies from the spent fuel pool.
+
+        .. test:: Show that we can add and remove Assemblies from the spent fuel pool.
+            :id: T_ARMI_SFP1
+            :tests: R_ARMI_SFP
+        """
         self.assertEqual(len(self.sfp.getChildren()), 0)
 
         # add one assembly object and validate
@@ -101,6 +115,10 @@ class TestSpentFuelPool(TestCase):
         loc = self.sfp.spatialGrid[(1, -4, 0)]
         self.sfp.add(a1, loc)
         self.assertEqual(len(self.sfp.getChildren()), 2)
+
+        # remove the first assembly we added and validate
+        self.sfp.remove(a0)
+        self.assertEqual(len(self.sfp.getChildren()), 1)
 
     def test_getAssembly(self):
         a0 = makeTestAssembly(1, 678, spatialGrid=self.sfp.spatialGrid)

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -811,12 +811,11 @@ def defineSettings() -> List[setting.Setting]:
             CONF_CYCLES,
             default=[],
             label="Cycle information",
-            description="YAML list defining the cycle history of the case. Options"
-            " at each cycle include: `name`, `cumulative days`, `step days`, `availability"
-            " factor`, `cycle length`, `burn steps`, and `power fractions`."
-            " If specified, do not use any of the case settings `cycleLength(s)`,"
-            " `availabilityFactor(s)`, `powerFractions`, or `burnSteps`. Must also"
-            " specify `nCycles` and `power`.",
+            description="YAML dict defining the cycle history of the case. Options at each cycle "
+            "include: `name`, `cumulative days`, `step days`, `availability factor`, "
+            "`cycle length`, `burn steps`, and `power fractions`. If specified, do not use any of "
+            "the case settings `cycleLength(s)`, `availabilityFactor(s)`, `powerFractions`, or "
+            "`burnSteps`. Must also specify `nCycles` and `power`.",
             schema=vol.Schema(
                 [
                     vol.All(
@@ -838,9 +837,9 @@ def defineSettings() -> List[setting.Setting]:
             CONF_USER_PLUGINS,
             default=[],
             label=CONF_USER_PLUGINS,
-            description="YAML list defining the locations of UserPlugin subclasses. "
-            "You can enter the full armi import path: armi.test.test_what.MyPlugin, "
-            "or you can enter the full file path: /path/to/my/pluginz.py:MyPlugin ",
+            description="YAML list defining the locations of UserPlugin subclasses. You can enter "
+            "the full ARMI import path: armi.test.test_what.MyPlugin, or you can enter the full "
+            "file path: /path/to/my/pluginz.py:MyPlugin ",
             schema=vol.Any([vol.Coerce(str)], None),
         ),
         setting.Setting(
@@ -861,6 +860,11 @@ def _isMonotonicIncreasing(inputList):
 
 
 def _mutuallyExclusiveCyclesInputs(cycle):
+    """Helper for `cycles` setting.
+
+    There are multiple different ways to define the time nodes of the simulation, but they are
+    exclusive, and you have to pick one. Here we verify it was done correcty.
+    """
     cycleKeys = cycle.keys()
     if (
         sum(
@@ -873,11 +877,10 @@ def _mutuallyExclusiveCyclesInputs(cycle):
         != 1
     ):
         baseErrMsg = (
-            "Must have exactly one of either 'cumulative days', 'step days', or"
-            " 'cycle length' + 'burn steps' in each cycle definition."
+            "Must have exactly one of either 'cumulative days', 'step days', or 'cycle length' + "
+            "'burn steps' in each cycle definition."
         )
 
-        raise vol.Invalid(
-            (baseErrMsg + " Check cycle {}.".format(cycle["name"])) if "name" in cycleKeys else baseErrMsg
-        )
+        raise vol.Invalid((baseErrMsg + f" Check cycle {cycle['name']}.") if "name" in cycleKeys else baseErrMsg)
+
     return cycle

--- a/doc/qa_docs/srsd/reactors_reqs.rst
+++ b/doc/qa_docs/srsd/reactors_reqs.rst
@@ -47,6 +47,13 @@ Functional Requirements
     :acceptance_criteria: Return neighboring assemblies from a given assembly in a core.
     :subtype: functional
 
+.. req:: ARMI shall provide an ex-core composite to represent spent fuel pools (SFP) for spent fuel assemblies.
+    :id: R_ARMI_SFP
+    :status: accepted
+    :basis: A SFP data model is a fundamental concept in modeling pin-type reactors.
+    :acceptance_criteria: Build a reactor data model with a SFP, then move an assembly from the reactor core to the the SFP and back.
+    :subtype: functional
+
 
 .. ## parameters ######################
 


### PR DESCRIPTION
## What is the change? Why is it being made?

Adding SQA for the SpentFuelPool and the setting "cycles".


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Adding SQA for the SpentFuelPool and the setting "cycles".

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Added the requirement `R_ARMI_SFP` to cover the SpentFuelPool feature. And added more testing of the "cycles" setting to `R_ARMI_FW_HISTORY`.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
