### PR TITLE
Step0 in removing global nuclides: create classes

### DIFF
--- a/armi/_bootstrap.py
+++ b/armi/_bootstrap.py
@@ -16,9 +16,7 @@
 
 from armi.nucDirectory import nuclideBases  # noqa: E402
 
-# Nuclide bases get built explicitly here to have better determinism
-# about when they get instantiated. The burn chain is not applied
-# at this point, but only after input is read. Nuclides need to be built super early
-# because some import-time code needs them to function. Namely, Block parameter
-# collection uses them to create number density params.
+# Nuclide bases get built explicitly here to have better determinism about when they get instantiated. The burn chain is
+# not applied at this point, but only after input is read. Nuclides need to be built super early because some
+# import-time code needs them to function. Namely, Block parameter collection uses them to create number density params.
 nuclideBases.factory()

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -13,26 +13,22 @@
 # limitations under the License.
 
 """
-This module provides fundamental element information to be used throughout the framework
-and applications.
+This module provides fundamental element information to be used throughout the framework and applications.
 
 .. impl:: A tool for querying basic data for elements of the periodic table.
     :id: I_ARMI_ND_ELEMENTS0
     :implements: R_ARMI_ND_ELEMENTS
 
     The :py:mod:`elements <armi.nucDirectory.elements>` module defines the
-    :py:class:`Element <armi.nucDirectory.elements.Element>` class which acts as
-    a data structure for organizing information about an individual element,
-    including number of protons, name, chemical symbol, phase (at STP), periodic
-    table group, standard weight, and a list of isotope :py:class:`nuclideBase
-    <armi.nucDirectory.nuclideBases.NuclideBase>` instances. The module includes
-    a factory that generates the :py:class:`Element
-    <armi.nucDirectory.elements.Element>` instances by reading from the
-    ``elements.dat`` file stored in the ARMI resources folder.  When an
-    :py:class:`Element <armi.nucDirectory.elements.Element>` instance is
-    initialized, it is added to a set of global dictionaries that are keyed by
-    number of protons, element name, and element symbol. The module includes
-    several helper functions for querying these global dictionaries.
+    :py:class:`Element <armi.nucDirectory.elements.Element>` class which acts as a data structure for organizing
+    information about an individual element, including number of protons, name, chemical symbol, phase (at STP),
+    periodic table group, standard weight, and a list of isotope
+    :py:class:`nuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` instances. The module includes a factory that
+    generates the :py:class:`Element <armi.nucDirectory.elements.Element>` instances by reading from the
+    ``elements.dat`` file stored in the ARMI resources folder. When an
+    :py:class:`Element <armi.nucDirectory.elements.Element>` instance is initialized, it is added to a set of global
+    dictionaries that are keyed by number of protons, element name, and element symbol. The module includes several
+    helper functions for querying these global dictionaries.
 
 The element class structure is outlined :ref:`here <elements-class-diagram>`.
 
@@ -136,9 +132,10 @@ from typing import List
 from armi import context
 from armi.utils.units import HEAVY_METAL_CUTOFF_Z
 
-byZ = {}
-byName = {}
-bySymbol = {}
+elements = None
+byZ = None
+byName = None
+bySymbol = None
 
 
 class ChemicalPhase(Enum):
@@ -242,8 +239,7 @@ class Element:
 
         Notes
         -----
-        This method will filter out any NaturalNuclideBases from the `nuclides`
-        attribute.
+        This method will filter out any NaturalNuclideBases from the `nuclides` attribute.
         """
         return [nuc for nuc in self.nuclides if nuc.abundance > 0.0 and nuc.a > 0]
 
@@ -253,199 +249,74 @@ class Element:
 
         Notes
         -----
-        Heavy metal in this instance is not related to an exact weight or density
-        cut-off, but rather is designated for nuclear fuel burn-up evaluations, where
-        the initial heavy metal mass within a component should be tracked. It is typical
-        to include any element/nuclide above Actinium.
+        Heavy metal in this instance is not related to an exact weight or density cut-off, but rather is designated for
+        nuclear fuel burn-up evaluations, where the initial heavy metal mass within a component should be tracked. It is
+        typical to include any element/nuclide above Actinium.
         """
         return self.z > HEAVY_METAL_CUTOFF_Z
 
 
 def getElementsByChemicalPhase(phase: ChemicalPhase) -> List[Element]:
-    """
-    Returns all elements that are of the given chemical phase.
-
-    Parameters
-    ----------
-    phase: ChemicalPhase
-        This should be one of the valid options from the `ChemicalPhase` class.
-
-    Returns
-    -------
-    elems : List[Element]
-        A list of elements that are associated with the given chemical phase.
-    """
-    elems = []
-    if not isinstance(phase, ChemicalPhase):
-        raise ValueError(f"{phase} is not an instance of {ChemicalPhase}")
-    for element in byName.values():
-        if element.phase == phase:
-            elems.append(element)
-    return elems
+    """Pass through to Elements.getElementsByChemicalPhase() for the global Elements object."""
+    global elements
+    return elements.getElementsByChemicalPhase(phase)
 
 
 def getElementsByChemicalGroup(group: ChemicalGroup) -> List[Element]:
-    """
-    Returns all elements that are of the given chemical group.
-
-    Parameters
-    ----------
-    group: ChemicalGroup
-        This should be one of the valid options from the `ChemicalGroup` class.
-
-    Returns
-    -------
-    elems : List[Element]
-        A list of elements that are associated with the given chemical group.
-    """
-    elems = []
-    if not isinstance(group, ChemicalGroup):
-        raise ValueError(f"{group} is not an instance of {ChemicalGroup}")
-    for element in byName.values():
-        if element.group == group:
-            elems.append(element)
-    return elems
+    """Pass through to Elements.getElementsByChemicalGroup() for the global Elements object."""
+    global elements
+    return elements.getElementsByChemicalGroup(group)
 
 
 def getName(z: int = None, symbol: str = None) -> str:
-    r"""
-    Returns element name.
-
-    Parameters
-    ----------
-    z : int
-        Atomic number
-    symbol : str
-        Element abbreviation e.g. 'Zr'
-
-    Examples
-    --------
-    >>> elements.getName(10)
-    'Neon'
-    >>> elements.getName(symbol='Ne')
-    'Neon'
-    """
-    element = None
-    if z:
-        element = byZ[z]
-    else:
-        element = byName[symbol.upper()]
-    return element.name
+    """Pass through to Elements.getName() for the global Elements object."""
+    global elements
+    return elements.getName(z, symbol)
 
 
 def getSymbol(z: int = None, name: str = None) -> str:
-    r"""
-    Returns element abbreviation given atomic number Z.
-
-    Parameters
-    ----------
-    z : int
-        Atomic number
-    name : str
-        Element name E.g. Zirconium
-
-    Examples
-    --------
-    >>> elements.getSymbol(10)
-    'Ne'
-    >>> elements.getSymbol(name='Neon')
-    'Ne'
-
-    """
-    element = None
-    if z:
-        element = byZ[z]
-    else:
-        element = byName[name.lower()]
-    return element.symbol
+    """Pass through to Elements.getSymbol() for the global Elements object."""
+    global elements
+    return elements.getSymbol(z, name)
 
 
 def getElementZ(symbol: str = None, name: str = None) -> int:
-    """
-    Get element atomic number given a symbol or name.
-
-    Parameters
-    ----------
-    symbol : str
-        Element symbol e.g. 'Zr'
-    name : str
-        Element name e.g. 'Zirconium'
-
-    Examples
-    --------
-    >>> elements.getZ('Zr')
-    40
-    >>> elements.getZ(name='Zirconium')
-    40
-
-    Notes
-    -----
-    Element Z is stored in elementZBySymbol, indexed by upper-case element symbol.
-    """
-    if not symbol and not name:
-        return None
-    element = None
-    if symbol:
-        element = bySymbol[symbol.upper()]
-    else:
-        element = byName[name.lower()]
-    return element.z
+    """Pass through to Elements.getElementZ() for the global Elements object."""
+    global elements
+    return elements.getElementZ(symbol, name)
 
 
 def factory():
-    """
-    Generate the :class:`Elements <Element>` instances.
-
-    .. warning::
-        This method gets called by default when loading the module, so don't call it
-        unless you know what you're doing.
-        Any existing :class:`Nuclides <armi.nucDirectory.nuclide.Nuclide>`
-        may lose their reference to the underlying :class:`Element`.
-    """
-    destroyGlobalElements()
-    with open(os.path.join(context.RES, "elements.dat"), "r") as f:
-        for line in f:
-            # Skip header lines
-            if line.startswith("#") or line.startswith("Z"):
-                continue
-            # read z, symbol, name, phase, and chemical group
-            lineData = line.split()
-            z = int(lineData[0])
-            sym = lineData[1].upper()
-            name = lineData[2]
-            phase = lineData[3]
-            group = lineData[4]
-            standardWeight = lineData[5]
-            e = Element(z, sym, name, phase, group)
-            if standardWeight != "Derived":
-                e.standardWeight = float(standardWeight)
-
-
-def addGlobalElement(element: Element):
-    """Add an element to the global dictionaries."""
-    if element.z in byZ or element.name in byName or element.symbol in bySymbol:
-        raise ValueError(f"{element} has already been added and cannot be duplicated.")
-
-    byZ[element.z] = element
-    byName[element.name] = element
-    bySymbol[element.symbol] = element
-
-
-def destroyGlobalElements():
-    """Delete all global elements."""
+    """Pass through to Elements.factory() for the global Elements object."""
+    print("xxxxxxxxxxxxxxxxxxxxxxxxxx Elements factory xxxxxxxxxxxxxxxxxxxxxxxxxx")
+    global elements
     global byZ
     global byName
     global bySymbol
 
-    byZ.clear()
-    byName.clear()
-    bySymbol.clear()
+    elements = Elements()
+    elements.factory()
+
+    byZ = elements.byZ
+    byName = elements.byName
+    bySymbol = elements.bySymbol
 
 
-factory()
+def addGlobalElement(element: Element):
+    """Pass through to Elements.addElement() for the global Elements object."""
+    global elements
+    elements.addElement(element)
+
+
+def destroyGlobalElements():
+    """Pass through to Elements.clear() for the global Elements object."""
+    global elements
+    elements.clear()
 
 
 """
+TODO: This split is only temporary. Global nuclides are going away. Document that.
+
 TODO: Above this point is the old "global nuclides" code. Soon to be deleted.
       Below this point is the new code.
 """
@@ -629,3 +500,6 @@ class Elements:
             element = self.byName[name.lower()]
 
         return element.z
+
+
+factory()

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -313,16 +313,12 @@ def destroyGlobalElements():
     elements.clear()
 
 
-"""
-TODO: This split is only temporary. Global nuclides are going away. Document that.
-
-TODO: Above this point is the old "global nuclides" code. Soon to be deleted.
-      Below this point is the new code.
-"""
-
-
 class Elements:
-    """TODO."""
+    """
+    A container for all the elements information in the simulation.
+
+    By design, you would only expect to have one instance of this object in memory during a simulation.
+    """
 
     def __init__(self):
         self.byZ = {}

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -288,7 +288,6 @@ def getElementZ(symbol: str = None, name: str = None) -> int:
 
 def factory():
     """Pass through to Elements.factory() for the global Elements object."""
-    print("xxxxxxxxxxxxxxxxxxxxxxxxxx Elements factory xxxxxxxxxxxxxxxxxxxxxxxxxx")
     global elements
     global byZ
     global byName

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -170,18 +170,14 @@ class Element:
             :id: I_ARMI_ND_ELEMENTS1
             :implements: R_ARMI_ND_ELEMENTS
 
-            The :py:class:`Element <armi.nucDirectory.elements.Element>` class
-            acts as a data structure for organizing information about an
-            individual element, including number of protons, name, chemical
-            symbol, phase (at STP), periodic table group, standard weight, and a
-            list of isotope
-            :py:class:`nuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
-            instances.
+            The :py:class:`Element <armi.nucDirectory.elements.Element>` class acts as a data structure for organizing
+            information about an individual element, including number of protons, name, chemical symbol, phase (at STP),
+            periodic table group, standard weight, and a list of isotope
+            :py:class:`nuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` instances.
 
-            The :py:class:`Element <armi.nucDirectory.elements.Element>` class
-            has a few methods for appending additional isotopes, checking
-            whether an isotope is naturally occurring, retrieving the natural
-            isotopic abundance, or whether the element is a heavy metal.
+            The :py:class:`Element <armi.nucDirectory.elements.Element>` class has a few methods for appending
+            additional isotopes, checking whether an isotope is naturally occurring, retrieving the natural isotopic
+            abundance, or whether the element is a heavy metal.
 
         Parameters
         ----------

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -1312,7 +1312,9 @@ class NuclideBases:
         matches = [nuc for nuc in self.instances if predicate(nuc)]
         if len(matches) != 1:
             raise IndexError(
-                f"Expected single match, but got {len(matches)} matches:\n  {'\n  '.join(str(mo) for mo in matches)}"
+                "Expected single match, but got {} matches:\n  {}".format(
+                    len(matches), "\n  ".join(str(mo) for mo in matches)
+                )
             )
 
         return matches[0]

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -1024,7 +1024,6 @@ def imposeBurnChain(burnChainStream):
 
 def factory():
     """Pass through to NuclideBases.factory() for the global NuclideBases object."""
-    print("xxxxxxxxxxxxxxxxxxxxxxxxxx NuclideBases factory xxxxxxxxxxxxxxxxxxxxxxxxxx")
     global nuclideBases
     global burnChainImposed
     global instances
@@ -1201,7 +1200,7 @@ class NuclideBases:
         missingActiveNuclides = set()
         memo = set()
         nucNames = [nucName.decode() for nucName in nuclides]
-        difference = set(numberDensities).difference(memo)
+        difference = set(nucNames).difference(memo)
         while any(difference):
             newNucs = set()
             nuclide = difference.pop()
@@ -1217,8 +1216,8 @@ class NuclideBases:
                     # Interaction nuclides can only be added to the number density dictionary if they are a part of the
                     # user-defined active nuclides
                     productNuclide = interaction.getPreferredProduct(activeNuclides)
-                    if productNuclide not in numberDensities:
-                        numberDensities[productNuclide] = 0.0
+                    if productNuclide not in nucNames:
+                        newNucs.add(productNuclide.encode())
                 except KeyError:
                     # Keep track of the first production nuclide
                     missingActiveNuclides.add(interaction.productNuclides)

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -100,20 +100,13 @@ import numpy as np
 from ruamel.yaml import YAML
 
 from armi import context, runLog
-from armi.nucDirectory import transmutations
+from armi.nucDirectory import elements, transmutations
 from armi.utils.units import HEAVY_METAL_CUTOFF_Z
-
-# Used to prevent multiple applications of burn chains, which would snowball unphysically. This is a bit of a crutch for
-# the global state that is the nuclide directory.
-burnChainImposed = False
-
-instances = []
-# The elements must be imported after the instances list is established to allow for simultaneous initialization of the
-# nuclides and elements together to maintain self-consistency.
-from armi.nucDirectory import elements  # noqa: E402
 
 # Global nuclide and nuclideBases data
 nuclideBases = None
+instances = []
+burnChainImposed = False
 byName = None
 byDBName = None
 byLabel = None
@@ -123,7 +116,6 @@ byMcc3IdEndfbVII0 = None
 byMcc3IdEndfbVII1 = None
 byMcnpId = None
 byAAAZZZSId = None
-
 
 # lookup table from https://t2.lanl.gov/nis/data/endf/endfvii-n.html
 BASE_ENDFB7_MAT_NUM = {

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -19,25 +19,29 @@ framework and applications.
     :id: I_ARMI_ND_ISOTOPES0
     :implements: R_ARMI_ND_ISOTOPES
 
-    The :py:mod:`nuclideBases <armi.nucDirectory.nuclideBases>` module defines the
-    :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` class which is used to
-    organize and store metadata about each nuclide. The metadata is read from ``nuclides.dat`` file
-    in the ARMI resources folder, which contains metadata for 4,614 isotopes. The module also
-    contains classes for special types of nuclides, including :py:class:`DummyNuclideBase
+    The :py:mod:`nuclideBases <armi.nucDirectory.nuclideBases>` module defines
+    the :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
+    class which is used to organize and store metadata about each nuclide. The
+    metadata is read from ``nuclides.dat`` file in the ARMI resources folder,
+    which contains metadata for 4,614 isotopes. The module also contains classes
+    for special types of nuclides, including :py:class:`DummyNuclideBase
     <armi.nucDirectory.nuclideBases.DummyNuclideBase>` for dummy nuclides,
-    :py:class:`LumpNuclideBase <armi.nucDirectory.nuclideBases.LumpNuclideBase>`, for lumped fission
+    :py:class:`LumpNuclideBase
+    <armi.nucDirectory.nuclideBases.LumpNuclideBase>`, for lumped fission
     product nuclides, and :py:class:`NaturalNuclideBase
-    <armi.nucDirectory.nuclideBases.NaturalNuclideBase>` for when data is given collectively for an
-    element at natural abundance rather than for individual isotopes.
+    <armi.nucDirectory.nuclideBases.NaturalNuclideBase>` for when data is given
+    collectively for an element at natural abundance rather than for individual
+    isotopes.
 
-    The :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` provides a data
-    structure for information about a single nuclide, including the atom number, atomic weight,
-    element, isomeric state, half-life, and name.
+    The :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
+    provides a data structure for information about a single nuclide, including
+    the atom number, atomic weight, element, isomeric state, half-life, and
+    name.
 
-    The :py:mod:`nuclideBases <armi.nucDirectory.nuclideBases>` module provides a factory and
-    associated functions for instantiating the
-    :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` objects and building the
-    global nuclide dictionaries, including:
+    The :py:mod:`nuclideBases <armi.nucDirectory.nuclideBases>` module provides
+    a factory and associated functions for instantiating the
+    :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` objects
+    and building the global nuclide dictionaries, including:
 
     * ``instances`` (list of nuclides)
     * ``byName`` (keyed by name, e.g., ``U235``)
@@ -50,7 +54,8 @@ framework and applications.
     * ``byMcnpId`` (keyed by MCNP ID, e.g., ``92235``)
     * ``byAAAZZZSId`` (keyed by AAAZZZS, e.g., ``2350920``)
 
-The nuclide class structure is outlined :ref:`here <nuclide-bases-class-diagram>`.
+The nuclide class structure is outlined :ref:`here
+<nuclide-bases-class-diagram>`.
 
 .. _nuclide-bases-class-diagram:
 
@@ -99,13 +104,15 @@ from armi import context, runLog
 from armi.nucDirectory import transmutations
 from armi.utils.units import HEAVY_METAL_CUTOFF_Z
 
-# Used to prevent multiple applications of burn chains, which would snowball unphysically. This is a
-# bit of a crutch for the global state that is the nuclide directory.
+# used to prevent multiple applications of burn chains, which would snowball
+# unphysically. This is a bit of a crutch for the global state that is the nuclide
+# directory.
 burnChainImposed = False
 
 instances = []
-# The elements must be imported after the instances list is established to allow for simultaneous
-# initialization of the nuclides and elements together to maintain self-consistency.
+# The elements must be imported after the instances list is established
+# to allow for simultaneous initialization of the nuclides and elements
+# together to maintain self-consistency.
 from armi.nucDirectory import elements  # noqa: E402
 
 # Dictionary of INuclides by the INuclide.name for fast indexing
@@ -286,21 +293,25 @@ class INuclide(NuclideInterface):
         Indicates excitement, 1 is more excited than 0.
 
     abundance : float
-        Isotopic fraction of a naturally occurring nuclide. The sum of all nuclide abundances for a
-        naturally occurring element should be 1.0. This is atom fraction, not mass fraction.
+        Isotopic fraction of a naturally occurring nuclide. The sum of all nuclide
+        abundances for a naturally occurring element should be 1.0. This is atom
+        fraction, not mass fraction.
 
     name : str
         ARMI's unique name for the given nuclide.
 
     label : str
-        ARMI's unique 4 character label for the nuclide. These are not human readable, but do not
-        lose any information. The label is effectively the
-        :attr:`Element.symbol `armi.nucDirectory.elements.Element.symbol` padded to two characters,
-        plus the mass number (A) in base-26 (0-9, A-Z). Additional support for meta-states is
-        provided by adding 100 * the state to the mass number (A).
+        ARMI's unique 4 character label for the nuclide.
+        These are not human readable, but do not lose any information.
+        The label is effectively the
+        :attr:`Element.symbol `armi.nucDirectory.elements.Element.symbol`
+        padded to two characters, plus the mass number (A) in base-26 (0-9, A-Z).
+        Additional support for meta-states is provided by adding 100 * the state
+        to the mass number (A).
 
     nuSF : float
-        Neutrons released per spontaneous fission. This should probably be moved at some point.
+        Neutrons released per spontaneous fission.
+        This should probably be moved at some point.
     """
 
     fissile = ["U235", "PU239", "PU241", "AM242M", "CM244", "U233"]
@@ -321,6 +332,7 @@ class INuclide(NuclideInterface):
         mcc2id=None,
         mcc3idEndfbVII0=None,
         mcc3idEndfbVII1=None,
+        skipGlobal=False,
     ):
         """
         Create an instance of an INuclide.
@@ -356,7 +368,8 @@ class INuclide(NuclideInterface):
         self.mcc2id = mcc2id or ""
         self.mcc3idEndfbVII0 = mcc3idEndfbVII0 or ""
         self.mcc3idEndfbVII1 = mcc3idEndfbVII1 or ""
-        addGlobalNuclide(self)
+        if not skipGlobal:
+            addGlobalNuclide(self)
         self.element.append(self)
 
     def __hash__(self):
@@ -425,8 +438,8 @@ class INuclide(NuclideInterface):
     def getDecay(self, decayType):
         """Get a :py:class:`~armi.nucDirectory.transmutations.DecayMode`.
 
-        Retrieve the first :py:class:`~armi.nucDirectory.transmutations.DecayMode` matching the
-        specified decType.
+        Retrieve the first :py:class:`~armi.nucDirectory.transmutations.DecayMode`
+        matching the specified decType.
 
         Parameters
         ----------
@@ -499,15 +512,18 @@ class NuclideBase(INuclide, IMcnpNuclide):
         :id: I_ARMI_ND_ISOTOPES1
         :implements: R_ARMI_ND_ISOTOPES
 
-        Instances of this class provide a data structure for information about a single nuclide,
-        including the atom number, atomic weight, element, isomeric state, half-life, and name. The
-        class contains static methods for creating an internal ARMI name or label for a nuclide.
-        There are instance methods for generating the nuclide ID for external codes, e.g. MCNP or
-        Serpent, and retrieving the nuclide ID for MC\ :sup:`2`-2 or MC\ :sup:`2`-3. There are also
-        instance methods for generating an AAAZZZS ID and an ENDF MAT number.
+        The :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
+        class provides a data structure for information about a single nuclide,
+        including the atom number, atomic weight, element, isomeric state,
+        half-life, and name. The class contains static methods for creating an
+        internal ARMI name or label for a nuclide. There are instance methods
+        for generating the nuclide ID for external codes, e.g. MCNP or Serpent,
+        and retrieving the nuclide ID for MC\ :sup:`2`-2 or MC\ :sup:`2`-3.
+        There are also instance methods for generating an AAAZZZS ID and an ENDF
+        MAT number.
     """
 
-    def __init__(self, element, a, weight, abundance, state, halflife):
+    def __init__(self, element, a, weight, abundance, state, halflife, skipGlobal=False):
         IMcnpNuclide.__init__(self)
         INuclide.__init__(
             self,
@@ -519,6 +535,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
             halflife=halflife,
             name=NuclideBase._createName(element, a, state),
             label=NuclideBase._createLabel(element, a, state),
+            skipGlobal=skipGlobal,
         )
 
     def __repr__(self):
@@ -540,10 +557,10 @@ class NuclideBase(INuclide, IMcnpNuclide):
         """
         Make label for nuclide base.
 
-        The logic causes labels for things with A<10 to be zero padded like H03 or tritium instead
-        of H3. This avoids the metastable tritium collision which would look like elemental HE. It
-        also allows things like MO100 to be held within 4 characters, which is a constraint of the
-        ISOTXS format if we append 2 characters for XS type.
+        The logic causes labels for things with A<10 to be zero padded like H03 or tritium
+        instead of H3. This avoids the metastable tritium collision which would look
+        like elemental HE. It also allows things like MO100 to be held within 4 characters,
+        which is a constraint of the ISOTXS format if we append 2 characters for XS type.
         """
         # len(e.symbol) is 1 or 2 => a % (either 1000 or 100)
         #                         => gives exact a, or last two digits.
@@ -577,9 +594,9 @@ class NuclideBase(INuclide, IMcnpNuclide):
             :implements: R_ARMI_ND_ISOTOPES
 
             This method returns the ``mcc2id`` attribute of a
-            :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` instance. This
-            attribute is initially populated by reading from the mcc-nuclides.yaml file in the ARMI
-            resources folder.
+            :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
+            instance.  This attribute is initially populated by reading from the
+            mcc-nuclides.yaml file in the ARMI resources folder.
         """
         return self.mcc2id
 
@@ -595,9 +612,9 @@ class NuclideBase(INuclide, IMcnpNuclide):
             :implements: R_ARMI_ND_ISOTOPES
 
             This method returns the ``mcc3idEndfbVII0`` attribute of a
-            :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` instance. This
-            attribute is initially populated by reading from the mcc-nuclides.yaml file in the ARMI
-            resources folder.
+            :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
+            instance.  This attribute is initially populated by reading from the
+            mcc-nuclides.yaml file in the ARMI resources folder.
         """
         return self.mcc3idEndfbVII0
 
@@ -609,9 +626,9 @@ class NuclideBase(INuclide, IMcnpNuclide):
             :implements: R_ARMI_ND_ISOTOPES
 
             This method returns the ``mcc3idEndfbVII1`` attribute of a
-            :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` instance. This
-            attribute is initially populated by reading from the mcc-nuclides.yaml file in the ARMI
-            resources folder.
+            :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
+            instance.  This attribute is initially populated by reading from the
+            mcc-nuclides.yaml file in the ARMI resources folder.
         """
         return self.mcc3idEndfbVII1
 
@@ -623,9 +640,10 @@ class NuclideBase(INuclide, IMcnpNuclide):
             :id: I_ARMI_ND_ISOTOPES4
             :implements: R_ARMI_ND_ISOTOPES
 
-            This method generates the MCNP ID for an isotope using the standard MCNP format based on
-            the atomic number A, number of protons Z, and excited state. The implementation includes
-            the special rule for Am-242m, which is 95242. 95642 is used for the less common ground
+            This method generates the MCNP ID for an isotope using the standard
+            MCNP format based on the atomic number A, number of protons Z, and
+            excited state. The implementation includes the special rule for
+            Am-242m, which is 95242. 95642 is used for the less common ground
             state Am-242.
 
         Returns
@@ -657,9 +675,10 @@ class NuclideBase(INuclide, IMcnpNuclide):
             :id: I_ARMI_ND_ISOTOPES5
             :implements: R_ARMI_ND_ISOTOPES
 
-            This method generates the AAAZZZS format ID for an isotope. Where AAA is the mass
-            number, ZZZ is the atomic number, and S is the isomeric state. This is a general format
-            independent of any code that precisely defines an isotope or isomer.
+            This method generates the AAAZZZS format ID for an isotope. Where
+            AAA is the mass number, ZZZ is the atomic number, and S is the
+            isomeric state. This is a general format independent of any code that
+            precisely defines an isotope or isomer.
 
         Notes
         -----
@@ -674,8 +693,8 @@ class NuclideBase(INuclide, IMcnpNuclide):
         Returns
         -------
         id: str
-            The ID of this nuclide based on it's elemental name, weight, and state, eg ``U-235``,
-            ``Te-129m``.
+            The ID of this nuclide based on it's elemental name, weight,
+            and state, eg ``U-235``, ``Te-129m``,
         """
         symbol = self.element.symbol.capitalize()
         return "{}-{}{}".format(symbol, self.a, "m" if self.state else "")
@@ -684,11 +703,12 @@ class NuclideBase(INuclide, IMcnpNuclide):
         """
         Gets the ENDF MAT number.
 
-        MAT numbers are defined as described in section 0.4.1 of the NJOY manual. Basically, it's
-        Z * 100 + I where I is an isotope number. I=25 is defined as the lightest known stable
-        isotope of element Z, so for Uranium, Z=92 and I=25 refers to U234. The values of I go up by
-        3 for each mass number, so U235 is 9228. This leaves room for three isomeric states of each
-        nuclide.
+        MAT numbers are defined as described in section 0.4.1 of the NJOY manual.
+        Basically, it's Z * 100 + I where I is an isotope number. I=25 is defined
+        as the lightest known stable isotope of element Z, so for Uranium,
+        Z=92 and I=25 refers to U234. The values of I go up by 3 for each
+        mass number, so U235 is 9228. This leaves room for three isomeric
+        states of each nuclide.
 
         Returns
         -------
@@ -717,12 +737,12 @@ class NaturalNuclideBase(INuclide, IMcnpNuclide):
 
     Notes
     -----
-    This is meant to represent the combination of all naturally occurring nuclides within an
-    element. The abundance is forced to zero here so that it does not have any interactions with the
-    NuclideBase objects.
+    This is meant to represent the combination of all naturally occurring nuclides
+    within an element. The abundance is forced to zero here so that it does not
+    have any interactions with the NuclideBase objects.
     """
 
-    def __init__(self, name, element):
+    def __init__(self, name, element, skipGlobal=False):
         INuclide.__init__(
             self,
             element=element,
@@ -733,6 +753,7 @@ class NaturalNuclideBase(INuclide, IMcnpNuclide):
             halflife=np.inf,
             name=name,
             label=name,
+            skipGlobal=skipGlobal,
         )
 
     def __repr__(self):
@@ -807,11 +828,11 @@ class DummyNuclideBase(INuclide):
 
     Notes
     -----
-    This may be used to store mass from a depletion calculation, specifically in the instances where
-    the burn chain is truncated.
+    This may be used to store mass from a depletion calculation, specifically
+    in the instances where the burn chain is truncated.
     """
 
-    def __init__(self, name, weight):
+    def __init__(self, name, weight, skipGlobal=False):
         INuclide.__init__(
             self,
             element=elements.byName["Dummy"],
@@ -822,6 +843,7 @@ class DummyNuclideBase(INuclide):
             halflife=np.inf,
             name=name,
             label="DMP" + name[4],
+            skipGlobal=skipGlobal,
         )
 
     def __repr__(self):
@@ -885,7 +907,7 @@ class LumpNuclideBase(INuclide):
         Describes what nuclides LumpNuclideBase is expend to.
     """
 
-    def __init__(self, name, weight):
+    def __init__(self, name, weight, skipGlobal=False):
         INuclide.__init__(
             self,
             element=elements.byName["LumpedFissionProduct"],
@@ -896,6 +918,7 @@ class LumpNuclideBase(INuclide):
             halflife=np.inf,
             name=name,
             label=name[1:],
+            skipGlobal=skipGlobal,
         )
 
     def __repr__(self):
@@ -1083,9 +1106,9 @@ def single(predicate):
     """
     Return a single :py:class:`INuclide` object meeting the specified condition.
 
-    Similar to :py:func:`where`, this function uses a lambda input to filter the
-    :py:attr:`INuclide instances <instances>`. If there is not 1 and only 1 match for the specified
-    condition, an exception is raised.
+    Similar to :py:func:`where`, this function uses a lambda input to filter
+    the :py:attr:`INuclide instances <instances>`. If there is not 1 and only
+    1 match for the specified condition, an exception is raised.
 
     Examples
     --------
@@ -1112,8 +1135,8 @@ def changeLabel(nuclideBase, newLabel):
 
     Notes
     -----
-    Since nuclide objects are defined and stored globally, any change to the attributes will be
-    maintained.
+    Since nuclide objects are defined and stored globally, any change to the
+    attributes will be maintained.
     """
     nuclideBase.label = newLabel
     byLabel[newLabel] = nuclideBase
@@ -1131,16 +1154,16 @@ def imposeBurnChain(burnChainStream):
     Notes
     -----
     You cannot impose a burn chain twice. Doing so would require that you clean out the
-    transmutations and decays from all the module-level nuclide bases, which generally requires that
-    you rebuild them. But rebuilding those is not an option because some of them get set as class-
-    level attributes and would be orphaned. If a need to change burn chains mid-run re-arises, then
-    a better nuclideBase-level burnchain cleanup should be implemented so the objects don't have to
-    change identity.
+    transmutations and decays from all the module-level nuclide bases, which generally
+    requires that you rebuild them. But rebuilding those is not an option because some
+    of them get set as class-level attributes and would be orphaned. If a need to change
+    burn chains mid-run re-arises, then a better nuclideBase-level burnchain cleanup
+    should be implemented so the objects don't have to change identity.
 
     Notes
     -----
-    We believe the transmutation information would probably be better stored on a less fundamental
-    place (e.g. not on the NuclideBase).
+    We believe the transmutation information would probably be better stored on a
+    less fundamental place (e.g. not on the NuclideBase).
 
     See Also
     --------
@@ -1168,17 +1191,19 @@ def factory():
     Reads data files to instantiate the :py:class:`INuclides <INuclide>`.
 
     Reads NIST, MC**2 and burn chain data files to instantiate the :py:class:`INuclides <INuclide>`.
-    Also clears and fills in the :py:data:`~armi.nucDirectory.nuclideBases.instances`,
+    Also clears and fills in the
+    :py:data:`~armi.nucDirectory.nuclideBases.instances`,
     :py:data:`byName`, :py:attr:`byLabel`, :py:data:`byMcc3IdEndfbVII0`, and
-    :py:data:`byMcc3IdEndfbVII1` module attributes. This method is automatically run upon loading
-    the module, hence it is not usually necessary to re-run it unless there is a change to the data
-    files, which should not happen during run time, or a *bad* :py:class`INuclide` is created.
+    :py:data:`byMcc3IdEndfbVII1` module attributes. This method is automatically run upon
+    loading the module, hence it is not usually necessary to re-run it unless there is a
+    change to the data files, which should not happen during run time, or a *bad*
+    :py:class`INuclide` is created.
 
     Notes
     -----
-    This cannot be run more than once. NuclideBase instances are used throughout the ARMI ecosystem
-    and are even class attributes in some cases. Re-instantiating them would orphan any existing
-    ones and break everything.
+    This cannot be run more than once. NuclideBase instances are used throughout the ARMI
+    ecosystem and are even class attributes in some cases. Re-instantiating them would orphan
+    any existing ones and break everything.
     """
     if len(instances) != 0:
         raise RuntimeError(
@@ -1210,11 +1235,13 @@ def addNuclideBases():
         :id: I_ARMI_ND_DATA0
         :implements: R_ARMI_ND_DATA
 
-        This function reads the ``nuclides.dat`` file from the ARMI resources folder. This file
-        contains metadata for 4,614 nuclides, including number of protons, number of neutrons,
-        atomic number, excited state, element symbol, atomic mass, natural abundance, half-life, and
-        spontaneous fission yield. The data in ``nuclides.dat`` have been collected from multiple
-        different sources; the references are given in comments at the top of that file.
+        This function reads the ``nuclides.dat`` file from the ARMI resources
+        folder. This file contains metadata for 4,614 nuclides, including
+        number of protons, number of neutrons, atomic number, excited
+        state, element symbol, atomic mass, natural abundance, half-life,
+        and spontaneous fission yield. The data in ``nuclides.dat`` have been
+        collected from multiple different sources; the references are given
+        in comments at the top of that file.
     """
     with open(os.path.join(context.RES, "nuclides.dat")) as f:
         for line in f:
@@ -1250,7 +1277,13 @@ def __addNaturalNuclideBases():
 
 
 def __addDummyNuclideBases():
-    """Generates a set of dummy nuclides."""
+    """
+    Generates a set of dummy nuclides.
+
+    Notes
+    -----
+    These nuclides can be used to truncate a depletion / burn-up chain within the
+    """
     DummyNuclideBase(name="DUMP1", weight=10.0)
     DummyNuclideBase(name="DUMP2", weight=240.0)
 
@@ -1271,13 +1304,14 @@ def readMCCNuclideData():
         :id: I_ARMI_ND_DATA1
         :implements: R_ARMI_ND_DATA
 
-        This function reads the mcc-nuclides.yaml file from the ARMI resources folder. This file
-        contains the MC\ :sup:`2`-2 ID (from ENDF/B-V.2) and MC\ :sup:`2`-3 ID (from ENDF/B-VII.0)
-        for all nuclides in MC\ :sup:`2`. The ``mcc2id``, ``mcc3idEndfVII0``, and ``mcc3idEndfVII1``
-        attributes of each :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
-        instance are updated as the data is read, and the global dictionaries ``byMcc2Id``
-        ``byMcc3IdEndfVII0`` and ``byMcc3IdEndfVII1`` are populated with the nuclide bases keyed by
-        their corresponding ID for each code.
+        This function reads the mcc-nuclides.yaml file from the ARMI resources
+        folder. This file contains the MC\ :sup:`2`-2 ID (from ENDF/B-V.2) and MC\ :sup:`2`-3 ID
+        (from ENDF/B-VII.0) for all nuclides in MC\ :sup:`2`. The ``mcc2id``,
+        ``mcc3idEndfVII0``, and  ``mcc3idEndfVII1`` attributes of each :py:class:`NuclideBase
+        <armi.nucDirectory.nuclideBases.NuclideBase>` instance are updated as
+        the data is read, and the global dictionaries ``byMcc2Id``
+        ``byMcc3IdEndfVII0`` and ``byMcc3IdEndfVII1`` are populated with the nuclide bases
+        keyed by their corresponding ID for each code.
     """
     global byMcc2Id
     global byMcc3Id
@@ -1316,16 +1350,18 @@ def updateNuclideBasesForSpecialCases():
         :implements: R_ARMI_ND_ISOTOPES
 
         This function updates the keys for the :py:class:`NuclideBase
-        <armi.nucDirectory.nuclideBases.NuclideBase>` instances for Am-242m and Am-242 in the
-        ``byName`` and ``byDBName`` global dictionaries. This function associates the more common
-        isomer Am-242m with the name "AM242", and uses "AM242G" to denote the ground state.
+        <armi.nucDirectory.nuclideBases.NuclideBase>` instances for Am-242m and
+        Am-242 in the ``byName`` and ``byDBName`` global dictionaries.  This
+        function associates the more common isomer Am-242m with the name
+        "AM242", and uses "AM242G" to denote the ground state.
 
     Notes
     -----
-    This function is specifically added to change the definition of `AM242` to refer to its
-    metastable isomer, `AM242M` by default. `AM242M` is most common isomer of `AM242` and is
-    typically the desired isomer when being requested rather than than the ground state (i.e., S=0)
-    of `AM242`.
+    This function is specifically added to change the definition of
+    `AM242` to refer to its metastable isomer, `AM242M` by default. `AM242M`
+    is most common isomer of `AM242` and is typically the desired isomer
+    when being requested rather than than the ground state (i.e., S=0) of
+    `AM242`.
     """
     # Change the name of `AM242` to specific represent its ground state.
     am242g = byName["AM242"]
@@ -1405,3 +1441,458 @@ def destroyGlobalNuclides():
     byMcc3IdEndfbVII0.clear()
     byMcnpId.clear()
     byAAAZZZSId.clear()
+
+
+"""
+TODO: Above this point is the old "global nuclides" code. Soon to be deleted.
+      Below this point is the new code.
+"""
+
+
+class NuclideBases:
+    """
+    TODO: This is the class I am crafting to replace global nuclides.
+    To start with, I will keep everything global, but use this class.
+    """
+
+    def __init__(self):
+        self.burnChainImposed = False
+        self.instances = []
+        self.byName = {}
+        self.byDBName = {}
+        self.byLabel = {}
+        self.byMcc2Id = {}
+        self.byMcc3Id = {}  # for backwards compat. Identical to byMcc3IdEndfbVII1
+        self.byMcc3IdEndfbVII0 = {}
+        self.byMcc3IdEndfbVII1 = {}
+        self.byMcnpId = {}
+        self.byAAAZZZSId = {}
+        self.nuclidesFile = os.path.join(context.RES, "nuclides.dat")
+        self.mccNuclidesFile = os.path.join(context.RES, "mcc-nuclides.yaml")
+        self.factory()
+
+    def clear(self):
+        self.burnChainImposed = False
+        self.instances = []
+        self.byName = {}
+        self.byDBName = {}
+        self.byLabel = {}
+        self.byMcc2Id = {}
+        self.byMcc3Id = {}
+        self.byMcc3IdEndfbVII0 = {}
+        self.byMcc3IdEndfbVII1 = {}
+        self.byMcnpId = {}
+        self.byAAAZZZSId = {}
+
+    def addNuclide(self, nuclide: INuclide):
+        """Add an element to the dictionaries in this class."""
+        if nuclide.name in self.byName or nuclide.getDatabaseName() in self.byDBName or nuclide.label in self.byLabel:
+            raise ValueError(f"{nuclide} has already been added.")
+
+        self.instances.append(nuclide)
+        self.byName[nuclide.name] = nuclide
+        self.byDBName[nuclide.getDatabaseName()] = nuclide
+        self.byLabel[nuclide.label] = nuclide
+
+        # Add look-up based on the MCNP nuclide ID
+        if isinstance(nuclide, IMcnpNuclide):
+            if nuclide.getMcnpId() in self.byMcnpId:
+                raise ValueError(f"{nuclide} with McnpId {nuclide.getMcnpId()} has already been added.")
+            self.byMcnpId[nuclide.getMcnpId()] = nuclide
+
+        if not isinstance(nuclide, (NaturalNuclideBase, LumpNuclideBase, DummyNuclideBase)):
+            self.byAAAZZZSId[nuclide.getAAAZZZSId()] = nuclide
+
+    def factory(self):
+        """
+        Reads data files to instantiate the :py:class:`INuclides <INuclide>`.
+
+        Reads NIST, MC**2 and burn chain data files to instantiate the :py:class:`INuclides <INuclide>`. Also clears and
+        fills in the :py:data:`~armi.nucDirectory.nuclideBases.instances`, :py:data:`byName`, :py:attr:`byLabel`,
+        :py:data:`byMcc3IdEndfbVII0`, and :py:data:`byMcc3IdEndfbVII1` module attributes. This method is automatically
+        run upon loading the module, hence it is not usually necessary to re-run it unless there is a change to the data
+        files, which should not happen during run time, or a *bad* :py:class`INuclide` is created.
+
+        Notes
+        -----
+        This cannot be run more than once. NuclideBase instances are used throughout the ARMI ecosystem and are even
+        class attributes in some cases. Re-instantiating them would orphan any existing ones and break everything.
+        """
+        if len(self.instances) != 0:
+            raise RuntimeError(
+                "Nuclides are already initialized and cannot be re-initialized unless `nuclideBases.clear()` is called "
+                "first."
+            )
+
+        self.addNuclideBases()
+        self.__addNaturalNuclideBases()
+        self.__addDummyNuclideBases()
+        self.__addLumpedFissionProductNuclideBases()
+        self.updateNuclideBasesForSpecialCases()
+        self.readMCCNuclideData()
+        self.__renormalizeNuclideToElementRelationship()
+        self.__deriveElementalWeightsByNaturalNuclideAbundances()
+
+        # reload the thermal scattering library with the new nuclideBases too
+        from armi.nucDirectory import thermalScattering
+
+        thermalScattering.factory()
+
+    def initReachableActiveNuclidesThroughBurnChain(self, nuclides, numberDensities, activeNuclides):
+        """
+        March through the depletion chain and find all nuclides that can be reached by depleting nuclides passed in.
+
+        This limits depletion to the smallest set of nuclides that matters.
+
+        Parameters
+        ----------
+        nuclides : np.array, dtype="S6"
+            Starting array of nuclide names
+        numberDensities : np.array, dtype=np.float64
+            Starting array of number densities
+        activeNuclides : OrderedSet
+            Active nuclides defined on the reactor blueprints object. See: armi.reactor.blueprints.py
+        """
+        if not self.burnChainImposed:
+            return
+
+        missingActiveNuclides = set()
+        memo = set()
+        nucNames = [nucName.decode() for nucName in nuclides]
+        difference = set(numberDensities).difference(memo)
+        while any(difference):
+            newNucs = set()
+            nuclide = difference.pop()
+            memo.add(nuclide)
+            # Skip the nuclide if it is not `active` in the burn-chain
+            if nuclide not in activeNuclides:
+                continue
+
+            nuclideObj = self.byName[nuclide]
+
+            for interaction in nuclideObj.trans + nuclideObj.decays:
+                try:
+                    # Interaction nuclides can only be added to the number density dictionary if they are a part of the
+                    # user-defined active nuclides
+                    productNuclide = interaction.getPreferredProduct(activeNuclides)
+                    if productNuclide not in numberDensities:
+                        numberDensities[productNuclide] = 0.0
+                except KeyError:
+                    # Keep track of the first production nuclide
+                    missingActiveNuclides.add(interaction.productNuclides)
+
+            # add the new nuclides to the number density arrays
+            newNDens = np.zeros(len(newNucs), dtype=np.float64)
+            nuclides = np.append(nuclides, list(newNucs))
+            numberDensities = np.append(numberDensities, newNDens)
+
+            nucNames = [nucName.decode() for nucName in nuclides]
+            difference = set(nucNames).difference(memo)
+
+        if self.burnChainImposed and missingActiveNuclides:
+            self._failOnMissingActiveNuclides(missingActiveNuclides)
+
+        return nuclides, numberDensities
+
+    def _failOnMissingActiveNuclides(self, missingActiveNuclides):
+        """Raise ValueError with notification of which nuclides to include in the burn-chain."""
+        msg = "Missing active nuclides in loading file. Add the following nuclides:"
+        for i, nucList in enumerate(missingActiveNuclides, 1):
+            msg += f"\n {i} - "  # Index of
+            for j, nuc in enumerate(nucList, 1):
+                delimiter = " or " if j < len(nucList) else ""
+                msg += f"{nuc}{delimiter}"
+
+        raise ValueError(msg)
+
+    def isotopes(self, z: int):
+        """TODO."""
+        return elements.byZ[z].nuclides
+
+    def getIsotopics(self, nucName):
+        """Expand elemental nuc name to isotopic nuc bases."""
+        nb = self.byName[nucName]
+        if isinstance(nb, (LumpNuclideBase, DummyNuclideBase)):
+            # skip lumped fission products or dumps
+            return []
+        elif isinstance(nb, NaturalNuclideBase):
+            isotopics = nb.getNaturalIsotopics()
+        else:
+            isotopics = [nb]
+
+        return isotopics
+
+    def fromName(self, name):
+        """Return a nuclide from its name."""
+        matches = [nn for nn in self.instances if nn.name == name]
+        if len(matches) != 1:
+            raise Exception(f"Too many or too few ({len(matches)}) matches for {name}")
+
+        return matches[0]
+
+    def isMonoIsotopicElement(self, name):
+        """Return true if this is the only naturally occurring isotope of its element."""
+        base = self.byName[name]
+        return base.abundance > 0 and len([e for e in base.element.nuclides if e.abundance > 0]) == 1
+
+    def where(self, predicate):
+        """
+        Return all :py:class:`INuclides <INuclide>` objects matching a condition.
+
+        Returns an iterator of :py:class:`INuclides <INuclide>` matching the specified condition.
+
+        Attributes
+        ----------
+        predicate: lambda
+            A lambda, or function, accepting a :py:class:`INuclide` as a parameter
+
+        Examples
+        --------
+        >>> from armi.nucDirectory.nuclideBases import NuclideBases
+        >>> nuclideBases = NuclideBases()
+        >>> [nn.name for nn in nuclideBases.where(lambda nb: 'Z' in nb.name)]
+        ['ZN64', 'ZN66', 'ZN67', 'ZN68', 'ZN70', 'ZR90', 'ZR91', 'ZR92', 'ZR94', 'ZR96', 'ZR93', 'ZR95', 'ZR']
+        >>> # in order to get length, convert to list
+        >>> isomers90 = list(nuclideBases.where(lambda nb: nb.a == 95))
+        >>> len(isomers90)
+        3
+        >>> for iso in isomers: print(iso)
+        <NuclideBase MO95: Z:42, A:95, S:0, label:MO2N>
+        <NuclideBase NB95: Z:41, A:95, S:0, label:NB2N>
+        <NuclideBase ZR95: Z:40, A:95, S:0, label:ZR2N>
+        """
+        for nuc in self.instances:
+            if predicate(nuc):
+                yield (nuc)
+
+    def single(self, predicate):
+        """
+        Return a single :py:class:`INuclide` object meeting the specified condition.
+
+        Similar to :py:func:`where`, this function uses a lambda input to filter the
+        :py:attr:`INuclide instances <instances>`. If there is not 1 and only 1 match for the specified condition, an
+        exception is raised.
+
+        Examples
+        --------
+        >>> from armi.nucDirectory import nuclideBases
+        >>> nuclideBases.single(lambda nb: nb.name == 'C')
+        <NaturalNuclideBase C: Z:6, w:12.0107358968, label:C>
+        >>> nuclideBases.single(lambda nb: nb.z == 95 and nb.a == 242 and nb.state == 1)
+        <NuclideBase AM242M: Z:95, A:242, S:1, label:AM4C>
+        """
+        matches = [nuc for nuc in self.instances if predicate(nuc)]
+        if len(matches) != 1:
+            raise IndexError(
+                "Expected single match, but got {} matches:\n  {}".format(
+                    len(matches), "\n  ".join(str(mo) for mo in matches)
+                )
+            )
+
+        return matches[0]
+
+    def changeLabel(self, nuclideBase, newLabel):
+        """
+        Updates a nuclide label and modifies the ``byLabel`` look-up dictionary.
+
+        Notes
+        -----
+        Since nuclide objects are defined and stored globally, any change to the attributes will be maintained.
+        """
+        nuclideBase.label = newLabel
+        self.byLabel[newLabel] = nuclideBase
+
+    def getDepletableNuclides(self, activeNuclides, obj):
+        """Get nuclides in this object that are in the burn chain."""
+        return sorted(set(activeNuclides) & set(obj.getNuclides()))
+
+    def imposeBurnChain(self, burnChainStream):
+        """
+        Apply transmutation and decay information to each nuclide.
+
+        Notes
+        -----
+        You cannot impose a burn chain twice. Doing so would require that you clean out the transmutations and decays
+        from all the module-level nuclide bases, which generally requires that you rebuild them. But rebuilding those is
+        not an option because some of them get set as class-level attributes and would be orphaned. If a need to change
+        burn chains mid-run re-arises, then a better nuclideBase-level burnchain cleanup should be implemented so the
+        objects don't have to change identity.
+
+        Notes
+        -----
+        We believe the transmutation information would probably be better stored on a less fundamental place (e.g. not
+        on the NuclideBase).
+
+        See Also
+        --------
+        armi.nucDirectory.transmutations : describes file format
+        """
+        if self.burnChainImposed:
+            # The only time this should happen is if in a unit test that has already processed
+            # conftest.py and is now building a Case that also imposes this.
+            runLog.warning("Burn chain already imposed. Skipping reimposition.")
+            return
+
+        self.burnChainImposed = True
+        yaml = YAML(typ="rt")
+        yaml.allow_duplicate_keys = False
+        burnData = yaml.load(burnChainStream)
+
+        for nucName, burnInfo in burnData.items():
+            nuclide = self.byName[nucName]
+            # think of this protected stuff as "module level protection" rather than class.
+            nuclide._processBurnData(burnInfo)
+
+    def addNuclideBases(self):
+        """
+        Read natural abundances of any natural nuclides.
+
+        This adjusts already-existing NuclideBases and Elements with the new information.
+
+        .. impl:: Separating natural abundance data from code.
+            :id: I_ARMI_ND_DATA0
+            :implements: R_ARMI_ND_DATA
+
+            This function reads the ``nuclides.dat`` file from the ARMI resources folder. This file contains metadata
+            for 4,614 nuclides, including number of protons, number of neutrons, atomic number, excited state, element
+            symbol, atomic mass, natural abundance, half-life, and spontaneous fission yield. The data in
+            ``nuclides.dat`` have been collected from multiple different sources; the references are given in comments
+            at the top of that file.
+        """
+        with open(self.nuclidesFile, "r") as f:
+            for line in f:
+                # Skip header lines
+                if line.startswith("#") or line.startswith("Z"):
+                    continue
+                lineData = line.split()
+                _z = int(lineData[0])
+                _n = int(lineData[1])
+                a = int(lineData[2])
+                state = int(lineData[3])
+                sym = lineData[4].upper()
+                mass = float(lineData[5])
+                abun = float(lineData[6])
+                halflife = lineData[7]
+                if halflife == "inf":
+                    halflife = np.inf
+                else:
+                    halflife = float(halflife)
+                nuSF = float(lineData[8])
+
+                element = elements.bySymbol[sym]
+                nb = NuclideBase(element, a, mass, abun, state, halflife, skipGlobal=True)
+                nb.nuSF = nuSF
+                self.addNuclide(nb)
+
+    def __addNaturalNuclideBases(self):
+        """Generates a complete set of nuclide bases for each naturally occurring element."""
+        for element in elements.byZ.values():
+            if element.symbol not in self.byName:
+                if element.isNaturallyOccurring():
+                    self.addNuclide(NaturalNuclideBase(element.symbol, element, skipGlobal=True))
+
+    def __addDummyNuclideBases(self):
+        """
+        Generates a set of dummy nuclides.
+
+        Notes
+        -----
+        These nuclides can be used to truncate a depletion / burn-up chain within the
+        """
+        self.addNuclide(DummyNuclideBase(name="DUMP1", weight=10.0, skipGlobal=True))
+        self.addNuclide(DummyNuclideBase(name="DUMP2", weight=240.0, skipGlobal=True))
+
+    def __addLumpedFissionProductNuclideBases(self):
+        """TODO."""
+        self.addNuclide(LumpNuclideBase(name="LFP35", weight=233.273, skipGlobal=True))
+        self.addNuclide(LumpNuclideBase(name="LFP38", weight=235.78, skipGlobal=True))
+        self.addNuclide(LumpNuclideBase(name="LFP39", weight=236.898, skipGlobal=True))
+        self.addNuclide(LumpNuclideBase(name="LFP40", weight=237.7, skipGlobal=True))
+        self.addNuclide(LumpNuclideBase(name="LFP41", weight=238.812, skipGlobal=True))
+        self.addNuclide(LumpNuclideBase(name="LREGN", weight=1.0, skipGlobal=True))
+
+    def readMCCNuclideData(self):
+        r"""Read in the label data for the MC2-2 and MC2-3 cross section codes to the nuclide bases.
+
+        .. impl:: Separating MCC data from code.
+            :id: I_ARMI_ND_DATA1
+            :implements: R_ARMI_ND_DATA
+
+            This function reads the mcc-nuclides.yaml file from the ARMI resources folder. This file contains the
+            MC\ :sup:`2`-2 ID (from ENDF/B-V.2) and MC\ :sup:`2`-3 ID (from ENDF/B-VII.0) for all nuclides in
+            MC\ :sup:`2`. The ``mcc2id``, ``mcc3idEndfVII0``, and  ``mcc3idEndfVII1`` attributes of each
+            :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` instance are updated as the data is
+            read, and the global dictionaries ``byMcc2Id`` ``byMcc3IdEndfVII0`` and ``byMcc3IdEndfVII1`` are populated
+            with the nuclide bases keyed by their corresponding ID for each code.
+        """
+        with open(self.mccNuclidesFile, "r") as f:
+            yaml = YAML(typ="rt")
+            nuclides = yaml.load(f)
+
+        for n in nuclides:
+            nb = self.byName[n]
+            mcc2id = nuclides[n]["ENDF/B-V.2"]
+            mcc3idEndfbVII0 = nuclides[n]["ENDF/B-VII.0"]
+            mcc3idEndfbVII1 = nuclides[n]["ENDF/B-VII.1"]
+            if mcc2id is not None:
+                nb.mcc2id = mcc2id
+                self.byMcc2Id[nb.getMcc2Id()] = nb
+            if mcc3idEndfbVII0 is not None:
+                nb.mcc3idEndfbVII0 = mcc3idEndfbVII0
+                self.byMcc3IdEndfbVII0[nb.getMcc3IdEndfbVII0()] = nb
+            if mcc3idEndfbVII1 is not None:
+                nb.mcc3idEndfbVII1 = mcc3idEndfbVII1
+                self.byMcc3IdEndfbVII1[nb.getMcc3IdEndfbVII1()] = nb
+
+        # Have the byMcc3Id dictionary be VII.1 IDs.
+        self.byMcc3Id = self.byMcc3IdEndfbVII1
+
+    def updateNuclideBasesForSpecialCases(self):
+        """
+        Update the nuclide bases for special case name changes.
+
+        .. impl:: The special case name Am242g is supported.
+            :id: I_ARMI_ND_ISOTOPES6
+            :implements: R_ARMI_ND_ISOTOPES
+
+            This function updates the keys for the :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
+            instances for Am-242m and Am-242 in the ``byName`` and ``byDBName`` global dictionaries. This function
+            associates the more common isomer Am-242m with the name "AM242", and uses "AM242G" to denote the ground
+            state.
+
+        Notes
+        -----
+        This function is specifically added to change the definition of `AM242` to refer to its metastable isomer,
+        `AM242M` by default. `AM242M` is most common isomer of `AM242` and is typically the desired isomer when being
+        requested rather than than the ground state (i.e., S=0) of `AM242`.
+        """
+        # Change the name of `AM242` to specific represent its ground state.
+        am242g = self.byName["AM242"]
+        am242g.name = "AM242G"
+        self.byName["AM242G"] = am242g
+        self.byDBName[self.byName["AM242G"].getDatabaseName()] = am242g
+
+        # Update the pointer of `AM242` to refer to `AM242M`.
+        am242m = self.byName["AM242M"]
+        self.byName["AM242"] = am242m
+        self.byDBName["nAm242"] = am242m
+        self.byDBName[self.byName["AM242"].getDatabaseName()] = am242m
+
+    def __renormalizeNuclideToElementRelationship(self):
+        """TODO."""
+        for nuc in self.instances:
+            if nuc.element is not None:
+                nuc.element = elements.byZ[nuc.z]
+                nuc.element.append(nuc)
+
+    def __deriveElementalWeightsByNaturalNuclideAbundances(self):
+        """Derives and sets the standard atomic weights for each element that has naturally occurring nuclides."""
+        for element in elements.byName.values():
+            numer = 0.0
+            denom = 0.0
+            for nb in element.getNaturalIsotopics():
+                numer += nb.weight * nb.abundance
+                denom += nb.abundance
+
+            if denom:
+                element.standardWeight = numer / denom

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -400,9 +400,8 @@ class INuclide(NuclideInterface):
             # Check that the burn category has only one defined burn type
             if len(nuclideBurnCategory) > 1:
                 raise ValueError(
-                    "Improperly defined ``burn-chain`` of {}. {} should be a single burn type.".format(
-                        self, nuclideBurnCategory.keys()
-                    )
+                    f"Improperly defined ``burn-chain`` of {self}. {nuclideBurnCategory.keys()} should be a single "
+                    "burn type."
                 )
             nuclideBurnType = list(nuclideBurnCategory.keys())[0]
             if nuclideBurnType == self.TRANSMUTATION:
@@ -424,13 +423,8 @@ class INuclide(NuclideInterface):
                         self.nuSF = userSpontaneousFissionYield
             else:
                 raise Exception(
-                    "Undefined Burn Data {} for {}. Expected {}, {}, or {}.".format(
-                        nuclideBurnType,
-                        self,
-                        self.TRANSMUTATION,
-                        self.DECAY,
-                        self.SPONTANEOUS_FISSION,
-                    )
+                    f"Undefined Burn Data {nuclideBurnType} for {self}. Expected {self.TRANSMUTATION}, {self.DECAY}, "
+                    f"or {self.SPONTANEOUS_FISSION}."
                 )
 
     def getDecay(self, decayType):
@@ -690,17 +684,16 @@ class NuclideBase(INuclide, IMcnpNuclide):
             and state, eg ``U-235``, ``Te-129m``,
         """
         symbol = self.element.symbol.capitalize()
-        return "{}-{}{}".format(symbol, self.a, "m" if self.state else "")
+        return f"{symbol}-{self.a}{'m' if self.state else ''}"
 
     def getEndfMatNum(self):
         """
         Gets the ENDF MAT number.
 
-        MAT numbers are defined as described in section 0.4.1 of the NJOY manual.
-        Basically, it's Z * 100 + I where I is an isotope number. I=25 is defined
-        as the lightest known stable isotope of element Z, so for Uranium,
-        Z=92 and I=25 refers to U234. The values of I go up by 3 for each
-        mass number, so U235 is 9228. This leaves room for three isomeric states of each nuclide.
+        MAT numbers are defined as described in section 0.4.1 of the NJOY manual. Basically, it's Z * 100 + I where I is
+        an isotope number. I=25 is defined as the lightest known stable isotope of element Z, so for Uranium, Z=92 and
+        I=25 refers to U234. The values of I go up by 3 for each mass number, so U235 is 9228. This leaves room for
+        three isomeric states of each nuclide.
 
         Returns
         -------
@@ -720,7 +713,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
 
         isotopeNum = (a - smallestStableA) * 3 + self.state + 25
         mat = z * 100 + isotopeNum
-        return "{0}".format(mat)
+        return f"{mat}"
 
 
 class NaturalNuclideBase(INuclide, IMcnpNuclide):
@@ -1319,9 +1312,7 @@ class NuclideBases:
         matches = [nuc for nuc in self.instances if predicate(nuc)]
         if len(matches) != 1:
             raise IndexError(
-                "Expected single match, but got {} matches:\n  {}".format(
-                    len(matches), "\n  ".join(str(mo) for mo in matches)
-                )
+                f"Expected single match, but got {len(matches)} matches:\n  {'\n  '.join(str(mo) for mo in matches)}"
             )
 
         return matches[0]
@@ -1518,7 +1509,7 @@ class NuclideBases:
     def __renormalizeNuclideToElementRelationship(self):
         """TODO."""
         for nuc in self.instances:
-            if nuc.element is not None:
+            if nuc.element is None:
                 nuc.element = elements.byZ[nuc.z]
                 nuc.element.append(nuc)
 

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""
-This module provides fundamental nuclide information to be used throughout the
-framework and applications.
+This module provides fundamental nuclide information to be used throughout the framework and applications.
 
 .. impl:: Isotopes and isomers can be queried by name, label, MC2-3 ID, MCNP ID, and AAAZZZS ID.
     :id: I_ARMI_ND_ISOTOPES0
@@ -104,27 +103,27 @@ from armi import context, runLog
 from armi.nucDirectory import transmutations
 from armi.utils.units import HEAVY_METAL_CUTOFF_Z
 
-# used to prevent multiple applications of burn chains, which would snowball
-# unphysically. This is a bit of a crutch for the global state that is the nuclide
-# directory.
+# Used to prevent multiple applications of burn chains, which would snowball unphysically. This is a bit of a crutch for
+# the global state that is the nuclide directory.
 burnChainImposed = False
 
 instances = []
-# The elements must be imported after the instances list is established
-# to allow for simultaneous initialization of the nuclides and elements
-# together to maintain self-consistency.
+# The elements must be imported after the instances list is established to allow for simultaneous initialization of the
+# nuclides and elements together to maintain self-consistency.
 from armi.nucDirectory import elements  # noqa: E402
 
-# Dictionary of INuclides by the INuclide.name for fast indexing
-byName = {}
-byDBName = {}
-byLabel = {}
-byMcc2Id = {}
-byMcc3Id = {}  # for backwards compatibility. Identical to byMcc3IdEndfbVII1
-byMcc3IdEndfbVII0 = {}
-byMcc3IdEndfbVII1 = {}
-byMcnpId = {}
-byAAAZZZSId = {}
+# Global nuclide and nuclideBases data
+nuclideBases = None
+byName = None
+byDBName = None
+byLabel = None
+byMcc2Id = None
+byMcc3Id = None  # for backwards compatibility. Identical to byMcc3IdEndfbVII1
+byMcc3IdEndfbVII0 = None
+byMcc3IdEndfbVII1 = None
+byMcnpId = None
+byAAAZZZSId = None
+
 
 # lookup table from https://t2.lanl.gov/nis/data/endf/endfvii-n.html
 BASE_ENDFB7_MAT_NUM = {
@@ -347,8 +346,8 @@ class INuclide(NuclideInterface):
             )
         if state < 0:
             raise ValueError(
-                f"Error in initializing nuclide {name}. An invalid state {state} is provided. The "
-                "state must be a positive integer."
+                f"Error in initializing nuclide {name}. An invalid state {state} is provided. The state must be a "
+                "positive integer."
             )
         if halflife < 0.0:
             raise ValueError(f"Error in initializing nuclide {name}. The halflife must be a positive value.")
@@ -413,15 +412,14 @@ class INuclide(NuclideInterface):
             elif nuclideBurnType == self.SPONTANEOUS_FISSION:
                 userSpontaneousFissionYield = nuclideBurnCategory.get(nuclideBurnType, None)
 
-                # Check for user-defined value of nuSF within the burn-chain data. If this is
-                # updated then prefer the user change and then note this to the user. Otherwise,
-                # maintain the default loaded from the nuclide bases.
+                # Check for user-defined value of nuSF within the burn-chain data. If this is updated then prefer the
+                # user change and then note this to the user. Otherwise, maintain the default loaded from the nuclide
+                # bases.
                 if userSpontaneousFissionYield:
                     if userSpontaneousFissionYield != self.nuSF:
                         runLog.info(
-                            f"nuSF provided for {self} will be updated from "
-                            f"{self.nuSF:<8.6e} to {userSpontaneousFissionYield:<8.6e} based on "
-                            "user provided burn-chain data."
+                            f"nuSF provided for {self} will be updated from {self.nuSF:<8.6e} to "
+                            f"{userSpontaneousFissionYield:<8.6e} based on user provided burn-chain data."
                         )
                         self.nuSF = userSpontaneousFissionYield
             else:
@@ -438,8 +436,7 @@ class INuclide(NuclideInterface):
     def getDecay(self, decayType):
         """Get a :py:class:`~armi.nucDirectory.transmutations.DecayMode`.
 
-        Retrieve the first :py:class:`~armi.nucDirectory.transmutations.DecayMode`
-        matching the specified decType.
+        Retrieve the first :py:class:`~armi.nucDirectory.transmutations.DecayMode` matching the specified decType.
 
         Parameters
         ----------
@@ -512,15 +509,12 @@ class NuclideBase(INuclide, IMcnpNuclide):
         :id: I_ARMI_ND_ISOTOPES1
         :implements: R_ARMI_ND_ISOTOPES
 
-        The :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
-        class provides a data structure for information about a single nuclide,
-        including the atom number, atomic weight, element, isomeric state,
-        half-life, and name. The class contains static methods for creating an
-        internal ARMI name or label for a nuclide. There are instance methods
-        for generating the nuclide ID for external codes, e.g. MCNP or Serpent,
-        and retrieving the nuclide ID for MC\ :sup:`2`-2 or MC\ :sup:`2`-3.
-        There are also instance methods for generating an AAAZZZS ID and an ENDF
-        MAT number.
+        The :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` class provides a data structure for
+        information about a single nuclide, including the atom number, atomic weight, element, isomeric state,
+        half-life, and name. The class contains static methods for creating an internal ARMI name or label for a
+        nuclide. There are instance methods for generating the nuclide ID for external codes, e.g. MCNP or Serpent, and
+        retrieving the nuclide ID for MC\ :sup:`2`-2 or MC\ :sup:`2`-3. There are also instance methods for generating
+        an AAAZZZS ID and an ENDF MAT number.
     """
 
     def __init__(self, element, a, weight, abundance, state, halflife, skipGlobal=False):
@@ -550,17 +544,17 @@ class NuclideBase(INuclide, IMcnpNuclide):
         metaChar = ["", "M", "M2", "M3"]
         if state > len(metaChar):
             raise ValueError(f"The state of NuclideBase is not valid and must not be larger than {len(metaChar)}.")
-        return "{}{}{}".format(element.symbol, a, metaChar[state])
+
+        return f"{element.symbol}{a}{metaChar[state]}"
 
     @staticmethod
     def _createLabel(element, a, state):
         """
         Make label for nuclide base.
 
-        The logic causes labels for things with A<10 to be zero padded like H03 or tritium
-        instead of H3. This avoids the metastable tritium collision which would look
-        like elemental HE. It also allows things like MO100 to be held within 4 characters,
-        which is a constraint of the ISOTXS format if we append 2 characters for XS type.
+        The logic causes labels for things with A<10 to be zero padded like H03 or tritium instead of H3. This avoids
+        the metastable tritium collision which would look like elemental HE. It also allows things like MO100 to be held
+        within 4 characters, which is a constraint of the ISOTXS format if we append 2 characters for XS type.
         """
         # len(e.symbol) is 1 or 2 => a % (either 1000 or 100)
         #                         => gives exact a, or last two digits.
@@ -568,7 +562,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
         firstTwoDigits = (a % (10 ** (4 - len(element.symbol)))) // 10
         # the last digit is either 0-9 if state=0, or A-J if state=1, or K-T if state=2, or U-d if state=3
         lastDigit = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcd"[(a % 10) + state * 10]
-        return "{}{}{}".format(element.symbol, firstTwoDigits, lastDigit)
+        return f"{element.symbol}{firstTwoDigits}{lastDigit}"
 
     def getNaturalIsotopics(self):
         """Gets the natural isotopics root :py:class:`~elements.Element`.
@@ -594,9 +588,8 @@ class NuclideBase(INuclide, IMcnpNuclide):
             :implements: R_ARMI_ND_ISOTOPES
 
             This method returns the ``mcc2id`` attribute of a
-            :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
-            instance.  This attribute is initially populated by reading from the
-            mcc-nuclides.yaml file in the ARMI resources folder.
+            :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>` instance. This attribute is initially
+            populated by reading from the mcc-nuclides.yaml file in the ARMI resources folder.
         """
         return self.mcc2id
 
@@ -613,7 +606,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
 
             This method returns the ``mcc3idEndfbVII0`` attribute of a
             :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
-            instance.  This attribute is initially populated by reading from the
+            instance. This attribute is initially populated by reading from the
             mcc-nuclides.yaml file in the ARMI resources folder.
         """
         return self.mcc3idEndfbVII0
@@ -627,7 +620,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
 
             This method returns the ``mcc3idEndfbVII1`` attribute of a
             :py:class:`NuclideBase <armi.nucDirectory.nuclideBases.NuclideBase>`
-            instance.  This attribute is initially populated by reading from the
+            instance. This attribute is initially populated by reading from the
             mcc-nuclides.yaml file in the ARMI resources folder.
         """
         return self.mcc3idEndfbVII1
@@ -707,8 +700,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
         Basically, it's Z * 100 + I where I is an isotope number. I=25 is defined
         as the lightest known stable isotope of element Z, so for Uranium,
         Z=92 and I=25 refers to U234. The values of I go up by 3 for each
-        mass number, so U235 is 9228. This leaves room for three isomeric
-        states of each nuclide.
+        mass number, so U235 is 9228. This leaves room for three isomeric states of each nuclide.
 
         Returns
         -------
@@ -737,9 +729,8 @@ class NaturalNuclideBase(INuclide, IMcnpNuclide):
 
     Notes
     -----
-    This is meant to represent the combination of all naturally occurring nuclides
-    within an element. The abundance is forced to zero here so that it does not
-    have any interactions with the NuclideBase objects.
+    This is meant to represent the combination of all naturally occurring nuclides within an element. The abundance is
+    forced to zero here so that it does not have any interactions with the NuclideBase objects.
     """
 
     def __init__(self, name, element, skipGlobal=False):
@@ -809,17 +800,17 @@ class NaturalNuclideBase(INuclide, IMcnpNuclide):
         id: str
             SERPENT ID: ``C-nat``, `Fe-nat``
         """
-        return "{}-nat".format(self.element.symbol.capitalize())
+        return f"{self.element.symbol.capitalize()}-nat"
 
     def getEndfMatNum(self):
         """Get the ENDF mat number for this element."""
         if self.z != 6:
             runLog.warning(
-                "The only elemental in ENDF/B VII.1 is carbon. "
-                "ENDF mat num was requested for the elemental {} and will not be helpful "
-                "for working with ENDF/B VII.1. Try to expandElementalsToIsotopics".format(self)
+                f"The only elemental in ENDF/B VII.1 is carbon. ENDF mat num was requested for the elemental {self} and"
+                "will not be helpful for working with ENDF/B VII.1. Try to expandElementalsToIsotopics"
             )
-        return "{0}".format(self.z * 100)
+
+        return f"{self.z * 100}"
 
 
 class DummyNuclideBase(INuclide):
@@ -828,8 +819,8 @@ class DummyNuclideBase(INuclide):
 
     Notes
     -----
-    This may be used to store mass from a depletion calculation, specifically
-    in the instances where the burn chain is truncated.
+    This may be used to store mass from a depletion calculation, specifically in the instances where the burn chain is
+    truncated.
     """
 
     def __init__(self, name, weight, skipGlobal=False):
@@ -973,453 +964,69 @@ class LumpNuclideBase(INuclide):
 
 
 def initReachableActiveNuclidesThroughBurnChain(nuclides, numberDensities, activeNuclides):
-    """
-    March through the depletion chain and find all nuclides that can be reached by depleting nuclides passed in.
-
-    This limits depletion to the smallest set of nuclides that matters.
-
-    Parameters
-    ----------
-    nuclides : np.array, dtype="S6"
-        Starting array of nuclide names
-    numberDensities : np.array, dtype=np.float64
-        Starting array of number densities
-    activeNuclides : OrderedSet
-        Active nuclides defined on the reactor blueprints object. See: armi.reactor.blueprints.py
-    """
-    if not burnChainImposed:
-        return nuclides, numberDensities
-
-    missingActiveNuclides = set()
-    memo = set()
-    nucNames = [nucName.decode() for nucName in nuclides]
-    difference = set(nucNames).difference(memo)
-    while any(difference):
-        newNucs = set()
-        nuclide = difference.pop()
-        memo.add(nuclide)
-        # Skip the nuclide if it is not `active` in the burn-chain
-        if nuclide not in activeNuclides:
-            continue
-
-        nuclideObj = byName[nuclide]
-
-        for interaction in nuclideObj.trans + nuclideObj.decays:
-            try:
-                # Interaction nuclides can only be added to the number density arrays if they
-                # are a part of the user-defined active nuclides
-                productNuclide = interaction.getPreferredProduct(activeNuclides)
-                if productNuclide not in nucNames:
-                    newNucs.add(productNuclide.encode())
-            except KeyError:
-                # Keep track of the first production nuclide
-                missingActiveNuclides.add(interaction.productNuclides)
-
-        # add the new nuclides to the number density arrays
-        newNDens = np.zeros(len(newNucs), dtype=np.float64)
-        nuclides = np.append(nuclides, list(newNucs))
-        numberDensities = np.append(numberDensities, newNDens)
-
-        nucNames = [nucName.decode() for nucName in nuclides]
-        difference = set(nucNames).difference(memo)
-
-    if burnChainImposed and missingActiveNuclides:
-        _failOnMissingActiveNuclides(missingActiveNuclides)
-
-    return nuclides, numberDensities
-
-
-def _failOnMissingActiveNuclides(missingActiveNuclides):
-    """Raise ValueError with notification of which nuclides to include in the burn-chain."""
-    msg = "Missing active nuclides in loading file. Add the following nuclides:"
-    for i, nucList in enumerate(missingActiveNuclides, 1):
-        msg += "\n {} - ".format(i)  # Index of
-        for j, nuc in enumerate(nucList, 1):
-            delimiter = " or " if j < len(nucList) else ""
-            msg += "{}{}".format(nuc, delimiter)
-    raise ValueError(msg)
+    """Pass through to NuclideBases.initReachableActiveNuclidesThroughBurnChain() for the global NuclideBases object."""
+    global nuclideBases
+    return nuclideBases.initReachableActiveNuclidesThroughBurnChain(nuclides, numberDensities, activeNuclides)
 
 
 def isotopes(z):
+    # TODO: Seems like this is in the wrong file.
     return elements.byZ[z].nuclides
 
 
 def getIsotopics(nucName):
-    """Expand elemental nuc name to isotopic nuc bases."""
-    nb = byName[nucName]
-    if isinstance(nb, (LumpNuclideBase, DummyNuclideBase)):
-        # skip lumped fission products or dumps
-        return []
-    elif isinstance(nb, NaturalNuclideBase):
-        isotopics = nb.getNaturalIsotopics()
-    else:
-        isotopics = [nb]
-    return isotopics
+    """Pass through to NuclideBases.getIsotopics() for the global NuclideBases object."""
+    global nuclideBases
+    return nuclideBases.getIsotopics(nucName)
 
 
 def fromName(name):
-    """Return a nuclide from its name."""
-    matches = [nn for nn in instances if nn.name == name]
-    if len(matches) != 1:
-        raise Exception("Too many or too few ({}) matches for {}".format(len(matches), name))
-    return matches[0]
+    """Pass through to NuclideBases.fromName() for the global NuclideBases object."""
+    global nuclideBases
+    return nuclideBases.fromName(name)
 
 
 def isMonoIsotopicElement(name):
-    """Return true if this is the only naturally occurring isotope of its element."""
-    base = byName[name]
-    return base.abundance > 0 and len([e for e in base.element.nuclides if e.abundance > 0]) == 1
+    """Pass through to NuclideBases.isMonoIsotopicElement() for the global NuclideBases object."""
+    global nuclideBases
+    return nuclideBases.isMonoIsotopicElement(name)
 
 
 def where(predicate):
-    """
-    Return all :py:class:`INuclides <INuclide>` objects matching a condition.
-
-    Returns an iterator of :py:class:`INuclides <INuclide>` matching the specified condition.
-
-    Attributes
-    ----------
-    predicate: lambda
-        A lambda, or function, accepting a :py:class:`INuclide` as a parameter
-
-    Examples
-    --------
-    >>> from armi.nucDirectory import nuclideBases
-    >>> [nn.name for nn in nuclideBases.where(lambda nb: 'Z' in nb.name)]
-    ['ZN64', 'ZN66', 'ZN67', 'ZN68', 'ZN70', 'ZR90', 'ZR91', 'ZR92', 'ZR94', 'ZR96', 'ZR93', 'ZR95', 'ZR']
-
-    >>> # in order to get length, convert to list
-    >>> isomers90 = list(nuclideBases.where(lambda nb: nb.a == 95))
-    >>> len(isomers90)
-    3
-    >>> for iso in isomers: print(iso)
-    <NuclideBase MO95: Z:42, A:95, S:0, label:MO2N>
-    <NuclideBase NB95: Z:41, A:95, S:0, label:NB2N>
-    <NuclideBase ZR95: Z:40, A:95, S:0, label:ZR2N>
-    """
-    for nuc in instances:
-        if predicate(nuc):
-            yield (nuc)
+    """Pass through to NuclideBases.where() for the global NuclideBases object."""
+    global nuclideBases
+    return nuclideBases.where(predicate)
 
 
 def single(predicate):
-    """
-    Return a single :py:class:`INuclide` object meeting the specified condition.
-
-    Similar to :py:func:`where`, this function uses a lambda input to filter
-    the :py:attr:`INuclide instances <instances>`. If there is not 1 and only
-    1 match for the specified condition, an exception is raised.
-
-    Examples
-    --------
-    >>> from armi.nucDirectory import nuclideBases
-    >>> nuclideBases.single(lambda nb: nb.name == 'C')
-    <NaturalNuclideBase C: Z:6, w:12.0107358968, label:C>
-
-    >>> nuclideBases.single(lambda nb: nb.z == 95 and nb.a == 242 and nb.state == 1)
-    <NuclideBase AM242M: Z:95, A:242, S:1, label:AM4C>
-    """
-    matches = [nuc for nuc in instances if predicate(nuc)]
-    if len(matches) != 1:
-        raise IndexError(
-            "Expected single match, but got {} matches:\n  {}".format(
-                len(matches), "\n  ".join(str(mo) for mo in matches)
-            )
-        )
-    return matches[0]
+    """Pass through to NuclideBases.single() for the global NuclideBases object."""
+    global nuclideBases
+    return nuclideBases.single(predicate)
 
 
 def changeLabel(nuclideBase, newLabel):
-    """
-    Updates a nuclide label and modifies the ``byLabel`` look-up dictionary.
-
-    Notes
-    -----
-    Since nuclide objects are defined and stored globally, any change to the
-    attributes will be maintained.
-    """
-    nuclideBase.label = newLabel
-    byLabel[newLabel] = nuclideBase
+    """Pass through to NuclideBases.changeLabel() for the global NuclideBases object."""
+    global nuclideBases
+    nuclideBases.changeLabel(nuclideBase, newLabel)
 
 
 def getDepletableNuclides(activeNuclides, obj):
-    """Get nuclides in this object that are in the burn chain."""
-    return sorted(set(activeNuclides) & set(obj.getNuclides()))
+    """Pass through to NuclideBases.getDepletableNuclides() for the global NuclideBases object."""
+    global nuclideBases
+    return nuclideBases.getDepletableNuclides(activeNuclides, obj)
 
 
 def imposeBurnChain(burnChainStream):
-    """
-    Apply transmutation and decay information to each nuclide.
-
-    Notes
-    -----
-    You cannot impose a burn chain twice. Doing so would require that you clean out the
-    transmutations and decays from all the module-level nuclide bases, which generally
-    requires that you rebuild them. But rebuilding those is not an option because some
-    of them get set as class-level attributes and would be orphaned. If a need to change
-    burn chains mid-run re-arises, then a better nuclideBase-level burnchain cleanup
-    should be implemented so the objects don't have to change identity.
-
-    Notes
-    -----
-    We believe the transmutation information would probably be better stored on a
-    less fundamental place (e.g. not on the NuclideBase).
-
-    See Also
-    --------
-    armi.nucDirectory.transmutations : describes file format
-    """
-    global burnChainImposed
-    if burnChainImposed:
-        # the only time this should happen is if in a unit test that has already
-        # processed conftest.py and is now building a Case that also imposes this.
-        runLog.warning("Burn chain already imposed. Skipping reimposition.")
-        return
-    burnChainImposed = True
-    yaml = YAML(typ="rt")
-    yaml.allow_duplicate_keys = False
-    burnData = yaml.load(burnChainStream)
-
-    for nucName, burnInfo in burnData.items():
-        nuclide = byName[nucName]
-        # think of this protected stuff as "module level protection" rather than class.
-        nuclide._processBurnData(burnInfo)
+    """Pass through to NuclideBases.imposeBurnChain() for the global NuclideBases object."""
+    global nuclideBases
+    nuclideBases.imposeBurnChain(burnChainStream)
 
 
 def factory():
-    """
-    Reads data files to instantiate the :py:class:`INuclides <INuclide>`.
-
-    Reads NIST, MC**2 and burn chain data files to instantiate the :py:class:`INuclides <INuclide>`.
-    Also clears and fills in the
-    :py:data:`~armi.nucDirectory.nuclideBases.instances`,
-    :py:data:`byName`, :py:attr:`byLabel`, :py:data:`byMcc3IdEndfbVII0`, and
-    :py:data:`byMcc3IdEndfbVII1` module attributes. This method is automatically run upon
-    loading the module, hence it is not usually necessary to re-run it unless there is a
-    change to the data files, which should not happen during run time, or a *bad*
-    :py:class`INuclide` is created.
-
-    Notes
-    -----
-    This cannot be run more than once. NuclideBase instances are used throughout the ARMI
-    ecosystem and are even class attributes in some cases. Re-instantiating them would orphan
-    any existing ones and break everything.
-    """
-    if len(instances) != 0:
-        raise RuntimeError(
-            "Nuclides are already initialized and cannot be re-initialized unless "
-            "`nuclideBases.destroyGlobalNuclides` is called first."
-        )
-    addNuclideBases()
-    __addNaturalNuclideBases()
-    __addDummyNuclideBases()
-    __addLumpedFissionProductNuclideBases()
-    updateNuclideBasesForSpecialCases()
-    readMCCNuclideData()
-    __renormalizeNuclideToElementRelationship()
-    __deriveElementalWeightsByNaturalNuclideAbundances()
-
-    # reload the thermal scattering library with the new nuclideBases too
-    from armi.nucDirectory import thermalScattering
-
-    thermalScattering.factory()
-
-
-def addNuclideBases():
-    """
-    Read natural abundances of any natural nuclides.
-
-    This adjusts already-existing NuclideBases and Elements with the new information.
-
-    .. impl:: Separating natural abundance data from code.
-        :id: I_ARMI_ND_DATA0
-        :implements: R_ARMI_ND_DATA
-
-        This function reads the ``nuclides.dat`` file from the ARMI resources
-        folder. This file contains metadata for 4,614 nuclides, including
-        number of protons, number of neutrons, atomic number, excited
-        state, element symbol, atomic mass, natural abundance, half-life,
-        and spontaneous fission yield. The data in ``nuclides.dat`` have been
-        collected from multiple different sources; the references are given
-        in comments at the top of that file.
-    """
-    with open(os.path.join(context.RES, "nuclides.dat")) as f:
-        for line in f:
-            # Skip header lines
-            if line.startswith("#") or line.startswith("Z"):
-                continue
-            lineData = line.split()
-            _z = int(lineData[0])
-            _n = int(lineData[1])
-            a = int(lineData[2])
-            state = int(lineData[3])
-            sym = lineData[4].upper()
-            mass = float(lineData[5])
-            abun = float(lineData[6])
-            halflife = lineData[7]
-            if halflife == "inf":
-                halflife = np.inf
-            else:
-                halflife = float(halflife)
-            nuSF = float(lineData[8])
-
-            element = elements.bySymbol[sym]
-            nb = NuclideBase(element, a, mass, abun, state, halflife)
-            nb.nuSF = nuSF
-
-
-def __addNaturalNuclideBases():
-    """Generates a complete set of nuclide bases for each naturally occurring element."""
-    for element in elements.byZ.values():
-        if element.symbol not in byName:
-            if element.isNaturallyOccurring():
-                NaturalNuclideBase(element.symbol, element)
-
-
-def __addDummyNuclideBases():
-    """
-    Generates a set of dummy nuclides.
-
-    Notes
-    -----
-    These nuclides can be used to truncate a depletion / burn-up chain within the
-    """
-    DummyNuclideBase(name="DUMP1", weight=10.0)
-    DummyNuclideBase(name="DUMP2", weight=240.0)
-
-
-def __addLumpedFissionProductNuclideBases():
-    LumpNuclideBase(name="LFP35", weight=233.273)
-    LumpNuclideBase(name="LFP38", weight=235.78)
-    LumpNuclideBase(name="LFP39", weight=236.898)
-    LumpNuclideBase(name="LFP40", weight=237.7)
-    LumpNuclideBase(name="LFP41", weight=238.812)
-    LumpNuclideBase(name="LREGN", weight=1.0)
-
-
-def readMCCNuclideData():
-    r"""Read in the label data for the MC2-2 and MC2-3 cross section codes to the nuclide bases.
-
-    .. impl:: Separating MCC data from code.
-        :id: I_ARMI_ND_DATA1
-        :implements: R_ARMI_ND_DATA
-
-        This function reads the mcc-nuclides.yaml file from the ARMI resources
-        folder. This file contains the MC\ :sup:`2`-2 ID (from ENDF/B-V.2) and MC\ :sup:`2`-3 ID
-        (from ENDF/B-VII.0) for all nuclides in MC\ :sup:`2`. The ``mcc2id``,
-        ``mcc3idEndfVII0``, and  ``mcc3idEndfVII1`` attributes of each :py:class:`NuclideBase
-        <armi.nucDirectory.nuclideBases.NuclideBase>` instance are updated as
-        the data is read, and the global dictionaries ``byMcc2Id``
-        ``byMcc3IdEndfVII0`` and ``byMcc3IdEndfVII1`` are populated with the nuclide bases
-        keyed by their corresponding ID for each code.
-    """
-    global byMcc2Id
-    global byMcc3Id
-    global byMcc3IdEndfbVII0
-    global byMcc3IdEndfbVII1
-
-    with open(os.path.join(context.RES, "mcc-nuclides.yaml"), "r") as f:
-        yaml = YAML(typ="rt")
-        nuclides = yaml.load(f)
-
-    for n in nuclides:
-        nb = byName[n]
-        mcc2id = nuclides[n]["ENDF/B-V.2"]
-        mcc3idEndfbVII0 = nuclides[n]["ENDF/B-VII.0"]
-        mcc3idEndfbVII1 = nuclides[n]["ENDF/B-VII.1"]
-        if mcc2id is not None:
-            nb.mcc2id = mcc2id
-            byMcc2Id[nb.getMcc2Id()] = nb
-        if mcc3idEndfbVII0 is not None:
-            nb.mcc3idEndfbVII0 = mcc3idEndfbVII0
-            byMcc3IdEndfbVII0[nb.getMcc3IdEndfbVII0()] = nb
-        if mcc3idEndfbVII1 is not None:
-            nb.mcc3idEndfbVII1 = mcc3idEndfbVII1
-            byMcc3IdEndfbVII1[nb.getMcc3IdEndfbVII1()] = nb
-
-    # Have the byMcc3Id dictionary be VII.1 IDs.
-    byMcc3Id = byMcc3IdEndfbVII1
-
-
-def updateNuclideBasesForSpecialCases():
-    """
-    Update the nuclide bases for special case name changes.
-
-    .. impl:: The special case name Am242g is supported.
-        :id: I_ARMI_ND_ISOTOPES6
-        :implements: R_ARMI_ND_ISOTOPES
-
-        This function updates the keys for the :py:class:`NuclideBase
-        <armi.nucDirectory.nuclideBases.NuclideBase>` instances for Am-242m and
-        Am-242 in the ``byName`` and ``byDBName`` global dictionaries.  This
-        function associates the more common isomer Am-242m with the name
-        "AM242", and uses "AM242G" to denote the ground state.
-
-    Notes
-    -----
-    This function is specifically added to change the definition of
-    `AM242` to refer to its metastable isomer, `AM242M` by default. `AM242M`
-    is most common isomer of `AM242` and is typically the desired isomer
-    when being requested rather than than the ground state (i.e., S=0) of
-    `AM242`.
-    """
-    # Change the name of `AM242` to specific represent its ground state.
-    am242g = byName["AM242"]
-    am242g.name = "AM242G"
-    byName["AM242G"] = am242g
-    byDBName[byName["AM242G"].getDatabaseName()] = am242g
-
-    # Update the pointer of `AM242` to refer to `AM242M`.
-    am242m = byName["AM242M"]
-    byName["AM242"] = am242m
-    byDBName["nAm242"] = am242m
-    byDBName[byName["AM242"].getDatabaseName()] = am242m
-
-
-def __renormalizeNuclideToElementRelationship():
-    for nuc in instances:
-        if nuc.element is not None:
-            nuc.element = elements.byZ[nuc.z]
-            nuc.element.append(nuc)
-
-
-def __deriveElementalWeightsByNaturalNuclideAbundances():
-    """Derives and sets the standard atomic weights for each element that has naturally occurring nuclides."""
-    for element in elements.byName.values():
-        numer = 0.0
-        denom = 0.0
-        for nb in element.getNaturalIsotopics():
-            numer += nb.weight * nb.abundance
-            denom += nb.abundance
-
-        if denom:
-            element.standardWeight = numer / denom
-
-
-def addGlobalNuclide(nuclide: NuclideBase):
-    """Add an element to the global dictionaries."""
-    if nuclide.name in byName or nuclide.getDatabaseName() in byDBName or nuclide.label in byLabel:
-        raise ValueError(f"{nuclide} has already been added and cannot be duplicated.")
-
-    instances.append(nuclide)
-    byName[nuclide.name] = nuclide
-    byDBName[nuclide.getDatabaseName()] = nuclide
-    byLabel[nuclide.label] = nuclide
-
-    # Add look-up based on the MCNP nuclide ID
-    if isinstance(nuclide, IMcnpNuclide):
-        if nuclide.getMcnpId() in byMcnpId:
-            raise ValueError(
-                f"{nuclide} with McnpId {nuclide.getMcnpId()} has already been added and cannot be duplicated."
-            )
-        byMcnpId[nuclide.getMcnpId()] = nuclide
-    if not isinstance(nuclide, (NaturalNuclideBase, LumpNuclideBase, DummyNuclideBase)):
-        # There are no AZS ID for elements / natural nuclides, or fictitious lump or dummy nuclides
-        byAAAZZZSId[nuclide.getAAAZZZSId()] = nuclide
-
-
-def destroyGlobalNuclides():
-    """Delete all global nuclide bases."""
+    """Pass through to NuclideBases.factory() for the global NuclideBases object."""
+    print("xxxxxxxxxxxxxxxxxxxxxxxxxx NuclideBases factory xxxxxxxxxxxxxxxxxxxxxxxxxx")
+    global nuclideBases
+    global burnChainImposed
     global instances
     global byName
     global byDBName
@@ -1431,19 +1038,54 @@ def destroyGlobalNuclides():
     global byMcnpId
     global byAAAZZZSId
 
-    instances = []
-    byName.clear()
-    byDBName.clear()
-    byLabel.clear()
-    byMcc2Id.clear()
-    byMcc3Id.clear()
-    byMcc3IdEndfbVII1.clear()
-    byMcc3IdEndfbVII0.clear()
-    byMcnpId.clear()
-    byAAAZZZSId.clear()
+    nuclideBases = NuclideBases()
+
+    instances = nuclideBases.instances
+    burnChainImposed = nuclideBases.burnChainImposed
+    byName = nuclideBases.byName
+    byDBName = nuclideBases.byDBName
+    byLabel = nuclideBases.byLabel
+    byMcc2Id = nuclideBases.byMcc2Id
+    byMcc3Id = nuclideBases.byMcc3Id  # for backwards compatibility. Identical to byMcc3IdEndfbVII1
+    byMcc3IdEndfbVII0 = nuclideBases.byMcc3IdEndfbVII0
+    byMcc3IdEndfbVII1 = nuclideBases.byMcc3IdEndfbVII1
+    byMcnpId = nuclideBases.byMcnpId
+    byAAAZZZSId = nuclideBases.byAAAZZZSId
+
+
+def addNuclideBases():
+    """Pass through to NuclideBases.addNuclideBases() for the global NuclideBases object."""
+    global nuclideBases
+    nuclideBases.addNuclideBases()
+
+
+def readMCCNuclideData():
+    """Pass through to NuclideBases.readMCCNuclideData() for the global NuclideBases object."""
+    global nuclideBases
+    nuclideBases.readMCCNuclideData()
+
+
+def updateNuclideBasesForSpecialCases():
+    """Pass through to NuclideBases.updateNuclideBasesForSpecialCases() for the global NuclideBases object."""
+    global nuclideBases
+    nuclideBases.updateNuclideBasesForSpecialCases()
+
+
+def addGlobalNuclide(nuclide: NuclideBase):
+    """Pass through to NuclideBases.addNuclide() for the global NuclideBases object."""
+    global nuclideBases
+    nuclideBases.addNuclide(nuclide)
+
+
+def destroyGlobalNuclides():
+    """Pass through to NuclideBases.clear() for the global NuclideBases object."""
+    global nuclideBases
+    nuclideBases.clear()
 
 
 """
+TODO: Document that this global stuff is on its way out.
+
 TODO: Above this point is the old "global nuclides" code. Soon to be deleted.
       Below this point is the new code.
 """
@@ -1536,7 +1178,7 @@ class NuclideBases:
         # reload the thermal scattering library with the new nuclideBases too
         from armi.nucDirectory import thermalScattering
 
-        thermalScattering.factory()
+        thermalScattering.factory(self.byName)
 
     def initReachableActiveNuclidesThroughBurnChain(self, nuclides, numberDensities, activeNuclides):
         """
@@ -1554,7 +1196,7 @@ class NuclideBases:
             Active nuclides defined on the reactor blueprints object. See: armi.reactor.blueprints.py
         """
         if not self.burnChainImposed:
-            return
+            return nuclides, numberDensities
 
         missingActiveNuclides = set()
         memo = set()
@@ -1728,12 +1370,14 @@ class NuclideBases:
         armi.nucDirectory.transmutations : describes file format
         """
         if self.burnChainImposed:
-            # The only time this should happen is if in a unit test that has already processed
-            # conftest.py and is now building a Case that also imposes this.
+            # The only time this should happen is if in a unit test that has already processed conftest.py and is now
+            # building a Case that also imposes this.
             runLog.warning("Burn chain already imposed. Skipping reimposition.")
             return
 
         self.burnChainImposed = True
+        global burnChainImposed
+        burnChainImposed = True
         yaml = YAML(typ="rt")
         yaml.allow_duplicate_keys = False
         burnData = yaml.load(burnChainStream)
@@ -1797,7 +1441,7 @@ class NuclideBases:
 
         Notes
         -----
-        These nuclides can be used to truncate a depletion / burn-up chain within the
+        These nuclides can be used to truncate a depletion / burn-up chain within the MC2 program.
         """
         self.addNuclide(DummyNuclideBase(name="DUMP1", weight=10.0, skipGlobal=True))
         self.addNuclide(DummyNuclideBase(name="DUMP2", weight=240.0, skipGlobal=True))
@@ -1896,3 +1540,6 @@ class NuclideBases:
 
             if denom:
                 element.standardWeight = numer / denom
+
+
+factory()

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -1082,18 +1082,11 @@ def destroyGlobalNuclides():
     nuclideBases.clear()
 
 
-"""
-TODO: Document that this global stuff is on its way out.
-
-TODO: Above this point is the old "global nuclides" code. Soon to be deleted.
-      Below this point is the new code.
-"""
-
-
 class NuclideBases:
     """
-    TODO: This is the class I am crafting to replace global nuclides.
-    To start with, I will keep everything global, but use this class.
+    A container for all the nuclide information in the simulation.
+
+    By design, you would only expect to have one instance of this object in memory during a simulation.
     """
 
     def __init__(self):
@@ -1113,6 +1106,7 @@ class NuclideBases:
         self.factory()
 
     def clear(self):
+        """Empty all the data containers in this object."""
         self.burnChainImposed = False
         self.instances = []
         self.byName = {}
@@ -1247,7 +1241,7 @@ class NuclideBases:
         raise ValueError(msg)
 
     def isotopes(self, z: int):
-        """TODO."""
+        """TODO: This seems like it's in the wrong file."""
         return elements.byZ[z].nuclides
 
     def getIsotopics(self, nucName):
@@ -1446,7 +1440,7 @@ class NuclideBases:
         self.addNuclide(DummyNuclideBase(name="DUMP2", weight=240.0, skipGlobal=True))
 
     def __addLumpedFissionProductNuclideBases(self):
-        """TODO."""
+        """Generates a set of nuclides for use as lumped fission products."""
         self.addNuclide(LumpNuclideBase(name="LFP35", weight=233.273, skipGlobal=True))
         self.addNuclide(LumpNuclideBase(name="LFP38", weight=235.78, skipGlobal=True))
         self.addNuclide(LumpNuclideBase(name="LFP39", weight=236.898, skipGlobal=True))

--- a/armi/nucDirectory/tests/test_elements.py
+++ b/armi/nucDirectory/tests/test_elements.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for elements."""
+"""Tests for Elements."""
 
 import os
 import unittest
@@ -79,8 +79,7 @@ class TestElement(unittest.TestCase):
         with mockRunLogs.BufferLog():
             nuclideBases.destroyGlobalNuclides()
             nuclideBases.factory()
-            # Ensure that the burn chain data is initialized after clearing
-            # out the nuclide data and reinitializing it.
+            # Ensure that the burn chain data is initialized after clearing out the nuclide data and reinitializing it.
             nuclideBases.burnChainImposed = False
             with open(os.path.join(RES, "burn-chain.yaml"), "r") as burnChainStream:
                 nuclideBases.imposeBurnChain(burnChainStream)

--- a/armi/nucDirectory/tests/test_elementsGlobal.py
+++ b/armi/nucDirectory/tests/test_elementsGlobal.py
@@ -13,20 +13,21 @@
 # limitations under the License.
 """Tests for elements."""
 
+import os
 import unittest
 
-from armi.nucDirectory.elements import Element, Elements
+from armi import nuclideBases
+from armi.context import RES
+from armi.nucDirectory import elements
+from armi.tests import mockRunLogs
 
 
 class TestElement(unittest.TestCase):
-    def setUp(self):
-        self.elements = Elements()
-
     def test_elements_elementBulkProperties(self):
-        numElements = len(self.elements.byZ)
-        self.assertEqual(numElements, len(self.elements.byZ.values()))
-        self.assertEqual(numElements, len(self.elements.byName))
-        self.assertEqual(numElements, len(self.elements.bySymbol))
+        numElements = len(elements.byZ)
+        self.assertEqual(numElements, len(elements.byZ.values()))
+        self.assertEqual(numElements, len(elements.byName))
+        self.assertEqual(numElements, len(elements.bySymbol))
 
     def test_element_elementByNameReturnsElement(self):
         """Get elements by name.
@@ -35,8 +36,8 @@ class TestElement(unittest.TestCase):
             :id: T_ARMI_ND_ELEMENTS0
             :tests: R_ARMI_ND_ELEMENTS
         """
-        for ee in self.elements.byZ.values():
-            self.assertIs(ee, self.elements.byName[ee.name])
+        for ee in elements.byZ.values():
+            self.assertIs(ee, elements.byName[ee.name])
 
     def test_element_elementByZReturnsElement(self):
         """Get elements by Z.
@@ -45,8 +46,8 @@ class TestElement(unittest.TestCase):
             :id: T_ARMI_ND_ELEMENTS1
             :tests: R_ARMI_ND_ELEMENTS
         """
-        for ee in self.elements.byZ.values():
-            self.assertIs(ee, self.elements.byZ[ee.z])
+        for ee in elements.byZ.values():
+            self.assertIs(ee, elements.byZ[ee.z])
 
     def test_element_elementBySymbolReturnsElement(self):
         """Get elements by symbol.
@@ -55,28 +56,36 @@ class TestElement(unittest.TestCase):
             :id: T_ARMI_ND_ELEMENTS2
             :tests: R_ARMI_ND_ELEMENTS
         """
-        for ee in self.elements.byZ.values():
-            self.assertIs(ee, self.elements.bySymbol[ee.symbol])
+        for ee in elements.byZ.values():
+            self.assertIs(ee, elements.bySymbol[ee.symbol])
 
     def test_element_addExistingElementFails(self):
-        for ee in self.elements.byZ.values():
+        for ee in elements.byZ.values():
             with self.assertRaises(ValueError):
-                self.elements.Element(ee.z, ee.symbol, ee.name, skipGlobal=True)
+                elements.Element(ee.z, ee.symbol, ee.name)
 
     def test_element_addedElementAppearsInElementList(self):
-        self.assertNotIn("bacon", self.elements.byName)
-        self.assertNotIn(999, self.elements.byZ)
-        self.assertNotIn("BZ", self.elements.bySymbol)
-        self.elements.addElement(Element(999, "BZ", "bacon", skipGlobal=True))
-        self.assertIn("bacon", self.elements.byName)
-        self.assertIn(999, self.elements.byZ)
-        self.assertIn("BZ", self.elements.bySymbol)
+        self.assertNotIn("bacon", elements.byName)
+        self.assertNotIn(999, elements.byZ)
+        self.assertNotIn("BZ", elements.bySymbol)
+        elements.Element(999, "BZ", "bacon")
+        self.assertIn("bacon", elements.byName)
+        self.assertIn(999, elements.byZ)
+        self.assertIn("BZ", elements.bySymbol)
+        # re-initialize the elements
+        with mockRunLogs.BufferLog():
+            nuclideBases.destroyGlobalNuclides()
+            nuclideBases.factory()
+            # Ensure that the burn chain data is initialized after clearing
+            # out the nuclide data and reinitializing it.
+            nuclideBases.burnChainImposed = False
+            with open(os.path.join(RES, "burn-chain.yaml"), "r") as burnChainStream:
+                nuclideBases.imposeBurnChain(burnChainStream)
 
     def test_elementGetNatrualIsotpicsOnlyRetrievesAbund(self):
-        for ee in self.elements.byZ.values():
+        for ee in elements.byZ.values():
             if not ee.isNaturallyOccurring():
                 continue
-
             for nuc in ee.getNaturalIsotopics():
                 self.assertGreater(nuc.abundance, 0.0)
                 self.assertGreater(nuc.a, 0)
@@ -85,14 +94,14 @@ class TestElement(unittest.TestCase):
         """
         Test isNaturallyOccurring method by manually testing all elements.
 
-        Uses RIPL definitions of naturally occurring. Protactinium is debated as naturally occurring. Yeah it exists as
-        a U235 decay product but it's kind of pseudo-natural.
+        Uses RIPL definitions of naturally occurring. Protactinium is debated as naturally
+        occurring. Yeah it exists as a U235 decay product but it's kind of pseudo-natural.
 
         .. test:: Get elements by Z to show if they are naturally occurring.
             :id: T_ARMI_ND_ELEMENTS3
             :tests: R_ARMI_ND_ELEMENTS
         """
-        for ee in self.elements.byZ.values():
+        for ee in elements.byZ.values():
             if ee.z == 43 or ee.z == 61 or 84 <= ee.z <= 89 or ee.z >= 93:
                 self.assertFalse(ee.isNaturallyOccurring())
             else:
@@ -100,10 +109,9 @@ class TestElement(unittest.TestCase):
                 self.assertTrue(nat)
 
     def test_abundancesAddToOne(self):
-        for ee in self.elements.byZ.values():
+        for ee in elements.byZ.values():
             if not ee.isNaturallyOccurring():
                 continue
-
             totAbund = sum([iso.abundance for iso in ee.nuclides])
             self.assertAlmostEqual(
                 totAbund,
@@ -118,7 +126,7 @@ class TestElement(unittest.TestCase):
             :id: T_ARMI_ND_ELEMENTS4
             :tests: R_ARMI_ND_ELEMENTS
         """
-        for ee in self.elements.byZ.values():
+        for ee in elements.byZ.values():
             if ee.z > 89:
                 self.assertTrue(ee.isHeavyMetal())
             else:

--- a/armi/nucDirectory/tests/test_nuclideBasesGlobal.py
+++ b/armi/nucDirectory/tests/test_nuclideBasesGlobal.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for NuclideBases."""
+"""Tests for nuclideBases."""
 
 import math
 import os
@@ -22,36 +22,31 @@ import unittest
 from ruamel.yaml import YAML
 
 from armi.context import RES
-from armi.nucDirectory.nuclideBases import (
-    DummyNuclideBase,
-    LumpNuclideBase,
-    NaturalNuclideBase,
-    NuclideBases,
-)
+from armi.nucDirectory import nuclideBases
 from armi.nucDirectory.tests import NUCDIRECTORY_TESTS_DEFAULT_DIR_PATH
 from armi.utils.units import AVOGADROS_NUMBER, CURIE_PER_BECQUEREL, SECONDS_PER_HOUR
 
 
-class TestNuclideBases(unittest.TestCase):
+class TestNuclide(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.nucDirectoryTestsPath = NUCDIRECTORY_TESTS_DEFAULT_DIR_PATH
-        cls.nuclideBases = NuclideBases()
-
+        nuclideBases.destroyGlobalNuclides()
+        nuclideBases.factory()
         # Ensure that the burn chain data is initialized before running these tests.
-        cls.nuclideBases.burnChainImposed = False
+        nuclideBases.burnChainImposed = False
         with open(os.path.join(RES, "burn-chain.yaml"), "r") as burnChainStream:
-            cls.nuclideBases.imposeBurnChain(burnChainStream)
+            nuclideBases.imposeBurnChain(burnChainStream)
 
     def test_nucBases_fromNameBadNameRaisesException(self):
         with self.assertRaises(KeyError):
-            self.nuclideBases.byName["Cat"]
+            nuclideBases.byName["Cat"]
 
     def test_nucBase_AllAbundancesAddToOne(self):
         for zz in range(1, 102):
-            nuclides = self.nuclideBases.isotopes(zz)
+            nuclides = nuclideBases.isotopes(zz)
             # We only process nuclides with measured masses. Some are purely theoretical, mostly over z=100
-            self.assertTrue(len(nuclides) > 0, msg=f"z={zz} unexpectedly has no nuclides")
+            self.assertTrue(len(nuclides) > 0, msg="z={} unexpectedly has no nuclides".format(zz))
             total = sum([nn.abundance for nn in nuclides if nn.a > 0])
             self.assertAlmostEqual(
                 any([nn.abundance > 0 for nn in nuclides]),
@@ -64,18 +59,18 @@ class TestNuclideBases(unittest.TestCase):
 
     def test_nucBases_AllLabelsAreUnique(self):
         labels = []
-        for nn in self.nuclideBases.instances:
-            self.assertTrue(nn.label not in labels, f"Label already exists: {nn.label}")
+        for nn in nuclideBases.instances:
+            self.assertTrue(nn.label not in labels, "Label already exists: {}".format(nn.label))
             labels.append(nn.label)
 
     def test_nucBases_NegativeZRaisesException(self):
         for _ in range(0, 5):
             with self.assertRaises(Exception):
-                self.nuclideBases.isotopes(random.randint(-1000, -1))
+                nuclideBases.isotopes(random.randint(-1000, -1))
 
     def test_nucBases_Z295RaisesException(self):
         with self.assertRaises(Exception):
-            self.nuclideBases.isotopes(295)
+            nuclideBases.isotopes(295)
 
     def test_nucBases_Mc2Elementals(self):
         notElemental = [
@@ -89,36 +84,36 @@ class TestNuclideBases(unittest.TestCase):
             "DUMP2",
             "LREGN",
         ]
-        for lump in self.nuclideBases.where(lambda nn: isinstance(nn, LumpNuclideBase)):
+        for lump in nuclideBases.where(lambda nn: isinstance(nn, nuclideBases.LumpNuclideBase)):
             if lump.name in notElemental:
-                self.assertIsInstance(lump, LumpNuclideBase)
+                self.assertIsInstance(lump, nuclideBases.LumpNuclideBase)
             else:
-                self.assertIsInstance(lump, NaturalNuclideBase)
+                self.assertIsInstance(lump, nuclideBases.NaturalNuclideBase)
 
     def test_LumpNucBaseGetNatIsotopDoesNotFail(self):
-        for nuc in self.nuclideBases.where(lambda nn: isinstance(nn, LumpNuclideBase) and nn.z == 0):
+        for nuc in nuclideBases.where(lambda nn: isinstance(nn, nuclideBases.LumpNuclideBase) and nn.z == 0):
             self.assertEqual(0, len(list(nuc.getNaturalIsotopics())), nuc)
 
     def test_NaturalNuclideBase_getNatrualIsotpics(self):
-        for nuc in self.nuclideBases.where(lambda nn: isinstance(nn, NaturalNuclideBase)):
+        for nuc in nuclideBases.where(lambda nn: isinstance(nn, nuclideBases.NaturalNuclideBase)):
             numNaturals = len(list(nuc.getNaturalIsotopics()))
             self.assertGreaterEqual(len(nuc.element.nuclides) - 1, numNaturals)
 
     def test_nucBases_singleFailsWithMultipleMatches(self):
         with self.assertRaises(Exception):
-            self.nuclideBases.single(lambda nuc: nuc.z == 92)
+            nuclideBases.single(lambda nuc: nuc.z == 92)
 
     def test_nucBases_singleFailsWithNoMatches(self):
         with self.assertRaises(Exception):
-            self.nuclideBases.single(lambda nuc: nuc.z == 1000)
+            nuclideBases.single(lambda nuc: nuc.z == 1000)
 
     def test_nucBases_singleIsPrettySpecific(self):
-        u235 = self.nuclideBases.single(lambda nuc: nuc.name == "U235")
+        u235 = nuclideBases.single(lambda nuc: nuc.name == "U235")
         self.assertEqual(235, u235.a)
         self.assertEqual(92, u235.z)
 
     def test_natNucStomicWgtIsAvgOfNatIsotopes(self):
-        for natNuk in self.nuclideBases.where(lambda nn: isinstance(nn, NaturalNuclideBase)):
+        for natNuk in nuclideBases.where(lambda nn: isinstance(nn, nuclideBases.NaturalNuclideBase)):
             atomicMass = 0.0
             for natIso in natNuk.getNaturalIsotopics():
                 atomicMass += natIso.abundance * natIso.weight
@@ -132,16 +127,16 @@ class TestNuclideBases(unittest.TestCase):
             :tests: R_ARMI_ND_ISOTOPES
         """
         count = 0
-        for nuc in self.nuclideBases.where(lambda nn: nn.name == nn.label):
+        for nuc in nuclideBases.where(lambda nn: nn.name == nn.label):
             count += 1
-            self.assertEqual(nuc, self.nuclideBases.byName[nuc.name])
-            self.assertEqual(nuc, self.nuclideBases.byDBName[nuc.getDatabaseName()])
-            self.assertEqual(nuc, self.nuclideBases.byLabel[nuc.label])
+            self.assertEqual(nuc, nuclideBases.byName[nuc.name])
+            self.assertEqual(nuc, nuclideBases.byDBName[nuc.getDatabaseName()])
+            self.assertEqual(nuc, nuclideBases.byLabel[nuc.label])
         self.assertGreater(count, 10)
 
     def test_nucBases_imposeBurnChainDecayBulkStats(self):
         """Test must be updated manually when burn chain is modified."""
-        decayers = list(self.nuclideBases.where(lambda nn: len(nn.decays) > 0))
+        decayers = list(nuclideBases.where(lambda nn: len(nn.decays) > 0))
         self.assertTrue(decayers)
         for nuc in decayers:
             if nuc.name in [
@@ -161,21 +156,21 @@ class TestNuclideBases(unittest.TestCase):
         """
         Make sure all branches are equal to 1 for every transmutation type.
 
-        Exception: We allow 3e-4 threshold to account for ternary fissions, which are usually < 2e-4 per fission.
+        Exception: We allow 3e-4 threshold to account for ternary fissions,
+        which are usually < 2e-4 per fission.
         """
-        trasmuters = self.nuclideBases.where(lambda nn: len(nn.trans) > 0)
+        trasmuters = nuclideBases.where(lambda nn: len(nn.trans) > 0)
         self.assertTrue(trasmuters)
         for nuc in trasmuters:
             expected = len(set(tt.type for tt in nuc.trans))
             self.assertTrue(all(0.0 <= tt.branch <= 1.0 for tt in nuc.trans))
             actual = sum(tt.branch for tt in nuc.trans)
-            # ternary fission
             self.assertAlmostEqual(
                 expected,
                 actual,
-                msg=f"{nuc} has {expected} transmutation but the branches add up to {actual}",
+                msg="{0} has {1} transmutation but the branches add up to {2}".format(nuc, expected, actual),
                 delta=3e-4,
-            )
+            )  # ternary fission
 
     def test_nucBases_imposeBurn_nuSF(self):
         """Test the nuclide data from file (specifically neutrons / sponaneous fission).
@@ -184,7 +179,7 @@ class TestNuclideBases(unittest.TestCase):
             :id: T_ARMI_ND_DATA0
             :tests: R_ARMI_ND_DATA
         """
-        actual = {nn.name: nn.nuSF for nn in self.nuclideBases.where(lambda nn: nn.nuSF > 0.0)}
+        actual = {nn.name: nn.nuSF for nn in nuclideBases.where(lambda nn: nn.nuSF > 0.0)}
         expected = {
             "CM248": 3.1610,
             "BK249": 3.4000,
@@ -222,13 +217,13 @@ class TestNuclideBases(unittest.TestCase):
             self.assertEqual(val, expected[key])
 
     def test_nucBases_databaseNamesStartWith_n(self):
-        for nb in self.nuclideBases.instances:
+        for nb in nuclideBases.instances:
             self.assertEqual("n", nb.getDatabaseName()[0])
 
     def test_nucBases_AllDatabaseNamesAreUnique(self):
         self.assertEqual(
-            len(self.nuclideBases.instances),
-            len(set(nb.getDatabaseName() for nb in self.nuclideBases.instances)),
+            len(nuclideBases.instances),
+            len(set(nb.getDatabaseName() for nb in nuclideBases.instances)),
         )
 
     def test_nucBases_Am242m(self):
@@ -238,28 +233,28 @@ class TestNuclideBases(unittest.TestCase):
             :id: T_ARMI_ND_ISOTOPES1
             :tests: R_ARMI_ND_ISOTOPES
         """
-        am242m = self.nuclideBases.byName["AM242"]
-        self.assertEqual(am242m, self.nuclideBases.byName["AM242M"])
+        am242m = nuclideBases.byName["AM242"]
+        self.assertEqual(am242m, nuclideBases.byName["AM242M"])
         self.assertEqual("nAm242m", am242m.getDatabaseName())
-        self.assertEqual(am242m, self.nuclideBases.byDBName["nAm242"])
+        self.assertEqual(am242m, nuclideBases.byDBName["nAm242"])
         self.assertAlmostEqual(am242m.weight, 242.059601666)
 
-        am242g = self.nuclideBases.byName["AM242G"]
-        self.assertEqual(am242g, self.nuclideBases.byName["AM242G"])
+        am242g = nuclideBases.byName["AM242G"]
+        self.assertEqual(am242g, nuclideBases.byName["AM242G"])
         self.assertEqual("nAm242g", am242g.getDatabaseName())
-        self.assertEqual(am242g, self.nuclideBases.byDBName["nAm242g"])
+        self.assertEqual(am242g, nuclideBases.byDBName["nAm242g"])
 
     def test_nucBases_isHeavyMetal(self):
-        for nb in self.nuclideBases.where(lambda nn: nn.z <= 89):
+        for nb in nuclideBases.where(lambda nn: nn.z <= 89):
             self.assertFalse(nb.isHeavyMetal())
-        for nb in self.nuclideBases.where(lambda nn: nn.z > 89):
-            if isinstance(nb, (DummyNuclideBase, LumpNuclideBase)):
+        for nb in nuclideBases.where(lambda nn: nn.z > 89):
+            if isinstance(nb, (nuclideBases.DummyNuclideBase, nuclideBases.LumpNuclideBase)):
                 self.assertFalse(nb.isHeavyMetal())
             else:
                 self.assertTrue(nb.isHeavyMetal())
 
     def test_getDecay(self):
-        nb = list(self.nuclideBases.where(lambda nn: nn.z == 89))[0]
+        nb = list(nuclideBases.where(lambda nn: nn.z == 89))[0]
         # This test is a bit boring, because the test nuclide library is a bit boring.
         self.assertIsNone(nb.getDecay("sf"))
 
@@ -270,19 +265,19 @@ class TestNuclideBases(unittest.TestCase):
             :id: T_ARMI_ND_ISOTOPES2
             :tests: R_ARMI_ND_ISOTOPES
         """
-        self.assertEqual(self.nuclideBases.byName["U235"].getEndfMatNum(), "9228")
-        self.assertEqual(self.nuclideBases.byName["U238"].getEndfMatNum(), "9237")
-        self.assertEqual(self.nuclideBases.byName["PU239"].getEndfMatNum(), "9437")
-        self.assertEqual(self.nuclideBases.byName["TC99"].getEndfMatNum(), "4325")
-        self.assertEqual(self.nuclideBases.byName["AM242"].getEndfMatNum(), "9547")  # meta 1
-        self.assertEqual(self.nuclideBases.byName["CF252"].getEndfMatNum(), "9861")
-        self.assertEqual(self.nuclideBases.byName["NP237"].getEndfMatNum(), "9346")
-        self.assertEqual(self.nuclideBases.byName["PM151"].getEndfMatNum(), "6161")
-        self.assertEqual(self.nuclideBases.byName["PA231"].getEndfMatNum(), "9131")
+        self.assertEqual(nuclideBases.byName["U235"].getEndfMatNum(), "9228")
+        self.assertEqual(nuclideBases.byName["U238"].getEndfMatNum(), "9237")
+        self.assertEqual(nuclideBases.byName["PU239"].getEndfMatNum(), "9437")
+        self.assertEqual(nuclideBases.byName["TC99"].getEndfMatNum(), "4325")
+        self.assertEqual(nuclideBases.byName["AM242"].getEndfMatNum(), "9547")  # meta 1
+        self.assertEqual(nuclideBases.byName["CF252"].getEndfMatNum(), "9861")
+        self.assertEqual(nuclideBases.byName["NP237"].getEndfMatNum(), "9346")
+        self.assertEqual(nuclideBases.byName["PM151"].getEndfMatNum(), "6161")
+        self.assertEqual(nuclideBases.byName["PA231"].getEndfMatNum(), "9131")
 
     def test_NonMc2Nuclide(self):
         """Make sure nuclides that aren't in MC2 still get nuclide bases."""
-        nuc = self.nuclideBases.byName["YB154"]
+        nuc = nuclideBases.byName["YB154"]
         self.assertEqual(nuc.a, 154)
 
     def test_kryptonDecayConstants(self):
@@ -330,20 +325,24 @@ class TestNuclideBases(unittest.TestCase):
         ]
 
         for nucName, refDecayConstant in REF_KR_DECAY_CONSTANTS:
-            refNb = self.nuclideBases.byName[nucName]
+            refNb = nuclideBases.byName[nucName]
             decayConstantNb = math.log(2) / refNb.halflife
             try:
-                self.assertAlmostEqual((refDecayConstant - decayConstantNb) / refDecayConstant, 0, 6)
+                self.assertAlmostEqual(
+                    (refDecayConstant - decayConstantNb) / refDecayConstant,
+                    0,
+                    6,
+                )
             except ZeroDivisionError:
                 self.assertEqual(refDecayConstant, decayConstantNb)
             except AssertionError:
-                errorMessage = (
-                    f"{nucName} reference decay constant {refDecayConstant} ARMI decay constant {decayConstantNb}"
+                errorMessage = "{} reference decay constant {} ARMI decay constant {}".format(
+                    nucName, refDecayConstant, decayConstantNb
                 )
                 raise AssertionError(errorMessage)
 
         for nucName in ["XE134", "XE136", "EU151"]:
-            nb = self.nuclideBases.byName[nucName]
+            nb = nuclideBases.byName[nucName]
             decayConstantNb = math.log(2) / nb.halflife
             self.assertAlmostEqual(decayConstantNb, 0, places=3)
 
@@ -353,10 +352,11 @@ class TestNuclideBases(unittest.TestCase):
 
         Notes
         -----
-        The original definition of 1 Ci was based on the half-life of Ra-226 for 1 gram. The latest evaluations show
-        that 1 gram is defined as 0.988 Ci.
+        The original definition of 1 Ci was based on the half-life of Ra-226
+        for 1 gram. The latest evaluations show that 1 gram is defined as
+        0.988 Ci.
         """
-        ra226 = self.nuclideBases.byName["RA226"]
+        ra226 = nuclideBases.byName["RA226"]
         decayConstantRa226 = math.log(2) / ra226.halflife
         weight = ra226.weight
         mass = 1  # gram
@@ -376,12 +376,12 @@ class TestNuclideBases(unittest.TestCase):
             data = yaml.load(f)
             expectedNuclides = set([nuc for nuc in data.keys() if data[nuc]["ENDF/B-V.2"] is not None])
 
-        for nuc, nb in self.nuclideBases.byMcc2Id.items():
+        for nuc, nb in nuclideBases.byMcc2Id.items():
             self.assertIn(nb.name, expectedNuclides)
             self.assertEqual(nb.getMcc2Id(), nb.mcc2id)
             self.assertEqual(nb.getMcc2Id(), nuc)
 
-        self.assertEqual(len(self.nuclideBases.byMcc2Id), len(expectedNuclides))
+        self.assertEqual(len(nuclideBases.byMcc2Id), len(expectedNuclides))
 
     def test_loadMcc3EndfVII0Data(self):
         """Tests consistency with the `mcc-nuclides.yaml` input and the ENDF/B-VII.0 nuclides in the data model.
@@ -399,13 +399,13 @@ class TestNuclideBases(unittest.TestCase):
             data = yaml.load(f)
             expectedNuclides = set([nuc for nuc in data.keys() if data[nuc]["ENDF/B-VII.0"] is not None])
 
-        for nuc, nb in self.nuclideBases.byMcc3IdEndfbVII0.items():
+        for nuc, nb in nuclideBases.byMcc3IdEndfbVII0.items():
             self.assertIn(nb.name, expectedNuclides)
             self.assertEqual(nb.getMcc3IdEndfbVII0(), nb.mcc3idEndfbVII0)
             self.assertEqual(nb.getMcc3IdEndfbVII0(), nuc)
 
         # Subtract 1 nuclide due to DUMP2.
-        self.assertEqual(len(self.nuclideBases.byMcc3IdEndfbVII0), len(expectedNuclides) - 1)
+        self.assertEqual(len(nuclideBases.byMcc3IdEndfbVII0), len(expectedNuclides) - 1)
 
     def test_loadMcc3EndfVII1Data(self):
         """Tests consistency with the `mcc-nuclides.yaml` input and the ENDF/B-VII.1 nuclides in the data model.
@@ -423,15 +423,15 @@ class TestNuclideBases(unittest.TestCase):
             data = yaml.load(f)
             expectedNuclides = set([nuc for nuc in data.keys() if data[nuc]["ENDF/B-VII.1"] is not None])
 
-        for nuc, nb in self.nuclideBases.byMcc3IdEndfbVII1.items():
+        for nuc, nb in nuclideBases.byMcc3IdEndfbVII1.items():
             self.assertIn(nb.name, expectedNuclides)
             self.assertEqual(nb.getMcc3IdEndfbVII1(), nb.mcc3idEndfbVII1)
             self.assertEqual(nb.getMcc3IdEndfbVII1(), nuc)
             self.assertEqual(nb.getMcc3Id(), nb.mcc3idEndfbVII1)
             self.assertEqual(nb.getMcc3Id(), nuc)
 
-        # Subtract 1 nuclide due to DUMP2
-        self.assertEqual(len(self.nuclideBases.byMcc3IdEndfbVII1), len(expectedNuclides) - 1)
+        # Subtract 1 nuclide due to DUMP2.
+        self.assertEqual(len(nuclideBases.byMcc3IdEndfbVII1), len(expectedNuclides) - 1)
 
 
 class TestAAAZZZSId(unittest.TestCase):
@@ -442,9 +442,12 @@ class TestAAAZZZSId(unittest.TestCase):
             :id: T_ARMI_ND_ISOTOPES5
             :tests: R_ARMI_ND_ISOTOPES
         """
-        referenceNucNames = [("C12", "120060"), ("U235", "2350920"), ("AM242M", "2420951")]
+        referenceNucNames = [
+            ("C12", "120060"),
+            ("U235", "2350920"),
+            ("AM242M", "2420951"),
+        ]
 
-        nuclideBases = NuclideBases()
         for nucName, refAaazzzs in referenceNucNames:
             nb = nuclideBases.byName[nucName]
             if refAaazzzs:

--- a/armi/nucDirectory/thermalScattering.py
+++ b/armi/nucDirectory/thermalScattering.py
@@ -14,18 +14,16 @@
 """
 Handle awareness of Thermal Scattering Laws.
 
-Scattering characteristics of thermal neutrons are often significantly different
-between a free atom and one bound in a particular molecule. Nuclear data libraries
-often have special tables to account for the bound states.
-These data are commonly represented as S(alpha, beta) tables.
+Scattering characteristics of thermal neutrons are often significantly different between a free atom and one bound in a
+particular molecule. Nuclear data libraries often have special tables to account for the bound states. These data are
+commonly represented as S(alpha, beta) tables.
 
-Here we provide objects representing the thermal scattering law (TSL) information.
-We expect them to be most useful as class attributes on :py:class:`~armi.materials.material.Material` subclasses
-to inform physics solvers that support thermal scattering of the TSLs. See
-:py:class:`~armi.materials.graphite.Graphite` for an example.
+Here we provide objects representing the thermal scattering law (TSL) information. We expect them to be most useful as
+class attributes on :py:class:`~armi.materials.material.Material` subclasses to inform physics solvers that support
+thermal scattering of the TSLs. See :py:class:`~armi.materials.graphite.Graphite` for an example.
 
-We do not provide special versions of various NuclideBases like C12 because of
-potential errors in choosing one over the other
+We do not provide special versions of various NuclideBases like C12 because of potential errors in choosing one over the
+other
 
 The information contained in here is based on Parsons, LA-UR-18-25096,
 https://mcnp.lanl.gov/pdf_files/la-ur-18-25096.pdf
@@ -42,14 +40,12 @@ Scattering law data are currently available for a variety of classifications:
 * Just compound (benzene)
 * Just isotope (Fe56, Al27)
 
-The labels for these vary across evaluations (e.g. ENDF/B-VII, ENDF/B-VIII, etc.). We provide
-ENDF/B-III.0 and ACE labels. Other physics kernels will have to derive their own labels
-as appropriate in client code.
+The labels for these vary across evaluations (e.g. ENDF/B-VII, ENDF/B-VIII, etc.). We provide ENDF/B-III.0 and ACE
+labels. Other physics kernels will have to derive their own labels as appropriate in client code.
 
-Like NuclideBase and Element, we want to have only one ThermalScattering instance
-for each TSL, so we use a module-level directory called ``byNbAndCompound``. This improves
-efficiency and allows better cross-referencing when thousands of material instances
-would otherwise have identical instances of these.
+Like NuclideBase and Element, we want to have only one ThermalScattering instance for each TSL, so we use a module-level
+directory called ``byNbAndCompound``. This improves efficiency and allows better cross-referencing when thousands of
+material instances would otherwise have identical instances of these.
 
 Thus, in practice, users should rarely instantiate these on their own.
 """
@@ -82,9 +78,9 @@ class ThermalScattering:
     Parameters
     ----------
     nuclideBases : INuclide or tuple of INuclide
-        One or more nuclide bases whose existence would trigger the inclusion of the TSL.
-        Generally items here will be a NaturalNuclideBase like ``nb.byName["C"]`` for Carbon
-        but it is a tuple to capture, e.g. the C and H in *methane*.
+        One or more nuclide bases whose existence would trigger the inclusion of the TSL. Generally items here will be a
+        NaturalNuclideBase like ``nb.byName["C"]`` for Carbon but it is a tuple to capture, e.g. the C and H in
+        *methane*.
     compoundName : str, optional
         Label indicating what the subjects are in (e.g. ``"Graphite"`` or ``"H2O"``.
         Can be left off for, e.g. Fe56.
@@ -122,9 +118,8 @@ class ThermalScattering:
         """
         Return all nuclide bases that could be subject to this law.
 
-        In cases where the law is defined by a NaturalNuclideBase, all potential
-        isotopes of the element as well as the element it self should trigger it.
-        This helps handle cases where, for example, C or C12 is present.
+        In cases where the law is defined by a NaturalNuclideBase, all potential isotopes of the element as well as the
+        element it self should trigger it. This helps handle cases where, for example, C or C12 is present.
         """
         subjectNbs = set()
         for nbi in self.nbs:
@@ -139,21 +134,21 @@ class ThermalScattering:
         """
         Generate the ENDF/B-VIII.0 label.
 
-        Several ad-hoc assumptions are made in converting this object to a ENDF/B-VIII label
-        which may not apply in all cases.
+        Several ad-hoc assumptions are made in converting this object to a ENDF/B-VIII label which may not apply in all
+        cases.
 
         It is believed that these rules cover most ENDF TSLs listed in
         Parsons, LA-UR-18-25096, https://mcnp.lanl.gov/pdf_files/la-ur-18-25096.pdf
 
         Unfortunately, the ace labels are not as easily derived.
 
-        * If nuclideBases is length one and contains a ``NaturalNuclideBase``, then the
-          name will be assumed to be ``Element_in_compoundName``
-        * If nuclideBases is length one and is a NuclideBase, it is assumed to be an isotope
-          like Fe-56 and  the label will be (for example) 026_Fe_056
-        * If nuclideBases has length greater than one, the compoundName will form the
-          entire of the label. So, if Si and O are in the bases, the compoundName must
-          be ``SiO2-alpha`` in order to get ``tsl-SiO2-alpha.endf`` as a endf8 label.
+        * If nuclideBases is length one and contains a ``NaturalNuclideBase``, then the name will be assumed to be
+          ``Element_in_compoundName``
+        * If nuclideBases is length one and is a NuclideBase, it is assumed to be an isotope like Fe-56 and  the label
+          will be (for example) 026_Fe_056
+        * If nuclideBases has length greater than one, the compoundName will form the entire of the label. So, if Si and
+          O are in the bases, the compoundName must be ``SiO2-alpha`` in order to get ``tsl-SiO2-alpha.endf`` as a endf8
+          label.
         """
         first = next(iter(self.nbs))
         if len(self.nbs) > 1:
@@ -174,8 +169,8 @@ class ThermalScattering:
         """
         Attempt to derive the ACE label of a TSL.
 
-        There are certain exceptions that cannot be derived and must be provided
-        by the user upon instantiation, for example:
+        There are certain exceptions that cannot be derived and must be provided by the user upon instantiation, for
+        example:
 
         * ``grph10``
         * ``grph30``
@@ -195,64 +190,79 @@ class ThermalScattering:
             label = f"{element.symbol.lower()}-{first.a:d}"
         else:
             raise ValueError(f"{self} label cannot be generated")
+
         return label
 
 
-def factory():
+def factory(byName):
     """
     Generate the :class:`ThermalScattering` instances.
 
-    The logic for these is a bit complex so we skip reading a text file and code
-    it up here.
+    The logic for these is a bit complex so we skip reading a text file and code it up here.
 
-    This is called by the nuclideBases factory since it must ALWAYS be re-run when
-    the nuclideBases are rebuilt.
+    This is called by the nuclideBases factory since it must ALWAYS be re-run when the nuclideBases are rebuilt.
 
     See Also
     --------
     armi.nucDirectory.nuclideBases.factory
         Calls this during ARMI initialization.
-
-    .. warning::
-        This gets called automatically during init, so don't call it
-        unless you know what you're doing.
     """
+    print("xxxxxxxxxxxxxxxxxxxxxxxxxx Thermal Scattering factory xxxxxxxxxxxxxxxxxxxxxxxxxx")
     global byNbAndCompound
     byNbAndCompound.clear()
 
-    al27 = nb.byName["AL27"]
-    fe56 = nb.byName["FE56"]
-    be = nb.byName["BE"]
-    c = nb.byName["C"]
-    d = nb.byName["H2"]
-    n = nb.byName["N"]
-    o = nb.byName["O"]
-    h = nb.byName["H"]
-    u = nb.byName["U"]
-    zr = nb.byName["ZR"]
-    si = nb.byName["SI"]
+    if "AL27" in byName:
+        al27 = byName["AL27"]
+        byNbAndCompound[al27, None] = ThermalScattering(al27)
 
-    for isotope in [al27, fe56]:
-        byNbAndCompound[isotope, None] = ThermalScattering(isotope)
+    if "BE" in byName:
+        be = byName["BE"]
+        byNbAndCompound[be, BE_METAL] = ThermalScattering(
+            be, BE_METAL, endf8Label=f"tsl-{BE_METAL}.endf", aceLabel="be-met"
+        )
+        byNbAndCompound[be, BEO] = ThermalScattering(be, BEO, endf8Label=BEO, aceLabel="be-beo")
 
-    byNbAndCompound[be, BE_METAL] = ThermalScattering(
-        be, BE_METAL, endf8Label=f"tsl-{BE_METAL}.endf", aceLabel="be-met"
-    )
-    byNbAndCompound[be, BEO] = ThermalScattering(be, BEO, endf8Label=BEO, aceLabel="be-beo")
-    byNbAndCompound[c, SIC] = ThermalScattering(c, SIC)
-    byNbAndCompound[d, D2O] = ThermalScattering(d, D2O, f"tsl-Din{D2O}.endf", "d-d2o")
-    byNbAndCompound[h, H2O] = ThermalScattering(h, H2O)
-    byNbAndCompound[h, ZRH] = ThermalScattering(h, ZRH)
-    byNbAndCompound[n, UN] = ThermalScattering(n, UN)
-    byNbAndCompound[o, BEO] = ThermalScattering(o, BEO)
-    byNbAndCompound[o, D2O] = ThermalScattering(o, D2O, f"tsl-Oin{D2O}.endf", "o-d2o")
-    byNbAndCompound[o, UO2] = ThermalScattering(o, UO2)
-    byNbAndCompound[u, UO2] = ThermalScattering(u, UO2)
-    byNbAndCompound[u, UN] = ThermalScattering(u, UN)
-    byNbAndCompound[zr, ZRH] = ThermalScattering(zr, ZRH)
-    byNbAndCompound[si, SIC] = ThermalScattering(si, SIC)
-    byNbAndCompound[c, CRYSTALLINE_GRAPHITE] = ThermalScattering(
-        c, CRYSTALLINE_GRAPHITE, f"tsl-{CRYSTALLINE_GRAPHITE}.endf", "grph"
-    )
-    byNbAndCompound[c, GRAPHITE_10P] = ThermalScattering(c, GRAPHITE_10P, f"tsl-{GRAPHITE_10P}.endf", "grph10")
-    byNbAndCompound[c, GRAPHITE_30P] = ThermalScattering(c, GRAPHITE_30P, f"tsl-{GRAPHITE_30P}.endf", "grph30")
+    if "C" in byName:
+        c = byName["C"]
+        byNbAndCompound[c, SIC] = ThermalScattering(c, SIC)
+        byNbAndCompound[c, GRAPHITE_10P] = ThermalScattering(c, GRAPHITE_10P, f"tsl-{GRAPHITE_10P}.endf", "grph10")
+        byNbAndCompound[c, GRAPHITE_30P] = ThermalScattering(c, GRAPHITE_30P, f"tsl-{GRAPHITE_30P}.endf", "grph30")
+        byNbAndCompound[c, CRYSTALLINE_GRAPHITE] = ThermalScattering(
+            c, CRYSTALLINE_GRAPHITE, f"tsl-{CRYSTALLINE_GRAPHITE}.endf", "grph"
+        )
+
+    if "FE56" in byName:
+        fe56 = byName["FE56"]
+        byNbAndCompound[fe56, None] = ThermalScattering(fe56)
+
+    if "H2" in byName:
+        h = byName["H"]
+
+    if "H2" in byName:
+        d = byName["H2"]
+        byNbAndCompound[d, D2O] = ThermalScattering(d, D2O, f"tsl-Din{D2O}.endf", "d-d2o")
+        byNbAndCompound[h, H2O] = ThermalScattering(h, H2O)
+        byNbAndCompound[h, ZRH] = ThermalScattering(h, ZRH)
+
+    if "N" in byName:
+        n = byName["N"]
+        byNbAndCompound[n, UN] = ThermalScattering(n, UN)
+
+    if "O" in byName:
+        o = byName["O"]
+        byNbAndCompound[o, BEO] = ThermalScattering(o, BEO)
+        byNbAndCompound[o, D2O] = ThermalScattering(o, D2O, f"tsl-Oin{D2O}.endf", "o-d2o")
+        byNbAndCompound[o, UO2] = ThermalScattering(o, UO2)
+
+    if "SI" in byName:
+        si = byName["SI"]
+        byNbAndCompound[si, SIC] = ThermalScattering(si, SIC)
+
+    if "U" in byName:
+        u = byName["U"]
+        byNbAndCompound[u, UO2] = ThermalScattering(u, UO2)
+        byNbAndCompound[u, UN] = ThermalScattering(u, UN)
+
+    if "ZR" in byName:
+        zr = byName["ZR"]
+        byNbAndCompound[zr, ZRH] = ThermalScattering(zr, ZRH)

--- a/armi/nucDirectory/thermalScattering.py
+++ b/armi/nucDirectory/thermalScattering.py
@@ -79,11 +79,9 @@ class ThermalScattering:
     ----------
     nuclideBases : INuclide or tuple of INuclide
         One or more nuclide bases whose existence would trigger the inclusion of the TSL. Generally items here will be a
-        NaturalNuclideBase like ``nb.byName["C"]`` for Carbon but it is a tuple to capture, e.g. the C and H in
-        *methane*.
+        NaturalNuclideBase like ``nb.byName["C"]`` for Carbon but it is a tuple to capture, e.g. the C and H in methane.
     compoundName : str, optional
-        Label indicating what the subjects are in (e.g. ``"Graphite"`` or ``"H2O"``.
-        Can be left off for, e.g. Fe56.
+        Label indicating what the subjects are in (e.g. ``"Graphite"`` or ``"H2O"``. Can be left off for, e.g. Fe56.
     endf8Label : str, optional
         Label for endf8 evaluation
     aceLabel: str, optional
@@ -137,8 +135,8 @@ class ThermalScattering:
         Several ad-hoc assumptions are made in converting this object to a ENDF/B-VIII label which may not apply in all
         cases.
 
-        It is believed that these rules cover most ENDF TSLs listed in
-        Parsons, LA-UR-18-25096, https://mcnp.lanl.gov/pdf_files/la-ur-18-25096.pdf
+        It is believed that these rules cover most ENDF TSLs listed in Parsons, LA-UR-18-25096,
+        https://mcnp.lanl.gov/pdf_files/la-ur-18-25096.pdf
 
         Unfortunately, the ace labels are not as easily derived.
 

--- a/armi/nucDirectory/thermalScattering.py
+++ b/armi/nucDirectory/thermalScattering.py
@@ -163,6 +163,7 @@ class ThermalScattering:
             label = f"tsl-{first.z:03d}_{element.symbol.capitalize()}_{first.a:03d}.endf"
         else:
             raise ValueError(f"{self} label cannot be generated")
+
         return label
 
     def _genACELabel(self):
@@ -207,7 +208,6 @@ def factory(byName):
     armi.nucDirectory.nuclideBases.factory
         Calls this during ARMI initialization.
     """
-    print("xxxxxxxxxxxxxxxxxxxxxxxxxx Thermal Scattering factory xxxxxxxxxxxxxxxxxxxxxxxxxx")
     global byNbAndCompound
     byNbAndCompound.clear()
 

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -386,17 +386,29 @@ def expandElementals(mat, blueprint):
     armi.reactor.blueprints.Blueprints._resolveNuclides
         Sets the metadata defining this behavior.
     """
+    print("\n\n\nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n\n\n")
+
     elementExpansionPairs = []
     for elementToExpand in blueprint.elementsToExpand:
+        print(f"elementToExpand.symbol: {elementToExpand.symbol}")
+
         if elementToExpand.symbol not in mat.massFrac:
             continue
         nucFlags = blueprint.nuclideFlags.get(elementToExpand.symbol)
+
+        print(f"nucFlags: {nucFlags}")
+        #print(f"nuclideBases.byName: {nuclideBases.byName.keys()}")
+
         nuclidesToBecome = (
             [nuclideBases.byName[nn] for nn in nucFlags.expandTo] if (nucFlags and nucFlags.expandTo) else None
         )
+        print(nuclidesToBecome)
+
         elementExpansionPairs.append((elementToExpand, nuclidesToBecome))
 
     densityTools.expandElementalMassFracsToNuclides(mat.massFrac, elementExpansionPairs)
+    
+    print("\n\n\nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n\n\n")
 
 
 def insertDepletableNuclideKeys(c, blueprint):

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 """
-This module defines the ARMI input for a component definition, and code for constructing an ARMI
-``Component``.
+This module defines the ARMI input for a component definition, and code for constructing an ARMI ``Component``.
 
 Special logic is required for handling component links.
 """
@@ -42,10 +41,10 @@ class ComponentDimension(yamlize.Object):
         self.value = value
         if isinstance(value, str):
             if not components.COMPONENT_LINK_REGEX.search(value):
-                raise ValueError("Bad component link `{}`, must be in form `name.dimension`".format(value))
+                raise ValueError(f"Bad component link `{value}`, must be in form `name.dimension`")
 
     def __repr__(self):
-        return "<ComponentDimension value: {}>".format(self.value)
+        return f"<ComponentDimension value: {self.value}>"
 
     @classmethod
     def from_yaml(cls, loader, node, _rtd=None):
@@ -219,7 +218,6 @@ class ComponentBlueprint(yamlize.Object):
                 _setComponentFlags(component, self.flags, blueprint)
                 insertDepletableNuclideKeys(component, blueprint)
                 constructedObject.add(component)
-
         else:
             constructedObject = components.factory(shape, [], kwargs)
             _setComponentFlags(constructedObject, self.flags, blueprint)
@@ -275,11 +273,9 @@ class ComponentBlueprint(yamlize.Object):
             if isinstance(mat, materials.Fluid):
                 densityRatio = densityFromCustomIsotopic / mat.density(Tc=comp.inputTemperatureInC)
             else:
-                # for solids we need to consider if the input heights are hot or
-                # cold, in order to get the density correct.
-                # There may be a better place in the initialization to determine
-                # if the block height will be interpreted as hot dimensions, which would
-                # allow us to not have to pass the case settings down this far
+                # For solids we need to consider if the input heights are hot or cold, in order to get the density
+                # correct. There may be a better place in the initialization to determine if the block height will be
+                # interpreted as hot, which would allow us to not have to pass the case settings down this far.
                 dLL = mat.linearExpansionFactor(Tc=comp.temperatureInC, T0=comp.inputTemperatureInC)
                 if inputHeightsConsideredHot:
                     f = 1.0 / (1 + dLL) ** 2
@@ -315,14 +311,14 @@ class ComponentBlueprint(yamlize.Object):
                 # They're applied during block construction.
                 continue
             elif attr.name == "flags":
-                # Don't pass these to the component constructor. These are used to
-                # override the flags derived from the type, if present.
+                # Don't pass these to the component constructor. These are used to override the flags derived from the
+                # type, if present.
                 continue
             else:
                 value = attr.get_value(self)
 
-            # Keep digging until the actual value is found. This is a bit of a hack to get around an
-            # issue in yamlize/ComponentDimension where Dimensions can end up chained.
+            # Keep digging until the actual value is found. This is a bit of a hack to get around an issue in
+            # yamlize/ComponentDimension where Dimensions can end up chained.
             while isinstance(value, ComponentDimension):
                 value = value.value
 
@@ -336,8 +332,7 @@ class ComponentBlueprint(yamlize.Object):
         mat = materials.resolveMaterialClassByName(self.material)()
 
         if self.isotopics is not None:
-            # Apply custom isotopics before processing input mods so
-            # the input mods have the final word
+            # Apply custom isotopics before processing input mods so the input mods have the final word
             blueprint.customIsotopics.apply(mat, self.isotopics)
 
         # add mass fraction custom isotopics info, since some material modifications need
@@ -351,14 +346,13 @@ class ComponentBlueprint(yamlize.Object):
             except TypeError as ee:
                 errorMessage = ee.args[0]
                 if "got an unexpected keyword argument" in errorMessage:
-                    # This component does not accept material modification inputs of the names passed in
-                    # Keep going since the modification could work for another component
+                    # This component does not accept material modification inputs of the names passed in Keep going
+                    # since the modification could work for another component.
                     pass
                 else:
                     raise ValueError(
-                        f"Something went wrong in applying the material modifications {matMods} "
-                        f"to component {self.name}.\n"
-                        f"Error message is: \n{errorMessage}."
+                        f"Something went wrong in applying the material modifications {matMods} to component "
+                        "{self.name}.\nError message is: \n{errorMessage}."
                     )
 
         expandElementals(mat, blueprint)
@@ -367,9 +361,9 @@ class ComponentBlueprint(yamlize.Object):
 
         if missing:
             raise ValueError(
-                "The nuclides {} are present in material {} by compositions, but are not "
-                "specified in the `nuclide flags` section of the input file. "
-                "They need to be added, or custom isotopics need to be applied.".format(missing, mat)
+                f"The nuclides {missing} are present in material {mat} by compositions, but are not specified in the "
+                "`nuclide flags` section of the input file. They need to be added, or custom isotopics need to be "
+                "applied."
             )
 
         return mat
@@ -397,7 +391,7 @@ def expandElementals(mat, blueprint):
         nucFlags = blueprint.nuclideFlags.get(elementToExpand.symbol)
 
         print(f"nucFlags: {nucFlags}")
-        #print(f"nuclideBases.byName: {nuclideBases.byName.keys()}")
+        # print(f"nuclideBases.byName: {nuclideBases.byName.keys()}")
 
         nuclidesToBecome = (
             [nuclideBases.byName[nn] for nn in nucFlags.expandTo] if (nucFlags and nucFlags.expandTo) else None
@@ -407,7 +401,7 @@ def expandElementals(mat, blueprint):
         elementExpansionPairs.append((elementToExpand, nuclidesToBecome))
 
     densityTools.expandElementalMassFracsToNuclides(mat.massFrac, elementExpansionPairs)
-    
+
     print("\n\n\nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n\n\n")
 
 
@@ -422,21 +416,19 @@ def insertDepletableNuclideKeys(c, blueprint):
         This is called during the component construction process for each component from within
         :py:meth:`~armi.reactor.blueprints.componentBlueprint.ComponentBlueprint.construct`.
 
-        For a given initialized component, check its flags to determine if it has been marked as
-        depletable. If it is, use
-        :py:func:`~armi.nucDirectory.nuclideBases.initReachableActiveNuclidesThroughBurnChain` to
-        apply the user-specifications in the "nuclide flags" section of the blueprints to the
-        Component such that all active isotopes and derivatives of those isotopes in the burn chain
-        are initialized to have an entry in the component's ``nuclides`` array.
+        For a given initialized component, check its flags to determine if it has been marked as depletable. If it is,
+        use :py:func:`~armi.nucDirectory.nuclideBases.initReachableActiveNuclidesThroughBurnChain` to apply the
+        user-specifications in the "nuclide flags" section of the blueprints to the Component such that all active
+        isotopes and derivatives of those isotopes in the burn chain are initialized to have an entry in the component's
+        ``nuclides`` array.
 
-        Note that certain case settings, including ``fpModel`` and ``fpModelLibrary``, may trigger
-        modifications to the active nuclides specified by the user in the "nuclide flags" section of
-        the blueprints.
+        Note that certain case settings, including ``fpModel`` and ``fpModelLibrary``, may trigger modifications to the
+        active nuclides specified by the user in the "nuclide flags" section of the blueprints.
 
     Notes
     -----
-    This should be moved to a neutronics/depletion plugin hook but requires some refactoring in how
-    active nuclides and reactors are initialized first.
+    This should be moved to a neutronics/depletion plugin hook but requires some refactoring in how active nuclides and
+    reactors are initialized first.
 
     See Also
     --------
@@ -461,8 +453,8 @@ class ComponentKeyedList(yamlize.KeyedList):
 
     This is used within the ``components:`` main entry of the blueprints.
 
-    This is *not* (yet) used when components are defined within a block blueprint. That is handled
-    in the blockBlueprint construct method.
+    This is *not* (yet) used when components are defined within a block blueprint. That is handled in the blockBlueprint
+    construct method.
     """
 
     item_type = ComponentBlueprint
@@ -509,11 +501,9 @@ class ComponentGroups(yamlize.KeyedList):
     item_type = ComponentGroup
 
 
-# This import-time magic requires all possible components
-# be imported before this module imports. The intent
-# was to make registration basically automatic. This has proven
-# to be quite problematic and will be replaced with an
-# explicit plugin-level component registration system.
+# This import-time magic requires all possible components be imported before this module imports. The intent was to make
+# registration basically automatic. This has proven to be quite problematic and will be replaced with an explicit
+# plugin-level component registration system.
 for dimName in set([kw for cType in components.ComponentType.TYPES.values() for kw in cType.DIMENSION_NAMES]):
     setattr(
         ComponentBlueprint,
@@ -524,15 +514,13 @@ for dimName in set([kw for cType in components.ComponentType.TYPES.values() for 
 
 def _setComponentFlags(component, flags, blueprint):
     """Update component flags based on user input in blueprint."""
-    # the component __init__ calls setType(), which gives us our initial guess at
-    # what the flags should be.
+    # The component __init__ calls setType(), which gives us our initial guess at what the flags should be.
     if flags is not None:
         # override the flags from __init__ with the ones from the blueprint
         component.p.flags = Flags.fromString(flags)
     else:
-        # potentially add the DEPLETABLE flag. Don't do this if we set flags
-        # explicitly. WARNING: If you add flags explicitly, it will
-        # turn off depletion so be sure to add depletable to your list of flags
-        # if you expect depletion
+        # Potentially add the DEPLETABLE flag. Don't do this if we set flags explicitly.
+        # WARNING: If you add flags explicitly, it will turn off depletion so be sure to add depletable to your list of
+        # flags if you expect depletion.
         if any(nuc in blueprint.activeNuclides for nuc in component.getNuclides()):
             component.p.flags |= Flags.DEPLETABLE

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -380,29 +380,18 @@ def expandElementals(mat, blueprint):
     armi.reactor.blueprints.Blueprints._resolveNuclides
         Sets the metadata defining this behavior.
     """
-    print("\n\n\nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n\n\n")
-
     elementExpansionPairs = []
     for elementToExpand in blueprint.elementsToExpand:
-        print(f"elementToExpand.symbol: {elementToExpand.symbol}")
-
         if elementToExpand.symbol not in mat.massFrac:
             continue
+
         nucFlags = blueprint.nuclideFlags.get(elementToExpand.symbol)
-
-        print(f"nucFlags: {nucFlags}")
-        # print(f"nuclideBases.byName: {nuclideBases.byName.keys()}")
-
         nuclidesToBecome = (
             [nuclideBases.byName[nn] for nn in nucFlags.expandTo] if (nucFlags and nucFlags.expandTo) else None
         )
-        print(nuclidesToBecome)
-
         elementExpansionPairs.append((elementToExpand, nuclidesToBecome))
 
     densityTools.expandElementalMassFracsToNuclides(mat.massFrac, elementExpansionPairs)
-
-    print("\n\n\nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n\n\n")
 
 
 def insertDepletableNuclideKeys(c, blueprint):

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -121,8 +121,10 @@ assemblies:
         a = bp.constructAssem(cs, "assembly")
         expectedNuclides = ["B10", "B11", "C", "DUMP1"]
         unexpectedNuclides = ["U234", "U325", "U238"]
+        print(a[0][0].getNuclides())
         for nuc in expectedNuclides:
             self.assertIn(nuc, a[0][0].getNuclides())
+
         for nuc in unexpectedNuclides:
             self.assertNotIn(nuc, a[0][0].getNuclides())
 

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -121,7 +121,6 @@ assemblies:
         a = bp.constructAssem(cs, "assembly")
         expectedNuclides = ["B10", "B11", "C", "DUMP1"]
         unexpectedNuclides = ["U234", "U325", "U238"]
-        print(a[0][0].getNuclides())
         for nuc in expectedNuclides:
             self.assertIn(nuc, a[0][0].getNuclides())
 
@@ -130,8 +129,8 @@ assemblies:
 
         c = a[0][0]
 
-        # Since we didn't supply flags, we should get the DEPLETABLE flag added
-        # automatically, since this one has depletable nuclides
+        # Since we didn't supply flags, we should get the DEPLETABLE flag added automatically, since this one has
+        # depletable nuclides
         self.assertEqual(c.p.flags, Flags.DEPLETABLE)
         # More robust test, but worse unittest.py output when it fails
         self.assertTrue(c.hasFlags(Flags.DEPLETABLE))

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -353,12 +353,6 @@ assemblies:
     def test_unmodified(self):
         """Ensure that unmodified components have the correct isotopics."""
         fuel = self.a[0].getComponent(Flags.FUEL)
-        print("=======================================")
-        print(fuel.p.numberDensities)
-        for b in self.a:
-            for c in b:
-                print(c.p.numberDensities)
-        print("=======================================")
         self.assertEqual(self.numUZrNuclides, len(fuel.p.numberDensities))
         # NOTE: This density does not come from the material but is based on number densities.
         self.assertAlmostEqual(15.5, fuel.density(), 0)  # i.e. it is not 19.1

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -353,6 +353,12 @@ assemblies:
     def test_unmodified(self):
         """Ensure that unmodified components have the correct isotopics."""
         fuel = self.a[0].getComponent(Flags.FUEL)
+        print("=======================================")
+        print(fuel.p.numberDensities)
+        for b in self.a:
+            for c in b:
+                print(c.p.numberDensities)
+        print("=======================================")
         self.assertEqual(self.numUZrNuclides, len(fuel.p.numberDensities))
         # NOTE: This density does not come from the material but is based on number densities.
         self.assertAlmostEqual(15.5, fuel.density(), 0)  # i.e. it is not 19.1

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -1851,14 +1851,14 @@ class TestMaterialAdjustments(unittest.TestCase):
         dims = {"Tinput": 25.0, "Thot": 600.0, "od": 10.0, "id": 5.0, "mult": 1.0}
         self.fuel = Circle("fuel", "UZr", **dims)
 
-        class fakeBlock:
-            def getHeight(self):  # unit height
+        class FakeBlock:
+            def getHeight(self):
                 return 1.0
 
             def getSymmetryFactor(self):
                 return 1.0
 
-        self.fuel.parent = fakeBlock()
+        self.fuel.parent = FakeBlock()
 
     def test_setMassFrac(self):
         """Make sure we can set a mass fraction properly."""

--- a/armi/utils/densityTools.py
+++ b/armi/utils/densityTools.py
@@ -377,8 +377,7 @@ def expandElementalNuclideMassFracs(
     massFrac : float
         Mass fraction of the initial element
     isotopicSubset : list of NuclideBases
-        Natural isotopes to include in the expansion. Useful e.g. for
-        excluding O18 from an expansion of Oxygen.
+        Natural isotopes to include in the expansion. Useful e.g. for excluding O18 from an expansion of Oxygen.
     """
     elementNucBases = element.getNaturalIsotopics()
     if isotopicSubset:

--- a/armi/utils/densityTools.py
+++ b/armi/utils/densityTools.py
@@ -60,6 +60,7 @@ def getNDensFromMasses(rho, massFracs, normalize=False):
         atomicWeight = nuclideBases.byName[nucName].weight
         nuclides.append(nucName.encode())
         numberDensities.append(massFrac * rho / atomicWeight)
+
     return np.array(nuclides), np.array(numberDensities)
 
 
@@ -113,6 +114,7 @@ def calculateMassDensity(numberDensities):
     for nucName, nDensity in numberDensities.items():
         atomicWeight = nuclideBases.byName[nucName].weight
         rho += nDensity * atomicWeight / units.MOLES_PER_CC_TO_ATOMS_PER_BARN_CM
+
     return rho
 
 
@@ -223,7 +225,9 @@ def formatMaterialCard(
         list of material card strings
     """
     if all(isinstance(nuc, (nuclideBases.LumpNuclideBase, nuclideBases.DummyNuclideBase)) for nuc in densities):
-        return []  # no valid nuclides to write
+        # no valid nuclides to write
+        return []
+
     if matNum >= 0:
         mCard = ["m{matNum}\n".format(matNum=matNum)]
     else:
@@ -235,8 +239,9 @@ def formatMaterialCard(
             runLog.important("The material card returned will ignore LFPs.", single=True)
             continue
         elif isinstance(nuc, nuclideBases.DummyNuclideBase):
-            runLog.info("Omitting dummy nuclides such as {}".format(nuc), single=True)
+            runLog.info(f"Omitting dummy nuclides such as {nuc}", single=True)
             continue
+
         mcnpNucName = nuc.getMcnpId()
         newEntry = ("      {nucName:5d} {ndens:." + str(sigFigs) + "e}\n").format(
             nucName=int(mcnpNucName), ndens=max(dens, minDens)
@@ -352,7 +357,7 @@ def expandElementalMassFracsToNuclides(
 
         total = sum(expandedNucs.values())
         if massFrac > 0.0 and abs(total - massFrac) / massFrac > 1e-6:
-            raise ValueError("Mass fractions not normalized properly {}!".format((total, massFrac)))
+            raise ValueError(f"Mass fractions not normalized properly {(total, massFrac)}")
 
 
 def expandElementalNuclideMassFracs(
@@ -363,8 +368,7 @@ def expandElementalNuclideMassFracs(
     """
     Return a dictionary of nuclide names to isotopic mass fractions.
 
-    If an isotopic subset is passed in, the mass fractions get scaled up
-    s.t. the total mass fraction remains constant.
+    If an isotopic subset is passed in, the mass fractions get scaled up s.t. the total mass fraction remains constant.
 
     Parameters
     ----------
@@ -381,12 +385,15 @@ def expandElementalNuclideMassFracs(
         expandedNucBases = [nb for nb in elementNucBases if nb in isotopicSubset]
     else:
         expandedNucBases = elementNucBases
+
     elementalWeightGperMole = sum(nb.weight * nb.abundance for nb in expandedNucBases)
     if not any(expandedNucBases):
-        raise ValueError("Cannot expand element `{}` into isotopes: `{}`".format(element, expandedNucBases))
+        raise ValueError(f"Cannot expand element `{element}` into isotopes: `{expandedNucBases}`")
+
     expanded = {}
     for nb in expandedNucBases:
         expanded[nb.name] = massFrac * nb.abundance * nb.weight / elementalWeightGperMole
+
     return expanded
 
 
@@ -420,12 +427,11 @@ def applyIsotopicsMix(material, enrichedMassFracs: Dict[str, float], fertileMass
     """
     Update material heavy metal mass fractions based on its enrichment and two nuclide feeds.
 
-    This will remix the heavy metal in a Material object based on the object's
-    ``class1_wt_frac`` parameter and the input nuclide information.
+    This will remix the heavy metal in a Material object based on the object's ``class1_wt_frac`` parameter and the
+    input nuclide information.
 
-    This can be used for inputting mixtures of two external custom isotopic feeds
-    as well as for fabricating assemblies from two  closed-cycle collections
-    of material.
+    This can be used for inputting mixtures of two external custom isotopic feeds as well as for fabricating assemblies
+    from two  closed-cycle collections of material.
 
     See Also
     --------
@@ -446,6 +452,7 @@ def applyIsotopicsMix(material, enrichedMassFracs: Dict[str, float], fertileMass
         nb = nuclideBases.byName[nucName]
         if nb.isHeavyMetal():
             hm += massFrac
+
     hmFrac = hm / total
     hmEnrich = material.class1_wt_frac
     for nucName in (

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -42,6 +42,15 @@ class TestPlotting(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        from armi.nucDirectory import elements, nuclideBases
+
+        elements.factory()
+        nuclideBases.factory()
+        print("=================================================")
+        print(nuclideBases.nuclideBases)
+        print([k for k in nuclideBases.nuclideBases.byName.keys() if k.startswith("AL")])
+        print("=================================================")
+
         cls.o, cls.r = test_reactors.loadTestReactor(inputFileName="smallestTestReactor/armiRunSmallest.yaml")
 
     def test_plotDepthMap(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

> This PR does not change the ARMI API.

This is just step zero of the plan to remove global nuclides as outlined in issue #473.

This PR does not actually remove global nuclides, it sets the groundwork in a non-API-breaking way. Essentially, the files `nuclideBases.py` and `elements.py` have a bunch of data saved to the global scope. So this PR creates the classes `NuclideBases` and `Elements` to contain that data.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Making classes to contain the global data in `nuclideBases.py` and `elements.py`.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: The code related to nuclideBases and elements is being refactored to be more contained: `I_ARMI_ND_ELEMENTS0`, `I_ARMI_ND_ELEMENTS1`, `I_ARMI_ND_DATA0`, `I_ARMI_ND_DATA1`, `I_ARMI_ND_ISOTOPES0`, `I_ARMI_ND_ISOTOPES1`, `I_ARMI_ND_ISOTOPES2`, `I_ARMI_ND_ISOTOPES3`, `I_ARMI_ND_ISOTOPES4`, `I_ARMI_ND_ISOTOPES5`, `I_ARMI_ND_ISOTOPES6`, and `I_ARMI_ND_ISOTOPES7` for `R_ARMI_ND_ELEMENTS`, `R_ARMI_ND_DATA`, and `R_ARMI_ND_ISOTOPES`.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
