### PR TITLE
Clean up runtime warnings

### DIFF
--- a/armi/bookkeeping/historyTracker.py
+++ b/armi/bookkeeping/historyTracker.py
@@ -241,7 +241,7 @@ class HistoryTrackerInterface(interfaces.Interface):
             except KeyError:
                 if name in {a.name for a in self.r.core}:
                     raise Exception("Found it")
-                runLog.warning(
+                runLog.extra(
                     "Cannot find detail assembly {} in assemblies-by-name lookup table, which has {} entries".format(
                         name, len(self.r.core.assembliesByName)
                     )

--- a/armi/bookkeeping/report/data.py
+++ b/armi/bookkeeping/report/data.py
@@ -59,7 +59,6 @@ class Report:
         try:
             return self.groups[group]
         except KeyError:
-            runLog.warning("Cannot locate group {} in report {}".format(group.title, self.title))
             return None
 
 
@@ -77,7 +76,7 @@ class Group:
         self.titleStyle = "font-weight: bold; padding-top: 20px;"
 
     def __str__(self):
-        str_ = "\n{} - (GROUP) {}\n".format(self.title, self.description)
+        str_ = f"\n{self.title} - (GROUP) {self.description}\n"
         for name, value in self.data.items():
             str_ += "\t{:<30} {}\n".format(name, value)
         return str_
@@ -86,7 +85,7 @@ class Group:
         try:
             return self.data[name]
         except KeyError:
-            runLog.warning("Given name {} not present in report group {}".format(name, self.title))
+            runLog.extra(f"Given name {name} not present in report group {self.title}")
 
         return None
 

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -89,7 +89,7 @@ class ReportInterface(interfaces.Interface):
 
                 blocks.Block.plotFlux(self.r.core, fName=figName, peak=True, adjoint=adjoint)
             else:
-                runLog.warning("No mgFlux to plot in reports")
+                runLog.info("No mgFlux to plot in reports")
 
     def interactBOC(self, cycle=None):
         self.fuelCycleSummary["bocFissile"] = self.r.core.getTotalBlockParam("kgFis")

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -587,9 +587,7 @@ def setNeutronBalancesReport(core):
     core : armi.reactor.reactors.Core
     """
     if not core.getFirstBlock().p.rateCap:
-        runLog.warning(
-            "No rate information (rateCap, rateAbs, etc.) available on the blocks. Skipping balance summary."
-        )
+        runLog.info("No rate information (rateCap, rateAbs, etc.) available on the blocks. Skipping balance summary.")
         return
 
     cap = core.calcAvgParam("rateCap", volumeAveraged=False, generationNum=2)

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -381,8 +381,7 @@ def getSystemInfo():
         return _getSystemInfoLinux()
     else:
         runLog.warning(
-            f"Cannot get system information for {sys.platform} because ARMI only "
-            + "supports Linux, MacOS, and Windows."
+            f"Cannot get system information for {sys.platform} because ARMI only supports Linux, MacOS, and Windows."
         )
         return ""
 
@@ -696,7 +695,7 @@ def summarizePinDesign(core):
         runLog.info(report.ALL[report.PIN_ASSEM_DESIGN])
 
         first_fuel_block = core.getFirstBlock(Flags.FUEL)
-        runLog.info("Design & component information for first fuel block {}".format(first_fuel_block))
+        runLog.info(f"Design & component information for first fuel block {first_fuel_block}")
 
         runLog.info(first_fuel_block.setAreaFractionsReport())
 
@@ -704,8 +703,7 @@ def summarizePinDesign(core):
             runLog.info(component_.setDimensionReport())
 
     except Exception as error:
-        runLog.warning("Pin summarization failed to work")
-        runLog.warning(error)
+        runLog.warning(f"Pin summarization failed to work: {error}")
 
 
 def summarizePowerPeaking(core):

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -40,8 +40,7 @@ class B4C(material.Material):
 
     def applyInputParams(self, B10_wt_frac=None, theoretical_density=None, TD_frac=None, *args, **kwargs):
         if B10_wt_frac is not None:
-            # we can't just use the generic enrichment adjustment here because the
-            # carbon has to change with enrich.
+            # We can not just use the generic enrichment adjustment here because the carbon has to change with enrich.
             self.adjustMassEnrichment(B10_wt_frac)
         if theoretical_density is not None:
             runLog.warning(
@@ -50,7 +49,7 @@ class B4C(material.Material):
                 single=True,
             )
             if TD_frac is not None:
-                runLog.warning(
+                runLog.info(
                     f"Both 'theoretical_density' and 'TD_frac' are specified for {self}. 'TD_frac' will be used."
                 )
             else:

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -484,13 +484,12 @@ class Material(MatPropsMaterial):
         # no YAML, use linear expansion
         Tk = getTk(Tc, Tk)
         dLL = self.linearExpansionPercent(Tk=Tk)
-        refD = self.refDens
-        if refD is None:
+        if self.refDens is None:
             runLog.warning(f"{self} has no reference density", single=True, label=f"No refD {self.getName()}")
             return None
 
         f = (1.0 + dLL / 100.0) ** 3
-        return refD / f
+        return self.refDens / f
 
     def dynamicVisc(self, Tk: float = None, Tc: float = None) -> float:
         """Dynamic viscosity in Pa-s."""

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -291,7 +291,7 @@ class Assembly(composites.Composite):
         try:
             return self[0].getArea()
         except IndexError:
-            runLog.warning(f"{self} has no blocks and therefore no area.")
+            runLog.info(f"{self} has no blocks and therefore no area.")
             return None
 
     def getVolume(self):
@@ -331,7 +331,7 @@ class Assembly(composites.Composite):
 
         # no plenum blocks, use the top block of the assembly for plenum temperature
         if not plenumTemps:
-            runLog.warning("No plenum blocks exist. Using outlet coolant temperature.")
+            runLog.info("No plenum blocks exist. Using outlet coolant temperature.")
             plenumTemps = [self[-1].p.THcoolantOutletT]
 
         return sum(plenumTemps) / len(plenumTemps)

--- a/armi/reactor/blocks/block.py
+++ b/armi/reactor/blocks/block.py
@@ -1061,7 +1061,7 @@ class Block(composites.Composite):
         if tFrac:
             return tFrac
         else:
-            runLog.warning(
+            runLog.info(
                 f"No component {typeSpec} exists on {self}, so area fraction is zero.",
                 single=True,
                 label=f"{typeSpec} areaFrac is zero",

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -437,7 +437,7 @@ class Core(composites.Composite):
             try:
                 del self.blocksByName[b.getName()]
             except KeyError:
-                runLog.warning(
+                runLog.info(
                     "Cannot delete block {0}. It is not in the Core.blocksByName structure".format(b),
                     single=True,
                     label="cannot dereference: lost block",
@@ -1149,7 +1149,6 @@ class Core(composites.Composite):
             try:
                 return next(a for a in self if a.hasFlags(typeSpec, exact))
             except StopIteration:
-                runLog.warning("No assem of type {0} in reactor".format(typeSpec))
                 return None
 
         # Assumes at least one assembly in `self`
@@ -1906,12 +1905,12 @@ class Core(composites.Composite):
             dP1 = meshList[i + 1] - innerMeshVal
 
             if dP0 / (dP0 + dP1) < ratio:
-                runLog.warning("Mesh gap too small. Adjusting mesh to be more reasonable.")
+                runLog.extra("Mesh gap too small. Adjusting mesh to be more reasonable.")
                 meshList.append(innerMeshVal + dP1 * ratio)
                 meshList.sort()
                 return meshList, False
             elif dP0 / (dP0 + dP1) > (1.0 - ratio):
-                runLog.warning("Mesh gap too large. Adjusting mesh to be more reasonable.")
+                runLog.extra("Mesh gap too large. Adjusting mesh to be more reasonable.")
                 meshList.append(meshList[i - 1] + dP0 * (1.0 - ratio))
                 meshList.sort()
                 return meshList, False

--- a/armi/tests/tutorials/pin-rotations.ipynb
+++ b/armi/tests/tutorials/pin-rotations.ipynb
@@ -166,7 +166,6 @@
       "                           NI58, FE56, C, W183, B10, W184, FE57, W186\n",
       "       ------------------  -----------------------------------------------------\n",
       "[info] Constructing the `Spent Fuel Pool`\n",
-      "[warn] Changing the name of the Spent Fuel Pool to 'sfp'.\n",
       "=========== Creating Interfaces ===========\n",
       "=========== Interface Stack Summary  ===========\n",
       "[info] -------  ------------------------  ---------------  ----------  ---------  -----------  ------------\n",

--- a/armi/utils/directoryChangers.py
+++ b/armi/utils/directoryChangers.py
@@ -211,15 +211,15 @@ class DirectoryChanger:
             for fromName, destName in copies:
                 fromPath = os.path.join(initialPath, fromName)
                 if not os.path.exists(fromPath):
-                    runLog.warning(f"{fromPath} does not exist and will not be copied.")
+                    runLog.extra(f"{fromPath} does not exist and will not be copied.")
                     continue
 
                 toPath = os.path.join(destinationPath, destName)
                 if moveFiles:
-                    runLog.extra("Moving {} to {}".format(fromPath, toPath))
+                    runLog.debug(f"Moving {fromPath} to {toPath}")
                     safeMove(fromPath, toPath)
                 else:
-                    runLog.extra("Copying {} to {}".format(fromPath, toPath))
+                    runLog.debug(f"Copying {fromPath} to {toPath}")
                     safeCopy(fromPath, toPath)
 
 

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -53,7 +53,7 @@ def copyOrWarn(filepathDescription, sourcePath, destinationPath):
     except shutil.SameFileError:
         pass
     except Exception as e:
-        runLog.warning(
+        runLog.info(
             "Could not copy {} from {} to {}\nError was: {}".format(filepathDescription, sourcePath, destinationPath, e)
         )
 
@@ -61,8 +61,7 @@ def copyOrWarn(filepathDescription, sourcePath, destinationPath):
 def isFilePathNewer(path1, path2):
     """Returns true if path1 is newer than path2.
 
-    Returns true if path1 is newer than path2, or if path1 exists and path2 does not, otherwise
-    raises an IOError.
+    Returns true if path1 is newer than path2, or if path1 exists and path2 does not, otherwise raises an IOError.
     """
     exist1 = os.path.exists(path1)
     exist2 = os.path.exists(path2)
@@ -73,7 +72,7 @@ def isFilePathNewer(path1, path2):
     elif exist1 and not exist2:
         return True
     else:
-        raise IOError("Path 1 does not exist: {}".format(path1))
+        raise IOError(f"Path 1 does not exist: {path1}")
 
 
 def isAccessible(path):


### PR DESCRIPTION
## What is the change? Why is it being made?

I spoke with some of our analysts and found that they were having to disposition warnings that appeared in the run time of their code that they believed were not real warnings and not interesting.

So, out of that discussion came this PR, to remove or reduce in priority several warnings that were bothering our user base. 

Thanks to @wcscherer !

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: ARMI should not be in the business of causing warning fatigue.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
