### PR TITLE
Fixing incorrect variable name in Pitch class

### DIFF
--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -164,7 +164,7 @@ class Pitch(yamlize.Object):
         if not any([hexPitch, x, y, z]):
             raise InputError("`lattice pitch` must have at least one non-zero attribute! Check the blueprints.")
 
-        self.hex = hex or x
+        self.hex = hexPitch or x
         self.x = x
         self.y = y
         self.z = z

--- a/armi/reactor/blueprints/tests/test_gridBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_gridBlueprints.py
@@ -454,11 +454,28 @@ class TestGridBlueprintsSection(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.assertEqual(gridDesign4.gridContents[-4, -3], "1")
 
+    def test_pitchBasics(self):
+        # use only hex input
+        p = Pitch(123, 0, 0, 0)
+        self.assertEqual(p.hex, 123)
+        self.assertEqual(p.x, 0)
+        self.assertEqual(p.y, 0)
+        self.assertEqual(p.z, 0)
+
+        # use only X, Y, Z inputs
+        p = Pitch(0, 1, 2, 3)
+        self.assertEqual(p.hex, 1)
+        self.assertEqual(p.x, 1)
+        self.assertEqual(p.y, 2)
+        self.assertEqual(p.z, 3)
+
     def test_pitchEdgeCases(self):
         with self.assertRaises(InputError):
+            # cannot mix hex with x,y,z pitch
             Pitch(1, 2, 3, 4)
 
         with self.assertRaises(InputError):
+            # SOMETHING needs to be non-zero
             Pitch(0, 0, 0, 0)
 
     def test_simpleReadLatticeMap(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

There was a bug introduced in [PR #2245](https://github.com/terrapower/armi/pull/2245). It is a simple typo that yields invalid Python.

Thanks to Chris for [finding this one](https://github.com/terrapower/armi/pull/2245/files#r2353160634).


## SCR Information

Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Fixing incorrect variable name in Pitch class.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
