### PR TITLE
Removing exception logging on HexBlock.verifyBlockDims

### DIFF
--- a/armi/reactor/blocks/hexBlock.py
+++ b/armi/reactor/blocks/hexBlock.py
@@ -330,14 +330,20 @@ class HexBlock(Block):
             self.p.displacementY = dispx * math.sin(rad) + dispy * math.cos(rad)
 
     def verifyBlockDims(self):
-        """Perform some checks on this type of block before it is assembled."""
+        """Perform some checks on this type of block before it is assembled.
+
+        This method assumes the HexBlock has at least one DUCT component, at
+        most one WIRE component, and at most one CLAD component. If any of these
+        conditions are not met, the dimensions will not be checked.
+        """
         try:
             wireComp = self.getComponent(Flags.WIRE, quiet=True)  # Quiet because None case is checked for below
             ductComps = self.getComponents(Flags.DUCT)
             cladComp = self.getComponent(Flags.CLAD, quiet=True)  # Quiet because None case is checked for below
         except ValueError:
-            # there are probably more that one clad/wire, so we really dont know what this block looks like
-            runLog.info(f"Block design {self} is too complicated to verify dimensions. Make sure they are correct!")
+            # silent exit
+            # there is no duct or more that one clad/wire, the logic below cannot
+            # check the dimensions of the block.
             return
 
         # check wire wrap in contact with clad

--- a/armi/reactor/blocks/hexBlock.py
+++ b/armi/reactor/blocks/hexBlock.py
@@ -341,9 +341,8 @@ class HexBlock(Block):
             ductComps = self.getComponents(Flags.DUCT)
             cladComp = self.getComponent(Flags.CLAD, quiet=True)  # Quiet because None case is checked for below
         except ValueError:
-            # silent exit
-            # there is no duct or more that one clad/wire, the logic below cannot
-            # check the dimensions of the block.
+            # Silent Exit
+            # There is no duct or more that one clad/wire, the logic below cannot check the dimensions of the block.
             return
 
         # check wire wrap in contact with clad


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
Removes logging from try-except block in `HexBlock.verifyBlockDims` due to excessive logging described in #2557, and replaces it with a silent exit. 
Explain in the function docstring the cases in which `HexBlock.verifyBlockDims` will silent exit.

closes #2557 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
Change Type: trivial
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Better explains the behavior of `HexBlock.verifyBlockDims` and removes excessive logging.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
