### PR TITLE
Reducing log spam when creating a lot of spatial grids

### DIFF
--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -313,13 +313,13 @@ class GridBlueprint(yamlize.Object):
         """
         Build spatial grid.
 
-        If you do not enter ``latticeDimensions``, a unit grid will be produced which must be
-        adjusted to the proper dimensions (often by inspection of children) at a later time.
+        If you do not enter ``latticeDimensions``, a unit grid will be produced which must be adjusted to the proper
+        dimensions (often by inspection of children) at a later time.
         """
         symmetry = geometry.SymmetryType.fromStr(self.symmetry) if self.symmetry else None
         geom = self.geom
         maxIndex = self._getMaxIndex()
-        runLog.extra("Creating the spatial grid")
+        runLog.extra(f"Creating the spatial grid {self.name}", single=True)
         if geom in (geometry.RZT, geometry.RZ):
             if self.gridBounds is None:
                 # This check is regrettably late. It would be nice if we could validate that bounds


### PR DESCRIPTION
## What is the change? Why is it being made?

To reduce the log spam when creating spatial grids, we add the name of the grid to the log message.

(In an abundance of caution, I also added the `single=True` flag to this logging message. But I am considering that a secondary aspect of the solution.)

close #2296


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Reducing log spam when creating a lot of spatial grids.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Minor logging change to `I_ARMI_BP_GRID` for `R_ARMI_BP_GRID`.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
