### PR TITLE
Clarifying that ARMI materials are of testing quality

### DIFF
--- a/armi/materials/air.py
+++ b/armi/materials/air.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Simple air material."""
+"""Simple air material.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials import material
 from armi.utils.units import G_PER_CM3_TO_KG_PER_M3, getTk

--- a/armi/materials/alloy200.py
+++ b/armi/materials/alloy200.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Alloy-200 are wrought commercially pure nickel."""
+"""Alloy-200 are wrought commercially pure nickel.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from numpy import interp
 

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -18,6 +18,10 @@ Boron carbide; a very typical reactor control material.
 Note that this material defaults to a theoretical density fraction of 0.9, reflecting the difficulty of producing B4C at
 100% theoretical density in real life. To get different fraction, use the `TD_frac` material modification in your
 assembly definition.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi import runLog

--- a/armi/materials/be9.py
+++ b/armi/materials/be9.py
@@ -16,6 +16,10 @@
 Beryllium is a lightweight metal with lots of interesting nuclear use-cases.
 
 It has a nice (n,2n) reaction and is an inhalation hazard.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi.materials.material import Material

--- a/armi/materials/caH2.py
+++ b/armi/materials/caH2.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Calcium Hydride."""
+"""Calcium Hydride.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/californium.py
+++ b/armi/materials/californium.py
@@ -15,8 +15,12 @@
 """
 Californium is a synthetic element made in nuclear reactors.
 
-It is interesting in that it has a large spontaneous fission decay mode that
-produces lots of neutrons. It's often used as a neutron source.
+It is interesting in that it has a large spontaneous fission decay mode that produces lots of neutrons. It's often used
+as a neutron source.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi.materials.material import SimpleSolid

--- a/armi/materials/concrete.py
+++ b/armi/materials/concrete.py
@@ -15,8 +15,11 @@
 """
 Concrete.
 
-Concrete is often used to provide structural support of nuclear equipment. It can also provide
-radiation shielding.
+Concrete is often used to provide structural support of nuclear equipment. It can also provide radiation shielding.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi.materials.material import Material

--- a/armi/materials/copper.py
+++ b/armi/materials/copper.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Copper metal."""
+"""Copper metal.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import Material
 from armi.utils.units import getTk

--- a/armi/materials/cs.py
+++ b/armi/materials/cs.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Cesium."""
+"""Cesium.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import Fluid
 from armi.utils.units import getTk

--- a/armi/materials/graphite.py
+++ b/armi/materials/graphite.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Graphite is often used as a moderator in gas-cooled nuclear reactors."""
+"""Graphite is often used as a moderator in gas-cooled nuclear reactors.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import Material
 from armi.nucDirectory import thermalScattering as tsl

--- a/armi/materials/hafnium.py
+++ b/armi/materials/hafnium.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Hafnium is an element that has high capture cross section across multiple isotopes."""
+"""Hafnium is an element that has high capture cross section across multiple isotopes.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import SimpleSolid
 from armi.nucDirectory import nucDir

--- a/armi/materials/hastelloyN.py
+++ b/armi/materials/hastelloyN.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Hastelloy-N is a high-nickel structural material invented by ORNL for handling molten fluoride salts."""
+"""Hastelloy-N is a high-nickel structural material invented by ORNL for handling molten fluoride salts.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import Material
 from armi.utils.units import getTc, getTk

--- a/armi/materials/ht9.py
+++ b/armi/materials/ht9.py
@@ -16,6 +16,10 @@
 Simple/academic/incomplete HT9 ferritic-martensitic stainless steel material.
 
 This is a famous SFR cladding/duct material because it doesn't void swell that much.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi import materials

--- a/armi/materials/inconel.py
+++ b/armi/materials/inconel.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Inconel is a austenitic nickel-chromium superalloy."""
+"""Inconel is a austenitic nickel-chromium superalloy.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/inconel600.py
+++ b/armi/materials/inconel600.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Inconel600."""
+"""Inconel600.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 import numpy as np
 

--- a/armi/materials/inconel625.py
+++ b/armi/materials/inconel625.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Inconel625."""
+"""Inconel625.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 import numpy as np
 

--- a/armi/materials/inconel800.py
+++ b/armi/materials/inconel800.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Incoloy 800."""
+"""Incoloy 800.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import Material
 from armi.utils.units import getTc

--- a/armi/materials/inconelPE16.py
+++ b/armi/materials/inconelPE16.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Inconel PE16."""
+"""Inconel PE16.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi import runLog
 from armi.materials.material import SimpleSolid

--- a/armi/materials/inconelX750.py
+++ b/armi/materials/inconelX750.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Inconel X750."""
+"""Inconel X750.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 import numpy as np
 

--- a/armi/materials/lead.py
+++ b/armi/materials/lead.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Lead."""
+"""Lead.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials import material
 from armi.utils.units import getTk

--- a/armi/materials/leadBismuth.py
+++ b/armi/materials/leadBismuth.py
@@ -16,6 +16,10 @@
 Lead-Bismuth eutectic.
 
 This is a great coolant for superfast neutron reactors. It's heavy though.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 import math

--- a/armi/materials/lithium.py
+++ b/armi/materials/lithium.py
@@ -15,7 +15,13 @@
 """
 Lithium.
 
-.. WARNING:: Whenever you irradiate lithium you will get tritium.
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+
+Warning
+-------
+Whenever you irradiate lithium you will get tritium.
 """
 
 from armi import runLog

--- a/armi/materials/magnesium.py
+++ b/armi/materials/magnesium.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Magnesium."""
+"""Magnesium.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials import material
 from armi.utils.units import getTk

--- a/armi/materials/mgO.py
+++ b/armi/materials/mgO.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Magnesium Oxide."""
+"""Magnesium Oxide.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import Material
 from armi.utils.units import getTc, getTk

--- a/armi/materials/molybdenum.py
+++ b/armi/materials/molybdenum.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Molybdenum."""
+"""Molybdenum.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/mox.py
+++ b/armi/materials/mox.py
@@ -21,6 +21,9 @@ A definitive source for these properties is [#ornltm20002]_.
     Irradiation. S.G. Popov, et.al.  Oak Ridge National Laboratory.
     ORNL/TM-2000/351 https://rsicc.ornl.gov/fmdp/tm2000-351.pdf
 
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi import runLog

--- a/armi/materials/nZ.py
+++ b/armi/materials/nZ.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Niobium Zirconium Alloy."""
+"""Niobium Zirconium Alloy.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/potassium.py
+++ b/armi/materials/potassium.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Potassium."""
+"""Potassium.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials import material
 from armi.utils.units import getTc, getTk

--- a/armi/materials/scandiumOxide.py
+++ b/armi/materials/scandiumOxide.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Scandium Oxide."""
+"""Scandium Oxide.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import Material
 from armi.utils.units import getTk

--- a/armi/materials/siC.py
+++ b/armi/materials/siC.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Silicon Carbide."""
+"""Silicon Carbide.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 import math
 

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Simple sodium material."""
+"""Simple sodium material.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi import runLog
 from armi.materials import material

--- a/armi/materials/sodiumChloride.py
+++ b/armi/materials/sodiumChloride.py
@@ -15,6 +15,10 @@
 """
 Sodium Chloride salt.
 
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+
 Notes
 -----
 This is a very simple description of this material.

--- a/armi/materials/sulfur.py
+++ b/armi/materials/sulfur.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Sulfur."""
+"""Sulfur.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi import runLog
 from armi.materials import material

--- a/armi/materials/tZM.py
+++ b/armi/materials/tZM.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""TZM."""
+"""TZM.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from numpy import interp
 

--- a/armi/materials/tantalum.py
+++ b/armi/materials/tantalum.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tantalum."""
+"""Tantalum.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import SimpleSolid
 

--- a/armi/materials/thU.py
+++ b/armi/materials/thU.py
@@ -17,6 +17,9 @@ Thorium Uranium metal.
 
 Data is from [IAEA-TECDOC-1450]_.
 
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi import runLog

--- a/armi/materials/thorium.py
+++ b/armi/materials/thorium.py
@@ -17,6 +17,9 @@ Thorium Metal.
 
 Data is from [IAEA-TECDOC-1450]_.
 
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi.materials.material import FuelMaterial

--- a/armi/materials/thoriumOxide.py
+++ b/armi/materials/thoriumOxide.py
@@ -19,6 +19,10 @@ Data is from [IAEA-TECDOC-1450]_.
 
 .. [IAEA-TECDOC-1450] Thorium fuel cycle -- Potential benefits and challenges, IAEA-TECDOC-1450 (2005).
     https://www-pub.iaea.org/mtcd/publications/pdf/te_1450_web.pdf
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi import runLog

--- a/armi/materials/uThZr.py
+++ b/armi/materials/uThZr.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Uranium Thorium Zirconium alloy metal."""
+"""Uranium Thorium Zirconium alloy metal.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi import runLog
 from armi.materials.material import FuelMaterial

--- a/armi/materials/uZr.py
+++ b/armi/materials/uZr.py
@@ -16,6 +16,10 @@
 Simplified UZr alloy.
 
 This is a notional U-10Zr material based on [Chandrabhanu]_.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from armi.materials import material

--- a/armi/materials/uranium.py
+++ b/armi/materials/uranium.py
@@ -17,7 +17,11 @@ Uranium metal.
 
 Much info is from [AAAFuels]_.
 
-.. [AAAFuels]  Kim, Y S, and Hofman, G L. AAA fuels handbook.. United States: N. p., 2003. Web. doi:10.2172/822554. .
+.. [AAAFuels]  Kim, Y S, and Hofman, G L. AAA fuels handbook.. United States: N. p., 2003. Web. doi:10.2172/822554.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 from numpy import interp

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -20,6 +20,10 @@ uses data from [#ornltm2000]_.
 
 .. [#ornltm2000] Thermophysical Properties of MOX and UO2 Fuels Including the Effects of Irradiation. S.G. Popov,
     et.al. Oak Ridge National Laboratory. ORNL/TM-2000/351 https://rsicc.ornl.gov/fmdp/tm2000-351.pdf
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
 """
 
 import collections

--- a/armi/materials/water.py
+++ b/armi/materials/water.py
@@ -11,7 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Basic water material."""
+"""Basic water material.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 import math
 
@@ -28,17 +33,15 @@ class Water(Fluid):
     """
     Water.
 
-    This is a good faith implementation of the Revised Supplementary Properties
-    of Ordinary Water Substance (1992) by IAPWS -- International Association for
-    the Properties of Water and Steam .
+    This is a good faith implementation of the Revised Supplementary Properties of Ordinary Water Substance (1992) by
+    IAPWS -- International Association for the Properties of Water and Steam .
 
-    This is an abstract class implemented on the Saturated Water Material Class
-    and the Saturated Steam Material Class, which should be good enough for
+    This is an abstract class implemented on the Saturated Water Material  and the Saturated Steam Material Class, which
+    should be good enough for
     most uses.
 
     http://www.iapws.org/relguide/supsat.pdf
-    IAPWS-IF97 is now the international standard for calculations in the steam
-    power industry
+    IAPWS-IF97 is now the international standard for calculations in the steam power industry
     """
 
     thermalScatteringLaws = (tsl.fromNameAndCompound("H", tsl.H2O),)
@@ -61,8 +64,7 @@ class Water(Fluid):
     ALPHA_0 = 1000
     PHI_0 = ALPHA_0 / TEMPERATURE_CRITICAL_K
 
-    # coefficients for auxiliary quantity for enthalpy and entropy
-    # kept as d to match original source
+    # coefficients for auxiliary quantity for enthalpy and entropy kept as d to match original source
     d = {
         1: -5.65134998e-08,
         2: 2690.66631,

--- a/armi/materials/yttriumOxide.py
+++ b/armi/materials/yttriumOxide.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Yttrium Oxide."""
+"""Yttrium Oxide.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import Material
 from armi.utils.units import getTk

--- a/armi/materials/zincOxide.py
+++ b/armi/materials/zincOxide.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Zinc Oxide."""
+"""Zinc Oxide.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from armi.materials.material import Material
 from armi.utils.units import getTk

--- a/armi/materials/zr.py
+++ b/armi/materials/zr.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Zirconium metal."""
+"""Zirconium metal.
+
+The data in this file exists for testing and demonstration purposes only. Developers of ARMI applications can refer to
+this file for a fully worked example of an ARMI material. And this material has proven useful for testing. The data
+contained in this file should not be used in production simulations.
+"""
 
 from numpy import interp
 


### PR DESCRIPTION
## What is the change? Why is it being made?

I added a comment to the docstring of each ARMI material clarifying that each ARMI material is presented for testing and demonstration purposes only.

It concerns me that people might depend on unqualified ARMI materials for production runs. There will have to be more work on this in the near future.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe the change in one sentence -->
One-Sentence Description: It is important to ensure that downstream users understand that ARMI materials are not of production quality, and ARMI is a modeling framework not a data source.
One-Sentence Rationale: It should be clear to ARMI users that ARMI does not qualify material data.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
