### PR TITLE
Adding unit tests for `HexBlocks.setPinPowers()`

### DIFF
--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -2568,6 +2568,63 @@ class TestHexBlock(unittest.TestCase):
         # all z coords equal to zero
         np.testing.assert_equal(z, 0)
 
+    def test_setPinPowersNoSuffix(self):
+        """Test setting the pin powers."""
+        locs = set(self.hexBlock.getPinLocations())
+        powers = np.arange(0, len(locs))
+
+        # Check that pin powers are set correctly
+        self.hexBlock.setPinPowers(powers)
+        np.testing.assert_array_equal(powers, self.hexBlock.p["linPowByPin"])
+
+    def test_setPinPowersWithSuffix(self):
+        """Test setting the pin powers."""
+        locs = set(self.hexBlock.getPinLocations())
+        powers = np.arange(0, len(locs))
+
+        # Check that a given key works
+        powerKeySuffix = "Neutron"
+        self.hexBlock.setPinPowers(powers, powerKeySuffix=powerKeySuffix)
+        np.testing.assert_array_equal(powers, self.hexBlock.p[f"linPowByPin{powerKeySuffix}"])
+
+    def test_setPinPowersGamma(self):
+        """Test setting the pin powers."""
+        locs = set(self.hexBlock.getPinLocations())
+        powers = np.arange(0, len(locs))
+
+        # Set neutron power
+        powerKeySuffix = "Neutron"
+        self.hexBlock.setPinPowers(powers, powerKeySuffix=powerKeySuffix)
+        # Check Gamma suffix
+        powerKeySuffix = "Gamma"
+        self.hexBlock.setPinPowers(powers, powerKeySuffix=powerKeySuffix)
+        np.testing.assert_array_equal(
+            self.hexBlock.p.linPowByPin, self.hexBlock.p["linPowByPinGamma"] + self.hexBlock.p["linPowByPinNeutron"]
+        )
+
+    def test_setPinPowersGammaNoNeutron(self):
+        locs = set(self.hexBlock.getPinLocations())
+        powers = np.arange(0, len(locs))
+
+        # Check unset neutron power
+        self.hexBlock.p["linPowByPinNeutron"] = None
+        with self.assertRaisesRegex(UnboundLocalError, "Neutron power has not been set yet."):
+            powerKeySuffix = "Gamma"
+            self.hexBlock.setPinPowers(powers, powerKeySuffix=powerKeySuffix)
+
+    @patch.object(blocks.HexBlock, "getNumPins")
+    def test_setPinPowersBadNumPins(self, mock_np):
+        # Check mismatched power data
+        mock_np.return_value = 100
+        powers = np.arange(0, 5)
+        with self.assertRaisesRegex(ValueError, "Invalid power data"):
+            self.hexBlock.setPinPowers(powers)
+
+        # Check unset pins
+        mock_np.return_value = None
+        with self.assertRaisesRegex(ValueError, "Invalid power data"):
+            self.hexBlock.setPinPowers(powers)
+
     def test_getPitchHomogeneousBlock(self):
         """
         Demonstrate how to communicate pitch on a hex block with unshaped components.

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -423,7 +423,7 @@ class TestValidateSFPSpatialGrids(unittest.TestCase):
             self.assertEqual(a.p.orientation[2], 0.0)
 
 
-class Block_TestCase(unittest.TestCase):
+class TestBlock(unittest.TestCase):
     def setUp(self):
         self.block = loadTestBlock()
         self._hotBlock = loadTestBlock(cold=False)
@@ -2234,7 +2234,7 @@ class Block_TestCase(unittest.TestCase):
         self.assertEqual(len(linked), 0)
 
 
-class BlockInputHeightsTests(unittest.TestCase):
+class TestBlockInputHeights(unittest.TestCase):
     def test_foundReactor(self):
         """Test the input height is pullable from blueprints."""
         r = loadTestReactor()[1]
@@ -2267,7 +2267,7 @@ class BlockInputHeightsTests(unittest.TestCase):
             b.getInputHeight()
 
 
-class BlockEnergyDepositionConstants(unittest.TestCase):
+class TestBlockEnergyDepositionConstants(unittest.TestCase):
     """Tests the energy deposition methods.
 
     MagicMocks xsCollections.compute*Constants() -- we're not testing those methods specifically
@@ -2806,7 +2806,7 @@ class TestHexBlock(unittest.TestCase):
         self.assertEqual(self.hexBlock.getRotationNum(), 2.0)
 
 
-class MultiPinIndicesTests(unittest.TestCase):
+class TestMultiPinIndices(unittest.TestCase):
     BP_STR = """
 blocks:
     fuel: &fuel_block
@@ -3111,7 +3111,7 @@ class TestHexBlockOrientation(unittest.TestCase):
         self.assertAlmostEqual(ratio, 2 / math.sqrt(3), delta=0.0001)
 
 
-class ThRZBlock_TestCase(unittest.TestCase):
+class TestThRZBlock(unittest.TestCase):
     def setUp(self):
         self.ThRZBlock = blocks.ThRZBlock("TestThRZBlock")
         self.ThRZBlock.add(
@@ -3259,7 +3259,7 @@ class ThRZBlock_TestCase(unittest.TestCase):
         self.assertAlmostEqual(self.ThRZBlock.getBoronMassEnrich(), 0.0)
 
 
-class CartesianBlockTests(unittest.TestCase):
+class TestCartesianBlock(unittest.TestCase):
     """Tests for blocks with rectangular/square outer shape."""
 
     PITCH = 70
@@ -3426,7 +3426,7 @@ class CartesianBlockTests(unittest.TestCase):
         self.assertEqual(self.cartesianBlock.numRingsToHoldNumCells(65), 5)
 
 
-class MassConservationTests(unittest.TestCase):
+class TestMassConservation(unittest.TestCase):
     """Tests designed to verify mass conservation during thermal expansion."""
 
     def setUp(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
In #2565 I discovered that there were untested `HexBlock` functions. This PR is the first of a series to ensure every `HexBlock` function is tested.

This PR adds missing tests for `HexBlock.setPinPowers()`.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Improving code coverage improves the quality of the codebase.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
