### PR TITLE
Adding Composite.getFirstComponent method

### DIFF
--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2656,7 +2656,42 @@ class Composite(ArmiObject):
         return list(items)
 
     def getComponents(self, typeSpec: TypeSpec = None, exact=False):
+        """
+        Return a list of Component objects within this Composite.
+
+        Parameters
+        ----------
+        typeSpec : TypeSpec
+            Component flags. Will restrict Components to specific ones matching the flags specified.
+        exact : bool, optional
+            Only match exact component labels (names). If True, 'coolant' will not match 'interCoolant'. This has no
+            impact if typeSpec is None.
+
+        Returns
+        -------
+        list of Component
+            items matching typeSpec and exact criteria
+        """
         return list(self.iterComponents(typeSpec, exact))
+
+    def getFirstComponent(self, typeSpec: TypeSpec = None, exact=False):
+        """
+        Returns a single Component object within this Composite.
+
+        Parameters
+        ----------
+        typeSpec : TypeSpec
+            Component flags. Will restrict Components to specific ones matching the flags specified.
+        exact : bool, optional
+            Only match exact component labels (names). If True, 'coolant' will not match 'interCoolant'. This has no
+            impact if typeSpec is None.
+
+        Returns
+        -------
+        Component
+            The first item matching typeSpec and exact criteria
+        """
+        return next(self.iterComponents(typeSpec, exact))
 
     def iterComponents(self, typeSpec: TypeSpec = None, exact: bool = False) -> Iterator["Component"]:
         """

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2691,7 +2691,10 @@ class Composite(ArmiObject):
         Component
             The first item matching typeSpec and exact criteria
         """
-        return next(self.iterComponents(typeSpec, exact))
+        try:
+            return next(self.iterComponents(typeSpec, exact))
+        except StopIteration:
+            raise ValueError(f"No component matches {typeSpec} {exact}")
 
     def iterComponents(self, typeSpec: TypeSpec = None, exact: bool = False) -> Iterator["Component"]:
         """

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -95,7 +95,7 @@ class TestCompositePattern(unittest.TestCase):
         runLog.setVerbosity("error")
         container = DummyComposite("inner test fuel", 99)
         for i in range(5):
-            leaf = DummyLeaf("duct {}".format(i), i + 100)
+            leaf = DummyLeaf(f"duct {i}", i + 100)
             leaf.setType("duct")
             container.add(leaf)
         nested = DummyComposite("clad", 98)
@@ -472,6 +472,28 @@ class TestCompositePattern(unittest.TestCase):
             self.assertAlmostEqual(rRatesAssem[key], val)
             self.assertAlmostEqual(rRatesCore[key], val)
             self.assertAlmostEqual(rRatesReactor[key], val)
+
+    def test_getFirstComponent(self):
+        c = self.container.getComponents()[0]
+        c0 = self.container.getFirstComponent()
+        self.assertEqual(c, c0)
+        self.assertIsInstance(c0, composites.Composite)
+
+        c = self.cladChild.getComponents()[0]
+        c0 = self.cladChild.getFirstComponent()
+        self.assertEqual(c, c0)
+        self.assertIsInstance(c0, composites.Composite)
+
+        c = self.secondGen.getComponents()[0]
+        c0 = self.secondGen.getFirstComponent()
+        self.assertEqual(c, c0)
+        self.assertIsInstance(c0, composites.Composite)
+
+        b = loadTestBlock()
+        c = b.getComponents()[0]
+        c0 = b.getFirstComponent()
+        self.assertEqual(c, c0)
+        self.assertIsInstance(c0, composites.Composite)
 
     def test_syncParameters(self):
         data = [{"serialNum": 123}, {"flags": "FAKE"}]

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -476,23 +476,23 @@ class TestCompositePattern(unittest.TestCase):
     def test_getFirstComponent(self):
         c = self.container.getComponents()[0]
         c0 = self.container.getFirstComponent()
-        self.assertEqual(c, c0)
+        self.assertIs(c, c0)
         self.assertIsInstance(c0, composites.Composite)
 
         c = self.cladChild.getComponents()[0]
         c0 = self.cladChild.getFirstComponent()
-        self.assertEqual(c, c0)
+        self.assertIs(c, c0)
         self.assertIsInstance(c0, composites.Composite)
 
         c = self.secondGen.getComponents()[0]
         c0 = self.secondGen.getFirstComponent()
-        self.assertEqual(c, c0)
+        self.assertIs(c, c0)
         self.assertIsInstance(c0, composites.Composite)
 
         b = loadTestBlock()
         c = b.getComponents()[0]
         c0 = b.getFirstComponent()
-        self.assertEqual(c, c0)
+        self.assertIs(c, c0)
         self.assertIsInstance(c0, composites.Composite)
 
     def test_syncParameters(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

Adding Composite.getFirstComponent method, because it would be useful for people that have this a lot in their code:

```python
c = X.getComponents()[0]
```

I just want to add the new method to help performance.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Adding Composite.getFirstComponent method

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
