### PR TITLE
Renaming matProps.Material to MatPropsMaterial

### DIFF
--- a/armi/matProps/__init__.py
+++ b/armi/matProps/__init__.py
@@ -85,7 +85,7 @@ import os
 import sysconfig
 from glob import glob
 
-from armi.matProps.material import Material
+from armi.matProps.material import MatPropsMaterial
 
 loadedRootDirs = []
 materials = {}
@@ -108,14 +108,14 @@ def getPaths(rootDir: str) -> list:
 
 def addMaterial(yamlPath: str, mat):
     """
-    Adds Material object instance to matProps.materials dict.
+    Adds MatPropsMaterial object instance to matProps.materials dict.
 
     Parameters
     ----------
     yamlPath: str
         Yaml file path whose information is being parsed.
-    mat: Material
-        Material object whose data will be saved.
+    mat: MatPropsMaterial
+        MatPropsMaterial object whose data will be saved.
     """
     global materials
     if mat.name in materials:
@@ -151,7 +151,7 @@ def loadAll(rootDir: str = None) -> None:
 
     paths = getPaths(rootDir)
     for yamlPath in paths:
-        mat = Material()
+        mat = MatPropsMaterial()
         try:
             mat.loadFile(yamlPath)
         except Exception as exc:
@@ -193,7 +193,7 @@ def loadSafe(rootDir: str = None) -> None:
 
 
 def getHashes() -> dict:
-    """Calls Material.hash() for each Material object in materials."""
+    """Calls Material.hash() for each MatPropsMaterial object in materials."""
     global materials
     hashes = {}
     for material in materials.values():
@@ -202,7 +202,7 @@ def getHashes() -> dict:
     return hashes
 
 
-def getMaterial(name: str) -> Material:
+def getMaterial(name: str) -> MatPropsMaterial:
     """
     Returns a material object with the given name from matProps.materials.
 
@@ -213,8 +213,8 @@ def getMaterial(name: str) -> Material:
 
     Returns
     -------
-    Material
-        Material object returned from matProps.materials.
+    MatPropsMaterial
+        MatPropsMaterial object returned from matProps.materials.
     """
     global materials
     try:
@@ -224,7 +224,7 @@ def getMaterial(name: str) -> Material:
         raise KeyError(msg) from None
 
 
-def loadMaterial(yamlPath: str, saveMaterial: bool = False) -> Material:
+def loadMaterial(yamlPath: str, saveMaterial: bool = False) -> MatPropsMaterial:
     """
     Loads an individual material file.
 
@@ -233,14 +233,14 @@ def loadMaterial(yamlPath: str, saveMaterial: bool = False) -> Material:
     yamlPath: str
         Path to YAML file that will be parsed into this object instance.
     saveMaterial: bool
-        If True, Material object instance will be saved into matProps.materials.
+        If True, MatPropsMaterial object instance will be saved into matProps.materials.
 
     Returns
     -------
-    Material
-        Material object whose data is parsed from material file provided by yamlPath.
+    MatPropsMaterial
+        MatPropsMaterial object whose data is parsed from material file provided by yamlPath.
     """
-    mat = Material()
+    mat = MatPropsMaterial()
     mat.loadFile(yamlPath)
     if saveMaterial:
         addMaterial(yamlPath, mat)
@@ -259,12 +259,12 @@ def loadMaterial(yamlPath: str, saveMaterial: bool = False) -> Material:
 
 def loadedMaterials() -> list:
     """
-    Returns all the Material objects that have been loaded into matProps.materials.
+    Returns all the MatPropsMaterial objects that have been loaded into matProps.materials.
 
     Returns
     -------
-    list of Material
-        Loaded Material objects
+    list of MatPropsMaterial
+        Loaded MatPropsMaterial objects
     """
     global materials
     mats = []

--- a/armi/matProps/material.py
+++ b/armi/matProps/material.py
@@ -25,44 +25,44 @@ from armi.matProps.function import Function
 from armi.matProps.materialType import MaterialType
 
 
-class Material:
+class MatPropsMaterial:
     """
-    The Material class is a generic container for all Material types, whether they contain ASME properties, fluid
-    properties, or steel properties.
+    The MatPropsMaterial class is a generic container for all material types, whether they contain ASME properties,
+    fluid properties, or steel properties.
 
-    It may be necessary to have multiple Material definitions for a single material containing different phases.
+    It may be necessary to have multiple MatPropsMaterial definitions for a single material containing different phases.
 
     .. impl:: Materials can be defined in custom YAML files.
         :id: I_ARMI_MAT_YAML
         :implements: R_ARMI_MAT_YAML
 
-        The ARMI matProps package can build a material object from a custom YAML format. This file format is flexible
-        and extensible. It is designed around the idea that mostly what scientists and engineers want from a material in
-        software is the ability to define it in terms of nuclide fractions and properties. In particular, the most work
-        in this code is to allow users to define material properties (like density) using simple mathematical syntax or
-        tabular data.
+        The ARMI matProps package can build a MatPropsMaterial object from a custom YAML format. This file format is
+        flexible and extensible. It is designed around the idea that mostly what scientists and engineers want from a
+        material in software is the ability to define it in terms of nuclide fractions and properties. In particular,
+        the most work in this code is to allow users to define material properties (like density) using simple
+        mathematical syntax or tabular data.
     """
 
     validFileFormatVersions = [3.0, "TESTS"]
     YAML_PATH = None
 
     def __init__(self, yamlPath=None):
-        """Constructor for Material class."""
+        """Constructor for MatPropsMaterial class."""
         # during unpickling, we do not want to reload the YAML file
         if hasattr(self, "materialType") and self.materialType is not None:
             return
 
         self._saved = False
-        """Boolean denoting whether or not Material object is saved in materials dict."""
+        """Boolean denoting whether or not MatPropsMaterial object is saved in materials dict."""
 
         self.materialType = None
-        """Enum represting type for the Material object"""
+        """Enum represting type for the MatPropsMaterial object"""
 
         self.composition = []
-        """List of Constituent objects representing composition of Material."""
+        """List of Constituent objects representing composition of MatPropsMaterial."""
 
         self.name = None
-        """Name of Material object."""
+        """Name of MatPropsMaterial object."""
 
         self._sha1 = None
         """SHA1 value of parsed material file."""
@@ -75,22 +75,22 @@ class Material:
             self.loadFile(self.yamlPath)
 
     def __repr__(self):
-        """Provides string representation for Material class."""
-        return f"<MatProps Material {self.name} {str(self.materialType)}>"
+        """Provides string representation for MatPropsMaterial class."""
+        return f"<MatPropsMaterial {self.name} {str(self.materialType)}>"
 
     def hash(self) -> str:
-        """Returns the SHA1 hash value of a Material instance."""
+        """Returns the SHA1 hash value of a MatPropsMaterial instance."""
         return self._sha1
 
     def saved(self) -> bool:
         """
-        Returns a bool value indicating whether the Material has been stored internally in the matProps.materials map
-        via matProps.addMaterial().
+        Returns a bool value indicating whether the MatPropsMaterial has been stored internally in the
+        matProps.materials map via matProps.addMaterial().
         """
         return self._saved
 
     def save(self):
-        """Sets Material._saved flag to True."""
+        """Sets MatPropsMaterial._saved flag to True."""
         self._saved = True
 
     @staticmethod
@@ -107,8 +107,8 @@ class Material:
         rootNode: dict
             Root YAML node of file parsed from filePath.
         """
-        file_format = Material.getNode(rootNode, "file format")
-        if file_format not in Material.validFileFormatVersions:
+        file_format = MatPropsMaterial.getNode(rootNode, "file format")
+        if file_format not in MatPropsMaterial.validFileFormatVersions:
             msg = f"Invalid file format version `{file_format}` used in: {filePath}"
             raise ValueError(msg)
 
@@ -123,7 +123,7 @@ class Material:
     @staticmethod
     def getValidFileFormatVersions():
         """Get a vector of strings with all of the valid file format versions."""
-        return Material.validFileFormatVersions
+        return MatPropsMaterial.validFileFormatVersions
 
     @staticmethod
     def getNode(node: dict, subnodeName: str):
@@ -145,12 +145,12 @@ class Material:
 
     def loadNode(self, node: dict):
         """
-        Loads YAML and parses information to fill in Material data members including all relevant Function objects.
+        Loads YAML and parses information to fill in material data members including all relevant Function objects.
 
         Parameters
         ----------
         node: dict
-            Material definition, like a dict that is loaded from a YAML file.
+            MatPropsMaterial definition, like a dict that is loaded from a YAML file.
         """
         self.materialType = MaterialType.fromString(self.getNode(node, "material type"))
         self.composition = Constituent.parseComposition(self.getNode(node, "composition"))
@@ -164,7 +164,8 @@ class Material:
 
     def loadFile(self, yamlPath: str):
         """
-        Loads YAML file and parses information to fill in Material data members including all relevant Function objects.
+        Loads YAML file and parses information to fill in MatPropsMaterial data members including all relevant Function
+        objects.
 
         Parameters
         ----------

--- a/armi/matProps/tests/__init__.py
+++ b/armi/matProps/tests/__init__.py
@@ -17,7 +17,7 @@
 import math
 import unittest
 
-from armi.matProps.material import Material
+from armi.matProps.material import MatPropsMaterial
 
 
 class MatPropsFunTestBase(unittest.TestCase):
@@ -119,7 +119,7 @@ class MatPropsFunTestBase(unittest.TestCase):
             "density": {"function": funcBody},
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(materialData)
 
         return mat
@@ -148,7 +148,7 @@ class MatPropsFunTestBase(unittest.TestCase):
             "density": {"function": funcBody, "tabulated data": tableData or {}},
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(materialData)
 
         return mat

--- a/armi/matProps/tests/test_1DSymbolicFunction.py
+++ b/armi/matProps/tests/test_1DSymbolicFunction.py
@@ -72,7 +72,7 @@ class Test1DSymbolicFunction(MatPropsFunTestBase):
         # these polynomials have up to 8 powers/terms (including 0)
         mat = self._createFunction(self.basePolynomialData)
         mat.name = self.testName
-        self.assertEqual(str(mat), f"<MatProps Material {self.testName} <MaterialType Metal>>")
+        self.assertEqual(str(mat), f"<MatPropsMaterial {self.testName} <MaterialType Metal>>")
 
         # test using input dict for calc
         self.assertAlmostEqual(mat.rho.calc({"T": 0}), self.polynomialEvaluation(self.basePolynomialMap, 0))
@@ -133,7 +133,7 @@ class Test1DSymbolicFunction(MatPropsFunTestBase):
 
         mat = self._createFunction(data, minT=0.0)
         mat.name = self.testName
-        self.assertEqual(str(mat), f"<MatProps Material {self.testName} <MaterialType Metal>>")
+        self.assertEqual(str(mat), f"<MatPropsMaterial {self.testName} <MaterialType Metal>>")
         func = mat.rho
 
         self.assertAlmostEqual(func.calc({"T": 0.0}), self.polynomialEvaluation(coefficientsMap, 0.0))

--- a/armi/matProps/tests/test_composition.py
+++ b/armi/matProps/tests/test_composition.py
@@ -21,7 +21,7 @@ from ruamel.yaml.constructor import DuplicateKeyError
 
 import armi.matProps
 from armi.matProps.constituent import Constituent
-from armi.matProps.material import Material
+from armi.matProps.material import MatPropsMaterial
 
 
 class TestComposition(unittest.TestCase):
@@ -48,7 +48,7 @@ class TestComposition(unittest.TestCase):
             },
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(materialMap)
 
         return mat
@@ -60,7 +60,7 @@ class TestComposition(unittest.TestCase):
             "density": "whatever",
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
 
         with self.assertRaisesRegex(KeyError, "Missing YAML node `composition`"):
             mat.loadNode(materialMap)
@@ -68,7 +68,7 @@ class TestComposition(unittest.TestCase):
     def test_compositionVoid(self):
         node = {"file format": "TESTS", "material type": "Metal", "density": "whatever", "composition": {"V": "void"}}
 
-        mat = Material()
+        mat = MatPropsMaterial()
         c = Constituent.parseComposition(mat.getNode(node, "composition"))
         self.assertEqual(len(c), 0)
 
@@ -103,7 +103,7 @@ class TestComposition(unittest.TestCase):
         compMap = {"a": [15.0, 20.0], "b": [30.0, 35.0], "c": "balance"}
         mat = self._createFunction(compMap)
         mat.name = self.testName
-        self.assertEqual(str(mat), f"<MatProps Material {self.testName} <MaterialType Metal>>")
+        self.assertEqual(str(mat), f"<MatPropsMaterial {self.testName} <MaterialType Metal>>")
         c_minValue, c_maxValue = None, None
         sumMin, sumMax = 0.0, 0.0
         for compElement in mat.composition:
@@ -133,7 +133,7 @@ class TestComposition(unittest.TestCase):
 
         mat = self._createFunction(compMap)
         mat.name = self.testName
-        self.assertEqual(str(mat), f"<MatProps Material {self.testName} <MaterialType Metal>>")
+        self.assertEqual(str(mat), f"<MatPropsMaterial {self.testName} <MaterialType Metal>>")
         sumMin = 0.0
         d_minValue, d_maxValue = None, None
         for compElement in mat.composition:

--- a/armi/matProps/tests/test_functions.py
+++ b/armi/matProps/tests/test_functions.py
@@ -14,7 +14,7 @@
 
 """Unit tests for the Function class."""
 
-from armi.matProps.material import Material
+from armi.matProps.material import MatPropsMaterial
 from armi.matProps.tests import MatPropsFunTestBase
 
 
@@ -42,7 +42,7 @@ class TestFunctions(MatPropsFunTestBase):
         """
         mat = self._createFunction(self.baseConstantData)
         mat.name = self.testName
-        self.assertEqual(str(mat), f"<MatProps Material {self.testName} <MaterialType Metal>>")
+        self.assertEqual(str(mat), f"<MatPropsMaterial {self.testName} <MaterialType Metal>>")
         density = mat.rho
         self.assertEqual(density.getMinBound("T"), -100.0)
         self.assertEqual(density.getMaxBound("T"), 500.0)
@@ -118,7 +118,7 @@ class TestFunctions(MatPropsFunTestBase):
             "density": {"function": {"T": {"min": 1.0}, "type": "symbolic", "equation": 1.0}},
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         with self.assertRaises(KeyError):
             mat.loadNode(materialData)
 
@@ -137,7 +137,7 @@ class TestFunctions(MatPropsFunTestBase):
             },
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(materialData)
         self.assertEqual(len(mat.rho.references), 1)
         self.assertEqual(mat.rho.references[0].getRef(), "things")
@@ -167,7 +167,7 @@ class TestFunctions(MatPropsFunTestBase):
             },
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(materialData)
         self.assertEqual(len(mat.rho.references), 0)
         self.assertEqual(len(mat.rho.tableData._values), 7)

--- a/armi/matProps/tests/test_material.py
+++ b/armi/matProps/tests/test_material.py
@@ -18,14 +18,14 @@ import os
 import unittest
 
 import armi.matProps
-from armi.matProps.material import Material
+from armi.matProps.material import MatPropsMaterial
 from armi.matProps.materialType import MaterialType
 
 THIS_DIR = os.path.dirname(__file__)
 
 
 class TestMapPropsMaterial(unittest.TestCase):
-    """Class which tests the functionality of the matProps Material class."""
+    """Class which tests the functionality of the matProps MatPropsMaterial class."""
 
     @staticmethod
     def _createFunction(materialType):
@@ -55,21 +55,21 @@ class TestMapPropsMaterial(unittest.TestCase):
             },
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(testNode)
 
         return mat
 
     def test_getValidFileFormatVersions(self):
-        versions = armi.matProps.Material.getValidFileFormatVersions()
+        versions = armi.matProps.MatPropsMaterial.getValidFileFormatVersions()
         self.assertGreater(len(versions), 1)
         for version in versions:
             if type(version) is not float:
                 self.assertEqual(version, "TESTS")
 
     def test_loadFile(self):
-        mat = armi.matProps.Material()
-        self.assertEqual(str(mat), "<MatProps Material None None>")
+        mat = armi.matProps.MatPropsMaterial()
+        self.assertEqual(str(mat), "<MatPropsMaterial None None>")
         fPath = os.path.join(THIS_DIR, "testMaterialsData", "materialA.yaml")
         self.assertEqual(len(sorted(armi.matProps.materials.keys())), 0)
         mat.loadFile(fPath)
@@ -94,7 +94,7 @@ class TestMapPropsMaterial(unittest.TestCase):
 
     def test_invalidFileFormat(self):
         fPath = os.path.join(THIS_DIR, "invalidTestFiles", "badFileFormat.YAML")
-        mat = armi.matProps.Material()
+        mat = armi.matProps.MatPropsMaterial()
 
         with self.assertRaises(ValueError):
             mat.loadFile(fPath)

--- a/armi/matProps/tests/test_parsing.py
+++ b/armi/matProps/tests/test_parsing.py
@@ -55,19 +55,19 @@ class TestParsing(unittest.TestCase):
             matNam = path.splitext(matFile)[0]
             # the default behavior is loadMaterial(matPath, false)
             m = armi.matProps.loadMaterial(matPath)
-            self.assertIsInstance(m, armi.matProps.Material)
+            self.assertIsInstance(m, armi.matProps.MatPropsMaterial)
             with self.assertRaisesRegex(KeyError, f"No material named `{matNam}` was loaded within loaded data."):
                 armi.matProps.getMaterial(matNam)
 
             m = armi.matProps.loadMaterial(self.dummyMatFiles[matFile], False)
-            self.assertIsInstance(m, armi.matProps.Material)
+            self.assertIsInstance(m, armi.matProps.MatPropsMaterial)
             with self.assertRaisesRegex(KeyError, f"No material named `{matNam}` was loaded within loaded data."):
                 armi.matProps.getMaterial(matNam)
 
             m = armi.matProps.loadMaterial(self.dummyMatFiles[matFile], True)
-            self.assertIsInstance(m, armi.matProps.Material)
+            self.assertIsInstance(m, armi.matProps.MatPropsMaterial)
             m = armi.matProps.getMaterial(matNam)
-            self.assertIsInstance(m, armi.matProps.Material)
+            self.assertIsInstance(m, armi.matProps.MatPropsMaterial)
 
     def test_multiDataLoadingLoadingAll(self):
         armi.matProps.loadAll(self.dummyDataPath)

--- a/armi/matProps/tests/test_piecewiseFunction.py
+++ b/armi/matProps/tests/test_piecewiseFunction.py
@@ -14,7 +14,7 @@
 
 """Tests related to piecewise functions."""
 
-from armi.matProps.material import Material
+from armi.matProps.material import MatPropsMaterial
 from armi.matProps.tests import MatPropsFunTestBase
 
 
@@ -244,7 +244,7 @@ class TestPiecewiseFunction(MatPropsFunTestBase):
             "density": {"function": funcBody, "tabulated data": {}},
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(materialData)
 
         return mat

--- a/armi/matProps/tests/test_symbolicFunction.py
+++ b/armi/matProps/tests/test_symbolicFunction.py
@@ -22,7 +22,7 @@ import unittest
 
 import numpy as np
 
-from armi.matProps.material import Material
+from armi.matProps.material import MatPropsMaterial
 
 
 class TestSymbolicFunction(unittest.TestCase):
@@ -46,7 +46,7 @@ class TestSymbolicFunction(unittest.TestCase):
 
     def loadMaterial(self, num=1):
         """Loads the material file based on `self.yaml` and returns the material object."""
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(self.yaml)
         return mat
 
@@ -862,7 +862,7 @@ class TestBrokenSymbolicFunctions(unittest.TestCase):
             },
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(yaml)
 
         # stomp all over the equation, to force it to return a complex number
@@ -887,7 +887,7 @@ class TestBrokenSymbolicFunctions(unittest.TestCase):
             },
         }
 
-        mat = Material()
+        mat = MatPropsMaterial()
         mat.loadNode(yaml)
 
         # stomp all over the equation, to force it to return a complex number

--- a/armi/matProps/tests/test_tableFunctions.py
+++ b/armi/matProps/tests/test_tableFunctions.py
@@ -46,7 +46,7 @@ class TestTableFunctions(MatPropsFunTestBase):
         """Test interpolation for a two-point one-dimensional table."""
         mat = self._createFunction(self.baseOneDimTableData, self.baseOneDimTable)
         mat.name = self.testName
-        self.assertEqual(str(mat), f"<MatProps Material {self.testName} <MaterialType Metal>>")
+        self.assertEqual(str(mat), f"<MatPropsMaterial {self.testName} <MaterialType Metal>>")
         func = mat.rho
         self.assertIn("TableFunction1D", str(func))
         for index in range(9):
@@ -80,7 +80,7 @@ class TestTableFunctions(MatPropsFunTestBase):
 
         mat = self._createFunction(data, tableData)
         mat.name = self.testName
-        self.assertEqual(str(mat), f"<MatProps Material {self.testName} <MaterialType Metal>>")
+        self.assertEqual(str(mat), f"<MatPropsMaterial {self.testName} <MaterialType Metal>>")
         self.assertAlmostEqual(mat.rho.calc(T=250), 25.68)
         self.assertAlmostEqual(mat.rho.calc(T=275), 25.825)
         self.assertAlmostEqual(mat.rho.calc(T=500), 26.26)
@@ -111,7 +111,7 @@ class TestTableFunctions(MatPropsFunTestBase):
 
         mat = self._createFunction(self.baseOneDimTableData, tableData, minT=250, maxT=900)
         mat.name = self.testName
-        self.assertEqual(str(mat), f"<MatProps Material {self.testName} <MaterialType Metal>>")
+        self.assertEqual(str(mat), f"<MatPropsMaterial {self.testName} <MaterialType Metal>>")
         self.assertAlmostEqual(mat.rho.calc(T=275), 5.5)
         self.assertAlmostEqual(mat.rho.calc(T=312.5), 6.125)
 
@@ -119,7 +119,7 @@ class TestTableFunctions(MatPropsFunTestBase):
         """Test that evaluates TableFunction2D for different combinations of integer and floating values."""
         mat = self._createFunction(self.baseTwoDimTableData, self.baseTwoDimTable)
         mat.name = self.testName
-        self.assertEqual(str(mat), f"<MatProps Material {self.testName} <MaterialType Metal>>")
+        self.assertEqual(str(mat), f"<MatPropsMaterial {self.testName} <MaterialType Metal>>")
         func = mat.rho
         self.assertIn("TableFunction2D", str(func))
         self.assertAlmostEqual(func.calc({"T": 2, "t": 1}), 10)

--- a/armi/materials/__init__.py
+++ b/armi/materials/__init__.py
@@ -252,7 +252,7 @@ def resolveMaterialClassByName(name: str, namespaceOrder: List[str] = None):
     armi.reactor.reactors.factory
         Applies user settings to default namespace order.
     """
-    from armi.matProps import Material as MatPropsMaterial
+    from armi.matProps import MatPropsMaterial
 
     # 1. Try to import the material from a path like `armi.materials.uZr:UZr`
     if ":" in name:

--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -21,7 +21,7 @@ Most temperatures may be specified in either K or C and the functions will conve
 import numpy as np
 
 from armi import runLog
-from armi.matProps.material import Material as MatPropsMaterial
+from armi.matProps.material import MatPropsMaterial
 from armi.nucDirectory import nuclideBases
 from armi.reactor.flags import TypeSpec
 from armi.utils import densityTools


### PR DESCRIPTION
## What is the change? Why is it being made?

ARMI currently has two important `Material` classes:

* `armi.materials.Material`
* `armi.matProps.Material`

Well, that's confusing. Let's simplify this.

close #2476


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: We are reducing a naming collision to make the code easier to understand for developers.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: This rename is a change to I_ARMI_MAT_YAML.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
