### PR TITLE
Adding a count of how many settings are in ARMI

### DIFF
--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -1630,7 +1630,7 @@ Settings Report
 .. exec::
     from armi import settings
     cs = settings.Settings()
-    numSettings = len(cs)
+    numSettings = len(cs.values())
 
     return f"This document lists all {numSettings} `settings <#the-settings-input-file>`_ in ARMI.\n"
 


### PR DESCRIPTION
## What is the change? Why is it being made?

The documentation currently contains a "Settings Report". This PR is a very small change to that report; right at the start it adds a simple count of how many `Setting`s ARMI defines.

This is not a huge change, but I found myself wanting to know the answer. And I would also like to watch and see how this number changes over time.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: For long-term tracking, it would be nice to see how many Settings are defined in ARMI.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
