### PR TITLE
Stopping forked repos from running MacOS CI

### DIFF
--- a/.github/workflows/mac_tests.yaml
+++ b/.github/workflows/mac_tests.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-
+    if: github.repository == 'terrapower/armi'
     runs-on: macos-14
 
     steps:


### PR DESCRIPTION
## What is the change? Why is it being made?

There is not much interesting about our MacOS GitHub Action. It's just running the unit tests on a different OS, to prove we support it.

So let's save people running our CI in a forked repo a little time and effort.

close #2497


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Saving developers time speeds up product delivery.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
