### PR TITLE
Resolve TEST_ROOT path

### DIFF
--- a/armi/testing/__init__.py
+++ b/armi/testing/__init__.py
@@ -65,7 +65,7 @@ def loadTestReactor(inputFilePath=TEST_ROOT, customSettings=None, inputFileName=
     global _TEST_REACTOR
     fName = os.path.join(inputFilePath, inputFileName)
     customSettings = customSettings or {}
-    isPickeledReactor = os.path.realpath(fName) == os.path.realpath(ARMI_RUN_PATH) and customSettings == {}
+    isPickeledReactor = fName == ARMI_RUN_PATH and customSettings == {}
 
     if isPickeledReactor and _TEST_REACTOR:
         # return test reactor only if no custom settings are needed.


### PR DESCRIPTION
## What is the change? Why is it being made?

#2315 added `TEST_ROOT` to the testing module rather than importing it from the tests module. It looked like a sane path, and is a sane path....

But, the default of `armi/testing/../tests/armiRun.yaml` didn't resolve to the same path **_STRING_** as the old TEST_ROOT (which is being used in downstream repos), so this check resulted in false: `isPickeledReactor = fName == ARMI_RUN_PATH`. Some unit tests that heavily relied on the reactor being pickeled were slowed down as a result.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Process TEST_ROOT so that the path string for a test case will resolve to match ARMI_RUN_PATH for test reactor pickeling. 

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
