### PR TITLE
Slight refactor on b.getSmearDensity to accommodate downstream work

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -229,10 +229,16 @@ class Block(composites.Composite):
         # Compute component areas
         cladID = np.mean([clad.getDimension("id", cold=cold) for clad in clads])
         innerCladdingArea = math.pi * (cladID**2) / 4.0 * self.getNumComponents(Flags.FUEL)
+        sortedCompsInsideClad = self.getSortedComponentsInsideOfComponent(clads.pop())
+
+        return self.computeSmearDensity(innerCladdingArea, sortedCompsInsideClad, cold)
+
+    @staticmethod
+    def computeSmearDensity(innerCladdingArea: float, sortedCompsInsideClad: list[components.Component], cold: bool):
         fuelComponentArea = 0.0
         unmovableComponentArea = 0.0
         negativeArea = 0.0
-        for c in self.getSortedComponentsInsideOfComponent(clads.pop()):
+        for c in sortedCompsInsideClad:
             componentArea = c.getArea(cold=cold)
             if c.isFuel():
                 fuelComponentArea += componentArea
@@ -255,10 +261,10 @@ class Block(composites.Composite):
                     negativeArea += abs(componentArea)
         if cold and negativeArea:
             raise ValueError(
-                f"Negative component areas exist on {self}. Check that the cold dimensions are "
+                "Negative component areas exist. Check that the cold dimensions are "
                 "properly aligned and no components overlap."
             )
-        innerCladdingArea += negativeArea  # See note 2
+        innerCladdingArea += negativeArea  # See note 2 of self.getSmearDensity
         totalMovableArea = innerCladdingArea - unmovableComponentArea
         smearDensity = fuelComponentArea / totalMovableArea
 


### PR DESCRIPTION
## What is the change? Why is it being made?

To accommodate downstream work supporting assemblies with multiple pin types, this PR refactors block.getSmearDensity to allow users to provide an explicit list of components rather than relying on the block itself. 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
Change Type: trivial
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Refactor block.getSmearDensity to allow users to provide an explicit list of components rather than relying on the block itself. 

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
