### PR TITLE
Removing Deprecation Warning on sortReactor setting

### DIFF
--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -689,7 +689,7 @@ def defineSettings() -> List[setting.Setting]:
             CONF_SORT_REACTOR,
             default=True,
             label="Do we want to automatically sort the Reactor?",
-            description="Deprecation Warning! This setting will be remove by 2024.",
+            description="If unsorted, ArmiObject IDs will be by the order they were added to the Reactor.",
         ),
         setting.Setting(
             CONF_RM_EXT_FILES_AT_BOC,


### PR DESCRIPTION
## What is the change? Why is it being made?

We've decided to keep the `sortReactor` setting for a while longer.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing Deprecation Warning on sortReactor setting.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
