### PR TITLE
Trying to fix docs

### DIFF
--- a/doc/gallery-src/framework/run_programmaticReactorDefinition.py
+++ b/doc/gallery-src/framework/run_programmaticReactorDefinition.py
@@ -76,8 +76,7 @@ def buildComponents():
     fuel.name = "fuel"
     fuel.shape = "Circle"
     fuel.mult = 217
-    fuel.material = "Custom"
-    fuel.isotopics = "steel"
+    fuel.material = "UZr"
     fuel.Tinput = ISOTHERMAL_TEMPERATURE_IN_C
     fuel.Thot = ISOTHERMAL_TEMPERATURE_IN_C
     fuel.id = 0.0


### PR DESCRIPTION
## What is the change? Why is it being made?

At some point recently, the docs started failing during the gallery build:

https://github.com/terrapower/armi/actions/runs/18723643252/job/53402506242#step:7:605

With the error:

```bash
generating gallery for gallery/framework... [ 85%] run_programmaticReactorDefinition.py
WARNING: /home/runner/work/armi/armi/doc/gallery-src/framework/run_programmaticReactorDefinition.py failed to execute correctly: Traceback (most recent call last):
  File "/home/runner/work/armi/armi/doc/gallery-src/framework/run_programmaticReactorDefinition.py", line 226, in <module>
    o = case.initializeOperator()
...
    b = bDesign.construct(cs, blueprint, axialIndex, meshPoints, height, xsType, materialInput)
  File "/home/runner/work/armi/armi/armi/reactor/blueprints/blockBlueprint.py", line 143, in construct
    c = componentDesign.construct(
        blueprint,
        filteredMaterialInput,
        cs[CONF_INPUT_HEIGHTS_HOT],
    )
  File "/home/runner/work/armi/armi/armi/reactor/blueprints/componentBlueprint.py", line 232, in construct
    raise IOError(msg)
OSError: Custom material does not have isotopics: {self}
```

The PR that caused the build to fail was this one: https://github.com/terrapower/armi/pull/2328


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Trying to fix docs

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
