### PR TITLE
Removing volume from getMgFlux()

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -319,12 +319,12 @@ class Block(composites.Composite):
     def assignPinIndices(self):
         pass
 
-    def getMgFlux(self, adjoint=False, average=False, volume=None, gamma=False):
+    def getMgFlux(self, adjoint=False, average=False, gamma=False):
         """
         Returns the multigroup neutron flux in [n/cm^2/s].
 
-        The first entry is the first energy group (fastest neutrons). Each additional
-        group is the next energy group, as set in the ISOTXS library.
+        The first entry is the first energy group (fastest neutrons). Each additional group is the next energy group, as
+        set in the ISOTXS library.
 
         It is stored integrated over volume on self.p.mgFlux
 
@@ -332,15 +332,8 @@ class Block(composites.Composite):
         ----------
         adjoint : bool, optional
             Return adjoint flux instead of real
-
         average : bool, optional
-            If true, will return average flux between latest and previous. Doesn't work
-            for pin detailed yet
-
-        volume: float, optional
-            If average=True, the volume-integrated flux is divided by volume before being returned.
-            The user may specify a volume, or the function will obtain the block volume directly.
-
+            If true, will return average flux between latest and previous. Doesn't work for pin detailed yet.
         gamma : bool, optional
             Whether to return the neutron flux or the gamma flux.
 
@@ -348,11 +341,12 @@ class Block(composites.Composite):
         -------
         flux : multigroup neutron flux in [n/cm^2/s]
         """
-        flux = composites.ArmiObject.getMgFlux(self, adjoint=adjoint, average=False, volume=volume, gamma=gamma)
+        flux = composites.ArmiObject.getMgFlux(self, adjoint=adjoint, average=False, gamma=gamma)
         if average and np.any(self.p.lastMgFlux):
-            volume = volume or self.getVolume()
+            volume = self.getVolume()
             lastFlux = self.p.lastMgFlux / volume
             flux = (flux + lastFlux) / 2.0
+
         return flux
 
     def setPinMgFluxes(self, fluxes, adjoint=False, gamma=False):

--- a/armi/reactor/components/component.py
+++ b/armi/reactor/components/component.py
@@ -1252,23 +1252,19 @@ class Component(composites.Composite, metaclass=ComponentType):
             adjustedMassFracs[baseNucName] = massFracEnrichedElement * (1 - massFraction) * frac
         self.setMassFracs(adjustedMassFracs)
 
-    def getMgFlux(self, adjoint=False, average=False, volume=None, gamma=False):
+    def getMgFlux(self, adjoint=False, average=False, gamma=False):
         """
         Return the multigroup neutron flux in [n/cm^2/s].
 
-        The first entry is the first energy group (fastest neutrons). Each additional group is the
-        next energy group, as set in the ISOTXS library.
+        The first entry is the first energy group (fastest neutrons). Each additional group is the next energy group, as
+        set in the ISOTXS library.
 
         Parameters
         ----------
         adjoint : bool, optional
             Return adjoint flux instead of real
         average : bool, optional
-            If True, will return average flux between latest and previous. Does not work for pin
-            detailed.
-        volume: float, optional
-            The volume-integrated flux is divided by volume before being returned. The user may
-            specify a volume here, or the function will obtain the block volume directly.
+            If True, will return average flux between latest and previous. Does not work for pin detailed.
         gamma : bool, optional
             Whether to return the neutron flux or the gamma flux.
 
@@ -1280,7 +1276,7 @@ class Component(composites.Composite, metaclass=ComponentType):
         if average:
             raise NotImplementedError("Component has no method for producing average MG flux -- tryusing blocks")
 
-        volume = volume or self.getVolume() / self.parent.getSymmetryFactor()
+        volume = self.getVolume() / self.parent.getSymmetryFactor()
         return self.getIntegratedMgFlux(adjoint=adjoint, gamma=gamma) / volume
 
     def getIntegratedMgFlux(self, adjoint=False, gamma=False):

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1974,12 +1974,12 @@ class ArmiObject(metaclass=CompositeModelType):
     def getIntegratedMgFlux(self, adjoint=False, gamma=False):
         raise NotImplementedError
 
-    def getMgFlux(self, adjoint=False, average=False, volume=None, gamma=False):
+    def getMgFlux(self, adjoint=False, average=False, gamma=False):
         """
         Return the multigroup neutron flux in [n/cm^2/s].
 
-        The first entry is the first energy group (fastest neutrons). Each additional
-        group is the next energy group, as set in the ISOTXS library.
+        The first entry is the first energy group (fastest neutrons). Each additional group is the next energy group, as
+        set in the ISOTXS library.
 
         On blocks, it is stored integrated over volume on <block>.p.mgFlux
 
@@ -1987,16 +1987,9 @@ class ArmiObject(metaclass=CompositeModelType):
         ----------
         adjoint : bool, optional
             Return adjoint flux instead of real
-
         average : bool, optional
             If true, will return average flux between latest and previous. Doesn't work
             for pin detailed yet
-
-        volume: float, optional
-            The volume-integrated flux is divided by volume before being
-            returned. The user may specify a volume here, or the function will
-            obtain the block volume directly.
-
         gamma : bool, optional
             Whether to return the neutron flux or the gamma flux.
 
@@ -2010,7 +2003,7 @@ class ArmiObject(metaclass=CompositeModelType):
                 f"{self.__class__} class has no method for producing average MG flux -- tryusing blocks"
             )
 
-        volume = volume or self.getVolume()
+        volume = self.getVolume()
         return self.getIntegratedMgFlux(adjoint=adjoint, gamma=gamma) / volume
 
     def removeMass(self, nucName, mass):


### PR DESCRIPTION
## What is the change? Why is it being made?

It was found that no one actually uses this method argument. 

close #2087


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Removing volume from getMgFlux()

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
