### PR TITLE
Track assemblies if discharged to SFP

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -157,7 +157,7 @@ class FuelHandlerInterface(interfaces.Interface):
             if movesThisCycle is not None:
                 for move in movesThisCycle:
                     enrichLine = " ".join(["{0:.8f}".format(enrich) for enrich in move.enrichList])
-                    if move.fromLoc in ["ExCore", "SFP"]:
+                    if move.fromLoc in ["Delete", "SFP"]:
                         # this is a re-entering assembly. Give extra info so repeat shuffles can handle it
                         out.write(
                             "{0} moved to {1} with assembly type {2} ANAME={4} with enrich list: {3}\n".format(

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -67,7 +67,7 @@ class AssemblyMove:
     assemType : str, optional
         Type of assembly that is moving.
     nameAtDischarge : str, optional
-        Name of the assembly moving (for SFP/ExCore interactions).
+        Name of the assembly moving (for SFP/delete interactions).
     rotation : float, optional
         Degrees of manual rotation to apply after shuffling.
     """
@@ -107,7 +107,7 @@ class FuelHandler:
     with the ``fuelHandler`` setting. In that file, subclass this object.
     """
 
-    DISCHARGE_LOCS = frozenset({"SFP", "ExCore"})
+    DISCHARGE_LOCS = frozenset({"SFP", "Delete"})
     """Special strings to indicate an assembly is no longer in the core."""
 
     def __init__(self, operator):
@@ -1133,8 +1133,8 @@ class FuelHandler:
         r"""
         Read a shuffle file in YAML format.
 
-        A cascade with no explicit final location discharges the assembly to
-        ``ExCore`` by default.
+        A cascade with no explicit final location deletes the assembly
+        by default.
 
         Parameters
         ----------
@@ -1230,7 +1230,7 @@ class FuelHandler:
                     for i in range(len(locs) - 1):
                         moves[cycle].append(AssemblyMove(locs[i], locs[i + 1]))
                     if locs[-1] not in FuelHandler.DISCHARGE_LOCS:
-                        moves[cycle].append(AssemblyMove(locs[-1], "ExCore"))
+                        moves[cycle].append(AssemblyMove(locs[-1], "Delete"))
 
                 elif "misloadSwap" in action:
                     swap = action["misloadSwap"]
@@ -1389,7 +1389,7 @@ class FuelHandler:
             loadNames : list[Optional[str]]
                 Assembly names of loads (e.g., from SFP).
             dischargeDests : list[str]
-                Final destinations for discharged assemblies.
+                Final destinations for discharged assemblies (e.g., ``SFP`` or ``Delete``).
             rotations : list[tuple[str, float]]
                 Manual rotations to apply (location, degrees).
             alreadyDone : list[str]
@@ -1414,7 +1414,7 @@ class FuelHandler:
         dischargeDests = []  # final destinations for discharged assemblies
         rotations = []
 
-        # first handle all charge/discharge chains by looking for things going to SFP/ExCore
+        # first handle all charge/discharge chains by looking for things going to SFP/Delete
         for move in moveList:
             fromLoc = move.fromLoc
             toLoc = move.toLoc
@@ -1493,7 +1493,7 @@ class FuelHandler:
             The assembly names of assemblies that get brought into the core (useful for pulling out
             of SFP for round 2, etc.)
         dischargeDests : list
-            Final destination for each load chain (e.g., ``SFP`` or ``ExCore``)
+            Final destination for each load chain (e.g., ``SFP`` or ``Delete``)
 
         See Also
         --------

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -1449,7 +1449,9 @@ class FuelHandler:
                 continue
             else:
                 # normal move
-                chain, _enrichList, _assemType, _loadAssemName, _dest = FuelHandler.trackChain(moveList, startingAt=fromLoc)
+                chain, _enrichList, _assemType, _loadAssemName, _dest = FuelHandler.trackChain(
+                    moveList, startingAt=fromLoc
+                )
                 loopChains.append(chain)
                 alreadyDone.extend(chain)
 
@@ -1466,9 +1468,7 @@ class FuelHandler:
             alreadyDone,
         )
 
-    def doRepeatShuffle(
-        self, loadChains, loopChains, enriches, loadChargeTypes, loadNames, dischargeDests
-    ):
+    def doRepeatShuffle(self, loadChains, loopChains, enriches, loadChargeTypes, loadNames, dischargeDests):
         r"""
         Actually does the fuel movements required to repeat a shuffle order.
 

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -36,7 +36,6 @@ from armi.physics.fuelCycle.settings import (
     CONF_RUN_LATTICE_BEFORE_SHUFFLING,
     CONF_SHUFFLE_SEQUENCE_FILE,
 )
-from armi.settings.fwSettings.globalSettings import CONF_TRACK_ASSEMS
 from armi.physics.neutronics.crossSectionGroupManager import CrossSectionGroupManager
 from armi.physics.neutronics.latticePhysics.latticePhysicsInterface import (
     LatticePhysicsInterface,
@@ -47,6 +46,7 @@ from armi.reactor.parameters import ParamLocation
 from armi.reactor.tests import test_reactors
 from armi.reactor.zones import Zone
 from armi.settings import caseSettings
+from armi.settings.fwSettings.globalSettings import CONF_TRACK_ASSEMS
 from armi.tests import TEST_ROOT, ArmiTestHelper, mockRunLogs
 from armi.utils import directoryChangers
 from armi.utils.customExceptions import InputError
@@ -725,9 +725,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
             locs = ["009-045", "008-004", "007-001", "006-005"]
             before = {loc: self.r.core.getAssemblyWithStringLocation(loc).getName() for loc in locs}
             self.r.p.cycle = 1
-            self.o.cs = self.o.cs.modified(
-                newSettings={CONF_SHUFFLE_SEQUENCE_FILE: fname, CONF_TRACK_ASSEMS: False}
-            )
+            self.o.cs = self.o.cs.modified(newSettings={CONF_SHUFFLE_SEQUENCE_FILE: fname, CONF_TRACK_ASSEMS: False})
             self.r.core._trackAssems = False
             fh.outage()
 
@@ -765,9 +763,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         try:
             before = self.r.core.getAssemblyWithStringLocation("009-045").getName()
             self.r.p.cycle = 1
-            self.o.cs = self.o.cs.modified(
-                newSettings={CONF_SHUFFLE_SEQUENCE_FILE: fname, CONF_TRACK_ASSEMS: False}
-            )
+            self.o.cs = self.o.cs.modified(newSettings={CONF_SHUFFLE_SEQUENCE_FILE: fname, CONF_TRACK_ASSEMS: False})
             self.r.core._trackAssems = False
             fh.outage()
 

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -610,7 +610,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         firstPassResults = {}
         for a in self.r.core:
             firstPassResults[a.getLocation()] = a.getName()
-            self.assertNotIn(a.getLocation(), ["SFP", "LoadQueue", "ExCore"])
+            self.assertNotIn(a.getLocation(), ["SFP", "LoadQueue", "Delete"])
 
         # reset core to BOL state
         # reset assembly counter to get the same assem nums.
@@ -678,31 +678,31 @@ class TestFuelHandler(FuelHandlerTestHelper):
                 AssemblyMove("009-045", "008-004"),
                 AssemblyMove("008-004", "007-001"),
                 AssemblyMove("007-001", "006-005"),
-                AssemblyMove("006-005", "ExCore"),
+                AssemblyMove("006-005", "Delete"),
                 AssemblyMove("009-045", "009-045", rotation=60.0),
                 AssemblyMove("LoadQueue", "010-046", [0.0, 0.12, 0.14, 0.15, 0.0], "outer fuel"),
                 AssemblyMove("010-046", "011-046"),
                 AssemblyMove("011-046", "012-046"),
-                AssemblyMove("012-046", "ExCore"),
+                AssemblyMove("012-046", "Delete"),
             ],
             2: [
                 AssemblyMove("LoadQueue", "009-045", [0.0, 0.12, 0.14, 0.15, 0.0], "outer fuel"),
                 AssemblyMove("009-045", "008-004"),
                 AssemblyMove("008-004", "007-001"),
                 AssemblyMove("007-001", "006-005"),
-                AssemblyMove("006-005", "ExCore"),
+                AssemblyMove("006-005", "Delete"),
                 AssemblyMove("009-045", "009-045", rotation=60.0),
                 AssemblyMove("LoadQueue", "010-046", [0.0, 0.12, 0.14, 0.15, 0.0], "outer fuel"),
                 AssemblyMove("010-046", "011-046"),
                 AssemblyMove("011-046", "012-046"),
-                AssemblyMove("012-046", "ExCore"),
+                AssemblyMove("012-046", "Delete"),
             ],
             3: [
                 AssemblyMove("LoadQueue", "009-045", [0.0, 0.12, 0.14, 0.15, 0.0], "outer fuel"),
                 AssemblyMove("009-045", "008-004"),
                 AssemblyMove("008-004", "007-001"),
                 AssemblyMove("007-001", "006-005"),
-                AssemblyMove("006-005", "ExCore"),
+                AssemblyMove("006-005", "Delete"),
             ],
         }
         self.assertEqual(moves, expected)

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -775,30 +775,21 @@ class TestFuelHandler(FuelHandlerTestHelper):
     def test_processMoveList(self):
         fh = fuelHandlers.FuelHandler(self.o)
         moves = fh.readMoves("armiRun-SHUFFLES.txt")
-        (
-            loadChains,
-            loopChains,
-            _,
-            _,
-            loadNames,
-            _,
-            rotations,
-            _,
-        ) = fh.processMoveList(moves[2])
-        self.assertIn("A0073", loadNames)
-        self.assertIn(None, loadNames)
-        self.assertNotIn("SFP", loadChains)
-        self.assertNotIn("LoadQueue", loadChains)
-        self.assertFalse(loopChains)
-        self.assertFalse(rotations)
+        result = fh.processMoveList(moves[2])
+        self.assertIn("A0073", result.loadNames)
+        self.assertIn(None, result.loadNames)
+        self.assertTrue(all("SFP" not in chain for chain in result.loadChains))
+        self.assertTrue(all("LoadQueue" not in chain for chain in result.loadChains))
+        self.assertFalse(result.loopChains)
+        self.assertFalse(result.rotations)
 
     def test_processMoveList_yaml(self):
         fh = fuelHandlers.FuelHandler(self.o)
         moves, _ = fh.readMovesYaml("armiRun-SHUFFLES.yaml")
-        loadChains, loopChains, enriches, loadTypes, loadNames, _, rotations, _ = fh.processMoveList(moves[1])
-        self.assertEqual(len(loadChains), 2)
-        self.assertTrue(any(enriches))
-        self.assertTrue(rotations)
+        result = fh.processMoveList(moves[1])
+        self.assertEqual(len(result.loadChains), 2)
+        self.assertTrue(any(result.enriches))
+        self.assertTrue(result.rotations)
 
     def test_getFactorList(self):
         fh = fuelHandlers.FuelHandler(self.o)

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -347,7 +347,7 @@ class Core(composites.Composite):
         for a in self.getAssemblies(includeAll=True):
             a.lastLocationLabel = a.getLocation()
 
-    def removeAssembly(self, a1, discharge=True):
+    def removeAssembly(self, a1, discharge=True, addToSFP=False):
         """
         Takes an assembly and puts it out of core.
 
@@ -357,11 +357,14 @@ class Core(composites.Composite):
             The assembly to remove
         discharge : bool, optional
             Discharge the assembly, including adding it to the SFP. Default: True
+        addToSFP : bool, optional
+            Store the discharged assembly in the SFP regardless of the
+            ``trackAssems`` setting. Default: False
 
         Notes
         -----
         Please expect this method will delete your assembly (instead of moving it into a Spent Fuel
-        Pool) unless you set the ``trackAssems`` to True in your settings file.
+        Pool) unless you set ``trackAssems`` to True or ``addToSFP`` is set to True.
 
         Originally, this held onto all assemblies in the Spend Fuel Pool. However, they use memory.
         And it is possible to have the history interface record only the parameters you need.
@@ -384,7 +387,7 @@ class Core(composites.Composite):
         a1.p.dischargeTime = self.r.p.time
         self.remove(a1)
 
-        if discharge and self._trackAssems:
+        if discharge and (self._trackAssems or addToSFP):
             if self.parent.excore.get("sfp") is not None:
                 self.parent.excore.sfp.add(a1)
             else:

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -713,10 +713,11 @@ def defineSettings() -> List[setting.Setting]:
             CONF_TRACK_ASSEMS,
             default=False,
             label="Save Discharged Assemblies",
-            description="Track assemblies for detailed fuel histories. For instance, "
-            "assemblies are tracked after they come out of a reactor by putting them "
-            "in a Spent Fuel Pool. This might be necessary for your work, but it "
-            "certainly increases the memory usage of the program.",
+            description="Retain discharged assemblies in a spent fuel pool so their histories "
+            "can be analyzed or the assemblies reused. Turning this off removes "
+            "discharged assemblies to minimize memory and database size. "
+            "Assemblies explicitly discharged to the spent fuel pool remain "
+            "regardless, allowing selective tracking.",
         ),
         setting.Setting(
             CONF_VERBOSITY,

--- a/armi/tests/armiRun-SHUFFLES.yaml
+++ b/armi/tests/armiRun-SHUFFLES.yaml
@@ -4,7 +4,7 @@ sequence:
       cascade: ["outer fuel", "009-045", "008-004", "007-001", "006-005"]
       fuelEnrichment: [0, 0.12, 0.14, 0.15, 0]
     - extraRotations: {"009-045": 60}
-    - cascade: ["outer fuel", "010-046", "011-046", "012-046", "ExCore"]
+    - cascade: ["outer fuel", "010-046", "011-046", "012-046", "Delete"]
       fuelEnrichment: [0, 0.12, 0.14, 0.15, 0]
   2: *cycle_1
   3:

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -398,11 +398,11 @@ Extra rotations therefore:
 * rotate the assembly relative to its current orientation; and
 * execute after any algorithmic rotation routines.
 
-A cascade with no final destination defaults to discharging the assembly to
-``ExCore``. Assemblies can be retained in the model by ending the cascade with
+A cascade with no final destination defaults to deleting the assembly. 
+Assemblies can be retained in the model by ending the cascade with
 ``SFP``. When ``SFP`` is specified, the discharged assembly is stored in the
-spent fuel pool even if the ``trackAssems`` setting is ``False``; ``ExCore``
-always deletes the assembly.
+spent fuel pool even if the ``trackAssems`` setting is ``False``; ``Delete``
+always removes the assembly from the model.
 For example
    
 ..  code:: yaml
@@ -414,7 +414,7 @@ For example
            - misloadSwap: ["009-045", "008-004"]
            - extraRotations: {"009-045": 60}
          2:
-           - cascade: ["outer fuel", "010-046", "009-045", "ExCore"]
+           - cascade: ["outer fuel", "010-046", "009-045", "Delete"]
              fuelEnrichment: [0, 0.12, 0.14, 0.15, 0]
 
 .. note:: Consider using yaml anchors ``&`` and aliases ``*`` to reduce repetition.

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -399,10 +399,10 @@ Extra rotations therefore:
 * execute after any algorithmic rotation routines.
 
 A cascade with no final destination defaults to discharging the assembly to
-the spent fuel pool ``SFP``. Assemblies can also be removed from the model
-entirely by ending with ``ExCore``. When an assembly is sent to the ``SFP`` it
-is only retained in memory if the ``trackAssems`` setting is True; ``ExCore`` always
-deletes the assembly.
+``ExCore``. Assemblies can be retained in the model by ending the cascade with
+``SFP``. When ``SFP`` is specified, the discharged assembly is stored in the
+spent fuel pool even if the ``trackAssems`` setting is ``False``; ``ExCore``
+always deletes the assembly.
 For example
    
 ..  code:: yaml


### PR DESCRIPTION
## What is the change? Why is it being made?

Currently, assemblies are only tracked after discharge if `trackAssems == True`. However, this forces you to track every discharged assembly which can be costly with respect to DB size. 

This PR changes the default discharge location (if the user does not specify a discharge location in their cascades) to be deleted after discharge. If the user specifies `SFP` at the end of a cascade, the assembly will now be stored in the database in the SFP, even if `trackAssems == False`. This allows us to selectively track assemblies. 

The situation will now be:

* If `trackAssems == True`: store all discharged assemblies
* If `trackAssems == False`:
  * If the user specifies `SFP` at the end of a cascade, some Assemblies will be placed in the SFP, and thus in the DB
  * If the user does not specify `SFP` at the end of a cascade, no Assemblies will be tracked.

## SCR Information

Change Type: features

One-Sentence Description: Enhance fuel handling logic to support flexible assembly discharge destinations and update documentation accordingly. 

One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
