### PR TITLE
Removing unnecessary warning

### DIFF
--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -104,8 +104,6 @@ class Reactor(composites.Composite):
         if isinstance(container, ExcoreStructure):
             nomen = container.name.replace(" ", "").lower()
             if nomen == "spentfuelpool":
-                runLog.warning("Changing the name of the Spent Fuel Pool to 'sfp'.")
-                # special case
                 nomen = "sfp"
             self.excore[nomen] = container
 


### PR DESCRIPTION
## What is the change? Why is it being made?

This warning (a) isn't really "warning" of anything bad happening, and (b) is not helpful to the user. So we are just removing it.

close #2501 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Having too many warning and log messages can muddy the waters and make it hard for users to get important information from their run logs.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
