### PR TITLE
Make singleMixedAssembly more flexible for downstream testing

### DIFF
--- a/armi/testing/singleMixedAssembly.py
+++ b/armi/testing/singleMixedAssembly.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import io
-from typing import Optional
 
 from armi.reactor.blueprints import Blueprints
 from armi.settings import Settings


### PR DESCRIPTION
## What is the change? Why is it being made?

Recently, we added `singleMixedAssembly.py` to create a test assembly with multiple pins. This change simply enables downstream applications to modify the blueprints that get used to create the assembly. 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
Change Type: trivial
<!-- Change Type: docs -->

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: Improve testing flexibility.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
