### PR TITLE
Moving the README text up in the PDF ToC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,28 +5,24 @@
 ARMI Introduction
 #################
 
-The Advanced Reactor Modeling Interface (ARMI\ :sup:`®`) is an open-source tool that
-streamlines your nuclear reactor design/analysis needs by providing a
-software *reactor at your fingertips* and a rich ecosystem of utilities working in concert.
-It is made for and by professional reactor analysis teams and
-is maintained by `TerraPower LLC <http://terrapower.com/>`_, a nuclear technology
-development company.
+The Advanced Reactor Modeling Interface (ARMI\ :sup:`®`) is an open-source tool that streamlines your nuclear reactor
+design/analysis needs by providing a software *reactor at your fingertips* and a rich ecosystem of utilities working in
+concert. It is made for and by professional reactor analysis teams and is maintained by
+`TerraPower LLC <http://terrapower.com/>`_, a nuclear technology development company.
 
 ARMI:
 
-* Provides a hub-and-spoke mechanism to standardize communication and coupling between
-  physics kernels and the specialist analysts who use them,
+* Provides a hub-and-spoke mechanism to standardize communication and coupling between physics kernels and the
+  specialist analysts who use them,
 
-* Facilitates the creation and execution of detailed models and complex analysis
-  methodologies,
+* Facilitates the creation and execution of detailed models and complex analysis methodologies,
 
-* Provides an ecosystem within which to rapidly and collaboratively build new analysis
-  and physics simulation capabilities, and
+* Provides an ecosystem within which to rapidly and collaboratively build new analysis and physics simulation
+  capabilities, and
 
 * Provides useful utilities to assist in reactor development.
 
-A few demos of ARMI can be seen in the `ARMI example gallery
-<https://terrapower.github.io/armi/gallery/index.html>`_.
+A few demos of ARMI can be seen in the `ARMI example gallery <https://terrapower.github.io/armi/gallery/index.html>`_.
 
 Using ARMI plus a collection of ARMI-aware physics plugins, an engineering team can
 perform a full analysis of a reactor system and then repeat the same level of analysis
@@ -63,7 +59,7 @@ found in [#touranarmi]_.
      - armi-devs@terrapower.com
 
 Quick start
-===========
+***********
 Before starting, you need to have `Python <https://www.python.org/downloads/>`_ 3.9+.
 
 Get the ARMI code, install the prerequisites, and fire up the launcher with the following
@@ -96,7 +92,7 @@ start touring the features and capabilities and then move on to the
 
 
 Background
-==========
+**********
 Nuclear reactor design requires, among other things, answers to the following questions:
 
 * Where are the neutrons? How fast are they moving? In which direction?
@@ -166,7 +162,7 @@ Because of ARMI's high-level nature, we believe we can collaborate effectively w
 ongoing reactor software developments.
 
 Communication and coupling
-==========================
+**************************
 ARMI provides a central place for all physics kernels to interact: the Reactor Model.
 All modules read *state* information from this Reactor and write their output to it.
 This common interface allows seamless communication and coupling between different
@@ -182,7 +178,7 @@ perform basic data management and to help align efforts on external physics kern
 
 
 Automation
-==========
+**********
 
 ARMI can quickly and easily produce complex input files with high levels of detail in
 various approximations. This enables users to perform rapid high-fidelity analyses to
@@ -200,7 +196,7 @@ Carlo, subchannel vs. CFD, etc.).
 
 
 New analysis and physics capabilities
-=====================================
+*************************************
 The ARMI reactor model is fully accessible via a Python-based API, meaning that
 power-users and developers have full access to the details of the plant at all times.
 Developers adding new physics features can take advantage of the ARMI data management
@@ -233,7 +229,7 @@ Writing a module within ARMI automatically features access to the ARMI API, incl
 
 
 Use cases
-=========
+*********
 
 Given input describing a reactor, a typical ARMI run loops over a set of plugins in a
 certain sequence. Some plugins trigger third-party simulation codes, producing input
@@ -271,7 +267,7 @@ considering all important physics at the same time.
 Other interest may come from the following:
 
 The Research Scientist
-----------------------
+======================
 A nuclear reactor research scientist, whether at a national lab or on a graduate or
 undergraduate university team, may benefit greatly from using ARMI. It's not uncommon
 for such people to spend significant fractions of effort on data management. ARMI will
@@ -291,7 +287,7 @@ ARMI ecosystem will be a great way to prove its true value (note that this requi
 rich ARMI physics ecosystem).
 
 The Nuclear Startup Engineer
-----------------------------
+============================
 As various companies evaluate their ideas, they need tools for analysis. They
 can pick up ARMI and save 10 years of development and hit the ground running by
 plugging in their design-specific physics kernels and proprietary design
@@ -300,12 +296,12 @@ all come in handy immediately.
 
 
 Operating and Vendor Engineers
-------------------------------
-People at well-established utilities or vendors can hook ARMI into their legacy
-systems and increase their overall productivity.
+==============================
+People at well-established utilities or vendors can hook ARMI into their legacy systems and increase their overall
+productivity.
 
 The Enthusiast
---------------
+==============
 If an enthusiast wants to try out a reactor idea they have, they can use ARMI
 (plus some physics kernels) to quickly get some performance metrics. They can
 see if their idea has wings, and if it does, they can then find a way to bring
@@ -313,7 +309,7 @@ it to engineering and commercial reality.
 
 
 History of ARMI
-===============
+***************
 ARMI was originally created by TerraPower, LLC near Seattle WA starting in 2009. Its
 founding mission was to determine the optimal fuel management operations required to
 transition a fresh Traveling Wave Reactor core from startup into an equilibrium state.
@@ -345,7 +341,7 @@ ideas, limited available funding can be spent more effectively.
 
 
 System Requirements
-===================
+*******************
 Being largely written in the Python programming language, the ARMI system works on
 basically any kind of computer. We have developed it predominantly within a Microsoft
 Windows environment, but have performed tests under various flavors of Linux as well. It
@@ -360,13 +356,13 @@ needed to support the more traditional Linux HPC environments.
 
 .. _getting-help:
 
-Getting help
-============
+Getting Help
+************
 You can get help with ARMI by either making issues on `our github page
 <https://github.com/terrapower/armi/issues>`_ or by e-mailing armi-devs@terrapower.com.
 
 Disclaimers
-===========
+***********
 Due to TerraPower goals and priorities, many ARMI modules were developed with the
 sodium-cooled TWR as the target, and are not necessarily yet optimized for other plants.
 On the other hand, we have attempted to keep the framework general where possible, and
@@ -383,29 +379,26 @@ consumer software product, but rather a powerful and flexible engineering tool. 
 the potential to accelerate work on many kinds of reactors. But in many cases, it will
 require serious and targeted investment.
 
-ARMI was largely written by nuclear and mechanical engineers. We (as a whole) only
-really, truly, recognized the value of things like static typing in a complex system
-like ARMI somewhat recently.
+ARMI was largely written by nuclear and mechanical engineers. We (as a whole) only really, truly, recognized the value
+of things like static typing in a complex system like ARMI somewhat recently.
 
-ARMI has been written to support specific engineering/design tasks. As such, polish in
-the GUIs and output is somewhat lacking.
+ARMI has been written to support specific engineering/design tasks. As such, polish in the GUIs and output is somewhat
+lacking.
 
-The ARMI framework uses the ``camelCase`` style, which is not the standard style for Python. As this
-is an issue of style, it is not considered worth the API-breaking cost to our downstream users to
-change it.
+The ARMI framework uses the ``camelCase`` style, which is not the standard style for Python. As this is an issue of
+style, it is not considered worth the API-breaking cost to our downstream users to change it.
 
 
 License
-=======
-TerraPower and ARMI are registered trademarks of TerraPower, LLC.
-Other trademarks and registered trademarks used in this Manual are the property of the
-respective trademark holders.
+*******
+TerraPower and ARMI are registered trademarks of TerraPower, LLC. Other trademarks and registered trademarks used in
+this Manual are the property of the respective trademark holders.
 
 The ARMI system is licensed as follows:
 
 .. code-block:: none
 
-	Copyright 2009-2024 TerraPower, LLC
+	Copyright 2009-2026 TerraPower, LLC
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -419,14 +412,13 @@ The ARMI system is licensed as follows:
 	See the License for the specific language governing permissions and
 	limitations under the License.
 
-Be careful when including any dependency in ARMI (say in the ``pyproject.toml`` file) not
-to include anything with a license that supersedes our Apache license. For instance,
-any third-party Python library included in ARMI with a GPL license will make the whole
-project fall under the GPL license. But a lot of potential users of ARMI will want to
-keep some of their work private, so we can't allow any GPL dependencies.
+Be careful when including any dependency in ARMI (say in the ``pyproject.toml`` file) not to include anything with a
+license that supersedes our Apache license. For instance, any third-party Python library included in ARMI with a GPL
+license will make the whole project fall under the GPL license. But a lot of potential users of ARMI will want to keep
+some of their work private, so we can't allow any GPL dependencies.
 
-For that reason, it is generally considered best-practice in the ARMI ecosystem to
-only use third-party Python libraries that have MIT or BSD licenses.
+For that reason, it is generally considered best-practice in the ARMI ecosystem to only use third-party Python libraries
+that have MIT or BSD licenses.
 
 .. [#touranarmi] Touran, Nicholas W., et al. "Computational tools for the integrated design of advanced nuclear reactors."
    Engineering 3.4 (2017): 518-526. https://doi.org/10.1016/J.ENG.2017.04.016

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,12 +4,11 @@ ARMI
 
 .. image:: .static/armi-logo.png
 
-.. include:: ../README.rst
-
 .. toctree::
    :hidden:
    :maxdepth: 2
 
+   readme
    installation
    user/index
    developer/index
@@ -24,4 +23,3 @@ ARMI
 *  :ref:`genindex`
 *  :ref:`modindex`
 *  :ref:`search`
-

--- a/doc/readme.rst
+++ b/doc/readme.rst
@@ -1,0 +1,1 @@
+.. include:: ../README.rst


### PR DESCRIPTION
## What is the change? Why is it being made?

Moving the position of the README file in the PDF Table of Contents. It already looks right in the HTML version.

close #2415


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: The PDF version of the docs should look as clean as the HTML version, if at all possible.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
