### PR TITLE
Improving the error messages for invalid settings data

### DIFF
--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 """
-This defines a Settings object that acts mostly like a dictionary. It
-is meant so that each ARMI run has one-and-only-one Settings object. It records
-user settings like the core power level, the input file names, the number of cycles to
-run, the run type, the environment setup, and hundreds of other things.
+This defines a Settings object that acts mostly like a dictionary. It is meant so that each ARMI run has
+one-and-only-one Settings object. It records user settings like the core power level, the input file names, the number
+of cycles to run, the run type, the environment setup, and hundreds of other things.
 
-A Settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to
-create this settings file, which is then loaded by an ARMI process on the cluster.
+A Settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to create this settings file,
+which is then loaded by an ARMI process on the cluster.
 """
 
 import io
@@ -53,19 +52,17 @@ class Settings:
         :id: I_ARMI_SETTING0
         :implements: R_ARMI_SETTING
 
-        The Settings object is accessible to most ARMI objects through self.cs
-        (for 'case settings'). It acts largely as a dictionary, and setting values
-        are accessed by keys.
+        The Settings object is accessible to most ARMI objects through self.cs (for 'case settings'). It acts largely as
+        a dictionary, and setting values are accessed by keys.
 
-        The Settings object has a 1-to-1 correspondence with the ARMI settings
-        input file. This file may be created by hand or by a GUI.
+        The Settings object has a 1-to-1 correspondence with the ARMI settings input file. This file may be created by
+        hand or by a GUI.
 
     Notes
     -----
-    While it is possible to modify case settings during the course of a run, this
-    is highly discouraged because there will be no record of this happening in your
-    results or in the database produced from your run. There is no guarantee that
-    doing so will not cause unexpected problems with your calculation.
+    While it is possible to modify case settings during the course of a run, this is highly discouraged because there
+    will be no record of this happening in your results or in the database produced from your run. There is no guarantee
+    that doing so will not cause unexpected problems with your calculation.
     """
 
     defaultCaseTitle = "armi"
@@ -85,11 +82,10 @@ class Settings:
         self._failOnLoad = False
         """This is state information.
 
-        The command line can take settings, which override a value in the current
-        settings file; however, if the settings file is listed after a setting value,
-        the setting from the settings file will be used rather than the one explicitly
-        provided by the user on the command line.  Therefore, _failOnLoad is used to
-        prevent this from happening.
+        The command line can take settings, which override a value in the current settings file; however, if the
+        settings file is listed after a setting value, the setting from the settings file will be used rather than the
+        one explicitly provided by the user on the command line. Therefore, _failOnLoad is used to prevent this from
+        happening.
         """
         from armi import getApp
 
@@ -118,14 +114,11 @@ class Settings:
             :id: I_ARMI_SETTINGS_META0
             :implements: R_ARMI_SETTINGS_META
 
-            Every Settings object has a "case title"; a string for users to
-            help identify their run. This case title is used in log file
-            names, it is printed during a run, it is frequently used to
-            name the settings file. It is designed to be an easy-to-use
-            and easy-to-understand way to keep track of simulations. The
-            general idea here is that the average analyst that is using
-            ARMI will run many ARMI-based simulations, and there needs
-            to be an easy to identify them all.
+            Every Settings object has a "case title"; a string for users to help identify their run. This case title is
+            used in log file names, it is printed during a run, it is frequently used to name the settings file. It is
+            designed to be an easy-to-use and easy-to-understand way to keep track of simulations. The general idea here
+            is that the average analyst that is using ARMI will run many ARMI-based simulations, and there needs to be
+            an easy to identify them all.
         """
         if not self.path:
             return self.defaultCaseTitle
@@ -150,7 +143,7 @@ class Settings:
         isAltered = lambda s: 1 if s.value != s.default else 0
         altered = sum([isAltered(setting) for setting in self.__settings.values()])
 
-        return "<{} name:{} total:{} altered:{}>".format(self.__class__.__name__, self.caseTitle, total, altered)
+        return f"<{self.__class__.__name__} name:{self.caseTitle} total:{total} altered:{altered}>"
 
     def _directAccessOfSettingAllowed(self, key):
         """
@@ -160,20 +153,19 @@ class Settings:
 
         Notes
         -----
-        Checking the validity of grabbing specific settings at this point, as is done for the
-        SIMPLE_CYCLES_INPUT's, feels a bit intrusive and out of place. In particular, the fact that
-        the check is done every time that a setting is reached for, no matter if it is the setting
-        in question, is quite clunky. In the future, it would be desirable if the settings system
-        were more flexible to control this type of thing at a deeper level.
+        Checking the validity of grabbing specific settings at this point, as is done for the SIMPLE_CYCLES_INPUT's,
+        feels a bit intrusive and out of place. In particular, the fact that the check is done every time that a setting
+        is reached for, no matter if it is the setting in question, is quite clunky. In the future, it would be
+        desirable if the settings system were more flexible to control this type of thing at a deeper level.
         """
         if key not in self.__settings:
             return False, NonexistentSetting(key)
 
         if key in SIMPLE_CYCLES_INPUTS and self.__settings["cycles"].value != []:
             err = ValueError(
-                "Cannot grab simple cycles information from the case settings when detailed cycles "
-                "information is also entered. In general cycles information should be pulled off "
-                "the operator or parsed using the appropriate getter in the utils."
+                "Cannot grab simple cycles information from the case settings when detailed cycles information is also "
+                "entered. In general cycles information should be pulled off the operator or parsed using the "
+                "appropriate getter in the utils."
             )
 
             return False, err
@@ -217,8 +209,7 @@ class Settings:
         """
         Rebuild schema upon unpickling since schema is unpickleable.
 
-        Pickling happens during mpi broadcasts and also during testing where the test reactor is
-        cached.
+        Pickling happens during mpi broadcasts and also during testing where the test reactor is cached.
 
         See Also
         --------
@@ -255,8 +246,8 @@ class Settings:
         """Return a duplicate copy of this settings object."""
         cs = deepcopy(self)
         cs._failOnLoad = False
-        # It's not really protected access since it is a new Settings object. _failOnLoad is set to
-        # false, because this new settings object should be independent of the command line
+        # It's not really protected access since it is a new Settings object. _failOnLoad is set to false, because this
+        # new settings object should be independent of the command line
         return cs
 
     def revertToDefaults(self):
@@ -267,8 +258,8 @@ class Settings:
     def failOnLoad(self):
         """This method is used to force loading a file to fail.
 
-        After command line processing of settings has begun, the settings should be fully defined.
-        If the settings are loaded
+        After command line processing of settings has begun, the settings should be fully defined. If the settings are
+        loaded
         """
         self._failOnLoad = True
 
@@ -276,8 +267,8 @@ class Settings:
         """
         Read in settings from an input YAML file.
 
-        Passes the reader back out in case you want to know something about how the reading went
-        like for knowing if a file contained deprecated settings, etc.
+        Passes the reader back out in case you want to know something about how the reading went like for knowing if a
+        file contained deprecated settings, etc.
         """
         reader, path = self._prepToRead(fName)
         reader.readFromFile(fName, handleInvalids)
@@ -298,9 +289,9 @@ class Settings:
     def _prepToRead(self, fName):
         if self._failOnLoad:
             raise RuntimeError(
-                "Cannot load settings file after processing of command line options begins.\nYou "
-                "may be able to fix this by reordering the command line arguments, and making sure "
-                f"the settings file `{fName}` comes before any modified settings."
+                "Cannot load settings file after processing of command line options begins.\nYou may be able to fix "
+                f"this by reordering the command line arguments, and making sure the settings file `{fName}` comes "
+                "before any modified settings."
             )
         path = pathTools.armiAbsPath(fName)
         return settingsIO.SettingsReader(self), path
@@ -308,13 +299,13 @@ class Settings:
     def loadFromString(self, string, handleInvalids=True):
         """Read in settings from a YAML string.
 
-        Passes the reader back out in case you want to know something about how the reading went
-        like for knowing if a file contained deprecated settings, etc.
+        Passes the reader back out in case you want to know something about how the reading went like for knowing if a
+        file contained deprecated settings, etc.
         """
         if self._failOnLoad:
             raise RuntimeError(
-                "Cannot load settings after processing of command line options begins.\nYou may be "
-                "able to fix this by reordering the command line arguments."
+                "Cannot load settings after processing of command line options begins.\nYou may be able to fix this by "
+                "reordering the command line arguments."
             )
 
         reader = settingsIO.SettingsReader(self)
@@ -336,8 +327,7 @@ class Settings:
 
         Notes
         -----
-        This means that creating a Settings object sets the global logging level of the entire code
-        base.
+        This means that creating a Settings object sets the global logging level of the entire code base.
         """
         if context.MPI_RANK == 0:
             runLog.setVerbosity(self["verbosity"])
@@ -359,11 +349,11 @@ class Settings:
         fName : str
             the file to write to
         style : str (optional)
-            the method of output to be used when creating the file for the current state of settings
-            (short, medium, or full)
+            the method of output to be used when creating the file for the current state of settings (short, medium, or
+            full).
         fromFile : str (optional)
-            if the source file and destination file are different (i.e. for cloning) and the style
-            argument is ``medium``, then this arg is used
+            if the source file and destination file are different (i.e. for cloning) and the style argument is
+            ``medium``, then this arg is used
         """
         self.path = pathTools.armiAbsPath(fName)
         if style == "medium":
@@ -371,6 +361,7 @@ class Settings:
             settingsSetByUser = self.getSettingsSetByUser(getSettingsPath)
         else:
             settingsSetByUser = []
+
         with open(self.path, "w") as stream:
             writer = self.writeToYamlStream(stream, style, settingsSetByUser)
 
@@ -378,8 +369,8 @@ class Settings:
 
     def getSettingsSetByUser(self, fPath):
         """
-        Grabs the list of settings in the user-defined input file so that the settings can be
-        tracked outside of a Settings object.
+        Grabs the list of settings in the user-defined input file so that the settings can be tracked outside of a
+        Settings object.
 
         Parameters
         ----------
@@ -391,8 +382,8 @@ class Settings:
         userSettingsNames : list
             The settings names read in from a yaml settings file
         """
-        # We do not want to load these as settings, but just grab the dictionary straight from the
-        # settings file to know which settings are user-defined.
+        # We do not want to load these as settings, but just grab the dictionary straight from the settings file to know
+        # which settings are user-defined.
         with open(fPath, "r") as stream:
             yaml = YAML()
             yaml.allow_duplicate_keys = False
@@ -424,15 +415,14 @@ class Settings:
         return writer
 
     def updateEnvironmentSettingsFrom(self, otherCs):
-        """Updates the environment settings in this object based on some other cs (from the GUI,
-        most likely).
+        """Updates the environment settings in this object based on some other cs (from the GUI, most likely).
 
         Parameters
         ----------
         otherCs : Settings
             A cs object that environment settings will be inherited from.
 
-        This enables users to run tests with their environment rather than the reference environment
+        This enables users to run tests with their environment rather than the reference environment.
         """
         for replacement in self.environmentSettings:
             self[replacement] = otherCs[replacement]
@@ -456,14 +446,14 @@ class Settings:
         return settings
 
     def setModuleVerbosities(self, force=False):
-        """Attempt to grab the module-level logger verbosities from the settings file,
-        and then set their log levels (verbosities).
+        """Attempt to grab the module-level logger verbosities from the settings file, and then set their log levels
+        (verbosities).
 
         Parameters
         ----------
         force : bool, optional
-            If force is False, don't overwrite the log verbosities if the logger already exists.
-            IF this needs to be used mid-run, force=False is safer.
+            If force is False, don't overwrite the log verbosities if the logger already exists. IF this needs to be
+            used mid-run, force=False is safer.
 
         Notes
         -----

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 """
-This defines a Settings object that acts mostly like a dictionary. It is meant so that each ARMI run has
-one-and-only-one Settings object. It records user settings like the core power level, the input file names, the number
-of cycles to run, the run type, the environment setup, and hundreds of other things.
+This defines a Settings object that acts mostly like a dictionary. It
+is meant so that each ARMI run has one-and-only-one Settings object. It records
+user settings like the core power level, the input file names, the number of cycles to
+run, the run type, the environment setup, and hundreds of other things.
 
-A Settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to create this settings file,
-which is then loaded by an ARMI process on the cluster.
+A Settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to
+create this settings file, which is then loaded by an ARMI process on the cluster.
 """
 
 import io
@@ -52,17 +53,19 @@ class Settings:
         :id: I_ARMI_SETTING0
         :implements: R_ARMI_SETTING
 
-        The Settings object is accessible to most ARMI objects through self.cs (for 'case settings'). It acts largely as
-        a dictionary, and setting values are accessed by keys.
+        The Settings object is accessible to most ARMI objects through self.cs
+        (for 'case settings'). It acts largely as a dictionary, and setting values
+        are accessed by keys.
 
-        The Settings object has a 1-to-1 correspondence with the ARMI settings input file. This file may be created by
-        hand or by a GUI.
+        The Settings object has a 1-to-1 correspondence with the ARMI settings
+        input file. This file may be created by hand or by a GUI.
 
     Notes
     -----
-    While it is possible to modify case settings during the course of a run, this is highly discouraged because there
-    will be no record of this happening in your results or in the database produced from your run. There is no guarantee
-    that doing so will not cause unexpected problems with your calculation.
+    While it is possible to modify case settings during the course of a run, this
+    is highly discouraged because there will be no record of this happening in your
+    results or in the database produced from your run. There is no guarantee that
+    doing so will not cause unexpected problems with your calculation.
     """
 
     defaultCaseTitle = "armi"
@@ -82,10 +85,11 @@ class Settings:
         self._failOnLoad = False
         """This is state information.
 
-        The command line can take settings, which override a value in the current settings file; however, if the
-        settings file is listed after a setting value, the setting from the settings file will be used rather than the
-        one explicitly provided by the user on the command line. Therefore, _failOnLoad is used to prevent this from
-        happening.
+        The command line can take settings, which override a value in the current
+        settings file; however, if the settings file is listed after a setting value,
+        the setting from the settings file will be used rather than the one explicitly
+        provided by the user on the command line.  Therefore, _failOnLoad is used to
+        prevent this from happening.
         """
         from armi import getApp
 
@@ -114,11 +118,14 @@ class Settings:
             :id: I_ARMI_SETTINGS_META0
             :implements: R_ARMI_SETTINGS_META
 
-            Every Settings object has a "case title"; a string for users to help identify their run. This case title is
-            used in log file names, it is printed during a run, it is frequently used to name the settings file. It is
-            designed to be an easy-to-use and easy-to-understand way to keep track of simulations. The general idea here
-            is that the average analyst that is using ARMI will run many ARMI-based simulations, and there needs to be
-            an easy to identify them all.
+            Every Settings object has a "case title"; a string for users to
+            help identify their run. This case title is used in log file
+            names, it is printed during a run, it is frequently used to
+            name the settings file. It is designed to be an easy-to-use
+            and easy-to-understand way to keep track of simulations. The
+            general idea here is that the average analyst that is using
+            ARMI will run many ARMI-based simulations, and there needs
+            to be an easy to identify them all.
         """
         if not self.path:
             return self.defaultCaseTitle
@@ -143,7 +150,7 @@ class Settings:
         isAltered = lambda s: 1 if s.value != s.default else 0
         altered = sum([isAltered(setting) for setting in self.__settings.values()])
 
-        return f"<{self.__class__.__name__} name:{self.caseTitle} total:{total} altered:{altered}>"
+        return "<{} name:{} total:{} altered:{}>".format(self.__class__.__name__, self.caseTitle, total, altered)
 
     def _directAccessOfSettingAllowed(self, key):
         """
@@ -153,19 +160,20 @@ class Settings:
 
         Notes
         -----
-        Checking the validity of grabbing specific settings at this point, as is done for the SIMPLE_CYCLES_INPUT's,
-        feels a bit intrusive and out of place. In particular, the fact that the check is done every time that a setting
-        is reached for, no matter if it is the setting in question, is quite clunky. In the future, it would be
-        desirable if the settings system were more flexible to control this type of thing at a deeper level.
+        Checking the validity of grabbing specific settings at this point, as is done for the
+        SIMPLE_CYCLES_INPUT's, feels a bit intrusive and out of place. In particular, the fact that
+        the check is done every time that a setting is reached for, no matter if it is the setting
+        in question, is quite clunky. In the future, it would be desirable if the settings system
+        were more flexible to control this type of thing at a deeper level.
         """
         if key not in self.__settings:
             return False, NonexistentSetting(key)
 
         if key in SIMPLE_CYCLES_INPUTS and self.__settings["cycles"].value != []:
             err = ValueError(
-                "Cannot grab simple cycles information from the case settings when detailed cycles information is also "
-                "entered. In general cycles information should be pulled off the operator or parsed using the "
-                "appropriate getter in the utils."
+                "Cannot grab simple cycles information from the case settings when detailed cycles "
+                "information is also entered. In general cycles information should be pulled off "
+                "the operator or parsed using the appropriate getter in the utils."
             )
 
             return False, err
@@ -209,7 +217,8 @@ class Settings:
         """
         Rebuild schema upon unpickling since schema is unpickleable.
 
-        Pickling happens during mpi broadcasts and also during testing where the test reactor is cached.
+        Pickling happens during mpi broadcasts and also during testing where the test reactor is
+        cached.
 
         See Also
         --------
@@ -246,8 +255,8 @@ class Settings:
         """Return a duplicate copy of this settings object."""
         cs = deepcopy(self)
         cs._failOnLoad = False
-        # It's not really protected access since it is a new Settings object. _failOnLoad is set to false, because this
-        # new settings object should be independent of the command line
+        # It's not really protected access since it is a new Settings object. _failOnLoad is set to
+        # false, because this new settings object should be independent of the command line
         return cs
 
     def revertToDefaults(self):
@@ -258,8 +267,8 @@ class Settings:
     def failOnLoad(self):
         """This method is used to force loading a file to fail.
 
-        After command line processing of settings has begun, the settings should be fully defined. If the settings are
-        loaded
+        After command line processing of settings has begun, the settings should be fully defined.
+        If the settings are loaded
         """
         self._failOnLoad = True
 
@@ -267,8 +276,8 @@ class Settings:
         """
         Read in settings from an input YAML file.
 
-        Passes the reader back out in case you want to know something about how the reading went like for knowing if a
-        file contained deprecated settings, etc.
+        Passes the reader back out in case you want to know something about how the reading went
+        like for knowing if a file contained deprecated settings, etc.
         """
         reader, path = self._prepToRead(fName)
         reader.readFromFile(fName, handleInvalids)
@@ -289,9 +298,9 @@ class Settings:
     def _prepToRead(self, fName):
         if self._failOnLoad:
             raise RuntimeError(
-                "Cannot load settings file after processing of command line options begins.\nYou may be able to fix "
-                f"this by reordering the command line arguments, and making sure the settings file `{fName}` comes "
-                "before any modified settings."
+                "Cannot load settings file after processing of command line options begins.\nYou "
+                "may be able to fix this by reordering the command line arguments, and making sure "
+                f"the settings file `{fName}` comes before any modified settings."
             )
         path = pathTools.armiAbsPath(fName)
         return settingsIO.SettingsReader(self), path
@@ -299,13 +308,13 @@ class Settings:
     def loadFromString(self, string, handleInvalids=True):
         """Read in settings from a YAML string.
 
-        Passes the reader back out in case you want to know something about how the reading went like for knowing if a
-        file contained deprecated settings, etc.
+        Passes the reader back out in case you want to know something about how the reading went
+        like for knowing if a file contained deprecated settings, etc.
         """
         if self._failOnLoad:
             raise RuntimeError(
-                "Cannot load settings after processing of command line options begins.\nYou may be able to fix this by "
-                "reordering the command line arguments."
+                "Cannot load settings after processing of command line options begins.\nYou may be "
+                "able to fix this by reordering the command line arguments."
             )
 
         reader = settingsIO.SettingsReader(self)
@@ -327,7 +336,8 @@ class Settings:
 
         Notes
         -----
-        This means that creating a Settings object sets the global logging level of the entire code base.
+        This means that creating a Settings object sets the global logging level of the entire code
+        base.
         """
         if context.MPI_RANK == 0:
             runLog.setVerbosity(self["verbosity"])
@@ -349,11 +359,11 @@ class Settings:
         fName : str
             the file to write to
         style : str (optional)
-            the method of output to be used when creating the file for the current state of settings (short, medium, or
-            full).
+            the method of output to be used when creating the file for the current state of settings
+            (short, medium, or full)
         fromFile : str (optional)
-            if the source file and destination file are different (i.e. for cloning) and the style argument is
-            ``medium``, then this arg is used
+            if the source file and destination file are different (i.e. for cloning) and the style
+            argument is ``medium``, then this arg is used
         """
         self.path = pathTools.armiAbsPath(fName)
         if style == "medium":
@@ -361,7 +371,6 @@ class Settings:
             settingsSetByUser = self.getSettingsSetByUser(getSettingsPath)
         else:
             settingsSetByUser = []
-
         with open(self.path, "w") as stream:
             writer = self.writeToYamlStream(stream, style, settingsSetByUser)
 
@@ -369,8 +378,8 @@ class Settings:
 
     def getSettingsSetByUser(self, fPath):
         """
-        Grabs the list of settings in the user-defined input file so that the settings can be tracked outside of a
-        Settings object.
+        Grabs the list of settings in the user-defined input file so that the settings can be
+        tracked outside of a Settings object.
 
         Parameters
         ----------
@@ -382,8 +391,8 @@ class Settings:
         userSettingsNames : list
             The settings names read in from a yaml settings file
         """
-        # We do not want to load these as settings, but just grab the dictionary straight from the settings file to know
-        # which settings are user-defined.
+        # We do not want to load these as settings, but just grab the dictionary straight from the
+        # settings file to know which settings are user-defined.
         with open(fPath, "r") as stream:
             yaml = YAML()
             yaml.allow_duplicate_keys = False
@@ -415,14 +424,15 @@ class Settings:
         return writer
 
     def updateEnvironmentSettingsFrom(self, otherCs):
-        """Updates the environment settings in this object based on some other cs (from the GUI, most likely).
+        """Updates the environment settings in this object based on some other cs (from the GUI,
+        most likely).
 
         Parameters
         ----------
         otherCs : Settings
             A cs object that environment settings will be inherited from.
 
-        This enables users to run tests with their environment rather than the reference environment.
+        This enables users to run tests with their environment rather than the reference environment
         """
         for replacement in self.environmentSettings:
             self[replacement] = otherCs[replacement]
@@ -446,14 +456,14 @@ class Settings:
         return settings
 
     def setModuleVerbosities(self, force=False):
-        """Attempt to grab the module-level logger verbosities from the settings file, and then set their log levels
-        (verbosities).
+        """Attempt to grab the module-level logger verbosities from the settings file,
+        and then set their log levels (verbosities).
 
         Parameters
         ----------
         force : bool, optional
-            If force is False, don't overwrite the log verbosities if the logger already exists. IF this needs to be
-            used mid-run, force=False is safer.
+            If force is False, don't overwrite the log verbosities if the logger already exists.
+            IF this needs to be used mid-run, force=False is safer.
 
         Notes
         -----

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -17,7 +17,7 @@ System to handle basic configuration settings.
 
 Notes
 -----
-The type of each setting is derived from the type of the default value. When users set values to their settings, ARMI
+The type of each Setting is derived from the type of the default value. When users set values to their settings, ARMI
 enforces these types with schema validation. This also allows for more complex schema validation for settings that are
 more complex dictionaries (e.g. XS, rx coeffs).
 """
@@ -160,20 +160,6 @@ class Setting:
         return self._default
 
     @property
-    def options(self):
-        return self._options
-
-    @options.setter
-    def options(self, opts):
-        if self._options is None:
-            raise AttributeError(
-                f"The Setting {self.name} has no default options, it looks like you want to add that to the Setting "
-                "definition."
-            )
-
-        self._options = opts
-
-    @property
     def value(self):
         return self._value
 
@@ -205,6 +191,19 @@ class Setting:
             raise
 
         self._value = self._load(val)
+
+    @property
+    def options(self):
+        return self._options
+
+    @options.setter
+    def options(self, opts):
+        if self._options is None:
+            raise AttributeError(
+                f"The Setting {self.name} has no default options, it looks like you want to add that to the definition."
+            )
+
+        self._options = opts
 
     def addOptions(self, options: List[Option]):
         """Extend this Setting's options with extra options."""
@@ -275,7 +274,7 @@ class Setting:
         """
         Returns a boolean based on whether or not the setting equals its default value.
 
-        It's possible for a setting to change and not be reported as such when it is changed back to its default. That
+        It is possible for a setting to change and not be reported as such when it is changed back to its default. That
         behavior seems acceptable.
         """
         return self.value == self.default
@@ -366,6 +365,7 @@ class FlagListSetting(Setting):
                 flagVals.append(v)
             else:
                 raise ValueError(f"Invalid flag input `{v}` in `FlagListSetting`")
+
         return flagVals
 
     def dump(self) -> List[str]:

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -108,7 +108,7 @@ class Setting:
         self.name = name
         self.description = description or name
         self.label = label or name
-        self._options = options
+        self.options = options
         self.enforcedOptions = enforcedOptions
         self.subLabels = subLabels
         self.isEnvironment = isEnvironment
@@ -192,22 +192,21 @@ class Setting:
 
         self._value = self._load(val)
 
-    @property
-    def options(self):
-        return self._options
-
-    @options.setter
-    def options(self, opts):
-        if self._options is None:
-            raise AttributeError(
-                f"The Setting {self.name} has no default options, it looks like you want to add that to the definition."
-            )
-
-        self._options = opts
-
     def addOptions(self, options: List[Option]):
         """Extend this Setting's options with extra options."""
-        self.options.extend([o.option for o in options])
+        try:
+            self.options.extend([o.option for o in options])
+        except AttributeError:
+            if self.options is None:
+                msg = (
+                    f"The Setting {self.name} has no default options, it looks like you want to add that to the "
+                    + "definition."
+                )
+                runLog.error(msg)
+                raise AttributeError(msg)
+            else:
+                raise
+
         self._setSchema()
 
     def addOption(self, option: Option):

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -17,11 +17,9 @@ System to handle basic configuration settings.
 
 Notes
 -----
-The type of each setting is derived from the type of the default
-value. When users set values to their settings, ARMI enforces
-these types with schema validation. This also allows for more
-complex schema validation for settings that are more complex
-dictionaries (e.g. XS, rx coeffs).
+The type of each setting is derived from the type of the default value. When users set values to their settings, ARMI
+enforces these types with schema validation. This also allows for more complex schema validation for settings that are
+more complex dictionaries (e.g. XS, rx coeffs).
 """
 
 import copy
@@ -34,10 +32,9 @@ import voluptuous as vol
 from armi import runLog
 from armi.reactor.flags import Flags
 
-# Options are used to imbue existing settings with new Options. This allows a setting
-# like `neutronicsKernel` to strictly enforce options, even though the plugin that
-# defines it does not know all possible options, which may be provided from other
-# plugins.
+# Options are used to imbue existing settings with new Options. This allows a setting like `neutronicsKernel` to
+# strictly enforce options, even though the plugin that defines it does not know all possible options, which may be
+# provided from other plugins.
 Option = namedtuple("Option", ["option", "settingName"])
 Default = namedtuple("Default", ["value", "settingName"])
 
@@ -50,15 +47,13 @@ class Setting:
         :id: I_ARMI_SETTINGS_DEFAULTS
         :implements: R_ARMI_SETTINGS_DEFAULTS
 
-        Setting objects hold all associated information of a setting in ARMI and should
-        typically be accessed through the Settings methods rather than directly.
-        Settings require a mandatory default value.
+        Setting objects hold all associated information of a setting in ARMI and should typically be accessed through
+        the Settings methods rather than directly. Settings require a mandatory default value.
 
-        Setting subclasses can implement custom ``load`` and ``dump`` methods that can
-        enable serialization (to/from dicts) of custom objects. When you set a
-        setting's value, the value will be unserialized into the custom object and when
-        you call ``dump``, it will be serialized. Just accessing the value will return
-        the actual object in this case.
+        Setting subclasses can implement custom ``load`` and ``dump`` methods that can enable serialization (to/from
+        dicts) of custom objects. When you set a setting's value, the value will be unserialized into the custom object
+        and when you call ``dump``, it will be serialized. Just accessing the value will return the actual object in
+        this case.
     """
 
     def __init__(
@@ -90,28 +85,22 @@ class Setting:
         options : list, optional
             Legal values (useful in GUI drop-downs)
         schema : callable, optional
-            A function that gets called with the configuration
-            VALUES that build this setting. The callable will
-            either raise an exception, safely modify/update,
-            or leave unchanged the value. If left blank,
-            a type check will be performed against the default.
+            A function that gets called with the configuration VALUES that build this setting. The callable will either
+            raise an exception, safely modify/update, or leave unchanged the value. If left blank, a type check will be
+            performed against the default.
         enforcedOptions : bool, optional
             Require that the value be one of the valid options.
         subLabels : tuple, optional
-            The names of the fields in each tuple for a setting that accepts a list
-            of tuples. For example, if a setting is a list of (assembly name, file name)
-            tuples, the sublabels would be ("assembly name", "file name").
-            This is needed for building GUI widgets to input such data.
+            The names of the fields in each tuple for a setting that accepts a list of tuples. For example, if a setting
+            is a list of (assembly name, file name) tuples, the sublabels would be ("assembly name", "file name"). This
+            is needed for building GUI widgets to input such data.
         isEnvironment : bool, optional
-            Whether this should be considered an "environment" setting. These can be
-            used by the Case system to propagate environment options through
-            command-line flags.
+            Whether this should be considered an "environment" setting. These can be used by the Case system to
+            propagate environment options through command-line flags.
         oldNames : list of tuple, optional
-            List of previous names that this setting used to have, along with optional
-            expiration dates. These can aid in automatic migration of old inputs. When
-            provided, if it is appears that the expiration date has passed, old names
-            will result in errors, requiring to user to update their input by hand to
-            use more current settings.
+            List of previous names that this setting used to have, along with optional expiration dates. These can aid
+            in automatic migration of old inputs. When provided, if it is appears that the expiration date has passed,
+            old names will result in errors, requiring to user to update their input by hand to use more current names.
         """
         assert description, f"Setting {name} defined without description."
         assert description != "None", f"Setting {name} defined without description."
@@ -119,15 +108,14 @@ class Setting:
         self.name = name
         self.description = description or name
         self.label = label or name
-        self.options = options
+        self._options = options
         self.enforcedOptions = enforcedOptions
         self.subLabels = subLabels
         self.isEnvironment = isEnvironment
         self.oldNames: List[Tuple[str, Optional[datetime.date]]] = oldNames or []
         self._default = default
         self._value = copy.deepcopy(default)  # break link from _default
-        # Retain the passed schema so that we don't accidentally stomp on it in
-        # addOptions(), et.al.
+        # Retain the passed schema so that we don't accidentally stomp on it in addOptions(), et.al.
         self._customSchema = schema
         self._setSchema()
 
@@ -143,8 +131,7 @@ class Setting:
         try:
             containedSchema = self.schema.schema[0]
             if isinstance(containedSchema, vol.Coerce):
-                # special case for Coerce objects, which
-                # store their underlying type as ``.type``.
+                # special case for Coerce objects, which store their underlying type as ``.type``.
                 return containedSchema.type
             return containedSchema
         except TypeError:
@@ -161,10 +148,9 @@ class Setting:
         else:
             # Coercion is needed in some GUI instances where lists are getting set as strings.
             if isinstance(self.default, list) and self.default:
-                # Non-empty default: assume the default has the desired contained type
-                # Coerce all values to the first entry in the default so mixed floats and ints work.
-                # Note that this will not work for settings that allow mixed
-                # types in their lists (e.g. [0, '10R']), so those all need custom schemas.
+                # Non-empty default: assume the default has the desired contained type Coerce all values to the first
+                # entry in the default so mixed floats and ints work. Note that this will not work for settings that
+                # allow mixed types in their lists (e.g. [0, '10R']), so those all need custom schemas.
                 self.schema = vol.Schema([vol.Coerce(type(self.default[0]))])
             else:
                 self.schema = vol.Schema(vol.Coerce(type(self.default)))
@@ -172,6 +158,20 @@ class Setting:
     @property
     def default(self):
         return self._default
+
+    @property
+    def options(self):
+        return self._options
+
+    @options.setter
+    def options(self, opts):
+        if self._options is None:
+            raise AttributeError(
+                f"The Setting {self.name} has no default options, it looks like you want to add that to the Setting "
+                "definition."
+            )
+
+        self._options = opts
 
     @property
     def value(self):
@@ -184,9 +184,8 @@ class Setting:
 
         Notes
         -----
-        Can't just decorate ``setValue`` with ``@value.setter`` because
-        some callers use setting.value=val and others use setting.setValue(val)
-        and the latter fails with ``TypeError: 'XSSettings' object is not callable``
+        Can't just decorate ``setValue`` with ``@value.setter`` because some callers use setting.value=val and others
+        use setting.setValue(val) and the latter fails with ``TypeError: 'XSSettings' object is not callable``.
         """
         return self.setValue(val)
 
@@ -196,10 +195,8 @@ class Setting:
 
         This validates it against its value schema on the way in.
 
-        Some setting values are custom serializable objects.
-        Rather than writing them directly to YAML using
-        YAML's Python object-writing features, we prefer
-        to use our own custom serializers on subclasses.
+        Some setting values are custom serializable objects. Rather than writing them directly to YAML using YAML's
+        Python object-writing features, we prefer to use our own custom serializers on subclasses.
         """
         try:
             val = self.schema(val)
@@ -228,8 +225,7 @@ class Setting:
         """
         Create setting value from input value.
 
-        In some custom settings, this can return a custom object
-        rather than just the input value.
+        In some custom settings, this can return a custom object rather than just the input value.
         """
         return inputVal
 
@@ -242,7 +238,7 @@ class Setting:
         return self._value
 
     def __repr__(self):
-        return "<{} {} value:{} default:{}>".format(self.__class__.__name__, self.name, self.value, self.default)
+        return f"<{self.__class__.__name__} {self.name} value:{self.value} default:{self.default}>"
 
     def __getstate__(self):
         """
@@ -255,14 +251,14 @@ class Setting:
 
         See Also
         --------
-        armi.settings.caseSettings.Settings.__setstate__ : regenerates the schema upon load
-            Note that we don't do it at the individual setting level because it'd be too
-            O(N^2).
+        armi.settings.caseSettings.Settings.__setstate__ : regenerates the schema upon load.
+            Note that we don't do it at the individual setting level because it'd be too O(N^2).
         """
         state = copy.deepcopy(self.__dict__)
         for trouble in ("schema", "_customSchema"):
             if trouble in state:
                 del state[trouble]
+
         return state
 
     def revertToDefault(self):
@@ -271,8 +267,7 @@ class Setting:
 
         Notes
         -----
-        Skips the property setter because default val
-        should already be validated.
+        Skips the property setter because default val should already be validated.
         """
         self._value = copy.deepcopy(self.default)
 
@@ -280,8 +275,8 @@ class Setting:
         """
         Returns a boolean based on whether or not the setting equals its default value.
 
-        It's possible for a setting to change and not be reported as such when it is changed back to its default.
-        That behavior seems acceptable.
+        It's possible for a setting to change and not be reported as such when it is changed back to its default. That
+        behavior seems acceptable.
         """
         return self.value == self.default
 

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -29,7 +29,7 @@ from armi.physics.neutronics.settings import CONF_NEUTRONICS_KERNEL
 from armi.reactor.flags import Flags
 from armi.settings import caseSettings, setting
 from armi.settings.settingsValidation import Inspector, validateVersion
-from armi.tests import ARMI_RUN_PATH, TEST_ROOT
+from armi.tests import ARMI_RUN_PATH, TEST_ROOT, mockRunLogs
 from armi.utils import directoryChangers
 from armi.utils.customExceptions import NonexistentSetting
 
@@ -166,11 +166,18 @@ class TestAddingOptions(unittest.TestCase):
         )
 
         self.assertIsNone(s.options)
-        with self.assertRaises(AttributeError):
-            s.addOptions([1, 2])
 
-        with self.assertRaises(AttributeError):
-            s.addOption([3])
+        with mockRunLogs.BufferLog() as mock:
+            self.assertIs(mock.getStdout(), "")
+            with self.assertRaises(AttributeError):
+                s.addOptions([1, 2])
+            self.assertIn("has no default options", mock.getStdout())
+
+        with mockRunLogs.BufferLog() as mock:
+            self.assertIs(mock.getStdout(), "")
+            with self.assertRaises(AttributeError):
+                s.addOption(3)
+            self.assertIn("has no default options", mock.getStdout())
 
 
 class TestSettings2(unittest.TestCase):

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -155,6 +155,23 @@ class TestAddingOptions(unittest.TestCase):
         self.assertEqual(cs["burnSteps"], 2)
         self.assertEqual(cs[CONF_NEUTRONICS_KERNEL], "MCNP")
 
+    def test_illDefinedOptions(self):
+        """Test an edge case where the Setting was ill-defined."""
+        s = setting.Setting(
+            "illDefinedOptions",
+            default="DEFAULT",
+            label="stuff",
+            description="Whatever",
+            enforcedOptions=True,
+        )
+
+        self.assertIsNone(s.options)
+        with self.assertRaises(AttributeError):
+            s.addOptions([1, 2])
+
+        with self.assertRaises(AttributeError):
+            s.addOption([3])
+
 
 class TestSettings2(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

Improving the error messages for invalid settings data, because Arrielle and Tony ran into an awkward problem to be bug.

Okay @opotowsky I think the only class attribute that could be a problem here is `.options`. I think the rest are unlikely to be accessed for modification directly like this.

So I just protected the situation with `options` with a setter/getter and a more clear error message.

close #2284


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Improving the error messages for invalid settings data.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Minor change to improve I_ARMI_SETTINGS_DEFAULTS for requirement I_ARMI_SETTINGS_DEFAULTS, essentially just turning an internal variable into a setter/getter property.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
