### PR TITLE
Documenting physics parameters retained on shuffling

### DIFF
--- a/doc/user/spatial_block_data.rst
+++ b/doc/user/spatial_block_data.rst
@@ -329,3 +329,17 @@ Other parameters may be updated to reflect some geometric state. The second posi
 ``Block.p.orientation`` reflects the cumulative rotation around the z-axis and is updated through
 rotation. Displacement parameters like ``Block.p.displacementX`` are updated as the displacement
 vector rotates through space.
+
+Assembly Shuffling
+==================
+
+ARMI can be configured to move assemblies during an outage. See :ref:`fuel-management-input`.
+This can be further configured to rotate hexagonal assemblies via the ``assemblyRotationAlgorithm`` setting.
+During rotation, spatial parameters will be updated as mentioned above to match the current
+orientation.
+
+However, ARMI does not clear out parameters that may reflect the assembly's previous state. For example,
+at the last node of cycle 0, a global flux solve may take place to set parameters like ``fuelBlock.p.pinMgFluxes``.
+At the start of cycle 1, the parent assembly is moved to a new location and rotated. Until another
+global flux solve is performed, or some other plugin intervenes, ``fuelBlock.p.pinMgFluxes`` will contain the same
+data prior to the outage, subject to any rotations.


### PR DESCRIPTION

## What is the change? Why is it being made?

Add documentation to explain that physics parameters are not cleared out upon shuffling. This is generally okay as you're likely to run your physics stack again after shuffling.

Closes #1890

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Document retainment of physics parameters on shuffling

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.~
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html)~
- [x] The dependencies are still up-to-date in `pyproject.toml`~
