### PR TITLE
Trying to stop codecov.io from failng the build

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,6 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 80%    # the required coverage value
-        threshold: 1%  # allows a 1% drop from the previous base commit coverage


### PR DESCRIPTION
## What is the change? Why is it being made?

We are still having the problem with codecov.io failing our build. I like their website, but they fail our build WAY too aggressively. This is yet another attempt to stop that from happening.

Progress on: https://github.com/terrapower/armi/issues/2471


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: The code coverage build should not fail ARMI CI all the time, that will create alarm fatigue for real failures.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
