### PR TITLE
Preserve loading of CoordinateLocation in db load

### DIFF
--- a/armi/bookkeeping/db/layout.py
+++ b/armi/bookkeeping/db/layout.py
@@ -319,6 +319,7 @@ class Layout:
             serialNum,
             numChildren,
             location,
+            locationType,
             material,
             temperatures,
             gridIndex,
@@ -328,6 +329,7 @@ class Layout:
             self.serialNum,
             self.numChildren,
             self.location,
+            self.locationType,
             self.material,
             self.temperatures,
             self.gridIndex,
@@ -356,7 +358,7 @@ class Layout:
                 gridParams = self.gridParams[gridIndex]
                 comp.spatialGrid = self.gridClasses[gridParams[0]](*gridParams[1], armiObject=comp)
 
-            comps.append((comp, serialNum, numChildren, location))
+            comps.append((comp, serialNum, numChildren, location, locationType))
             groupedComps[compType].append(comp)
 
         return comps, groupedComps

--- a/armi/bookkeeping/db/tests/test_database3.py
+++ b/armi/bookkeeping/db/tests/test_database3.py
@@ -30,6 +30,7 @@ from armi.bookkeeping.db.databaseInterface import DatabaseInterface
 from armi.bookkeeping.db.jaggedArray import JaggedArray
 from armi.reactor import parameters
 from armi.reactor.excoreStructure import ExcoreCollection, ExcoreStructure
+from armi.reactor.grids import CoordinateLocation, MultiIndexLocation
 from armi.reactor.reactors import Core, Reactor
 from armi.reactor.spentFuelPool import SpentFuelPool
 from armi.settings.fwSettings.globalSettings import (
@@ -862,6 +863,8 @@ grids:
         self.r.p.timeNode = 0
         self.r.core.p.keff = 0.99
         b = self.r.core.getFirstBlock()
+        self.assertIsInstance(b[0].spatialLocator, MultiIndexLocation)
+        self.assertIsInstance(b[-1].spatialLocator, CoordinateLocation)
         b.p.power = 12345.6
 
         self.db.writeToDB(self.r)
@@ -899,6 +902,11 @@ grids:
             self.assertEqual(len(r0.core.getChildren()), 1)
             b0 = r0.core.getFirstBlock()
             self.assertEqual(b0.p.power, 12345.6)
+
+            self.assertIsInstance(b0[0].spatialLocator, MultiIndexLocation)
+            np.testing.assert_array_equal(b[0].spatialLocator.indices, b0[0].spatialLocator.indices)
+            self.assertIsInstance(b0[-1].spatialLocator, CoordinateLocation)
+            np.testing.assert_array_equal(b[-1].spatialLocator.indices, b0[-1].spatialLocator.indices)
 
             # the ex-core structures should be empty
             self.assertEqual(len(r0.excore["sfp"].getChildren()), 0)


### PR DESCRIPTION
## What is the change? Why is it being made?
When loading the DB, pass around the locator type for the spatial locator.

This helps us know what type of locator we've got. For index locations
and multi-index locations, we can directly query the grid[i,j,k] and get
the correct IndexLocation / MultiIndexLocation object out. But, if we
pass the indices of the coordinate location in, we get an index location
out. And that's problematic because we don't get a 1:1 identical reactor
on the reload.

We dump the location type information to DB already. This changes the
layout `_initComps` to produce that information in sync w/ the location
information. Then we can do a check if we're looking at a coordinate
location or not. This means if a coordinate location goes in, a
coordinate location comes out of the database.

Closes #2295 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Recover any CoordinateLocation spatial locators during DB load

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Correct behavior during DB load covered by R_ARMI_DB_TIME


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
