### PR TITLE
Fixing missing r+ DB mode

### DIFF
--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -181,7 +181,7 @@ class Database:
         filePath = self._fileName
         self._openCount += 1
 
-        if self._permission in {"r", "a"}:
+        if self._permission in {"r", "a", "r+"}:
             self._fullPath = os.path.abspath(filePath)
             self.h5db = h5py.File(filePath, self._permission)
             self.version = self.h5db.attrs["databaseVersion"]

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -582,7 +582,7 @@ class TestDatabaseReading(unittest.TestCase):
     def test_growToFullCoreFromFactoryWithCS(self):
         from armi.bookkeeping.db import databaseFactory
 
-        db = databaseFactory(self.dbName, "r")
+        db = databaseFactory(self.dbName, "r+")
         with db:
             r = db.load(0, 0, allowMissing=True)
 


### PR DESCRIPTION
## What is the change? Why is it being made?

We are adding `r+` mode to the `Database.open()` method.

This implementation assumes the file already exists.

close #2577


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: A user has requested to support opening a DB in r+ mode.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
