### PR TITLE
Blocking duplicate flags from being added

### DIFF
--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -246,9 +246,8 @@ class Flag(metaclass=_FlagMeta):
         <MyFlags.SUPER: 8>
         """
         # add explicit values first, so that autos know about them
-        toAdd = {}
         for field, value in ((f, v) for f, v in fields.items() if isinstance(v, int)):
-            toAdd[field] = cls._registerField(field, value)
+            cls._registerField(field, value)
 
         # find auto values (ignore if they already exist)
         toResolve = [field for field, val in fields.items() if isinstance(val, auto)]

--- a/armi/utils/flags.py
+++ b/armi/utils/flags.py
@@ -150,13 +150,14 @@ class Flag(metaclass=_FlagMeta):
         for k, v in self._nameToValue.items():
             if self._value & v:
                 flagsOn.add(k)
+
         return flagsOn
 
     def __repr__(self):
-        return "<{}.{}: {}>".format(type(self).__name__, "|".join(self._flagsOn()), self._value)
+        return f"<{type(self).__name__}.{'|'.join(self._flagsOn())}: {self._value}>"
 
     def __str__(self):
-        return "{}.{}".format(type(self).__name__, "|".join(self._flagsOn()))
+        return f"{type(self).__name__}.{'|'.join(self._flagsOn())}"
 
     def __getstate__(self):
         return self._value

--- a/armi/utils/tests/test_flags.py
+++ b/armi/utils/tests/test_flags.py
@@ -169,6 +169,8 @@ class TestFlag(unittest.TestCase):
             F.extend({f"FLAG{i - 1}": auto()})
             self.assertEqual(F.len(), num)
 
+            # While the next two lines do not assert anything, these lines used to raise an error.
+            # So these lines remain as proof against that error in the future.
             ff = getattr(F, f"FLAG{i}")
             FlagSerializer._packImpl(
                 [

--- a/armi/utils/tests/test_flags.py
+++ b/armi/utils/tests/test_flags.py
@@ -155,27 +155,43 @@ class TestFlag(unittest.TestCase):
         self.assertEqual(ExampleFlag["FOO"], ExampleFlag.FOO)
 
     def test_duplicateFlags(self):
-        class F(Flag):
-            pass
+        """Show that duplicate flags can be added and silently ignored."""
 
-        for i in range(1, 100):
+        class F(Flag):
+            @classmethod
+            def len(cls):
+                return len(cls._nameToValue)
+
+        F.extend({"FLAG0": auto()})
+        for i in range(1, 12):
             F.extend({f"FLAG{i}": auto()})
+            num = F.len()
             F.extend({f"FLAG{i - 1}": auto()})
+            self.assertEqual(F.len(), num)
+
             ff = getattr(F, f"FLAG{i}")
-            ff.to_bytes()
             FlagSerializer._packImpl(
                 [
                     ff,
                 ],
                 F,
             )
+            self.assertEqual(F.len(), num)
 
     def test_soManyFlags(self):
-        class F(Flag):
-            pass
+        """Show that many flags can be added without issue."""
 
-        for i in range(1000):
+        class F(Flag):
+            @classmethod
+            def len(cls):
+                return len(cls._nameToValue)
+
+        for i in range(1, 100):
+            num = F.len()
             flagName = f"FLAG{i}"
             F.extend({flagName: auto()})
+            self.assertEqual(F.len(), num + 1)
+
             flag = getattr(F, flagName)
             flag.to_bytes()
+            self.assertEqual(F.len(), num + 1)

--- a/armi/utils/tests/test_flags.py
+++ b/armi/utils/tests/test_flags.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+from armi.reactor.composites import FlagSerializer
 from armi.utils.flags import Flag, auto
 
 
@@ -152,3 +153,29 @@ class TestFlag(unittest.TestCase):
 
     def test_getitem(self):
         self.assertEqual(ExampleFlag["FOO"], ExampleFlag.FOO)
+
+    def test_duplicateFlags(self):
+        class F(Flag):
+            pass
+
+        for i in range(1, 100):
+            F.extend({f"FLAG{i}": auto()})
+            F.extend({f"FLAG{i - 1}": auto()})
+            ff = getattr(F, f"FLAG{i}")
+            ff.to_bytes()
+            FlagSerializer._packImpl(
+                [
+                    ff,
+                ],
+                F,
+            )
+
+    def test_soManyFlags(self):
+        class F(Flag):
+            pass
+
+        for i in range(1000):
+            flagName = f"FLAG{i}"
+            F.extend({flagName: auto()})
+            flag = getattr(F, flagName)
+            flag.to_bytes()


### PR DESCRIPTION
## What is the change? Why is it being made?

Here I block a duplicate flag from being added to a collection of flags. I can see no reason to support such a thing. And, indeed, doing so causes some trouble in the current code. So here I just silently pass any time someone tries to add a duplicate flag. I can't think of any good reason for that to raise an error.

close #2172


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Blocking duplicate flags from being added.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Changes the implementation `I_ARMI_FLAG_EXTEND0` of `R_ARMI_FLAG_EXTEND`, so that if someone tries to add a flag that already exists, it is silently ignored.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
