### PR TITLE
Fix issue with recent `runLog` changes

### DIFF
--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -531,6 +531,8 @@ class RunLogger(logging.Logger):
     """
 
     FMT = "%(levelname)s%(message)s"
+    # This is being set as a class attribute so it only runs once, before the class is initialized. For some bespoke
+    # MPI use cases, calling the function when setting the `filePath` causes issues. This sidesteps the problem.
     LOG_DIR = getLogDir()
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## What is the change? Why is it being made?

#2410 Introduced a change to how the `logs` directory was evaluated. To avoid code in the global scope, we put it in a function and replaced all instances of the global variable with that function call. This worked OK everywhere except during `RunLogger` initialization in some MPI scenarios (I suspect the issue I saw downstream was in the testing setup, but it was a little too complicated/heavy handed to untangle). If I replace the function call with a class attribute that calls the function instead, the desired behavior is restored. 

NOTE: While the GH label is bug, I'm tagging this as a feature since it's a fix to a prior feature PR and not a bug per the SCR.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: This addresses a shortcoming in the initial PR to update the `logs` dir feature in PR #2410.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
