### PR TITLE
Alter loop in `gamiso.addDummyNuclidesToLibrary` to use gamma groups

### DIFF
--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -101,16 +101,16 @@ def addDummyNuclidesToLibrary(lib, dummyNuclides):
 
         runLog.debug("Adding {} nuclide data to {}".format(dummyKey, lib))
         newDummy = xsNuclides.XSNuclide(lib, dummyKey)
-
         # Copy gamiso metadata from the isotxs metadata of the given dummy nuclide
         for kk, vv in dummyNuclide.isotxsMetadata.items():
             if kk in ["jj", "jband"]:
+                # clear out data here before populating with gamma groups
                 newDummy.gamisoMetadata[kk] = {}
-                for mm in vv:
-                    newDummy.gamisoMetadata[kk][mm] = 1
+                for gNum in range(lib.gamisoMetadata["numGroups"]):
+                    for bNum in range(lib.gamisoMetadata["maxScatteringBlocks"]):
+                        newDummy.gamisoMetadata[kk][(gNum, bNum)] = 1
             else:
                 newDummy.gamisoMetadata[kk] = vv
-
         lib[dummyKey] = newDummy
         dummyNuclideKeysAddedToLibrary.append(dummyKey)
 

--- a/armi/nuclearDataIO/cccc/tests/test_gamiso.py
+++ b/armi/nuclearDataIO/cccc/tests/test_gamiso.py
@@ -19,7 +19,7 @@ import unittest
 from copy import deepcopy
 
 from armi.nuclearDataIO import xsLibraries
-from armi.nuclearDataIO.cccc import gamiso
+from armi.nuclearDataIO.cccc import gamiso, isotxs
 from armi.nuclearDataIO.xsNuclides import XSNuclide
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
@@ -69,3 +69,14 @@ class TestGamiso(unittest.TestCase):
         diff = set(after).difference(set(before))
         self.assertEqual(len(diff), 1)
         self.assertEqual(list(diff)[0].xsId, "38")
+
+    def test_addDummyNuclidesToLibraryNumGroups(self):
+        isoLib = isotxs.readBinary(os.path.join(FIXTURE_DIR, "ISOAA"))
+        gamLib = gamiso.readBinary(GAMISO_AA)
+        gamLib.gamisoMetadata["numGroups"] = 50
+        dummyNuc = XSNuclide(isoLib, "DMP1AA")
+        dummyNuc.isotxsMetadata = isoLib.getNuclides("AA")[0].isotxsMetadata
+        gamiso.addDummyNuclidesToLibrary(gamLib, [dummyNuc])
+        # Why doesn't  lib.getNuclide("DMP1", "AA") work?
+        self.assertEqual(gamLib.getNuclides("AA")[-1].nucLabel, "DMP1")
+        self.assertEqual(gamLib.getNuclides("AA")[-1].gamisoMetadata["jband"][(49, 3)], 1)


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->

The code in `gamiso.addDummyNuclidesToLibrary` was looping over the isotxs metadata, which is giving things like `jband` the neutron energy group data structure. When someone wanted to increase the number of gamma energy groups in their simulation beyond 33, the simulation failed. 

So the loop was using the `jband` data structure from isotxs, but it is a different structure for gamiso. This fixes that problem by getting the necessary numbers from the gamiso lib, and making a new dictionary based on that. 

The isotxs metadata for dummy nuclides is still useful. It comes prepopulated with all the useful nuclide metadata that would otherwise be blank if I was starting from scratch with gamiso.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->

Alter loop in `gamiso.addDummyNuclidesToLibrary` to use gamma groups instead of neutron groups.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
