### PR TITLE
Clearing out Component.p.pinIndices prior to assignment

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2176,6 +2176,11 @@ class HexBlock(Block):
         locations = self.getPinLocations()
         if not locations:
             return
+        # Clear out any previous values. If your block is built with one ordering
+        # and then sorted, things that used to have pin indices may now have invalid
+        # pin indices. Wipe them out just to be safe
+        for c in self:
+            c.p.pinIndices = None
         ijGetter = operator.attrgetter("i", "j")
         allIJ: tuple[tuple[int, int]] = tuple(map(ijGetter, locations))
         # Flags for components that we want to set this parameter

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2950,6 +2950,17 @@ nuclide flags:
         for c in nonFuel.iterComponents(Flags.CLAD):
             self.assertIsNotNone(c.getPinIndices())
 
+    def test_assignmentChangesPreviousPinIndices(self):
+        """Show successive calls to assignPinIndices clear out previous state."""
+        # assign pin indices to something that maybe doesn't need it
+        firstFuel = self.block.getFirstComponent(Flags.FUEL)
+        firstClad = self.block.getFirstComponent(Flags.CLAD)
+        self.assertIsNone(firstClad.p.pinIndices)
+        self.assertIsNotNone(firstFuel.p.pinIndices)
+        firstClad.p.pinIndices = firstFuel.p.pinIndices
+        self.block.assignPinIndices()
+        self.assertIsNone(firstClad.p.pinIndices)
+
     def test_fuelAndNonFuel(self):
         """If you have fuel and non-fuel pins in the block, all pins should have indices still."""
         firstBefore = self.fuelPins[0].getPinIndices()


### PR DESCRIPTION
## What is the change? Why is it being made?

In some edge testing, it was discovered you could have components with pin indices that reflected some previous state. e.g., prior to sorting. This would be very confusing and wrong if certain pins indicated they were at different locations.

Now `HexBlock.assignPinIndices` will set `pinIndices` to None on every component prior to assignment.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Clear out Component.p.pinIndices prior to assignment

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
