### PR TITLE
Fixing `compareLines` so that it doesn't trip on zeros

### DIFF
--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -293,7 +293,10 @@ class ArmiTestHelper(unittest.TestCase):
 
             if actualVal is not None:
                 # we have two floats and can compare them
-                if abs(actualVal - expectedVal) / expectedVal > eps:
+                if actualVal == expectedVal:
+                    # will catch the case where they are zero
+                    return True
+                elif abs(actualVal - expectedVal) / expectedVal > eps:
                     return False
             else:
                 # strings, compare directly

--- a/armi/tests/test_tests.py
+++ b/armi/tests/test_tests.py
@@ -21,17 +21,17 @@ from armi import tests
 
 class TestCompareFiles(unittest.TestCase):
     def test_compareFileLine(self):
-        expected = "oh look, a number! 3.14 and some text and another number 1.5"
+        expected = "oh look, a number! 3.14 and some text and another number 1.5 and another 0.0"
 
         self.assertTrue(tests.ArmiTestHelper.compareLines(expected, expected))
         self.assertTrue(tests.ArmiTestHelper.compareLines(expected, expected, eps=0.01))
 
-        actual = "oh look, a number! 3.15 and some text and another number 1.6  "
+        actual = "oh look, a number! 3.15 and some text and another number 1.6 and another 0.0  "
         self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))
         self.assertTrue(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.07))
 
-        actual = "oh look, a number! 3.15 and some text and another number 1.6 extra"
+        actual = "oh look, a number! 3.15 and some text and another number 1.6 extra and another 0.0"
         self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))
 
-        actual = "oh look, a number! notANumber and some text and another number 1.5"
+        actual = "oh look, a number! notANumber and some text and another number 1.5 and another 0.0"
         self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
The `compareLines` utility has a little quirk that if the two lines you're trying to compare has a bunch of zeros on it, the comparison will fail because you'll encounter a `DivideByZeroError` here: 
https://github.com/terrapower/armi/blob/aba9095f4d78a98813a2027b0531bfe24954ca44/armi/tests/__init__.py#L296

This PR makes a small change to the method to avoid this scenario.

## SCR Information

Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Fixing `compareLines()` so that it doesn't trip on zeros

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
