### PR TITLE
Using iterators more in our unit tests

### DIFF
--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -580,7 +580,7 @@ class DistributeStateAction(MpiAction):
 
         self.r.o = self.o
 
-        runLog.debug(f"The reactor has {len(self.r.core.getAssemblies())} assemblies")
+        runLog.debug(f"The reactor has {len(self.r.core)} assemblies")
         # attach here so any interface actions use a properly-setup reactor.
         self.o.reattach(self.r, cs)  # sets r and cs
 

--- a/armi/reactor/converters/tests/test_geometryConverters.py
+++ b/armi/reactor/converters/tests/test_geometryConverters.py
@@ -43,7 +43,7 @@ class TestGeometryConverters(unittest.TestCase):
         converter.ringsToAdd = 1 * ["radial shield"]
         converter.convert(self.r)
 
-        numAssems = len(self.r.core.getAssemblies())
+        numAssems = len(self.r.core)
         self.assertEqual(numAssems, 13)  # should end up with 6 reflector assemblies per 1/3rd Core
         locator = self.r.core.spatialGrid.getLocatorFromRingAndPos(4, 1)
         shieldtype = self.r.core.childrenByLocator[locator].getType()
@@ -52,7 +52,7 @@ class TestGeometryConverters(unittest.TestCase):
         # one more test with an uneven number of rings
         converter.numFuelAssems = 8
         converter.convert(self.r)
-        numAssems = len(self.r.core.getAssemblies())
+        numAssems = len(self.r.core)
         self.assertEqual(numAssems, 19)  # should wind up with 11 reflector assemblies per 1/3rd core
 
     def test_setNumberOfFuelAssems(self):
@@ -270,13 +270,13 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
                     return a
             return None
 
-        numAssemsOrig = len(self.r.core.getAssemblies())
+        numAssemsOrig = len(self.r.core)
         # assert that there is no assembly in the (3, 4) (ring, position).
         self.assertIsNone(getAssemByRingPos((3, 4)))
         # add the assembly
         converter = geometryConverters.EdgeAssemblyChanger()
         converter.addEdgeAssemblies(self.r.core)
-        numAssemsWithEdgeAssem = len(self.r.core.getAssemblies())
+        numAssemsWithEdgeAssem = len(self.r.core)
         # assert that there is an assembly in the (3, 4) (ring, position).
         self.assertIsNotNone(getAssemByRingPos((3, 4)))
         self.assertTrue(numAssemsWithEdgeAssem > numAssemsOrig)
@@ -285,7 +285,7 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
         with mockRunLogs.BufferLog() as mock:
             converter.addEdgeAssemblies(self.r.core)
             self.assertIn("Skipping addition of edge assemblies", mock.getStdout())
-            self.assertTrue(numAssemsWithEdgeAssem, len(self.r.core.getAssemblies()))
+            self.assertTrue(numAssemsWithEdgeAssem, len(self.r.core))
 
         # must be added after geom transform
         for b in self.o.r.core.iterBlocks():
@@ -297,7 +297,7 @@ class TestEdgeAssemblyChanger(unittest.TestCase):
         # remove the assembly that was added
         converter.removeEdgeAssemblies(self.r.core)
         self.assertIsNone(getAssemByRingPos((3, 4)))
-        self.assertEqual(numAssemsOrig, len(self.r.core.getAssemblies()))
+        self.assertEqual(numAssemsOrig, len(self.r.core))
 
 
 class TestThirdCoreHexToFullCoreChanger(unittest.TestCase):

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -643,13 +643,13 @@ class HexReactorTests(ReactorTests):
             :tests: R_ARMI_SFP
         """
         # where are we starting
-        numCoreStart = len(self.r.core.getAssemblies())
+        numCoreStart = len(self.r.core)
         numTotalStart = len(self.r.core.getAssemblies(includeSFP=True))
 
         # remove one assembly and confirm behavior
         for i in range(1, 5):
             self.r.core.removeAssembly(self.r.core.getFirstAssembly())
-            self.assertEqual(len(self.r.core.getAssemblies()), numCoreStart - i)
+            self.assertEqual(len(self.r.core), numCoreStart - i)
             self.assertEqual(len(self.r.core.getAssemblies(includeSFP=True)), numTotalStart)
 
     def test_restoreReactor(self):
@@ -659,7 +659,7 @@ class HexReactorTests(ReactorTests):
             :id: T_ARMI_THIRD_TO_FULL_CORE1
             :tests: R_ARMI_THIRD_TO_FULL_CORE
         """
-        numOfAssembliesOneThird = len(self.r.core.getAssemblies())
+        numOfAssembliesOneThird = len(self.r.core)
         self.assertFalse(self.r.core.isFullCore)
         self.assertEqual(
             self.r.core.symmetry,
@@ -668,17 +668,17 @@ class HexReactorTests(ReactorTests):
         # grow to full core
         converter = self.r.core.growToFullCore(self.o.cs)
         self.assertTrue(self.r.core.isFullCore)
-        self.assertGreater(len(self.r.core.getAssemblies()), numOfAssembliesOneThird)
+        self.assertGreater(len(self.r.core), numOfAssembliesOneThird)
         self.assertEqual(self.r.core.symmetry.domain, geometry.DomainType.FULL_CORE)
         # restore back to 1/3 core
         converter.restorePreviousGeometry(self.r)
-        self.assertEqual(numOfAssembliesOneThird, len(self.r.core.getAssemblies()))
+        self.assertEqual(numOfAssembliesOneThird, len(self.r.core))
         self.assertEqual(
             self.r.core.symmetry,
             geometry.SymmetryType(geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC),
         )
         self.assertFalse(self.r.core.isFullCore)
-        self.assertEqual(numOfAssembliesOneThird, len(self.r.core.getAssemblies()))
+        self.assertEqual(numOfAssembliesOneThird, len(self.r.core))
         self.assertEqual(
             self.r.core.symmetry,
             geometry.SymmetryType(geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC),


### PR DESCRIPTION
## What is the change? Why is it being made?

This PR is a very minor performance improvement. Essentially, this is just using iterators instead of lists where possible.

This is a direct follow on to other, recent PRs:

* https://github.com/terrapower/armi/pull/2190
* https://github.com/terrapower/armi/pull/2106
* https://github.com/terrapower/armi/pull/2031


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Using iterators more in our unit tests

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
