### PR TITLE
Adding `forceClean` to snapshot deletions

### DIFF
--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -167,7 +167,7 @@ class MainInterface(interfaces.Interface):
             cycle = int(snapText[0:3])
             node = int(snapText[3:])
             newFolder = "snapShot{0}_{1}".format(cycle, node)
-            utils.pathTools.cleanPath(newFolder)
+            utils.pathTools.cleanPath(newFolder, forceClean=True)
 
         # delete database if it's SQLlite
         # no need to delete because the database won't have copied it back if using fastpath.

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -1111,7 +1111,7 @@ class Operator:
         newFolder = f"snapShot{cycle}_{node}"
         if os.path.exists(newFolder):
             runLog.important(f"Deleting existing snapshot data in {newFolder}")
-            pathTools.cleanPath(newFolder)  # careful with cleanPath!
+            pathTools.cleanPath(newFolder, forceClean=True)  # careful with cleanPath!
             # give it a minute.
             time.sleep(1)
 


### PR DESCRIPTION
## What is the change? Why is it being made?

Given the recent `cleanPath` changes, the snapshot directories were no longer greenlit for deletion like they were before. `snapshot` was in the `DO_NOT_CLEAN_PATHS` list, which opposite to its name, was actually a list of greenlit deletions. At the time of removing that list, we didn't think any of those paths were accurate to more recent ARMI uses. Well, `snapshot` proved that theory wrong! This fixes that.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: This is a change that was determined to be needed based on recent feature updates to `cleanPath`.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
