### PR TITLE
Fixing bug in Air.pseudoDensity when given Celsius T

### DIFF
--- a/armi/materials/air.py
+++ b/armi/materials/air.py
@@ -85,7 +85,7 @@ class Air(material.Fluid):
         """
         Tk = getTk(Tc, Tk)
         self.checkPropertyTempRange("pseudoDensity", Tk)
-        inv_Tk = 1.0 / getTk(Tc, Tk)
+        inv_Tk = 1.0 / Tk
         rho_kgPerM3 = 1.15675e03 * inv_Tk**2 + 3.43413e02 * inv_Tk + 2.99731e-03
         return rho_kgPerM3 / G_PER_CM3_TO_KG_PER_M3
 

--- a/armi/materials/tests/test_air.py
+++ b/armi/materials/tests/test_air.py
@@ -19,6 +19,7 @@ import unittest
 
 from armi.materials.air import Air
 from armi.utils import densityTools
+from armi.utils.units import getTc
 
 """
 Reference thermal physical properties from Table A.4 in Incropera, Frank P., et al. Fundamentals of
@@ -195,6 +196,8 @@ class Test_Air(unittest.TestCase):
         for Tk, densKgPerM3 in zip(REFERENCE_Tk, REFERENCE_DENSITY_KG_PER_M3):
             if Tk < 2400:
                 error = math.fabs((air.pseudoDensityKgM3(Tk=Tk) - densKgPerM3) / densKgPerM3)
+                self.assertLess(error, 1e-2)
+                error = math.fabs((air.pseudoDensityKgM3(Tc=getTc(Tk=Tk)) - densKgPerM3) / densKgPerM3)
                 self.assertLess(error, 1e-2)
 
     def test_heatCapacity(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

While working on #2198 I found a bug in air.pseudoDensity. If you supply `Tc` to `air.pseudoDensity`, then on line 86 you get `Tk`. Then two lines later when `1/Tk` is calculated, you supply both `Tc` and `Tk` to `getTk` and that errors out. A fix here is to simply just use `Tk` and not try to convert it again. 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Fixing bug in Air.pseudoDensity when given Celsius temperature.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
