### PR TITLE
Lowering the priority of some settings-related log messages

### DIFF
--- a/armi/settings/__init__.py
+++ b/armi/settings/__init__.py
@@ -97,7 +97,7 @@ def recursivelyLoadSettingsFiles(
     runLog.info("Checking for valid settings files.")
     for possibleSettingsFile in possibleSettings:
         if os.path.getsize(possibleSettingsFile) > 1e6:
-            runLog.info("skipping {} -- looks too big".format(possibleSettingsFile))
+            runLog.extra("skipping {} -- looks too big".format(possibleSettingsFile))
             continue
         try:
             cs = Settings()
@@ -105,9 +105,9 @@ def recursivelyLoadSettingsFiles(
             csFiles.append(cs)
             runLog.extra("loaded {}".format(possibleSettingsFile))
         except InvalidSettingsFileError as ee:
-            runLog.info("skipping {}\n    {}".format(possibleSettingsFile, ee))
+            runLog.extra("skipping {}\n    {}".format(possibleSettingsFile, ee))
         except yaml.composer.ComposerError as ee:
-            runLog.info(
+            runLog.extra(
                 "skipping {}; it appears to be an incomplete YAML snippet\n    {}".format(possibleSettingsFile, ee)
             )
         except Exception as ee:


### PR DESCRIPTION
## What is the change? Why is it being made?

This downgrades a few settings-related runLogs from `info` to `extra` verbosity level.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
Change Type: trivial
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: These runLogs are not necessary for the average user to see. 

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] ~[Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.~ (Tests on this still pass, so they must already be set to this verbosity level)
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
