### PR TITLE
Handle pinIndices for blocks that don't have fuel

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2165,6 +2165,7 @@ class HexBlock(Block):
         # Usually things are linked to one of these "primary" flags, like
         # a cladding component having linked dimensions to a fuel component
         targetFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD)
+        found = False
         for c in self.iterChildren(predicate=lambda c: c.hasFlags(targetFlags) and isinstance(c, Circle)):
             localLocations = c.spatialLocator
             if isinstance(localLocations, grids.MultiIndexLocation):
@@ -2175,6 +2176,20 @@ class HexBlock(Block):
                 continue
             localIndices = list(map(allIJ.index, localIJ))
             c.p.pinIndices = localIndices
+            found = True
+        if found:
+            return
+        for c in self.iterChildren(predicate=lambda c: c.hasFlags(Flags.CLAD) and isinstance(c, Circle)):
+            localLocations = c.spatialLocator
+            if isinstance(localLocations, grids.MultiIndexLocation):
+                localIJ = list(map(ijGetter, localLocations))
+            elif isinstance(localLocations, grids.IndexLocation):
+                localIJ = [ijGetter(localLocations)]
+            else:
+                continue
+            localIndices = list(map(allIJ.index, localIJ))
+            c.p.pinIndices = localIndices
+
 
     def getPinCenterFlatToFlat(self, cold=False):
         """Return the flat-to-flat distance between the centers of opposing pins in the outermost ring."""

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -25,7 +25,7 @@ import functools
 import math
 import operator
 import warnings
-from typing import ClassVar, Optional, Tuple, Type
+from typing import Callable, ClassVar, Optional, Tuple, Type
 
 import numpy as np
 
@@ -2162,9 +2162,23 @@ class HexBlock(Block):
         ijGetter = operator.attrgetter("i", "j")
         allIJ: tuple[tuple[int, int]] = tuple(map(ijGetter, locations))
         # Flags for components that we want to set this parameter
-        # Usually things are linked to one of these "primary" flags, like
+        # Usually things are linked to one of these "important" flags, like
         # a cladding component having linked dimensions to a fuel component
         targetFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD)
+        found = self._assignPinIndices(ijGetter, allIJ, targetFlags)
+        if found:
+            return
+        # If we didn't find any "important" components, but we have pins, we need to
+        # provide some information about where the pins live still. Fall back to
+        # assigning on the cladding components
+        self._assignPinIndices(ijGetter, allIJ, Flags.CLAD)
+
+    def _assignPinIndices(
+        self,
+        ijGetter: Callable[[grids.IndexLocation], tuple[int, int]],
+        allIJ: tuple[int, int],
+        targetFlags: Flags,
+    ) -> bool:
         found = False
         for c in self.iterChildren(predicate=lambda c: c.hasFlags(targetFlags) and isinstance(c, Circle)):
             localLocations = c.spatialLocator
@@ -2177,19 +2191,7 @@ class HexBlock(Block):
             localIndices = list(map(allIJ.index, localIJ))
             c.p.pinIndices = localIndices
             found = True
-        if found:
-            return
-        for c in self.iterChildren(predicate=lambda c: c.hasFlags(Flags.CLAD) and isinstance(c, Circle)):
-            localLocations = c.spatialLocator
-            if isinstance(localLocations, grids.MultiIndexLocation):
-                localIJ = list(map(ijGetter, localLocations))
-            elif isinstance(localLocations, grids.IndexLocation):
-                localIJ = [ijGetter(localLocations)]
-            else:
-                continue
-            localIndices = list(map(allIJ.index, localIJ))
-            c.p.pinIndices = localIndices
-
+        return found
 
     def getPinCenterFlatToFlat(self, cold=False):
         """Return the flat-to-flat distance between the centers of opposing pins in the outermost ring."""

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1372,16 +1372,22 @@ class Component(composites.Composite, metaclass=ComponentType):
             runLog.error(ee)
             raise ValueError(msg) from ee
 
-    def getPinIndices(self) -> Optional[np.ndarray[tuple[int], np.uint16]]:
+    def getPinIndices(self) -> np.ndarray[tuple[int], np.uint16]:
         """Find the indices for the locations where this component can be found in the block.
 
         Returns
         -------
-        np.array[int] or None
-            None if this object is not a pin, or if this object is not the central component
-            in the pin. Otherwise, return the indices in various Block-level pin methods,
+        np.array[int]
+            The indices in various Block-level pin methods,
             e.g., :meth:`armi.reactor.blocks.Block.getPinLocations`, that correspond to
             this component.
+
+        Raises
+        ------
+        ValueError
+            If this does not have pin indices. This can be the case for components that live
+            on blocks without spatial grids, or if they do not share lattice sites, via
+            ``spatialLocator`` with other pins.
 
         See Also
         --------
@@ -1395,7 +1401,8 @@ class Component(composites.Composite, metaclass=ComponentType):
         for sibling in withPinIndices:
             if sibling.spatialLocator == self.spatialLocator:
                 return sibling.p.pinIndices
-        return None
+        msg = f"{self} on {self.parent} has no pin indices."
+        raise ValueError(msg)
 
     def density(self) -> float:
         """Returns the mass density of the object in g/cc."""

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -21,7 +21,7 @@ This module contains the abstract definition of a Component.
 
 import copy
 import re
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2650,8 +2650,8 @@ nuclide flags:
         """Test we never get pin indices for hexagons."""
         duct = self.block.getComponent(Flags.DUCT)
         self.assertIsNone(duct.p.pinIndices)
-        indices = duct.getPinIndices()
-        self.assertIsNone(indices)
+        with self.assertRaisesRegex(ValueError, "no pin indices"):
+            duct.getPinIndices()
 
     def test_recoverCladIndicesFromFuel(self):
         """Show the same indices for cladding are found for fuel that it wraps."""

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2710,6 +2710,18 @@ nuclide flags:
             ringPos = loc.getRingPos()
             self.assertIn(ringPos, expectedRingPos, msg=f"{ix=} : {loc=}")
 
+    def test_nonFueledBlock(self):
+        """If we have no fuel, but we have clad, we should still have pin indices."""
+        nonFuel = copy.deepcopy(self._originalBlock)
+        # strip out fuel flags
+        for c in nonFuel.iterComponents(Flags.FUEL):
+            c.p.flags &= ~Flags.FUEL
+        nonFuel.assignPinIndices()
+        # Should still have what ARMI considers pins
+        self.assertTrue(nonFuel.getPinLocations())
+        for c in nonFuel.iterComponents(Flags.CLAD):
+            self.assertIsNotNone(c.getPinIndices())
+
 
 class TestHexBlockOrientation(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

In a discussion w @mgjarrett and @john-science, we realized you could have a plenum block that has pins but no fuel. Nor any of the "magic" / "important" flags used to set `Component.p.pinIndices`. But it's still a pin so it should have `pinIndices`. If we don't find any components with the "important" flags, we'll assign pin indices to the cladding components.

We could just as easily only assign to cladding components always. The rationale is fuel and control are things where you are more likely to care about the pin power or pin mg flux directly on that component. So, having direct access to `Component.p.pinIndices` on fuel is valuable. Otherwise, everytime you query `fuel.getPinIndices`, it will loop over all siblings and compare the spatial locators. Not the worst, but I speculate asking for `fuel.getPinIndices` will be more common than asking for `clad.getPinIndices`. 

Additionally, having `Component.getPinIndices` is not super helpful. What does that mean? Is it not a pin? Does it occupy all the lattice sites? Now it will raise an exception.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Assign pinIndices to clad components if there are no fuel nor control components

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
