### PR TITLE
Fixing invalid any() signature

### DIFF
--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -161,7 +161,7 @@ class Pitch(yamlize.Object):
         if hexPitch and (x or y):
             raise InputError("Cannot mix `hex` with `x` and `y` attributes of `latticePitch`.")
 
-        if not any(hexPitch) and not any([x, y, z]):
+        if not any([hexPitch, x, y, z]):
             raise InputError("`lattice pitch` must have at least one non-zero attribute! Check the blueprints.")
 
         self.hex = hex or x

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -138,7 +138,7 @@ class Pitch(yamlize.Object):
     y = yamlize.Attribute(type=float, default=0.0)
     z = yamlize.Attribute(type=float, default=0.0)
 
-    def __init__(self, hex=0.0, x=0.0, y=0.0, z=0.0):
+    def __init__(self, hexPitch=0.0, x=0.0, y=0.0, z=0.0):
         """
         Parameters
         ----------
@@ -155,13 +155,13 @@ class Pitch(yamlize.Object):
         Raises
         ------
         InputError
-            * If a `hex` pitch and `x` or `y` pitch are provided simultaneously.
+            * If a `hexPitch` and `x` or `y` pitch are provided simultaneously.
             * If no non-zero value is provided for any parameter.
         """
-        if hex and (x or y):
+        if hexPitch and (x or y):
             raise InputError("Cannot mix `hex` with `x` and `y` attributes of `latticePitch`.")
 
-        if not any(hex, x, y, z):
+        if not any(hexPitch) and not any([x, y, z]):
             raise InputError("`lattice pitch` must have at least one non-zero attribute! Check the blueprints.")
 
         self.hex = hex or x

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -23,7 +23,8 @@ if not isConfigured():
     configure()
 
 from armi.reactor.blueprints import Blueprints
-from armi.reactor.blueprints.gridBlueprint import Grids, saveToStream
+from armi.reactor.blueprints.gridBlueprint import Grids, Pitch, saveToStream
+from armi.utils.customExceptions import InputError
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 LATTICE_BLUEPRINT = """
@@ -452,6 +453,16 @@ class TestGridBlueprintsSection(unittest.TestCase):
         self.assertEqual(gridDesign4.gridContents[-3, -3], "1")
         with self.assertRaises(KeyError):
             self.assertEqual(gridDesign4.gridContents[-4, -3], "1")
+
+    def test_pitchEdgeCases(self):
+        with self.assertRaises(TypeError):
+            Pitch(0, 0, 0, 0)
+
+        with self.assertRaises(InputError):
+            Pitch([1], 2, 3, 4)
+
+        with self.assertRaises(InputError):
+            Pitch([0], 0, 0, 0)
 
     def test_simpleReadLatticeMap(self):
         """Read lattice map and create a grid.

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -455,14 +455,11 @@ class TestGridBlueprintsSection(unittest.TestCase):
             self.assertEqual(gridDesign4.gridContents[-4, -3], "1")
 
     def test_pitchEdgeCases(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(InputError):
+            Pitch(1, 2, 3, 4)
+
+        with self.assertRaises(InputError):
             Pitch(0, 0, 0, 0)
-
-        with self.assertRaises(InputError):
-            Pitch([1], 2, 3, 4)
-
-        with self.assertRaises(InputError):
-            Pitch([0], 0, 0, 0)
 
     def test_simpleReadLatticeMap(self):
         """Read lattice map and create a grid.


### PR DESCRIPTION
## What is the change? Why is it being made?

This PR seeks to close #2244 , which is a fix for a syntax error in PR #1654. There was a mis-use of the `any()` standard library function.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Fixing invalid any() signature

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
