### PR TITLE
Remove traces of `black`

### DIFF
--- a/doc/qa_docs/srsd.rst
+++ b/doc/qa_docs/srsd.rst
@@ -87,4 +87,4 @@ similarly fully open-source and that make no onerous demands on ARMI's distribut
 ARMI makes use of a huge suite of unit tests to cover the codebase. The tests are run via Continuous
 Integration (CI) both internally and publicly. Every unit test must pass on every commit to the ARMI
 main branch. Also, as part of our rigorous quality system, ARMI enforces tight controls on code
-style using Black as our code formatter and Ruff as our linter.
+style using Ruff as our code formatter and linter.


### PR DESCRIPTION
## What is the change? Why is it being made?

Did a grep for traces of `black` and found this reference. This PR just cleans that out. 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Ensuring the software attributes in the ARMI docs are up to date with current practices. 

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
