### PR TITLE
Validating the PR correctly fills the SCR

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -67,10 +67,8 @@ jobs:
       - name: Fail if SCR exists
         if: ${{ hashFiles('**/scr_error.txt') != '' }}
         run: |
-          echo "SCR build failed"
+          echo "SCR build failed:"
           cd /home/runner/work/armi/armi
-          pwd
-          ls
           cat scr_error.txt
           exit 1
       - name: Deploy

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -68,6 +68,10 @@ jobs:
         if: ${{ hashFiles('**/scr_error.txt') != '' }}
         run: |
           echo "SCR build failed"
+          cd ~/
+          pwd
+          ls
+          cat scr_error.txt
           exit 1
       - name: Deploy
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -65,8 +65,9 @@ jobs:
           cd _build/latex/
           latexmk -pdf -f -interaction=nonstopmode ARMI.tex
       - name: Fail if SCR exists
-        if: ${{ hashFiles('scr_error.txt') != '' }}
+        if: ${{ hashFiles('/scr_error.txt') != '' }}
         run: |
+          echo "SCR build failed"
           exit 1
       - name: Deploy
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -64,6 +64,10 @@ jobs:
           make latex
           cd _build/latex/
           latexmk -pdf -f -interaction=nonstopmode ARMI.tex
+      - name: Fail if SCR exists
+        if: ${{ hashFiles('scr_error.txt') != '' }}
+        run: |
+          exit 1
       - name: Deploy
         if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4.6.1

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ hashFiles('**/scr_error.txt') != '' }}
         run: |
           echo "SCR build failed"
-          cd ~/
+          cd /home/runner/work/armi/armi
           pwd
           ls
           cat scr_error.txt

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -65,7 +65,7 @@ jobs:
           cd _build/latex/
           latexmk -pdf -f -interaction=nonstopmode ARMI.tex
       - name: Fail if SCR exists
-        if: ${{ hashFiles('/scr_error.txt') != '' }}
+        if: ${{ hashFiles('**/scr_error.txt') != '' }}
         run: |
           echo "SCR build failed"
           exit 1

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -72,7 +72,6 @@ def _findOneLineData(lines: list, prNum: str, key: str):
         if line.startswith(key):
             return line.split(key)[1].strip()
 
-    print(f"WARNING: SCR: Could not find {key} in PR#{prNum}.")
     raise ValueError(f"Problem parsing PR#{prNum} for key {key}")
 
 

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -73,7 +73,7 @@ def _findOneLineData(lines: list, prNum: str, key: str):
             return line.split(key)[1].strip()
 
     print(f"WARNING: SCR: Could not find {key} in PR#{prNum}.")
-    return "TBD"
+    raise ValueError(f"Problem parsing PR#{prNum} for key {key}")
 
 
 def _buildScrLine(prNum: str, ghUsers: dict):

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -30,6 +30,8 @@ PR_TYPES = {
     "fixes": "Code Changes, Bugs and Fixes",
     "trivial": "Code Changes, Maintenance, or Trivial",
 }
+THIS_DIR = os.path.dirname(__file__)
+ERROR_FILE = os.path.join(THIS_DIR, "..", "scr_error.txt")
 
 
 def main():
@@ -47,6 +49,13 @@ def main():
     args = parser.parse_args()
     pastCommit = args.pastCommit
     prNum = int(args.prNum)
+
+    # clean up any old SCR error files
+    if os.path.exists(ERROR_FILE):
+        try:
+            os.remove(ERROR_FILE)
+        except FileNotFoundError:
+            pass
 
     buildScrListing(pastCommit, prNum)
 
@@ -72,7 +81,11 @@ def _findOneLineData(lines: list, prNum: str, key: str):
         if line.startswith(key):
             return line.split(key)[1].strip()
 
-    raise ValueError(f"Problem parsing PR#{prNum} for key {key}")
+    # handle error reading PR description
+    with open(ERROR_FILE, "a") as f:
+        f.write(f"PR#{prNum}: {key}")
+
+    return "TBD"
 
 
 def _buildScrLine(prNum: str, ghUsers: dict):

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -83,7 +83,9 @@ def _findOneLineData(lines: list, prNum: str, key: str):
 
     # handle error reading PR description
     with open(ERROR_FILE, "a") as f:
-        f.write(f"PR#{prNum}: {key}")
+        msg = f"WARNING: SCR: Invalid change type '{key}' for PR#{prNum}"
+        print(msg)
+        f.write(msg)
 
     return "TBD"
 

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -50,6 +50,12 @@ def main():
     pastCommit = args.pastCommit
     prNum = int(args.prNum)
 
+    clearScrLog()
+    buildScrListing(pastCommit, prNum)
+
+
+def clearScrLog():
+    """Just a little helper method to clear the SCR error log before we start."""
     # clean up any old SCR error files
     if os.path.exists(ERROR_FILE):
         try:
@@ -57,7 +63,13 @@ def main():
         except FileNotFoundError:
             pass
 
-    buildScrListing(pastCommit, prNum)
+
+def logScrError(msg: str):
+    """Handle errors when there is a problem parsing an PR into the SCR format."""
+    # handle error reading PR description
+    with open(ERROR_FILE, "a") as f:
+        print(f"WARNING: SCR: {msg}")
+        f.write(f"{msg}\n")
 
 
 def _findOneLineData(lines: list, prNum: str, key: str):
@@ -81,12 +93,7 @@ def _findOneLineData(lines: list, prNum: str, key: str):
         if line.startswith(key):
             return line.split(key)[1].strip()
 
-    # handle error reading PR description
-    with open(ERROR_FILE, "a") as f:
-        msg = f"WARNING: SCR: Invalid change type '{key}' for PR#{prNum}"
-        print(msg)
-        f.write(msg)
-
+    logScrError(f"Invalid change type '{key}' for PR#{prNum}")
     return "TBD"
 
 
@@ -125,7 +132,7 @@ def _buildScrLine(prNum: str, ghUsers: dict):
     # grab one-line description
     scrType = _findOneLineData(lines, prNum, "Change Type:")
     if scrType not in PR_TYPES:
-        print(f"WARNING: SCR: Invalid change type '{scrType}' for PR#{prNum}")
+        logScrError(f"Invalid change type '{scrType}' for PR#{prNum}")
         scrType = "trivial"
 
     # grab one-line description
@@ -179,7 +186,7 @@ def isMainPR(prNum: int):
         r = requests.get(url)
         return "terrapower/armi:main" in r.text
     except Exception as e:
-        print(f"WARNING: SCR: Failed to determine if PR#{prNum} merged into the main branch: {e}")
+        logScrError(f"Failed to determine if PR#{prNum} merged into the main branch: {e}")
         return True
 
 

--- a/doc/.static/automateScr.py
+++ b/doc/.static/automateScr.py
@@ -31,7 +31,7 @@ PR_TYPES = {
     "trivial": "Code Changes, Maintenance, or Trivial",
 }
 THIS_DIR = os.path.dirname(__file__)
-ERROR_FILE = os.path.join(THIS_DIR, "..", "scr_error.txt")
+ERROR_FILE = os.path.join(THIS_DIR, "..", "..", "scr_error.txt")
 
 
 def main():


### PR DESCRIPTION
## What is the change? Why is it being made?

Here I amend the script that we use to generate the SCR in our docs so it fails if there is a problem reading the required fields from the PR description field.

We have a release coming up soon, and I just noticed we have two PRs with descriptions that are incomplete. That's an easy fix today, but BOY would it be unpleasant if we were most of the way through the release when we found that out.  This should help solve that problem in the future.

close #2590


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: We want the SCR in our docs to always be up-to-date and correct.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
