### PR TITLE
Set materials.FAIL_ON_RANGE to True by default

### DIFF
--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -34,7 +34,7 @@ class B4C(material.Material):
     DEFAULT_THEORETICAL_DENSITY_FRAC = 0.90
     enrichedNuclide = "B10"
     NATURAL_B10_NUM_FRAC = 0.199
-    propertyValidTemperature = {"linear expansion percent": ((25, 500), "C")}
+    propertyValidTemperature = {"linear expansion percent": ((25, 600), "C")}
 
     def __init__(self):
         self.b10NumFrac = self.NATURAL_B10_NUM_FRAC

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -627,12 +627,12 @@ class Material:
             msg = "Temperature {0} out of range ({1} to {2}) for {3} {4}".format(val, minT, maxT, self.name, label)
             if FAIL_ON_RANGE or np.isnan(val):
                 runLog.error(msg)
-                raise ValueError
+                raise ValueError(msg)
             else:
                 runLog.warning(
                     msg,
                     single=True,
-                    label="T out of bounds for {} {}".format(self.name, label),
+                    label=f"T out of bounds for {self.name} {label}",
                 )
 
     def densityTimesHeatCapacity(self, Tk: float = None, Tc: float = None) -> float:

--- a/armi/materials/sodium.py
+++ b/armi/materials/sodium.py
@@ -41,7 +41,7 @@ class Sodium(material.Fluid):
     propertyValidTemperature = {
         "density": ((97.85, 2230.55), "C"),
         "enthalpy": ((371.0, 2000.0), "K"),
-        "thermal conductivity": ((3715, 1500), "K"),
+        "thermal conductivity": ((371.5, 1500), "K"),
     }
 
     def setDefaultMassFracs(self):

--- a/armi/materials/tests/test_sulfur.py
+++ b/armi/materials/tests/test_sulfur.py
@@ -21,6 +21,7 @@ from armi.materials.tests.test_materials import _Material_Test
 
 class Sulfur_TestCase(_Material_Test, unittest.TestCase):
     MAT_CLASS = Sulfur
+    VALID_TEMP_K = 400
 
     def setUp(self):
         _Material_Test.setUp(self)
@@ -36,15 +37,16 @@ class Sulfur_TestCase(_Material_Test, unittest.TestCase):
         self.Sulfur_both.applyInputParams(sulfur_density_frac=0.5, TD_frac=0.4)
 
     def test_sulfur_density_frac(self):
-        ref = self.mat.pseudoDensity(500)
+        tk = 410
+        ref = self.mat.pseudoDensity(tk)
 
-        reduced = self.Sulfur_sulfur_density_frac.pseudoDensity(500)
+        reduced = self.Sulfur_sulfur_density_frac.pseudoDensity(tk)
         self.assertAlmostEqual(ref * 0.5, reduced)
 
-        reduced = self.Sulfur_TD_frac.pseudoDensity(500)
+        reduced = self.Sulfur_TD_frac.pseudoDensity(tk)
         self.assertAlmostEqual(ref * 0.4, reduced)
 
-        reduced = self.Sulfur_both.pseudoDensity(500)
+        reduced = self.Sulfur_both.pseudoDensity(tk)
         self.assertAlmostEqual(ref * 0.4, reduced)
 
     def test_propertyValidTemperature(self):

--- a/armi/materials/uraniumOxide.py
+++ b/armi/materials/uraniumOxide.py
@@ -52,7 +52,7 @@ class UraniumOxide(material.FuelMaterial, material.SimpleSolid):
     propertyUnits = {"heat capacity": "J/mol-K"}
 
     propertyValidTemperature = {
-        "density": ((300, 3100), "K"),
+        "density": ((293.15, 3100), "K"),
         "heat capacity": ((298.15, 3120), "K"),
         "linear expansion": ((273, 3120), "K"),
         "linear expansion percent": ((273, __meltingPoint), "K"),

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -674,8 +674,8 @@ class TestBlockCollectionComponentAverage1DCylinder(unittest.TestCase):
         controlComponent = components.Circle(
             "control",
             baseComponents[0].material,
-            20.0,
-            20.0,
+            100.0,
+            100.0,
             id=0.0,
             od=0.6,
             mult=multiplicity,
@@ -683,8 +683,8 @@ class TestBlockCollectionComponentAverage1DCylinder(unittest.TestCase):
         cladComponent = components.Circle(
             "clad",
             baseComponents[2].material,
-            20.0,
-            20.0,
+            100.0,
+            100.0,
             id=0.6,
             od=0.7,
             mult=multiplicity,
@@ -692,8 +692,8 @@ class TestBlockCollectionComponentAverage1DCylinder(unittest.TestCase):
         coolantComponent = components.Circle(
             "coolant",
             baseComponents[4].material,
-            20.0,
-            20.0,
+            100.0,
+            100.0,
             id=0.7,
             od=0.8,
             mult=multiplicity,

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -153,7 +153,7 @@ blocks:
         sodium1:
             shape: Circle
             material: Sodium
-            Tinput: 25
+            Tinput: 100
             Thot: 600
             id: 0
             mult: 1
@@ -163,7 +163,7 @@ blocks:
             shape: Circle
             material: Sodium
             isotopics: sodium custom isotopics
-            Tinput: 25
+            Tinput: 100
             Thot: 600
             id: 0
             mult: 1
@@ -218,7 +218,7 @@ blocks:
             shape: Hexagon
             material: Custom
             isotopics: steel
-            Tinput: 25.0
+            Tinput: 100
             Thot: 600.0
             ip: 0.0
             mult: 169.0
@@ -242,7 +242,7 @@ blocks:
         fuel: &basic_fuel
             shape: Hexagon
             material: UZr
-            Tinput: 25.0
+            Tinput: 100
             Thot: 600.0
             ip: 0.0
             mult: 1.0
@@ -251,7 +251,7 @@ blocks:
         clad:
             shape: Circle
             material: HT9
-            Tinput: 25.0
+            Tinput: 100
             Thot: 600.0
             id: 0.0
             mult: 1.0
@@ -268,7 +268,7 @@ blocks:
             shape: Hexagon
             material: Custom
             isotopics: steel
-            Tinput: 25.0
+            Tinput: 100
             Thot: 600.0
             ip: 0.0
             mult: 169.0
@@ -429,7 +429,7 @@ assemblies:
         # has a density from the blueprint and adjusted from Tinput -> Thot
         s = Sodium()
         self.assertAlmostEqual(sodium1.density(), s.density(Tc=600))
-        self.assertAlmostEqual(sodium2.density(), s.density(Tc=600) * (666 / s.density(Tc=25)))
+        self.assertAlmostEqual(sodium2.density(), s.density(Tc=600) * (666 / s.density(Tc=100)))
 
     def test_customDensityLogsAndErrors(self):
         """Test that the right warning messages and errors are emitted when applying custom densities."""

--- a/armi/reactor/converters/tests/test_assemblyAxialLinkage.py
+++ b/armi/reactor/converters/tests/test_assemblyAxialLinkage.py
@@ -153,7 +153,7 @@ class TestAxialLinkHelper(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.LOWER_BLOCK = _buildDummySodium(20, 10)
+        cls.LOWER_BLOCK = _buildDummySodium(98, 10)
 
     def test_override(self):
         """Test lower attribute can be set after construction."""

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -145,7 +145,7 @@ class TestBlockConverter(unittest.TestCase):
         self._test_dissolve(loadTestBlock(), "wire", "coolant")
         hotBlock = loadTestBlock(cold=False)
         self._test_dissolve(hotBlock, "wire", "coolant")
-        hotBlock = self._perturbTemps(hotBlock, "wire", 127, 800)
+        hotBlock = self._perturbTemps(hotBlock, "wire", 127, 700)
         self._test_dissolve(hotBlock, "wire", "coolant")
 
     def test_dissolveLinerIntoClad(self):
@@ -159,7 +159,7 @@ class TestBlockConverter(unittest.TestCase):
         self._test_dissolve(loadTestBlock(), "outer liner", "clad")
         hotBlock = loadTestBlock(cold=False)
         self._test_dissolve(hotBlock, "outer liner", "clad")
-        hotBlock = self._perturbTemps(hotBlock, "outer liner", 127, 800)
+        hotBlock = self._perturbTemps(hotBlock, "outer liner", 127, 700)
         self._test_dissolve(hotBlock, "outer liner", "clad")
 
     def test_dissolveBondIntoClad(self):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -1783,17 +1783,17 @@ class Block_TestCase(unittest.TestCase):
         emptyBlock = blocks.HexBlock("empty")
         self.assertEqual(emptyBlock.getNumPins(), 0)
 
-        holedRectangle = complexShapes.HoledRectangle("holedRectangle", "HT9", 1, 1, 0.5, 1.0, 1.0)
+        holedRectangle = complexShapes.HoledRectangle("holedRectangle", "HT9", 100, 100, 0.5, 1.0, 1.0)
         holedRectangle.setType("component", flags=Flags.CONTROL)
         emptyBlock.add(holedRectangle)
         self.assertEqual(emptyBlock.getNumPins(), 0)
 
-        hexagon = basicShapes.Hexagon("hexagon", "HT9", 1, 1, 1)
+        hexagon = basicShapes.Hexagon("hexagon", "HT9", 100, 100, 1)
         hexagon.setType("component", flags=Flags.SHIELD)
         emptyBlock.add(hexagon)
         self.assertEqual(emptyBlock.getNumPins(), 0)
 
-        pins = basicShapes.Circle("circle", "HT9", 1, 1, 1, 0, 8)
+        pins = basicShapes.Circle("circle", "HT9", 100, 100, 1, 0, 8)
         pins.setType("component", flags=Flags.PLENUM)
         emptyBlock.add(pins)
         self.assertEqual(emptyBlock.getNumPins(), 8)
@@ -2071,11 +2071,10 @@ class Block_TestCase(unittest.TestCase):
 
         Notes
         -----
-        This test calculates a reference coolant area by subtracting the areas of the intercoolant,
-        duct, wire wrap, and pins from the total hex block area. The area of the pins is calculated
-        using only the outer radius of the clad. This avoids the use of negative areas as
-        implemented in Block.getVolumeFractions. Na-23 mass will not be conserved as when duct/clad
-        expands sodium is evacuated.
+        This test calculates a reference coolant area by subtracting the areas of the intercoolant, duct, wire wrap, and
+        pins from the total hex block area. The area of the pins is calculated using only the outer radius of the clad.
+        This avoids the use of negative areas as implemented in Block.getVolumeFractions. Na-23 mass will not be
+        conserved as when duct/clad expands sodium is evacuated.
 
         See Also
         --------
@@ -2084,7 +2083,7 @@ class Block_TestCase(unittest.TestCase):
         numFE56 = self.block.getNumberOfAtoms("FE56")
         numU235 = self.block.getNumberOfAtoms("U235")
         for c in self.block:
-            c.setTemperature(800)
+            c.setTemperature(700)
         hasNegativeArea = any(c.getArea() < 0 for c in self.block)
         self.assertTrue(hasNegativeArea)
         self.block.getVolumeFractions()  # sets coolant area

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -678,7 +678,7 @@ class TestCircle(TestShapedComponent):
             :id: T_ARMI_COMP_EXPANSION1
             :tests: R_ARMI_COMP_EXPANSION
         """
-        for hotTemp in range(600, 901, 25):
+        for hotTemp in range(200, 400, 25):
             ref = self._od * self.component.getThermalExpansionFactor(Tc=hotTemp)
             cur = self.component.getDimension("od", Tc=hotTemp)
             self.assertAlmostEqual(cur, ref)
@@ -855,7 +855,7 @@ class TestCircle(TestShapedComponent):
 
 
 class TestComponentExpansion(unittest.TestCase):
-    tCold = 20
+    tCold = 25
     tWarm = 50
     tHot = 500
     coldOuterDiameter = 1.0


### PR DESCRIPTION
## What is the change? Why is it being made?

We want to set `armi.material.materials.FAIL_ON_RANGE` to `True` by default. For the past ~14 years, there has been an uncomfortable situation where if someone called a material property (say Uranium density) outside a temperature range that where we know the values, the simulation would just continue. That meant ARMI simulations could continue even if they have invalid inputs.

We are finally changing the default value, and it feels great.

close #1077 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: A simulation that has found that it has invalid or insufficient material data should fail by default.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
