### PR TITLE
Clarifying PIP version in user install docs

### DIFF
--- a/doc/user/user_install.rst
+++ b/doc/user/user_install.rst
@@ -63,7 +63,7 @@ If you are using an older version of Python, say 3.9 or older, you should ensure
 
     (armi-venv) $ pip install pip>=22.1
 
-or, again, probably it will be enough to just do::
+or it will be enough to just do::
 
     (armi-venv) $ pip install -U pip
 


### PR DESCRIPTION
## What is the change? Why is it being made?

Before Python 3.10, we had some version concerns with PIP. These aren't really important any more. We should clarify this in our docs.

close #2406


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: It is important to keep the docs clear, and this section is only important to a small number of the ARMI user base.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
