### PR TITLE
Checking for unrepresented XS IDs

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -1376,9 +1376,9 @@ class CrossSectionGroupManager(interfaces.Interface):
 
         Notes
         -----
-        This should be run after `CrossSectionGroupManager._updateEnvironmentGroups()`, which resets
-        `b.p.envGroup` and can result in unrepresented cross section IDs. This is usually invoked
-        as a result of a call to `CrossSectionGroupManager.makeCrossSectionGroups()`
+        This should be run after :meth:`CrossSectionGroupManager._updateEnvironmentGroups`, which resets
+        ``b.p.envGroup`` and can result in unrepresented cross section IDs. This is usually invoked
+        as a result of a call to :meth:`CrossSectionGroupManager.makeCrossSectionGroups`
         """
         self._unrepresentedXSIDs = []
         for xsID, collection in blockCollectionsByXsGroup.items():

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -906,10 +906,8 @@ class TestXSGM(unittest.TestCase):
 
         # set valid flags to something the fuel block would not have to trigger unrepresented block
         fuelXStype = "AD"
-        blocksWithType = [b for b in self.csm.r.core.getBlocks(Flags.FUEL) if b.getMicroSuffix() == fuelXStype]
-        print(blockCollectionsByXsGroup)
+        blocksWithType = [b for b in self.csm.r.core.iterBlocks(Flags.FUEL) if b.getMicroSuffix() == fuelXStype]
         fuelCollection = blockCollectionsByXsGroup[fuelXStype]
-        print(fuelCollection)
         fuelCollection._validRepresentativeBlockTypes = Flags.CLAD
 
         # check for unrepresented XS ID, assert that it is found


### PR DESCRIPTION
## What is the change? Why is it being made?

When the method `CrossSectionGroupManager.createRepresentativeBlocks()` is invoked, it checks for unrepresented XS IDs and modifies them as necessary. However, when `CrossSectionGroupManager.makeCrossSectionGroups()` is called outside of `createRepresentativeBlocks()`, it can generate unrepresented XS IDs without addressing them. This change ensures that unrepresented XS IDs are always identified and modified to avoid errors.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: This change prevents a condition where a block has a XS type that is not represented by any representative block in the `CrossSectionGroupManager`, which would cause a XS generation application to fail.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA

---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
