### PR TITLE
Reverting previous global nuclides change

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -41,6 +41,7 @@ import coverage
 
 from armi import context, getPluginManager, interfaces, operators, runLog, settings
 from armi.bookkeeping.db import compareDatabases
+from armi.nucDirectory import nuclideBases
 from armi.physics.neutronics.settings import CONF_LOADING_FILE
 from armi.reactor import blueprints, reactors
 from armi.utils import pathTools, tabulate, textProcessors
@@ -444,24 +445,19 @@ class Case:
     def initializeOperator(self, r=None):
         """Creates and returns an Operator."""
         with DirectoryChanger(self.cs.inputDirectory, dumpOnException=False):
+            self._initBurnChain()
             o = operators.factory(self.cs)
             if r is None:
                 r = reactors.factory(self.cs, self.bp)
-            self._initBurnChain(r)
             o.initializeInterfaces(r)
             # Set this here to make sure the full duration of initialization is properly captured.
             # Cannot be done in reactors since the above self.bp call implicitly initializes blueprints.
             r.core.timeOfStart = self._startTime
             return o
 
-    def _initBurnChain(self, r):
+    def _initBurnChain(self):
         """
         Apply the burn chain setting to the nucDir.
-
-        Parameters
-        ----------
-        r: Reactor
-            The reactor object for this case.
 
         Notes
         -----
@@ -481,7 +477,7 @@ class Case:
             )
 
         with open(self.cs["burnChainFileName"]) as burnChainStream:
-            r.nuclideBases.imposeBurnChain(burnChainStream)
+            nuclideBases.imposeBurnChain(burnChainStream)
 
     def checkInputs(self):
         """


### PR DESCRIPTION
## What is the change? Why is it being made?

Reverting part of a recent PR: https://github.com/terrapower/armi/pull/2536

Essentially, the burn chain needs to be initialized BEFORE the `Reactor` is initialized. And that break the logical flow of my previous change.

HOW we get around that, and still get rid of global nuclides, I'm not yet sure.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: A previous change broke some downstream code, so we are reverting part of that change.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
