### PR TITLE
Fixing bad Return in safeCopy

### DIFF
--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -788,7 +788,7 @@ def safeCopy(src: str, dst: str) -> None:
                 f"File copy from {dst} to {src} has failed due to exceeding "
                 + f"a maximum wait time of {maxWaitTime / 60} minutes."
             )
-            Return
+            return
 
     runLog.extra("Copied {} -> {}".format(src, dst))
 

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -1108,8 +1108,8 @@ def _makeBlockPinPatches(block, cold):
     cold : bool
         true for cold temps, hot = false
 
-    Return
-    ------
+    Returns
+    -------
     patches : list
         list of patches for block components
     data : list
@@ -1205,8 +1205,8 @@ def _makeComponentPatch(component, position, cold, cornersUp=False):
     cornersUp: bool, optional
         If this is a HexBlock, is it corners-up or flats-up?
 
-    Return
-    ------
+    Returns
+    -------
     blockPatch: list
         A list of Patch objects that together represent a component in the diagram.
 


### PR DESCRIPTION
## What is the change? Why is it being made?

In the method `safeCopy()` there was an invalid keyword `Return`, which should have been `return`. 

I grepped through the entire repo, this is the only instance of this spelling error.  I would guess this hasn't been found before because this is a "timeout" catch clause, and people must not have run into a timeout situation much in the past year or so.


## SCR Information

Change Type: fixes

One-Sentence Description: Fixing the method `safeCopy()` there was an invalid keyword `Return`, which should have been `return`. 

One-line Impact on Requirements: This is a low-level file system tool and could technically affect lots of unit tests by making them fail. But the only requirement that is directly affected is `R_ARMI_XSGM_FREQ` because `safeCopy` is used in the implementation of `I_ARMI_XSGM_FREQ3`.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
