### PR TITLE
Fix equality of MultiIndexLocator and CoordinateLocation

### DIFF
--- a/armi/reactor/grids/locations.py
+++ b/armi/reactor/grids/locations.py
@@ -435,6 +435,10 @@ class CoordinateLocation(IndexLocation):
             return self.grid == other.grid and self.i == other.i and self.j == other.j and self.k == other.k
         return NotImplemented
 
+    def __hash__(self):
+        """Hash based on the coordinates but not the grid."""
+        return hash((self.i, self.j, self.k))
+
     def getLocalCoordinates(self, nativeCoords=False):
         """Return x,y,z coordinates in cm within the grid's coordinate system."""
         return self.indices

--- a/armi/reactor/grids/locations.py
+++ b/armi/reactor/grids/locations.py
@@ -340,6 +340,17 @@ class MultiIndexLocation(IndexLocation):
         IndexLocation.__init__(self, 0, 0, 0, grid)
         self._locations = []
 
+    def __eq__(self, other):
+        """Considered equal if the grids are identical and contained locations are identical.
+
+        Two ``MultiIndexLocation`` objects with the same total collection of locations, but in
+        different orders, will not be considered equal.
+        """
+        if isinstance(other, type(self)):
+            return self.grid == other.grid and self._locations == other._locations
+        # Different objects -> let other.__eq__(self) handle it
+        return NotImplemented
+
     def __getstate__(self) -> List[IndexLocation]:
         """Used in pickling and deepcopy, this detaches the grid."""
         return self._locations

--- a/armi/reactor/grids/locations.py
+++ b/armi/reactor/grids/locations.py
@@ -427,6 +427,14 @@ class CoordinateLocation(IndexLocation):
 
     __slots__ = ()
 
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            # Mainly to avoid comparing against MultiIndexLocations
+            # Fuel pins may have a multi index location and the duct may
+            # have a coordinate location and we don't want them to be equal
+            return self.grid == other.grid and self.i == other.i and self.j == other.j and self.k == other.k
+        return NotImplemented
+
     def getLocalCoordinates(self, nativeCoords=False):
         """Return x,y,z coordinates in cm within the grid's coordinate system."""
         return self.indices

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -84,6 +84,10 @@ class TestSpatialLocator(unittest.TestCase):
         b.append(grids.IndexLocation(1, 1, 1, None))
         self.assertNotEqual(a, b)
 
+        c = grids.MultiIndexLocation(None)
+        c.append(grids.IndexLocation(0, 0, 0, None))
+        self.assertEqual(a, c)
+
     def test_multiIndexEqWithLocations(self):
         """Two multi index locators on the same grid are equal."""
         grid = MockStructuredGrid()

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -76,6 +76,14 @@ class TestSpatialLocator(unittest.TestCase):
         loc2 = grids.IndexLocation(2, 2, 0, None)
         self.assertEqual(loc1 + loc2, grids.IndexLocation(3, 4, 0, None))
 
+    def test_multiIndexEq(self):
+        """Check multi index locations are only true if they live on the same grid and have the same locations."""
+        a = grids.MultiIndexLocation(None)
+        a.append(grids.IndexLocation(0, 0, 0, None))
+        b = grids.MultiIndexLocation(None)
+        b.append(grids.IndexLocation(1, 1, 1, None))
+        self.assertNotEqual(a, b)
+
     def test_recursion(self):
         """
         Make sure things work as expected with a chain of locators/grids/locators.

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -113,6 +113,13 @@ class TestSpatialLocator(unittest.TestCase):
         self.assertNotEqual(base, grids.CoordinateLocation(base.i, base.j - 2, base.k, base.grid))
         self.assertNotEqual(base, grids.CoordinateLocation(base.i, base.j, base.k + 13, base.grid))
 
+    def test_coordinateLocationHash(self):
+        """Ensure we can hash the location based on it's position, not the grid."""
+        a = grids.CoordinateLocation(5, 9, 1, MockStructuredGrid())
+        self.assertEqual(hash(a), hash((a.i, a.j, a.k)))
+        b = grids.CoordinateLocation(a.i, a.j, a.k, None)
+        self.assertEqual(hash(b), hash(a))
+
     def test_recursion(self):
         """
         Make sure things work as expected with a chain of locators/grids/locators.

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -84,6 +84,35 @@ class TestSpatialLocator(unittest.TestCase):
         b.append(grids.IndexLocation(1, 1, 1, None))
         self.assertNotEqual(a, b)
 
+    def test_multiIndexEqWithLocations(self):
+        """Two multi index locators on the same grid are equal."""
+        grid = MockStructuredGrid()
+        a = grids.MultiIndexLocation(grid)
+        a.extend((grids.IndexLocation(i, -i, i, grid) for i in range(5)))
+
+        b = grids.MultiIndexLocation(grid)
+        b.extend(a)
+
+        self.assertEqual(a, b)
+        # If the order differs but all the locations are the same, the locators are considered not equal
+        locs = list(a)
+        locs.insert(0, locs.pop())
+        c = grids.MultiIndexLocation(grid)
+        c.extend(locs)
+        self.assertNotEqual(c, a)
+
+    def test_coordinateLocationEq(self):
+        """Test for equality on the coordinate location object."""
+        base = grids.CoordinateLocation(1, -3, 5, MockStructuredGrid())
+        self.assertEqual(base, base)
+        self.assertEqual(base, grids.CoordinateLocation(base.i, base.j, base.k, base.grid))
+        self.assertNotEqual(base, grids.CoordinateLocation(base.i, base.j, base.k, None))
+        # Pick some points with different indices in one dimension
+        # Offsets are arbitrary
+        self.assertNotEqual(base, grids.CoordinateLocation(base.i + 1, base.j, base.k, base.grid))
+        self.assertNotEqual(base, grids.CoordinateLocation(base.i, base.j - 2, base.k, base.grid))
+        self.assertNotEqual(base, grids.CoordinateLocation(base.i, base.j, base.k + 13, base.grid))
+
     def test_recursion(self):
         """
         Make sure things work as expected with a chain of locators/grids/locators.


### PR DESCRIPTION
## What is the change? Why is it being made?

Closes #2224 

- `MultiIndexLocator` objects are equal if their grids are equal and all their locations are equal, including ordering.
- `CoordinateLocation` objects are equal if their grids are equal and their misnamed `(i, j, k)` coordinate locations (real positions in space, not an index like ijk would imply) are equal

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Fix equality of `MultiIndexLocator` and `CoordinateLocation`

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Strengthens behavior related to `R_ARMI_GRID_MULT` but does not directly modify that requirement.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
