### PR TITLE
Use np.int32 when reading geodst files

### DIFF
--- a/armi/nuclearDataIO/cccc/geodst.py
+++ b/armi/nuclearDataIO/cccc/geodst.py
@@ -263,7 +263,7 @@ class GeodstStream(cccc.StreamWithDataContainer):
                     self._metadata["NCINTJ"],
                     self._metadata["NCINTK"],
                 ),
-                dtype=np.int16,
+                dtype=np.int32,
             )
         for ki in range(self._metadata["NCINTK"]):
             with self.createRecord() as record:


### PR DESCRIPTION
## What is the change? Why is it being made?

A user encountered a problem reading a GEODST file with at least 32773 indices along one axis of the GEODST matrix. This caused an `OverflowError` by numpy trying to downcast `32773` to a short integer with `np.int16`.

We could just increase the size and call it good. But this led us down a small rabbit hole of "is ARMI missing the spec or trying to be clever?" And I think ARMI missed the spec here and the `coarseMeshRegions` should be a "long int" or `np.int32`.

The GEODST specification [1] lists this field as a integer through the magic implicit Fortran `M` variable naming. So this tells us it should match the default fortran integer sizing of 8-byte or (c-speak) `long int` or `np.int32` [2].

Sources:

[1] https://www.osti.gov/servlets/purl/4350057 - CCCC specification from 1974, photo scanned so quality is not great. See the 6D record on page 33 for "Region Assignments to Coarse Mesh Intervals"

[2] https://docs.oracle.com/cd/E19957-01/802-2998/802-2998.pdf - Fortran 77 specification, integer constants on page 30. Note the integer range by default is `(-2,147,483,648 to 2,147,483,648)` or a 8-byte integer. A short integer (page 31) has an upper limit range 32,767 which is lower than the size the model that triggered this investigation.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Use a `numpy.int32` when reading GEODST files

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: R_ARMI_NUCDATA_GEODST holds the requirement to read a GEODST file.


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
