### PR TITLE
Remove assert statements from `FilletedHexagon` instantiation.

### DIFF
--- a/armi/reactor/components/complexShapes.py
+++ b/armi/reactor/components/complexShapes.py
@@ -173,8 +173,6 @@ class FilletedHexagon(basicShapes.Hexagon):
             components=components,
         )
         self._linkAndStoreDimensions(components, op=op, ip=ip, iR=iR, oR=oR, mult=mult, modArea=modArea)
-        assert oR <= op / 2, f"The outer radius of curvature is too large: {oR} > {op / 2}."
-        assert iR <= ip / 2, f"The inner radius of curvature is too large: {iR} > {ip / 2}."
 
     @staticmethod
     def _area(D, r):


### PR DESCRIPTION
## What is the change? Why is it being made?

Remove `assert` statements in the `FilletedHexagon` instantiation.

The `assert` statement exists to ensure that a user does not specify a fillet radius that is not physically possible for the given hexagon `ip` and `op`. This is a good idea, but the math for this check can only be performed if all of the dimensions (`ip`, `op`, `iR`, and `oR`) are provided as floats. It is common practice to define these dimensions with links to the dimension of other components within the same block, in which case the dimension will be a `str` instead of a `float`, and there will be a fatal error when trying to perform the arithmetic on a `str`.

It does not appear that there is a way to convert the linked `str` dimension to a float at this point in component instantiation, since there is no guarantee that the other component it is linked to has even been created yet.

See also #2118 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

Describe the change in one sentence -->
Remove `assert` statements in the `FilletedHexagon` instantiation.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
-  @[ ] The dependencies are still up-to-date in `pyproject.toml`.
