### PR TITLE
Adding support for moving assemblies from SFP to Core in YAML shuffle input

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -1210,11 +1210,13 @@ class FuelHandler:
                         raise InputError("cascade entries must be strings")
 
                     if chain[0] == "SFP":
+                        # move an assembly from the SFP into the Core
                         assemType = None
                         locs = chain
                         if len(locs) < 2:
                             raise InputError("cascade starting with SFP must include a destination location")
                     else:
+                        # move an assembly around the Core
                         assemType = chain[0]
                         locs = chain[1:]
                         if not locs:

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -1197,7 +1197,7 @@ class FuelHandler:
                 )
 
             for action in actions:
-                allowed = {"cascade", "fuelEnrichment", "extraRotations", "misloadSwap"}
+                allowed = {"cascade", "fuelEnrichment", "extraRotations", "misloadSwap", "assemblyName"}
                 unknown = set(action) - allowed
                 if unknown:
                     raise InputError(f"Unknown action keys {unknown} in shuffle YAML")
@@ -1205,12 +1205,21 @@ class FuelHandler:
                 if "cascade" in action:
                     chain = list(action["cascade"])
                     if len(chain) < 2:
-                        raise InputError("cascade must contain an assembly type and at least one location")
+                        raise InputError("cascade must contain at least two entries")
                     if any(not isinstance(item, str) for item in chain):
                         raise InputError("cascade entries must be strings")
 
-                    assemType = chain[0]
-                    locs = chain[1:]
+                    if chain[0] == "SFP":
+                        assemType = None
+                        locs = chain
+                        if len(locs) < 2:
+                            raise InputError("cascade starting with SFP must include a destination location")
+                    else:
+                        assemType = chain[0]
+                        locs = chain[1:]
+                        if not locs:
+                            raise InputError("cascade must contain at least one location after the assembly type")
+
                     for loc in locs:
                         FuelHandler.validateLoc(loc, cycle)
                         if loc not in FuelHandler.DISCHARGE_LOCS and loc in seenLocs:
@@ -1226,8 +1235,19 @@ class FuelHandler:
                     if any(e < 0 or e > 1 for e in enrich):
                         raise InputError("fuelEnrichment values must be between 0 and 1. Got {enrich}")
 
-                    moves[cycle].append(AssemblyMove("LoadQueue", locs[0], enrich, assemType))
-                    for i in range(len(locs) - 1):
+                    assemblyName = action.get("assemblyName")
+                    if locs[0] == "SFP":
+                        if assemblyName is None:
+                            raise InputError("assemblyName required when loading from SFP")
+                        moves[cycle].append(AssemblyMove("SFP", locs[1], [], None, assemblyName))
+                        startIdx = 1
+                    else:
+                        if assemblyName is not None:
+                            raise InputError("assemblyName is only valid when loading from SFP")
+                        moves[cycle].append(AssemblyMove("LoadQueue", locs[0], enrich, assemType))
+                        startIdx = 0
+
+                    for i in range(startIdx, len(locs) - 1):
                         moves[cycle].append(AssemblyMove(locs[i], locs[i + 1]))
                     if locs[-1] not in FuelHandler.DISCHARGE_LOCS:
                         moves[cycle].append(AssemblyMove(locs[-1], "Delete"))

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -780,10 +780,10 @@ class TestFuelHandler(FuelHandlerTestHelper):
                 - cascade: ["SFP", "005-003", "SFP"]
                   assemblyName: "{assem.getName()}"
         """
-        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
-            tf.write(yaml_text)
-            fname = tf.name
-        try:
+        with directoryChangers.TemporaryDirectoryChanger():
+            fname = "moves.yaml"
+            with open(fname, "w", encoding="utf-8") as stream:
+                stream.write(yaml_text)
             moves, _ = fuelHandlers.FuelHandler.readMovesYaml(fname)
             expected = {
                 1: [
@@ -792,8 +792,6 @@ class TestFuelHandler(FuelHandlerTestHelper):
                 ]
             }
             self.assertEqual(moves, expected)
-        finally:
-            os.remove(fname)
 
     def test_performShuffleYaml_loadFromSfp(self):
         fh = fuelHandlers.FuelHandler(self.o)
@@ -804,18 +802,16 @@ class TestFuelHandler(FuelHandlerTestHelper):
                 - cascade: ["SFP", "009-045", "SFP"]
                   assemblyName: "{sfpAssem.getName()}"
         """
-        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
-            tf.write(yaml_text)
-            fname = tf.name
-        try:
+        with directoryChangers.TemporaryDirectoryChanger():
+            fname = "moves.yaml"
+            with open(fname, "w", encoding="utf-8") as stream:
+                stream.write(yaml_text)
             before = self.r.core.getAssemblyWithStringLocation("009-045").getName()
             self.r.p.cycle = 1
             self.o.cs = self.o.cs.modified(newSettings={CONF_SHUFFLE_SEQUENCE_FILE: fname})
             fh.outage()
             self.assertEqual(self.r.core.getAssemblyWithStringLocation("009-045").getName(), sfpAssem.getName())
             self.assertIsNotNone(self.r.excore["sfp"].getAssembly(before))
-        finally:
-            os.remove(fname)
 
     def test_processMoveList(self):
         fh = fuelHandlers.FuelHandler(self.o)

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -772,6 +772,51 @@ class TestFuelHandler(FuelHandlerTestHelper):
         finally:
             os.remove(fname)
 
+    def test_readMovesYaml_loadFromSfp(self):
+        assem = self.r.excore["sfp"].getChildren()[0]
+        yaml_text = f"""
+        sequence:
+            1:
+                - cascade: ["SFP", "005-003", "SFP"]
+                  assemblyName: "{assem.getName()}"
+        """
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
+            tf.write(yaml_text)
+            fname = tf.name
+        try:
+            moves, _ = fuelHandlers.FuelHandler.readMovesYaml(fname)
+            expected = {
+                1: [
+                    AssemblyMove("SFP", "005-003", [], None, assem.getName()),
+                    AssemblyMove("005-003", "SFP"),
+                ]
+            }
+            self.assertEqual(moves, expected)
+        finally:
+            os.remove(fname)
+
+    def test_performShuffleYaml_loadFromSfp(self):
+        fh = fuelHandlers.FuelHandler(self.o)
+        sfpAssem = self.r.excore["sfp"].getChildren()[0]
+        yaml_text = f"""
+        sequence:
+            1:
+                - cascade: ["SFP", "009-045", "SFP"]
+                  assemblyName: "{sfpAssem.getName()}"
+        """
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
+            tf.write(yaml_text)
+            fname = tf.name
+        try:
+            before = self.r.core.getAssemblyWithStringLocation("009-045").getName()
+            self.r.p.cycle = 1
+            self.o.cs = self.o.cs.modified(newSettings={CONF_SHUFFLE_SEQUENCE_FILE: fname})
+            fh.outage()
+            self.assertEqual(self.r.core.getAssemblyWithStringLocation("009-045").getName(), sfpAssem.getName())
+            self.assertIsNotNone(self.r.excore["sfp"].getAssembly(before))
+        finally:
+            os.remove(fname)
+
     def test_processMoveList(self):
         fh = fuelHandlers.FuelHandler(self.o)
         moves = fh.readMoves("armiRun-SHUFFLES.txt")

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -403,7 +403,10 @@ Assemblies can be retained in the model by ending the cascade with
 ``SFP``. When ``SFP`` is specified, the discharged assembly is stored in the
 spent fuel pool even if the ``trackAssems`` setting is ``False``; ``Delete``
 always removes the assembly from the model.
-For example
+Assemblies may also be re-inserted from the spent fuel pool by starting a
+cascade with ``SFP`` and providing an ``assemblyName`` for the assembly to
+load. No assembly type is required in this case. The cascade then proceeds as
+normal from the destination location. For example
    
 ..  code:: yaml
 
@@ -416,6 +419,17 @@ For example
          2:
            - cascade: ["outer fuel", "010-046", "009-045", "Delete"]
              fuelEnrichment: [0, 0.12, 0.14, 0.15, 0]
+
+A cascade that loads an assembly from the SFP may look like::
+
+       sequence:
+         1:
+           - cascade: ["SFP", "005-003", "SFP"]
+             assemblyName: "A0073"
+
+This example retrieves assembly ``A0073`` from the spent fuel pool and places it
+in location ``005-003`` while sending the previous occupant of ``005-003`` 
+to the pool.
 
 .. note:: Consider using yaml anchors ``&`` and aliases ``*`` to reduce repetition.
 

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -403,6 +403,7 @@ Assemblies can be retained in the model by ending the cascade with
 ``SFP``. When ``SFP`` is specified, the discharged assembly is stored in the
 spent fuel pool even if the ``trackAssems`` setting is ``False``; ``Delete``
 always removes the assembly from the model.
+
 Assemblies may also be re-inserted from the spent fuel pool by starting a
 cascade with ``SFP`` and providing an ``assemblyName`` for the assembly to
 load. No assembly type is required in this case. The cascade then proceeds as
@@ -421,6 +422,8 @@ normal from the destination location. For example
              fuelEnrichment: [0, 0.12, 0.14, 0.15, 0]
 
 A cascade that loads an assembly from the SFP may look like::
+
+..  code:: yaml
 
        sequence:
          1:


### PR DESCRIPTION
## What is the change? Why is it being made?

Enhance `FuelHandler` to support loading assemblies from `SFP` with` assemblyName` parameter and update documentation accordingly.

- Adding ``assemblyName`` support in YAML shuffle parsing to load cascades from the SFP, validating its presence when starting a cascade with SFP and prohibiting it otherwise.
- Updating move processing to retrieve named assemblies from the SFP during outage execution, raising an error if the requested assembly is absent.
- Expanding tests to cover reading and executing YAML cascades utilizing the charge from SFP functionality.
- Updating docs with an example of an assembly being loaded from the SFP.

Here's an example YAML input:

```
sequence:
         1:
           - cascade: ["SFP", "005-003", "SFP"]
             assemblyName: "A0073"
```


## SCR Information

Change Type: features

One-Sentence Description: Adding support for moving assemblies from SFP to Core in YAML shuffle input.

One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
