### PR TITLE
Redesigning our codecov.io config

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -4,5 +4,11 @@ coverage:
   status:
     project:
       default:
-        target: 1%    # the required coverage value: stop codecov.io from failing the build
+        target: 90%     # the required coverage value: 90%
         threshold: 99%  # allows a 99% drop from the previous base commit coverage
+    patch:
+      default:
+        informational: true  # set non-blocking status check
+github_checks:
+  # https://docs.codecov.com/docs/common-recipe-list#disable-github-check-run-annotations
+  annotations: false


### PR DESCRIPTION
## What is the change? Why is it being made?

Feel free to double-check me on the [codecov.io docs](https://docs.codecov.com/docs/common-recipe-list).

In this PR I set the new codecov.io custom cofig file (`.github/.codecov.yml) to these settings:

Stop reporting on, or caring about, the code coverage from the PR difference, we only care about the coverage of the entire repo:

```yaml
coverage:
    patch:
      default:
        informational: true
```

Our bare minimum code coverage for ARMI is 90%, but codecov.io is WAY to finicky and will fail the build if the coverage goes down even 0.02%, which is annoying and wrong:

```yaml
coverage:
  status:
    project:
      default:
        target: 90%
        threshold: 99%
```

Stop building in-github view of the coverage (we use the codecov.io website anyway):

```yaml
github_checks:
  annotations: false
```

progress on #2471

**NOTE**: If this doesn't work, I think we can go with the nuclear option of forcing codecov.io to stop complaining about coverage numbers no matter what:

```yaml
coverage:
  status:
    project:
      default:
        informational: true
```

Thoughts?

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: We need our CI to be stable to fight alarm fatigue

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
