### PR TITLE
Fix bug in finding ISOTXS libraries to merge

### DIFF
--- a/armi/nuclearDataIO/xsLibraries.py
+++ b/armi/nuclearDataIO/xsLibraries.py
@@ -122,7 +122,7 @@ def getISOTXSLibrariesToMerge(xsLibrarySuffix, xsLibFileNames):
             iso
             for iso in isosToMerge
             if "-" not in os.path.basename(iso)
-            and not any(iso == os.path.basename(iws).split("-")[0] for iws in isosWithSuffix)
+            and not any(os.path.basename(iso) == os.path.basename(iws).split("-")[0] for iws in isosWithSuffix)
         ]
         isosToMerge += isosWithSuffix
     else:


### PR DESCRIPTION
## What is the change? Why is it being made?

When searching for a matching file, compare the base file name with another base file name instead of the full path.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: fix a bug where a full file path was compared to a file name only.
<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
