### PR TITLE
Defaulting the Database to read mode

### DIFF
--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -122,7 +122,7 @@ class Database:
     # Allows matching for, e.g., c01n02EOL
     timeNodeGroupPattern = re.compile(r"^c(\d\d)n(\d\d).*$")
 
-    def __init__(self, fileName: os.PathLike, permission: str):
+    def __init__(self, fileName: os.PathLike, permission: str = "r"):
         """
         Create a new Database object.
 

--- a/armi/bookkeeping/db/tests/test_database.py
+++ b/armi/bookkeeping/db/tests/test_database.py
@@ -892,7 +892,7 @@ grids:
         self.db.close()
 
         # open the DB and verify, the first timenode
-        with Database(self.db.fileName, "r") as db:
+        with Database(self.db.fileName) as db:
             r0 = db.load(0, 0, allowMissing=True)
             self.assertEqual(r0.p.cycle, 0)
             self.assertEqual(r0.p.timeNode, 0)


### PR DESCRIPTION
## What is the change? Why is it being made?

Improving the Database constructor to default to read mode. This saves time for people who want to read databases, which I believe is the most common use case. ARMI apps write a lot of databases, but people in ipython / scripts / notebooks / etc. are (I believe) primarily reading dbs for post processing

This is backwards compatible. Since the permission is required, I have high confidence everyone is providing this argument already.

close #2440

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Improving defaults to read to streamline the API.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: R_ARMI_DB_H5 by making the permission default to read mode

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
