### PR TITLE
Removing old setting mpiTasksPerNode from ZPPR test file

### DIFF
--- a/armi/tests/zpprTest.yaml
+++ b/armi/tests/zpprTest.yaml
@@ -10,7 +10,6 @@ settings:
   comment: ZPPR test case
   cycleLength: 365.25
   loadingFile: zpprTestGeom.yaml
-  mpiTasksPerNode: 6
   nTasks: 12
   outputFileExtension: pdf
   power: 75000000.0


### PR DESCRIPTION
## What is the change? Why is it being made?

Removing the defunct setting `mpiTasksPerNode` from ZPPR test file. This setting was removed as part of an older PR: https://github.com/terrapower/armi/pull/1958


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing old setting mpiTasksPerNode from ZPPR test file.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
