### PR TITLE
Documenting database cycle and node values

### DIFF
--- a/doc/user/outputs.rst
+++ b/doc/user/outputs.rst
@@ -92,6 +92,8 @@ method to get a recovered ``Reactor`` object. For instance, given a database fil
    with db:
        r = db.load(5, 2)
 
+.. note:: The cycles are 0-indexed, but the time nodes, in practice, are not. Therefore, cycle 5 above is actually the 6th cycle in the simulation. For cycle 5 with two time nodes, there will be three time steps saved to the database: c5n0 (BOC), c5n1 (time node 1), and c5n2 (time node 2).
+
 Extracting Reactor History
 --------------------------
 Not only can the database reproduce reactor state for a given time node, it can also


### PR DESCRIPTION
## What is the change? Why is it being made?

A new user was training and was confused about the C/N timesteps saved to the DB. When I looked into it, I realized it actually isn't super obvious what's happening. Hopefully this note clarifies what's happening?

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Improves database behavior clarity for users.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
