### PR TITLE
Attempting to fix GH Pages docs deploy

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.13
+          persist-credentials: false
       - name: Update package index
         run: sudo apt-get update
       - name: Install apt-get libs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: 3.13
           persist-credentials: false

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -65,7 +65,7 @@ jobs:
           latexmk -pdf -f -interaction=nonstopmode ARMI.tex
       - name: Deploy
         #if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        uses: JamesIves/github-pages-deploy-action@v4.6.1
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           repository-name: ${{ github.repository_owner }}/terrapower.github.io

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,5 +1,8 @@
 name: Documentation
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:
@@ -61,7 +64,7 @@ jobs:
           cd _build/latex/
           latexmk -pdf -f -interaction=nonstopmode ARMI.tex
       - name: Deploy
-        if: github.ref == 'refs/heads/main'
+        #if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -65,7 +65,7 @@ jobs:
           cd _build/latex/
           latexmk -pdf -f -interaction=nonstopmode ARMI.tex
       - name: Deploy
-        #if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4.6.1
         with:
           token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
## What is the change? Why is it being made?

Updating the docs workflow file caused trouble. It looks like the latest github-pages-deploy action doesn't play nice with the latest repo checkout action. So I have to revert those two versions to get everything working again.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Users find it helpful to have the ARMI documentation published online.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
