### PR TITLE
Increasing test coverage - matProps loadAll exception

### DIFF
--- a/armi/matProps/__init__.py
+++ b/armi/matProps/__init__.py
@@ -90,6 +90,8 @@ from armi.matProps.material import MatPropsMaterial
 loadedRootDirs = []
 materials = {}
 
+_DEFAULT_ROOT_DIR = os.path.join(sysconfig.get_paths()["purelib"], "materials_data")
+
 
 def getPaths(rootDir: str) -> list:
     """Get the paths of all the YAML files in a given directory."""
@@ -145,7 +147,7 @@ def loadAll(rootDir: str = None) -> None:
     global loadedRootDirs
 
     if rootDir is None:
-        rootDir = os.path.join(sysconfig.get_paths()["purelib"], "materials_data")
+        rootDir = _DEFAULT_ROOT_DIR
         if not os.path.exists(rootDir):
             raise OSError(f"No material directory provided, and default not found: {rootDir}")
 

--- a/armi/matProps/tests/test_parsing.py
+++ b/armi/matProps/tests/test_parsing.py
@@ -15,6 +15,7 @@
 """Test YAML parsers for all files in the matProps data directory to ensure that there are no parsing errors."""
 
 import os
+import sysconfig
 import tempfile
 import unittest
 from os import path
@@ -75,6 +76,18 @@ class TestParsing(unittest.TestCase):
 
         armi.matProps.clear()
         self.assertEqual(0, len(armi.matProps.loadedMaterials()))
+
+    def test_loadAllBadRootDir(self):
+        defaultRootDir = os.path.join(sysconfig.get_paths()["purelib"], "materials_data")
+        tempRootDir = os.path.join(sysconfig.get_paths()["purelib"], "materials_data_temp")
+        if os.path.exists(defaultRootDir):
+            os.rename(defaultRootDir, tempRootDir)
+
+        with self.assertRaisesRegex(OSError, "No material directory provided"):
+            armi.matProps.loadAll()
+
+        if os.path.exists(tempRootDir):
+            os.rename(tempRootDir, defaultRootDir)
 
     def test_loadSafe(self):
         armi.matProps.clear()

--- a/armi/matProps/tests/test_parsing.py
+++ b/armi/matProps/tests/test_parsing.py
@@ -19,6 +19,7 @@ import sysconfig
 import tempfile
 import unittest
 from os import path
+from unittest.mock import patch
 
 import armi.matProps
 
@@ -77,17 +78,10 @@ class TestParsing(unittest.TestCase):
         armi.matProps.clear()
         self.assertEqual(0, len(armi.matProps.loadedMaterials()))
 
+    @patch("armi.matProps._DEFAULT_ROOT_DIR", os.path.join(sysconfig.get_paths()["purelib"], "materials_data_temp"))
     def test_loadAllBadRootDir(self):
-        defaultRootDir = os.path.join(sysconfig.get_paths()["purelib"], "materials_data")
-        tempRootDir = os.path.join(sysconfig.get_paths()["purelib"], "materials_data_temp")
-        if os.path.exists(defaultRootDir):
-            os.rename(defaultRootDir, tempRootDir)
-
         with self.assertRaisesRegex(OSError, "No material directory provided"):
             armi.matProps.loadAll()
-
-        if os.path.exists(tempRootDir):
-            os.rename(tempRootDir, defaultRootDir)
 
     def test_loadSafe(self):
         armi.matProps.clear()


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
Adds a test to cover an untested exception in `matProps.loadAll()`

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Covers an exception that with testing.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
