### PR TITLE
Removing commented out code

### DIFF
--- a/armi/bookkeeping/db/tests/test_jaggedArray.py
+++ b/armi/bookkeeping/db/tests/test_jaggedArray.py
@@ -141,7 +141,7 @@ class TestJaggedArray(unittest.TestCase):
         - Empty lists become `None`
 
         """
-        # self.assertEqual(type(src), JaggedArray)
+        self.assertEqual(type(src), JaggedArray)
         if isinstance(ref, np.ndarray):
             ref = ref.tolist()
             src = src.tolist()

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -66,7 +66,6 @@ class UThZr(FuelMaterial):
         zr0 = 6.52
         th0 = 11.68
         # use vegard's law to mix densities by weight fraction at 50C
-        # uzr0 = 1.0/(zrFrac/zr0+(1-zrFrac)/u0)
         uThZr0 = 1.0 / (zrFrac / zr0 + (uFrac) / u0 + thFrac / th0)
 
         dLL = self.linearExpansionPercent(Tk=Tk)

--- a/armi/nuclearDataIO/xsCollections.py
+++ b/armi/nuclearDataIO/xsCollections.py
@@ -510,9 +510,7 @@ class MacroscopicCrossSectionCreator:
         within-group n2n is accounted for by simply not including n2n in the removal xs.
         """
         self.macros.removal = self.macros.absorption - self.macros.n2n
-        # columnSum = self.macros.totalScatter.columnSum(self.ng) # convert to ndarray
         columnSum = self.macros.totalScatter.sum(axis=0).getA1()  # convert to ndarray
-        # diags = self.macros.totalScatter.diagonal(self.ng)
         diags = self.macros.totalScatter.diagonal()
         self.macros.removal += columnSum - diags
 

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -828,7 +828,6 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
             a.p.timeToLimit = a.getMinParam("timeToLimit", Flags.FUEL)
             a.p.buLimit = a.getMaxParam("buLimit")
 
-            # self.p.kgFis = self.getFissileMass()
             if totalAbs > 0:
                 a.p.kInf = totalSrc / totalAbs  # assembly average k-inf.
 
@@ -985,7 +984,6 @@ def calcReactionRates(obj, keff, lib):
         mgFlux = obj.getMgFlux()
         for name in RX_ABS_MICRO_LABELS:
             for g, (groupFlux, xs) in enumerate(zip(mgFlux, micros[name])):
-                # dE = flux_e*dE
                 dphi = numberDensity * groupFlux
                 nucrate["rateAbs"] += dphi * xs
 

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -68,7 +68,6 @@ class TestLatticePhysicsInterfaceBase(unittest.TestCase):
         cls.assembly.spatialGrid = grids.AxialGrid.fromNCells(1)
         cls.assembly.spatialGrid.armiObject = cls.assembly
         cls.assembly.add(buildSimpleFuelBlock())
-        # cls.o.r.core.add(assembly)
         # init and add interfaces
         cls.xsGroupInterface = CrossSectionGroupManager(cls.o.r, cls.o.cs)
         cls.o.addInterface(cls.xsGroupInterface)

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -327,10 +327,8 @@ class Assembly(composites.Composite):
         for i, b in enumerate(self):
             refB = refA[i + newBlocks]  # pick the block that is "supposed to" line up with refB.
 
-            # runLog.important('Dealing with {0}, ref b {1}'.format(b,refB))
             if refB.getHeight() == b.getHeight():
                 # these blocks line up
-                # runLog.important('They are the same.')
                 newBlockStack.append(b)
                 continue
             elif refB.getHeight() > b.getHeight():

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1264,7 +1264,6 @@ class Block(composites.Composite):
 
         numDensities = self.getNumberDensities()
 
-        # vol = self.getVolume()
         for nucName, nDen in numDensities.items():
             nucMc = nuclideBases.byName[nucName].label + self.getMicroSuffix()
             if gamma:

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -68,7 +68,6 @@ class Sphere(ShapedComponent):
             raise NotImplementedError(f"Cannot calculate area at specified temperature: {Tc}")
         block = self.getAncestor(lambda c: isinstance(c, Block))
         return self.getComponentVolume(cold) / block.getHeight()
-        # raise NotImplementedError("Cannot compute area of a sphere component.")
 
     def getComponentVolume(self, cold=False):
         """Computes the volume of the sphere in cm^3."""

--- a/armi/reactor/parameters/resolveCollections.py
+++ b/armi/reactor/parameters/resolveCollections.py
@@ -101,13 +101,6 @@ class ResolveParametersMeta(type):
         # Make sure that these are what we expect them to be
         assert all([issubclass(c, ParameterCollection) for c in baseCollections if c is not None])
 
-        # Make sure that we aren't doing some sort of multiple inheritance. We may
-        # wish to support this in the future, but at this point we don't need it and
-        # there are probably lots of snakes in that grass.
-        # Turning this off to support multiple-inheritance materials/matprops material.
-        # But we should still be careful.
-        # assert len(baseCollections) <= 1, "Multiple inheritance is not yet supported in the ARMI composite pattern"
-
         # Pull out the one element of the list if it exists
         inferredBaseCollection = next(iter(baseCollections), None)
 

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -295,7 +295,7 @@ class MpiDistributeStateTests(unittest.TestCase):
 class MpiPathToolsTests(unittest.TestCase):
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
     def test_cleanPathMpi(self):
-        # """Simple tests of cleanPath(), in the MPI scenario"""
+        """Simple tests of cleanPath(), in the MPI scenario."""
         with TemporaryDirectoryChanger():
             # TEST 0: File is not safe to delete, due to name pathing
             filePath0 = "test0_cleanPathNoMpi"

--- a/armi/utils/mathematics.py
+++ b/armi/utils/mathematics.py
@@ -454,7 +454,6 @@ def newtonsMethod(func, goal, guess, maxIterations=None, cs=None, positiveGuesse
     if (maxIterations is None) and (cs is not None):
         maxIterations = cs["maxNewtonsIterations"]
 
-    # try:
     ans = float(
         sciopt.newton(
             goalFunc,

--- a/armi/utils/tabulate.py
+++ b/armi/utils/tabulate.py
@@ -912,7 +912,7 @@ def _alignHeader(header, alignment, width, visibleWidth, isMultiline=False, widt
         headerLines = re.split(_multilineCodes, header)
         paddedLines = [_alignHeader(h, alignment, width, widthFn(h)) for h in headerLines]
         return "\n".join(paddedLines)
-    # else: not multiline
+
     ninvisible = len(header) - visibleWidth
     width += ninvisible
     if alignment == "left":

--- a/armi/utils/tests/test_asciimaps.py
+++ b/armi/utils/tests/test_asciimaps.py
@@ -451,5 +451,5 @@ class TestAsciiMaps(unittest.TestCase):
         bases = []
         for li in range(3):
             bases.append(asciimap._getIJBaseByAsciiLine(li))
-        # self.assertEqual(bases, [(0, -10), (-1, -9), (-2, -8)]) # unchopped
+
         self.assertEqual(bases, [(-2, -8), (-3, -7), (-4, -6)])  # chopped

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -187,7 +187,6 @@ class PyReverse(Directive):
                 new_content.append("    " + line)
 
             para = nodes.container()
-            # tab_width = self.options.get('tab-width', self.state.document.settings.tab_width)
             lines = statemachine.StringList(new_content)
             self.state.nested_parse(lines, self.content_offset, para)
             return [para]

--- a/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
+++ b/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
@@ -22,7 +22,6 @@ Normally, code-specific utility code would belong in a code-specific ARMI
 plugin. But in this case, the need for MCNP materials cards is so pervasive
 that it made it into the framework
 """
-# sphinx_gallery_thumbnail_path = '.static/armi-logo.png'
 
 from armi import configure
 from armi.nucDirectory import nuclideBases as nb

--- a/doc/gallery-src/analysis/run_hexReactorToRZ.py
+++ b/doc/gallery-src/analysis/run_hexReactorToRZ.py
@@ -24,7 +24,6 @@ automatically converted to a 2-D or 3-D RZ case with conserved mass.
     appropriate.
 """
 
-# sphinx_gallery_thumbnail_number=2
 import math
 
 import matplotlib.pyplot as plt

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -28,8 +28,6 @@ ARMI to do fuel management. Thus, this example applies a dummy burnup distributi
 demonstration purposes.
 """
 
-# Tell the gallery to feature the 2nd image
-# sphinx_gallery_thumbnail_number = 2
 import math
 
 from armi import configure


### PR DESCRIPTION
## What is the change? Why is it being made?

Here I remove all the commented-out code in ARMI. As a matter of style and standards, we have had a long-standing rule in ARMI that you can't commit new commented-out code to the repo. It appears we still had some lying around. Luckily, this is a safe change to make.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing code that was commented out.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
