### PR TITLE
Improving Docs for 0.6.0 Release

### DIFF
--- a/armi/bookkeeping/tests/test_snapshot.py
+++ b/armi/bookkeeping/tests/test_snapshot.py
@@ -59,7 +59,7 @@ class TestSnapshotInterface(unittest.TestCase):
         self.si.interactCoupled(2)
         self.assertTrue(mockSnapshotRequest.called)
 
-    def test_activeateDefaultSnapshots_30cycles2BurnSteps(self):
+    def test_activateDefSnapshots_30cyc2burns(self):
         """
         Test snapshots for 30 cycles and 2 burnsteps, checking the dumpSnapshot setting.
 
@@ -79,7 +79,7 @@ class TestSnapshotInterface(unittest.TestCase):
         self.si.activateDefaultSnapshots()
         self.assertEqual(["000000", "014000", "029002"], self.si.cs["dumpSnapshot"])
 
-    def test_activeateDefaultSnapshots_17cycles5BurnSteps(self):
+    def test_activateDeftSnapshots_17cyc5surns(self):
         """
         Test snapshots for 17 cycles and 5 burnsteps, checking the dumpSnapshot setting.
 

--- a/armi/nucDirectory/tests/test_elements.py
+++ b/armi/nucDirectory/tests/test_elements.py
@@ -64,7 +64,7 @@ class TestElement(unittest.TestCase):
             with self.assertRaises(ValueError):
                 elements.Element(ee.z, ee.symbol, ee.name)
 
-    def test_element_addedElementAppearsInElementList(self):
+    def test_addedElementAppearsInElementList(self):
         self.assertNotIn("bacon", elements.byName)
         self.assertNotIn(999, elements.byZ)
         self.assertNotIn("BZ", elements.bySymbol)
@@ -82,7 +82,7 @@ class TestElement(unittest.TestCase):
             with open(os.path.join(RES, "burn-chain.yaml"), "r") as burnChainStream:
                 nuclideBases.imposeBurnChain(burnChainStream)
 
-    def test_elementGetNatrualIsotpicsOnlyRetrievesAbund(self):
+    def test_elementGetNatIsosOnlyRetrievesAbund(self):
         for ee in elements.byZ.values():
             if not ee.isNaturallyOccurring():
                 continue
@@ -90,7 +90,7 @@ class TestElement(unittest.TestCase):
                 self.assertGreater(nuc.abundance, 0.0)
                 self.assertGreater(nuc.a, 0)
 
-    def test_element_isNaturallyOccurring(self):
+    def test_elementIsNatOccurring(self):
         """
         Test isNaturallyOccurring method by manually testing all elements.
 

--- a/armi/nuclearDataIO/tests/test_xsCollections.py
+++ b/armi/nuclearDataIO/tests/test_xsCollections.py
@@ -36,7 +36,7 @@ class TestXsCollections(unittest.TestCase):
         self.block.setNumberDensity("U235", 0.02)
         self.block.setNumberDensity("FE", 0.01)
 
-    def test_generateTotalScatteringMatrix(self):
+    def test_genTotScatteringMatrix(self):
         """Generates the total scattering matrix by summing elastic, inelastic, and n2n scattering matrices."""
         nuc = self.microLib.nuclides[0]
         totalScatter = nuc.micros.getTotalScatterMatrix()
@@ -45,7 +45,7 @@ class TestXsCollections(unittest.TestCase):
             (nuc.micros.elasticScatter[0, 0] + nuc.micros.inelasticScatter[0, 0] + 2.0 * nuc.micros.n2nScatter[0, 0]),
         )
 
-    def test_genScatteringMatrixWithMissingData(self):
+    def test_totalScatteringMatrixWithMissingData(self):
         """
         Generates the total scattering matrix by summing elastic and n2n scattering matrices.
 
@@ -62,10 +62,7 @@ class TestXsCollections(unittest.TestCase):
         )
 
     def test_plotNucXs(self):
-        """
-        Testing this plotting method here because we need a XS library
-        to run the test.
-        """
+        """Testing this plotting method here because we need a XS library to run the test."""
         fName = "test_plotNucXs.png"
         with TemporaryDirectoryChanger():
             plotNucXs(self.microLib, "U235AA", "fission", fName=fName)

--- a/armi/nuclearDataIO/tests/test_xsCollections.py
+++ b/armi/nuclearDataIO/tests/test_xsCollections.py
@@ -45,7 +45,7 @@ class TestXsCollections(unittest.TestCase):
             (nuc.micros.elasticScatter[0, 0] + nuc.micros.inelasticScatter[0, 0] + 2.0 * nuc.micros.n2nScatter[0, 0]),
         )
 
-    def test_generateTotalScatteringMatrixWithMissingData(self):
+    def test_genScatteringMatrixWithMissingData(self):
         """
         Generates the total scattering matrix by summing elastic and n2n scattering matrices.
 

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -26,13 +26,13 @@ class NuclideTests(unittest.TestCase):
     def setUpClass(cls):
         cls.lib = isotxs.readBinary(ISOAA_PATH)
 
-    def test_nucl_createFromLabelFailsOnBadName(self):
+    def test_nuclCreateFromLabelFailsOnBadName(self):
         nuc = xsNuclides.XSNuclide(None, "BACONAA")
         nuc.isotxsMetadata["nuclideId"] = "BACN87"
         with self.assertRaises(OSError):
             nuc.updateBaseNuclide()
 
-    def test_nuc_creatingNucNotMessWithUnderlyingNucDict(self):
+    def test_creatingNucNotMessWithUnderlyingNucDict(self):
         nuc = nuclideBases.byName["U238"]
         self.assertFalse(hasattr(nuc, "xsId"))
         nrAA = xsNuclides.XSNuclide(None, "U238AA")
@@ -41,7 +41,7 @@ class NuclideTests(unittest.TestCase):
         self.assertEqual("AA", nrAA.xsId)
         self.assertFalse(hasattr(nuc, "xsId"))
 
-    def test_nucl_modifyingNucAttrUpdatesTheIsotxsNuc(self):
+    def test_nuclModifyingNucAttrUpdatesTheIsotxsNuc(self):
         lib = xsLibraries.IsotxsLibrary()
         nuc = nuclideBases.byName["FE"]
         nrAA = xsNuclides.XSNuclide(lib, "FEAA")
@@ -98,7 +98,7 @@ class NuclideTests(unittest.TestCase):
         self.assertEqual(0.0008645406924188137, sum(nuc.micros.n2n))
         self.assertEqual(0.008091875669521187, sum(nuc.micros.nGamma))
 
-    def test_nuclide_2dXsArrangementIsCorrect(self):
+    def test_nuclide2dXsArrangementIsCorrect(self):
         """Manually compare some 2d XS data to ensure the correct coordinates."""
         u235 = self.lib["U235AA"]
         self.assertAlmostEqual(5.76494979858, u235.micros.total[0, 0])
@@ -119,7 +119,7 @@ class NuclideTests(unittest.TestCase):
         self.assertAlmostEqual(383.891998291, pu239.micros.total[31, 1])
         self.assertAlmostEqual(973.399902343, pu239.micros.total[32, 1])
 
-    def test_nuclide_scatterXsArrangementIsCorrect(self):
+    def test_nucScatterXsArrangementIsCorrect(self):
         """Manually compare scatter XS data to ensure the correct coordinates."""
         u235 = self.lib["U235AA"]
         elasticScatter = u235.micros.elasticScatter

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -1055,7 +1055,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
         self.assertEqual(a1PostSwapStationaryBlocks, a2PreSwapStationaryBlocks)
         self.assertEqual(a2PostSwapStationaryBlocks, a1PreSwapStationaryBlocks)
 
-    def test_dischargeSwapIncompatibleStationaryBlocks(self):
+    def test_dischargeSwapStationaryBlocks(self):
         """
         Test the _transferStationaryBlocks method for the case where the input assemblies have
         different numbers as well as unaligned locations of stationary blocks.

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -282,7 +282,7 @@ class TestComponentAveraging(unittest.TestCase):
                 msg=f"{c} avg temperature {avgTemp} not equal to expected {expectedTemps[compIndex]}!",
             )
 
-    def test_getAverageComponentTemperatureVariedWeights(self):
+    def test_getAvgCompTempVariedWeights(self):
         """Test mass-weighted component temperature averaging with variable weights."""
         # make up a fake weighting with power param
         self.bc.weightingParam = "power"
@@ -299,7 +299,7 @@ class TestComponentAveraging(unittest.TestCase):
                 msg=f"{c} avg temperature {avgTemp} not equal to expected {expectedTemps[compIndex]}!",
             )
 
-    def test_getAverageComponentTemperatureNoMass(self):
+    def test_getAvgCompTempNoMass(self):
         """Test component temperature averaging when the components have no mass."""
         for b in self.bc:
             for nuc in b.getNuclides():
@@ -900,7 +900,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
         self.assertIsNone(blocks[0].p.detailedNDens)
         self.assertIsNone(blocks[1].p.detailedNDens)
 
-    def _createRepresentativeBlocksUsingExistingBlocks(self, validBlockTypes):
+    def _createRepresentativeBlocksExistingBlocks(self, validBlockTypes):
         """Reusable code used in multiple unit tests."""
         o, r = test_reactors.loadTestReactor(TEST_ROOT, inputFileName="smallestTestReactor/armiRunSmallest.yaml")
         # set a few random non-default settings on AA to be copied to the new BA group
@@ -957,7 +957,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
         """
         self._createRepresentativeBlocksUsingExistingBlocks(["fuel"])
 
-    def test_createRepBlocksFromDisableValidBlockTypes(self):
+    def test_createRepBlocksDisableValidBlockTypes(self):
         """
         Demonstrates that a new representative block can be generated from an existing
         representative block with the setting `disableBlockTypeExclusionInXsGeneration: true`.

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -900,7 +900,7 @@ class TestCrossSectionGroupManager(unittest.TestCase):
         self.assertIsNone(blocks[0].p.detailedNDens)
         self.assertIsNone(blocks[1].p.detailedNDens)
 
-    def _createRepresentativeBlocksExistingBlocks(self, validBlockTypes):
+    def _createRepresentativeBlocksUsingExistingBlocks(self, validBlockTypes):
         """Reusable code used in multiple unit tests."""
         o, r = test_reactors.loadTestReactor(TEST_ROOT, inputFileName="smallestTestReactor/armiRunSmallest.yaml")
         # set a few random non-default settings on AA to be copied to the new BA group

--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -344,8 +344,7 @@ class TestGriddedBlock(unittest.TestCase):
     def test_latticeNotInComponents(self):
         """
         Ensure that we catch cases when a latticeID listed in the grid is not present
-        in any of the components on the block. In this case, latticeID "2" is not
-        in the lattice.
+        in any of the components on the block. In this case, latticeID "2" is not in the lattice.
         """
         with self.assertRaises(ValueError) as ee:
             with io.StringIO(FULL_BP_NO_COMP) as stream:
@@ -386,7 +385,7 @@ class TestGriddedBlock(unittest.TestCase):
         self.assertTrue(a1.hasFlags(Flags.FUEL, exact=True))
         self.assertTrue(a2.hasFlags(Flags.FUEL | Flags.TEST, exact=True))
 
-    def test_densityConsistentWithComponentConstructor(self):
+    def test_densConsistentCompConstructor(self):
         a1 = self.blueprints.assemDesigns.bySpecifier["IC"].construct(self.cs, self.blueprints)
         fuelBlock = a1[0]
         clad = fuelBlock.getComponent(Flags.CLAD)

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -45,7 +45,7 @@ assemblies:
         xs types: [A]
 """
 
-    def test_componentInitIncompleteBurnChain(self):
+    def test_compInitIncompleteBurnChain(self):
         nuclideFlagsFuelWithBurn = (
             inspect.cleandoc(
                 r"""
@@ -64,7 +64,7 @@ assemblies:
         with self.assertRaises(ValueError):
             bp.constructAssem(cs, "assembly")
 
-    def test_componentInitControlCustomIsotopics(self):
+    def test_compInitControlCustomIso(self):
         nuclideFlags = (
             inspect.cleandoc(
                 """
@@ -147,7 +147,7 @@ assemblies:
         # More robust test, but worse unittest.py output when it fails
         self.assertTrue(c.hasFlags(Flags.FUEL | Flags.TEST))
 
-    def test_componentInitAmericiumCustomIsotopics(self):
+    def test_compInitAmericiumCustomIso(self):
         nuclideFlags = (
             inspect.cleandoc(
                 r"""
@@ -235,7 +235,7 @@ assemblies:
         for nuc in unexpectedNuclides:
             self.assertNotIn(nuc, a[0][0].getNuclides())
 
-    def test_componentInitThoriumBurnCustomIsotopics(self):
+    def test_compInitThoriumBurnCustomIso(self):
         nuclideFlags = (
             inspect.cleandoc(
                 r"""
@@ -291,7 +291,7 @@ assemblies:
         for nuc in expectedNuclides:
             self.assertIn(nuc, a[0][0].getNuclides())
 
-    def test_componentInitThoriumNoBurnCustomIsotopics(self):
+    def test_compInitThoriumNoBurnCustomIso(self):
         nuclideFlags = (
             inspect.cleandoc(
                 r"""

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -374,7 +374,7 @@ assemblies:
         keys2 = set([i for i, v in enumerate(fuel2.p.numberDensities) if v == 0.0])
         self.assertEqual(keys1, keys2)
 
-    def test_densitiesAppliedToNonCustomMaterials(self):
+    def test_densAppliedToNonCustomMats(self):
         """Ensure that a density can be set in custom isotopics for components using library materials."""
         # The template block
         fuel0 = self.a[0].getComponent(Flags.FUEL)
@@ -404,7 +404,7 @@ assemblies:
         self.assertEqual(fuel6.material.name, fuel0.material.name)
         self.assertEqual("UZr", fuel0.material.name)
 
-    def test_densitiesAppliedToNonCustomMaterialsFluid(self):
+    def test_densAppliedToNonCustomMatsFluid(self):
         """
         Ensure that a density can be set in custom isotopics for components using library materials,
         specifically in the case of a fluid component. In this case, inputHeightsConsideredHot

--- a/armi/reactor/converters/tests/test_axialExpansionChanger_MultiPin.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger_MultiPin.py
@@ -160,7 +160,7 @@ class TestRedistributeMass(TestMultiPinConservationBase):
         self.assertAlmostEqual(refC0Ztop, self.c0.ztop, places=self.places)
         self.assertAlmostEqual(refC1Zbottom, self.c1.zbottom, places=self.places)
 
-    def test_redistributeMass_nonTargetExpansion_noThermal(self):
+    def test_redistributeMassNonTargetExpNoTherm(self):
         """With no temperature changes anywere, grow c0 by 10% and show that 10% of the c0 mass is moved to c1.
 
         Notes
@@ -174,7 +174,7 @@ class TestRedistributeMass(TestMultiPinConservationBase):
         self._initializeTest(growFrac, fromComp=self.c0)
         self._redistributeMassWithTempAssert(fromComp=self.c0, toComp=self.c1, thermalExp=False)
 
-    def test_addMassToComponent_nonTargetCompression_noThermal(self):
+    def test_addMassToCompNonTargetCompNoTherm(self):
         """With no temperature changes anywere, shrink c0 by 10% and show that 10% of the c1 mass is moved to c0.
 
         Notes
@@ -188,7 +188,7 @@ class TestRedistributeMass(TestMultiPinConservationBase):
         self._initializeTest(growFrac, fromComp=self.c1)
         self._redistributeMassWithTempAssert(fromComp=self.c1, toComp=self.c0, thermalExp=False)
 
-    def test_addMassToComponent_nonTargetCompression_yesThermal(self):
+    def test_addMassToCompNonTargetComprYesTherm(self):
         """Decrease c0 by 100 deg C and and show that c1 mass is moved to c0.
 
         Notes
@@ -208,7 +208,7 @@ class TestRedistributeMass(TestMultiPinConservationBase):
         self._initializeTest(growFrac, fromComp=self.c1)
         self._redistributeMassWithTempAssert(fromComp=self.c1, toComp=self.c0, thermalExp=True)
 
-    def test_addMassToComponent_nonTargetExpansion_yesThermal(self):
+    def test_addMassToCompNonTargetExpanYesTherm(self):
         """Increase c0 by 100 deg C and and show that c0 mass is moved to c1.
 
         Notes
@@ -633,7 +633,7 @@ class TestExceptionForMultiPin(TestMultiPinConservationBase):
         self.axialExpChngr = AxialExpansionChanger()
         self.axialExpChngr.setAssembly(self.a)
 
-    def test_failExpansionNegativeComponentHeight(self):
+    def test_failExpansionNegativeCompHeight(self):
         """Show that the negative component height check can be caught."""
         cList = []
         for _i, b in self._iterFuelBlocks():

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1910,7 +1910,8 @@ class Block_TestCase(unittest.TestCase):
         assert_allclose(235.0, mfpAbs, rtol=0.1)
         assert_allclose(17.0, diffusionLength, rtol=0.1)
 
-    def test_consistentMassDensVolBetweenColdBlockAndComp(self):
+    def test_consistentMassDensVolCold(self):
+        """Consistent mass density and volume betwen cold block and component."""
         block = self.block
         expectedData = []
         actualData = []
@@ -1926,7 +1927,8 @@ class Block_TestCase(unittest.TestCase):
             for expectedVal, actualVal in zip(expected, actual):
                 self.assertAlmostEqual(expectedVal, actualVal, msg=msg)
 
-    def test_consistentMassDensVolBetweenHotBlockAndComp(self):
+    def test_consistentMassDensVolHot(self):
+        """Consistent mass density and volume betwen hot block and component."""
         block = self._hotBlock
         expectedData = []
         actualData = []

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -686,7 +686,7 @@ class TestCircle(TestShapedComponent):
         """Test that ARMI can thermally expands a circle."""
         self.assertTrue(self.component.THERMAL_EXPANSION_DIMS)
 
-    def test_getBoundingCircleOuterDiameter(self):
+    def test_getBoundingCircleOuterDiam(self):
         ref = self._od
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
@@ -729,7 +729,7 @@ class TestCircle(TestShapedComponent):
             cur = self.component.getArea()
             self.assertAlmostEqual(cur, ref)
 
-    def test_componentInteractionsLinkingByDimensions(self):
+    def test_compInteractionsLinkingByDims(self):
         """Tests linking of Components by dimensions.
 
         The component ``gap``, representing the fuel-clad gap filled with Void, is defined with
@@ -783,7 +783,7 @@ class TestCircle(TestShapedComponent):
         with self.assertRaises(ValueError):
             _gap = Circle("gap", "Void", **gapDims)
 
-    def test_componentInteractionsLinkingBySubtraction(self):
+    def test_compInteractionsLinkingBySubt(self):
         """Tests linking of components by subtraction."""
         nPins = 217
         gapDims = {"Tinput": 25.0, "Thot": 430.0, "od": 1.0, "id": 0.9, "mult": nPins}
@@ -1085,7 +1085,7 @@ class TestRectangle(TestShapedComponent):
             negativeRectangle = Rectangle("test", "UZr", **dims)
             negativeRectangle.getArea()
 
-    def test_getBoundingCircleOuterDiameter(self):
+    def test_getBoundingCircleOuterDiam(self):
         """Get outer diameter bounding circle.
 
         .. test:: Rectangle shaped component
@@ -1103,7 +1103,7 @@ class TestRectangle(TestShapedComponent):
         cur = self.component.getArea(cold=True)
         self.assertAlmostEqual(cur, ref)
 
-    def test_getCircleInnerDiameter(self):
+    def test_getCircleInnerDiam(self):
         cur = self.component.getCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(math.sqrt(25.0), cur)
 
@@ -1151,7 +1151,7 @@ class TestSolidRectangle(TestShapedComponent):
         "mult": 1,
     }
 
-    def test_getBoundingCircleOuterDiameter(self):
+    def test_getBoundingCircleOuterDiam(self):
         """Test get bounding circle of the outer diameter."""
         ref = math.sqrt(50)
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
@@ -1210,7 +1210,7 @@ class TestSquare(TestShapedComponent):
             negativeRectangle = Square("test", "UZr", **dims)
             negativeRectangle.getArea()
 
-    def test_getBoundingCircleOuterDiameter(self):
+    def test_getBoundingCircleOuterDiam(self):
         """Get bounding circle outer diameter.
 
         .. test:: Square shaped component
@@ -1226,7 +1226,7 @@ class TestSquare(TestShapedComponent):
         cur = self.component.getComponentArea(cold=True)
         self.assertAlmostEqual(cur, ref)
 
-    def test_getCircleInnerDiameter(self):
+    def test_getCircleInnerDiam(self):
         ref = math.sqrt(8.0)
         cur = self.component.getCircleInnerDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)
@@ -1322,7 +1322,7 @@ class TestHexagon(TestShapedComponent):
     componentCls = Hexagon
     componentDims = {"Tinput": 25.0, "Thot": 430.0, "op": 10.0, "ip": 5.0, "mult": 1}
 
-    def test_getBoundingCircleOuterDiameter(self):
+    def test_getBoundingCircleOuterDiam(self):
         ref = 2.0 * 10 / math.sqrt(3)
         cur = self.component.getBoundingCircleOuterDiameter(cold=True)
         self.assertAlmostEqual(ref, cur)

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -409,7 +409,7 @@ class TestCompositePattern(unittest.TestCase):
         for c in self.container:
             self.assertIsNotNone(c._lumpedFissionProducts)
 
-    def test_requiresLumpedFissionProducts(self):
+    def test_requiresLumpedFissionProds(self):
         # build a lumped fission product collection
         fpd = getDummyLFPFile()
         lfps = fpd.createLFPsFromFile()
@@ -427,7 +427,7 @@ class TestCompositePattern(unittest.TestCase):
         result = self.container.requiresLumpedFissionProducts(["LFP35"])
         self.assertTrue(result)
 
-    def test_getLumpedFissionProductsIfNecessaryNullCase(self):
+    def test_getLumpedFissionProdsIfNullCase(self):
         # build a lumped fission product collection
         fpd = getDummyLFPFile()
         lfps = fpd.createLFPsFromFile()

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -171,7 +171,7 @@ class ParameterTests(unittest.TestCase):
         self.assertEqual(17, mock1.doodle)
         self.assertEqual(42, mock2.doodle)
 
-    def test_paramPropertyDoesNotConflictWithNoneDefault(self):
+    def test_paramPropDoesNotConflictWithNoneDefault(self):
         class Mock(parameters.ParameterCollection):
             pDefs = parameters.ParameterDefinitionCollection()
             with pDefs.createBuilder() as pb:
@@ -324,7 +324,7 @@ class ParameterTests(unittest.TestCase):
         self.assertEqual(data["n"], 99)
         self.assertEqual(data["nPlus1"], 100)
 
-    def test_cannotDefineParameterWithSameName(self):
+    def test_cannotDefineParamWithSameName(self):
         with self.assertRaises(parameters.ParameterDefinitionError):
 
             class MockParamCollection(parameters.ParameterCollection):
@@ -361,7 +361,7 @@ class ParameterTests(unittest.TestCase):
         self.assertTrue(set(base.paramDefs._paramDefs).issubset(set(derB.paramDefs._paramDefs)))
         self.assertTrue(set(derA.paramDefs._paramDefs).issubset(set(derB.paramDefs._paramDefs)))
 
-    def test_cannotDefineParamSameNameCollectionSubclass(self):
+    def test_cannotDefineParamSameNameColSubclass(self):
         class MockPCParent(parameters.ParameterCollection):
             pDefs = parameters.ParameterDefinitionCollection()
             with pDefs.createBuilder() as pb:
@@ -383,7 +383,7 @@ class ParameterTests(unittest.TestCase):
             with pDefs.createBuilder() as pb:
                 pb.defParam("sameName", "units", "description 5", "location")
 
-    def test_cannotCreateAttrbuteOnParameterCollectionSubclass(self):
+    def test_cannotCreateAttrOnParamColSubclass(self):
         class MockPC(parameters.ParameterCollection):
             pDefs = parameters.ParameterDefinitionCollection()
             with pDefs.createBuilder() as pb:
@@ -450,7 +450,7 @@ class ParameterTests(unittest.TestCase):
             self.assertTrue(p.hasCategory(category))
         self.assertFalse(p.hasCategory("this_shouldnot_exist"))
 
-    def test_parameterCollectionsHave__slots__(self):
+    def test_paramColHaveSlots(self):
         """Tests we prevent accidental creation of attributes."""
         self.assertEqual(
             set(

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -586,13 +586,13 @@ class HexReactorTests(ReactorTests):
     def test_getAssemblyPitch(self):
         self.assertEqual(self.r.core.getAssemblyPitch(), 16.75)
 
-    def test_getNumAssembliesWithAllRingsFilledOut(self):
+    def test_getNumAssemsWithAllRingsFilledOut(self):
         nRings = self.r.core.getNumRings(indexBased=True)
         nAssmWithBlanks = self.r.core.getNumAssembliesWithAllRingsFilledOut(nRings)
         self.assertEqual(77, nAssmWithBlanks)
 
     @patch("armi.reactor.reactors.Core.powerMultiplier", 1)
-    def test_getNumAssembliesWithAllRingsFilledOutBipass(self):
+    def test_getNumAssemsWithAllRingsFilledOutBipass(self):
         nAssems = self.r.core.getNumAssembliesWithAllRingsFilledOut(3)
         self.assertEqual(19, nAssems)
 

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -17,11 +17,9 @@ System to handle basic configuration settings.
 
 Notes
 -----
-The type of each setting is derived from the type of the default
-value. When users set values to their settings, ARMI enforces
-these types with schema validation. This also allows for more
-complex schema validation for settings that are more complex
-dictionaries (e.g. XS, rx coeffs).
+The type of each Setting is derived from the type of the default value. When users set values to their settings, ARMI
+enforces these types with schema validation. This also allows for more complex schema validation for settings that are
+more complex dictionaries (e.g. XS, rx coeffs).
 """
 
 import copy
@@ -34,10 +32,9 @@ import voluptuous as vol
 from armi import runLog
 from armi.reactor.flags import Flags
 
-# Options are used to imbue existing settings with new Options. This allows a setting
-# like `neutronicsKernel` to strictly enforce options, even though the plugin that
-# defines it does not know all possible options, which may be provided from other
-# plugins.
+# Options are used to imbue existing settings with new Options. This allows a setting like `neutronicsKernel` to
+# strictly enforce options, even though the plugin that defines it does not know all possible options, which may be
+# provided from other plugins.
 Option = namedtuple("Option", ["option", "settingName"])
 Default = namedtuple("Default", ["value", "settingName"])
 
@@ -50,15 +47,13 @@ class Setting:
         :id: I_ARMI_SETTINGS_DEFAULTS
         :implements: R_ARMI_SETTINGS_DEFAULTS
 
-        Setting objects hold all associated information of a setting in ARMI and should
-        typically be accessed through the Settings methods rather than directly.
-        Settings require a mandatory default value.
+        Setting objects hold all associated information of a setting in ARMI and should typically be accessed through
+        the Settings methods rather than directly. Settings require a mandatory default value.
 
-        Setting subclasses can implement custom ``load`` and ``dump`` methods that can
-        enable serialization (to/from dicts) of custom objects. When you set a
-        setting's value, the value will be unserialized into the custom object and when
-        you call ``dump``, it will be serialized. Just accessing the value will return
-        the actual object in this case.
+        Setting subclasses can implement custom ``load`` and ``dump`` methods that can enable serialization (to/from
+        dicts) of custom objects. When you set a setting's value, the value will be unserialized into the custom object
+        and when you call ``dump``, it will be serialized. Just accessing the value will return the actual object in
+        this case.
     """
 
     def __init__(
@@ -90,28 +85,22 @@ class Setting:
         options : list, optional
             Legal values (useful in GUI drop-downs)
         schema : callable, optional
-            A function that gets called with the configuration
-            VALUES that build this setting. The callable will
-            either raise an exception, safely modify/update,
-            or leave unchanged the value. If left blank,
-            a type check will be performed against the default.
+            A function that gets called with the configuration VALUES that build this setting. The callable will either
+            raise an exception, safely modify/update, or leave unchanged the value. If left blank, a type check will be
+            performed against the default.
         enforcedOptions : bool, optional
             Require that the value be one of the valid options.
         subLabels : tuple, optional
-            The names of the fields in each tuple for a setting that accepts a list
-            of tuples. For example, if a setting is a list of (assembly name, file name)
-            tuples, the sublabels would be ("assembly name", "file name").
-            This is needed for building GUI widgets to input such data.
+            The names of the fields in each tuple for a setting that accepts a list of tuples. For example, if a setting
+            is a list of (assembly name, file name) tuples, the sublabels would be ("assembly name", "file name"). This
+            is needed for building GUI widgets to input such data.
         isEnvironment : bool, optional
-            Whether this should be considered an "environment" setting. These can be
-            used by the Case system to propagate environment options through
-            command-line flags.
+            Whether this should be considered an "environment" setting. These can be used by the Case system to
+            propagate environment options through command-line flags.
         oldNames : list of tuple, optional
-            List of previous names that this setting used to have, along with optional
-            expiration dates. These can aid in automatic migration of old inputs. When
-            provided, if it is appears that the expiration date has passed, old names
-            will result in errors, requiring to user to update their input by hand to
-            use more current settings.
+            List of previous names that this setting used to have, along with optional expiration dates. These can aid
+            in automatic migration of old inputs. When provided, if it is appears that the expiration date has passed,
+            old names will result in errors, requiring to user to update their input by hand to use more current names.
         """
         assert description, f"Setting {name} defined without description."
         assert description != "None", f"Setting {name} defined without description."
@@ -126,8 +115,7 @@ class Setting:
         self.oldNames: List[Tuple[str, Optional[datetime.date]]] = oldNames or []
         self._default = default
         self._value = copy.deepcopy(default)  # break link from _default
-        # Retain the passed schema so that we don't accidentally stomp on it in
-        # addOptions(), et.al.
+        # Retain the passed schema so that we don't accidentally stomp on it in addOptions(), et.al.
         self._customSchema = schema
         self._setSchema()
 
@@ -143,8 +131,7 @@ class Setting:
         try:
             containedSchema = self.schema.schema[0]
             if isinstance(containedSchema, vol.Coerce):
-                # special case for Coerce objects, which
-                # store their underlying type as ``.type``.
+                # special case for Coerce objects, which store their underlying type as ``.type``.
                 return containedSchema.type
             return containedSchema
         except TypeError:
@@ -161,10 +148,9 @@ class Setting:
         else:
             # Coercion is needed in some GUI instances where lists are getting set as strings.
             if isinstance(self.default, list) and self.default:
-                # Non-empty default: assume the default has the desired contained type
-                # Coerce all values to the first entry in the default so mixed floats and ints work.
-                # Note that this will not work for settings that allow mixed
-                # types in their lists (e.g. [0, '10R']), so those all need custom schemas.
+                # Non-empty default: assume the default has the desired contained type Coerce all values to the first
+                # entry in the default so mixed floats and ints work. Note that this will not work for settings that
+                # allow mixed types in their lists (e.g. [0, '10R']), so those all need custom schemas.
                 self.schema = vol.Schema([vol.Coerce(type(self.default[0]))])
             else:
                 self.schema = vol.Schema(vol.Coerce(type(self.default)))
@@ -184,9 +170,8 @@ class Setting:
 
         Notes
         -----
-        Can't just decorate ``setValue`` with ``@value.setter`` because
-        some callers use setting.value=val and others use setting.setValue(val)
-        and the latter fails with ``TypeError: 'XSSettings' object is not callable``
+        Can't just decorate ``setValue`` with ``@value.setter`` because some callers use setting.value=val and others
+        use setting.setValue(val) and the latter fails with ``TypeError: 'XSSettings' object is not callable``.
         """
         return self.setValue(val)
 
@@ -196,10 +181,8 @@ class Setting:
 
         This validates it against its value schema on the way in.
 
-        Some setting values are custom serializable objects.
-        Rather than writing them directly to YAML using
-        YAML's Python object-writing features, we prefer
-        to use our own custom serializers on subclasses.
+        Some setting values are custom serializable objects. Rather than writing them directly to YAML using YAML's
+        Python object-writing features, we prefer to use our own custom serializers on subclasses.
         """
         try:
             val = self.schema(val)
@@ -211,7 +194,19 @@ class Setting:
 
     def addOptions(self, options: List[Option]):
         """Extend this Setting's options with extra options."""
-        self.options.extend([o.option for o in options])
+        try:
+            self.options.extend([o.option for o in options])
+        except AttributeError:
+            if self.options is None:
+                msg = (
+                    f"The Setting {self.name} has no default options, it looks like you want to add that to the "
+                    + "definition."
+                )
+                runLog.error(msg)
+                raise AttributeError(msg)
+            else:
+                raise
+
         self._setSchema()
 
     def addOption(self, option: Option):
@@ -228,8 +223,7 @@ class Setting:
         """
         Create setting value from input value.
 
-        In some custom settings, this can return a custom object
-        rather than just the input value.
+        In some custom settings, this can return a custom object rather than just the input value.
         """
         return inputVal
 
@@ -242,7 +236,7 @@ class Setting:
         return self._value
 
     def __repr__(self):
-        return "<{} {} value:{} default:{}>".format(self.__class__.__name__, self.name, self.value, self.default)
+        return f"<{self.__class__.__name__} {self.name} value:{self.value} default:{self.default}>"
 
     def __getstate__(self):
         """
@@ -255,14 +249,14 @@ class Setting:
 
         See Also
         --------
-        armi.settings.caseSettings.Settings.__setstate__ : regenerates the schema upon load
-            Note that we don't do it at the individual setting level because it'd be too
-            O(N^2).
+        armi.settings.caseSettings.Settings.__setstate__ : regenerates the schema upon load.
+            Note that we don't do it at the individual setting level because it'd be too O(N^2).
         """
         state = copy.deepcopy(self.__dict__)
         for trouble in ("schema", "_customSchema"):
             if trouble in state:
                 del state[trouble]
+
         return state
 
     def revertToDefault(self):
@@ -271,8 +265,7 @@ class Setting:
 
         Notes
         -----
-        Skips the property setter because default val
-        should already be validated.
+        Skips the property setter because default val should already be validated.
         """
         self._value = copy.deepcopy(self.default)
 
@@ -280,8 +273,8 @@ class Setting:
         """
         Returns a boolean based on whether or not the setting equals its default value.
 
-        It's possible for a setting to change and not be reported as such when it is changed back to its default.
-        That behavior seems acceptable.
+        It is possible for a setting to change and not be reported as such when it is changed back to its default. That
+        behavior seems acceptable.
         """
         return self.value == self.default
 
@@ -371,6 +364,7 @@ class FlagListSetting(Setting):
                 flagVals.append(v)
             else:
                 raise ValueError(f"Invalid flag input `{v}` in `FlagListSetting`")
+
         return flagVals
 
     def dump(self) -> List[str]:

--- a/armi/settings/tests/test_inspectors.py
+++ b/armi/settings/tests/test_inspectors.py
@@ -165,7 +165,7 @@ class TestInspector(unittest.TestCase):
         self.assertEqual(self.inspector.cs["nCycles"], 1)
         self.assertEqual(self.inspector.cs["burnSteps"], 0)
 
-    def test_checkForBothSimpleAndDetailedCyclesInputs(self):
+    def test_checkForSimpleAndDetailedCycInps(self):
         self.inspector._assignCS(
             "cycles",
             [

--- a/armi/utils/tests/test_tabulate.py
+++ b/armi/utils/tests/test_tabulate.py
@@ -418,7 +418,7 @@ class TestTabulateInternal(unittest.TestCase):
         ]
         self.assertEqual(expected, result)
 
-    def test_alignColumnDecimalWithThousandSeparators(self):
+    def test_alignColDecWithThousandSeps(self):
         """Internal: _align_column(..., 'decimal')."""
         column = ["12.345", "-1234.5", "1.23", "1,234.5", "1e+234", "1.0e234"]
         output = _alignColumn(column, "decimal")
@@ -432,7 +432,7 @@ class TestTabulateInternal(unittest.TestCase):
         ]
         self.assertEqual(expected, output)
 
-    def test_alignColDecimalIncorrectThousandSeparators(self):
+    def test_alignColDecIncorrectThousandSeps(self):
         """Internal: _align_column(..., 'decimal')."""
         column = ["12.345", "-1234.5", "1.23", "12,34.5", "1e+234", "1.0e234"]
         output = _alignColumn(column, "decimal")
@@ -473,32 +473,32 @@ class TestTabulateInternal(unittest.TestCase):
         expected = ["one line"]
         assert top == center == bottom == none == expected
 
-    def test_alignCellVertTopSingleTextMultiPad(self):
+    def test_alignCellVertTopSingleTxtMultiPad(self):
         """Internal: Align single cell text to top."""
         result = _alignCellVeritically(["one line"], 3, 8, "top")
         expected = ["one line", "        ", "        "]
         self.assertEqual(expected, result)
 
-    def test_alignCellVertCenterSingleTextMultiPad(self):
+    def test_alignCellVertCenterSingleTxtMultiPad(self):
         """Internal: Align single cell text to center."""
         result = _alignCellVeritically(["one line"], 3, 8, "center")
         expected = ["        ", "one line", "        "]
         self.assertEqual(expected, result)
 
-    def test_alignCellVertBottomSingleTextMultiPad(self):
+    def test_alignCellVertBottomSingleTxtMultiPad(self):
         """Internal: Align single cell text to bottom."""
         result = _alignCellVeritically(["one line"], 3, 8, "bottom")
         expected = ["        ", "        ", "one line"]
         self.assertEqual(expected, result)
 
-    def test_alignCellVertTopMultiTextMultiPad(self):
+    def test_alignCellVertTopMultiTxtMultiPad(self):
         """Internal: Align multiline celltext text to top."""
         text = ["just", "one ", "cell"]
         result = _alignCellVeritically(text, 6, 4, "top")
         expected = ["just", "one ", "cell", "    ", "    ", "    "]
         self.assertEqual(expected, result)
 
-    def test_alignCellVertCenterMultiTextMultiPad(self):
+    def test_alignCellVertCenterMultiTxtMultiPad(self):
         """Internal: Align multiline celltext text to center."""
         text = ["just", "one ", "cell"]
         result = _alignCellVeritically(text, 6, 4, "center")
@@ -508,7 +508,7 @@ class TestTabulateInternal(unittest.TestCase):
         expected = ["    ", "just", "one ", "cell", "    ", "    "]
         self.assertEqual(expected, result)
 
-    def test_alignCellVertBottomMultiTextMultiPad(self):
+    def test_alignCellVertBottomMultiTxtMultiPad(self):
         """Internal: Align multiline celltext text to bottom."""
         text = ["just", "one ", "cell"]
         result = _alignCellVeritically(text, 6, 4, "bottom")

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -138,14 +138,11 @@ def _buildScrLine(prNum: str):
 
     # build RST list item, representing this data
     tab = "  "
-    content = f"* PR #{prNum}: {title}\n"
+    content = f"* PR #{prNum}: {title}\n\n"
     content += f"{tab}* Change: {desc}\n"
     content += f"{tab}* Impact on Requirements: {impact}\n"
     content += f"{tab}* Author: {author}\n"
-    content += f"{tab}* {reviewerHeader}: {reviewers}\n"
-
-    print("TODO: JOHN")
-    print(content)
+    content += f"{tab}* {reviewerHeader}: {reviewers}\n\n"
 
     return content, scrType
 

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -144,6 +144,9 @@ def _buildScrLine(prNum: str):
     content += f"{tab}* Author: {author}\n"
     content += f"{tab}* {reviewerHeader}: {reviewers}\n"
 
+    print("TODO: JOHN")
+    print(content)
+
     return content, scrType
 
 

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -259,7 +259,7 @@ def buildScrTable(thisPrNum: int, pastCommit: str):
 
     # 4. Build final RST for all four tables, to return to the docs
     content = ""
-    for typ in ["features", "fixes", "trivial", "docs"]:
+    for typ in ["features", "fixes", "docs", "trivial"]:
         if len(data[typ]):
             print(f"Found {len(data[typ])} SCRs in the {typ} category")
             content += _buildTableHeader(typ)
@@ -267,7 +267,7 @@ def buildScrTable(thisPrNum: int, pastCommit: str):
                 content += line
             content += "\n\n"
 
-    return content
+    return content + "\n\n"
 
 
 if __name__ == "__main__":

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -33,6 +33,7 @@ GITHUB_USERS = {
     "drewj-tp": "Drew Johnson",
     "HunterPSmith": "Hunter Smith",
     "jakehader": "Jake Hader",
+    "jasonbmeng": "Jason Meng",
     "john-science": "John Stilley",
     "keckler": "Chris Keckler",
     "mgjarrett": "Michael Jarrett",

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -160,7 +160,7 @@ def _buildHeader(scrType: str):
     str
         RST-formatted header title.
     """
-    return f"List of SCRs of type: {PR_TYPES[scrType]}\n\n"
+    return f"\nList of SCRs of type: {PR_TYPES[scrType]}\n\n"
 
 
 def isMainPR(prNum: int):

--- a/doc/qa_docs/scr/0.6.rst
+++ b/doc/qa_docs/scr/0.6.rst
@@ -18,3 +18,5 @@ The following tables list all the SCRs in this release of the ARMI framework.
 
    thisPrNum = int(os.environ.get('PR_NUMBER', -1) or -1)
    return buildScrTable(thisPrNum, "e263c26")
+
+End of SCR for this release.

--- a/doc/qa_docs/scr/0.6.rst
+++ b/doc/qa_docs/scr/0.6.rst
@@ -19,4 +19,9 @@ The following tables list all the SCRs in this release of the ARMI framework.
    thisPrNum = int(os.environ.get('PR_NUMBER', -1) or -1)
    return buildScrTable(thisPrNum, "e263c26")
 
-End of SCR for this release.
+
+.. list-table:: End of SCR
+   :widths: 20 25
+
+   * - This is the end of
+     - the SCR this release.

--- a/doc/qa_docs/scr/0.6.rst
+++ b/doc/qa_docs/scr/0.6.rst
@@ -14,7 +14,7 @@ The following lists display all the SCRs in this release of the ARMI framework.
 
 .. exec::
    import os
-   from automateScr import buildScrTable
+   from automateScr import buildScrListing
 
    thisPrNum = int(os.environ.get('PR_NUMBER', -1) or -1)
-   return buildScrTable(thisPrNum, "e263c26")
+   return buildScrListing(thisPrNum, "e263c26")

--- a/doc/qa_docs/scr/0.6.rst
+++ b/doc/qa_docs/scr/0.6.rst
@@ -3,8 +3,6 @@ SCR for ARMI 0.6.0
 
 This is a listing of all the Software Change Request (SCR) changes in the ARMI repository, as part of release number 0.6.0.
 
-Please note that the Software Test Report (STR) documents for all of the changes listed below will be updated as part of this release. This is a necessary part of every ARMI release, that the STRs are all updated.
-
 Below, this SCR is organized into the individual changes that comprise the net SCR for this release.
 
 

--- a/doc/qa_docs/scr/0.6.rst
+++ b/doc/qa_docs/scr/0.6.rst
@@ -9,7 +9,7 @@ Below, this SCR is organized into the individual changes that comprise the net S
 SCR Listing
 -----------
 
-The following tables list all the SCRs in this release of the ARMI framework.
+The following lists display all the SCRs in this release of the ARMI framework.
 
 
 .. exec::
@@ -18,10 +18,3 @@ The following tables list all the SCRs in this release of the ARMI framework.
 
    thisPrNum = int(os.environ.get('PR_NUMBER', -1) or -1)
    return buildScrTable(thisPrNum, "e263c26")
-
-
-.. list-table:: End of SCR
-   :widths: 20 25
-
-   * - This is the end of
-     - the SCR this release.

--- a/doc/qa_docs/scr/0.6.rst
+++ b/doc/qa_docs/scr/0.6.rst
@@ -3,7 +3,7 @@ SCR for ARMI 0.6.0
 
 This is a listing of all the Software Change Request (SCR) changes in the ARMI repository, as part of release number 0.6.0.
 
-Below, this SCR is organized into the individual changes that comprise the net SCR for this release.
+Below, this SCR is organized into the individual changes that comprise the net SCR for this release. Each SCR below explicitly lists its impact on ARMI requirements, if any. It is also important to note ARMI and all its requirements are tested entirely by the automated testing that happens during the ARMI build. None of the SCRs below will be allowed to happen if any single test fails, so it can be guaranteed that all SCRs below have fully passed all testing.
 
 
 SCR Listing

--- a/doc/qa_docs/str.rst
+++ b/doc/qa_docs/str.rst
@@ -265,9 +265,7 @@ Appendix A Pytest Verbose Output
 
 Shown here is the verbose output from pytest.
 
-Note that the skipped tests are either skipped because they require MPI (and are run via a separate command) or because
-they have hard-coded skips in the codebase (``test_canRemoveIsotopes``, ``test_ENDFVII1DecayConstants``, and
-``test_ENDFVII1NeutronsPerFission``). None of these hard-coded skipped tests are linked to requirements.
+Note that if a test says "skipped" in the first table below (serial unit tests), then it will appear in the "MPI-enabled unit tests" sections below. Some tests can be run in serial and parallel, but some can only be run in parallel. The preference in ARMI is to be explicit about which are which. As long as all the tests are run at least once.
 
 Serial unit tests:
 


### PR DESCRIPTION
## What is the change? Why is it being made?

Here I am just responding to reviewer comments on the ARMI docs for the upcoming 0.6.0 release.

In this PR, I also move the SCR "tables" to "lists", because the PDF conversion was being a pain.

Another change you will notice (that might be confusing) is that I reduced the length of some of the unit test names. This is to make test report tables easier to read.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Improving Docs for 0.6.0 release, responding to reviewer comments.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
