### PR TITLE
Provide Component.pinIndices for helping understand where pins are

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1222,6 +1222,9 @@ class Assembly(composites.Composite):
                     b.autoCreateSpatialGrids(parentSpatialGrid)
                 except (ValueError, NotImplementedError) as e:
                     runLog.extra(str(e), single=True)
+            # Do more grid initializations from a manual or auto created grid
+            if b.spatialGrid is not None:
+                b.assignPinIndices()
 
 
 class HexAssembly(Assembly):

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -23,6 +23,7 @@ import collections
 import copy
 import functools
 import math
+import operator
 from typing import ClassVar, Optional, Tuple, Type
 
 import numpy as np
@@ -2146,6 +2147,31 @@ class HexBlock(Block):
                     c.spatialLocator = spatialLocators
                 elif c.getDimension("mult") == 1:
                     c.spatialLocator = grids.CoordinateLocation(0.0, 0.0, 0.0, grid)
+
+    def assignPinIndices(self):
+        """Assign pin indices for pin components on the block."""
+        if self.spatialGrid is None:
+            return
+        locations = self.getPinLocations()
+        if not locations:
+            return
+        ijGetter = operator.attrgetter("i", "j")
+        allIJ: tuple[tuple[int, int]] = tuple(map(ijGetter, locations))
+        # Flags for components that we want to set this parameter
+        # Usually things are linked to one of these "primary" flags, like
+        # a cladding component having linked dimensions to a fuel component
+        targetFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD)
+        for c in self.iterChildren(predicate=lambda c: c.hasFlags(targetFlags) and isinstance(c, Circle)):
+            localLocations = c.spatialLocator
+            if isinstance(localLocations, grids.MultiIndexLocation):
+                localIJ = list(map(ijGetter, localLocations))
+            elif isinstance(localLocations, grids.IndexLocation):
+                localIJ = [ijGetter(localLocations)]
+            else:
+                continue
+            localIndices = list(map(allIJ.index, localIJ))
+            # TODO Handle trivial case where one pin lives at all locations
+            c.p.pinIndices = localIndices
 
     def getPinCenterFlatToFlat(self, cold=False):
         """Return the flat-to-flat distance between the centers of opposing pins in the outermost ring."""

--- a/armi/reactor/components/componentParameters.py
+++ b/armi/reactor/components/componentParameters.py
@@ -14,6 +14,8 @@
 
 """Component parameter definitions."""
 
+import numpy as np
+
 from armi.reactor import parameters
 from armi.reactor.parameters import ParamLocation
 from armi.reactor.parameters.parameterDefinitions import isNumpyArray, isNumpyF32Array
@@ -196,6 +198,25 @@ def getCircleParameterDefinitions():
 
         pb.defParam("op", units=units.CM, description="Outer pitch")
 
+        def _validatePinIndices(self, val):
+            if val is not None:
+                # unsigned "short" integer, typically 8 bytes
+                # holds [0, 65_535] so at most, 65_535 pins per block
+                self._p_pinIndices = np.array(val, dtype=np.uint8)
+            else:
+                self._p_pinIndices = None
+
+        pb.defParam(
+            "pinIndices",
+            default=None,
+            description=(
+                "Indices within data arrays where values for this component are stored. "
+                "The array is zero indexed and structured such that the j-th pin on this "
+                "component can be found at ``Block.getPinLocations()[pinIndices[j]]``"
+            ),
+            units=units.UNITLESS,
+            setter=_validatePinIndices,
+        )
     return pDefs
 
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -35,7 +35,6 @@ from armi.physics.neutronics.settings import (
     CONF_XS_KERNEL,
 )
 from armi.reactor import blocks, blueprints, components, geometry, grids
-from armi.reactor.blueprints import blockBlueprint
 from armi.reactor.components import basicShapes, complexShapes
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_assemblies import makeTestAssembly

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -35,6 +35,7 @@ from armi.physics.neutronics.settings import (
     CONF_XS_KERNEL,
 )
 from armi.reactor import blocks, blueprints, components, geometry, grids
+from armi.reactor.blueprints import blockBlueprint
 from armi.reactor.components import basicShapes, complexShapes
 from armi.reactor.flags import Flags
 from armi.reactor.tests.test_assemblies import makeTestAssembly
@@ -2479,6 +2480,141 @@ class HexBlock_TestCase(unittest.TestCase):
         self.hexBlock.spatialGrid = None  # clear existing
         self.hexBlock.autoCreateSpatialGrids(self.r.core.spatialGrid)
         self.assertIsNone(self.hexBlock.spatialGrid)
+
+    def test_assignPinIndicesToFullGrid(self):
+        """Ensure we can assign pin indices to fuel if it occupies the entire spatial grid."""
+        # TODO Maybe this test is going away if we allow the use of None for pins where mult > 1
+        # NOTE Maybe a dimension link?
+        b = blocks.HexBlock("fuel")
+        fuel = components.Circle(
+            "fuel",
+            "UZr",
+            Tinput=25.0,
+            Thot=600.0,
+            od=0.76,
+            mult=169,
+        )
+        b.add(fuel)
+
+        clad = components.Circle(
+            "clad",
+            "HT9",
+            Tinput=25.0,
+            Thot=450.0,
+            id=0.77,
+            od=0.80,
+            mult=169,
+        )
+        b.add(clad)
+
+        wire = components.Helix(
+            "wire", "HT9", Tinput=25.0, Thot=600, id=0, od=0.1, axialPitch=30, helixDiameter=0.9, mult=169
+        )
+        b.add(wire)
+
+        duct = components.Hexagon("duct", "HT9", Tinput=25.0, Thot=400, ip=15.3, op=16, mult=1)
+        b.add(duct)
+
+        b.autoCreateSpatialGrids(self.r.core.spatialGrid)
+        self.assertIsNotNone(b.spatialGrid)
+
+        b.assignPinIndices()
+        self.assertIsNotNone(fuel.p.pinIndices)
+        np.testing.assert_allclose(fuel.p.pinIndices, np.arange(169, dtype=int))
+
+
+class MultiPinIndicesTests(unittest.TestCase):
+    BP_STR = """
+blocks:
+    fuel: &fuel_block
+        grid name: fuel grid
+        fuel 1: &fuel_def
+            shape: Circle
+            # Use void material because we don't need nuclides, just components with flags
+            material: Void
+            od: 0.68
+            Tinput: 25
+            Thot: 600
+            latticeIDs: [1]
+        clad 1: &clad_def
+            shape: Circle
+            material: Void
+            id: 0.7
+            od: 0.71
+            Tinput: 600
+            Thot: 450
+            latticeIDs: [1]
+        fuel 2:
+            <<: *fuel_def
+            latticeIDs: [2]
+        clad 2:
+            <<: *clad_def
+            latticeIDs: [2]
+        duct:
+            shape: Hexagon
+            material: Void
+            Tinput: 25
+            Thot: 450
+            ip: 15.3
+            op: 16
+assemblies:
+    fuel:
+        specifier: F
+        blocks: [*fuel_block]
+        height: [10]
+        axial mesh points: [1]
+        xs types: [A]
+grids:
+    fuel grid:
+        geom: hex_corners_up
+        symmetry: full
+        lattice map: |
+            - - -  1 1 1 1
+              - - 1 1 2 1 1
+               - 1 1 2 2 1 1
+                1 1 2 2 2 2 1
+                 1 1 2 2 1 1
+                  1 1 2 1 1
+                   1 1 1 1
+nuclide flags:
+
+"""
+
+    @classmethod
+    def setUpClass(cls):
+        cs = settings.Settings()
+        bp: blueprints.Blueprints = blueprints.Blueprints.load(cls.BP_STR)
+        bp._prepConstruction(cs)
+        cls._originalBlock: blocks.HexBlock = bp.blockDesigns["fuel"].construct(cs, bp, 0, 2, 10, "A", {})
+
+    def setUp(self):
+        self.block = copy.deepcopy(self._originalBlock)
+        self.block.assignPinIndices()
+        self.allLocations = self.block.getPinLocations()
+        self.fuelPins = self.block.getComponents(Flags.FUEL)
+
+    def test_nonOverlappingIndices(self):
+        """Test pin indices are complete and non-overlapping."""
+        foundIndices: set[int] = set()
+        for fp in self.fuelPins:
+            actualIndices = fp.p.pinIndices
+            self.assertIsNotNone(actualIndices, fp)
+            overlap = foundIndices.intersection(actualIndices)
+            self.assertFalse(overlap, msg="Found overlapping indices on unique fuel pin")
+            foundIndices.update(actualIndices)
+        # Make sure we have all the indices covered
+        for i in range(len(self.allLocations)):
+            self.assertIn(i, foundIndices)
+
+    def test_consistentPinOrdering(self):
+        """Test values of pin indices on a component align with pin locations of that component within the block."""
+        for fp in self.fuelPins:
+            locations: list[grids.IndexLocation] = list(fp.spatialLocator)
+            indices = fp.p.pinIndices
+            self.assertEqual(len(locations), len(indices), msg=fp)
+            for loc, ix in zip(locations, indices):
+                indexInBlock = self.allLocations.index(loc)
+                self.assertEqual(ix, indexInBlock, msg=f"{loc=} in {fp}")
 
 
 class TestHexBlockOrientation(unittest.TestCase):


### PR DESCRIPTION
🚨 Draft for some initial stakeholder review 🚨 

## What is the change? Why is it being made?

Provides `Block.assignPinIndices` which is responsible for setting the new `Component.p.pinIndices` parameter. `Component.p.pinIndices` helps us know two things:

1. Where, in `Block.getPinLocations` and `Block.getPinCoordinates`, do each of the pins for a given `Component` reside?
2. Where, in data arrays derived from `Block.getPinLocations`, do values for pins on a given `Component` reside?

The idea is, for a block with `locations = b.getPinLocations()` as a
list of `IndexLocations` for all the pins in the block, circular
components have a `Component.p.pinIndices` parameter. This data is used
to determine where each of the pins reside in space, and where data for
the pins reside in various data arrays like `linPowByPin`. For example,
```python
locations = b.getPinLocations()
fuel = b.getComponents(Flags.FUEL)[0]
fuelLocations = list(fuel.spatialLocator)
assert len(fuelLocations) == fuel.p.pinIndices.size
for ix, loc in zip(fuel.p.pinIndices, fuelLocations):
    assert loc == locations[ix]
```
One could then find all the pin-powers with
```python
pinPows = b.p.linPowByPin
powersForThisPin = pinPows[fuel.p.pinIndices]
```

Closes #2200 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Provides `Block.assignPinIndices` which is responsible for setting the new `Component.p.pinIndices` parameter. 

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA

Do we need new requirements for this?

---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
