### PR TITLE
Making ParamMapper symmetry-aware

### DIFF
--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -18,6 +18,9 @@ import copy
 import os
 import random
 import unittest
+from unittest.mock import Mock
+
+import numpy as np
 
 from armi.nuclearDataIO.cccc import isotxs
 from armi.physics.neutronics.settings import CONF_XS_KERNEL
@@ -714,3 +717,49 @@ class TestUniformMeshNonUniformAssemFlags(unittest.TestCase):
             for b in a:
                 self.assertTrue(b.p.rateCap)
                 self.assertTrue(b.p.rateAbs)
+
+
+class TestParamMapper(unittest.TestCase):
+    """Test how the ParamMapper maps params."""
+
+    def setUp(self):
+        sourceAssem, destinationAssem = test_assemblies.buildTestAssemblies()[2:]
+        self.sourceBlock = sourceAssem.getBlocks()[0]
+        self.destinationBlock = destinationAssem.getBlocks()[0]
+
+        # volume integrated parameters
+        self.sourceBlock.p.power = 2.0
+        self.sourceBlock.p.mgFlux = np.array([2.0, 2.0, 2.0])
+        self.volumeIntegratedParameterNames = ["power", "mgFlux"]
+        # non-volume integrated parameters
+        self.sourceBlock.p.rateFis = 2.0
+        self.sourceBlock.p.linPowByPin = np.array([2.0, 2.0, 2.0])
+        self.regularParameterNames = ["rateFis", "linPowByPin"]
+        self.allParameterNames = self.volumeIntegratedParameterNames + self.regularParameterNames
+
+        self.sourceBlock.getSymmetryFactor = Mock()
+        self.destinationBlock.getSymmetryFactor = Mock()
+
+    def _mappingTestHelper(self, sourceBlock, destinationBlock, expectedRatioVolumeIntegrated):
+        """Test helper to run block comparison when mapping parameters."""
+        paramMapper = uniformMesh.ParamMapper([], self.allParameterNames, sourceBlock)
+        sourceValues = paramMapper.paramGetter(sourceBlock, self.allParameterNames)
+        paramMapper.paramSetter(destinationBlock, sourceValues, self.allParameterNames)
+        for paramName in self.volumeIntegratedParameterNames:
+            ratio = destinationBlock.p[paramName] / sourceBlock.p[paramName]
+            np.testing.assert_equal(ratio, expectedRatioVolumeIntegrated)
+        for paramName in self.regularParameterNames:
+            ratio = destinationBlock.p[paramName] / sourceBlock.p[paramName]
+            np.testing.assert_equal(ratio, 1)
+
+    def test_mappingSameSymmetry(self):
+        """Test mapping parameters between blocks with similar and dissimilar symmetry factors."""
+        self.sourceBlock.getSymmetryFactor.return_value = 3
+        self.destinationBlock.getSymmetryFactor.return_value = 3
+        self._mappingTestHelper(self.sourceBlock, self.destinationBlock, 1)
+
+    def test_mappingDifferentSymmetry(self):
+        """Test mapping parameters between blocks with similar and dissimilar symmetry factors."""
+        self.sourceBlock.getSymmetryFactor.return_value = 3
+        self.destinationBlock.getSymmetryFactor.return_value = 1
+        self._mappingTestHelper(self.sourceBlock, self.destinationBlock, 3)

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -740,26 +740,33 @@ class TestParamMapper(unittest.TestCase):
         self.sourceBlock.getSymmetryFactor = Mock()
         self.destinationBlock.getSymmetryFactor = Mock()
 
-    def _mappingTestHelper(self, sourceBlock, destinationBlock, expectedRatioVolumeIntegrated):
-        """Test helper to run block comparison when mapping parameters."""
-        paramMapper = uniformMesh.ParamMapper([], self.allParameterNames, sourceBlock)
-        sourceValues = paramMapper.paramGetter(sourceBlock, self.allParameterNames)
-        paramMapper.paramSetter(destinationBlock, sourceValues, self.allParameterNames)
+    def mappingTestHelper(self, expectedRatioVolumeIntegrated):
+        """
+        Test helper to run block comparison when mapping parameters.
+
+        Parameters
+        ----------
+        expectedRatioVolumeIntegrated : int, float
+            The ratio expected for volume integrated parameters when dividing the destination value by the source value.
+        """
+        paramMapper = uniformMesh.ParamMapper([], self.allParameterNames, self.sourceBlock)
+        sourceValues = paramMapper.paramGetter(self.sourceBlock, self.allParameterNames)
+        paramMapper.paramSetter(self.destinationBlock, sourceValues, self.allParameterNames)
         for paramName in self.volumeIntegratedParameterNames:
-            ratio = destinationBlock.p[paramName] / sourceBlock.p[paramName]
+            ratio = self.destinationBlock.p[paramName] / self.sourceBlock.p[paramName]
             np.testing.assert_equal(ratio, expectedRatioVolumeIntegrated)
         for paramName in self.regularParameterNames:
-            ratio = destinationBlock.p[paramName] / sourceBlock.p[paramName]
+            ratio = self.destinationBlock.p[paramName] / self.sourceBlock.p[paramName]
             np.testing.assert_equal(ratio, 1)
 
     def test_mappingSameSymmetry(self):
         """Test mapping parameters between blocks with similar and dissimilar symmetry factors."""
         self.sourceBlock.getSymmetryFactor.return_value = 3
         self.destinationBlock.getSymmetryFactor.return_value = 3
-        self._mappingTestHelper(self.sourceBlock, self.destinationBlock, 1)
+        self.mappingTestHelper(1)
 
     def test_mappingDifferentSymmetry(self):
         """Test mapping parameters between blocks with similar and dissimilar symmetry factors."""
         self.sourceBlock.getSymmetryFactor.return_value = 3
         self.destinationBlock.getSymmetryFactor.return_value = 1
-        self._mappingTestHelper(self.sourceBlock, self.destinationBlock, 3)
+        self.mappingTestHelper(3)

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -57,8 +57,8 @@ import collections
 import copy
 import glob
 import re
-from timeit import default_timer as timer
 import typing
+from timeit import default_timer as timer
 
 import numpy as np
 
@@ -1441,10 +1441,16 @@ class ParamMapper:
             multiplier = self.getFactorSymmetry(paramName, symmetryFactor)
             val = block.p[paramName]
             # list-like should be treated as a numpy array
-            if isinstance(val, (tuple, list, np.ndarray)):
-                paramVals.append(np.array(val) * multiplier if len(val) > 0 else None)
+            if val is None:
+                if isinstance(val, (tuple, list, np.ndarray)):
+                    paramVals.append(np.array(val) if len(val) > 0 else None)
+                else:
+                    paramVals.append(val)
             else:
-                paramVals.append(val * multiplier)
+                if isinstance(val, (tuple, list, np.ndarray)):
+                    paramVals.append(np.array(val) * multiplier if len(val) > 0 else None)
+                else:
+                    paramVals.append(val * multiplier)
 
         return np.array(paramVals, dtype=object)
 
@@ -1452,7 +1458,10 @@ class ParamMapper:
         """Assigns a set of float/integer/string values to a given set of parameters on a block."""
         symmetryFactor = block.getSymmetryFactor()
         for paramName, val in zip(paramNames, vals):
-            block.p[paramName] = val / self.getFactorSymmetry(paramName, symmetryFactor)
+            if val is None:
+                block.p[paramName] = val
+            else:
+                block.p[paramName] = val / self.getFactorSymmetry(paramName, symmetryFactor)
 
     def _arrayParamSetter(self, block: "Block", arrayVals, paramNames):
         """Assigns a set of list/array values to a given set of parameters on a block."""

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -1430,7 +1430,6 @@ class ParamMapper:
             if isinstance(val, (tuple, list, np.ndarray)):
                 self._arrayParamSetter(block, [val], [paramName])
             else:
-                print(paramName)
                 self._scalarParamSetter(block, [val], [paramName])
 
     def paramGetter(self, block: "Block", paramNames: list[str]):

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -58,6 +58,7 @@ import copy
 import glob
 import re
 from timeit import default_timer as timer
+import typing
 
 import numpy as np
 
@@ -71,6 +72,9 @@ from armi.reactor.reactors import Core, Reactor
 from armi.settings.fwSettings.globalSettings import CONF_UNIFORM_MESH_MINIMUM_SIZE
 from armi.utils import iterables, plotting
 from armi.utils.mathematics import average1DWithinTolerance
+
+if typing.TYPE_CHECKING:
+    from armi.reactor.blocks import Block
 
 HEAVY_METAL_PARAMS = ["molesHmBOL", "massHmBOL"]
 
@@ -1416,8 +1420,7 @@ class ParamMapper:
         self.reactorParamNames = reactorParamNames
         self.blockParamNames = blockParamNames
 
-    @staticmethod
-    def paramSetter(block, vals, paramNames):
+    def paramSetter(self, block: "Block", vals, paramNames):
         """Sets block parameter data."""
         for paramName, val in zip(paramNames, vals):
             # Skip setting None values.
@@ -1425,36 +1428,46 @@ class ParamMapper:
                 continue
 
             if isinstance(val, (tuple, list, np.ndarray)):
-                ParamMapper._arrayParamSetter(block, [val], [paramName])
+                self._arrayParamSetter(block, [val], [paramName])
             else:
-                ParamMapper._scalarParamSetter(block, [val], [paramName])
+                print(paramName)
+                self._scalarParamSetter(block, [val], [paramName])
 
-    def paramGetter(self, block, paramNames):
+    def paramGetter(self, block: "Block", paramNames):
         """Returns block parameter values as an array in the order of the parameter names given."""
         paramVals = []
+        symmetryFactor = block.getSymmetryFactor()
         for paramName in paramNames:
+            multiplier = self.getFactorSymmetry(paramName, symmetryFactor)
             val = block.p[paramName]
             # list-like should be treated as a numpy array
             if isinstance(val, (tuple, list, np.ndarray)):
-                paramVals.append(np.array(val) if len(val) > 0 else None)
+                paramVals.append(np.array(val) * multiplier if len(val) > 0 else None)
             else:
-                paramVals.append(val)
+                paramVals.append(val * multiplier)
 
         return np.array(paramVals, dtype=object)
 
-    @staticmethod
-    def _scalarParamSetter(block, vals, paramNames):
+    def _scalarParamSetter(self, block: "Block", vals, paramNames):
         """Assigns a set of float/integer/string values to a given set of parameters on a block."""
+        symmetryFactor = block.getSymmetryFactor()
         for paramName, val in zip(paramNames, vals):
-            block.p[paramName] = val
+            block.p[paramName] = val / self.getFactorSymmetry(paramName, symmetryFactor)
 
-    @staticmethod
-    def _arrayParamSetter(block, arrayVals, paramNames):
+    def _arrayParamSetter(self, block: "Block", arrayVals, paramNames):
         """Assigns a set of list/array values to a given set of parameters on a block."""
+        symmetryFactor = block.getSymmetryFactor()
         for paramName, vals in zip(paramNames, arrayVals):
             if vals is None:
                 continue
-            block.p[paramName] = np.array(vals)
+            block.p[paramName] = np.array(vals) / self.getFactorSymmetry(paramName, symmetryFactor)
+
+    def getFactorSymmetry(self, paramName, symmetryFactor):
+        """Returns the symmetry factor if the parameter is volume integrated, returns 1 otherwise."""
+        if self.isVolIntegrated[paramName]:
+            return symmetryFactor
+        else:
+            return 1
 
 
 def setNumberDensitiesFromOverlaps(block, overlappingBlockInfo):

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -1392,7 +1392,7 @@ class ParamMapper:
     the same data.
     """
 
-    def __init__(self, reactorParamNames, blockParamNames, b):
+    def __init__(self, reactorParamNames: list[str], blockParamNames: list[str], b: "Block"):
         """
         Initialize the list of parameter defaults.
 
@@ -1420,7 +1420,7 @@ class ParamMapper:
         self.reactorParamNames = reactorParamNames
         self.blockParamNames = blockParamNames
 
-    def paramSetter(self, block: "Block", vals, paramNames):
+    def paramSetter(self, block: "Block", vals: list, paramNames: list[str]):
         """Sets block parameter data."""
         for paramName, val in zip(paramNames, vals):
             # Skip setting None values.
@@ -1433,7 +1433,7 @@ class ParamMapper:
                 print(paramName)
                 self._scalarParamSetter(block, [val], [paramName])
 
-    def paramGetter(self, block: "Block", paramNames):
+    def paramGetter(self, block: "Block", paramNames: list[str]):
         """Returns block parameter values as an array in the order of the parameter names given."""
         paramVals = []
         symmetryFactor = block.getSymmetryFactor()
@@ -1442,19 +1442,15 @@ class ParamMapper:
             val = block.p[paramName]
             # list-like should be treated as a numpy array
             if val is None:
-                if isinstance(val, (tuple, list, np.ndarray)):
-                    paramVals.append(np.array(val) if len(val) > 0 else None)
-                else:
-                    paramVals.append(val)
+                paramVals.append(val)
+            elif isinstance(val, (tuple, list, np.ndarray)):
+                paramVals.append(np.array(val) * multiplier if len(val) > 0 else None)
             else:
-                if isinstance(val, (tuple, list, np.ndarray)):
-                    paramVals.append(np.array(val) * multiplier if len(val) > 0 else None)
-                else:
-                    paramVals.append(val * multiplier)
+                paramVals.append(val * multiplier)
 
         return np.array(paramVals, dtype=object)
 
-    def _scalarParamSetter(self, block: "Block", vals, paramNames):
+    def _scalarParamSetter(self, block: "Block", vals: list, paramNames: list[str]):
         """Assigns a set of float/integer/string values to a given set of parameters on a block."""
         symmetryFactor = block.getSymmetryFactor()
         for paramName, val in zip(paramNames, vals):
@@ -1463,7 +1459,7 @@ class ParamMapper:
             else:
                 block.p[paramName] = val / self.getFactorSymmetry(paramName, symmetryFactor)
 
-    def _arrayParamSetter(self, block: "Block", arrayVals, paramNames):
+    def _arrayParamSetter(self, block: "Block", arrayVals: list, paramNames: list[str]):
         """Assigns a set of list/array values to a given set of parameters on a block."""
         symmetryFactor = block.getSymmetryFactor()
         for paramName, vals in zip(paramNames, arrayVals):
@@ -1471,7 +1467,7 @@ class ParamMapper:
                 continue
             block.p[paramName] = np.array(vals) / self.getFactorSymmetry(paramName, symmetryFactor)
 
-    def getFactorSymmetry(self, paramName, symmetryFactor):
+    def getFactorSymmetry(self, paramName: str, symmetryFactor: int):
         """Returns the symmetry factor if the parameter is volume integrated, returns 1 otherwise."""
         if self.isVolIntegrated[paramName]:
             return symmetryFactor


### PR DESCRIPTION
## What is the change? Why is it being made?

The parameter mapper did not account for symmetry when mapping parameters between blocks. This was an issue when using the parameter mapper to assign parameters to an assembly that was not yet placed in the reactor grid from an assembly that had a non-unity symmetry factor. Now, the ParamMapper will internally convert volume integrated parameters to full-block values when getting parameters, and reduce parameters to partial values when assigning.

This specifically fixes an issue with some current development that @mgjarrett is doing, and prevents having a hyper-specific local fix for symmetry handling.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: ParamMapper now converts volume integrated parameters to full size when getting parameters (when appropriate), and converts parameters to partial size when setting parameters (when appropriate).

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
