### PR TITLE
Ensuring density and pseudoDensity match for custom materials

### DIFF
--- a/armi/materials/custom.py
+++ b/armi/materials/custom.py
@@ -38,12 +38,28 @@ class Custom(Material):
         Material.__init__(self)
         self.customDensity = 1.0
 
+    def linearExpansion(self, Tk=None, Tc=None):
+        """There is not enough information to calculate the linear expansion for this material."""
+        return 0.0
+
+    def linearExpansionPercent(self, Tk=None, Tc=None):
+        """There is not enough information to calculate the linear expansion for this material."""
+        return 0.0
+
     def pseudoDensity(self, Tk=None, Tc=None):
         """
         The density value is set in the loading input.
 
         In some cases it needs to be set after full core assemblies are populated (e.g. for CustomLocation materials),
         so the missing density warning will appear no matter what.
+        """
+        return self.customDensity
+
+    def density(self, Tk=None, Tc=None):
+        """The density value is set in the loading input.
+
+        As there is not enough information to calculate the linear expansion of this material, the density and pseudo-
+        density are set equal.
         """
         return self.customDensity
 

--- a/armi/reactor/blueprints/tests/test_componentBlueprint.py
+++ b/armi/reactor/blueprints/tests/test_componentBlueprint.py
@@ -313,3 +313,32 @@ assemblies:
         expectedNuclides = ["TH232"]
         for nuc in expectedNuclides:
             self.assertIn(nuc, a[0][0].getNuclides())
+
+    def test_customMaterials(self):
+        nuclideFlags = (
+            inspect.cleandoc(
+                r"""
+            nuclide flags:
+                TH232: {burn: false, xs: true}
+            custom isotopics:
+                Thorium:
+                    input format: number densities
+                    TH232: 1.0
+            """
+            )
+            + "\n"
+        )
+        bp = blueprints.Blueprints.load(
+            nuclideFlags + self.componentString.format(material="Custom", isotopics="isotopics: Thorium", flags="")
+        )
+        cs = settings.Settings()
+        a = bp.constructAssem(cs, "assembly")
+
+        mat = a[0][0].material
+        customDensity = mat.customDensity
+        self.assertAlmostEqual(customDensity, 385.30820803695826, delta=1)
+        for t in range(400, 701, 100):
+            self.assertEqual(mat.linearExpansion(Tc=t), 0.0)
+            self.assertEqual(mat.linearExpansionPercent(Tc=t), 0.0)
+            self.assertEqual(mat.density(Tc=t), customDensity)
+            self.assertEqual(mat.pseudoDensity(Tc=t), customDensity)


### PR DESCRIPTION
## What is the change? Why is it being made?

The concern was raised that the density of a custom material was always zero, even though pseudoDensity isn't zero. Well, since the linear expansion always returns zero anyway, we can set the density and pseudoDensity equal.

To help this, I explicitly set the linear expansion of custom materials to zero. I should be clear, these were ALREADY zero, since the custom isotopics do not include enough information to calculate these things. I am just making them more clear here.

close #1695


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: The density of custom materials should be non-zero.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
