### PR TITLE
Reducing warnings from settings version and Composite.getComponent

### DIFF
--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2208,22 +2208,20 @@ class ArmiObject(metaclass=CompositeModelType):
         else:
             return components[0]
 
-    def getComponent(self, typeSpec: TypeSpec, exact: bool = False, quiet: bool = False) -> Optional["Component"]:
+    def getComponent(self, typeSpec: TypeSpec, exact: bool = False, quiet: bool = True) -> Optional["Component"]:
         """
         Get a particular component from this object.
+
+        Be careful with multiple similar names in one object.
 
         Parameters
         ----------
         typeSpec : flags.Flags or list of Flags
             The type specification of the component to return
-
         exact : boolean, optional
             Demand that the component flags be exactly equal to the typespec. Default: False
-
         quiet : boolean, optional
-            Warn if the component is not found. Default: False
-
-        Careful with multiple similar names in one object
+            Log if the component is not found. Default: True
 
         Returns
         -------
@@ -2238,7 +2236,7 @@ class ArmiObject(metaclass=CompositeModelType):
             return results[0]
         elif not results:
             if not quiet:
-                runLog.warning(
+                runLog.extra(
                     f"No component matched {typeSpec} in {self}. Returning None",
                     single=True,
                     label=f"None component returned instead of {typeSpec}",

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -2236,7 +2236,7 @@ class ArmiObject(metaclass=CompositeModelType):
             return results[0]
         elif not results:
             if not quiet:
-                runLog.extra(
+                runLog.debug(
                     f"No component matched {typeSpec} in {self}. Returning None",
                     single=True,
                     label=f"None component returned instead of {typeSpec}",

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -111,18 +111,8 @@ class SettingRenamer:
 
         activeRename = self._activeRenames.get(name, None)
         if activeRename is not None:
-            runLog.extra(f"Invalid setting {name} found. Renaming to {activeRename}.")
+            runLog.extra(f"Invalid setting {name} found. Renaming to {activeRename}.", single=True)
             return activeRename, True
-
-        expiredCandidates = {val[1]: val[2] for val in self._expiredRenames if val[0] == name}
-
-        if expiredCandidates:
-            msg = "\n".join(
-                ["   {}: {}".format(expiredRename, date) for expiredRename, date in expiredCandidates.items()]
-            )
-            runLog.info(
-                f"Encountered an invalid setting `{name}`. There are expired renames to newer setting names:\n{msg}"
-            )
 
         return name, False
 

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -111,7 +111,7 @@ class SettingRenamer:
 
         activeRename = self._activeRenames.get(name, None)
         if activeRename is not None:
-            runLog.warning(f"Invalid setting {name} found. Renaming to {activeRename}.")
+            runLog.extra(f"Invalid setting {name} found. Renaming to {activeRename}.")
             return activeRename, True
 
         expiredCandidates = {val[1]: val[2] for val in self._expiredRenames if val[0] == name}
@@ -120,7 +120,7 @@ class SettingRenamer:
             msg = "\n".join(
                 ["   {}: {}".format(expiredRename, date) for expiredRename, date in expiredCandidates.items()]
             )
-            runLog.warning(
+            runLog.info(
                 f"Encountered an invalid setting `{name}`. There are expired renames to newer setting names:\n{msg}"
             )
 
@@ -204,7 +204,7 @@ class SettingsReader:
         if CONF_VERSIONS in setts and "armi" in setts[CONF_VERSIONS]:
             self.inputVersion = setts[CONF_VERSIONS]["armi"]
         else:
-            runLog.warning("Versions setting section not found. Continuing with uncontrolled versions.")
+            # Versions setting section not found; continuing with uncontrolled versions.
             self.inputVersion = "uncontrolled"
 
         for settingName, settingVal in caseSettings.items():
@@ -228,7 +228,7 @@ class SettingsReader:
         if not proceed:
             raise InvalidSettingsStopProcess(self)
         else:
-            runLog.warning(f"Ignoring invalid settings: {invalidNames}")
+            runLog.info(f"Ignoring invalid settings: {invalidNames}")
 
     def _applySettings(self, name, val):
         """Add a setting, if it is valid. Capture invalid settings."""
@@ -240,8 +240,8 @@ class SettingsReader:
             # apply validations
             _settingObj = self.cs.getSetting(name)
 
-            # The val is automatically coerced into the expected type when set using either the
-            # default or user-defined schema
+            # The val is automatically coerced into the expected type when set using either the default or user-defined
+            # schema
             self.cs[name] = val
 
 
@@ -263,8 +263,7 @@ class SettingsWriter:
         self.style = style
         if style not in {WRITE_SHORT, WRITE_MEDIUM, WRITE_FULL}:
             raise ValueError(f"Invalid supplied setting writing style {style}")
-        # The writer should know about the old settings it is overwriting, but only sometimes (when
-        # the style is medium)
+        # The writer should know about the old settings it is overwriting, but only sometimes (when the style is medium)
         self.settingsSetByUser = settingsSetByUser
 
     @staticmethod


### PR DESCRIPTION
## What is the change? Why is it being made?

This PR reduces the frequency of certain log messages in an ARMI run:

1. The Settings Validation section is optional, so if the user doesn't touch it, they don't want a `warning`.
2. The `Composite.getComponent()` method was raising too many warnings.

close #2496


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Too many warnings can cause Alarm Fatigue, and the user base singled out these two warnings as being particularly fatiguing.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
