### PR TITLE
Removing deprecated API endpoints

### DIFF
--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -737,12 +737,6 @@ class Database:
         # return a Reactor object
         if cs[CONF_SORT_REACTOR]:
             root.sort()
-        else:
-            runLog.warning(
-                "DeprecationWarning: This Reactor is not being sorted on DB load. Due to the setting "
-                f"{CONF_SORT_REACTOR}, this Reactor is unsorted. But this feature is temporary and will be removed by "
-                "2024."
-            )
 
         if cs[CONF_GROW_TO_FULL_CORE_AFTER_LOAD] and not root.core.isFullCore:
             root.core.growToFullCore(cs)

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -22,7 +22,6 @@ assembly definition.
 This is an example of a material implement purely in Python, without any matProps YAML inputs.
 """
 
-from armi import runLog
 from armi.materials import material
 from armi.utils.units import getTc
 
@@ -38,22 +37,11 @@ class B4C(material.Material):
         self.b10NumFrac = self.NATURAL_B10_NUM_FRAC
         super().__init__()
 
-    def applyInputParams(self, B10_wt_frac=None, theoretical_density=None, TD_frac=None, *args, **kwargs):
+    def applyInputParams(self, B10_wt_frac=None, TD_frac=None, *args, **kwargs):
         if B10_wt_frac is not None:
             # We can not just use the generic enrichment adjustment here because the carbon has to change with enrich.
             self.adjustMassEnrichment(B10_wt_frac)
-        if theoretical_density is not None:
-            runLog.warning(
-                "The 'theoretical_density' material modification for B4C will be deprecated. Update your inputs to use "
-                "'TD_frac' instead.",
-                single=True,
-            )
-            if TD_frac is not None:
-                runLog.info(
-                    f"Both 'theoretical_density' and 'TD_frac' are specified for {self}. 'TD_frac' will be used."
-                )
-            else:
-                self.updateTD(theoretical_density)
+
         if TD_frac is not None:
             self.updateTD(TD_frac)
 

--- a/armi/materials/tests/test_b4c.py
+++ b/armi/materials/tests/test_b4c.py
@@ -26,25 +26,13 @@ class B4C_TestCase(AbstractMaterialTest, unittest.TestCase):
         AbstractMaterialTest.setUp(self)
         self.mat = B4C()
 
-        self.B4C_theoretical_density = B4C()
-        self.B4C_theoretical_density.applyInputParams(theoretical_density=0.5)
-
         self.B4C_TD_frac = B4C()
         self.B4C_TD_frac.applyInputParams(TD_frac=0.4)
-
-        self.B4C_both = B4C()
-        self.B4C_both.applyInputParams(theoretical_density=0.5, TD_frac=0.4)
 
     def test_theoretical_pseudoDensity(self):
         ref = self.mat.pseudoDensity(500)
 
-        reduced = self.B4C_theoretical_density.pseudoDensity(500)
-        self.assertAlmostEqual(ref * 0.5 / B4C.DEFAULT_THEORETICAL_DENSITY_FRAC, reduced)
-
         reduced = self.B4C_TD_frac.pseudoDensity(500)
-        self.assertAlmostEqual(ref * 0.4 / B4C.DEFAULT_THEORETICAL_DENSITY_FRAC, reduced)
-
-        reduced = self.B4C_both.pseudoDensity(500)
         self.assertAlmostEqual(ref * 0.4 / B4C.DEFAULT_THEORETICAL_DENSITY_FRAC, reduced)
 
     def test_propertyValidTemperature(self):

--- a/armi/operators/operator.py
+++ b/armi/operators/operator.py
@@ -1067,7 +1067,7 @@ class Operator:
                     self.restartData.append((float(match.group(1)), float(match.group(2)), factorList))
         runLog.info("loaded restart data for {0} cycles".format(len(self.restartData)))
 
-    def loadState(self, cycle, timeNode, timeStepName="", fileName=None, updateMassFractions=None):
+    def loadState(self, cycle, timeNode, timeStepName="", fileName=None):
         """
         Convenience method reroute to the database interface state reload method.
 
@@ -1084,9 +1084,6 @@ class Operator:
         dbi = self.getInterface("database")
         if not dbi:
             raise RuntimeError("Cannot load from snapshot without a database interface")
-
-        if updateMassFractions is not None:
-            runLog.warning("deprecated: updateMassFractions is no longer a valid option for loadState")
 
         dbi.loadState(cycle, timeNode, timeStepName, fileName)
 


### PR DESCRIPTION
## What is the change? Why is it being made?

This PR finally removes all the deprecation warnings in ARMI. 

Here I removed 2 deprecated API end points:

* the `theoretical_density` parameter of `applyInputParamters()`
* the `updateMassFractions` parameter of `loadState()`

And I actually am giving up on deprecating the `sortReactor` Setting; it is actually in strong use.

close #2526

## SCR Information

Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: These deprecation warnings have been in place so long, I think it is time to clean up the API.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
