### PR TITLE
Revmoing unused `matProps` test function parameter docstring

### DIFF
--- a/armi/matProps/tests/test_material.py
+++ b/armi/matProps/tests/test_material.py
@@ -34,8 +34,6 @@ class TestMapPropsMaterial(unittest.TestCase):
 
         Parameters
         ----------
-        fileName
-            String containing name of yaml file being written
         materialType
             String containing the "material type" node value
         """


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
This PR removes a docstring for a now-deleted test function parameter.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
Change Type: trivial 
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: ARMI function docstrings should be accurate and up to date.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
