### PR TITLE
Explaining Entry Points and command discovery in user guide

### DIFF
--- a/doc/user/accessingEntryPoints.rst
+++ b/doc/user/accessingEntryPoints.rst
@@ -1,6 +1,33 @@
 **********************
-Accessing Entry Points 
+Accessing Entry Points
 **********************
+
+**Entry points** are the commands that ARMI exposes on the command line; they are
+the "verbs" that an ARMI-based application can perform, such as running a case,
+generating a report, or launching the grid GUI. Each entry point maps a command
+name (what you type after ``armi``) to a block of code and an optional set of
+command-line options. The built-in entry points live in :py:mod:`armi.cli`, and
+applications built on ARMI can add their own.
+
+For details on how entry points are implemented and how to write your own, see
+:doc:`/developer/entrypoints`.
+
+Listing available commands
+==========================
+
+To see every entry point registered with your application, pass the
+``-l``/``--list-commands`` flag::
+
+    (venv) $ armi -l
+
+To see the options and arguments for a specific command, run it with
+``--help``::
+
+    (venv) $ armi <command> --help
+
+Most entry points accept a settings input file as a positional argument. Whether
+that argument is required, optional, or disallowed is controlled by the entry
+point's ``settingsArgument`` attribute (see :doc:`/developer/entrypoints`).
 
 Reports Entry Point
 ===================


### PR DESCRIPTION
## What is the change? Why is it being made?

Expands the **Accessing Entry Points** user-guide page (`doc/user/accessingEntryPoints.rst`), which previously jumped straight into the Reports example with no explanation of what an entry point is or how it connects to ARMI's CLI options.

close #2560

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: The entry points need a better introduction in the docs.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
