### PR TITLE
Adding method to DefaultExecuter for final parameter updates

### DIFF
--- a/armi/physics/executers.py
+++ b/armi/physics/executers.py
@@ -245,6 +245,7 @@ class DefaultExecuter(Executer):
             if self.options.applyResultsToReactor:
                 output.apply(self.r)
         self._undoGeometryTransformations()
+        self._updateAdditionalParameters()
         return output
 
     def _updateRunDir(self, directory):
@@ -306,4 +307,7 @@ class DefaultExecuter(Executer):
         pass
 
     def _undoGeometryTransformations(self):
+        pass
+
+    def _updateAdditionalParameters(self):
         pass


### PR DESCRIPTION

## What is the change? Why is it being made?

As currently implemented, the final call of the `DefaultExecuter.run` method is  `DefaultExecuter._undoGeometryTransformations`. If child classes of `DefaultExecuter` want any additional functions called at the end of `run`, those functions have to be put into `_undoGeometryTransformations`. Child classes have been handling this by over-writing the `_undoGeometryTransformations` function, in which they explicitly call the `DefaultExecuter._undoGeometryTransformations` method, then perform additional work. This can be messy and confusing.

e.g.

```python
class Dif3dExecuter(DefaultExecuter):
  def _undoGeometryTransformations(self):
    DefaultExecuter._undoGeometryTransformations(self)
    # Then do additional work
```

This change adds method `DefaultExecuter._updateAdditionalParameters` and calls it after `_undoGeometryTransformations` in `run()`. 

This purpose of the change is to provide a method for child classes of `DefaultExecuter` to do additional work, such as parameter updates or other cleanup, after `DefaultExecuters.run` has called `_undoGeometryTransformations` without having to shoehorn that additional work into `_undoGeometryTransformations`. 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Simplifying and organizing subclasses of `DefaultExecuter.run()`.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code. N/A
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
