### PR TITLE
Improving documentation of axial expansion

### DIFF
--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -15,9 +15,8 @@
 """
 Framework-wide settings definitions and constants.
 
-This should contain Settings definitions for general-purpose "framework"
-settings. These should only include settings that are not related to any
-particular physics or plugins.
+This should contain Settings definitions for general-purpose "framework" settings. These should only include settings
+that are not related to any particular physics or plugins.
 """
 
 import os
@@ -30,7 +29,6 @@ from armi.settings import setting
 from armi.settings.fwSettings import tightCouplingSettings
 from armi.utils.mathematics import isMonotonic
 
-# Framework settings
 CONF_ACCEPTABLE_BLOCK_AREA_ERROR = "acceptableBlockAreaError"
 CONF_ASSEM_FLAGS_SKIP_AXIAL_EXP = "assemFlagsToSkipAxialExpansion"
 CONF_AUTOMATIC_VARIABLE_MESH = "automaticVariableMesh"
@@ -40,7 +38,6 @@ CONF_AXIAL_MESH_REFINEMENT_FACTOR = "axialMeshRefinementFactor"
 CONF_BETA = "beta"
 CONF_BRANCH_VERBOSITY = "branchVerbosity"
 CONF_BU_GROUPS = "buGroups"
-CONF_TEMP_GROUPS = "tempGroups"
 CONF_BURN_CHAIN_FILE_NAME = "burnChainFileName"
 CONF_BURN_STEPS = "burnSteps"
 CONF_BURNUP_PEAKING_FACTOR = "burnupPeakingFactor"
@@ -79,8 +76,8 @@ CONF_MATERIAL_NAMESPACE_ORDER = "materialNamespaceOrder"
 CONF_MIN_MESH_SIZE_RATIO = "minMeshSizeRatio"
 CONF_MODULE_VERBOSITY = "moduleVerbosity"
 CONF_N_CYCLES = "nCycles"
-CONF_NON_UNIFORM_ASSEM_FLAGS = "nonUniformAssemFlags"
 CONF_N_TASKS = "nTasks"
+CONF_NON_UNIFORM_ASSEM_FLAGS = "nonUniformAssemFlags"
 CONF_OPERATOR_LOCATION = "operatorLocation"
 CONF_OUTPUT_CACHE_LOCATION = "outputCacheLocation"
 CONF_OUTPUT_FILE_EXTENSION = "outputFileExtension"
@@ -90,8 +87,8 @@ CONF_POWER = "power"
 CONF_POWER_DENSITY = "powerDensity"
 CONF_POWER_FRACTIONS = "powerFractions"
 CONF_PROFILE = "profile"
-CONF_RM_EXT_FILES_AT_BOC = "rmExternalFilesAtBOC"
 CONF_REMOVE_PER_CYCLE = "removePerCycle"
+CONF_RM_EXT_FILES_AT_BOC = "rmExternalFilesAtBOC"
 CONF_RUN_TYPE = "runType"
 CONF_SKIP_CYCLES = "skipCycles"
 CONF_SMALL_RUN = "rmExternalFilesAtEOL"
@@ -102,6 +99,7 @@ CONF_STATIONARY_BLOCK_FLAGS = "stationaryBlockFlags"
 CONF_T_IN = "Tin"
 CONF_T_OUT = "Tout"
 CONF_TARGET_K = "targetK"  # lots of things use this
+CONF_TEMP_GROUPS = "tempGroups"
 CONF_TIGHT_COUPLING = "tightCoupling"
 CONF_TIGHT_COUPLING_MAX_ITERS = "tightCouplingMaxNumIters"
 CONF_TIGHT_COUPLING_SETTINGS = "tightCouplingSettings"

--- a/doc/user/radial_and_axial_expansion.rst
+++ b/doc/user/radial_and_axial_expansion.rst
@@ -2,10 +2,13 @@
 Radial and Axial Expansion and Contraction
 ******************************************
 
-ARMI natively supports linear expansion in both the radial and axial dimensions. These expansion
-types function independently of one another and each have their own set of underlying assumptions
-and use-cases. Radial expansion happens by default but axial expansion only occurs if the setting
-``inputHeightsConsideredHot`` is set to ``False``.
+ARMI natively supports linear expansion in both the radial and axial dimensions for pin-type reactors. These expansion
+types function independently of one another and each have their own set of underlying assumptions and use-cases. Radial
+expansion happens by default but there are several settings that control axial expansion:
+
+* ``inputHeightsConsideredHot`` - Set this to ``False`` or axial expansion will not occur.
+* ``assemFlagsToSkipAxialExpansion`` - Assemblies with a flag in this list will not be axially expanded.
+* ``detailedAxialExpansion`` - Allow each assembly to expand independently. This will result in a non-uniform mesh.
 
 Thermal Expansion
 =================

--- a/doc/user/radial_and_axial_expansion.rst
+++ b/doc/user/radial_and_axial_expansion.rst
@@ -10,6 +10,11 @@ expansion happens by default but there are several settings that control axial e
 * ``assemFlagsToSkipAxialExpansion`` - Assemblies with a flag in this list will not be axially expanded.
 * ``detailedAxialExpansion`` - Allow each assembly to expand independently. This will result in a non-uniform mesh.
 
+By default, ARMI runs radial and axial expansion when objects are created from blueprints. That is, when the reactor is
+created from blueprints at BOL, these calculations are performed. But also at BOC if new assemblies are added to the
+core, then expansion will happen again when the assembly object is created from blueprints.
+
+
 Thermal Expansion
 =================
 ARMI treats thermal expansion as a linear phenomena using a standard linear expansion relationship,


### PR DESCRIPTION
## What is the change? Why is it being made?

There were some end-user requests for a little more information about axial expansion. I am attempting to improve that documentation here.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Improving documentation of axial expansion

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
