### PR TITLE
Support mixed Blocks for smear density calculation

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -229,8 +229,7 @@ class Block(composites.Composite):
 
         # Compute component areas
         innerCladdingArea = sum(
-            math.pi * clad.getDimension("id", cold=cold) ** 2 / 4.0  * clad.getDimension("mult")
-            for clad in clads
+            math.pi * clad.getDimension("id", cold=cold) ** 2 / 4.0 * clad.getDimension("mult") for clad in clads
         )
         sortedClads = sorted(clads)
         sortedCompsInsideClad = self.getSortedComponentsInsideOfComponent(sortedClads.pop())

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -289,9 +289,10 @@ class Block(composites.Composite):
 
         innerCladdingArea += negativeArea  # See note 2 of self.getSmearDensity
         totalMovableArea = innerCladdingArea - unmovableComponentArea
-        smearDensity = fuelComponentArea / totalMovableArea
-
-        return smearDensity
+        if totalMovableArea <= 0.0:
+            return 0.0
+        else:
+            return fuelComponentArea / totalMovableArea
 
     def autoCreateSpatialGrids(self, systemSpatialGrid=None):
         """

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -427,7 +427,8 @@ class Block_TestCase(unittest.TestCase):
         ref = (self.block.getDim(Flags.FUEL, "od") ** 2 - self.block.getDim(Flags.FUEL, "id") ** 2) / self.block.getDim(
             Flags.LINER, "id"
         ) ** 2
-        self.assertAlmostEqual(cur, ref, places=10)
+        places = 10
+        self.assertAlmostEqual(cur, ref, places=places)
 
         # test with liner instead of clad
         ref = (self.block.getDim(Flags.FUEL, "od") ** 2 - self.block.getDim(Flags.FUEL, "id") ** 2) / self.block.getDim(

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -427,8 +427,7 @@ class Block_TestCase(unittest.TestCase):
         ref = (self.block.getDim(Flags.FUEL, "od") ** 2 - self.block.getDim(Flags.FUEL, "id") ** 2) / self.block.getDim(
             Flags.LINER, "id"
         ) ** 2
-        places = 10
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=10)
 
         # test with liner instead of clad
         ref = (self.block.getDim(Flags.FUEL, "od") ** 2 - self.block.getDim(Flags.FUEL, "id") ** 2) / self.block.getDim(
@@ -501,8 +500,7 @@ class Block_TestCase(unittest.TestCase):
             innerArea -= liner.getArea(cold=True)
 
         ref = fuelArea / innerArea
-        places = 10
-        self.assertAlmostEqual(cur, ref, places=places)
+        self.assertAlmostEqual(cur, ref, places=10)
 
     def test_getSmearDensityMixedPin(self):
         fuel = self.block.getComponent(Flags.FUEL)

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -490,7 +490,9 @@ class Block_TestCase(unittest.TestCase):
         fuel = self.block.getComponent(Flags.FUEL, exact=True)
         liner = self.block.getComponent(Flags.LINER | Flags.INNER)
         clads = self.block.getComponents(Flags.CLAD)
-        ref = (fuel.getDimension("od", cold=True) ** 2 - fuel.getDimension("id", cold=True) ** 2) / liner.getDimension("id", cold=True) ** 2
+        ref = (fuel.getDimension("od", cold=True) ** 2 - fuel.getDimension("id", cold=True) ** 2) / liner.getDimension(
+            "id", cold=True
+        ) ** 2
         fuelArea = fuel.getArea(cold=True)
         innerArea = 0.0
         for clad in clads:
@@ -554,7 +556,12 @@ class Block_TestCase(unittest.TestCase):
         clads = self.block.getComponents(Flags.CLAD)
         fuelArea = 0.0
         fuelArea += math.pi / 4.0 * fuel.getDimension("od", cold=True) ** 2 * fuel.getDimension("mult")
-        fuelArea += math.pi / 4.0 * (annularFuel.getDimension("od", cold=True) ** 2 - annularFuel.getDimension("id", cold=True) ** 2) * annularFuel.getDimension("mult")
+        fuelArea += (
+            math.pi
+            / 4.0
+            * (annularFuel.getDimension("od", cold=True) ** 2 - annularFuel.getDimension("id", cold=True) ** 2)
+            * annularFuel.getDimension("mult")
+        )
         innerArea = 0.0
         for clad in clads:
             innerArea += math.pi / 4.0 * clad.getDimension("id", cold=True) ** 2 * clad.getDimension("mult")

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -549,13 +549,12 @@ class Block_TestCase(unittest.TestCase):
         }
         self.block.add(components.Circle("clad", "HT9", **cladDims))
 
-        cur = self.block.getSmearDensity()
+        # calculate reference smear density
         fuel = self.block.getComponent(Flags.FUEL, exact=True)
         annularFuel = self.block.getComponent(Flags.FUEL | Flags.ANNULAR)
         liner = self.block.getComponent(Flags.LINER | Flags.INNER)
         clads = self.block.getComponents(Flags.CLAD)
-        fuelArea = 0.0
-        fuelArea += math.pi / 4.0 * fuel.getDimension("od", cold=True) ** 2 * fuel.getDimension("mult")
+        fuelArea = math.pi / 4.0 * fuel.getDimension("od", cold=True) ** 2 * fuel.getDimension("mult")
         fuelArea += (
             math.pi
             / 4.0
@@ -569,8 +568,8 @@ class Block_TestCase(unittest.TestCase):
             innerArea -= liner.getArea(cold=True)
 
         ref = fuelArea / innerArea
-        places = 10
-        self.assertAlmostEqual(cur, ref, places=places)
+        cur = self.block.getSmearDensity()
+        self.assertAlmostEqual(cur, ref, places=10)
 
     def test_getSmearDensityMultipleLiner(self):
         numLiners = sum(1 for c in self.block if "liner" in c.name and "gap" not in c.name)


### PR DESCRIPTION
## What is the change? Why is it being made?

The smear density calculation in `Block.getSmearDensity()` made several assumptions that are not true for mixed assemblies.

1. The inner cladding area was calculated by averaging the `id` of all `clad`components without taking into account the `mult` of each component. The calculation was updated to correctly calculate area inside cladding.
2. The smear density was calculated from all components inside a randomly `pop`'ed component from the list of `clad`; this might not be the largest clad component, in which case some components could be missed. The `clad` components are now sorted before running `pop` to get the largest one.
3. When there are multiple `clad` components, some can be inside of the others and thus show up in the calculation of component areas inside the cladding. Any `clad` component needs to be excluded from this calculation, otherwise the smear density will be overestimated.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Fix the `Block.getSmearDensity()` calculation for assemblies with multiple different types of `clad` and/or `fuel` components.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
