### PR TITLE
Handling BOL times better

### DIFF
--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -404,8 +404,11 @@ class Operator:
     def _timeNodeLoop(self, cycle, timeNode):
         """Run the portion of the main loop that happens each subcycle."""
         self.r.p.timeNode = timeNode
-        if timeNode > 0:
-            self.r.p.time += self.r.o.stepLengths[cycle][timeNode - 1] / units.DAYS_PER_YEAR
+        if timeNode == 0:
+            dt = 0
+        else:
+            dt = self.r.o.stepLengths[cycle][timeNode - 1] / units.DAYS_PER_YEAR
+        self.r.p.time = self.r.p.time + dt
 
         self.interactAllEveryNode(cycle, timeNode)
         self._performTightCoupling(cycle, timeNode)


### PR DESCRIPTION
## What is the change? Why is it being made?

Ensuring that at BOL the default value of `r.p.time = 0` is written to the database. And trying to trap the restart BOC case for the same reason.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Ensuring that at BOL the default value of `r.p.time = 0` is written to the database.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
