### PR TITLE
Changing Interface.function to Interface.purpose

### DIFF
--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-A collection of miscellaneous functions used by ReportInterface to generate
-various reports.
-"""
+"""A collection of miscellaneous functions used by ReportInterface to generate various reports."""
 
 import collections
 import os
@@ -391,7 +388,7 @@ def getInterfaceStackSummary(o):
                 "{:02d}".format(ii),
                 i.__class__.__name__.replace("Interface", ""),
                 i.name,
-                i.function,
+                i.purpose,
                 "Yes" if i.enabled() else "No",
                 "Reversed" if i.reverseAtEOL else "Normal",
                 "Yes" if i.bolForce() else "No",
@@ -403,7 +400,7 @@ def getInterfaceStackSummary(o):
             "Index",
             "Type",
             "Name",
-            "Function",
+            "Purpose",
             "Enabled",
             "EOL order",
             "BOL forced",

--- a/armi/interfaces.py
+++ b/armi/interfaces.py
@@ -287,9 +287,9 @@ class Interface:
     concrete class that extends this one.
     """
 
-    function = None
+    purpose = None
     """
-    The function performed by an Interface. This is not required be be defined by implementations of
+    The action performed by an Interface. This is not required be be defined by implementations of
     Interface, but is used to form categories of interfaces.
     """
 
@@ -725,15 +725,15 @@ def _setTightCouplerByInterfaceFunction(interfaceClass, cs):
         Case settings that are parsed to determine if tight coupling is enabled
         globally and if both a target parameter and convergence criteria defined.
     """
-    # No tight coupling if there is no function for the Interface defined.
-    if interfaceClass.function is None:
+    # No tight coupling if there is no purpose for the Interface defined.
+    if interfaceClass.purpose is None:
         return None
 
-    if not cs["tightCoupling"] or (interfaceClass.function not in cs["tightCouplingSettings"]):
+    if not cs["tightCoupling"] or (interfaceClass.purpose not in cs["tightCouplingSettings"]):
         return None
 
-    parameter = cs["tightCouplingSettings"][interfaceClass.function]["parameter"]
-    tolerance = cs["tightCouplingSettings"][interfaceClass.function]["convergence"]
+    parameter = cs["tightCouplingSettings"][interfaceClass.purpose]["parameter"]
+    tolerance = cs["tightCouplingSettings"][interfaceClass.purpose]["convergence"]
     maxIters = cs["tightCouplingMaxNumIters"]
 
     return TightCoupler(parameter, tolerance, maxIters)

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -770,13 +770,12 @@ class Operator:
         Raises
         ------
         RuntimeError
-            If an interface of the same name or function is already attached to the
-            Operator.
+            If an interface of the same name or purpose is already attached to the Operator.
         """
         if self.getInterface(interface.name):
             raise RuntimeError("An interface with name {0} is already attached.".format(interface.name))
 
-        iFunc = self.getInterface(function=interface.function)
+        iFunc = self.getInterface(purpose=interface.purpose)
 
         if iFunc:
             if issubclass(type(iFunc), type(interface)):
@@ -796,7 +795,7 @@ class Operator:
                 raise RuntimeError(
                     "Cannot add {0}; the {1} already is designated "
                     "as the {2} interface. Multiple interfaces of the same "
-                    "function is not supported.".format(interface, iFunc, interface.function)
+                    "purpose is not supported.".format(interface, iFunc, interface.purpose)
                 )
 
         runLog.debug("Adding {0}".format(interface))
@@ -832,10 +831,10 @@ class Operator:
             for i in self.getInterfaces():
                 for dependency in i.getDependencies(self.cs):
                     name = dependency.name
-                    function = dependency.function
+                    purpose = dependency.purpose
                     klass = dependency
 
-                    if not self.getInterface(name, function=function):
+                    if not self.getInterface(name, purpose=purpose):
                         runLog.extra(
                             "Attaching {} interface (disabled, BOL forced) due to dependency in {}".format(
                                 klass.name, i.name
@@ -881,32 +880,32 @@ class Operator:
             runLog.warning("Cannot remove interface {0} because it is not in the interface stack.".format(interface))
             return False
 
-    def getInterface(self, name=None, function=None):
+    def getInterface(self, name=None, purpose=None):
         """
-        Returns a specific interface from the stack by its name or more generic function.
+        Returns a specific interface from the stack by its name or more generic purpose.
 
         Parameters
         ----------
         name : str, optional
             Interface name
-        function : str
-            Interface function (general, like 'globalFlux','th',etc.). This is useful when you need
+        purpose : str
+            Interface purpose (general, like 'globalFlux','th',etc.). This is useful when you need
             the ___ solver (e.g. globalFlux) but don't care which particular one is active (e.g. SERPENT vs. DIF3D)
 
         Raises
         ------
         RuntimeError
-            If there are more than one interfaces of the given name or function.
+            If there are more than one interfaces of the given name or purpose.
         """
         candidateI = None
         for i in self.interfaces:
-            if (name and i.name == name) or (function and i.function == function):
+            if (name and i.name == name) or (purpose and i.purpose == purpose):
                 if candidateI is None:
                     candidateI = i
                 else:
                     raise RuntimeError(
                         "Cannot retrieve a single interface as there are multiple "
-                        "interfaces with name {} or function {} attached. ".format(name, function)
+                        "interfaces with name {} or purpose {} attached. ".format(name, purpose)
                     )
 
         return candidateI

--- a/armi/operators/operatorMPI.py
+++ b/armi/operators/operatorMPI.py
@@ -31,9 +31,8 @@ The MPI-aware variant of the standard ARMI operator.
 
 Notes
 -----
-This is not *yet* smart enough to use shared memory when the MPI
-tasks are on the same machine. Everything goes through MPI. This can
-be optimized as needed.
+This is not *yet* smart enough to use shared memory when the MPI tasks are on the same machine. Everything goes through
+MPI. This can be optimized as needed.
 """
 
 import gc
@@ -71,7 +70,7 @@ class OperatorMPI(Operator):
         if context.MPI_RANK == 0:
             # this is the primary
             try:
-                # run the regular old operate function
+                # run the regular old operate method
                 Operator.operate(self)
                 runLog.important(time.ctime())
             except Exception as ee:
@@ -97,8 +96,7 @@ class OperatorMPI(Operator):
             except:
                 # grab the final command
                 runLog.warning("An error has occurred in one of the worker nodes. See STDERR for traceback.")
-                # bcasting quit won't work if the main is sitting around waiting for a
-                # different bcast or gather.
+                # bcasting quit won't work if the main is sitting around waiting for a different bcast or gather.
                 traceback.print_exc()
                 runLog.debug("Worker failed")
                 runLog.close()
@@ -150,12 +148,12 @@ class OperatorMPI(Operator):
                 runLog.debug("Worker syncing")
                 note = context.MPI_COMM.bcast("wait", root=0)
                 if note != "wait":
-                    raise RuntimeError('did not get "wait". Got {0}'.format(note))
+                    raise RuntimeError(f'did not get "wait". Got {note}')
             elif cmd == "reset":
                 runLog.extra("Workers are being reset.")
             else:
-                # we don't understand the command on our own. check the interfaces
-                # this allows all interfaces to have their own custom operation code.
+                # We don't understand the command on our own. Check the interfaces this allows all interfaces to have
+                # their own custom operation code.
                 handled = False
                 for i in self.interfaces:
                     handled = i.workerOperate(cmd)
@@ -168,12 +166,10 @@ class OperatorMPI(Operator):
                         "No interface understood worker command {0}\n check stdout for err\n"
                         "available interfaces:\n  {1}".format(
                             cmd,
-                            "\n  ".join(
-                                "name:{} typeName:{} {}".format(i.name, i.function, i) for i in self.interfaces
-                            ),
+                            "\n  ".join(f"name:{i.name} typeName:{i.purpose} {i}" for i in self.interfaces),
                         )
                     )
-                    raise RuntimeError("Failed to delegate worker command {} to an interface.".format(cmd))
+                    raise RuntimeError(f"Failed to delegate worker command {cmd} to an interface.")
 
             pm = getPluginManager()
             resetFlags = pm.hook.mpiActionRequiresReset(cmd=cmd)
@@ -181,8 +177,7 @@ class OperatorMPI(Operator):
             if all(resetFlags) or cmd == "reset":
                 self._resetWorker()
 
-            # might be an mpi action which has a reactor and everything, preventing
-            # garbage collection
+            # might be an mpi action which has a reactor and everything, preventing garbage collection
             del cmd
             gc.collect()
 
@@ -212,7 +207,9 @@ class OperatorMPI(Operator):
         or transforming their geometry is one approach. We hope to implement
         more efficient solutions in the future.
 
-        .. warning:: This should build empty non-core systems too.
+        Warning
+        -------
+        This should build empty non-core systems too.
         """
         # Nothing to do if we never had anything
         if self.r is None:

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -37,7 +37,7 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
         operatorMPI.OperatorMPI.createInterfaces(self)
 
         for toDisable in self.disabledInterfaces:
-            i = self.getInterface(name=toDisable, function=toDisable)
+            i = self.getInterface(name=toDisable, purpose=toDisable)
             if i:
                 i.enabled(False)
 

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -45,19 +45,19 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 class InterfaceA(Interface):
-    function = "A"
+    purpose = "A"
     name = "First"
 
 
 class InterfaceB(InterfaceA):
     """Dummy Interface that extends A."""
 
-    function = "A"
+    purpose = "A"
     name = "Second"
 
 
 class InterfaceC(Interface):
-    function = "A"
+    purpose = "A"
     name = "Third"
 
 
@@ -158,13 +158,13 @@ class OperatorTests(unittest.TestCase):
         self.assertEqual(self.o.getInterface("Second"), interfaceB)
         self.assertEqual(self.o.getInterface("First"), None)
 
-        # 3) Also if another class not a subclass has the same function,
+        # 3) Also if another class not a subclass has the same purpose,
         #    raise an error
         interfaceC = InterfaceC(self.r, cs)
         self.assertRaises(RuntimeError, self.o.addInterface, interfaceC)
 
-        # 4) Check adding a different function Interface
-        interfaceC.function = "C"
+        # 4) Check adding a different purpose Interface
+        interfaceC.purpose = "C"
         self.o.addInterface(interfaceC)
         self.assertEqual(self.o.getInterface("Second"), interfaceB)
         self.assertEqual(self.o.getInterface("Third"), interfaceC)

--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -85,7 +85,7 @@ class FuelHandlerInterface(interfaces.Interface):
         """
         # if lattice physics is requested, compute it here instead of after fuel management.
         # This enables XS to exist for branch searching, etc.
-        mc2 = self.o.getInterface(function="latticePhysics")
+        mc2 = self.o.getInterface(purpose="latticePhysics")
         xsgm = self.o.getInterface("xsGroups")
         if mc2 and self.cs[CONF_RUN_LATTICE_BEFORE_SHUFFLING]:
             runLog.extra(

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -42,7 +42,7 @@ class GlobalFluxInterface(interfaces.Interface):
     """
 
     name = "GlobalFlux"  # make sure to set this in subclasses
-    function = "globalFlux"
+    purpose = "globalFlux"
     _ENERGY_BALANCE_REL_TOL = 1e-5
 
     def __init__(self, r, cs):

--- a/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
+++ b/armi/physics/neutronics/isotopicDepletion/isotopicDepletionInterface.py
@@ -84,7 +84,7 @@ class AbstractIsotopicDepleter:
     """
 
     name = None
-    function = "depletion"
+    purpose = "depletion"
 
     def __init__(self, r=None, cs=None, o=None):
         self.r = r

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -67,7 +67,7 @@ def setBlockNeutronVelocities(r, neutronVelocities):
 class LatticePhysicsInterface(interfaces.Interface):
     """Class for interacting with lattice physics codes."""
 
-    function = LATTICE_PHYSICS
+    purpose = LATTICE_PHYSICS
 
     def __init__(self, r, cs):
         interfaces.Interface.__init__(self, r, cs)

--- a/armi/tests/test_interfaces.py
+++ b/armi/tests/test_interfaces.py
@@ -21,7 +21,7 @@ from armi import interfaces, settings
 
 class DummyInterface(interfaces.Interface):
     name = "Dummy"
-    function = "dummyAction"
+    purpose = "dummyAction"
 
 
 class TestCodeInterface(unittest.TestCase):

--- a/doc/user/physics_coupling.rst
+++ b/doc/user/physics_coupling.rst
@@ -33,7 +33,7 @@ The following settings are involved with enabling tight coupling in ARMI:
            convergence: 1.0e-2
 
 
-The ``tightCouplingSettings`` settings interact with the interfaces available in ARMI (or an ARMI app). The interface headers (i.e., "globalFlux" and "thermalHydraulics") must match the value prescribed for :py:attr:`Interface.function <armi.interfaces.interface.function>`. The option, ``parameter``, can be a registered parameter. The ``convergence`` option is expected to be any float value. In the current implementation, different interfaces may have different developer intended restrictions. For example, the global flux interface currently only allows the eigenvalue (i.e. :math:`k_{\text{eff}}`) or block-wise power to be valid ``parameter`` values.
+The ``tightCouplingSettings`` settings interact with the interfaces available in ARMI (or an ARMI app). The interface headers (i.e., "globalFlux" and "thermalHydraulics") must match the value prescribed for :py:attr:`Interface.purpose <armi.interfaces.interface.purpose>`. The option, ``parameter``, can be a registered parameter. The ``convergence`` option is expected to be any float value. In the current implementation, different interfaces may have different developer intended restrictions. For example, the global flux interface currently only allows the eigenvalue (i.e. :math:`k_{\text{eff}}`) or block-wise power to be valid ``parameter`` values.
 
 .. warning::
     The inherent limitations of the above interface-based tight coupling settings have been documented and a new and improved user-interface is currently being developed.


### PR DESCRIPTION
## What is the change? Why is it being made?

The name `function` in `Interface.function` classes heavily with the Python reserved word "function". It is also just not a very helpful name, as it could mean almost anything.

#close 2125

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Changing Interface.function to Interface.purpose.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Minor edit to the implementation `I_ARMI_INTERFACE` on the requirement `R_ARMI_INTERFACE`


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
