### PR TITLE
Fixing Uranium enrichment calculations

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -31,7 +31,7 @@ import numpy as np
 
 from armi import nuclideBases, runLog
 from armi.bookkeeping import report
-from armi.nucDirectory import elements, nucDir
+from armi.nucDirectory import nucDir
 from armi.nuclearDataIO import xsCollections
 from armi.physics.neutronics import GAMMA, NEUTRON
 from armi.reactor import (

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1583,15 +1583,18 @@ class Block(composites.Composite):
         return b10 / total
 
     def getUraniumMassEnrich(self):
-        """Returns U-235 mass fraction."""
-        u5 = self.getMass("U235")
+        """Returns fissile mass fraction of Uranium."""
         U = elements.bySymbol["U"]
-        blockNucs = self.getNuclides()
-        uraniumNucsPresent = [nuc.name for nuc in U.nuclides if nuc.name in blockNucs]
-        if u5 < 1e-10:
+        compNucs = set(self.getNuclides())
+        uraniumNucs = set(nuc.name for nuc in U.nuclides)
+        uraniumNucsPresent = compNucs & uraniumNucs
+        fissileNucsPresent = [nucName for nucName in uraniumNucsPresent if nuclideBases.byName[nucName].isFissile()]
+        fissileU = self.getMass(fissileNucsPresent)
+        totalU = self.getMass(list(uraniumNucsPresent))
+        if totalU < 1e-10:
             return 0.0
-        totalU = self.getMass(uraniumNucsPresent)
-        return u5 / totalU
+
+        return fissileU / totalU
 
     def getInputHeight(self) -> float:
         """Determine the input height from blueprints.

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -30,9 +30,8 @@ from typing import Callable, ClassVar, Optional, Tuple, Type
 import numpy as np
 
 from armi import nuclideBases, runLog
-from armi.nucDirectory import elements
 from armi.bookkeeping import report
-from armi.nucDirectory import nucDir
+from armi.nucDirectory import elements, nucDir
 from armi.nuclearDataIO import xsCollections
 from armi.physics.neutronics import GAMMA, NEUTRON
 from armi.reactor import (

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1582,7 +1582,7 @@ class Block(composites.Composite):
         return b10 / total
 
     def getUraniumMassEnrich(self):
-        """Returns fissile mass fraction of Uranium."""
+        """Returns fissile mass fraction of uranium."""
         U = elements.bySymbol["U"]
         compNucs = set(self.getNuclides())
         uraniumNucs = set(nuc.name for nuc in U.nuclides)

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -1583,16 +1583,11 @@ class Block(composites.Composite):
 
     def getUraniumMassEnrich(self):
         """Returns fissile mass fraction of uranium."""
-        U = elements.bySymbol["U"]
-        compNucs = set(self.getNuclides())
-        uraniumNucs = set(nuc.name for nuc in U.nuclides)
-        uraniumNucsPresent = compNucs & uraniumNucs
-        fissileNucsPresent = [nucName for nucName in uraniumNucsPresent if nuclideBases.byName[nucName].isFissile()]
-        fissileU = self.getMass(fissileNucsPresent)
-        totalU = self.getMass(list(uraniumNucsPresent))
+        totalU = self.getMass("U")
         if totalU < 1e-10:
             return 0.0
 
+        fissileU = self.getMass(["U233", "U235"])
         return fissileU / totalU
 
     def getInputHeight(self) -> float:

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -30,6 +30,7 @@ from typing import Callable, ClassVar, Optional, Tuple, Type
 import numpy as np
 
 from armi import nuclideBases, runLog
+from armi.nucDirectory import elements
 from armi.bookkeeping import report
 from armi.nucDirectory import nucDir
 from armi.nuclearDataIO import xsCollections
@@ -1582,12 +1583,15 @@ class Block(composites.Composite):
         return b10 / total
 
     def getUraniumMassEnrich(self):
-        """Returns U-235 mass fraction assuming U-235 and U-238 only."""
+        """Returns U-235 mass fraction."""
         u5 = self.getMass("U235")
+        U = elements.bySymbol["U"]
+        blockNucs = self.getNuclides()
+        uraniumNucsPresent = [nuc.name for nuc in U.nuclides if nuc.name in blockNucs]
         if u5 < 1e-10:
             return 0.0
-        u8 = self.getMass("U238")
-        return u5 / (u8 + u5)
+        totalU = self.getMass(uraniumNucsPresent)
+        return u5 / totalU
 
     def getInputHeight(self) -> float:
         """Determine the input height from blueprints.

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1565,11 +1565,14 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def getUraniumNumEnrich(self):
         """Returns U-235 number fraction."""
-        u8 = self.getNumberDensity("U238")
-        if u8 < 1e-10:
+        U = elements.bySymbol["U"]
+        uraniumNucsPresent = [nuc.name for nuc in U.nuclides if nuc.name in self.getNuclides()]
+        totalU = sum(self.getNuclideNumberDensities(uraniumNucsPresent))
+        if totalU < 1e-10:
             return 0.0
         u5 = self.getNumberDensity("U235")
-        return u5 / (u8 + u5)
+
+        return u5 / totalU
 
     def calcTotalParam(
         self,

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1564,15 +1564,18 @@ class ArmiObject(metaclass=CompositeModelType):
             return 0.0
 
     def getUraniumNumEnrich(self):
-        """Returns U-235 number fraction."""
+        """Returns fissile uranium number fraction."""
         U = elements.bySymbol["U"]
-        uraniumNucsPresent = [nuc.name for nuc in U.nuclides if nuc.name in self.getNuclides()]
-        totalU = sum(self.getNuclideNumberDensities(uraniumNucsPresent))
+        compNucs = set(self.getNuclides())
+        uraniumNucs = set(nuc.name for nuc in U.nuclides)
+        uraniumNucsPresent = compNucs & uraniumNucs
+        fissileNucsPresent = [nucName for nucName in uraniumNucsPresent if nuclideBases.byName[nucName].isFissile()]
+        totalU = sum(self.getNuclideNumberDensities(list(uraniumNucsPresent)))
         if totalU < 1e-10:
             return 0.0
-        u5 = self.getNumberDensity("U235")
+        fissileU = sum(self.getNuclideNumberDensities(fissileNucsPresent))
 
-        return u5 / totalU
+        return fissileU / totalU
 
     def calcTotalParam(
         self,

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1565,15 +1565,11 @@ class ArmiObject(metaclass=CompositeModelType):
 
     def getUraniumNumEnrich(self):
         """Returns fissile uranium number fraction."""
-        U = elements.bySymbol["U"]
-        compNucs = set(self.getNuclides())
-        uraniumNucs = set(nuc.name for nuc in U.nuclides)
-        uraniumNucsPresent = compNucs & uraniumNucs
-        fissileNucsPresent = [nucName for nucName in uraniumNucsPresent if nuclideBases.byName[nucName].isFissile()]
-        totalU = sum(self.getNuclideNumberDensities(list(uraniumNucsPresent)))
+        uraniumNucs = self._getNuclidesFromSpecifier("U")
+        totalU = sum(self.getNuclideNumberDensities(uraniumNucs))
         if totalU < 1e-10:
             return 0.0
-        fissileU = sum(self.getNuclideNumberDensities(fissileNucsPresent))
+        fissileU = sum(self.getNuclideNumberDensities(["U233", "U235"]))
 
         return fissileU / totalU
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1282,6 +1282,22 @@ class Block_TestCase(unittest.TestCase):
         cur = self.block.getUraniumNumEnrich()
         self.assertEqual(cur, 0.0)
 
+    def test_getUraniumNumEnrichWith233(self):
+        fuel = self.block.getComponent(Flags.FUEL)
+        u5 = fuel.getNumberDensity("U235")
+        fuel.setNumberDensity("U233", 0.005)
+        self.block.adjustUEnrich(0.25)
+
+        cur = self.block.getUraniumNumEnrich()
+        print(cur)
+
+        u3 = self.block.getNumberDensity("U233")
+        u5 = self.block.getNumberDensity("U235")
+        u8 = self.block.getNumberDensity("U238")
+        ref = (u3 + u5) / (u3 + u5 + u8)
+
+        self.assertAlmostEqual(cur, ref, places=6)
+
     def test_getNumberOfAtoms(self):
         self.block.clearNumberDensities()
         refDict = {

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1252,7 +1252,7 @@ class Block_TestCase(unittest.TestCase):
 
     def test_getUraniumMassEnrich(self):
         fuel = self.block.getComponent(Flags.FUEL)
-        fuel.setNumberDensity("U234", 1.0E-4)
+        fuel.setNumberDensity("U234", 1.0e-4)
         self.block.adjustUEnrich(0.25)
 
         ref = 0.25
@@ -1265,7 +1265,7 @@ class Block_TestCase(unittest.TestCase):
 
     def test_getUraniumNumEnrich(self):
         fuel = self.block.getComponent(Flags.FUEL)
-        fuel.setNumberDensity("U234", 1.0E-4)
+        fuel.setNumberDensity("U234", 1.0e-4)
         self.block.adjustUEnrich(0.25)
 
         cur = self.block.getUraniumNumEnrich()

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1251,7 +1251,8 @@ class Block_TestCase(unittest.TestCase):
             self.block.getMicroSuffix()
 
     def test_getUraniumMassEnrich(self):
-        self.block.setNumberDensity("U234", 1.0E-4)
+        fuel = self.block.getComponent(Flags.FUEL)
+        fuel.setNumberDensity("U234", 1.0E-4)
         self.block.adjustUEnrich(0.25)
 
         ref = 0.25
@@ -1263,13 +1264,16 @@ class Block_TestCase(unittest.TestCase):
         self.assertAlmostEqual(cur, ref, places=places)
 
     def test_getUraniumNumEnrich(self):
+        fuel = self.block.getComponent(Flags.FUEL)
+        fuel.setNumberDensity("U234", 1.0E-4)
         self.block.adjustUEnrich(0.25)
 
         cur = self.block.getUraniumNumEnrich()
 
         u8 = self.block.getNumberDensity("U238")
         u5 = self.block.getNumberDensity("U235")
-        ref = u5 / (u8 + u5)
+        u4 = self.block.getNumberDensity("U234")
+        ref = u5 / (u8 + u5 + u4)
 
         self.assertAlmostEqual(cur, ref, places=6)
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1289,7 +1289,6 @@ class Block_TestCase(unittest.TestCase):
         self.block.adjustUEnrich(0.25)
 
         cur = self.block.getUraniumNumEnrich()
-        print(cur)
 
         u3 = self.block.getNumberDensity("U233")
         u5 = self.block.getNumberDensity("U235")

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1251,6 +1251,7 @@ class Block_TestCase(unittest.TestCase):
             self.block.getMicroSuffix()
 
     def test_getUraniumMassEnrich(self):
+        self.block.setNumberDensity("U234", 1.0E-4)
         self.block.adjustUEnrich(0.25)
 
         ref = 0.25


### PR DESCRIPTION
## What is the change? Why is it being made?

Change uranium enrichment calculations from considering only U-235 and U-238 to considering all uranium isotopes.
Uranium materials can have minor fractions of other non-fissile isotopes (U-232, U-234, U-236) and other fissile isotopes (U-233).

The methods `Block.getUraniumMassEnrich()` and `ArmiObject.getUraniumNumEnrich()` now account for all uranium nuclides present.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Consider all uranium isotopes in the enrichment calculation.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
