### PR TITLE
Adding equality to Settings and Settings

### DIFF
--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -145,11 +145,17 @@ class Settings:
 
         return f"<{self.__class__.__name__} name:{self.caseTitle} total:{total} altered:{altered}>"
 
-    def __eq__(self, other): # TODO
+    def __eq__(self, other):
         if type(self) is not type(other):
             return False
-        
-        TODOreturn self.__members() == other.__members()
+        elif self.keys() != other.keys():
+            return False
+
+        for key in self.keys():  # noqa: SIM110
+            if self[key] != other[key]:
+                return False
+
+        return True
 
     def _directAccessOfSettingAllowed(self, key):
         """
@@ -159,11 +165,10 @@ class Settings:
 
         Notes
         -----
-        Checking the validity of grabbing specific settings at this point, as is done for the
-        SIMPLE_CYCLES_INPUT's, feels a bit intrusive and out of place. In particular, the fact that
-        the check is done every time that a setting is reached for, no matter if it is the setting
-        in question, is quite clunky. In the future, it would be desirable if the settings system
-        were more flexible to control this type of thing at a deeper level.
+        Checking the validity of grabbing specific settings at this point, as is done for the SIMPLE_CYCLES_INPUT's,
+        feels a bit intrusive and out of place. In particular, the fact that the check is done every time that a setting
+        is reached for, no matter if it is the setting in question, is quite clunky. In the future, it would be
+        desirable if the settings system were more flexible to control this type of thing at a deeper level.
         """
         if key not in self.__settings:
             return False, NonexistentSetting(key)

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 """
-This defines a Settings object that acts mostly like a dictionary. It
-is meant so that each ARMI run has one-and-only-one Settings object. It records
-user settings like the core power level, the input file names, the number of cycles to
-run, the run type, the environment setup, and hundreds of other things.
+This defines a Settings object that acts mostly like a dictionary. It is meant so that each ARMI run has
+one-and-only-one Settings object. It records user settings like the core power level, the input file names, the number
+of cycles to run, the run type, the environment setup, and hundreds of other things.
 
-A Settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to
-create this settings file, which is then loaded by an ARMI process on the cluster.
+A Settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to create this settings file,
+which is then loaded by an ARMI process on the cluster.
 """
 
 import io
@@ -53,19 +52,17 @@ class Settings:
         :id: I_ARMI_SETTING0
         :implements: R_ARMI_SETTING
 
-        The Settings object is accessible to most ARMI objects through self.cs
-        (for 'case settings'). It acts largely as a dictionary, and setting values
-        are accessed by keys.
+        The Settings object is accessible to most ARMI objects through self.cs (for 'case settings'). It acts largely as
+        a dictionary, and setting values are accessed by keys.
 
-        The Settings object has a 1-to-1 correspondence with the ARMI settings
-        input file. This file may be created by hand or by a GUI.
+        The Settings object has a 1-to-1 correspondence with the ARMI settings input file. This file may be created by
+        hand or by a GUI.
 
     Notes
     -----
-    While it is possible to modify case settings during the course of a run, this
-    is highly discouraged because there will be no record of this happening in your
-    results or in the database produced from your run. There is no guarantee that
-    doing so will not cause unexpected problems with your calculation.
+    While it is possible to modify case settings during the course of a run, this is highly discouraged because there
+    will be no record of this happening in your results or in the database produced from your run. There is no guarantee
+    that doing so will not cause unexpected problems with your calculation.
     """
 
     defaultCaseTitle = "armi"
@@ -85,11 +82,10 @@ class Settings:
         self._failOnLoad = False
         """This is state information.
 
-        The command line can take settings, which override a value in the current
-        settings file; however, if the settings file is listed after a setting value,
-        the setting from the settings file will be used rather than the one explicitly
-        provided by the user on the command line.  Therefore, _failOnLoad is used to
-        prevent this from happening.
+        The command line can take settings, which override a value in the current settings file; however, if the
+        settings file is listed after a setting value, the setting from the settings file will be used rather than the
+        one explicitly provided by the user on the command line.  Therefore, _failOnLoad is used to prevent this from
+        happening.
         """
         from armi import getApp
 
@@ -118,14 +114,11 @@ class Settings:
             :id: I_ARMI_SETTINGS_META0
             :implements: R_ARMI_SETTINGS_META
 
-            Every Settings object has a "case title"; a string for users to
-            help identify their run. This case title is used in log file
-            names, it is printed during a run, it is frequently used to
-            name the settings file. It is designed to be an easy-to-use
-            and easy-to-understand way to keep track of simulations. The
-            general idea here is that the average analyst that is using
-            ARMI will run many ARMI-based simulations, and there needs
-            to be an easy to identify them all.
+            Every Settings object has a "case title"; a string for users to help identify their run. This case title is
+            used in log file names, it is printed during a run, it is frequently used to name the settings file. It is
+            designed to be an easy-to-use and easy-to-understand way to keep track of simulations. The general idea here
+            is that the average analyst that is using ARMI will run many ARMI-based simulations, and there needs to be
+            an easy to identify them all.
         """
         if not self.path:
             return self.defaultCaseTitle
@@ -150,7 +143,13 @@ class Settings:
         isAltered = lambda s: 1 if s.value != s.default else 0
         altered = sum([isAltered(setting) for setting in self.__settings.values()])
 
-        return "<{} name:{} total:{} altered:{}>".format(self.__class__.__name__, self.caseTitle, total, altered)
+        return f"<{self.__class__.__name__} name:{self.caseTitle} total:{total} altered:{altered}>"
+
+    def __eq__(self, other): # TODO
+        if type(self) is not type(other):
+            return False
+        
+        TODOreturn self.__members() == other.__members()
 
     def _directAccessOfSettingAllowed(self, key):
         """
@@ -171,9 +170,9 @@ class Settings:
 
         if key in SIMPLE_CYCLES_INPUTS and self.__settings["cycles"].value != []:
             err = ValueError(
-                "Cannot grab simple cycles information from the case settings when detailed cycles "
-                "information is also entered. In general cycles information should be pulled off "
-                "the operator or parsed using the appropriate getter in the utils."
+                "Cannot grab simple cycles information from the case settings when detailed cycles information is also "
+                "entered. In general cycles information should be pulled off the operator or parsed using the "
+                "appropriate getter in the utils."
             )
 
             return False, err
@@ -217,8 +216,7 @@ class Settings:
         """
         Rebuild schema upon unpickling since schema is unpickleable.
 
-        Pickling happens during mpi broadcasts and also during testing where the test reactor is
-        cached.
+        Pickling happens during mpi broadcasts and also during testing where the test reactor is cached.
 
         See Also
         --------
@@ -276,8 +274,8 @@ class Settings:
         """
         Read in settings from an input YAML file.
 
-        Passes the reader back out in case you want to know something about how the reading went
-        like for knowing if a file contained deprecated settings, etc.
+        Passes the reader back out in case you want to know something about how the reading went like for knowing if a
+        file contained deprecated settings, etc.
         """
         reader, path = self._prepToRead(fName)
         reader.readFromFile(fName, handleInvalids)
@@ -336,8 +334,7 @@ class Settings:
 
         Notes
         -----
-        This means that creating a Settings object sets the global logging level of the entire code
-        base.
+        This means that creating a Settings object sets the global logging level of the entire code base.
         """
         if context.MPI_RANK == 0:
             runLog.setVerbosity(self["verbosity"])

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -315,6 +315,27 @@ class Setting:
         setting._value = copy.deepcopy(self._value)
         return setting
 
+    def __members(self):
+        """Utility to help test for equality."""
+        return (
+            self.name,
+            self.description,
+            self.label,
+            self.options,
+            self.enforcedOptions,
+            self.subLabels,
+            self.isEnvironment,
+            self.oldNames,
+            self._default,
+            self._value,
+        )
+
+    def __eq__(self, other):
+        if type(self) is type(other):
+            return self.__members() == other.__members()
+        else:
+            return False
+
 
 class FlagListSetting(Setting):
     """Subclass of :py:class:`Setting <armi.settings.Setting>` convert settings between flags and strings."""

--- a/armi/settings/setting.py
+++ b/armi/settings/setting.py
@@ -336,6 +336,9 @@ class Setting:
         else:
             return False
 
+    def __hash__(self):
+        return hash(str(self.__members()))
+
 
 class FlagListSetting(Setting):
     """Subclass of :py:class:`Setting <armi.settings.Setting>` convert settings between flags and strings."""

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -551,3 +551,21 @@ class TestSettingEquality(unittest.TestCase):
 
         s2 = setting.Setting("testSettingDiff", 654, description="whatever")
         self.assertNotEqual(s1, s2)
+        self.assertNotEqual(s1Copy, s2)
+        self.assertNotEqual(s1Same, s2)
+
+    def test_settings(self):
+        cs = caseSettings.Settings()
+        self.assertEqual(cs, cs)
+
+        csCopy = copy.deepcopy(cs)
+        self.assertEqual(cs, csCopy)
+
+        cs2 = caseSettings.Settings()
+        self.assertEqual(cs, cs2)
+        self.assertEqual(cs2, csCopy)
+
+        csMod = cs.modified(newSettings={"power": 7.7})
+        self.assertNotEqual(cs, csMod)
+        self.assertNotEqual(cs2, csMod)
+        self.assertNotEqual(csCopy, csMod)

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -535,3 +535,19 @@ class TestSettingsValidationUtils(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             validateVersion("1.2.3", "zzz")
+
+
+class TestSettingEquality(unittest.TestCase):
+    def test_setting(self):
+        s1 = setting.Setting("testSetting", 897, description="whatever")
+        self.assertEqual(s1, s1)
+
+        s1Copy = copy.deepcopy(s1)
+        self.assertEqual(s1, s1Copy)
+
+        s1Same = setting.Setting("testSetting", 897, description="whatever")
+        self.assertEqual(s1Same, s1)
+        self.assertEqual(s1Same, s1Copy)
+
+        s2 = setting.Setting("testSettingDiff", 654, description="whatever")
+        self.assertNotEqual(s1, s2)


### PR DESCRIPTION
## What is the change? Why is it being made?

Adding the Python-standard dunder method `__eq__` to `Setting` and `Settings`, so that we can check for the equality of both.

close #2535


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Adding the ability to check for the equality of settings objects.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: Adding a new feature that adds code to I_ARMI_SETTING0.


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
