### PR TITLE
Scale BOL component hm number density during axial expansion

### DIFF
--- a/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
@@ -735,18 +735,15 @@ class RedistributeMass:
             newHMNDensBOL[nuc] = densityTools.calculateNumberDensity(
                 nuc, hmMassBOLByNucFromComp + hmMassBOLByNucToComp, newBOLVol
             )
+
+        # update the hmNumberDensitiesBOL for toComp
+        self.toComp.p.hmNumberDensitiesBOL = array(list(newHMNDensBOL.values()))
+
+        # update the molesHmBOL and massHmBOL for toComp
         self.toComp.p.molesHmBOL = (
             sum(list(newHMNDensBOL.values())) / units.MOLES_PER_CC_TO_ATOMS_PER_BARN_CM * newBOLVol
         )
         self.toComp.p.massHmBOL = densityTools.calculateMassDensity(newHMNDensBOL) * newBOLVol
-
-        postNames = []
-        postNDens = []
-        for n, v in newHMNDensBOL.items():
-            postNames.append(n.encode())
-            postNDens.append(v)
-        self.toComp.p.hmNuclidesBOL = postNames
-        self.toComp.p.hmNumberDensitiesBOL = postNDens
 
         # update BOL Params for fromComp
         scalar = 1.0 - (abs(self.deltaZTop) / self.fromComp.parent.p.heightBOL)

--- a/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
+++ b/armi/reactor/converters/axialExpansionChanger/axialExpansionChanger.py
@@ -740,9 +740,19 @@ class RedistributeMass:
         )
         self.toComp.p.massHmBOL = densityTools.calculateMassDensity(newHMNDensBOL) * newBOLVol
 
+        postNames = []
+        postNDens = []
+        for n, v in newHMNDensBOL.items():
+            postNames.append(n.encode())
+            postNDens.append(v)
+        self.toComp.p.hmNuclidesBOL = postNames
+        self.toComp.p.hmNumberDensitiesBOL = postNDens
+
         # update BOL Params for fromComp
-        self.fromComp.p.molesHmBOL *= 1.0 - (abs(self.deltaZTop) / self.fromComp.parent.p.heightBOL)
-        self.fromComp.p.massHmBOL *= 1.0 - (abs(self.deltaZTop) / self.fromComp.parent.p.heightBOL)
+        scalar = 1.0 - (abs(self.deltaZTop) / self.fromComp.parent.p.heightBOL)
+        self.fromComp.p.molesHmBOL *= scalar
+        self.fromComp.p.massHmBOL *= scalar
+        self.fromComp.p.hmNumberDensitiesBOL *= scalar
 
     @staticmethod
     def _sortKey(item):

--- a/armi/reactor/converters/tests/test_axialExpansionChanger_MultiPin.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger_MultiPin.py
@@ -452,8 +452,10 @@ class TestMultiPinConservation(TestMultiPinConservationBase):
           existing at different temperatures.
         - The 150 deg C and 50 deg C based temperature changes are arbitrarily chosen.
         """
+        initialTotalHMBOL = 0
         for i, b in self._iterFuelBlocks():
             for c in b.iterChildrenWithFlags(Flags.FUEL):
+                initialTotalHMBOL += c.p.molesHmBOL
                 if c.hasFlags(Flags.TEST):
                     newTemp = c.temperatureInC + 150.0 * i
                 else:
@@ -462,6 +464,12 @@ class TestMultiPinConservation(TestMultiPinConservationBase):
         self.axialExpChngr.expansionData.computeThermalExpansionFactors()
         self.axialExpChngr.axiallyExpandAssembly()
         self.checkConservation()
+
+        postExpansionHM = 0
+        for _, b in self._iterFuelBlocks():
+            for c in b.iterChildrenWithFlags(Flags.FUEL):
+                postExpansionHM += c.p.molesHmBOL
+        self.assertAlmostEqual(postExpansionHM, initialTotalHMBOL)
 
     def test_roundTripThermalBothFuel(self):
         """Perform thermal expansion on both fuel and test fuel components and ensure that mass and total assembly

--- a/armi/reactor/converters/tests/test_axialExpansionChanger_MultiPin.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger_MultiPin.py
@@ -41,7 +41,7 @@ assemblies:
         specifier: LA
         blocks: [
             *block_grid_plate, *block_fuel_multiPin_axial_shield,
-            *block_fuel_multiPin, *block_fuel_multiPin, *block_fuel_multiPin,
+            *block_mixed_multiPin, *block_fuel_multiPin, *block_fuel_multiPin,
             *block_fuel_multiPin, *block_fuel_multiPin, *block_fuel_multiPin,
             *block_fuel_multiPin, *block_fuel_multiPin, *block_mixed_multiPin,
             *block_mixed_multiPin, *block_aclp_multiPin, *block_plenum_multiPin,


### PR DESCRIPTION
🚨 TBD BRB 🚨 
## What is the change? Why is it being made?

(Potential) bug in axial expansion logic not correctly aggregating / adjusting BOL hm information.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Bug fix to ensure BOL information is correctly adjusted through axial expansion

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
