### PR TITLE
Make axial linking aware of block grids for axial expansion

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -31,7 +31,7 @@ from scipy import interpolate
 from armi import runLog
 from armi.materials.material import Fluid
 from armi.reactor import assemblyParameters, blocks, composites, grids
-from armi.reactor.flags import Flags
+from armi.reactor.flags import Flags, TypeSpec
 from armi.reactor.parameters import ParamLocation
 from armi.reactor.spentFuelPool import SpentFuelPool
 
@@ -288,9 +288,9 @@ class Assembly(composites.Composite):
         """Calculate the total assembly volume in cm^3."""
         return self.getArea() * self.getTotalHeight()
 
-    def getPinPlenumVolumeInCubicMeters(self):
+    def getPinPlenumVolumeInCubicMeters(self) -> float:
         """
-        Return the volume of the plenum for a pin in an assembly.
+        Return the total volume of the plenum for an assembly in m^3.
 
         Notes
         -----
@@ -299,12 +299,19 @@ class Assembly(composites.Composite):
         Warning
         -------
         This is a bit design-specific for pinned assemblies.
+
+        Returns
+        -------
+        float: Total plenum volume for an assembly.
         """
         plenumVolume = 0.0
         for b in self.iterChildrenWithFlags(Flags.PLENUM):
-            cladId = b.getComponent(Flags.CLAD).getDimension("id")
             length = b.getHeight()
-            plenumVolume += math.pi * (cladId / 2.0) ** 2.0 * length * 1e-6  # convert cm^3 to m^3
+            for c in b.iterChildrenWithFlags(Flags.CLAD):
+                cladId = c.getDimension("id")
+                plenumVolume += math.pi * (cladId / 2.0) ** 2.0 * length
+        # convert vol from cm^3 to m^3
+        plenumVolume *= 1e-6
         return plenumVolume
 
     def getAveragePlenumTemperature(self):
@@ -848,14 +855,14 @@ class Assembly(composites.Composite):
     def hasContinuousCoolantChannel(self):
         return all(b.containsAtLeastOneChildWithFlags(Flags.COOLANT) for b in self)
 
-    def getFirstBlock(self, typeSpec=None, exact=False):
+    def getFirstBlock(self, typeSpec: TypeSpec = None, exact: bool = False) -> Optional[blocks.Block]:
         """Find the first block that matches the spec.
 
         Parameters
         ----------
-        typeSpec : flag or list of flags, optional
+        typeSpec
             Specification to require on the returned block.
-        exact : bool, optional
+        exact
             Require block to exactly match ``typeSpec``
 
         Returns
@@ -874,7 +881,7 @@ class Assembly(composites.Composite):
             # No items found in the iteration -> no blocks match the request
             return None
 
-    def getFirstBlockByType(self, typeName):
+    def getFirstBlockByType(self, typeName: str) -> Optional[blocks.Block]:
         blocks = filter(lambda b: b.getType() == typeName, self)
         try:
             return next(blocks)

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -168,8 +168,8 @@ class BlockBlueprint(yamlize.KeyedList):
                     mult = c.getDimension("mult")
                     if mult and mult != 1.0 and mult != len(c.spatialLocator):
                         raise ValueError(
-                            f"Conflicting ``mult`` input ({mult}) and number of "
-                            f"lattice positions ({len(c.spatialLocator)}) for {c}. "
+                            f"For {c} in {self.name} there is a conflicting ``mult`` input ({mult}) "
+                            f"and number of lattice positions ({len(c.spatialLocator)}). "
                             "Recommend leaving off ``mult`` input when using grids."
                         )
                     elif not mult or mult == 1.0:

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -20,7 +20,7 @@ This module contains the abstract definition of a Component.
 
 import copy
 import re
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
@@ -326,9 +326,12 @@ class Component(composites.Composite, metaclass=ComponentType):
                     self.p[dimName] = _DimensionLink((comp, linkedKey))
                 except Exception:
                     if value.count(".") > 1:
-                        raise ValueError(f"Component names should not have periods in them: `{value}`")
+                        raise ValueError(
+                            f"Name of {self} has a period in it. "
+                            f"Components cannot not have periods in their names: `{value}`"
+                        )
                     else:
-                        raise KeyError(f"Bad component link `{dimName}` defined as `{value}`")
+                        raise KeyError(f"Bad component link `{dimName}` defined as `{value}` in {self}")
 
     def setLink(self, key, otherComp, otherCompKey):
         """Set the dimension link."""
@@ -662,7 +665,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         """
         return self.p.numberDensities.get(nucName, 0.0)
 
-    def getNuclideNumberDensities(self, nucNames):
+    def getNuclideNumberDensities(self, nucNames: list[str]) -> list[float]:
         """Return a list of number densities for the nuc names requested."""
         return [self.p.numberDensities.get(nucName, 0.0) for nucName in nucNames]
 
@@ -826,7 +829,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         except ZeroDivisionError:
             return 0.0
 
-    def getMass(self, nuclideNames=None):
+    def getMass(self, nuclideNames: Union[None, str, list[str]] = None) -> float:
         r"""
         Determine the mass in grams of nuclide(s) and/or elements in this object.
 

--- a/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
+++ b/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
@@ -16,6 +16,7 @@ import dataclasses
 import functools
 import itertools
 import typing
+from textwrap import dedent
 
 from armi import runLog
 from armi.reactor.blocks import Block
@@ -23,6 +24,7 @@ from armi.reactor.components import Component, UnshapedComponent
 from armi.reactor.converters.axialExpansionChanger.expansionData import (
     iterSolidComponents,
 )
+from armi.reactor.grids import MultiIndexLocation
 
 if typing.TYPE_CHECKING:
     from armi.reactor.assemblies import Assembly
@@ -30,14 +32,6 @@ if typing.TYPE_CHECKING:
 
 def areAxiallyLinked(componentA: Component, componentB: Component) -> bool:
     """Determine axial component linkage for two components.
-
-    Components are considered linked if the following are found to be true:
-
-    1. Both contain solid materials.
-    2. They have identical types (e.g., ``Circle``).
-    3. Their multiplicities are the same.
-    4. The biggest inner bounding diameter of the two is less than the smallest outer
-       bounding diameter of the two.
 
     Parameters
     ----------
@@ -48,40 +42,67 @@ def areAxiallyLinked(componentA: Component, componentB: Component) -> bool:
 
     Notes
     -----
-    - Requires that shapes have the getCircleInnerDiameter and getBoundingCircleOuterDiameter
-      defined
-    - When component dimensions are retrieved, cold=True to ensure that dimensions are evaluated
-      at cold/input temperatures. At temperature, solid-solid interfaces in ARMI may produce
-      slight overlaps due to thermal expansion. Handling these potential overlaps are out of scope.
+    If componentA and componentB are both solids and the same type, geometric overlap can be checked via
+    getCircleInnerDiameter and getBoundingCircleOuterDiameter. Four different cases are accounted for.
+    If they do not meet these initial criteria, linkage is assumed to be False.
+    Case #1: Unshaped Components. There is no way to determine overlap so they're assumed to be not linked.
+    Case #2: Blocks with specified grids. If componentA and componentB have identical grid indices (cannot be a partial
+    case, ALL of the indices must be contained by one or the other), then overlap can be checked.
+    Case #3: If Component position is not specified via a grid, the multiplicity is checked. If consistent, they are
+    assumed to be in the same positions and their overlap is checked.
+    Case #4: Components are either not both solids, are not the same type, or Cases 1-3 are not True.
 
     Returns
     -------
     linked : bool
         status is componentA and componentB are axially linked to one another
     """
-    if (
-        (componentA.containsSolidMaterial() and componentB.containsSolidMaterial())
-        and type(componentA) is type(componentB)
-        and (componentA.getDimension("mult") == componentB.getDimension("mult"))
+    ## Cases 4
+    linked = False
+
+    if isinstance(componentA, type(componentB)) and (
+        componentA.containsSolidMaterial() and componentB.containsSolidMaterial()
     ):
         if isinstance(componentA, UnshapedComponent):
+            ## Case 1
             runLog.warning(
                 f"Components {componentA} and {componentB} are UnshapedComponents "
-                "and do not have 'getCircleInnerDiameter' or getBoundingCircleOuterDiameter "
-                "methods; nor is it physical to do so. Instead of crashing and raising an error, "
+                "and do not have 'getCircleInnerDiameter' or getBoundingCircleOuterDiameter methods; "
+                "nor is it physical to do so. Instead of crashing and raising an error, "
                 "they are going to be assumed to not be linked.",
                 single=True,
             )
-            return False
-        # Check if one component could fit within the other
-        idA = componentA.getCircleInnerDiameter(cold=True)
-        odA = componentA.getBoundingCircleOuterDiameter(cold=True)
-        idB = componentB.getCircleInnerDiameter(cold=True)
-        odB = componentB.getBoundingCircleOuterDiameter(cold=True)
-        biggerID = max(idA, idB)
-        smallerOD = min(odA, odB)
-        return biggerID < smallerOD
-    return False
+        elif isinstance(componentA.spatialLocator, MultiIndexLocation) and isinstance(
+            componentB.spatialLocator, MultiIndexLocation
+        ):
+            ## Case 2
+            fromA = set(tuple(index) for index in componentA.spatialLocator.indices)
+            fromB = set(tuple(index) for index in componentB.spatialLocator.indices)
+            if fromA == fromB:
+                linked = _checkOverlap(componentA, componentB)
+        elif componentA.getDimension("mult") == componentB.getDimension("mult"):
+            ## Case 3
+            linked = _checkOverlap(componentA, componentB)
+
+    return linked
+
+
+def _checkOverlap(componentA: Component, componentB: Component) -> bool:
+    """Check two components for geometric overlap by seeing if one can fit within the other.
+
+    Notes
+    -----
+    When component dimensions are retrieved, cold=True to ensure that dimensions are evaluated
+    at cold/input temperatures. At temperature, solid-solid interfaces in ARMI may produce
+    slight overlaps due to thermal expansion. Handling these potential overlaps are out of scope.
+    """
+    idA = componentA.getCircleInnerDiameter(cold=True)
+    odA = componentA.getBoundingCircleOuterDiameter(cold=True)
+    idB = componentB.getCircleInnerDiameter(cold=True)
+    odB = componentB.getBoundingCircleOuterDiameter(cold=True)
+    biggerID = max(idA, idB)
+    smallerOD = min(odA, odB)
+    return biggerID < smallerOD
 
 
 # Make a generic type so we can "template" the axial link class based on what could be above/below a thing
@@ -93,17 +114,15 @@ class AxialLink(typing.Generic[Comp]):
     """Small class for named references to objects above and below a specific object.
 
     Axial expansion in ARMI works by identifying what objects occupy the same axial space.
-    For components in blocks, identify which above and below axially align. This is used
+    For components in blocks, identify which below axially align. This is used
     to determine what, if any, mass needs to be re-assigned across blocks during expansion.
     For blocks, the linking determines what blocks need to move as a result of a specific block's
     axial expansion.
 
     Attributes
     ----------
-    lower : Composite or None
+    lower
         Object below, if any.
-    upper : Composite or None
-        Object above, if any.
 
     Notes
     -----
@@ -117,8 +136,7 @@ class AxialLink(typing.Generic[Comp]):
     * :attr:`AxialAssemblyLinkage.linkedComponents`
     """
 
-    lower: typing.Optional[Comp] = dataclasses.field(default=None)
-    upper: typing.Optional[Comp] = dataclasses.field(default=None)
+    lower: typing.Optional[list[Comp]] = dataclasses.field(default=None)
 
 
 class AssemblyAxialLinkage:
@@ -180,10 +198,9 @@ class AssemblyAxialLinkage:
     def _getLinkedBlocks(blocks: typing.Sequence[Block], nBlocks: int) -> dict[Block, AxialLink[Block]]:
         # Use islice to avoid making intermediate lists of subsequences of blocks
         lower = itertools.chain((None,), itertools.islice(blocks, 0, nBlocks - 1))
-        upper = itertools.chain(itertools.islice(blocks, 1, None), (None,))
         links = {}
-        for low, mid, high in zip(lower, blocks, upper):
-            links[mid] = AxialLink(lower=low, upper=high)
+        for low, mid in zip(lower, blocks):
+            links[mid] = AxialLink(lower=low)
         return links
 
     def _determineAxialLinkage(self):
@@ -202,14 +219,17 @@ class AssemblyAxialLinkage:
             if candidate is None:
                 candidate = otherComp
             else:
-                errMsg = (
-                    "Multiple component axial linkages have been found for "
-                    f"Component {c} in Block {c.parent} in Assembly {c.parent.parent}. "
-                    "This is indicative of an error in the blueprints! Linked "
-                    f"components found are {candidate} and {otherComp} in {otherBlock}"
-                )
-                runLog.error(msg=errMsg)
-                raise RuntimeError(errMsg)
+                errMsg = f"""
+                    Multiple component axial linkages have been found for the following component!
+                        Component {c}
+                          -> Block {c.parent}
+                          -> Assembly {c.parent.parent}
+                    This is indicative of an error in the blueprints! Candidate components in {otherBlock}:
+                        {candidate}
+                        {otherComp}
+                """
+                runLog.error(msg=dedent(errMsg))
+                raise RuntimeError(dedent(errMsg))
         return candidate
 
     def _getLinkedComponents(self, b: Block, c: Component):
@@ -227,20 +247,13 @@ class AssemblyAxialLinkage:
         RuntimeError
             multiple candidate components are found to be axially linked to a component
         """
-        linkedBlocks = self.linkedBlocks[b]
-        lowerC = self._findComponentLinkedTo(c, linkedBlocks.lower)
-        upperC = self._findComponentLinkedTo(c, linkedBlocks.upper)
-        lstLinkedC = AxialLink(lowerC, upperC)
+        lowerC = self._findComponentLinkedTo(c, self.linkedBlocks[b].lower)
+        lstLinkedC = AxialLink(lowerC)
         self.linkedComponents[c] = lstLinkedC
 
         if self.linkedBlocks[b].lower is None and lstLinkedC.lower is None:
             runLog.debug(
                 f"Assembly {self.a}, Block {b}, Component {c} has nothing linked below it!",
-                single=True,
-            )
-        if self.linkedBlocks[b].upper is None and lstLinkedC.upper is None:
-            runLog.debug(
-                f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
                 single=True,
             )
 

--- a/armi/reactor/converters/tests/test_assemblyAxialLinkage.py
+++ b/armi/reactor/converters/tests/test_assemblyAxialLinkage.py
@@ -1,0 +1,402 @@
+# Copyright 2025 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+from typing import TYPE_CHECKING, Callable, Type
+from unittest import TestCase
+
+from armi.reactor.assemblies import HexAssembly, grids
+from armi.reactor.blocks import HexBlock
+from armi.reactor.blueprints import Blueprints
+from armi.reactor.components import UnshapedComponent
+from armi.reactor.components.basicShapes import Circle, Hexagon, Rectangle
+from armi.reactor.components.complexShapes import Helix
+from armi.reactor.converters.axialExpansionChanger.assemblyAxialLinkage import (
+    AssemblyAxialLinkage,
+    AxialLink,
+    _checkOverlap,
+)
+from armi.reactor.converters.tests.test_axialExpansionChanger import (
+    AxialExpansionTestBase,
+    _buildDummySodium,
+    buildTestAssemblyWithFakeMaterial,
+)
+from armi.reactor.flags import Flags
+from armi.settings.caseSettings import Settings
+
+if TYPE_CHECKING:
+    from armi.reactor.components import Component
+
+TWOPIN_BLOCK = """
+    fuel twoPin: &block_fuel_twoPin
+        grid name: twoPin
+        fuel 1: &component_fueltwoPin
+            shape: Circle
+            material: UZr
+            Tinput: 25.0
+            Thot: 600.0
+            id: 0.0
+            od: 0.8
+            latticeIDs: [1]
+        fuel 2:
+            <<: *component_fueltwoPin
+            latticeIDs: [2]
+        coolant:
+            shape: DerivedShape
+            material: Sodium
+            Tinput: 450.0
+            Thot: 450.0
+        duct:
+            shape: Hexagon
+            material: HT9
+            Tinput: 25.0
+            Thot: 450.0
+            ip: 16.0
+            mult: 1.0
+            op: 16.6
+"""
+
+ONEPIN_BLOCK = """
+    fuel onePin: &block_fuel_onePin
+        grid name: onePin
+        fuel 1:
+            <<: *component_fueltwoPin
+        coolant:
+            shape: DerivedShape
+            material: Sodium
+            Tinput: 450.0
+            Thot: 450.0
+        duct:
+            shape: Hexagon
+            material: HT9
+            Tinput: 25.0
+            Thot: 450.0
+            ip: 16.0
+            mult: 1.0
+            op: 16.6
+"""
+
+CORRECT_ASSEMBLY = """
+    fuel pass:
+        specifier: LA
+        blocks: [*block_fuel_twoPin, *block_fuel_twoPin]
+        height: [25.0, 25.0]
+        axial mesh points: [1, 1]
+        xs types: [A, A]
+"""
+
+WRONG_ASSEMBLY = """
+    fuel fail:
+        specifier: LA
+        blocks: [*block_fuel_twoPin, *block_fuel_onePin]
+        height: [25.0, 25.0]
+        axial mesh points: [1, 1]
+        xs types: [A, A]
+"""
+
+TWOPIN_GRID = """
+    twoPin:
+       geom: hex_corners_up
+       symmetry: full
+       lattice map: |
+         - - -  1 1 1 1
+           - - 1 1 2 1 1
+            - 1 1 1 1 1 1
+             1 2 1 2 1 2 1
+              1 1 1 1 1 1
+               1 1 2 1 1
+                1 1 1 1
+"""
+
+ONEPIN_GRID = """
+    onePin:
+       geom: hex_corners_up
+       symmetry: full
+       lattice map: |
+         - - -  1 1 1 1
+           - - 1 1 1 1 1
+            - 1 1 1 1 1 1
+             1 1 1 1 1 1 1
+              1 1 1 1 1 1
+               1 1 1 1 1
+                1 1 1 1
+"""
+
+
+def createMultipinBlueprints(blockDef: list[str], assemDef: list[str], gridDef: list[str]) -> str:
+    multiPinDef = "blocks:"
+    for block in blockDef:
+        multiPinDef += block
+    multiPinDef += "\nassemblies:"
+    for assem in assemDef:
+        multiPinDef += assem
+    multiPinDef += "\ngrids:"
+    for grid in gridDef:
+        multiPinDef += grid
+
+    return multiPinDef
+
+
+class TestAxialLinkHelper(TestCase):
+    """Tests for the AxialLink dataclass / namedtuple like class."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.LOWER_BLOCK = _buildDummySodium(20, 10)
+
+    def test_override(self):
+        """Test lower attribute can be set after construction."""
+        empty = AxialLink()
+        self.assertIsNone(empty.lower)
+        empty.lower = self.LOWER_BLOCK
+        self.assertIs(empty.lower, self.LOWER_BLOCK)
+
+    def test_construct(self):
+        """Test lower attributes can be set at construction."""
+        link = AxialLink(self.LOWER_BLOCK)
+        self.assertIs(link.lower, self.LOWER_BLOCK)
+
+
+class TestAreAxiallyLinked(AxialExpansionTestBase):
+    """Provide test coverage for the different cases in assemblyAxialLinkage.areAxiallyLinked."""
+
+    def test_mismatchComponentType(self):
+        """Case 4; component type mismatch."""
+        compDims = ("test", "FakeMat", 25.0, 25.0)  # name, material, Tinput, Thot
+        comp1 = Circle(*compDims, od=1.0, id=0.0)
+        comp2 = Hexagon(*compDims, op=1.0, ip=0.0)
+        self.assertFalse(AssemblyAxialLinkage.areAxiallyLinked(comp1, comp2))
+
+    def test_unshapedComponents(self):
+        """Case 1; unshaped components."""
+        compDims = {"Tinput": 25.0, "Thot": 25.0}
+        comp1 = UnshapedComponent("unshaped_1", "FakeMat", **compDims)
+        comp2 = UnshapedComponent("unshaped_2", "FakeMat", **compDims)
+        self.assertFalse(AssemblyAxialLinkage.areAxiallyLinked(comp1, comp2))
+
+    def test_componentMult(self):
+        """Case 3; multiplicity based linking."""
+        compDims = ("test", "FakeMat", 25.0, 25.0)
+        comp1 = Circle(*compDims, od=1.0, id=0.0)
+        comp2 = Circle(*compDims, od=1.0, id=0.0)
+        # mult are same, comp1 and comp2 are linked
+        self.assertTrue(AssemblyAxialLinkage.areAxiallyLinked(comp1, comp2))
+        # mult is different, now they are not linked
+        comp2.p.mult = 2
+        self.assertFalse(AssemblyAxialLinkage.areAxiallyLinked(comp1, comp2))
+
+    def test_multiIndexLocation(self):
+        """Case 2; block-grid based linking."""
+        cs = Settings()
+        multiPinBPs = createMultipinBlueprints([TWOPIN_BLOCK], [CORRECT_ASSEMBLY], [TWOPIN_GRID])
+        with io.StringIO(multiPinBPs) as stream:
+            bps = Blueprints.load(stream)
+            bps._prepConstruction(cs)
+            lowerB: HexBlock = bps.assemblies["fuel pass"][0]
+            upperB: HexBlock = bps.assemblies["fuel pass"][1]
+            lowerFuel1, lowerFuel2 = lowerB.getComponents(Flags.FUEL)
+            upperFuel1, _upperFuel2 = upperB.getComponents(Flags.FUEL)
+            # same grid locs, are linked
+            self.assertTrue(AssemblyAxialLinkage.areAxiallyLinked(lowerFuel1, upperFuel1))
+            # different grid locs, are not linked
+            self.assertFalse(AssemblyAxialLinkage.areAxiallyLinked(lowerFuel2, upperFuel1))
+
+    def test_multiIndexLocation_Fail(self):
+        """Case 2; block-grid based linking."""
+        cs = Settings()
+        multiPinBPs = createMultipinBlueprints(
+            [TWOPIN_BLOCK, ONEPIN_BLOCK], [WRONG_ASSEMBLY], [TWOPIN_GRID, ONEPIN_GRID]
+        )
+        with io.StringIO(multiPinBPs) as stream:
+            bps = Blueprints.load(stream)
+            bps._prepConstruction(cs)
+            lowerB: HexBlock = bps.assemblies["fuel fail"][0]
+            upperB: HexBlock = bps.assemblies["fuel fail"][1]
+            lowerFuel1, lowerFuel2 = lowerB.getComponents(Flags.FUEL)
+            upperFuel1 = upperB.getComponent(Flags.FUEL)
+            # different/not exact match grid locs, are not linked
+            self.assertFalse(AssemblyAxialLinkage.areAxiallyLinked(lowerFuel1, upperFuel1))
+            # different/not exact match grid locs, are not linked
+            self.assertFalse(AssemblyAxialLinkage.areAxiallyLinked(lowerFuel2, upperFuel1))
+
+
+class TestCheckOverlap(AxialExpansionTestBase):
+    """Test axial linkage between components via the AssemblyAxialLinkage._checkOverlap."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Contains common dimensions for all component class types."""
+        super().setUp(cls)
+        cls.common = ("test", "FakeMat", 25.0, 25.0)  # name, material, Tinput, Thot
+
+    def runTest(
+        self,
+        componentsToTest: dict[Type["Component"], dict[str, float]],
+        assertion: Callable,
+    ):
+        """Runs various linkage tests.
+
+        Parameters
+        ----------
+        componentsToTest
+            dictionary keys indicate the component type for ``typeA`` and ``typeB`` checks. the values indicate the
+            neccessary geometry specifications of the ``typeA`` and ``typeB`` components.
+        assertion
+            unittest.TestCase assertion
+
+        Notes
+        -----
+        - components "typeA" and "typeB" are assumed to be candidates for axial linking
+        - two assertions: 1) comparing "typeB" component to "typeA"; 2) comparing "typeA" component to "typeB"
+        - the different assertions are particularly useful for comparing two annuli
+        """
+        for method, dims in componentsToTest.items():
+            typeA = method(*self.common, **dims[0])
+            typeB = method(*self.common, **dims[1])
+            msg = f"{self._testMethodName} failed for component type {str(method)}!"
+            assertion(_checkOverlap(typeA, typeB), msg=msg)
+            assertion(_checkOverlap(typeB, typeA), msg=msg)
+
+    def test_overlappingSolidPins(self):
+        componentTypesToTest = {
+            Circle: [{"od": 0.5, "id": 0.0}, {"od": 1.0, "id": 0.0}],
+            Hexagon: [{"op": 0.5, "ip": 0.0}, {"op": 1.0, "ip": 0.0}],
+            Rectangle: [
+                {
+                    "lengthOuter": 0.5,
+                    "lengthInner": 0.0,
+                    "widthOuter": 0.5,
+                    "widthInner": 0.0,
+                },
+                {
+                    "lengthOuter": 1.0,
+                    "lengthInner": 0.0,
+                    "widthOuter": 1.0,
+                    "widthInner": 0.0,
+                },
+            ],
+            Helix: [
+                {"od": 0.5, "axialPitch": 1.0, "helixDiameter": 1.0},
+                {"od": 1.0, "axialPitch": 1.0, "helixDiameter": 1.0},
+            ],
+        }
+        self.runTest(componentTypesToTest, self.assertTrue)
+
+    def test_solidPinNotOverlappingAnnulus(self):
+        componentTypesToTest = {
+            Circle: [{"od": 0.5, "id": 0.0}, {"od": 1.0, "id": 0.6}],
+        }
+        self.runTest(componentTypesToTest, self.assertFalse)
+
+    def test_solidPinOverlappingWithAnnulus(self):
+        componentTypesToTest = {
+            Circle: [{"od": 0.7, "id": 0.0}, {"od": 1.0, "id": 0.6}],
+        }
+        self.runTest(componentTypesToTest, self.assertTrue)
+
+    def test_annularPinNotOverlappingWithAnnulus(self):
+        componentTypesToTest = {
+            Circle: [{"od": 0.6, "id": 0.3}, {"od": 1.0, "id": 0.6}],
+        }
+        self.runTest(componentTypesToTest, self.assertFalse)
+
+    def test_annularPinOverlappingWithAnnuls(self):
+        componentTypesToTest = {
+            Circle: [{"od": 0.7, "id": 0.3}, {"od": 1.0, "id": 0.6}],
+        }
+        self.runTest(componentTypesToTest, self.assertTrue)
+
+    def test_thinAnnularPinOverlappingWithThickAnnulus(self):
+        componentTypesToTest = {
+            Circle: [{"od": 0.7, "id": 0.3}, {"od": 0.6, "id": 0.5}],
+        }
+        self.runTest(componentTypesToTest, self.assertTrue)
+
+    def test_AnnularHexOverlappingThickAnnularHex(self):
+        componentTypesToTest = {Hexagon: [{"op": 1.0, "ip": 0.8}, {"op": 1.2, "ip": 0.8}]}
+        self.runTest(componentTypesToTest, self.assertTrue)
+
+
+class TestMultipleComponentLinkage(AxialExpansionTestBase):
+    """Ensure that multiple component axial linkage can be caught."""
+
+    def test_getLinkedComponents(self):
+        """Test for multiple component axial linkage."""
+        linked = AssemblyAxialLinkage(buildTestAssemblyWithFakeMaterial("FakeMat"))
+        b = linked.a.getFirstBlockByType("fuel")
+        fuelComp = b.getComponent(Flags.FUEL)
+        cladComp = b.getComponent(Flags.CLAD)
+        fuelComp.setDimension("od", 0.5 * (cladComp.getDimension("id") + cladComp.getDimension("od")))
+        with self.assertRaisesRegex(
+            RuntimeError,
+            expected_regex="Multiple component axial linkages have been found for ",
+        ):
+            linked._getLinkedComponents(b, fuelComp)
+
+
+class TestBlockLink(TestCase):
+    """Test the ability to link blocks in an assembly."""
+
+    def test_singleBlock(self):
+        """Test an edge case where a single block exists."""
+        b = _buildDummySodium(300, 50)
+        links = AssemblyAxialLinkage.getLinkedBlocks([b])
+        self.assertEqual(len(links), 1)
+        self.assertIn(b, links)
+        linked = links.pop(b)
+        self.assertIsNone(linked.lower)
+
+    def test_multiBlock(self):
+        """Test links with multiple blocks."""
+        N_BLOCKS = 5
+        blocks = [_buildDummySodium(300, 50) for _ in range(N_BLOCKS)]
+        links = AssemblyAxialLinkage.getLinkedBlocks(blocks)
+        first = blocks[0]
+        lowLink = links[first]
+        self.assertIsNone(lowLink.lower)
+        for ix in range(1, N_BLOCKS - 1):
+            current = blocks[ix]
+            below = blocks[ix - 1]
+            link = links[current]
+            self.assertIs(link.lower, below)
+        top = blocks[-1]
+        lastLink = links[top]
+        self.assertIs(lastLink.lower, blocks[-2])
+
+    def test_emptyBlocks(self):
+        """Test even smaller edge case when no blocks are passed."""
+        with self.assertRaisesRegex(ValueError, "No blocks passed. Cannot determine links"):
+            AssemblyAxialLinkage.getLinkedBlocks([])
+
+    def test_onAssembly(self):
+        """Test assembly behavior is the same as sequence of blocks."""
+        assembly = HexAssembly("test")
+        N_BLOCKS = 5
+        assembly.spatialGrid = grids.AxialGrid.fromNCells(numCells=N_BLOCKS)
+        assembly.spatialGrid.armiObject = assembly
+
+        blocks = []
+        for _ in range(N_BLOCKS):
+            b = _buildDummySodium(300, 10)
+            assembly.add(b)
+            blocks.append(b)
+
+        fromBlocks = AssemblyAxialLinkage.getLinkedBlocks(blocks)
+        fromAssem = AssemblyAxialLinkage.getLinkedBlocks(assembly)
+
+        self.assertSetEqual(set(fromBlocks), set(fromAssem))
+
+        for b, bLink in fromBlocks.items():
+            aLink = fromAssem[b]
+            self.assertIs(aLink.lower, bLink.lower)

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -19,6 +19,7 @@ import copy
 import os
 import unittest
 from statistics import mean
+from typing import Callable
 
 from numpy import array, linspace, zeros
 
@@ -26,9 +27,8 @@ from armi import materials
 from armi.materials import _MATERIAL_NAMESPACE_ORDER, custom
 from armi.reactor.assemblies import HexAssembly, grids
 from armi.reactor.blocks import HexBlock
-from armi.reactor.components import Component, DerivedShape, UnshapedComponent
-from armi.reactor.components.basicShapes import Circle, Hexagon, Rectangle
-from armi.reactor.components.complexShapes import Helix
+from armi.reactor.components import Component, DerivedShape
+from armi.reactor.components.basicShapes import Circle, Hexagon
 from armi.reactor.converters.axialExpansionChanger import (
     AssemblyAxialLinkage,
     AxialExpansionChanger,
@@ -36,14 +36,11 @@ from armi.reactor.converters.axialExpansionChanger import (
     getSolidComponents,
     iterSolidComponents,
 )
-from armi.reactor.converters.axialExpansionChanger.assemblyAxialLinkage import (
-    AxialLink,
-    areAxiallyLinked,
-)
 from armi.reactor.flags import Flags
 from armi.testing import loadTestReactor
 from armi.tests import TEST_ROOT
 from armi.utils import units
+from armi.utils.customExceptions import InputError
 
 
 class AxialExpansionTestBase(unittest.TestCase):
@@ -158,11 +155,11 @@ class Temperature:
                 self.tempField[i, :] = tmp[i]
 
 
-class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
+class TestAxialExpansionHeight(AxialExpansionTestBase):
     """Verify that test assembly is expanded correctly."""
 
     def setUp(self):
-        AxialExpansionTestBase.setUp(self)
+        super().setUp()
         self.a = buildTestAssemblyWithFakeMaterial(name="FakeMat")
 
         self.temp = Temperature(self.a.getTotalHeight(), numTempGridPts=11, tempSteps=10)
@@ -174,9 +171,6 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
         for idt in range(self.temp.tempSteps):
             self.obj.performThermalAxialExpansion(self.a, self.temp.tempGrid, self.temp.tempField[idt, :], setFuel=True)
             self._getConservationMetrics(self.a)
-
-    def tearDown(self):
-        AxialExpansionTestBase.tearDown(self)
 
     def test_AssemblyAxialExpansionHeight(self):
         """Test the axial expansion gives correct heights for component-based expansion."""
@@ -228,15 +222,12 @@ class TestAxialExpansionHeight(AxialExpansionTestBase, unittest.TestCase):
         return mean(tmpMapping)
 
 
-class TestConservation(AxialExpansionTestBase, unittest.TestCase):
+class TestConservation(AxialExpansionTestBase):
     """Verify that conservation is maintained in assembly-level axial expansion."""
 
     def setUp(self):
-        AxialExpansionTestBase.setUp(self)
+        super().setUp()
         self.a = buildTestAssemblyWithFakeMaterial(name="FakeMat")
-
-    def tearDown(self):
-        AxialExpansionTestBase.tearDown(self)
 
     def expandAssemForMassConservationTest(self):
         """Do the thermal expansion and store conservation metrics of interest."""
@@ -308,13 +299,13 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
         )
         assems = list(rCold.blueprints.assemblies.values())
         for a in assems:
-            if a.hasFlags([Flags.MIDDLE, Flags.ANNULAR, Flags.TEST]):
+            if a.hasFlags([Flags.MIDDLE, Flags.ANNULAR]):
                 # assemblies with the above flags have liners and conservation of such assemblies is
                 # not currently supported
                 continue
             self.complexConservationTest(a)
 
-    def complexConservationTest(self, a):
+    def complexConservationTest(self, a: HexAssembly):
         origMesh = a.getAxialMesh()[:-1]
         origMasses, origNDens = self._getComponentMassAndNDens(a)
         axialExpChngr = AxialExpansionChanger(detailedAxialExpansion=True)
@@ -327,15 +318,16 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
                     axialExpChngr.expansionData.updateComponentTemp(c, c.temperatureInC + temp)
             # get U235/B10 and FE56 mass pre-expansion
             prevFE56Mass = a.getMass("FE56")
-            prevMass = self._getMass(a)
+            if a.hasFlags([Flags.FUEL, Flags.CONTROL]):
+                prevMass = a.getMass("U235" if a.hasFlags(Flags.FUEL) else "B10")
             # compute thermal expansion coeffs and expand
             axialExpChngr.expansionData.computeThermalExpansionFactors()
             axialExpChngr.axiallyExpandAssembly()
             # ensure that total U235/B10 and FE56 mass is conserved post-expansion
             newFE56Mass = a.getMass("FE56")
-            newMass = self._getMass(a)
             self.assertAlmostEqual(newFE56Mass / prevFE56Mass, 1.0, places=14, msg=f"{a}")
-            if newMass:
+            if a.hasFlags([Flags.FUEL, Flags.CONTROL]):
+                newMass = a.getMass("U235" if a.hasFlags(Flags.FUEL) else "B10")
                 self.assertAlmostEqual(newMass / prevMass, 1.0, places=14, msg=f"{a}")
 
         newMasses, newNDens = self._getComponentMassAndNDens(a)
@@ -344,18 +336,6 @@ class TestConservation(AxialExpansionTestBase, unittest.TestCase):
             self.assertAlmostEqual(orig, new, places=12, msg=f"{a}")
         self._checkMass(origMasses, newMasses)
         self._checkNDens(origNDens, newNDens, 1.0)
-
-    @staticmethod
-    def _getMass(a):
-        """Get the mass of an assembly. The conservation of HT9 pins in shield assems are accounted
-        for in FE56 conservation checks.
-        """
-        newMass = None
-        if a.hasFlags(Flags.FUEL):
-            newMass = a.getMass("U235")
-        elif a.hasFlags(Flags.CONTROL):
-            newMass = a.getMass("B10")
-        return newMass
 
     def test_prescribedExpansionContractionConservation(self):
         """Expand all components and then contract back to original state.
@@ -645,16 +625,13 @@ class TestManageCoreMesh(unittest.TestCase):
                 self.assertAlmostEqual(newMass / prevMass, 1.00, msg=f"{c}, {c.parent}")
 
 
-class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
+class TestExceptions(AxialExpansionTestBase):
     """Verify exceptions are caught."""
 
     def setUp(self):
-        AxialExpansionTestBase.setUp(self)
+        super().setUp()
         self.a = buildTestAssemblyWithFakeMaterial(name="FakeMatException")
         self.obj.setAssembly(self.a)
-
-    def tearDown(self):
-        AxialExpansionTestBase.tearDown(self)
 
     def test_isTopDummyBlockPresent(self):
         # build test assembly without dummy
@@ -666,62 +643,54 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
         assembly.reestablishBlockOrder()
         # create instance of expansion changer
         obj = AxialExpansionChanger(detailedAxialExpansion=True)
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Cannot run detailedAxialExpansion without a dummy block at the top of the assembly!",
+        ):
             obj.setAssembly(assembly)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
 
     def test_setExpansionFactors(self):
-        with self.assertRaises(RuntimeError) as cm:
-            cList = self.a[0].getChildren()
-            expansionGrowthFracs = range(len(cList) + 1)
-            self.obj.expansionData.setExpansionFactors(cList, expansionGrowthFracs)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
+        cList = self.a.getFirstBlock().getChildren()
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Number of components and expansion fractions must be the same!",
+        ):
+            self.obj.expansionData.setExpansionFactors(cList, range(len(cList) + 1))
 
-        with self.assertRaises(RuntimeError) as cm:
-            cList = self.a[0].getChildren()
-            expansionGrowthFracs = zeros(len(cList))
-            self.obj.expansionData.setExpansionFactors(cList, expansionGrowthFracs)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "L1/L0, is not physical. Expansion fractions should be greater than 0.0.",
+        ):
+            self.obj.expansionData.setExpansionFactors(cList, zeros(len(cList)))
 
-        with self.assertRaises(RuntimeError) as cm:
-            cList = self.a[0].getChildren()
-            expansionGrowthFracs = zeros(len(cList)) - 10.0
-            self.obj.expansionData.setExpansionFactors(cList, expansionGrowthFracs)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "L1/L0, is not physical. Expansion fractions should be greater than 0.0.",
+        ):
+            self.obj.expansionData.setExpansionFactors(cList, zeros(len(cList)) - 10.0)
 
     def test_updateCompTempsBy1DTempFieldValError(self):
         tempGrid = [5.0, 15.0, 35.0]
         tempField = linspace(25.0, 310.0, 3)
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaisesRegex(ValueError, "has no temperature points within it!"):
             self.obj.expansionData.updateComponentTempsBy1DTempField(tempGrid, tempField)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
 
     def test_updateCompTempsBy1DTempFieldError(self):
         tempGrid = [5.0, 15.0, 35.0]
         tempField = linspace(25.0, 310.0, 10)
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(RuntimeError, "tempGrid and tempField must have the same length."):
             self.obj.expansionData.updateComponentTempsBy1DTempField(tempGrid, tempField)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
 
     def test_AssemblyAxialExpansionException(self):
         """Test that negative height exception is caught."""
         # manually set axial exp target component for code coverage
         self.a[0].p.axialExpTargetComponent = self.a[0][0].name
         temp = Temperature(self.a.getTotalHeight(), numTempGridPts=11, tempSteps=10)
-        with self.assertRaises(ArithmeticError) as cm:
+        with self.assertRaisesRegex(ArithmeticError, "has a negative height!"):
             for idt in range(temp.tempSteps):
                 self.obj.expansionData.updateComponentTempsBy1DTempField(temp.tempGrid, temp.tempField[idt, :])
                 self.obj.expansionData.computeThermalExpansionFactors()
                 self.obj.axiallyExpandAssembly()
-
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
 
     def test_isFuelLocked(self):
         """Ensures that the RuntimeError statement in ExpansionData::_isFuelLocked is raised
@@ -733,7 +702,7 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
         to ExpansionData::_isFuelLocked.
         """
         expdata = ExpansionData(HexAssembly("testAssemblyType"), setFuel=True, expandFromTinputToThot=False)
-        b_NoFuel = HexBlock("fuel", height=10.0)
+        bNoFuel = HexBlock("fuel", height=10.0)
         shieldDims = {
             "Tinput": 25.0,
             "Thot": 25.0,
@@ -742,39 +711,19 @@ class TestExceptions(AxialExpansionTestBase, unittest.TestCase):
             "mult": 127.0,
         }
         shield = Circle("shield", "FakeMat", **shieldDims)
-        b_NoFuel.add(shield)
-        with self.assertRaises(RuntimeError) as cm:
-            expdata._isFuelLocked(b_NoFuel)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
-
-    def test_determineLinked(self):
-        compDims = {"Tinput": 25.0, "Thot": 25.0}
-        compA = UnshapedComponent("unshaped_1", "FakeMat", **compDims)
-        compB = UnshapedComponent("unshaped_2", "FakeMat", **compDims)
-        self.assertFalse(areAxiallyLinked(compA, compB))
-
-    def test_getLinkedComponents(self):
-        """Test for multiple component axial linkage."""
-        shieldBlock = self.obj.linked.a[0]
-        shieldComp = shieldBlock[0]
-        shieldComp.setDimension("od", 0.785, cold=True)
-        with self.assertRaises(RuntimeError) as cm:
-            self.obj.linked._getLinkedComponents(shieldBlock, shieldComp)
-            self.assertEqual(cm.exception, 3)
+        bNoFuel.add(shield)
+        with self.assertRaisesRegex(RuntimeError, f"No fuel component within {bNoFuel}!"):
+            expdata._isFuelLocked(bNoFuel)
 
 
-class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
+class TestDetermineTargetComponent(AxialExpansionTestBase):
     """Verify determineTargetComponent method is properly updating _componentDeterminesBlockHeight."""
 
     def setUp(self):
-        AxialExpansionTestBase.setUp(self)
+        super().setUp()
         self.expData = ExpansionData([], setFuel=True, expandFromTinputToThot=True)
         coolDims = {"Tinput": 25.0, "Thot": 25.0}
         self.coolant = DerivedShape("coolant", "Sodium", **coolDims)
-
-    def tearDown(self):
-        AxialExpansionTestBase.tearDown(self)
 
     def test_determineTargetComponent(self):
         """Provides coverage for searching TARGET_FLAGS_IN_PREFERRED_ORDER."""
@@ -822,14 +771,10 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         b = HexBlock("fuel", height=10.0)
         b.add(self.coolant)
         b.setType("fuel")
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(RuntimeError, "No target component found!"):
             self.expData.determineTargetComponent(b)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(RuntimeError, "No target component found!"):
             self.expData.determineTargetComponent(b, Flags.FUEL)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
 
     def test_specifyTargetComp_singleSolid(self):
         """Ensures that specifyTargetComponent is smart enough to set the only solid as the target component."""
@@ -865,10 +810,11 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
         b.add(fuelAnnular)
         b.add(self.coolant)
         b.setType("FuelBlock")
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Cannot have more than one component within a block that has the target flag!",
+        ):
             self.expData.determineTargetComponent(b, flagOfInterest=Flags.FUEL)
-            the_exception = cm.exception
-            self.assertEqual(the_exception.error_code, 3)
 
     def test_manuallySetTargetComponent(self):
         """
@@ -901,12 +847,10 @@ class TestDetermineTargetComponent(AxialExpansionTestBase, unittest.TestCase):
 class TestGetSolidComponents(unittest.TestCase):
     """Verify that getSolidComponents returns just solid components."""
 
-    def setUp(self):
-        self.a = buildTestAssemblyWithFakeMaterial(name="HT9")
-
     def test_getSolidComponents(self):
         """Show that getSolidComponents produces a list of solids, and is consistent with iterSolidComponents."""
-        for b in self.a:
+        a = buildTestAssemblyWithFakeMaterial(name="HT9")
+        for b in a:
             solids = getSolidComponents(b)
             ids = set(map(id, solids))
             for c in iterSolidComponents(b):
@@ -917,6 +861,16 @@ class TestGetSolidComponents(unittest.TestCase):
                 ids,
                 msg="Inconsistency between getSolidComponents and iterSolidComponents",
             )
+
+    def test_checkForBlocksWithoutSolids(self):
+        a = buildTestAssemblyWithFakeMaterial(name="Sodium")
+        changer = AxialExpansionChanger()
+        changer.linked = AssemblyAxialLinkage(a)
+        with self.assertRaisesRegex(
+            InputError,
+            expected_regex="is constructed improperly for use with the axial expansion changer",
+        ):
+            changer._checkForBlocksWithoutSolids()
 
 
 class TestInputHeightsConsideredHot(unittest.TestCase):
@@ -970,17 +924,14 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                 ),
             )
             for bStd, bExp in zip(aStd, aExp):
-                hasCustomMaterial = any(isinstance(c.material, custom.Custom) for c in bStd)
-                if hasCustomMaterial:
+                if any(isinstance(c.material, custom.Custom) for c in bStd):
                     checkColdBlockHeight(bStd, bExp, self.assertAlmostEqual, "the same")
                 else:
                     checkColdBlockHeight(bStd, bExp, self.assertNotEqual, "different")
-                if bStd.hasFlags(Flags.FUEL):
-                    self.checkColdHeightBlockMass(bStd, bExp, Flags.FUEL, "U235")
-                elif bStd.hasFlags(Flags.CONTROL):
-                    self.checkColdHeightBlockMass(bStd, bExp, Flags.CONTROL, "B10")
-
-                if not aStd.hasFlags(Flags.TEST) and not hasCustomMaterial:
+                    if bStd.hasFlags(Flags.FUEL):
+                        self.checkColdHeightBlockMass(bStd, bExp, "U235")
+                    elif bStd.hasFlags(Flags.CONTROL):
+                        self.checkColdHeightBlockMass(bStd, bExp, "B10")
                     for cExp in iterSolidComponents(bExp):
                         if cExp.zbottom == bExp.p.zbottom and cExp.ztop == bExp.p.ztop:
                             matDens = cExp.material.density(Tc=cExp.temperatureInC)
@@ -997,7 +948,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
                                 msg=msg,
                             )
 
-    def checkColdHeightBlockMass(self, bStd: HexBlock, bExp: HexBlock, flagType: Flags, nuclide: str):
+    def checkColdHeightBlockMass(self, bStd: HexBlock, bExp: HexBlock, nuclide: str):
         """Checks that nuclide masses for blocks with input cold heights and
         "inputHeightsConsideredHot": True are underpredicted.
 
@@ -1008,12 +959,10 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
         ultimately results in nuclide masses being underpredicted relative to the case where both
         nuclide densities and block heights are thermally expanded.
         """
-        # custom materials don't expand
-        if not isinstance(bStd.getComponent(flagType).material, custom.Custom):
-            self.assertGreater(bExp.getMass(nuclide), bStd.getMass(nuclide))
+        self.assertGreater(bExp.getMass(nuclide), bStd.getMass(nuclide))
 
 
-def checkColdBlockHeight(bStd, bExp, assertType, strForAssertion):
+def checkColdBlockHeight(bStd: HexBlock, bExp: HexBlock, assertType: Callable, strForAssertion: str):
     assertType(
         bStd.getHeight(),
         bExp.getHeight(),
@@ -1026,160 +975,6 @@ def checkColdBlockHeight(bStd, bExp, assertType, strForAssertion):
             strForAssertion,
         ),
     )
-
-
-class TestComponentLinks(AxialExpansionTestBase, unittest.TestCase):
-    """Test axial linkage between components."""
-
-    def setUp(self):
-        """Contains common dimensions for all component class types."""
-        AxialExpansionTestBase.setUp(self)
-        self.common = ("test", "FakeMat", 25.0, 25.0)  # name, material, Tinput, Thot
-
-    def tearDown(self):
-        AxialExpansionTestBase.tearDown(self)
-
-    def runTest(
-        self,
-        componentsToTest: dict,
-        assertionBool: bool,
-        name: str,
-        commonArgs: tuple = None,
-    ):
-        """Runs various linkage tests.
-
-        Parameters
-        ----------
-        componentsToTest : dict
-            keys --> component class type; values --> dimensions specific to key
-        assertionBool : boolean
-            expected truth value for test
-        name : str
-            the name of the test
-        commonArgs : tuple, optional
-            arguments common to all Component class types
-
-        Notes
-        -----
-        - components "typeA" and "typeB" are assumed to be vertically stacked
-        - two assertions: 1) comparing "typeB" component to "typeA"; 2) comparing "typeA" component
-          to "typeB"
-        - the different assertions are particularly useful for comparing two annuli
-        - to add Component class types to a test add dictionary entry with following:
-          {Component Class Type: [{<settings for component 1>}, {<settings for component 2>}]
-        """
-        if commonArgs is None:
-            common = self.common
-        else:
-            common = commonArgs
-        for method, dims in componentsToTest.items():
-            typeA = method(*common, **dims[0])
-            typeB = method(*common, **dims[1])
-            if assertionBool:
-                self.assertTrue(
-                    areAxiallyLinked(typeA, typeB),
-                    msg="Test {0:s} failed for component type {1:s}!".format(name, str(method)),
-                )
-                self.assertTrue(
-                    areAxiallyLinked(typeB, typeA),
-                    msg="Test {0:s} failed for component type {1:s}!".format(name, str(method)),
-                )
-            else:
-                self.assertFalse(
-                    areAxiallyLinked(typeA, typeB),
-                    msg="Test {0:s} failed for component type {1:s}!".format(name, str(method)),
-                )
-                self.assertFalse(
-                    areAxiallyLinked(typeB, typeA),
-                    msg="Test {0:s} failed for component type {1:s}!".format(name, str(method)),
-                )
-
-    def test_overlappingSolidPins(self):
-        componentTypesToTest = {
-            Circle: [{"od": 0.5, "id": 0.0}, {"od": 1.0, "id": 0.0}],
-            Hexagon: [{"op": 0.5, "ip": 0.0}, {"op": 1.0, "ip": 0.0}],
-            Rectangle: [
-                {
-                    "lengthOuter": 0.5,
-                    "lengthInner": 0.0,
-                    "widthOuter": 0.5,
-                    "widthInner": 0.0,
-                },
-                {
-                    "lengthOuter": 1.0,
-                    "lengthInner": 0.0,
-                    "widthOuter": 1.0,
-                    "widthInner": 0.0,
-                },
-            ],
-            Helix: [
-                {"od": 0.5, "axialPitch": 1.0, "helixDiameter": 1.0},
-                {"od": 1.0, "axialPitch": 1.0, "helixDiameter": 1.0},
-            ],
-        }
-        self.runTest(componentTypesToTest, True, "test_overlappingSolidPins")
-
-    def test_differentMultNotOverlapping(self):
-        componentTypesToTest = {
-            Circle: [{"od": 0.5, "mult": 10}, {"od": 0.5, "mult": 20}],
-            Hexagon: [{"op": 0.5, "mult": 10}, {"op": 1.0, "mult": 20}],
-            Rectangle: [
-                {"lengthOuter": 1.0, "widthOuter": 1.0, "mult": 10},
-                {"lengthOuter": 1.0, "widthOuter": 1.0, "mult": 20},
-            ],
-            Helix: [
-                {"od": 0.5, "axialPitch": 1.0, "helixDiameter": 1.0, "mult": 10},
-                {"od": 1.0, "axialPitch": 1.0, "helixDiameter": 1.0, "mult": 20},
-            ],
-        }
-        self.runTest(componentTypesToTest, False, "test_differentMultNotOverlapping")
-
-    def test_solidPinNotOverlappingAnnulus(self):
-        componentTypesToTest = {
-            Circle: [{"od": 0.5, "id": 0.0}, {"od": 1.0, "id": 0.6}],
-        }
-        self.runTest(componentTypesToTest, False, "test_solidPinNotOverlappingAnnulus")
-
-    def test_solidPinOverlappingWithAnnulus(self):
-        componentTypesToTest = {
-            Circle: [{"od": 0.7, "id": 0.0}, {"od": 1.0, "id": 0.6}],
-        }
-        self.runTest(componentTypesToTest, True, "test_solidPinOverlappingWithAnnulus")
-
-    def test_annularPinNotOverlappingWithAnnulus(self):
-        componentTypesToTest = {
-            Circle: [{"od": 0.6, "id": 0.3}, {"od": 1.0, "id": 0.6}],
-        }
-        self.runTest(componentTypesToTest, False, "test_annularPinNotOverlappingWithAnnulus")
-
-    def test_annularPinOverlappingWithAnnuls(self):
-        componentTypesToTest = {
-            Circle: [{"od": 0.7, "id": 0.3}, {"od": 1.0, "id": 0.6}],
-        }
-        self.runTest(componentTypesToTest, True, "test_annularPinOverlappingWithAnnuls")
-
-    def test_thinAnnularPinOverlappingWithThickAnnulus(self):
-        componentTypesToTest = {
-            Circle: [{"od": 0.7, "id": 0.3}, {"od": 0.6, "id": 0.5}],
-        }
-        self.runTest(componentTypesToTest, True, "test_thinAnnularPinOverlappingWithThickAnnulus")
-
-    def test_AnnularHexOverlappingThickAnnularHex(self):
-        componentTypesToTest = {Hexagon: [{"op": 1.0, "ip": 0.8}, {"op": 1.2, "ip": 0.8}]}
-        self.runTest(componentTypesToTest, True, "test_AnnularHexOverlappingThickAnnularHex")
-
-    def test_liquids(self):
-        componentTypesToTest = {
-            Circle: [{"od": 1.0, "id": 0.0}, {"od": 1.0, "id": 0.0}],
-            Hexagon: [{"op": 1.0, "ip": 0.0}, {"op": 1.0, "ip": 0.0}],
-        }
-        liquid = ("test", "Sodium", 425.0, 425.0)  # name, material, Tinput, Thot
-        self.runTest(componentTypesToTest, False, "test_liquids", commonArgs=liquid)
-
-    def test_unshapedComponentAndCircle(self):
-        comp1 = Circle(*self.common, od=1.0, id=0.0)
-        comp2 = UnshapedComponent(*self.common, area=1.0)
-        self.assertFalse(areAxiallyLinked(comp1, comp2))
 
 
 def buildTestAssemblyWithFakeMaterial(name: str, hot: bool = False):
@@ -1301,91 +1096,3 @@ class FakeMatException(materials.ht9.HT9):
         """A fake linear expansion percent."""
         Tc = units.getTc(Tc, Tk)
         return 0.08 * Tc
-
-
-class TestAxialLinkHelper(unittest.TestCase):
-    """Tests for the AxialLink dataclass / namedtuple like class."""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.LOWER_BLOCK = _buildDummySodium(20, 10)
-        cls.UPPER_BLOCK = _buildDummySodium(300, 50)
-
-    def test_override(self):
-        """Test the upper and lower attributes can be set after construction."""
-        empty = AxialLink()
-        self.assertIsNone(empty.lower)
-        self.assertIsNone(empty.upper)
-        empty.lower = self.LOWER_BLOCK
-        empty.upper = self.UPPER_BLOCK
-        self.assertIs(empty.lower, self.LOWER_BLOCK)
-        self.assertIs(empty.upper, self.UPPER_BLOCK)
-
-    def test_construct(self):
-        """Test the upper and lower attributes can be set at construction."""
-        link = AxialLink(self.LOWER_BLOCK, self.UPPER_BLOCK)
-        self.assertIs(link.lower, self.LOWER_BLOCK)
-        self.assertIs(link.upper, self.UPPER_BLOCK)
-
-
-class TestBlockLink(unittest.TestCase):
-    """Test the ability to link blocks in an assembly."""
-
-    def test_singleBlock(self):
-        """Test an edge case where a single block exists."""
-        b = _buildDummySodium(300, 50)
-        links = AssemblyAxialLinkage.getLinkedBlocks([b])
-        self.assertEqual(len(links), 1)
-        self.assertIn(b, links)
-        linked = links.pop(b)
-        self.assertIsNone(linked.lower)
-        self.assertIsNone(linked.upper)
-
-    def test_multiBlock(self):
-        """Test links with multiple blocks."""
-        N_BLOCKS = 5
-        blocks = [_buildDummySodium(300, 50) for _ in range(N_BLOCKS)]
-        links = AssemblyAxialLinkage.getLinkedBlocks(blocks)
-        first = blocks[0]
-        lowLink = links[first]
-        self.assertIsNone(lowLink.lower)
-        self.assertIs(lowLink.upper, blocks[1])
-        for ix in range(1, N_BLOCKS - 1):
-            current = blocks[ix]
-            below = blocks[ix - 1]
-            above = blocks[ix + 1]
-            link = links[current]
-            self.assertIs(link.lower, below)
-            self.assertIs(link.upper, above)
-        top = blocks[-1]
-        lastLink = links[top]
-        self.assertIsNone(lastLink.upper)
-        self.assertIs(lastLink.lower, blocks[-2])
-
-    def test_emptyBlocks(self):
-        """Test even smaller edge case when no blocks are passed."""
-        with self.assertRaisesRegex(ValueError, "No blocks passed. Cannot determine links"):
-            AssemblyAxialLinkage.getLinkedBlocks([])
-
-    def test_onAssembly(self):
-        """Test assembly behavior is the same as sequence of blocks."""
-        assembly = HexAssembly("test")
-        N_BLOCKS = 5
-        assembly.spatialGrid = grids.AxialGrid.fromNCells(numCells=N_BLOCKS)
-        assembly.spatialGrid.armiObject = assembly
-
-        blocks = []
-        for _ in range(N_BLOCKS):
-            b = _buildDummySodium(300, 10)
-            assembly.add(b)
-            blocks.append(b)
-
-        fromBlocks = AssemblyAxialLinkage.getLinkedBlocks(blocks)
-        fromAssem = AssemblyAxialLinkage.getLinkedBlocks(assembly)
-
-        self.assertSetEqual(set(fromBlocks), set(fromAssem))
-
-        for b, bLink in fromBlocks.items():
-            aLink = fromAssem[b]
-            self.assertIs(aLink.lower, bLink.lower)
-            self.assertIs(aLink.upper, bLink.upper)

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -39,7 +39,6 @@ class DummyFluxOptions:
 class TestConverterFactory(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion"))
-        reduceTestReactorRings(self.r, self.o.cs, 2)
 
         self.dummyOptions = DummyFluxOptions(self.o.cs)
 
@@ -62,7 +61,6 @@ class TestAssemblyUniformMesh(unittest.TestCase):
 
     def setUp(self):
         self.o, self.r = loadTestReactor(inputFilePath=os.path.join(TEST_ROOT, "detailedAxialExpansion"))
-        reduceTestReactorRings(self.r, self.o.cs, 2)
 
         self.converter = uniformMesh.NeutronicsUniformMeshConverter(cs=self.o.cs)
         self.converter._sourceReactor = self.r
@@ -81,7 +79,8 @@ class TestAssemblyUniformMesh(unittest.TestCase):
         )
 
         prevB = None
-        for newB, sourceB in zip(newAssem, sourceAssem):
+        for newB in newAssem:
+            sourceB = sourceAssem.getBlockAtElevation(newB.p.z)
             if newB.isFuel() and sourceB.isFuel():
                 self.assertEqual(newB.p["xsType"], sourceB.p["xsType"])
             elif not newB.isFuel() and not sourceB.isFuel():

--- a/armi/tests/detailedAxialExpansion/refSmallCoreGrid.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallCoreGrid.yaml
@@ -2,12 +2,20 @@ core:
   geom: hex
   symmetry: third periodic
   lattice map: |
-         -  PC
-          IC  IC
-            IC  OC
-          IC  LA  IC
-            IC  IC  SC
-              LA  IC
-            IC  IC  OC
-              IC  IC
-            AF  IC  OC
+    SH
+      AF
+    MC  SH
+      LA
+    PC  IC
+
+fourPin:
+  geom: hex_corners_up
+  symmetry: full
+  lattice map: |
+    - - -  1 4 4 1
+      - - 1 4 2 4 1
+       - 1 4 3 3 4 1
+        1 2 3 2 3 2 1
+         1 4 3 3 4 1
+          1 4 2 4 1
+           1 4 4 1

--- a/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
+++ b/armi/tests/detailedAxialExpansion/refSmallReactorBase.yaml
@@ -40,7 +40,7 @@ blocks:
             Thot: 450.0
             ip: grid.op
             mult: 1.0
-            op: 16.75
+            op: 19.0
 
     duct: &block_duct
         coolant: *component_coolant
@@ -49,9 +49,9 @@ blocks:
             material: HT9
             Tinput: 25.0
             Thot: 450.0
-            ip: 16.0
+            ip: 18.0
             mult: 1.0
-            op: 16.6
+            op: 18.5
         intercoolant: &component_intercoolant
             shape: Hexagon
             material: Sodium
@@ -59,7 +59,7 @@ blocks:
             Thot: 450.0
             ip: duct.op
             mult: 1.0
-            op: 16.75
+            op: 19.0
 
     SodiumBlock: &block_dummy
         flags: dummy
@@ -70,7 +70,7 @@ blocks:
             Thot: 450.0
             ip: 0.0
             mult: 1.0
-            op: 16.75
+            op: 19.0
 
     ## ------------------------------------------------------------------------------------
     ## fuel blocks
@@ -113,7 +113,84 @@ blocks:
         duct: *component_duct
         intercoolant: *component_intercoolant
 
-    fuel: &block_fuel
+    axial shield multiPin: &block_fuel_multiPin_axial_shield
+        grid name: fourPin
+        shield 1: &component_shield_shield1
+            shape: Circle
+            material: HT9
+            Tinput: 25.0
+            Thot: 600.0
+            id: 0.0
+            od: 0.86602
+            latticeIDs: [1]
+        bond 1: &component_shield_bond1
+            shape: Circle
+            material: Sodium
+            Tinput: 25.0
+            Thot: 470.0
+            id: shield 1.od
+            od: clad 1.id
+            latticeIDs: [1]
+        clad 1: &component_shield_clad1
+            shape: Circle
+            material: HT9
+            Tinput: 25.0
+            Thot: 470.0
+            id: 1.0
+            od: 1.09
+            latticeIDs: [1]
+        wire 1: &component_shield_wire1
+            shape: Helix
+            material: HT9
+            Tinput: 25.0
+            Thot: 470.0
+            axialPitch: 30.15
+            helixDiameter: 1.19056
+            id: 0.0
+            od: 0.10056
+            latticeIDs: [1]
+        shield 2:
+            <<: *component_shield_shield1
+            latticeIDs: [2]
+        bond 2:
+            <<: *component_shield_bond1
+            latticeIDs: [2]
+        clad 2:
+            <<: *component_shield_clad1
+            latticeIDs: [2]
+        wire 2:
+            <<: *component_shield_wire1
+            latticeIDs: [2]
+        shield 3:
+            <<: *component_shield_shield1
+            latticeIDs: [3]
+        bond 3:
+            <<: *component_shield_bond1
+            latticeIDs: [3]
+        clad 3:
+            <<: *component_shield_clad1
+            latticeIDs: [3]
+        wire 3:
+            <<: *component_shield_wire1
+            latticeIDs: [3]
+        shield 4:
+            <<: *component_shield_shield1
+            latticeIDs: [4]
+        bond 4:
+            <<: *component_shield_bond1
+            latticeIDs: [4]
+        clad 4:
+            <<: *component_shield_clad1
+            latticeIDs: [4]
+        wire 4:
+            <<: *component_shield_wire1
+            latticeIDs: [4]
+        coolant: *component_coolant
+        duct: *component_duct
+        intercoolant: *component_intercoolant
+        axial expansion target component: shield 1
+
+    fuel: &block_fuelPin
         fuel: &component_fuel_fuel
             shape: Circle
             material: UZr
@@ -122,7 +199,7 @@ blocks:
             id: 0.0
             mult: 169.0
             od: 0.86602
-        bond: &component_fuel_bond
+        bond:
             shape: Circle
             material: Sodium
             Tinput: 25.0
@@ -146,129 +223,46 @@ blocks:
             axialPitch: 30.15
             helixDiameter: 1.19056
             id: 0.0
-            mult: fuel.mult
-            od: 0.10056
-        coolant: *component_coolant
-        duct: *component_duct
-        intercoolant: *component_intercoolant
-
-    plenum: &block_plenum
-        gap: &component_plenum_gap
-            shape: Circle
-            material: Void
-            Tinput: 25.0
-            Thot: 600.0
-            id: 0.0
-            mult: clad.mult
-            od: clad.id
-        clad: &component_plenum_clad
-            shape: Circle
-            material: HT9
-            Tinput: 25.0
-            Thot: 470.0
-            id: 1.0
-            mult: 169.0
-            od: 1.09
-        wire: &component_plenum_wire
-            shape: Helix
-            material: HT9
-            Tinput: 25.0
-            Thot: 470.0
-            axialPitch: 30.15
-            helixDiameter: 1.19056
-            id: 0.0
             mult: clad.mult
             od: 0.10056
         coolant: *component_coolant
         duct: *component_duct
         intercoolant: *component_intercoolant
 
-    aclp plenum: &block_aclp
-        gap: *component_plenum_gap
-        clad: *component_plenum_clad
-        wire: *component_plenum_wire
-        coolant: *component_coolant
-        duct: *component_duct
-        intercoolant: *component_intercoolant
-
-    fuel2: &block_fuel2
+    fuel lined clad: &block_fuelPin_linedClad
         fuel:
-            shape: Circle
+            <<: *component_fuel_fuel
             material: Custom
-            Tinput: 25.0
-            Thot: 600.0
-            id: 0.0
             isotopics: MOX
-            mult: 169.0
-            od: 0.86602
         bond:
             shape: Circle
             material: Sodium
             Tinput: 25.0
-            Thot: 600.0
+            Thot: 470.0
             id: fuel.od
             mult: fuel.mult
-            od: liner2.id
-        liner2: &component_fuel2_liner2
+            od: liner.id
+        liner: &component_fuel_liner
             shape: Circle
             material: HT9
             Tinput: 25.0
-            Thot: 600.0
-            id: 0.98
+            Thot: 470.0
+            id: 0.90
             mergeWith: clad
             mult: 169.0
-            od: 0.99
-        liner1: &component_fuel2_liner1
-            shape: Circle
-            material: HT9
-            Tinput: 25.0
-            Thot: 600.0
-            id: 0.99
-            mergeWith: clad
-            mult: 169.0
-            od: 1.0
+            od: clad.id
         clad: *component_fuel_clad
         wire: *component_fuel_wire
         coolant: *component_coolant
         duct: *component_duct
         intercoolant: *component_intercoolant
 
-    lta fuel a: &block_lta1_fuel
-        fuel: *component_fuel_fuel
-        bond: *component_fuel_bond
-        liner2: *component_fuel2_liner2
-        liner1: *component_fuel2_liner1
-        clad: *component_fuel_clad
-        wire: *component_fuel_wire
-        coolant: *component_coolant
-        duct: *component_duct
-        intercoolant: *component_intercoolant
-
-    lta fuel b: &block_lta2_fuel
-        fuel:
-            shape: Circle
-            material: UZr
-            Tinput: 25.0
-            Thot: 600.0
-            id: 0.0
-            isotopics: PuUZr
-            mult: 169.0
-            od: 0.86602
-        bond: *component_fuel_bond
-        liner2: *component_fuel2_liner2
-        liner1: *component_fuel2_liner1
-        clad: *component_fuel_clad
-        wire: *component_fuel_wire
-        coolant: *component_coolant
-        duct: *component_duct
-        intercoolant: *component_intercoolant
-
-    annular fuel gap: &block_fuel3
+    annular fuel lined clad: &block_fuelAnnular_linedClad
         gap1:
             shape: Circle
             material: Void
             Tinput: 25.0
-            Thot: 430.0
+            Thot: 600.0
             id: 0.0
             mult: fuel.mult
             od: fuel.id
@@ -281,58 +275,158 @@ blocks:
             mult: 169.0
             od: 0.86602
             flags: annular fuel depletable
-        gap2:
+        gap:
             shape: Circle
             material: Void
             Tinput: 25.0
-            Thot: 430.0
+            Thot: 600.0
             id: fuel.od
             mult: fuel.mult
-            od: inner liner.id
-        inner liner:
+            od: liner.id
+        liner: *component_fuel_liner
+        clad: *component_fuel_clad
+        wire: *component_fuel_wire
+        coolant: *component_coolant
+        duct: *component_duct
+        intercoolant: *component_intercoolant
+
+    fuel multiPin: &block_fuel_multiPin
+        grid name: fourPin
+        fuel 1: &component_fuelmultiPin
+            shape: Circle
+            material: UZr
+            Tinput: 25.0
+            Thot: 600.0
+            id: 0.0
+            od: 0.86602
+            latticeIDs: [1]
+        bond 1: &component_fuelmultiPin_bond
+            shape: Circle
+            material: Sodium
+            Tinput: 25.0
+            Thot: 470.0
+            id: fuel 1.od
+            od: clad 1.id
+            latticeIDs: [1]
+        clad 1: &component_fuelmultiPin_clad1
             shape: Circle
             material: HT9
             Tinput: 25.0
-            Thot: 430.0
-            id: 0.878
-            mult: fuel.mult
-            od: 0.898
-        gap3:
+            Thot: 470.0
+            id: 1.0
+            od: 1.09
+            latticeIDs: [1]
+        wire 1: &component_fuelmultiPin_wire1
+            shape: Helix
+            material: HT9
+            Tinput: 25.0
+            Thot: 470.0
+            axialPitch: 30.15
+            helixDiameter: 1.19056
+            id: 0.0
+            od: 0.10056
+            latticeIDs: [1]
+        fuel 2:
+            <<: *component_fuelmultiPin
+            latticeIDs: [2]
+        bond 2:
+            <<: *component_fuelmultiPin_bond
+            latticeIDs: [2]
+        clad 2: &component_fuelmultiPin_clad2
+            <<: *component_fuelmultiPin_clad1
+            latticeIDs: [2]
+        wire 2: &component_fuelmultiPin_wire2
+            <<: *component_fuelmultiPin_wire1
+            latticeIDs: [2]
+        fuel 3:
+            <<: *component_fuelmultiPin
+            latticeIDs: [3]
+        bond 3:
+            <<: *component_fuelmultiPin_bond
+            latticeIDs: [3]
+        clad 3: &component_fuelmultiPin_clad3
+            <<: *component_fuelmultiPin_clad1
+            latticeIDs: [3]
+        wire 3: &component_fuelmultiPin_wire3
+            <<: *component_fuelmultiPin_wire1
+            latticeIDs: [3]
+        fuel 4:
+            <<: *component_fuelmultiPin
+            latticeIDs: [4]
+        bond 4:
+            <<: *component_fuelmultiPin_bond
+            latticeIDs: [4]
+        clad 4: &component_fuelmultiPin_clad4
+            <<: *component_fuelmultiPin_clad1
+            latticeIDs: [4]
+        wire 4: &component_fuelmultiPin_wire4
+            <<: *component_fuelmultiPin_wire1
+            latticeIDs: [4]
+        coolant: *component_coolant
+        duct: *component_duct
+        intercoolant: *component_intercoolant
+        axial expansion target component: fuel 1
+
+    plenum: &block_plenum
+        gap:
             shape: Circle
             material: Void
             Tinput: 25.0
-            Thot: 430.0
-            id: inner liner.od
-            mult: fuel.mult
-            od: outer liner.id
-        outer liner:
-            shape: Circle
-            material: Zr
-            Tinput: 25.0
-            Thot: 430.0
-            id: 0.898
-            mult: fuel.mult
-            od: 0.900
-        gap4:
-            shape: Circle
-            material: Void
-            Tinput: 25.0
-            Thot: 430.0
-            id: outer liner.od
-            mult: fuel.mult
+            Thot: 600.0
+            id: 0.0
+            mult: clad.mult
             od: clad.id
         clad:
             shape: Circle
             material: HT9
             Tinput: 25.0
             Thot: 470.0
-            id: 0.900
-            mult: fuel.mult
-            od: 1.000
+            id: 1.0
+            mult: 169.0
+            od: 1.09
         wire: *component_fuel_wire
         coolant: *component_coolant
         duct: *component_duct
         intercoolant: *component_intercoolant
+        axial expansion target component: clad
+
+    aclp plenum: &block_aclp
+        <<: *block_plenum
+
+    plenum 4pin: &block_plenum_multiPin
+        grid name: fourPin
+        gap 1: &component_plenummultiPin_gap1
+            shape: Circle
+            material: Void
+            Tinput: 25.0
+            Thot: 600.0
+            id: 0.0
+            od: clad 1.id
+            latticeIDs: [1]
+        clad 1: *component_fuelmultiPin_clad1
+        wire 1: *component_fuelmultiPin_wire1
+        gap 2:
+            <<: *component_plenummultiPin_gap1
+            latticeIDs: [2]
+        clad 2: *component_fuelmultiPin_clad2
+        wire 2: *component_fuelmultiPin_wire2
+        gap 3:
+            <<: *component_plenummultiPin_gap1
+            latticeIDs: [3]
+        clad 3: *component_fuelmultiPin_clad3
+        wire 3: *component_fuelmultiPin_wire3
+        gap 4:
+            <<: *component_plenummultiPin_gap1
+            latticeIDs: [4]
+        clad 4: *component_fuelmultiPin_clad4
+        wire 4: *component_fuelmultiPin_wire4
+        coolant: *component_coolant
+        duct: *component_duct
+        intercoolant: *component_intercoolant
+        axial expansion target component: clad 1
+
+    aclp plenum 4pin: &block_aclp_multiPin
+        <<: *block_plenum_multiPin
 
     ## ------------------------------------------------------------------------------------
     ## control
@@ -353,7 +447,7 @@ blocks:
             Thot: 450.0
             ip: duct.op
             mult: 1.0
-            op: 16.75
+            op: 19.0
 
     moveable control: &block_control
         control:
@@ -461,12 +555,7 @@ blocks:
         intercoolant: *component_intercoolant
 
     radial shield aclp: &block_shield_aclp
-        gap: *component_radial_shield_gap
-        clad: *component_radial_shield_clad
-        wire: *component_radial_shield_wire
-        coolant: *component_coolant
-        duct: *component_duct
-        intercoolant: *component_intercoolant
+        <<: *block_shield_plenum
         axial expansion target component: clad # not necessary, but useful for testing coverage
 
 assemblies:
@@ -474,59 +563,35 @@ assemblies:
     axial mesh points: &standard_axial_mesh_points [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     igniter fuel:
         specifier: IC
-        blocks: &igniter_fuel_blocks [*block_grid_plate, *block_fuel_axial_shield, *block_fuel, *block_fuel, *block_fuel, *block_plenum, *block_aclp, *block_plenum, *block_duct, *block_dummy]
+        blocks: [*block_grid_plate, *block_fuel_axial_shield, *block_fuelPin, *block_fuelPin, *block_fuelPin, *block_plenum, *block_aclp, *block_plenum, *block_duct, *block_dummy]
         height: *highOffset_height
         axial mesh points: *standard_axial_mesh_points
         material modifications:
-            U235_wt_frac: &igniter_fuel_u235_wt_frac ['', '', 0.11, 0.11, 0.11, '', '', '', '', '']
-            ZR_wt_frac: &igniter_fuel_zr_wt_frac ['', '', 0.06, 0.06, 0.06, '', '', '', '', '']
+            U235_wt_frac: ['', '', 0.11, 0.11, 0.11, '', '', '', '', '']
+            ZR_wt_frac: ['', '', 0.06, 0.06, 0.06, '', '', '', '', '']
         xs types: &igniter_fuel_xs_types [A, A, B, C, C, D, A, A, A, A]
     middle fuel:
         specifier: MC
-        blocks: [*block_grid_plate, *block_fuel_axial_shield, *block_fuel2, *block_fuel2, *block_fuel2, *block_plenum, *block_aclp, *block_plenum, *block_duct, *block_dummy]
+        blocks: [*block_grid_plate, *block_fuel_axial_shield, *block_fuelPin_linedClad, *block_fuelPin_linedClad, *block_fuelPin_linedClad, *block_plenum, *block_aclp, *block_plenum, *block_duct, *block_dummy]
         height: [25.0, 26.25, 26.25, 26.25, 26.25, 20.0, 25.0, 25.0, 25.0, 17.5]
         axial mesh points: *standard_axial_mesh_points
         xs types: *igniter_fuel_xs_types
     annular fuel:
         specifier: AF
-        blocks: [*block_grid_plate, *block_fuel_axial_shield, *block_fuel3, *block_fuel3, *block_fuel3, *block_plenum, *block_aclp, *block_plenum, *block_duct, *block_dummy]
+        blocks: [*block_grid_plate, *block_fuel_axial_shield, *block_fuelAnnular_linedClad, *block_fuelAnnular_linedClad, *block_fuelAnnular_linedClad, *block_plenum, *block_aclp, *block_plenum, *block_duct, *block_dummy]
         height: *highOffset_height
         axial mesh points: *standard_axial_mesh_points
         xs types: *igniter_fuel_xs_types
-    lead test fuel:
+    multi pin fuel:
         specifier: LA
-        blocks: [*block_grid_plate, *block_fuel_axial_shield, *block_lta1_fuel, *block_lta1_fuel, *block_lta1_fuel, *block_plenum, *block_aclp, *block_plenum, *block_duct, *block_dummy]
+        blocks: [*block_grid_plate, *block_fuel_multiPin_axial_shield, *block_fuel_multiPin, *block_fuel_multiPin, *block_fuel_multiPin, *block_plenum_multiPin, *block_aclp_multiPin, *block_plenum_multiPin, *block_duct, *block_dummy]
         height: *highOffset_height
         axial mesh points: *standard_axial_mesh_points
         material modifications:
-            U235_wt_frac: &lta_fuel_u235_wt_frac ['', '', 0.2, 0.2, 0.2, '', '', '', '', '']
-            ZR_wt_frac: &lta_fuel_zr_wt_frac ['', '', 0.07, 0.07, 0.06, '', '', '', '', '']
+            U235_wt_frac: ['', '', 0.2, 0.2, 0.2, '', '', '', '', '']
+            ZR_wt_frac: ['', '', 0.07, 0.07, 0.06, '', '', '', '', '']
         xs types: *igniter_fuel_xs_types
-    lead test fuel b:
-        specifier: LB
-        blocks: [*block_grid_plate, *block_fuel_axial_shield, *block_lta2_fuel, *block_lta2_fuel, *block_lta2_fuel, *block_plenum, *block_aclp, *block_plenum, *block_duct, *block_dummy]
-        height: *highOffset_height
-        axial mesh points: *standard_axial_mesh_points
-        material modifications:
-            U235_wt_frac: *lta_fuel_u235_wt_frac
-            ZR_wt_frac: *lta_fuel_zr_wt_frac
-        xs types: *igniter_fuel_xs_types
-    feed fuel:
-        specifier: OC
-        blocks: *igniter_fuel_blocks
-        height: [25.0, 25.625, 25.625, 25.625, 25.625, 22.5, 25.0, 25.0, 25.0, 17.5]
-        axial mesh points: *standard_axial_mesh_points
-        material modifications:
-            U235_wt_frac: *igniter_fuel_u235_wt_frac
-            ZR_wt_frac: *igniter_fuel_zr_wt_frac
-        xs types: *igniter_fuel_xs_types
-    secondary control:
-        specifier: SC
-        blocks: [*block_grid_plate, *block_ctrl_duct, *block_ctrl_duct, *block_control, *block_control, *block_control, *block_control_plenum, *block_ctrl_duct, *block_ctrl_duct, *block_dummy]
-        height: [25.0, 49.0, 49.0, 25.0, 25.0, 25.0, 25.0, 1.0, 1.0, 17.5]
-        axial mesh points: *standard_axial_mesh_points
-        xs types: *igniter_fuel_xs_types
-    primary control:
+    control:
         specifier: PC
         blocks: [*block_grid_plate, *block_ctrl_duct, *block_ctrl_duct, *block_control, *block_control, *block_control, *block_control_plenum, *block_ctrl_duct, *block_ctrl_duct, *block_dummy]
         height: [25.0, 1.0, 1.0, 25.0, 25.0, 25.0, 25.0, 49.0, 49.0, 17.5]


### PR DESCRIPTION
## What is the change? Why is it being made?

See https://github.com/terrapower/armi/pull/2145. Myself and @drewj-tp were holding this off on a side branch for some other potential downstream work, but have decided to just pull this into ARMI `main`. This PR only brings in #2145, which has already been reviewed, so there is nothing new to review with this PR. 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Enable multi-pin component support for axial expansion.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
