### PR TITLE
Changing MPI_COMM to the Pickle Protocol 5

### DIFF
--- a/armi/context.py
+++ b/armi/context.py
@@ -100,8 +100,9 @@ MPI_NODENAMES = [LOCAL]
 try:
     # Check for MPI
     from mpi4py import MPI
+    from mpi4py.util import pkl5
 
-    MPI_COMM = MPI.COMM_WORLD
+    MPI_COMM = pkl5.Intracomm(MPI.COMM_WORLD)
     MPI_RANK = MPI_COMM.Get_rank()
     MPI_SIZE = MPI_COMM.Get_size()
     MPI_NODENAME = MPI.Get_processor_name()


### PR DESCRIPTION
## What is the change? Why is it being made?

Altering MPI_COMM to be pkl5 Intracomm to allow larger reactors to be passed to workers.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: This allows for larger messages to be passed to workers due to efficient chunking of message size.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Indirect impact on `R_ARMI_OPERATOR_MPI`, in that it makes it more efficient for large reactors.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
