### PR TITLE
Improving documentation for zoneDefinions setting

### DIFF
--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -2196,14 +2196,14 @@ class Core(composites.Composite):
         Manual zones will be defined in a special string format, e.g.:
 
         >>> zoneDefinitions:
-        >>>     - ring-1: 001-001
-        >>>     - ring-2: 002-001, 002-002
-        >>>     - ring-3: 003-001, 003-002, 003-003
+        >>>     - "ring-1: 001-001"
+        >>>     - "ring-2: 002-001, 002-002"
+        >>>     - "ring-3: 003-001, 003-002, 003-003"
 
         Notes
         -----
-        This function will just define the Zones it sees in the settings, it does not do any
-        validation against a Core object to ensure those manual zones make sense.
+        This function will just define the Zones it sees in the settings, it does not do any validation against a Core
+        object to ensure those manual zones make sense.
         """
         if cs[CONF_ZONE_DEFINITIONS]:
             runLog.info(f"Building Zones by manual definitions in {CONF_ZONE_DEFINITIONS} setting")

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -740,7 +740,7 @@ def defineSettings() -> List[setting.Setting]:
             default=[],
             label="Zone Definitions",
             description="Manual definitions of zones as lists of assembly locations "
-            "(e.g. 'zoneName: loc1, loc2, loc3') . Zones are groups of assemblies used "
+            '(e.g. "zoneName: loc1, loc2, loc3") . Zones are groups of assemblies used '
             f"by various summary and calculation routines. See also {CONF_ZONES_FILE} "
             "for an alternative method of specifying zones.",
         ),


### PR DESCRIPTION
## What is the change? Why is it being made?

Improving documentation for `zoneDefinions` setting to close #2341


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Improving documentation for zoneDefinions setting

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
