### PR TITLE
Handle pin indices for fuel + non fuel on the same grid

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2203,7 +2203,9 @@ class HexBlock(Block):
                 withPinIndices.append(c)
 
     @staticmethod
-    def _setPinIndices(c: components.Component, ijGetter: Callable[[grids.IndexLocation], tuple[int, int]], allIJ: tuple[int, int]):
+    def _setPinIndices(
+        c: components.Component, ijGetter: Callable[[grids.IndexLocation], tuple[int, int]], allIJ: tuple[int, int]
+    ):
         localLocations = c.spatialLocator
         if isinstance(localLocations, grids.MultiIndexLocation):
             localIJ = list(map(ijGetter, localLocations))

--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2185,34 +2185,38 @@ class HexBlock(Block):
         # Flags for components that we want to set this parameter
         # Usually things are linked to one of these "important" flags, like
         # a cladding component having linked dimensions to a fuel component
-        targetFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD)
-        found = self._assignPinIndices(ijGetter, allIJ, targetFlags)
-        if found:
-            return
-        # If we didn't find any "important" components, but we have pins, we need to
-        # provide some information about where the pins live still. Fall back to
-        # assigning on the cladding components
-        self._assignPinIndices(ijGetter, allIJ, Flags.CLAD)
-
-    def _assignPinIndices(
-        self,
-        ijGetter: Callable[[grids.IndexLocation], tuple[int, int]],
-        allIJ: tuple[int, int],
-        targetFlags: Flags,
-    ) -> bool:
-        found = False
-        for c in self.iterChildren(predicate=lambda c: c.hasFlags(targetFlags) and isinstance(c, Circle)):
-            localLocations = c.spatialLocator
-            if isinstance(localLocations, grids.MultiIndexLocation):
-                localIJ = list(map(ijGetter, localLocations))
-            elif isinstance(localLocations, grids.IndexLocation):
-                localIJ = [ijGetter(localLocations)]
-            else:
+        primaryFlags = (Flags.FUEL, Flags.CONTROL, Flags.SHIELD)
+        withPinIndices: list[components.Component] = []
+        for c in self.iterChildrenWithFlags(primaryFlags):
+            if self._setPinIndices(c, ijGetter, allIJ):
+                withPinIndices.append(c)
+        # Iterate over every other thing on the grid and make sure
+        # 1) it share a lattice site with something that has pin indices, or
+        # 2) it itself declares the pin indices
+        for c in self:
+            if c.p.pinIndices is not None:
                 continue
-            localIndices = list(map(allIJ.index, localIJ))
-            c.p.pinIndices = localIndices
-            found = True
-        return found
+            # Does anything with pin indices share this lattice site?
+            if any(other.spatialLocator == c.spatialLocator for other in withPinIndices):
+                continue
+            if self._setPinIndices(c, ijGetter, allIJ):
+                withPinIndices.append(c)
+
+    @staticmethod
+    def _setPinIndices(c: components.Component, ijGetter: Callable[[grids.IndexLocation], tuple[int, int]], allIJ: tuple[int, int]):
+        localLocations = c.spatialLocator
+        if isinstance(localLocations, grids.MultiIndexLocation):
+            localIJ = list(map(ijGetter, localLocations))
+        # CoordinateLocations do not live on the grid, by definition
+        elif isinstance(localLocations, grids.CoordinateLocation):
+            return False
+        elif isinstance(localLocations, grids.IndexLocation):
+            localIJ = [ijGetter(localLocations)]
+        else:
+            return False
+        localIndices = list(map(allIJ.index, localIJ))
+        c.p.pinIndices = localIndices
+        return True
 
     def getPinCenterFlatToFlat(self, cold=False):
         """Return the flat-to-flat distance between the centers of opposing pins in the outermost ring."""

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2967,7 +2967,6 @@ nuclide flags:
         secondAfter = self.fuelPins[1].getPinIndices()
         assert_array_equal(secondAfter, secondBefore)
 
-
     def test_reassignOnSort(self):
         """Show the pin indices are reassigned when the block is sorted."""
         # Make sure we get new block-level pin locations or else this test is meaningless

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2950,6 +2950,24 @@ nuclide flags:
         for c in nonFuel.iterComponents(Flags.CLAD):
             self.assertIsNotNone(c.getPinIndices())
 
+    def test_fuelAndNonFuel(self):
+        """If you have fuel and non-fuel pins in the block, all pins should have indices still."""
+        firstBefore = self.fuelPins[0].getPinIndices()
+        secondBefore = self.fuelPins[1].getPinIndices()
+
+        for c in self.block:
+            c.p.pinIndices = None
+
+        self.fuelPins[1].p.flags &= ~Flags.FUEL
+
+        self.block.assignPinIndices()
+        firstAfter = self.fuelPins[0].getPinIndices()
+        assert_array_equal(firstAfter, firstBefore)
+
+        secondAfter = self.fuelPins[1].getPinIndices()
+        assert_array_equal(secondAfter, secondBefore)
+
+
     def test_reassignOnSort(self):
         """Show the pin indices are reassigned when the block is sorted."""
         # Make sure we get new block-level pin locations or else this test is meaningless


### PR DESCRIPTION
## What is the change? Why is it being made?

When you have fuel + non fuel pins in the same block, sharing the same lattice grid, the old implementation would not assign pin indices to non-fuel pins unless they had the magic flags. This is problematic, because you still have those pins, but without the indices you can't really do anything with them. 

The problem before is if we found e.g., one fuel pin, we would stop there. We would not examine all other lattice sites. So if you had fuel + e.g., poison pins on different lattice sites, the poison pins would not get pin indices assigned.

> This PR adds a test demonstrating this problem and then changes how the pin indices are assigned to solve the problem.

We still pick some "special" pins first. The logic is that fuel and control and shield pins are _likely_ the thing you _really_ care about for pin data and are more likely to call `c.getPinIndices()` directly on the fuel pin. For example, to examine `Block.p.linPowByPin` for that fuel pin. We have had logic to handle this for the clad or wire around the fuel pin, but the logic requires us to iterate over all the components and check the spatial locators which is not expensive but can take some time.

Now, we do one final iteration over all the components in the block and make sure

1. This component declares the `c.p.pinIndices` parameter, or
2. This component shares a lattice site with something else that declares `c.p.pinIndices`

## SCR Information

Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Support `Component.pinIndices` for fuel + non-fuel pins in the same Block.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA

## Notes

This solves the same problem as #2301 but is hopefully more general and has a smaller hit to DB size.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
