### PR TITLE
Documenting how to use the `zonesFile` Setting

### DIFF
--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -480,6 +480,22 @@ This example would produce four zones:
 3. ``fuel z1`` containing one fuel assembly: ``004-001``, and
 4. ``secondary control`` containing the assembly at ``004-002``.
 
+An alternative method is with the ``zoneDefinitions`` setting in the primary settings file. This contains a list of
+zone names and the assemblies that make up that zone. The following would create an identical zone structure as above.
+
+.. code:: yaml
+
+    settings:
+      zoneDefinitions:
+        - "primary control: 001-001"
+        - "fuel z0: 002-001, 003-001"
+        - "fuel z1: 004-001"
+        - "secondary control: 004-002"
+
+.. note::
+
+    These are list of strings, not additional maps. Wrapping in quotations is required to process the zone definitions.
+
 These zones will be populated according to the :meth:`~armi.reactor.cores.Core.buildManualZones` core method.
 
 .. _bp-input-file:


### PR DESCRIPTION
## What is the change? Why is it being made?

Document how to use the `zonesFile` setting. This information was missing and the alternative way to make zones, via `zoneDefinitions`, does not seem to work - #2341 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Documenting how to use the `zonesFile` Setting.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Documentation around the R_ARMI_ZONE functionality

---

## Checklist


- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
