### PR TITLE
New exception for mpi4py import

### DIFF
--- a/armi/context.py
+++ b/armi/context.py
@@ -111,7 +111,8 @@ except ImportError:
     # stick with defaults
     pass
 except RuntimeError:
-    # likely from MPI not being on system, this is OK for many armi invocations
+    # likely from MPI not being on system, this is OK for many ARMI invocations
+    # Note this exception was introduced upon upgrading to mpi4py 4.1.1
     pass
 
 if sys.platform.startswith("win"):


### PR DESCRIPTION
## What is the change? Why is it being made?

ARMI has a try/except for the from `mpi4py import MPI` that has historically worked for us downstream. The exception, `ImportError`, has captured all our needs up until now. 
 
Now (mpi4py 4.1.1 upgrade to go with the pkl5 change), that import has a different exception: `RuntimeError` (`RuntimeError: cannot load MPI library`). We are failing upon all invocations of armi as a result, unless we have an OMPI module loaded.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Upgrading mpi4py caused a new error; this update handles that situation.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
