### PR TITLE
Removing unused parameter fluxAdjPeak

### DIFF
--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -400,12 +400,6 @@ def _getNeutronicsBlockParams():
         )
 
         pb.defParam("fluxAdj", units=units.UNITLESS, description="Adjoint flux")
-        pb.defParam(
-            "fluxAdjPeak",
-            units=units.UNITLESS,
-            description="Adjoint flux",
-            location=ParamLocation.MAX,
-        )
 
         pb.defParam(
             "pdens",


### PR DESCRIPTION
## What is the change? Why is it being made?

The parameter `fluxAdjPeak` appears to be unused, so we are removing it.

Progress on #2384

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Our stated policy is to remove unused code.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
