### PR TITLE
Improving Core.libs to look for the current cycle and node

### DIFF
--- a/armi/nuclearDataIO/__init__.py
+++ b/armi/nuclearDataIO/__init__.py
@@ -15,8 +15,7 @@
 """Read and/or write data files associated with nuclear data and reactor physics data."""
 # ruff: noqa: F401
 
-# export the cccc modules here to keep external clients happy,
-# though prefer full imports in new code
+# Export the cccc modules here for backward compatibility, though prefer full imports in new code.
 from armi.nuclearDataIO.cccc import (
     compxs,
     dif3d,
@@ -79,8 +78,7 @@ def _getNeutronKeywords(cycle, node, suffix, xsID):
     if cycle is not None and xsID is not None:
         raise ValueError("Keywords are over-specified. Choose `cycle` or `xsID` only")
 
-    # If neither cycle or xsID are provided there are no additional keywords to add
-    # to the file name
+    # If neither cycle or xsID are provided there are no additional keywords to add to the file name
     if cycle is None and xsID is None:
         keywords = []
     else:
@@ -92,6 +90,7 @@ def _getNeutronKeywords(cycle, node, suffix, xsID):
             keywords = [xsID]
             if suffix not in [None, ""]:
                 keywords.append("-" + suffix)
+
     return keywords
 
 

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -213,14 +213,21 @@ class Core(composites.Composite):
     @property
     def lib(self) -> Optional[xsLibraries.IsotxsLibrary]:
         """
-        Return the microscopic cross section library if one exists.
+        Return the microscopic cross section library, if one exists.
 
-        - If there is a library currently associated with the core, it will be returned
-        - Otherwise, an ``ISOTXS`` file will be searched for in the working directory, opened as
-          ``ISOTXS`` object and returned.
-        - Finally, if no ``ISOTXS`` file exists in the working directory, a None will be returned.
+        - If there is a library currently associated with the Core, it will be returned
+        - Otherwise, an ``ISOTXS`` file will be searched for in the working directory, opened as ``ISOTXS`` object and
+          returned. If possible, it will find the correct file for the current cycle and timeNode.
+        - Finally, if no ``ISOTXS`` file exists in the working directory, a None value will be returned.
         """
-        isotxsFileName = nuclearDataIO.getExpectedISOTXSFileName()
+        # determine the current cycle and timeNode
+        cycle = None
+        node = None
+        if self.r is not None:
+            cycle = self.r.p.cycle
+            node = self.r.p.timeNode
+
+        isotxsFileName = nuclearDataIO.getExpectedISOTXSFileName(cycle, node)
         if self._lib is None and os.path.exists(isotxsFileName):
             runLog.info(f"Loading microscopic cross section library `{isotxsFileName}`")
             self._lib = nuclearDataIO.isotxs.readBinary(isotxsFileName)


### PR DESCRIPTION
## What is the change? Why is it being made?

When `Core.lib` called `nuclearDataIO.getExpectedISOTXSFileName()` it did it without passing in the `cycle` and `timeNode` parameters. But that could be a very helpful thing to do. So we are passing that option in now.

close #2094 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Improving Core.libs to look for the current cycle and node.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
