### PR TITLE
Raising error if no `driverBlock` is found by latticePhysicsWriter

### DIFF
--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -428,7 +428,12 @@ class LatticePhysicsWriter(interfaces.InputWriter):
     def _getDriverBlock(self):
         """Return the block that is driving the representative block for this writer."""
         xsgm = self.getInterface("xsGroups")
-        return xsgm.representativeBlocks.get(self.driverXsID, None)
+        driverBlock = xsgm.representativeBlocks.get(self.driverXsID, None)
+        if self.driverXsID != "" and driverBlock is None:
+            msg = "No representativeBlock found for driver XS ID {self.driverXsID} to use in {self}!"
+            runLog.error(msg)
+            raise ValueError(msg)
+        return driverBlock
 
 
 def _groupNuclidesByTemperature(nuclides):

--- a/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsWriter.py
@@ -430,7 +430,7 @@ class LatticePhysicsWriter(interfaces.InputWriter):
         xsgm = self.getInterface("xsGroups")
         driverBlock = xsgm.representativeBlocks.get(self.driverXsID, None)
         if self.driverXsID != "" and driverBlock is None:
-            msg = "No representativeBlock found for driver XS ID {self.driverXsID} to use in {self}!"
+            msg = f"No representativeBlock found for driver XS ID {self.driverXsID} to use in {self}!"
             runLog.error(msg)
             raise ValueError(msg)
         return driverBlock

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeWriter.py
@@ -183,5 +183,9 @@ class TestLatticePhysicsWriter(unittest.TestCase):
         self.assertTrue(isActive)
 
     def test_getDriverBlock(self):
+        self.w.driverXsID = ""
         b = self.w._getDriverBlock()
         self.assertIsNone(b)
+        self.w.driverXsID = "AA"
+        with self.assertRaises(ValueError):
+            b = self.w._getDriverBlock()


### PR DESCRIPTION
## What is the change? Why is it being made?

Some versions of the `latticePhysicsWriter` use a driver fuel material to produce a neutron source for the cross section model. 
The user provides the XS ID of the fuel material they want to use as a driver, and the writer uses the representative block for the XS group as the fuel material.

If the user requests a driver XS ID and it is not found among the representative blocks in the `CrossSectionGroupManager`, an error will now be thrown. Previously, this would be a silent error, and execution would have continued without any warning messages to alert the user to the problem.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Throw an error when a user requests a driver material for a lattice physics input but none is found.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
