### PR TITLE
Updating SCR to use the term Rationale

### DIFF
--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -142,7 +142,7 @@ def _buildScrLine(prNum: str):
     # build RST list item, representing this data
     tab = "  "
     content = f"* PR #{prNum}: {title}\n\n"
-    content += f"{tab}* Change: {desc}\n"
+    content += f"{tab}* Rationale: {desc}\n"
     content += f"{tab}* Impact on Requirements: {impact}\n"
     content += f"{tab}* Author: {author}\n"
     content += f"{tab}* {reviewerHeader}: {reviewers}\n\n"


### PR DESCRIPTION
## What is the change? Why is it being made?

The new PR form uses the phrase "One-Sentence Rationale", but the SCR still references the old verbiage "Change".  We are updating the SCR to be more in line with the PR forms.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: The SCR should list the reason for the change being made.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
