### PR TITLE
Hiding duplicate warning messages

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1058,9 +1058,9 @@ class Block(composites.Composite):
             return tFrac
         else:
             runLog.warning(
-                "No component {0} exists on {1}, so area fraction is zero.".format(typeSpec, self),
+                f"No component {typeSpec} exists on {self}, so area fraction is zero.",
                 single=True,
-                label="{0} areaFrac is zero".format(typeSpec),
+                label=f"{typeSpec} areaFrac is zero",
             )
             return 0.0
 
@@ -1094,7 +1094,7 @@ class Block(composites.Composite):
             if c.hasFlags(typeSpec):
                 return c.getDimension(dimName.lower())
 
-        raise ValueError("Cannot get Dimension because Flag not found: {0}".format(typeSpec))
+        raise ValueError(f"Cannot get Dimension because Flag not found: {typeSpec}")
 
     def getPinCenterFlatToFlat(self, cold=False):
         """Return the flat-to-flat distance between the centers of opposing pins in the outermost ring."""

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -442,7 +442,7 @@ class DeduplicationFilter(logging.Filter):
 
     def __init__(self, *args, **kwargs):
         logging.Filter.__init__(self, *args, **kwargs)
-        self.singleMessageCounts = {}
+        self.singleMessageCounts = set()
         self.warningCounts = {}
 
     def filter(self, record):
@@ -468,9 +468,8 @@ class DeduplicationFilter(logging.Filter):
             # in sub-warning cases, hash the label, for faster lookup
             label = hash(label)
             if label not in self.singleMessageCounts:
-                self.singleMessageCounts[label] = 1  # TODO: Could be a set
+                self.singleMessageCounts.add(label)
             else:
-                self.singleMessageCounts[label] += 1
                 return False
 
         # Handle some special string-mangling we want to do, for multi-line messages

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -357,7 +357,7 @@ class TestRunLog(unittest.TestCase):
             mock.emptyStdout()
 
     def test_deduplicationFilter(self):
-        """Test that the logic to ."""
+        """Test that the logic to only print a log message once works correctly."""
         with mockRunLogs.BufferLog() as mock:
             # we should start with a clean slate
             self.assertEqual("", mock.getStdout())

--- a/armi/tests/test_runLog.py
+++ b/armi/tests/test_runLog.py
@@ -356,6 +356,26 @@ class TestRunLog(unittest.TestCase):
             self.assertIn("hi333", mock.getStdout())
             mock.emptyStdout()
 
+    def test_deduplicationFilter(self):
+        """Test that the logic to ."""
+        with mockRunLogs.BufferLog() as mock:
+            # we should start with a clean slate
+            self.assertEqual("", mock.getStdout())
+            runLog.LOG.startLog("test_deduplicationFilter")
+            runLog.LOG.setVerbosity(logging.INFO)
+
+            msgInfo = "singleInfoMessage"
+            for i in range(4):
+                runLog.info(f"{msgInfo}: {i}", single=True, label=msgInfo)
+
+            msgWarn = "singleWarnMessage"
+            for j in range(4):
+                runLog.warning(f"{msgWarn}: {j}", single=True, label=msgWarn)
+
+            logs = mock.getStdout()
+            self.assertEqual(logs.count(msgInfo), 1)
+            self.assertEqual(logs.count(msgWarn), 1)
+
     def test_concatenateLogs(self):
         """
         Simple test of the concat logs function.


### PR DESCRIPTION
## What is the change? Why is it being made?

Duplicate warning messages were not being correctly hidden when they should be, so I fixed that.

close #2152

1. The first thing I did was write the new unit test. It failed, which was correct.
2. Then I fixed the bug in `runLog.py`.
3. THEN I realized our unit tests were using some test version of the `runLog.DeduplicationFilter`, which means the tests were still failing. I believe it will be more correct if `MockRunLogs` uses the `DeduplicationFilter` directly, so I did that.
4. Then I noticed that `DeduplicationFilter.singleMessageCounts` was a `dict`, but it only needed to be a `set`, so I made that change.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Hiding duplicate warning messages.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
