### PR TITLE
Improving and correcting the ARMI version semantics

### DIFF
--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -157,19 +157,19 @@ class NuclideInterface:
 
     def getMcc2Id(self):
         """Return the MC2-2 nuclide identification label based on the ENDF/B-V.2 cross section library."""
-        raise NotImplementedError
+        return NotImplementedError
 
     def getMcc3Id(self):
         """Return the MC2-3 nuclide identification label based on the ENDF/B-VII.1 cross section library."""
-        raise NotImplementedError
+        return NotImplementedError
 
     def getMcc3IdEndfbVII0(self):
         """Return the MC2-3 nuclide identification label based on the ENDF/B-VII.0 cross section library."""
-        raise NotImplementedError
+        return NotImplementedError
 
     def getMcc3IdEndfbVII1(self):
         """Return the MC2-3 nuclide identification label based on the ENDF/B-VII.1 cross section library."""
-        raise NotImplementedError
+        return NotImplementedError
 
     def getSerpentId(self):
         """Get the Serpent nuclide identification label."""

--- a/armi/reactor/grids/locations.py
+++ b/armi/reactor/grids/locations.py
@@ -100,8 +100,7 @@ class LocationBase(ABC):
             return (self.i, self.j, self.k) == other
         if isinstance(other, LocationBase):
             return self.i == other.i and self.j == other.j and self.k == other.k and self.grid is other.grid
-
-        raise NotImplementedError
+        return NotImplemented
 
     def __lt__(self, that: "LocationBase") -> bool:
         """
@@ -349,9 +348,8 @@ class MultiIndexLocation(IndexLocation):
         """
         if isinstance(other, type(self)):
             return self.grid == other.grid and self._locations == other._locations
-
         # Different objects -> let other.__eq__(self) handle it
-        raise NotImplementedError
+        return NotImplemented
 
     def __getstate__(self) -> List[IndexLocation]:
         """Used in pickling and deepcopy, this detaches the grid."""
@@ -435,8 +433,7 @@ class CoordinateLocation(IndexLocation):
             # Fuel pins may have a multi index location and the duct may
             # have a coordinate location and we don't want them to be equal
             return self.grid == other.grid and self.i == other.i and self.j == other.j and self.k == other.k
-
-        raise NotImplementedError
+        return NotImplemented
 
     def __hash__(self):
         """Hash based on the coordinates but not the grid."""


### PR DESCRIPTION
## What is the change? Why is it being made?

Improving and correcting the ARMI version semantics.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: It has been noted that the version semantics in the ARMI docs did not match the reality of the ARMI releases.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
