### PR TITLE
Cleaning trace and profile out of RunEntryPoint

### DIFF
--- a/armi/cli/run.py
+++ b/armi/cli/run.py
@@ -23,10 +23,6 @@ class RunEntryPoint(EntryPoint):
     name = "run"
     settingsArgument = "required"
 
-    def addOptions(self):
-        self.createOptionFromSetting("profile", "-p")
-        self.createOptionFromSetting("trace", "-t")
-
     def invoke(self):
         from armi import cases
 


### PR DESCRIPTION
## What is the change? Why is it being made?

Removing trace and profile command line arguments out of the `RunEntryProfile`.

close #2164

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Cleaning trace and profile out of RunEntryPoint

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
