### PR TITLE
Set pin indices on more types of pin components

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2183,7 +2183,16 @@ class HexBlock(Block):
         ijGetter = operator.attrgetter("i", "j")
         allIJ: tuple[tuple[int, int]] = tuple(map(ijGetter, locations))
         # Flags for components that we want to set this parameter
-        targetFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD, Flags.SLUG, Flags.CLAD, Flags.LINER, Flags.GAP, Flags.BOND)
+        targetFlags = (
+            Flags.FUEL,
+            Flags.CONTROL,
+            Flags.SHIELD,
+            Flags.SLUG,
+            Flags.CLAD,
+            Flags.LINER,
+            Flags.GAP,
+            Flags.BOND,
+        )
         self._assignPinIndices(ijGetter, allIJ, targetFlags)
 
     def _assignPinIndices(

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2183,7 +2183,7 @@ class HexBlock(Block):
         ijGetter = operator.attrgetter("i", "j")
         allIJ: tuple[tuple[int, int]] = tuple(map(ijGetter, locations))
         # Flags for components that we want to set this parameter
-        targetFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD, Flags.SLUG, Flags.CLAD, Flags.GAP, Flags.BOND)
+        targetFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD, Flags.SLUG, Flags.CLAD, Flags.LINER, Flags.GAP, Flags.BOND)
         self._assignPinIndices(ijGetter, allIJ, targetFlags)
 
     def _assignPinIndices(
@@ -2201,7 +2201,14 @@ class HexBlock(Block):
             else:
                 continue
             localIndices = list(map(allIJ.index, localIJ))
-            c.p.pinIndices = localIndices
+            start = localIndices[0]
+            if all(x == y for x, y in zip(localIndices, range(start, start + len(localIndices)))):
+                # this is a simple range; store a compressed format
+                c.p.pinIndexOffset = localIndices[0]
+                c.p.pinIndices = None
+            else:
+                c.p.pinIndices = localIndices
+                c.p.pinIndexOffset = None
 
     def getPinCenterFlatToFlat(self, cold=False):
         """Return the flat-to-flat distance between the centers of opposing pins in the outermost ring."""

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2183,16 +2183,8 @@ class HexBlock(Block):
         ijGetter = operator.attrgetter("i", "j")
         allIJ: tuple[tuple[int, int]] = tuple(map(ijGetter, locations))
         # Flags for components that we want to set this parameter
-        # Usually things are linked to one of these "important" flags, like
-        # a cladding component having linked dimensions to a fuel component
-        targetFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD)
-        found = self._assignPinIndices(ijGetter, allIJ, targetFlags)
-        if found:
-            return
-        # If we didn't find any "important" components, but we have pins, we need to
-        # provide some information about where the pins live still. Fall back to
-        # assigning on the cladding components
-        self._assignPinIndices(ijGetter, allIJ, Flags.CLAD)
+        targetFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD, Flags.SLUG, Flags.CLAD, Flags.GAP, Flags.BOND)
+        self._assignPinIndices(ijGetter, allIJ, targetFlags)
 
     def _assignPinIndices(
         self,
@@ -2200,7 +2192,6 @@ class HexBlock(Block):
         allIJ: tuple[int, int],
         targetFlags: Flags,
     ) -> bool:
-        found = False
         for c in self.iterChildren(predicate=lambda c: c.hasFlags(targetFlags) and isinstance(c, Circle)):
             localLocations = c.spatialLocator
             if isinstance(localLocations, grids.MultiIndexLocation):
@@ -2211,8 +2202,6 @@ class HexBlock(Block):
                 continue
             localIndices = list(map(allIJ.index, localIJ))
             c.p.pinIndices = localIndices
-            found = True
-        return found
 
     def getPinCenterFlatToFlat(self, cold=False):
         """Return the flat-to-flat distance between the centers of opposing pins in the outermost ring."""

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1391,15 +1391,15 @@ class Component(composites.Composite, metaclass=ComponentType):
         --------
         :meth`:armi.reactor.blocks.HexBlock.assignPinIndices`
         """
-        ix = self.p.pinIndices
-        if isinstance(ix, np.ndarray):
-            return ix
-        # Find a sibling that has pin indices and has the same spatial locator as us
-        withPinIndices = (c for c in self.parent if c is not self and c.p.pinIndices is not None)
-        for sibling in withPinIndices:
-            if sibling.spatialLocator == self.spatialLocator:
-                return sibling.p.pinIndices
-        msg = f"{self} on {self.parent} has no pin indices."
+        # expand if compressed
+        if self.p.pinIndexOffset is not None:
+            mult = int(self.getDimension("mult"))
+            return np.arange(self.p.pinIndexOffset, self.p.pinIndexOffset + mult)
+
+        if self.p.pinIndices is not None:
+            return self.p.pinIndices
+
+        msg = f"{self} has no `pinIndices` or `pinIndexOffset`."
         raise ValueError(msg)
 
     def density(self) -> float:

--- a/armi/reactor/components/componentParameters.py
+++ b/armi/reactor/components/componentParameters.py
@@ -226,6 +226,17 @@ def getComponentParameterDefinitions():
             setter=_validatePinIndices,
         )
 
+        pb.defParam(
+            "pinIndexOffset",
+            default=None,
+            description=(
+                "Offset for compressed pin index storage format. Pin indices are always "
+                "consecutive, so the full array can be constructed from an offset "
+                "and the component multiplicity."
+            ),
+            units=units.UNITLESS,
+        )
+
     return pDefs
 
 


### PR DESCRIPTION
## What is the change? Why is it being made?

`pinIndices` was recently added (#2202 and #2236) as a way to identify the indices for a given component within a block that has multiple types of pins. However, the `pinIndices` parameter would only be set for some types of component within the block. This update sets `pinIndices` for all components within a block that match one of the target flags.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Add `pinIndices` to more types of components.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
