### PR TITLE
Cleaning up strange counter line

### DIFF
--- a/armi/pluginManager.py
+++ b/armi/pluginManager.py
@@ -42,5 +42,4 @@ class ArmiPluginManager(pluggy.PluginManager):
         pluggy.PluginManager.register(self, *args, **kwargs)
 
     def unregister(self, *args, **kwargs):
-        self._counter += 1
         pluggy.PluginManager.unregister(self, *args, **kwargs)


### PR DESCRIPTION
## What is the change? Why is it being made?

Cleaning out a strange counter increment in the plugin manager. @opotowsky pointed this out. I removed it and ran all the internal testing I could find, and everything passed.

I can only conclude that this is not useful now. Perhaps it was once, in the distant past.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Cleaning out a strange counter increment in the plugin manager.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
