### PR TITLE
Stopping intermittent CI failures

### DIFF
--- a/armi/nuclearDataIO/tests/test_xsLibraries.py
+++ b/armi/nuclearDataIO/tests/test_xsLibraries.py
@@ -198,6 +198,7 @@ class TestXSLibrary(TempFileMixin, unittest.TestCase):
         if self.xsLibGenerationErrorStack is not None:
             print(self.xsLibGenerationErrorStack)
             raise Exception("see stdout for stack trace")
+
         # check to make sure they labels overlap, or are actually the same
         labels = set(self.xsLib.nuclideLabels)
         self.assertEqual(labels, set(self.isotxsAA.nuclideLabels))
@@ -225,6 +226,7 @@ class TestXSLibrary(TempFileMixin, unittest.TestCase):
         if self.xsLibGenerationErrorStack is not None:
             print(self.xsLibGenerationErrorStack)
             raise Exception("See stdout for stack trace")
+
         # check to make sure they labels overlap, or are actually the same
         writer.writeBinary(self.xsLib, self.testFileName)
         self.assertTrue(filecmp.cmp(refFile, self.testFileName))
@@ -455,6 +457,7 @@ class TestIsotxsMerge(AbstractTestXSlibraryMerging, unittest.TestCase):
             nucLabel = self.nuclideBases.byMcc3Id[nucId].label
             del emptyXSLib[nucLabel + "AA"]
             del emptyXSLib[nucLabel + "AB"]
+
         self.assertEqual(set(self.libLumped.nuclideLabels), set(emptyXSLib.nuclideLabels))
         self.getWriteFunc()(emptyXSLib, self.testFileName)
         self.assertTrue(filecmp.cmp(self.getLibLumpedPath(), self.testFileName))


### PR DESCRIPTION
## What is the change? Why is it being made?

In the past few days I have seen we are getting some intermittent unit test failures.

For instance: https://github.com/terrapower/armi/actions/runs/22322766528/job/64585126337?pr=2459#step:5:400

It is possible some upstream ARMI dependency had an update that has slightly affected our MPI tests. Though, for some reason, the intermittent and random failure is usually in the test file `test_xsLibraries.py`.

### Testing

I ran ARMI CI start-to-finish 10 times with this change without a failure. All of the ARMI unit tests are run 8 times during each CI run (linux x 5 python versions, mac, windows, and docs). So that means this error didn't pop up after running the tests 80 times.  So I am feeling more and more confident that this (semi over-the-top) fix works.

### Cleanup

In the process of testing this PR I did a bunch of cleanup in this test file. Mostly docstrings and global variable sorting.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: CI should be as stable as we can make it.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
