### PR TITLE
Trying to stop codecov.io from incorrectly failing the build

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -46,6 +46,7 @@ jobs:
           coverage combine --rcfile=pyproject.toml --keep -a
           coverage report --rcfile=pyproject.toml -i --skip-empty --skip-covered --sort=cover --fail-under=90
       - name: Publish to codecov.io
+        continue-on-error: true
         if: github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
## What is the change? Why is it being made?

As of yesterday, our codecov.io CI was still incorrectly failing the build: https://app.codecov.io/gh/terrapower/armi/commit/f6b78c5a000ae54ca2b5111d8d7721b1c70b93b9

It now appears codecov.io does this for multiple incorrect reasons. So I just want to block codecov's ability to fail our CI entirely. This is not worth it any more. 

Hopefully, this is progress on #2471.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: A build incorrectly failing can case Alarm Fatigue and waste people's time.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
