### PR TITLE
Adding context to depletion cycle settings

### DIFF
--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -147,7 +147,12 @@ In the case of burnup, the reactor cycle history may be specified using either t
     * ``availabilityFactor(s)`` (default = 1.0)
     * ``cycleLength(s)`` (default = 365.2425)
 
-In addition, one may optionally use the ``powerFractions`` setting to change the reactor power between each cycle. With these settings, a user can define a history in which each cycle may vary in power, length, and uptime. The history is restricted, however, to each cycle having a constant power, to each cycle having the same number of burnup nodes, and to those burnup nodes being evenly spaced within each cycle. An example simple cycle history might look like
+In addition, one may optionally use the ``powerFractions`` setting to change the reactor power between each cycle. With these settings, a user can define a history in which each cycle may vary in power, length, and uptime.
+The "uptime" being the amount of time the reactor is at ``power * powerFractions[i]`` for cycle ``i``.
+The uptime duration is determined by ``cycleLength[i] * availabilityFactor[i]`` days with "downtime" ``cycleLength[i] * (1 - availabilityFactor[i])``.
+The cycle length is then the amount of total time (uptime + downtime) between the start of two successive cycles.
+
+The history is restricted, however, to each cycle having a constant power, to each cycle having the same number of burnup nodes, and to those burnup nodes being evenly spaced within each cycle. An example simple cycle history might look like
 
 .. code-block:: yaml
 
@@ -164,15 +169,12 @@ Note the use of the special shorthand list notation, where repeated values in a 
 The above scheme would represent 3 cycles of operation:
 
     1. 100% power for 90 days, split into two segments of 45 days each, followed by 10 days shutdown (i.e. 90% capacity)
-
     2. 50% power for 30 days, split into two segments of 15 days each, followed by 70 days shutdown (i.e. 15% capacity)
-
     3. 100% power for 93 days, split into two segments of 46.5 days each, followed by 7 days shutdown (i.e. 93% capacity)
 
-In each cycle, criticality calculations will be performed at 3 nodes evenly-spaced through the uptime portion of the cycle (i.e. ``availabilityFactor``*``powerFraction``), without option for changing node spacing or frequency.
-This input format can be useful for quick scoping and certain types of real analyses, but clearly has its limitations.
+In each cycle, criticality calculations will be performed at 3 (``burnSteps + 1``) nodes evenly-spaced through the uptime portion of the cycle, without option for changing node spacing or frequency.
 
-To overcome these limitations, the detailed cycle history, consisting of the ``cycles`` setting may be specified instead.
+A more detailed cycle history, may be specified through the use of the ``cycles`` setting.
 For each cycle, an entry to the ``cycles`` list is made with the following optional fields:
 
     * ``name``
@@ -206,13 +208,10 @@ Note that repeated values in a list may be again be entered using the shorthand 
 
 Such a scheme would define the following cycles:
 
-    1. A 2 day power ramp followed by full power operations for 98 days, with three nodes clustered during the ramp and another at the end of the cycle, followed by 900 days of shutdown
-
-    2. A 2 day power ramp followed by a prolonged period at full power and then a slight power reduction for the last 14 days in the cycle
-
-    3. Constant full-power operation for 30 days split into six even increments
-
-    4. Constant full-power operation for 90 days, split into two equal-length 45 day segments, followed by 10 days of downtime
+    1. A 2 day power ramp followed by full power operations for 98 days, with three nodes clustered during the ramp and another at the end of the cycle, followed by 900 days of shutdown,
+    2. A 2 day power ramp followed by a prolonged period at full power and then a slight power reduction for the last 14 days in the cycle,
+    3. Constant full-power operation for 30 days split into six even increments,
+    4. Constant full-power operation for 90 days, split into two equal-length 45 day segments, followed by 10 days of downtime,
 
 As can be seen, the detailed cycle history option provides much flexibility for simulating realistic operations, particularly power ramps or scenarios that call for unevenly spaced burnup nodes, such as xenon buildup in the early period of thermal reactor operations.
 

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -174,8 +174,7 @@ The above scheme would represent 3 cycles of operation:
 
 In each cycle, criticality calculations will be performed at 3 (``burnSteps + 1``) nodes evenly-spaced through the uptime portion of the cycle, without option for changing node spacing or frequency.
 
-A more detailed cycle history may be specified through the use of the ``cycles`` setting.
-For each cycle, an entry to the ``cycles`` list is made with the following optional fields:
+A more detailed cycle history may be specified using the ``cycles`` setting. For each cycle, an entry to the ``cycles`` list is made with the following optional fields:
 
     * ``name``
     * ``power fractions``

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -149,7 +149,7 @@ In the case of burnup, the reactor cycle history may be specified using either t
 
 In addition, one may optionally use the ``powerFractions`` setting to change the reactor power between each cycle. With these settings, a user can define a history in which each cycle may vary in power, length, and uptime.
 The "uptime" being the amount of time the reactor is at ``power * powerFractions[i]`` for cycle ``i``.
-The uptime duration is determined by ``cycleLength[i] * availabilityFactor[i]`` days with "downtime" ``cycleLength[i] * (1 - availabilityFactor[i])``.
+The uptime duration is determined by ``cycleLengths[i] * availabilityFactors[i]`` days with "downtime" ``cycleLengths[i] * (1 - availabilityFactors[i])``.
 The cycle length is then the amount of total time (uptime + downtime) between the start of two successive cycles.
 
 The history is restricted, however, to each cycle having a constant power, to each cycle having the same number of burnup nodes, and to those burnup nodes being evenly spaced within each cycle. An example simple cycle history might look like
@@ -174,7 +174,7 @@ The above scheme would represent 3 cycles of operation:
 
 In each cycle, criticality calculations will be performed at 3 (``burnSteps + 1``) nodes evenly-spaced through the uptime portion of the cycle, without option for changing node spacing or frequency.
 
-A more detailed cycle history, may be specified through the use of the ``cycles`` setting.
+A more detailed cycle history may be specified through the use of the ``cycles`` setting.
 For each cycle, an entry to the ``cycles`` list is made with the following optional fields:
 
     * ``name``


### PR DESCRIPTION
## What is the change? Why is it being made?

Recent discussions led to some confusion / ambiguity with the depletion settings and the interplay between cycle + availability factor + power fraction and concepts like EFPD, uptime, downtime, etc. This adds some additional context.

## SCR Information

Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Adding context to depletion cycle settings

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
