### PR TITLE
Removing unused debugDB setting

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -45,6 +45,7 @@ jobs:
           coverage combine --rcfile=pyproject.toml --keep -a
           coverage report --rcfile=pyproject.toml -i --skip-empty --skip-covered --sort=cover --fail-under=90
       - name: Publish to coveralls.io
+        if: github.ref == 'refs/heads/main'
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -458,8 +458,6 @@ class Operator:
         interactMethodName = "interact{}".format(interactionName)
 
         printMemUsage = self.cs["verbosity"] == "debug" and self.cs["debugMem"]
-        if self.cs["debugDB"]:
-            self._debugDB(interactionName, "start", 0)
 
         halt = False
 
@@ -479,9 +477,6 @@ class Operator:
             with self.timer.getTimer(interactionMessage):
                 interactMethod = getattr(interface, interactMethodName)
                 halt = halt or interactMethod(*args)
-
-            if self.cs["debugDB"]:
-                self._debugDB(interactionName, interface.name, statePointIndex)
 
             if printMemUsage:
                 memAfter = memoryProfiler.PrintSystemMemoryUsageAction()
@@ -544,39 +539,6 @@ class Operator:
             )
 
         return cycleNodeInfo
-
-    def _debugDB(self, interactionName, interfaceName, statePointIndex=0):
-        """
-        Write state to DB with a unique "statePointName", or label.
-
-        Notes
-        -----
-        Used within _interactAll to write details between each physics interaction when cs['debugDB'] is enabled.
-
-        Parameters
-        ----------
-        interactionName : str
-            name of the interaction (e.g. BOL, BOC, EveryNode)
-        interfaceName : str
-            name of the interface that is interacting (e.g. globalflux, lattice, th)
-        statePointIndex : int (optional)
-            used as a counter to make labels that increment throughout an _interactAll call. The result should be fed
-            into the next call to ensure labels increment.
-        """
-        dbiForDetailedWrite = self.getInterface("database")
-        db = dbiForDetailedWrite.database if dbiForDetailedWrite is not None else None
-
-        if db is not None and db.isOpen():
-            # looks something like "c00t00-BOL-01-main"
-            statePointName = "c{:2<0}t{:2<0}-{}-{:2<0}-{}".format(
-                self.r.p.cycle,
-                self.r.p.timeNode,
-                interactionName,
-                statePointIndex,
-                interfaceName,
-            )
-
-            db.writeToDB(self.r, statePointName=statePointName)
 
     def interactAllInit(self):
         """Call interactInit on all interfaces in the stack after they are initialized."""

--- a/armi/settings/fwSettings/databaseSettings.py
+++ b/armi/settings/fwSettings/databaseSettings.py
@@ -17,7 +17,6 @@
 from armi.settings import setting
 
 CONF_DB = "db"
-CONF_DEBUG_DB = "debugDB"
 CONF_RELOAD_DB_NAME = "reloadDBName"
 CONF_LOAD_FROM_DB_EVERY_NODE = "loadFromDBEveryNode"
 CONF_SYNC_AFTER_WRITE = "syncDbAfterWrite"
@@ -32,12 +31,6 @@ def defineSettings():
             default=True,
             label="Activate Database",
             description="Write the state information to a database at every timestep",
-        ),
-        setting.Setting(
-            CONF_DEBUG_DB,
-            default=False,
-            label="Debug Database",
-            description="Write state to DB with a unique timestamp or label.",
         ),
         setting.Setting(
             CONF_RELOAD_DB_NAME,


### PR DESCRIPTION
## What is the change? Why is it being made?

After asking around, I believe the setting `debugDB` is broadly unused. And in a #2281, Drew points out that the setting is buggy. So perhaps it has _never_ been used. In any case, I do not think it is worth the time fixing a tool that no one wants.

close #2281


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing unused debugDB setting.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
