### PR TITLE
Change `setVerbosity` location in `mockRunLog`

### DIFF
--- a/armi/tests/mockRunLogs.py
+++ b/armi/tests/mockRunLogs.py
@@ -37,7 +37,6 @@ class BufferLog(runLog._RunLog):
         self._errStream = io.StringIO()
         self._deduplication = runLog.DeduplicationFilter()
         sys.stderr = self._errStream
-        self.setVerbosity(0)
 
     def __enter__(self):
         self.originalLog = runLog.LOG
@@ -54,6 +53,7 @@ class BufferLog(runLog._RunLog):
         This is a wrapper around logger.log() that does most of the work and is
         used by all message passers (e.g. info, warning, etc.).
         """
+        self.setVerbosity(0)
         # the message label is only used to determine unique for single-print warnings
         if label is None:
             label = msg


### PR DESCRIPTION
## What is the change? Why is it being made?

This moves the `setVerbosity` call from the `init` method to the `log` method.

But WHY?

I was making a unit test downstream and was using `loadTestReactor` and grabbing that log. And only the headers were printing and it was driving me insane! I printed out the current log verbosity and it was 40 ("error"). I tried a few things, eventually moving where the verbosity was set. 0 --> 10 when you do it right. Then I got my logs. The end. 

Running downstream testing now, since this is a cornerstone of many a unit test.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Change `setVerbosity` location in `mockRunLog` to `log` method rather than `init`.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
