### PR TITLE
Updated wetted perim calc

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2254,8 +2254,6 @@ class HexBlock(Block):
         wettedPinComponentFlags = (
             Flags.CLAD,
             Flags.WIRE,
-            Flags.CLAD | Flags.DEPLETABLE,
-            Flags.WIRE | Flags.DEPLETABLE,
         )
 
         # flags pertaining to components where both the interior and exterior are wetted
@@ -2272,8 +2270,8 @@ class HexBlock(Block):
 
         wettedPinComponents = []
         for flag in wettedPinComponentFlags:
-            c = self.getComponent(flag, exact=True)
-            wettedPinComponents.append(c) if c else None
+            comps = self.getComponents(flag)
+            wettedPinComponents += comps if comps else []
 
         wettedHollowCircleComponents = []
         wettedHollowHexComponents = []
@@ -2285,7 +2283,6 @@ class HexBlock(Block):
                 wettedHollowCircleComponents.append(c) if c else None
 
         # calculate wetted perimeters according to their geometries
-
         # hollow hexagon = 6 * ip / sqrt(3)
         wettedHollowHexagonPerimeter = 0.0
         for c in wettedHollowHexagonComponents:
@@ -2301,8 +2298,8 @@ class HexBlock(Block):
                     1.0,
                     math.pi * c.getDimension("helixDiameter") / c.getDimension("axialPitch"),
                 )
-            wettedPinPerimeter += c.getDimension("od") * correctionFactor
-        wettedPinPerimeter *= self.getNumPins() * math.pi
+            compWettedPerim = c.getDimension("od") * correctionFactor * c.getDimension("mult") * math.pi
+            wettedPinPerimeter += compWettedPerim
 
         # hollow circle = (id + od) * pi
         wettedHollowCirclePerimeter = 0.0


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->

This change updates the `getWettedPerimeter` function to work properly for blocks with multiple pin types. This function now uses the `mult` dimension for each component and grabs all components with `Flags.CLAD` and `Flags.WIRE` without the `exact=True` option.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: This PR updates the getWettedPerimeter function for blocks with multiple pin types.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
