### PR TITLE
Renaming old smallRun Setting to rmExternalFilesAtEOL

### DIFF
--- a/armi/tests/armiRun.yaml
+++ b/armi/tests/armiRun.yaml
@@ -17,7 +17,7 @@ settings:
   nCycles: 6
   outputFileExtension: png
   power: 100000000.0
-  smallRun: true
+  rmExternalFilesAtEOL: true
   startCycle: 1
   startNode: 2
   targetK: 1.002

--- a/armi/tests/smallestTestReactor/armiRunSmallest.yaml
+++ b/armi/tests/smallestTestReactor/armiRunSmallest.yaml
@@ -21,7 +21,7 @@ settings:
   nCycles: 2
   outputFileExtension: png
   power: 1000000.0
-  smallRun: true
+  rmExternalFilesAtEOL: true
   startCycle: 1
   startNode: 2
   targetK: 1.002


### PR DESCRIPTION
## What is the change? Why is it being made?

In a [recent PR](https://github.com/terrapower/armi/pull/1386) the setting name `smallRun` was changed to `rmExternalFilesAtEOL`. The setting `smallRun` no longer exists.

But there are still two occurrences of this setting in ARMI. This PR fixes the problem.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Renaming old smallRun Setting to rmExternalFilesAtEOL.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
