### PR TITLE
Switching from coveralls.io to codecov.io

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -46,7 +46,7 @@ jobs:
           coverage combine --rcfile=pyproject.toml --keep -a
           coverage report --rcfile=pyproject.toml -i --skip-empty --skip-covered --sort=cover --fail-under=90
       - name: Publish to codecov.io
-        #if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -362,8 +362,8 @@ that have MIT or BSD licenses.
 .. |Build Status| image:: https://github.com/terrapower/armi/actions/workflows/unittests.yaml/badge.svg?branch=main
     :target: https://github.com/terrapower/armi/actions/workflows/unittests.yaml
 
-.. |Code Coverage| image:: https://coveralls.io/repos/github/terrapower/armi/badge.svg?branch=main&kill_cache=2
-    :target: https://coveralls.io/github/terrapower/armi?branch=main
+.. |Code Coverage| image:: https://codecov.io/gh/terrapower/armi/branch/main/graph/badge.svg
+    :target: https://app.codecov.io/gh/terrapower/armi/tree/main
 
 .. |Commit Activity| image:: https://img.shields.io/github/commit-activity/m/terrapower/armi
     :target: https://github.com/terrapower/armi/pulse


### PR DESCRIPTION
## What is the change? Why is it being made?

We are switching from coveralls.io to codecov.io. 

We have been [having intermittent problems](https://github.com/terrapower/armi/issues/552) with coveralls for the past 4 years. And today the service is down entirely, which means ARMI CI has been broken all day.

Also, coveralls.io only allows people who are logged in to see the line-by-line coverage. And that's not very helpful for an open-source project.

close #552


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: We want ARMI CI to be more stable.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
