### PR TITLE
Adding a unit test to HexGrid.generateSortedHexLocationList

### DIFF
--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -241,6 +241,27 @@ class TestGrid(unittest.TestCase):
         reduction = grid.reduce()
         self.assertAlmostEqual(reduction[0][1][1], 1.0)
 
+    def test_generateSortedHexLocationList(self):
+        for pitch in [1.0, 3.14]:
+            for rings in [3, 12]:
+                grid = grids.HexGrid.fromPitch(pitch, numRings=rings)
+
+                lst = grid.generateSortedHexLocationList(1)
+                self.assertEqual(len(lst), 1)
+                self.assertEqual(lst[0].indices.tolist(), [0, 0, 0])
+
+                lst = grid.generateSortedHexLocationList(2)
+                self.assertEqual(len(lst), 2)
+                self.assertEqual(lst[0].indices.tolist(), [0, 0, 0])
+                self.assertEqual(lst[1].indices.tolist(), [-1, 0, 0])
+
+                lst = grid.generateSortedHexLocationList(4)
+                self.assertEqual(len(lst), 4)
+                self.assertEqual(lst[0].indices.tolist(), [0, 0, 0])
+                self.assertEqual(lst[1].indices.tolist(), [-1, 0, 0])
+                self.assertEqual(lst[2].indices.tolist(), [-1, 1, 0])
+                self.assertEqual(lst[3].indices.tolist(), [0, -1, 0])
+
     def test_getitem(self):
         """
         Test that locations are created on demand, and the multi-index locations are


### PR DESCRIPTION
## What is the change? Why is it being made?

Adding a unit test to `HexGrid.generateSortedHexLocationList`.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Adding a unit test to HexGrid.generateSortedHexLocationList.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
