### PR TITLE
Fixing bug in Uranium.pseudoDensity

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -461,7 +461,7 @@ class Material:
         dLL = self.linearExpansionPercent(Tk=Tk)
         if self.refDens is None:
             runLog.warning(
-                "{0} has no reference density".format(self),
+                f"{self} has no reference density",
                 single=True,
                 label="No refD " + self.getName(),
             )

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -618,6 +618,15 @@ class Uranium_TestCase(_Material_Test, unittest.TestCase):
                     mock.getStdout(),
                 )
 
+    def test_pseudoDensity(self):
+        cur = self.mat.pseudoDensity(Tc=500)
+        ref = 18.74504534852846
+        self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
+
+        cur = self.mat.pseudoDensity(Tc=1000)
+        ref = 18.1280492780791
+        self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
+
 
 class UraniumOxide_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = materials.UraniumOxide

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -208,8 +208,6 @@ class Uranium(FuelMaterial):
         "linear expansion percent": ["Metallic Fuels Handbook, ANL-NSE-3, Table B.3.3-1"],
     }
 
-    refDens = 19.07  # the value corresponding to linearExpansionPercent = 0
-
     def thermalConductivity(self, Tk: float = None, Tc: float = None) -> float:
         """The thermal conductivity of pure U in W-m/K."""
         Tk = getTk(Tc, Tk)
@@ -234,6 +232,8 @@ class Uranium(FuelMaterial):
 
         self.setMassFrac("U235", u235.weight * u235.abundance / gramsIn1Mol)
         self.setMassFrac("U238", u238.weight * u238Abundance / gramsIn1Mol)
+
+        self.refDens = 19.07
 
     def applyInputParams(self, U235_wt_frac: float = None, TD_frac: float = None, *args, **kwargs):
         if U235_wt_frac is not None:


### PR DESCRIPTION
## What is the change? Why is it being made?

The variable `Uranium.refDens` was set as a class attribute, rather than a class instance variable. So it was never correctly set, and always remained zero. This was causing lots of havok in the `Uranium` class.

I check, there are no other materials with this particular problem/typo.

close #2185

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Fixing bug in Uranium.pseudoDensity, it was incorrectly always zero.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
