### PR TITLE
Ensuring codecov.io does not fail if coverage drops a tiny amount

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%    # the required coverage value
+        threshold: 1%  # allows a 1% drop from the previous base commit coverage


### PR DESCRIPTION
## What is the change? Why is it being made?

This is a minor change. In the past, codecov.io would "fail" the build even if the coverage only went down by one line. That is not helpful or productive, so I am adding a codecov configuration file that will solve the problem.

This would be a frustrating PR to "prove" works, so let me just point to the codecov.io documentation, which seems pretty clear: https://docs.codecov.com/docs/common-recipe-list#ease-target-coverage

close #2471

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Ensuring the build does not falsely fail because of a statistical fluctuation in the code coverage.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
