### PR TITLE
Adding unit testing to HexBlock.getPinPitch

### DIFF
--- a/armi/reactor/blocks.py
+++ b/armi/reactor/blocks.py
@@ -2228,7 +2228,7 @@ class HexBlock(Block):
             return (self.getComponent(Flags.CLAD, quiet=True) is not None) and (
                 self.getComponent(Flags.WIRE, quiet=True) is not None
             )
-        except Exception:
+        except ValueError:
             # not well defined pitch due to multiple pin and/or wire components
             return False
 

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2373,7 +2373,7 @@ class TestNegativeVolume(unittest.TestCase):
             block.getVolumeFractions()
 
 
-class HexBlock_TestCase(unittest.TestCase):
+class TestHexBlock(unittest.TestCase):
     def setUp(self):
         self.hexBlock = blocks.HexBlock("TestHexBlock")
         hexDims = {"Tinput": 273.0, "Thot": 273.0, "op": 70.6, "ip": 70.0, "mult": 1.0}
@@ -2777,6 +2777,19 @@ class HexBlock_TestCase(unittest.TestCase):
         self.assertTrue(self.hexBlock.hasPinPitch())
         self.assertAlmostEqual(self.hexBlock.getPinPitch(cold=True), 0.11)
         self.assertAlmostEqual(self.hexBlock.getPinPitch(cold=False), 0.11)
+
+    def test_hasPinPitch(self):
+        # A HexBlock with no components inside should return False
+        b = blocks.HexBlock("EmptyHexBlock")
+        self.assertFalse(b.hasPinPitch())
+
+        # A HexBlock with only a clad or a wire component, but not both, should return False
+        b.add(components.Circle("clad", "HT9", Tinput=273.0, Thot=273.0, od=0.1, mult=169.0))
+        self.assertFalse(b.hasPinPitch())
+
+        # A HexBlock with a clad and a wire component should return True
+        b.add(components.Circle("wire", "HT9", Tinput=273.0, Thot=273.0, od=0.01, mult=169.0))
+        self.assertTrue(b.hasPinPitch())
 
     def test_getBlocks(self):
         self.assertEqual(len(self.hexBlock.getBlocks()), 1)


### PR DESCRIPTION
## What is the change? Why is it being made?

A [recent PR](https://github.com/terrapower/armi/pull/2389) was opened that should have added unit testing, but didn't. This PR solves that problem.

close #2392


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: We should always add new testing when we add new code.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
