### PR TITLE
Fixing MultiIndexLocation.getGlobalCoordinates

### DIFF
--- a/armi/reactor/grids/locations.py
+++ b/armi/reactor/grids/locations.py
@@ -390,6 +390,17 @@ class MultiIndexLocation(IndexLocation):
         """
         return [loc.indices for loc in self._locations]
 
+    def getLocalCoordinates(self, nativeCoords=False):
+        """Return the coordinates of the center of the mesh cell here in cm.
+
+        Returns
+        -------
+        np.ndarray
+            ``(N, 3)`` array of the local coordinates within the parent grid where ``N`` is the number
+            of spatial locators
+        """
+        return np.array([loc.getLocalCoordinates(nativeCoords=nativeCoords) for loc in self])
+
 
 class CoordinateLocation(IndexLocation):
     """

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -155,8 +155,8 @@ class TestSpatialLocator(unittest.TestCase):
         blockLoc = grids.IndexLocation(0, 0, 3, assemblyGrid)
         block.spatialLocator = blockLoc
 
-        pinIndexLoc = grids.IndexLocation(1, 5, 0, blockGrid)
-        pinFree = grids.CoordinateLocation(1.0, 2.0, 3.0, blockGrid)
+        compIndexLoc = grids.IndexLocation(1, 5, 0, blockGrid)
+        freeComp = grids.CoordinateLocation(1.0, 2.0, 3.0, blockGrid)
 
         assert_allclose(blockLoc.getCompleteIndices(), np.array((2, 3, 3)))
         assert_allclose(blockLoc.getGlobalCoordinates(), (2.0, 3.0, 3.5))
@@ -164,11 +164,11 @@ class TestSpatialLocator(unittest.TestCase):
         assert_allclose(blockLoc.getGlobalCellTop(), (2.5, 3.5, 4))
 
         # check coordinates of pins in block
-        assert_allclose(pinFree.getGlobalCoordinates(), (2.0 + 1.0, 3.0 + 2.0, 3.5 + 3.0))  # epic
-        assert_allclose(pinIndexLoc.getGlobalCoordinates(), (2.0 + 0.1, 3.0 + 0.5, 3.5))  # wow
+        assert_allclose(freeComp.getGlobalCoordinates(), (2.0 + 1.0, 3.0 + 2.0, 3.5 + 3.0))
+        assert_allclose(compIndexLoc.getGlobalCoordinates(), (2.0 + 0.1, 3.0 + 0.5, 3.5))
 
         # pin indices should not combine with the parent indices.
-        assert_allclose(pinIndexLoc.getCompleteIndices(), (1, 5, 0))
+        assert_allclose(compIndexLoc.getCompleteIndices(), (1, 5, 0))
 
     def test_recursionPin(self):
         """Ensure pin the center assem has axial coordinates consistent with a pin in

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -170,6 +170,7 @@ class TestSpatialLocator(unittest.TestCase):
         # pin indices should not combine with the parent indices.
         assert_allclose(compIndexLoc.getCompleteIndices(), (1, 5, 0))
 
+        # test MultiIndexLocation.getLocalCoordinates
         pinLocator = grids.MultiIndexLocation(blockGrid)
         pinLocator.append(compIndexLoc)
         single = compIndexLoc.getGlobalCoordinates()

--- a/armi/reactor/grids/tests/test_grids.py
+++ b/armi/reactor/grids/tests/test_grids.py
@@ -170,6 +170,13 @@ class TestSpatialLocator(unittest.TestCase):
         # pin indices should not combine with the parent indices.
         assert_allclose(compIndexLoc.getCompleteIndices(), (1, 5, 0))
 
+        pinLocator = grids.MultiIndexLocation(blockGrid)
+        pinLocator.append(compIndexLoc)
+        single = compIndexLoc.getGlobalCoordinates()
+        fromMulti = pinLocator.getGlobalCoordinates()
+        self.assertTupleEqual(fromMulti.shape, (1, 3))
+        assert_allclose(fromMulti[0], single)
+
     def test_recursionPin(self):
         """Ensure pin the center assem has axial coordinates consistent with a pin in
         an off-center assembly.


### PR DESCRIPTION
## What is the change? Why is it being made?

Fix `MultiIndexLocation.getGlobalCoordinates` and `getLocalCoordinates` by stitching together coordinates of the contained locations.

Closes #2262 

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Fix MultiIndexLocation.getGlobalCoordinates

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: R_ARMI_GRID_MULT relies on multi index locations


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
