### PR TITLE
Consider differences in special formatting params a diff

### DIFF
--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -313,8 +313,7 @@ def _diffSpecialData(
         return
 
     if srcData.attrs.get("dict", False):
-        # not bothering with dictionaries yet, though we will need to for things like
-        # number densities
+        out.writeln(f"Not comparing {name} as it is a dictionary.")
         return
 
     attrsMatch = True

--- a/armi/bookkeeping/db/compareDB3.py
+++ b/armi/bookkeeping/db/compareDB3.py
@@ -341,6 +341,7 @@ def _diffSpecialData(
             break
 
     if not attrsMatch:
+        diffResults.addDiff(compName, paramName, np.inf, np.inf, np.inf)
         return
 
     try:


### PR DESCRIPTION
## What is the change? Why is it being made?

In the case where two parameters in a database are considered "special", we have some machinery to do a slightly different database compare. #2239 noted that if you have two "special" arrays that are different sizes, the db checker will inform the user but not treat is as a (formal) diff. Despite the fields having different data.

This PR makes one major change: such things are now considered a (formal) diff and will be included in the diff table.

A smaller change: we silently skip dictionaries-as-datasets. Now, we still skip them, but we let the user know we're not checking a dataset that likely represents a parameter that was a dictionary and has been dumped to the database.

Closes #2239

Not considered a bug fix because the existing behavior was the intended, albeit undocumented, behavior.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Datasets with differences in special formatting parameters (e.g., jagged arrays) will now be considered a diff

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
