### PR TITLE
Removing defunct deprecation warning

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -191,10 +191,6 @@ def factory(cs, bp) -> Reactor:
     if cs[CONF_SORT_REACTOR]:
         r.sort()
     else:
-        runLog.warning(
-            "DeprecationWarning: This Reactor is not being sorted on blueprint read. Due to the "
-            f"setting {CONF_SORT_REACTOR}, this Reactor is unsorted. But this feature is temporary "
-            "and will be removed by 2024."
-        )
+        runLog.info(f"Due to the setting {CONF_SORT_REACTOR}, this Reactor is unsorted.")
 
     return r


### PR DESCRIPTION
## What is the change? Why is it being made?

At one point, we assumed we would be removing the little setting that lets the reactor remain unsorted. But, for better or worse, that setting is an important part of some people's workflows. So we are removing the deprecation warning, and keeping that setting long term.

close #2207 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing defunct deprecation warning from the unsorted reactor settings.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
