### PR TITLE
Moving 15 parameters out of ARMI

### DIFF
--- a/armi/physics/fuelPerformance/parameters.py
+++ b/armi/physics/fuelPerformance/parameters.py
@@ -71,34 +71,6 @@ def _getFuelPerformanceBlockParams():
         )
 
         pb.defParam(
-            "totalCladStrain",
-            units=units.PERCENT,
-            description="Total diametral clad strain.",
-            categories=["eq cumulative shift"],
-        )
-
-        pb.defParam(
-            "axialGrowthPct",
-            units=units.PERCENT,
-            description="Axial growth percentage",
-            categories=["eq cumulative shift"],
-        )
-
-        pb.defParam(
-            "fpPeakFuelTemp",
-            units=units.DEGC,
-            description="Fuel performance calculated peak fuel temperature.",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
-            "fpAveFuelTemp",
-            units=units.DEGC,
-            description="Fuel performance calculated average fuel temperature.",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "gasPorosity",
             units=units.UNITLESS,
             description="Fraction of fuel volume that is occupied by gas pores",

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -334,13 +334,6 @@ def _getNeutronicsBlockParams():
         )
 
         pb.defParam(
-            "capturePowerFrac",
-            units=units.UNITLESS,
-            description="Fraction of the power produced through capture in a block.",
-            saveToDB="True",
-        )
-
-        pb.defParam(
             "fluence",
             units=f"#/{units.CM}^2",
             description="Fluence",

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -255,12 +255,6 @@ def _getNeutronicsBlockParams():
         categories=[parameters.Category.detailedAxialExpansion, "depletion"],
     ) as pb:
         pb.defParam(
-            "pointsEdgeFastFluxFr",
-            units=units.UNITLESS,
-            description="Fraction of flux above 100keV at edges of the block",
-        )
-
-        pb.defParam(
             "pointsEdgeDpa",
             setter=isNumpyArray("pointsEdgeDpa"),
             units=units.DPA,

--- a/armi/physics/neutronics/parameters.py
+++ b/armi/physics/neutronics/parameters.py
@@ -287,12 +287,6 @@ def _getNeutronicsBlockParams():
         )
 
         pb.defParam(
-            "pointsCornerFastFluxFr",
-            units=units.UNITLESS,
-            description="Fraction of flux above 100keV at corners of the block",
-        )
-
-        pb.defParam(
             "pointsCornerDpa",
             setter=isNumpyArray("pointsCornerDpa"),
             units=units.DPA,

--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -160,18 +160,6 @@ def getAssemblyParameterDefinitions():
 
     with pDefs.createBuilder(location=ParamLocation.NA, default=0.0, categories=["control rods"]) as pb:
         pb.defParam(
-            "crCriticalFraction",
-            units=units.UNITLESS,
-            description=(
-                "The insertion fraction when the control rod assembly is in its critical "
-                "configuration. Note that the default of -1.0 is a trigger for this value not "
-                "being set yet."
-            ),
-            saveToDB=True,
-            default=-1.0,
-        )
-
-        pb.defParam(
             "crCurrentElevation",
             units=units.CM,
             description="The current elevation of the bottom of the moveable section of a control rod assembly.",
@@ -188,13 +176,6 @@ def getAssemblyParameterDefinitions():
                 "bottom-most moveable section in the assembly when fully inserted."
             ),
             categories=[parameters.Category.assignInBlueprints],
-            saveToDB=True,
-        )
-
-        pb.defParam(
-            "crRodLength",
-            units=units.CM,
-            description="length of the control material within the control rod",
             saveToDB=True,
         )
 

--- a/armi/reactor/blockParameters.py
+++ b/armi/reactor/blockParameters.py
@@ -220,13 +220,6 @@ def getBlockParameterDefinitions():
         )
 
         pb.defParam(
-            "heliumInB4C",
-            units=f"He/{units.SECONDS}/{units.CM}^3",
-            description="Alpha particle production rate in B4C control and shield material.",
-            location=ParamLocation.AVERAGE,
-        )
-
-        pb.defParam(
             "powerRx",
             units=f"{units.WATTS}/{units.CM}^3",
             description="Power density of the reactor",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -320,24 +320,6 @@ def defineCoreParameters():
             default=None,
         )
 
-    with pDefs.createBuilder(
-        default=0.0,
-        location=ParamLocation.AVERAGE,
-        categories=["reactivity coefficients", "core wide"],
-    ) as pb:
-        # CORE WIDE REACTIVITY COEFFICIENTS
-        pb.defParam(
-            "rxFuelAxialExpansionCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Fuel Axial Expansion Coefficient",
-        )
-
-        pb.defParam(
-            "rxGridPlateRadialExpansionCoeffPerTemp",
-            units=f"{units.REACTIVITY}/{units.DEGK}",
-            description="Grid Plate Radial Expansion Coefficient",
-        )
-
     with pDefs.createBuilder(location=ParamLocation.AVERAGE, categories=["equilibrium"]) as pb:
         pb.defParam(
             "cyclics",

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -97,32 +97,6 @@ def defineCoreParameters():
 
         pb.defParam("numMoves", units=units.UNITLESS, description="numMoves", default=0)
 
-    with pDefs.createBuilder(location=ParamLocation.NA, categories=["control rods"]) as pb:
-        pb.defParam(
-            "crMostValuablePrimaryRodLocation",
-            default="",
-            units=units.UNITLESS,
-            saveToDB=True,
-            description=("Core assembly location for the most valuable primary control rod."),
-        )
-        pb.defParam(
-            "crMostValuableSecondaryRodLocation",
-            default="",
-            units=units.UNITLESS,
-            saveToDB=True,
-            description=("Core assembly location for the most valuable secondary control rod."),
-        )
-        pb.defParam(
-            "crTransientOverpowerWorth",
-            default=0.0,
-            units=units.PCM,
-            saveToDB=True,
-            description=(
-                "Reactivity worth introduced by removal of the highest worth primary control rod "
-                "from the core, starting from its critical position"
-            ),
-        )
-
     with pDefs.createBuilder() as pb:
         pb.defParam(
             "axialMesh",

--- a/armi/reactor/tests/test_hexBlockRotate.py
+++ b/armi/reactor/tests/test_hexBlockRotate.py
@@ -21,12 +21,7 @@ import numpy as np
 
 from armi.reactor.blocks import HexBlock
 from armi.reactor.components import Component
-from armi.reactor.grids import (
-    CoordinateLocation,
-    HexGrid,
-    IndexLocation,
-    MultiIndexLocation,
-)
+from armi.reactor.grids import CoordinateLocation, HexGrid, IndexLocation, MultiIndexLocation
 from armi.reactor.tests.test_blocks import NUM_PINS_IN_TEST_BLOCK, loadTestBlock
 from armi.utils import iterables
 
@@ -38,13 +33,12 @@ class HexBlockRotateTests(unittest.TestCase):
         "cornerFastFlux",
         "pointsCornerDpa",
         "pointsCornerDpaRate",
-        "pointsCornerFastFluxFr",
         "pointsEdgeDpa",
         "pointsEdgeDpaRate",
         "THedgeTemp",
         "THcornTemp",
     ]
-    BOUNDARY_DATA = np.arange(6, dtype=float) * 10
+    BOUNDARY_DATA = np.arange(6, dtype=float) * 7
 
     PIN_PARAMS = [
         "percentBuByPin",

--- a/armi/reactor/tests/test_hexBlockRotate.py
+++ b/armi/reactor/tests/test_hexBlockRotate.py
@@ -41,7 +41,6 @@ class HexBlockRotateTests(unittest.TestCase):
         "pointsCornerFastFluxFr",
         "pointsEdgeDpa",
         "pointsEdgeDpaRate",
-        "pointsEdgeFastFluxFr",
         "THedgeTemp",
         "THcornTemp",
     ]

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -216,10 +216,10 @@ class HexReactorTests(ReactorTests):
 
         # Test at assembly level
         assembly = core.getFirstAssembly()
-        self.assertGreater(assembly.p.crRodLength, -1)
+        self.assertGreater(assembly.p.maxPercentBu, -1)
 
-        assembly.p.crRodLength = 234
-        self.assertEqual(assembly.p.crRodLength, 234)
+        assembly.p.maxPercentBu = 234
+        self.assertEqual(assembly.p.maxPercentBu, 234)
 
         # Test at block level
         block = core.getFirstBlock()


### PR DESCRIPTION
## What is the change? Why is it being made?

After quite a few PRs and a lot of waiting, we are moving the last Natrium-specific parameters out of ARMI. This PR will finally close #2384 .

The params moved out of ARMI here are:

* ``axialGrowthPct``
* ``capturePowerFrac``
* ``crCriticalFraction``
* ``crMostValuablePrimaryRodLocation``
* ``crMostValuableSecondaryRodLocation``
* ``crRodLength``
* ``crTransientOverpowerWorth``
* ``fpAveFuelTemp``
* ``fpPeakFuelTemp``
* ``heliumInB4C``
* ``pointsCornerFastFluxFr``
* ``pointsEdgeFastFluxFr``
* ``rxFuelAxialExpansionCoeffPerTemp``
* ``rxGridPlateRadialExpansionCoeffPerTemp``
* ``totalCladStrain``


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: If a Setting or a Parameter is not used in ARMI, it should be reviewed to decide if it is generally useful enough to be kept in ARMI.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
