### PR TITLE
Remove `callReactorConstructionHook` argument from `db.load` and `loadOperator`

### DIFF
--- a/armi/bookkeeping/db/__init__.py
+++ b/armi/bookkeeping/db/__init__.py
@@ -78,15 +78,7 @@ __all__ = [
 ]
 
 
-def loadOperator(
-    pathToDb,
-    loadCycle,
-    loadNode,
-    statePointName=None,
-    allowMissing=False,
-    handleInvalids=True,
-    callReactorConstructionHook=True,
-):
+def loadOperator(pathToDb, loadCycle, loadNode, statePointName=None, allowMissing=False, handleInvalids=True):
     """
     Return an operator given the path to a database.
 
@@ -106,8 +98,6 @@ def loadOperator(
         with undefined parameters. Default False.
     handleInvalids : bool
         Whether to check for invalid settings. Default True.
-    callReactorConstructionHook : bool
-        Flag for whether the beforeReactorConstruction plugin hook should be executed. Default is True.
 
     See Also
     --------
@@ -158,7 +148,6 @@ def loadOperator(
             statePointName=statePointName,
             allowMissing=allowMissing,
             handleInvalids=handleInvalids,
-            callReactorConstructionHook=callReactorConstructionHook,
         )
 
     o = thisCase.initializeOperator(r=r)

--- a/armi/bookkeeping/db/__init__.py
+++ b/armi/bookkeeping/db/__init__.py
@@ -85,7 +85,7 @@ def loadOperator(
     statePointName=None,
     allowMissing=False,
     handleInvalids=True,
-    callReactorConstructionHook=False,
+    callReactorConstructionHook=True,
 ):
     """
     Return an operator given the path to a database.
@@ -107,7 +107,7 @@ def loadOperator(
     handleInvalids : bool
         Whether to check for invalid settings. Default True.
     callReactorConstructionHook : bool
-        Flag for whether the beforeReactorConstruction plugin hook should be executed. Default is False.
+        Flag for whether the beforeReactorConstruction plugin hook should be executed. Default is True.
 
     See Also
     --------

--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -647,17 +647,7 @@ class Database:
         # Reload the file in append mode and continue on our merry way
         self.h5db = h5py.File(self._fullPath, "r+")
 
-    def load(
-        self,
-        cycle,
-        node,
-        cs=None,
-        bp=None,
-        statePointName=None,
-        allowMissing=False,
-        handleInvalids=True,
-        callReactorConstructionHook=True,
-    ):
+    def load(self, cycle, node, cs=None, bp=None, statePointName=None, allowMissing=False, handleInvalids=True):
         """Load a new reactor from a DB at (cycle, node).
 
         Case settings and blueprints can be provided, or read from the database. Providing  can be useful for snapshot
@@ -690,8 +680,6 @@ class Database:
             with undefined parameters. Default False.
         handleInvalids : bool
             Whether to check for invalid settings. Default True.
-        callReactorConstructionHook : bool
-            Flag for whether the beforeReactorConstruction plugin hook should be executed. Default is True.
 
         Returns
         -------
@@ -705,8 +693,7 @@ class Database:
         if bp is None:
             bp = self.loadBlueprints(cs)
 
-        if callReactorConstructionHook:
-            getPluginManagerOrFail().hook.beforeReactorConstruction(cs=cs)
+        getPluginManagerOrFail().hook.beforeReactorConstruction(cs=cs)
 
         if node < 0:
             numNodes = getNodesPerCycle(cs)[cycle]

--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -656,7 +656,7 @@ class Database:
         statePointName=None,
         allowMissing=False,
         handleInvalids=True,
-        callReactorConstructionHook=False,
+        callReactorConstructionHook=True,
     ):
         """Load a new reactor from a DB at (cycle, node).
 
@@ -691,7 +691,7 @@ class Database:
         handleInvalids : bool
             Whether to check for invalid settings. Default True.
         callReactorConstructionHook : bool
-            Flag for whether the beforeReactorConstruction plugin hook should be executed. Default is False.
+            Flag for whether the beforeReactorConstruction plugin hook should be executed. Default is True.
 
         Returns
         -------

--- a/armi/materials/__init__.py
+++ b/armi/materials/__init__.py
@@ -127,10 +127,10 @@ def importYamlMaterialDir(dirPath=None, overwriteExisting=False, clearFirst=True
     if not os.path.exists(dirPath):
         raise OSError(f"No material directory provided, and default not found: {dirPath}")
 
-    loadedRootDirs.append(dirPath)
     if clearFirst:
         # clear the loaded materials before loading this new directory
         clear()
+    loadedRootDirs.append(dirPath)
 
     # recursively get all the *.yaml and *.yml files from the provided directory
     paths = getYamlPaths(dirPath)

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -263,8 +263,10 @@ class ArmiPlugin:
         decorator with the following:
 
         .. code::
+            from <somewhere> import <PLUGIN>
 
             <PLUGIN>.beforeReactorConstruction.reset_onlyRunOnce()
+            # Proceed with database or operator loading
         """
 
     @staticmethod

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -237,7 +237,26 @@ class ArmiPlugin:
     @staticmethod
     @HOOKSPEC
     def beforeReactorConstruction(cs) -> None:
-        """Function to call before the reactor is constructed."""
+        """
+        Function to call before the reactor is constructed.
+
+        Warning
+        -------
+
+        This plugin hook runs during a simulation spin-up before reactor construction as well as during ``db.load()``. It is only meant to be run one time. Because ``db.load()`` may be run several times in the same script, it is strongly recommended that developers implement the following pattern when adding this hook to any plugin:
+
+        .. code::
+
+            @staticmethod
+            @HOOKSPEC
+            def beforeReactorConstruction(cs) -> None:
+                if getattr(<PLUGIN>.beforeReactorConstruction, "_hasRun", False):
+                    return
+
+                # <Code for before reactor construction>
+
+                <PLUGIN>.beforeReactorConstruction._hasRun = True
+        """
 
     @staticmethod
     @HOOKSPEC

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -243,7 +243,9 @@ class ArmiPlugin:
         Warning
         -------
 
-        This plugin hook runs during a simulation spin-up before reactor construction as well as during ``db.load()``. It is only meant to be run one time. Because ``db.load()`` may be run several times in the same script, it is strongly recommended that developers implement the following pattern when adding this hook to any plugin:
+        This plugin hook runs during a simulation spin-up before reactor construction as well as during ``db.load()``.
+        It is only meant to be run one time. Because ``db.load()`` may be run several times in the same script, it is
+        strongly recommended that developers implement the following pattern when adding this hook to any plugin:
 
         .. code::
 

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -248,16 +248,13 @@ class ArmiPlugin:
         strongly recommended that developers implement the following pattern when adding this hook to any plugin:
 
         .. code::
+            from armi.utils import onlyRunOnce
 
             @staticmethod
             @HOOKSPEC
+            @onlyRunOnce
             def beforeReactorConstruction(cs) -> None:
-                if getattr(<PLUGIN>.beforeReactorConstruction, "_hasRun", False):
-                    return
-
                 # <Code for before reactor construction>
-
-                <PLUGIN>.beforeReactorConstruction._hasRun = True
         """
 
     @staticmethod

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -238,10 +238,11 @@ class ArmiPlugin:
     @HOOKSPEC
     def beforeReactorConstruction(cs) -> None:
         """
-        Function to call before the reactor is constructed.
+        Function to call before the reactor is constructed, typically implemented as related to global materials
+        loading.
 
-        Warning
-        -------
+        Attention
+        ---------
 
         This plugin hook runs during a simulation spin-up before reactor construction as well as during ``db.load()``.
         It is only meant to be run one time. Because ``db.load()`` may be run several times in the same script, it is
@@ -255,6 +256,15 @@ class ArmiPlugin:
             @onlyRunOnce
             def beforeReactorConstruction(cs) -> None:
                 # <Code for before reactor construction>
+
+        Note that the custom ``onlyRunOnce`` decorator is to protect against repeated materials loading for global
+        materials. If a user requires repeated ``beforeReactorConstruction`` calls due to loading different reactors
+        with potentially different materials libraries in the same python instance, they may reset the ``onlyRunOnce``
+        decorator with the following:
+
+        .. code::
+
+            <PLUGIN>.beforeReactorConstruction.reset_onlyRunOnce()
         """
 
     @staticmethod

--- a/armi/reactor/__init__.py
+++ b/armi/reactor/__init__.py
@@ -22,6 +22,7 @@ See :doc:`/developer/index`.
 from typing import TYPE_CHECKING, Callable, Dict, Union
 
 from armi import materials, plugins
+from armi.utils import onlyRunOnce
 
 if TYPE_CHECKING:
     from armi.reactor.excoreStructure import ExcoreStructure
@@ -34,21 +35,17 @@ class ReactorPlugin(plugins.ArmiPlugin):
 
     @staticmethod
     @plugins.HOOKIMPL
+    @onlyRunOnce
     def beforeReactorConstruction(cs) -> None:
         """Just before reactor construction, update the material "registry" with user settings, if it is set. Often it
         is set by the application.
         """
-        if getattr(ReactorPlugin.beforeReactorConstruction, "_hasRun", False):
-            return
-
         from armi.settings.fwSettings.globalSettings import (
             CONF_MATERIAL_NAMESPACE_ORDER,
         )
 
         if cs[CONF_MATERIAL_NAMESPACE_ORDER]:
             materials.setMaterialNamespaceOrder(cs[CONF_MATERIAL_NAMESPACE_ORDER])
-
-        ReactorPlugin.beforeReactorConstruction._hasRun = True
 
     @staticmethod
     @plugins.HOOKIMPL

--- a/armi/reactor/__init__.py
+++ b/armi/reactor/__init__.py
@@ -35,15 +35,20 @@ class ReactorPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def beforeReactorConstruction(cs) -> None:
-        """Just before reactor construction, update the material "registry" with user settings,
-        if it is set. Often it is set by the application.
+        """Just before reactor construction, update the material "registry" with user settings, if it is set. Often it
+        is set by the application.
         """
+        if getattr(ReactorPlugin.beforeReactorConstruction, "_hasRun", False):
+            return
+
         from armi.settings.fwSettings.globalSettings import (
             CONF_MATERIAL_NAMESPACE_ORDER,
         )
 
         if cs[CONF_MATERIAL_NAMESPACE_ORDER]:
             materials.setMaterialNamespaceOrder(cs[CONF_MATERIAL_NAMESPACE_ORDER])
+
+        ReactorPlugin.beforeReactorConstruction._hasRun = True
 
     @staticmethod
     @plugins.HOOKIMPL

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -151,15 +151,9 @@ class TestPluginRegistration(unittest.TestCase):
                 db = dbi.database
                 db.writeToDB(r)
                 db.close()
-                o1 = loadOperator(self._testMethodName + ".h5", 0, 0, callReactorConstructionHook=False)
-                o2 = loadOperator(self._testMethodName + ".h5", 0, 0, callReactorConstructionHook=True)
-            # Check that hook is not called for database loading for o1
-            with self.assertRaisesRegex(
-                AttributeError, "'Settings' object has no attribute 'beforeReactorConstructionFlag'"
-            ):
-                self.assertFalse(o1.cs.beforeReactorConstructionFlag)
-            # Check that hook is called for database loading for o2
-            self.assertTrue(o2.cs.beforeReactorConstructionFlag)
+                o = loadOperator(self._testMethodName + ".h5", 0, 0)
+            # Check that hook is called for database loading
+            self.assertTrue(o.cs.beforeReactorConstructionFlag)
         finally:
             pm.unregister(BeforeReactorPlugin)
 

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -63,6 +63,7 @@ class SillyAxialPlugin(plugins.ArmiPlugin):
     def getAxialExpansionChanger() -> type[SillyAxialExpansionChanger]:
         return SillyAxialExpansionChanger
 
+
 class BeforeReactorPlugin(plugins.ArmiPlugin):
     """Trivial plugin that implements the before reactor construction hook."""
 

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -37,6 +37,7 @@ from armi.reactor.converters.axialExpansionChanger import AxialExpansionChanger
 from armi.reactor.flags import Flags
 from armi.testing import loadTestReactor
 from armi.tests import TEST_ROOT
+from armi.utils import onlyRunOnce
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
@@ -62,17 +63,14 @@ class SillyAxialPlugin(plugins.ArmiPlugin):
     def getAxialExpansionChanger() -> type[SillyAxialExpansionChanger]:
         return SillyAxialExpansionChanger
 
-
 class BeforeReactorPlugin(plugins.ArmiPlugin):
     """Trivial plugin that implements the before reactor construction hook."""
 
     @staticmethod
     @plugins.HOOKIMPL
+    @onlyRunOnce
     def beforeReactorConstruction(cs) -> None:
-        if getattr(BeforeReactorPlugin.beforeReactorConstruction, "_hasRun", False):
-            return
         cs.beforeReactorConstructionFlag = True
-        BeforeReactorPlugin.beforeReactorConstruction._hasRun = True
 
 
 class TestPluginRegistration(unittest.TestCase):
@@ -160,9 +158,9 @@ class TestPluginRegistration(unittest.TestCase):
                 db.close()
                 # Call `loadOperator`, which will trigger the plugin hook we are testing
                 o1 = loadOperator(self._testMethodName + ".h5", 0, 0)
-                # Asserts to prove that the plugin hook code ran
-                self.assertTrue(BeforeReactorPlugin.beforeReactorConstruction._hasRun)
+                # Assert to prove that the plugin hook code ran
                 self.assertTrue(o1.cs.beforeReactorConstructionFlag)
+                # Run `loadOperator` a second time
                 o2 = loadOperator(self._testMethodName + ".h5", 0, 0)
                 # Assert to prove that the plugin hook code did not run
                 with self.assertRaisesRegex(

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -69,13 +69,9 @@ class BeforeReactorPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def beforeReactorConstruction(cs) -> None:
-        print("~~~~~~~~~~~~~~~~~~~~")
-        print("Before Check")
         if getattr(BeforeReactorPlugin.beforeReactorConstruction, "_hasRun", False):
             return
-        print("After Check")
         cs.beforeReactorConstructionFlag = True
-
         BeforeReactorPlugin.beforeReactorConstruction._hasRun = True
 
 

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -145,15 +145,21 @@ class TestPluginRegistration(unittest.TestCase):
             o, r = loadTestReactor(TEST_ROOT, inputFileName="smallestTestReactor/armiRunSmallest.yaml", useCache=False)
             self.assertTrue(o.cs.beforeReactorConstructionFlag)
 
-            # Check that hook is called for database loading
             with TemporaryDirectoryChanger():
                 dbi = DatabaseInterface(r, o.cs)
                 dbi.initDB(fName=self._testMethodName + ".h5")
                 db = dbi.database
                 db.writeToDB(r)
                 db.close()
-                o = loadOperator(self._testMethodName + ".h5", 0, 0, callReactorConstructionHook=True)
-            self.assertTrue(o.cs.beforeReactorConstructionFlag)
+                o1 = loadOperator(self._testMethodName + ".h5", 0, 0, callReactorConstructionHook=False)
+                o2 = loadOperator(self._testMethodName + ".h5", 0, 0, callReactorConstructionHook=True)
+            # Check that hook is not called for database loading for o1
+            with self.assertRaisesRegex(
+                AttributeError, "'Settings' object has no attribute 'beforeReactorConstructionFlag'"
+            ):
+                self.assertFalse(o1.cs.beforeReactorConstructionFlag)
+            # Check that hook is called for database loading for o2
+            self.assertTrue(o2.cs.beforeReactorConstructionFlag)
         finally:
             pm.unregister(BeforeReactorPlugin)
 

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -69,7 +69,14 @@ class BeforeReactorPlugin(plugins.ArmiPlugin):
     @staticmethod
     @plugins.HOOKIMPL
     def beforeReactorConstruction(cs) -> None:
+        print("~~~~~~~~~~~~~~~~~~~~")
+        print("Before Check")
+        if getattr(BeforeReactorPlugin.beforeReactorConstruction, "_hasRun", False):
+            return
+        print("After Check")
         cs.beforeReactorConstructionFlag = True
+
+        BeforeReactorPlugin.beforeReactorConstruction._hasRun = True
 
 
 class TestPluginRegistration(unittest.TestCase):
@@ -139,21 +146,34 @@ class TestPluginRegistration(unittest.TestCase):
 
     def test_beforeReactorConstructionHook(self):
         """Test that plugin hook successfully injects code before reactor initialization."""
-        pm = getPluginManagerOrFail()
-        pm.register(BeforeReactorPlugin)
         try:
+            # Load a test reactor to save to DB. This should be loaded before the `BeforeReactorPlugin` is registered,
+            # because we aren't testing that functionality just yet
             o, r = loadTestReactor(TEST_ROOT, inputFileName="smallestTestReactor/armiRunSmallest.yaml", useCache=False)
-            self.assertTrue(o.cs.beforeReactorConstructionFlag)
+
+            # Now, register the plugin before `loadOperator` is called
+            pm = getPluginManagerOrFail()
+            pm.register(BeforeReactorPlugin)
 
             with TemporaryDirectoryChanger():
+                # Save loaded reactor to DB
                 dbi = DatabaseInterface(r, o.cs)
                 dbi.initDB(fName=self._testMethodName + ".h5")
                 db = dbi.database
                 db.writeToDB(r)
                 db.close()
-                o = loadOperator(self._testMethodName + ".h5", 0, 0)
-            # Check that hook is called for database loading
-            self.assertTrue(o.cs.beforeReactorConstructionFlag)
+                # Call `loadOperator`, which will trigger the plugin hook we are testing
+                o1 = loadOperator(self._testMethodName + ".h5", 0, 0)
+                # Asserts to prove that the plugin hook code ran
+                self.assertTrue(BeforeReactorPlugin.beforeReactorConstruction._hasRun)
+                self.assertTrue(o1.cs.beforeReactorConstructionFlag)
+                o2 = loadOperator(self._testMethodName + ".h5", 0, 0)
+                # Assert to prove that the plugin hook code did not run
+                with self.assertRaisesRegex(
+                    AttributeError, "'Settings' object has no attribute 'beforeReactorConstructionFlag'"
+                ):
+                    o2.cs.beforeReactorConstructionFlag
+
         finally:
             pm.unregister(BeforeReactorPlugin)
 

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -168,7 +168,10 @@ class TestPluginRegistration(unittest.TestCase):
                     AttributeError, "'Settings' object has no attribute 'beforeReactorConstructionFlag'"
                 ):
                     o2.cs.beforeReactorConstructionFlag
-
+                # Reset the decorator wrapper, and run `loadOperator` a third time
+                BeforeReactorPlugin.beforeReactorConstruction.reset_onlyRunOnce()
+                o3 = loadOperator(self._testMethodName + ".h5", 0, 0)
+                self.assertTrue(o3.cs.beforeReactorConstructionFlag)
         finally:
             pm.unregister(BeforeReactorPlugin)
 

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -16,6 +16,7 @@
 
 # ruff: noqa: F405
 import collections
+import functools
 import getpass
 import hashlib
 import math
@@ -745,3 +746,13 @@ def safeMove(src: str, dst: str) -> None:
 
     runLog.extra(f"Moved {src} -> {dst}")
     return dst
+
+def onlyRunOnce(method):
+    @functools.wraps(method)
+    def wrapper(*args, **kwargs):
+        if wrapper.hasRun:
+            return
+        wrapper.hasRun = True
+        return method(*args, **kwargs)
+    wrapper.hasRun = False
+    return wrapper

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -749,6 +749,7 @@ def safeMove(src: str, dst: str) -> None:
 
 
 def onlyRunOnce(method):
+    """A decorator to ensure a method is only run once."""
     @functools.wraps(method)
     def wrapper(*args, **kwargs):
         if wrapper.hasRun:

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -747,6 +747,7 @@ def safeMove(src: str, dst: str) -> None:
     runLog.extra(f"Moved {src} -> {dst}")
     return dst
 
+
 def onlyRunOnce(method):
     @functools.wraps(method)
     def wrapper(*args, **kwargs):
@@ -754,5 +755,6 @@ def onlyRunOnce(method):
             return
         wrapper.hasRun = True
         return method(*args, **kwargs)
+
     wrapper.hasRun = False
     return wrapper

--- a/armi/utils/__init__.py
+++ b/armi/utils/__init__.py
@@ -750,6 +750,7 @@ def safeMove(src: str, dst: str) -> None:
 
 def onlyRunOnce(method):
     """A decorator to ensure a method is only run once."""
+
     @functools.wraps(method)
     def wrapper(*args, **kwargs):
         if wrapper.hasRun:
@@ -758,4 +759,9 @@ def onlyRunOnce(method):
         return method(*args, **kwargs)
 
     wrapper.hasRun = False
+
+    def reset():
+        wrapper.hasRun = False
+
+    wrapper.reset_onlyRunOnce = reset
     return wrapper

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -41,6 +41,7 @@ from armi.utils import (
     getPreviousTimeNode,
     getStepLengths,
     hasBurnup,
+    onlyRunOnce,
     safeCopy,
     safeMove,
 )
@@ -263,6 +264,42 @@ class TestGeneralUtils(unittest.TestCase):
                 self.assertIn("dir1", mock.getStdout())
                 self.assertIn("dir2", mock.getStdout())
             self.assertTrue(os.path.exists(os.path.join("dir2", "file1.txt")))
+
+    def test_onlyRunOnce(self):
+        # 1. Test basic functionality
+        calls = []
+
+        @onlyRunOnce
+        def f(x):
+            calls.append(x)
+
+        # Call it 3x then test it only ran once
+        f(1)
+        f(2)
+        f(3)
+        self.assertEqual(calls, [1])
+
+        # 2. Test with args/kwargs
+        calls = []
+
+        @onlyRunOnce
+        def f(req, opt=0, **kw):
+            calls.append((req, opt, kw))
+
+        # Call it twice and ensure the first values prevail
+        f(1, opt=2, hello=3)
+        f(99, hello=999)
+        self.assertEqual(calls, [(1, 2, {"hello": 3})])
+
+        # 3. Since @wraps was needed to get the decorator to work, test that functionality too
+        def f(x):
+            """Docstring."""
+            return x
+
+        wrapped = onlyRunOnce(f)
+        self.assertEqual(wrapped.__name__, "f")
+        self.assertEqual(wrapped.__doc__, "Docstring.")
+        self.assertIs(wrapped.__wrapped__, f)
 
 
 class CyclesSettingsTests(unittest.TestCase):

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -278,6 +278,11 @@ class TestGeneralUtils(unittest.TestCase):
         f(2)
         f(3)
         self.assertEqual(calls, [1])
+        # Reset then try other calls
+        f.reset_onlyRunOnce()
+        f(4)
+        f(5)
+        self.assertEqual(calls, [1, 4])
 
         # 2. Test with args/kwargs
         calls = []

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -273,6 +273,8 @@ class TestGeneralUtils(unittest.TestCase):
         def f(x):
             calls.append(x)
 
+        # Test a specific use case first: calling the reset before the decorator has been used
+        f.reset_onlyRunOnce()
         # Call it 3x then test it only ran once
         f(1)
         f(2)


### PR DESCRIPTION
## What is the change? Why is it being made?

In #2115 this argument was added, and to preserve backwards compatibility it was defaulted to False. 

However, we have identified downstream that this really should default to True. The `beforeReactorConstruction` hook was added to support flexible materials database usage, and if that hook is missed during reactor loading, the default materials database will be loaded, not necessarily the one the user has chosen via their case settings. This potential mismatch could cause some materials differences one may not catch easily. 

The solution was to remove the argument entirely and always call the hook. The onus will be on developers to use the hook responsibly; documentation is added to the docstring to strongly encourage that.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: To support reactor loading during a `db.load` operation, it makes more sense to call the `beforeReactorConstruction` than for that to default to False. 

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
