### PR TITLE
Adding ArgumentDefaultsHelpFormatter to EntryPoint.parser

### DIFF
--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -104,6 +104,7 @@ class EntryPoint(metaclass=_EntryPointEnforcer):
         self.parser = argparse.ArgumentParser(
             prog="{} {}".format(context.APP_NAME, self.name),
             description=self.description or self.__doc__,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )
         if self.settingsArgument is not None:
             if self.settingsArgument not in ["required", "optional"]:


### PR DESCRIPTION
## What is the change? Why is it being made?

Helps show more information about the default value for a given argument. For example, from the output of `armi vis-file -h`
```
  --format, -f FORMAT   Output format. Supported formats: `vtk` and `xdmf` (default: vtk)
  --nodes NODES         An optional list of time nodes to include. Should look like `(1,0)(1,1)(1,2)`, etc (default: None)
  --max-node MAX_NODE   An optional (cycle,timeNode) tuple to specify the latest time step that should be included (default: None)
  --min-node MIN_NODE   An optional (cycle,timeNode) tuple to specify the earliest time step that should be included (default: None)
```

Other cases where this may be useful:
```
armi compare -h
[...]
  --tolerance TOLERANCE
                        If a test database entry differs by more than this percent from the reference database, then it will be marked as a difference between the two databases. (default: 0.01)
  --weights [WEIGHTS ...]
                        Period separated key/value pairs for database table weights (default: None)
  --exclude EXCLUDE [EXCLUDE ...]
                        Patterns for parameters to ignore in comparisons (default: ('^.*/minutesSinceStart$', '^.*/maxProcessMemoryInMB$', '^.*/minProcessMemoryInMB$', '^.*/serialNum$',
                        '^.*/temperatureInC$', '^.*/volume$', '^.*/layout/temperatures$'))
```

The `armi submit-suite` has a runtime dependent default for `--suiteDir` (current working directory) that also nicely populates

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
Change Type: trivial
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Plugins can have complicated, run time dependent defaults and this helps automatically display them

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [ ] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
