### PR TITLE
Removing python-dateutil dependency

### DIFF
--- a/armi/utils/parsing.py
+++ b/armi/utils/parsing.py
@@ -83,4 +83,3 @@ def parseValue(source, requestedType, allowNone=False, matchingNonetype=True):
         raise ValueError(msg.format(requestedType, evaluated_source))
 
     return evaluated_source
-

--- a/armi/utils/parsing.py
+++ b/armi/utils/parsing.py
@@ -17,8 +17,6 @@
 import ast
 import copy
 
-from dateutil import parser
-
 
 def tryLiteralEval(source):
     try:
@@ -86,10 +84,3 @@ def parseValue(source, requestedType, allowNone=False, matchingNonetype=True):
 
     return evaluated_source
 
-
-# -----------------------------------
-
-
-def datetimeFromStr(string):
-    """Converts an arbitrary string to a datetime object."""
-    return parser.parse(string)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "pluggy>=1.2.0", # Central tool behind the ARMI Plugin system
     "pyDOE>=0.3.8", # We import a Latin-hypercube algorithm to explore a phase space
     "pyevtk>=1.2.0", # Handles binary VTK visualization files
-    "python-dateutil>=2.2", # To read a datetime string more easily.
     "ruamel.yaml ; python_version >= '3.11.0'", # Our foundational YAML library
     "ruamel.yaml.clib ; python_version >= '3.11.0'", # C-based core of ruamel below
     "ruamel.yaml.clib<=0.2.7 ; python_version < '3.11.0'", # C-based core of ruamel below


### PR DESCRIPTION
## What is the change? Why is it being made?

There is a one-line function in ARMI that is entirely unused. And that one line requires ARMI to have an entire dependency. So, this PR removes that line and dependency.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing python-dateutil dependency

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
