### PR TITLE
Remove unused test code

### DIFF
--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -220,24 +220,6 @@ class Assembly_TestCase(unittest.TestCase):
             "ztop": 111.80279999999999,
         }
 
-        self.blockSettings = {
-            "axMesh": 1,
-            "bondBOL": 0.0028698019026172574,
-            "envGroup": "A",
-            "height": 14.4507,
-            "molesHmAtBOL": 65.8572895758245,
-            "nHMAtBOL": 0.011241485251783766,
-            "nPins": 169.0,
-            "name": "B0011F",
-            "newDPA": 0.0,
-            "pitch": 16.79,
-            "regName": False,
-            "topIndex": 5,
-            "tsIndex": 0,
-            "type": "igniter fuel",
-            "xsType": "C",
-            "z": 104.57745,
-        }
         # add some blocks with a component
         self.blockList = []
         for i in range(NUM_BLOCKS):


### PR DESCRIPTION
## What is the change? Why is it being made?

I found myself searching for the `bondBOL` parameter and found it in this test file. This is an unknown thing to ARMI and I found that this entire class variable is totally unused. This PR removes it. 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
Change Type: trivial
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Cleaning out unused test code.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
