### PR TITLE
Removing "power user" langauge from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,12 +173,12 @@ subchannel vs. CFD, etc.).
 
 New analysis and physics capabilities
 *************************************
-The ARMI reactor model is fully accessible via a Python-based API, meaning that power-users and developers have full
+The ARMI reactor model is fully accessible via a Python-based API, meaning that users have full
 access to the details of the plant at all times. Developers adding new physics features can take advantage of the ARMI
 data management structure by simply reading and writing to the Reactor state. Leveraging the infrastructure of ARMI,
 progress can be made rapidly.
 
-Power-user analysts can modify the plant in many ways. For instance, removing all sodium coolant is a one-liner::
+A user can modify the plant in many ways. For instance, removing all sodium coolant is a one-liner::
 
     core.setNumberDensity('NA23',0.0)
 

--- a/armi/cases/__init__.py
+++ b/armi/cases/__init__.py
@@ -20,6 +20,10 @@ and can perform useful operations like compare, clone, and run.
 
 A ``CaseSuite`` is a set of (often related) Cases. These are fundamental to parameter sweeps and test suites.
 
+This module also contains a variety of ``InputModifier`` classes, which are examples
+of how you can modify inputs for parameter sweeping. Users will generally implement
+their own ``Modifier`` classes that are application or design-specific.
+
 See Also
 --------
 armi.cli : Entry points that build Cases and/or CaseSuites and send them off to do work

--- a/armi/cases/suiteBuilder.py
+++ b/armi/cases/suiteBuilder.py
@@ -20,10 +20,6 @@ The general use case is to create a :py:class:`~SuiteBuilder` with a base
 adjust inputs according to the supplied arguments, and finally use ``.buildSuite`` to
 generate inputs. The case suite can then be discovered, submitted, and analyzed using
 the standard ``CaseSuite`` objects.
-
-This module contains a variety of ``InputModifier`` objects as well, which are examples
-of how you can modify inputs for parameter sweeping. Power-users will generally make
-their own ``Modifier``\ s that are design-specific.
 """
 
 import copy

--- a/armi/matProps/materialType.py
+++ b/armi/matProps/materialType.py
@@ -34,6 +34,7 @@ class MaterialType:
         "ASME2019": 64,
         "SimpleSolid": 128,
         "Composite": 256,
+"test": 69,
     }
 
     def __init__(self, value: int = 0):

--- a/armi/matProps/materialType.py
+++ b/armi/matProps/materialType.py
@@ -34,7 +34,6 @@ class MaterialType:
         "ASME2019": 64,
         "SimpleSolid": 128,
         "Composite": 256,
-"test": 69,
     }
 
     def __init__(self, value: int = 0):

--- a/armi/migration/__init__.py
+++ b/armi/migration/__init__.py
@@ -19,7 +19,7 @@ Users want to be able to upgrade to the latest version of the code without havin
 invest a bunch of time in updating their previous input and output files. Users have up
 to thousands of inputs that they want to keep working. Even more serious, follow-on
 analysts who got an output database (including associated inputs) from an ARMI
-power-user strongly prefer to be able to migrate old cases. Oftentimes, an output
+user strongly prefer to be able to migrate old cases. Oftentimes, an output
 database can be many GB large and be the result of many CPU-weeks, so there's monetary
 and temporal value to be preserved.
 

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -796,7 +796,7 @@ def defineSettings() -> List[setting.Setting]:
                 "Ordered list of Python namespaces for finding materials by class name. "
                 "This allows users to choose between different implementations of reactor "
                 "materials. For example, the framework comes with a basic UZr material, "
-                "but power users will want to override it with their own UZr subclass. "
+                "but users will want to override it with their own UZr subclass. "
                 "This allows users to specify to get materials out of a plugin rather "
                 "than from the framework."
             ),

--- a/doc/user/manual_data_access.rst
+++ b/doc/user/manual_data_access.rst
@@ -2,10 +2,10 @@
 Accessing Data in ARMI
 **********************
 
-A basic user only needs to know the CLI or GUI and can perform basic analysis and design with just
-that. But a power user will be more interested in programmatically building and manipulating inputs
-and gathering detailed information out of ARMI results. Let's now go into a bit more detail for the
-power user.
+A user only needs to know the CLI or GUI to perform basic analysis and design in ARMI.
+More in-depth analysis and design requires programmatically building and
+manipulating inputs and gathering detailed information from ARMI results.
+Let's now go into a bit more detail on what data can be accessed in ARMI.
 
 Settings and State Variables
 ============================


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
This PR removes language referencing "power users" from docs.

closes #2562 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: This improves the quality of the docs by removing ambiguous terminology.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA

---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
