### PR TITLE
move attributes to __init__

### DIFF
--- a/armi/testing/symmetryTesting.py
+++ b/armi/testing/symmetryTesting.py
@@ -106,15 +106,17 @@ class BasicArmiSymmetryTestHelper(unittest.TestCase):
     a test method that should adequately verify the the expected symmetric parameters are indeed expanded.
     """
 
-    coreParamsToTest = []
-    assemblyParamsToTest = []
-    blockParamsToTest = []
-    expectedSymmetricCoreParams = []
-    expectedSymmetricAssemblyParams = []
-    expectedSymmetricBlockParams = []
-    parameterOverrides = {}
-    paramsToIgnore = []
-    customSettings = {}
+    def __init__(self, methodName="runTest"):
+        self.coreParamsToTest = []
+        self.assemblyParamsToTest = []
+        self.blockParamsToTest = []
+        self.expectedSymmetricCoreParams = []
+        self.expectedSymmetricAssemblyParams = []
+        self.expectedSymmetricBlockParams = []
+        self.parameterOverrides = {}
+        self.paramsToIgnore = []
+        self.customSettings = {}
+        super().__init__(methodName)
 
     def setUp(self):
         self._preprocessPluginParams()


### PR DESCRIPTION
## What is the change? Why is it being made?

Refactor to prevent potential namespace pollution. See https://github.com/terrapower/armi/pull/2227#discussion_r2299186754 for details.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
Change Type: trivial
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Change class attributes to be assigned in __init__ rather than at the class level to prevent potential problems with namespace pollution.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: None


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
