### PR TITLE
Remove Component.p.puFrac

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -740,7 +740,6 @@ class Block(composites.Composite):
             if isinstance(child, components.Component):
                 child.p.massHmBOL = hmMass
                 child.p.molesHmBOL = child.getHMMoles()
-                child.p.puFrac = self.getPuMoles() / child.p.molesHmBOL if child.p.molesHmBOL > 0.0 else 0.0
 
         self.p.massHmBOL = massHmBOL
 

--- a/armi/reactor/components/componentParameters.py
+++ b/armi/reactor/components/componentParameters.py
@@ -175,13 +175,6 @@ def getComponentParameterDefinitions():
             description="Total number of moles of heavy metal at BOL.",
         )
 
-        pb.defParam(
-            "puFrac",
-            default=0.0,
-            units=units.UNITLESS,
-            description="Current average Pu fraction. Calculated as the ratio of Pu mass to total HM mass.",
-        )
-
     return pDefs
 
 


### PR DESCRIPTION
## What is the change? Why is it being made?

The component parameter `puFrac` has been removed. It is relatively new so hopefully people haven't started using it. Or if they have, they can maybe continue to do so. Internal usage has been removed and this likely does not need to be in the public framework anymore

`Block.p.puFrac` has not been removed since it's been around a long time and I think it has more widespread usage.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Remove Component.p.puFrac

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
