### PR TITLE
Cleaning up Tests to have Fewer Side Effects

### DIFF
--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -242,9 +242,11 @@ class TestDatabaseWriter(unittest.TestCase):
         cs = cs.modified(newSettings={"power": 0.0, "powerDensity": 9e4})
         self.o, cs = getSimpleDBOperator(cs)
         self.r = self.o.r
+        self.stateRetainer = self.r.retainState().__enter__()
 
     def tearDown(self):
         self.td.__exit__(None, None, None)
+        self.stateRetainer.__exit__()
 
     def test_writeSystemAttributes(self):
         """Test the writeSystemAttributes method.

--- a/armi/reactor/tests/test_excoreStructures.py
+++ b/armi/reactor/tests/test_excoreStructures.py
@@ -14,10 +14,12 @@
 """Direct tests of the Excore Structures and Spent Fuel Pools."""
 
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from armi.reactor import grids
 from armi.reactor.composites import Composite
 from armi.reactor.excoreStructure import ExcoreCollection, ExcoreStructure
+from armi.reactor.reactors import Reactor
 from armi.reactor.spentFuelPool import SpentFuelPool
 from armi.reactor.tests.test_assemblies import makeTestAssembly
 
@@ -42,11 +44,7 @@ class TestExcoreStructure(TestCase):
         self.assertIn("id:", rep)
 
     def test_parentReactor(self):
-        class Reactor(ExcoreStructure):
-            # This is just to make our tests lighter weight.
-            pass
-
-        fr = Reactor("Reactor")
+        fr = Reactor("Reactor", MagicMock())
         evst3 = ExcoreStructure("evst3", parent=fr)
         self.assertEqual(evst3.r, fr)
 


### PR DESCRIPTION
## What is the change? Why is it being made?

A couple ARMI tests are causing side effects and failures in other ARMI tests if the tests are run in an order different from the default. Both of these can be recreated by running the first test file and the second test file in the same pytest run on the same worker one after the other.

The `test_parentReactor` test in `test_excoreStructures.py` was causing failures with the `test_beforeReactorConstructionHook` test in `test_plugins.py`. I'm not exactly sure *how* this was happening, but using an actual `Reactor` object fixes the side effect and is still a very quick test.

The `TestDatabaseWriter` class in `test_databaseInterface.py` was causing failures with the `test_writeToDB` test in `test_database3.py` if they were run in a very specific order. This was because extra reactor parameters were being retained. 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Cleaning up a couple tests to have fewer side effects, so they can be run in any order.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: None


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
