### PR TITLE
Fixing issue loading from snapshots database

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -1418,11 +1418,14 @@ class CrossSectionGroupManager(interfaces.Interface):
         the core to get by region cross sections and flux factors.
         """
         missingBlueprintBlocks = []
+        blockList = []
         for a in self.r.blueprints.assemblies.values():
-            for b in a:
-                if b.getMicroSuffix() not in blockCollectionsByXsGroup:
-                    b2 = copy.deepcopy(b)
-                    missingBlueprintBlocks.append(b2)
+            blockList.extend(b for b in a)
+        self._updateEnvironmentGroups(blockList)
+        for b in blockList:
+            if b.getMicroSuffix() not in blockCollectionsByXsGroup:
+                b2 = copy.deepcopy(b)
+                missingBlueprintBlocks.append(b2)
         return missingBlueprintBlocks
 
     def makeCrossSectionGroups(self):

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -1421,6 +1421,7 @@ class CrossSectionGroupManager(interfaces.Interface):
         blockList = []
         for a in self.r.blueprints.assemblies.values():
             blockList.extend(b for b in a)
+
         self._updateEnvironmentGroups(blockList)
         for b in blockList:
             if b.getMicroSuffix() not in blockCollectionsByXsGroup:

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -807,7 +807,6 @@ class TestCrossSectionGroupManager(unittest.TestCase):
         blockCollectionsByXsGroup = self.csm._addXsGroupsFromBlocks(blockCollectionsByXsGroup, self.blockList)
         missingBlueprintBlocks = self.csm._getMissingBlueprintBlocks(blockCollectionsByXsGroup)
         envGroups = set(b.p.envGroup for b in missingBlueprintBlocks)
-        print(envGroups)
         self.assertGreater(len(envGroups), 1, "Blueprint block environment groups were not updated!")
 
     def test_calcWeightedBurnup(self):
@@ -1096,7 +1095,7 @@ class TestCrossSectionGroupManagerWithTempGrouping(unittest.TestCase):
         for b, env in zip(self.blockList, buAndTemps):
             bu, temp = env
             comps = b.getComponents(Flags.FUEL)
-            assert len(comps) == 1
+            self.assertEqual(len(comps), 1)
             c = next(iter(comps))
             c.setTemperature(temp)
             b.p.percentBu = bu

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -396,9 +396,10 @@ class TestBlockCollectionComponentAverage(unittest.TestCase):
                 for nuc in cNucs:
                     self.assertAlmostEqual(c.getNumberDensity(nuc), compDensity[nuc])
 
-        self.assertIn("AC", xsgm.representativeBlocks, (
-                "Assemblies not in the core should still have XS groups, see _getMissingBlueprintBlocks()"
-            )
+        self.assertIn(
+            "AC",
+            xsgm.representativeBlocks,
+            ("Assemblies not in the core should still have XS groups, see _getMissingBlueprintBlocks()"),
         )
 
 
@@ -806,6 +807,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
         blockCollectionsByXsGroup = self.csm._addXsGroupsFromBlocks(blockCollectionsByXsGroup, self.blockList)
         missingBlueprintBlocks = self.csm._getMissingBlueprintBlocks(blockCollectionsByXsGroup)
         envGroups = set(b.p.envGroup for b in missingBlueprintBlocks)
+        print(envGroups)
         self.assertGreater(len(envGroups), 1, "Blueprint block environment groups were not updated!")
 
     def test_calcWeightedBurnup(self):

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -744,7 +744,6 @@ class TestCrossSectionGroupManager(unittest.TestCase):
         for bi, b in enumerate(self.blockList):
             b.p.percentBu = bi / 19.0 * 100
         self.csm._setBuGroupBounds([3, 10, 30, 100])
-        self.csm._setTempGroupBounds([0, 100, 200])
         self.csm.interactBOL()
 
     def test_enableEnvGroupUpdates(self):
@@ -803,6 +802,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
 
     def test_getMissingBlueprintBlocks(self):
         """Test the function to get missing blueprints blocks."""
+        self.csm._setTempGroupBounds([0, 100, 200])
         blockCollectionsByXsGroup = {}
         blockCollectionsByXsGroup = self.csm._addXsGroupsFromBlocks(blockCollectionsByXsGroup, self.blockList)
         missingBlueprintBlocks = self.csm._getMissingBlueprintBlocks(blockCollectionsByXsGroup)


### PR DESCRIPTION
## What is the change? Why is it being made?

When creating cross section groups, update the `envGroup` for blueprints assemblies/blocks before creating a new group for them. This prevents the blueprints blocks from generating cross section groups that are otherwise not modeled in the core.

See #1987 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Update `envGroup` on blocks from blueprints assemblies.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
