### PR TITLE
Removing pinned wxpython dependency for grids

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ Repository = "https://github.com/terrapower/armi"
 "Bug Tracker" = "https://github.com/terrapower/armi/issues"
 
 [project.optional-dependencies]
-grids = ["wxpython==4.2.1"]
+grids = ["wxpython"]
 memprof = ["psutil"]
 mpi = ["mpi4py"]
 test = [


### PR DESCRIPTION
## What is the change? Why is it being made?

`wxpython` 4.2.1 was released in 2023 and can be difficult to build on modern systems (e.g. Ubuntu LTS 26.04). Using the latest version (4.2.5) was tested and works great.

Test case:

* Install Ubuntu 26.04
* Install armi with optional grids dependencies

## SCR Information

Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: A pinned dependency on an 3-year old library does not work on newer systems.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
