### PR TITLE
Fixing issue initial time node in previous PR

### DIFF
--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -210,7 +210,7 @@ class TestArmiCase(unittest.TestCase):
                 stdOut = mock.getStdout()
                 self.assertIn("Triggering BOL Event", stdOut)
                 self.assertIn("xsGroups", stdOut)
-                self.assertIn("Completed EveryNode - timestep: cycle 0, node 0, year 2.74 Event", stdOut)
+                self.assertIn("Completed EveryNode - timestep: cycle 0, node 0, year 0.00 Event", stdOut)
 
     def test_clone(self):
         testTitle = "CLONE_TEST"

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -406,6 +406,7 @@ class Operator:
         self.r.p.timeNode = timeNode
         if timeNode > 0:
             self.r.p.time += self.r.o.stepLengths[cycle][timeNode - 1] / units.DAYS_PER_YEAR
+
         self.interactAllEveryNode(cycle, timeNode)
         self._performTightCoupling(cycle, timeNode)
 


### PR DESCRIPTION
## What is the change? Why is it being made?

A previous PR was merged prematurely and we found an issue in downstream testing.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Follow up fix to last PR (BOL time nodes)

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
