### PR TITLE
Producing an ARMI wheel with every merge to main

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -5,8 +5,8 @@ permissions:
 
 on:
   push:
-    #branches:
-    #  - main
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## What is the change? Why is it being made?

With each ARMI merge into `main`, CI will now generate an ARMI wheel which will work for most operating systems and whatever versions of Python ARMI supports at the time.

That wheel will then be archived for a while, in case we want it.

close #2463


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Some ARMI users may find it helpful to install ARMI via wheel.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
