### PR TITLE
Provide Core.hasLib to check if there is a cross section library

### DIFF
--- a/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
+++ b/armi/physics/neutronics/latticePhysics/latticePhysicsInterface.py
@@ -383,7 +383,7 @@ class LatticePhysicsInterface(interfaces.Interface):
         if executeXSGen and not idsChangedBurnup:
             executeXSGen = False
 
-        if self.r.core._lib is not None:
+        if self.r.core.hasLib():
             # justification=r.core.lib property can raise exception or load pre-generated
             # ISOTXS, but the interface should have responsibility of loading
             # XS's have already generated for this cycle (maybe during fuel management). Should we update due to
@@ -391,21 +391,21 @@ class LatticePhysicsInterface(interfaces.Interface):
             missing = set(xsIDs) - set(self.r.core.lib.xsIDs)
             if missing and not executeXSGen:
                 runLog.info(
-                    f"Although a XS library {self.r.core._lib} exists on {self.r.core}, "
+                    f"Although a XS library {self.r.core.lib} exists on {self.r.core}, "
                     f"there are missing XS IDs {missing} required. The XS generation on cycle {cycle} "
                     "is not enabled, but will be run to generate these missing cross sections."
                 )
                 executeXSGen = True
             elif missing:
                 runLog.info(
-                    f"Although a XS library {self.r.core._lib} exists on {self.r.core}, "
+                    f"Although a XS library {self.r.core.lib} exists on {self.r.core}, "
                     f"there are missing XS IDs {missing} required. These will be generated "
                     f"on cycle {cycle}."
                 )
                 executeXSGen = True
             else:
                 runLog.info(
-                    f"A XS library {self.r.core._lib} exists on {self.r.core} and contains "
+                    f"A XS library {self.r.core.lib} exists on {self.r.core} and contains "
                     f"the required XS data for XS IDs {self.r.core.lib.xsIDs}. The generation "
                     "of XS will be skipped."
                 )

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -251,6 +251,15 @@ class Core(composites.Composite):
         runLog.extra(f"Updating cross section library on {self}.\nInitial: {self._lib}\nUpdated: {value}.")
         self._lib = value
 
+    def hasLib(self):
+        """Check if the microscopic cross section library is set.
+
+        Since the property ``lib`` will attempt to auto-load from a given ISOTXS file
+        in the working directory, checking ``r.core.lib is not None`` may result in unexpected
+        behavior. Use this instead.
+        """
+        return self._lib is not None
+
     @property
     def isFullCore(self):
         """Return True if reactor is full core, otherwise False."""

--- a/armi/reactor/tests/test_cores.py
+++ b/armi/reactor/tests/test_cores.py
@@ -133,10 +133,12 @@ class HexCoreTests(unittest.TestCase):
         # the default case will look something like this
         mockFileName.return_value = "ISOTXS-c0n0"
         self.assertIsNone(self.core.lib)
+        self.assertFalse(self.core.hasLib())
 
         # we can inject some mock data, and retrieve it
         mockFileName.return_value = ISOAA_PATH
         self.assertTrue(isinstance(self.core.lib, IsotxsLibrary))
+        self.assertTrue(self.core.hasLib())
 
     def test_getAssembliesInRing(self):
         assems = self.core.getAssembliesInRing(0)


### PR DESCRIPTION
## What is the change? Why is it being made?

In working on #2320 // #2316 I came across a weird pattern. If I want to check if the core currently has a cross section library, I could write `if self.r.core.lib is None`. But the `Core.lib` property will attempt to load a library if there is not one. This could have some unintentional side effects (and some have been handled e.g., #2173)

It's also not _great_ to encourage people to access what should be a protected attribute and check `if self.r.core._lib is None`. So, now `Core.hasLib() -> bool` will do this for you.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features 
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Provide Core.hasLib to check if there is a cross section library

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [ ] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [ ] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The dependencies are still up-to-date in `pyproject.toml`.
