### PR TITLE
Make a duplicated test tag unique

### DIFF
--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -336,7 +336,7 @@ class TestGridBPRoundTripFull(unittest.TestCase):
         Test that a lattice map can be defined, written, and read in from blueprint file.
 
         .. test:: Define a lattice map in reactor core.
-            :id: T_ARMI_BP_GRID1
+            :id: T_ARMI_BP_GRID2
             :tests: R_ARMI_BP_GRID
         """
         grid = Grids.load(BIG_FULL_HEX_CORE)


### PR DESCRIPTION
## What is the change? Why is it being made?

Noticed the following warning building docs locally

> [warn] Need could not be created: A need with ID 'T_ARMI_BP_GRID1' already exists. [needs.create_need]

https://github.com/terrapower/armi/blob/12f6883dc89db802a5432e93e477995b443a09df/armi/reactor/blueprints/tests/test_gridBlueprints.py#L313-L320

https://github.com/terrapower/armi/blob/12f6883dc89db802a5432e93e477995b443a09df/armi/reactor/blueprints/tests/test_gridBlueprints.py#L334-L341

Warning also shows up in most recent docs workflow

https://github.com/terrapower/armi/actions/runs/16893899224/job/47859752694#step:8:966


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Make a duplicated test tag unique

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Updated test tags for R_ARMI_BP_GRID


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
