### PR TITLE
Improving error handling in HexComponentsToCylConverter

### DIFF
--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -577,9 +577,9 @@ class HexComponentsToCylConverter(BlockAvgToCylConverter):
         self.mergeIntoFuel = mergeIntoFuel or []
         self.ductHeterogeneous = ductHeterogeneous
         self.interRingComponent = sourceBlock.getComponent(Flags.COOLANT, exact=True)
-        self._remainingCoolantFillArea = self.interRingComponent.getArea()
         if not self.interRingComponent:
-            raise ValueError("Block {} cannot be converted to rings without a `coolant` component".format(sourceBlock))
+            raise ValueError(f"Block {sourceBlock} cannot be converted to rings without a `coolant` component")
+        self._remainingCoolantFillArea = self.interRingComponent.getArea()
 
     def convert(self):
         """Perform the conversion.


### PR DESCRIPTION
## What is the change? Why is it being made?

An error was handled in the constructor for HexComponentsToCylConverter, but it was handled one line lower than it should have been.

close #2505


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: This error handling was essentially unreachable code, and unused.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
