### PR TITLE
Update logic for number density arrays and other cleanup

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -936,7 +936,7 @@ class Assembly(composites.Composite):
                 return bIndex
         return -1  # no block index found
 
-    def getBlocksBetweenElevations(self, zLower, zUpper):
+    def getBlocksBetweenElevations(self, zLower, zUpper, eps=1e-10):
         """
         Return block(s) between two axial elevations and their corresponding heights.
 
@@ -944,6 +944,9 @@ class Assembly(composites.Composite):
         ----------
         zLower, zUpper : float
             Elevations in cm where blocks should be found.
+        eps : float
+            Lower bound for relative block height fraction that we care about.
+            Below this bound, small slivers of overlapping block are ignored.
 
 
         Returns
@@ -967,7 +970,6 @@ class Assembly(composites.Composite):
         [(Block1, 25.0), (Block2, 5.0)]
 
         """
-        EPS = 1e-10
         blocksHere = []
         allMeshPoints = set()
 
@@ -981,7 +983,7 @@ class Assembly(composites.Composite):
                 heightHere = top - bottom
 
                 # Filter out blocks that have an extremely small height fraction
-                if heightHere / b.getHeight() > EPS:
+                if heightHere / b.getHeight() > eps:
                     blocksHere.append((b, heightHere))
 
         totalHeight = 0.0
@@ -993,7 +995,7 @@ class Assembly(composites.Composite):
 
         # Verify that the heights of all the blocks are equal to the expected
         # height for the given zUpper and zLower.
-        if abs(totalHeight - expectedHeight) > 1e-5:
+        if abs(totalHeight - expectedHeight) / expectedHeight > 10.0 * eps:
             raise ValueError(
                 f"The cumulative height of {blocksHere} is {totalHeight} cm "
                 f"and does not equal the expected height of {expectedHeight} cm.\n"

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -771,7 +771,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         """
         # prepare to change the densities with knowledge that dims could change due to material
         # thermal expansion dependence on composition
-        if self.p.numberDensities.size > 0:
+        if self.p.numberDensities is not None and self.p.numberDensities.size > 0:
             dLLprev = self.material.linearExpansionPercent(Tc=self.temperatureInC) / 100.0
             materialExpansion = True
         else:
@@ -788,8 +788,6 @@ class Component(composites.Composite, metaclass=ComponentType):
 
         # change the densities
         if wipe:
-            self.p.numberDensities = None  # clear things not passed
-            self.p.nuclides = None  # clear things not passed
             self.p.nuclides = np.asanyarray(list(numberDensities.keys()), dtype="S6")
             self.p.numberDensities = np.array(list(numberDensities.values()))
         else:

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -1042,7 +1042,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
             # Check if the source reactor has a value assigned for this
             # parameter and if so, then apply it. Otherwise, revert back to
             # the original value.
-            if sourceReactor.core.p[paramName] or paramName not in self._cachedReactorCoreParamData:
+            if sourceReactor.core.p[paramName] is not None or paramName not in self._cachedReactorCoreParamData:
                 val = sourceReactor.core.p[paramName]
             else:
                 val = self._cachedReactorCoreParamData[paramName]


### PR DESCRIPTION
## What is the change? Why is it being made?

* Update logic that checks for number densities to handle a `None`, which can happen when reading from a database.
* Make Assembly.getBlocksBetweenElevations() take a kwarg for the `EPS` parameter instead of having it hard-coded.
* Allow reactor parameter mapper to handle non-scalar parameters.

These changes are being made to enable a new downstream use case of the uniform mesh converter. These are mostly minor updates to control logic that can handle new situations that were previously not encountered in a downstream workflow.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
Updates to handling of reactor parameters and nuclides to enable new downstream uses cases for the uniform mesh converter.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
