### PR TITLE
Fixing missing f-string in component blueprints

### DIFF
--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -227,7 +227,7 @@ class ComponentBlueprint(yamlize.Object):
 
         if hasattr(constructedObject, "material") and "Custom" in str(constructedObject.material):
             if len(constructedObject.material.massFrac) == 0:
-                msg = "Custom material does not have isotopics: {self}"
+                msg = f"Custom material does not have isotopics: {self}"
                 runLog.error(msg, single=True)
                 raise IOError(msg)
 


### PR DESCRIPTION
## What is the change? Why is it being made?

In a recent PR I made a typo that reduces the usefulness of a print statement. Chris found it. Thanks, Chris!


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Fixing missing f-string in component blueprints.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
