### PR TITLE
Block collection nuclides

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -390,11 +390,11 @@ class AverageBlockCollection(BlockCollection):
         numberDensities : dict
             nucName, ndens data (atoms/bn-cm)
         """
-        nuclides = self.allNuclidesInProblem
         blocks = self.getCandidateBlocks()
         weights = np.array([self.getWeight(b) for b in blocks])
         weights /= weights.sum()  # normalize by total weight
         components = [sorted(b.getComponents())[compIndex] for b in blocks]
+        nuclides = self._getAllNucs(components)
         ndens = weights.dot([c.getNuclideNumberDensities(nuclides) for c in components])
         return dict(zip(nuclides, ndens))
 
@@ -463,6 +463,14 @@ class AverageBlockCollection(BlockCollection):
                     return False
         else:
             return True
+
+    @staticmethod
+    def _getAllNucs(components):
+        """Iterate through components and get all unique nuclides."""
+        nucs = set()
+        for c in components:
+            nucs = nucs.union(c.getNuclides())
+        return sorted(list(nucs))
 
 
 def getBlockNuclideTemperature(block, nuclide):
@@ -572,14 +580,6 @@ class CylindricalComponentsAverageBlockCollection(AverageBlockCollection):
         repBlock.clearCache()
         self.calcAvgNuclideTemperatures()
         return repBlock
-
-    @staticmethod
-    def _getAllNucs(components):
-        """Iterate through components and get all unique nuclides."""
-        nucs = set()
-        for c in components:
-            nucs = nucs.union(c.getNuclides())
-        return sorted(list(nucs))
 
     @staticmethod
     def _checkComponentConsistency(b, repBlock):

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -266,6 +266,7 @@ class TestComponentAveraging(unittest.TestCase):
                     avgDensities[nuc],
                     msg=f"{nuc} density {compDensities[nuc]} not equal to {avgDensities[nuc]}!",
                 )
+            self.assertEqual(len(compDensities), len(avgDensities))
 
     def test_getAverageComponentTemperature(self):
         """Test mass-weighted component temperature averaging."""


### PR DESCRIPTION
## What is the change? Why is it being made?

When creating a representative block for a block collection with `averageByComponent: true`, each component is assigned only the nuclides present in that component.

Previously, the component number densities were set for all nuclides in the problem. For many components, most of the nuclides are not present and were thus stored at a 0.0 number density.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: reduce the number of nuclides stored on each component in a representative block by ignoring those with 0.0 number density.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
