### PR TITLE
Fixing compareLines for a multiple numbers edge case

### DIFF
--- a/armi/tests/__init__.py
+++ b/armi/tests/__init__.py
@@ -253,9 +253,8 @@ class ArmiTestHelper(unittest.TestCase):
 
             if actualVal is not None:
                 # we have two floats and can compare them
-                if actualVal == expectedVal:
-                    # will catch the case where they are zero
-                    return True
+                if actualVal == expectedVal == 0:
+                    continue
                 elif abs(actualVal - expectedVal) / expectedVal > eps:
                     return False
             else:

--- a/armi/tests/test_tests.py
+++ b/armi/tests/test_tests.py
@@ -23,15 +23,51 @@ class TestCompareFiles(unittest.TestCase):
     def test_compareFileLine(self):
         expected = "oh look, a number! 3.14 and some text and another number 1.5 and another 0.0"
 
+        # any line compared with itself should pass
         self.assertTrue(tests.ArmiTestHelper.compareLines(expected, expected))
         self.assertTrue(tests.ArmiTestHelper.compareLines(expected, expected, eps=0.01))
 
+        # if we vary the numbers a tiny bit, the epsilon parameter should correctly control the comparison
         actual = "oh look, a number! 3.15 and some text and another number 1.6 and another 0.0  "
         self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))
         self.assertTrue(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.07))
 
+        # if we add an extra, non-number word, the comparison should fail
         actual = "oh look, a number! 3.15 and some text and another number 1.6 extra and another 0.0"
         self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))
 
+        # if we replace a number with not a number, the comparison should fail
         actual = "oh look, a number! notANumber and some text and another number 1.5 and another 0.0"
         self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.04))
+
+    def test_onlySomeMatch(self):
+        # only the first number in the line matches, so the line should fail
+        expected = "oh look, a number! 3.14 and some text and another number 1.5 and another 0.0"
+        actual = "oh look, a number! 3.14 and some text and another number 2.2 and another 9.9"
+        self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.01))
+
+        # only the second number in the line matches, so the line should fail
+        expected = "oh look, a number! 3.14 and some text and another number 1.5 and another 0.0"
+        actual = "oh look, a number! 7.7 and some text and another number 1.5 and another 9.9"
+        self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.01))
+
+        # only the last number in the line matches, so the line should fail
+        expected = "oh look, a number! 3.14 and some text and another number 1.5 and another 0.0"
+        actual = "oh look, a number! 7.7 and some text and another number 8.5 and another 0.0"
+        self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual, eps=0.01))
+
+    def test_strangeCases(self):
+        # comparing the same string should return True, even if there are no numbers
+        expected = "There are no numbers"
+        self.assertTrue(tests.ArmiTestHelper.compareLines(expected, expected))
+
+        # comparing different strings should return False, even if there are no numbers
+        actual = "There are SOME numbers"
+        self.assertFalse(tests.ArmiTestHelper.compareLines(expected, actual))
+
+        # comparing empty strings should return True
+        self.assertTrue(tests.ArmiTestHelper.compareLines("", ""))
+
+        # comparing equal strings of whitespace should return True
+        whiteSpace3 = "   "
+        self.assertTrue(tests.ArmiTestHelper.compareLines(whiteSpace3, str(whiteSpace3)))


### PR DESCRIPTION
## What is the change? Why is it being made?

This section of code was written to compare two lines where both lines contained a zero:

https://github.com/terrapower/armi/blob/a25238da894d37139b566a9335ed57b9024abf76/armi/tests/__init__.py#L256-L258

But it incorrectly passes the entire line with a `True` if there are multiple numbers on the line and the first numbers are equal, but the following aren't. For instance, these two lines are not equal, but would the old `compareLines()` would currently return `True`:

```python
expected = "oh look, a number! 3.14 and some text and another number 1.5 and another 0.0"
actual = "oh look, a number! 3.14 and some text and another number 2.2 and another 9.9"
```


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: If a line has multiple numbers on it, ALL the numbers must be equal for `compareLines()` to return `True`.
One-Sentence Rationale: There was an edge case in compareLines that could lead to incorrect results.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
