### PR TITLE
Adding in ruff setting D404

### DIFF
--- a/.github/workflows/find_test_crumbs.py
+++ b/.github/workflows/find_test_crumbs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This script exists so we can determine if new tests in CI are leaving crumbs."""
+"""Determine if new tests in CI are leaving crumbs."""
 
 import subprocess
 

--- a/armi/apps.py
+++ b/armi/apps.py
@@ -63,12 +63,11 @@ class App:
 
     def __init__(self):
         """
-        This mostly initializes the default plugin manager. Subclasses are free to adopt
-        this plugin manager and register more plugins of their own, or to throw it away
-        and start from scratch if they do not wish to use the default Framework plugins.
+        Initialize the default plugin manager. Subclasses are free to adopt this plugin manager and register more
+        plugins of their own, or to throw it away and start from scratch if they do not wish to use the default
+        Framework plugins.
 
-        For a description of the things that an ARMI plugin can do, see the
-        :py:mod:`armi.plugins` module.
+        For a description of the things that an ARMI plugin can do, see the :py:mod:`armi.plugins` module.
         """
         self._pluginFlagsRegistered: bool = False
         self._pm: Optional[pluginManager.ArmiPluginManager] = None

--- a/armi/bookkeeping/db/tests/test_database.py
+++ b/armi/bookkeeping/db/tests/test_database.py
@@ -651,7 +651,7 @@ class TestDatabaseSmaller(unittest.TestCase):
 
     def test_prepRestartRun(self):
         """
-        This test is based on the sodiumHexReactor case in armi.testing. In that cs, `reloadDBName` is set to
+        A test based on the sodiumHexReactor case in armi.testing. In that cs, `reloadDBName` is set to
         'reloadingDB.h5', `startCycle` = 1, and `startNode` = 2. The nonexistent 'reloadingDB.h5' must first be created
         here for this test.
 

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -78,7 +78,7 @@ class TestDatabaseInterfaceBOL(unittest.TestCase):
     """Test the DatabaseInterface class at the BOL."""
 
     def test_interactBOL(self):
-        """Because of temporary directory issues, this test is in its own class."""
+        """Because of versions of this test ran into temporary directory issues, this test is in its own class."""
         with directoryChangers.TemporaryDirectoryChanger():
             self.o, self.r = loadTestReactor(
                 TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"

--- a/armi/bookkeeping/db/tests/test_databaseInterface.py
+++ b/armi/bookkeeping/db/tests/test_databaseInterface.py
@@ -78,7 +78,7 @@ class TestDatabaseInterfaceBOL(unittest.TestCase):
     """Test the DatabaseInterface class at the BOL."""
 
     def test_interactBOL(self):
-        """This test is in its own class, because of temporary directory issues."""
+        """Because of temporary directory issues, this test is in its own class."""
         with directoryChangers.TemporaryDirectoryChanger():
             self.o, self.r = loadTestReactor(
                 TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"

--- a/armi/bookkeeping/mainInterface.py
+++ b/armi/bookkeeping/mainInterface.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This module performs some file manipulations, cleanups, state loads, etc.
+Perform some file manipulations, cleanups, state loads, etc.
 
 It's a bit of a catch-all interface, and it's name is admittedly not very descriptive.
 """

--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -75,7 +75,7 @@ def getTotalJobMemory(nTasks, cpusPerTask):
 
 
 def getCurrentMemoryUsage():
-    """This scavenges the memory profiler in ARMI to get the current memory usage."""
+    """Scavenges the memory profiler in ARMI to get the current memory usage."""
     memUsageAction = PrintSystemMemoryUsageAction()
     memUsageAction.broadcast()
     smpu = SystemAndProcessMemoryUsage()
@@ -415,7 +415,7 @@ class PrintSystemMemoryUsageAction(mpiActions.MpiAction):
         self.usages = self.gather(spmu)
 
     def printUsage(self, description=None):
-        """This method prints the usage of all MPI nodes.
+        """Print the usage of all MPI nodes.
 
         The printout looks something like:
 

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 """
-Interfac for reporting needs of ARMI.
+Interface for ARMI reporting needs of ARMI, including PDF format.
 
-If there is any information that a user desires to show in PDF form to others this is the place to do it.
 """
 
 import re

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 """
-This interface serves the reporting needs of ARMI.
+Interfac for reporting needs of ARMI.
 
-If there is any information that a user desires to show in PDF form to
-others this is the place to do it.
+If there is any information that a user desires to show in PDF form to others this is the place to do it.
 """
 
 import re

--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Interface for ARMI reporting needs of ARMI, including PDF format.
-
-"""
+"""Interface for ARMI reporting needs of ARMI, including PDF format."""
 
 import re
 

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -96,7 +96,7 @@ class TestHistoryTracker(ArmiTestHelper):
 
     def test_calcMGFluence(self):
         """
-        This test confirms that mg flux has many groups when loaded with the history tracker.
+        Confirms that mg flux has many groups when loaded with the history tracker.
 
         .. test:: Demonstrate that a parameter stored at differing time nodes can be recovered.
             :id: T_ARMI_HIST_TRACK0

--- a/armi/bookkeeping/tests/test_historyTracker.py
+++ b/armi/bookkeeping/tests/test_historyTracker.py
@@ -96,7 +96,7 @@ class TestHistoryTracker(ArmiTestHelper):
 
     def test_calcMGFluence(self):
         """
-        Confirms that mg flux has many groups when loaded with the history tracker.
+        Verify that multi-group flux has multiple energy groups when loaded with the history tracker.
 
         .. test:: Demonstrate that a parameter stored at differing time nodes can be recovered.
             :id: T_ARMI_HIST_TRACK0

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -36,7 +36,7 @@ armi.operators :  Operations that ARMI will perform on a reactor model.
 armi : Fundamental entry point that calls this package.
 """
 
-# Importing each module causes the any EntryPoints defined in the module that are decorated with @armi.command to be
+# Importing each module causes any EntryPoints defined in the module that are decorated with @armi.command to be
 # added to the collection of registered classes.
 
 import argparse

--- a/armi/cli/__init__.py
+++ b/armi/cli/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This package provides various operations users can ask ARMI to do with their inputs.
+Various operations users can ask ARMI to do with their inputs.
 
 An Entry Point might run a simulation, migrate inputs, build a suite of related inputs
 and submit them in a parameter sweep, validate inputs, open the GUI, run a test suite,
@@ -36,9 +36,8 @@ armi.operators :  Operations that ARMI will perform on a reactor model.
 armi : Fundamental entry point that calls this package.
 """
 
-# importing each module causes the any EntryPoints defined in the module that
-# are decorated with @armi.command to be added to the collection of registered
-# classes
+# Importing each module causes the any EntryPoints defined in the module that are decorated with @armi.command to be
+# added to the collection of registered classes.
 
 import argparse
 import re

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -323,7 +323,6 @@ def loadSettings(cs):
         """Loads the command line supplied settings file into the :py:data:`armi.settings.cs`."""
 
         def __call__(self, parser, namespace, values, option_string=None):
-            # since this is a positional argument, it can be called with values is None (i.e. default)
             if values is not None:
                 cs.loadFromInputFile(values)
 

--- a/armi/cli/entryPoint.py
+++ b/armi/cli/entryPoint.py
@@ -24,10 +24,7 @@ from armi import context, runLog, settings
 
 
 class _EntryPointEnforcer(type):
-    """
-    Simple metaclass used for the EntryPoint abstract base class to enforce class
-    attributes.
-    """
+    """Simple metaclass used for the EntryPoint abstract base class to enforce class attributes."""
 
     def __new__(mcs, name, bases, attrs):
         if "name" not in attrs:
@@ -296,9 +293,7 @@ def storeBool(boolDefault, ep):
 
 def setSetting(ep):
     class _SetSettingAction(argparse.Action):
-        """This class loads the command line supplied setting values into the
-        :py:data:`armi.settings.cs`.
-        """
+        """Loads the command line supplied setting values into the :py:data:`armi.settings.cs`."""
 
         def __call__(self, parser, namespace, values, option_string=None):
             # correctly converts type
@@ -314,9 +309,7 @@ def setSetting(ep):
 # A: Because caseTitle is no longer an actual cs setting. It's a instance attr.
 def setCaseTitle(cs):
     class _SetCaseTitleAction(argparse.Action):
-        """This class sets the case title to the supplied value of the
-        :py:data:`armi.settings.cs`.
-        """
+        """Sets the case title to the supplied value of the :py:data:`armi.settings.cs`."""
 
         def __call__(self, parser, namespace, value, option_string=None):
             cs.caseTitle = value
@@ -327,13 +320,10 @@ def setCaseTitle(cs):
 # Careful, this is used by physicalProgramming
 def loadSettings(cs):
     class LoadSettingsAction(argparse.Action):
-        """This class loads the command line supplied settings file into the
-        :py:data:`armi.settings.cs`.
-        """
+        """Loads the command line supplied settings file into the :py:data:`armi.settings.cs`."""
 
         def __call__(self, parser, namespace, values, option_string=None):
-            # since this is a positional argument, it can be called with values is
-            # None (i.e. default)
+            # since this is a positional argument, it can be called with values is None (i.e. default)
             if values is not None:
                 cs.loadFromInputFile(values)
 

--- a/armi/cli/tests/test_runEntryPoint.py
+++ b/armi/cli/tests/test_runEntryPoint.py
@@ -40,7 +40,7 @@ from armi.utils.dynamicImporter import getEntireFamilyTree
 
 
 def buildTestDB(fileName, numNodes=1, numCycles=1):
-    """This function builds a (super) simple test DB.
+    """Build a (super) simple test DB.
 
     Notes
     -----

--- a/armi/matProps/material.py
+++ b/armi/matProps/material.py
@@ -92,7 +92,7 @@ class MatPropsMaterial:
     @staticmethod
     def dataCheckMaterialFile(filePath, rootNode):
         """
-        This is a partial data check of the material data file.
+        A partial data check of the material data file.
 
         Checks the first level of data keywords and also check that the file format is a valid version.
 

--- a/armi/materials/tests/test__init__.py
+++ b/armi/materials/tests/test__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This module tests the __init__.py file since it has rather unique behavior."""
+"""Tests the __init__.py file since it has rather unique behavior."""
 
 import os
 import shutil

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -663,14 +663,14 @@ class VoidTests(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Void
 
     def test_pseudoDensity(self):
-        """This material has a no pseudo-density."""
+        """Void has a no pseudo-density."""
         self.mat.setDefaultMassFracs()
         for t in range(0, 1000, 100):
             cur = self.mat.pseudoDensity(Tc=t)
             self.assertEqual(cur, 0.0)
 
     def test_density(self):
-        """This material has no density."""
+        """Void has no density."""
         self.assertEqual(self.mat.density(500), 0)
 
         self.mat.setDefaultMassFracs()
@@ -679,7 +679,7 @@ class VoidTests(AbstractMaterialTest, unittest.TestCase):
             self.assertEqual(cur, 0.0)
 
     def test_linearExpansion(self):
-        """This material does not expand linearly."""
+        """Void does not expand linearly."""
         cur = self.mat.linearExpansion(400)
         ref = 0.0
         self.assertEqual(cur, ref)
@@ -689,7 +689,7 @@ class MixtureTests(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials._Mixture
 
     def test_density(self):
-        """This material has no density function."""
+        """No density function."""
         self.assertEqual(self.mat.density(500), 0)
 
     def test_setDefaultMassFracs(self):

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -663,7 +663,7 @@ class VoidTests(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Void
 
     def test_pseudoDensity(self):
-        """Void has a no pseudo-density."""
+        """Void has no pseudo-density."""
         self.mat.setDefaultMassFracs()
         for t in range(0, 1000, 100):
             cur = self.mat.pseudoDensity(Tc=t)

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -460,7 +460,7 @@ def runActionsInSerial(o, r, cs, actions):
 
 class DistributionAction(MpiAction):
     """
-    Ccatters the workload of multiple actions to available resources.
+    Scatters the workload of multiple actions to available resources.
 
     Notes
     -----

--- a/armi/mpiActions.py
+++ b/armi/mpiActions.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This module provides an abstract class to be used to implement "MPI actions.".
+An abstract class to be used to implement "MPI actions.".
 
 MPI actions are tasks, activities, or work that can be executed on the worker nodes. The standard
 workflow is essentially that the primary node creates an :py:class:`~armi.mpiActions.MpiAction`,
@@ -206,8 +206,7 @@ class MpiAction:
 
     def invoke(self, o, r, cs):
         """
-        This method is called by worker nodes, and passed the worker node's operator, reactor and
-        settings file.
+        Called by worker nodes, and passed the worker node's operator, reactor and settings file.
 
         Parameters
         ----------
@@ -271,7 +270,7 @@ class MpiAction:
             yield objectsForAllCoresToIter[objIndex]
 
     def invokeHook(self):
-        """This method must be overridden in sub-clases.
+        """Must be overridden in sub-clases.
 
         This method is called by worker nodes, and has access to the worker node's operator, reactor, and settings
         (through :code:`self.o`, :code:`self.r`, and :code:`self.cs`). It must return a boolean value of :code:`True` or
@@ -461,7 +460,7 @@ def runActionsInSerial(o, r, cs, actions):
 
 class DistributionAction(MpiAction):
     """
-    This MpiAction scatters the workload of multiple actions to available resources.
+    Ccatters the workload of multiple actions to available resources.
 
     Notes
     -----

--- a/armi/nucDirectory/elements.py
+++ b/armi/nucDirectory/elements.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This module provides fundamental element information to be used throughout the framework and applications.
+Provide fundamental element information to be used throughout the framework and applications.
 
 .. impl:: A tool for querying basic data for elements of the periodic table.
     :id: I_ARMI_ND_ELEMENTS0

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""
-This module provides access to fundamental nuclide information to be used throughout the framework and applications.
+Provide access to fundamental nuclide information to be used throughout the framework and applications.
 
 .. impl:: Isotopes and isomers can be queried by name, label, MC2-3 ID, MCNP ID, and AAAZZZS ID.
     :id: I_ARMI_ND_ISOTOPES0

--- a/armi/nucDirectory/transmutations.py
+++ b/armi/nucDirectory/transmutations.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 """
-This module contains the definition of :py:class:`~Transmutation` and :py:class:`~Decay` classes.
+The definition of :py:class:`~Transmutation` and :py:class:`~Decay` classes.
 
 .. inheritance-diagram::
     Transmutation DecayMode
 
-The mappings between active nuclides during transmutation and decay are described in a
-``burn-chain.yaml`` file pointed to by the ``burnChainFileName``
-setting. This file contains one entry per nuclide that can transmute or decay that
-look similar to the example below::
+The mappings between active nuclides during transmutation and decay are described in a ``burn-chain.yaml`` file pointed
+to by the ``burnChainFileName`` setting. This file contains one entry per nuclide that can transmute or decay that look
+similar to the example below::
 
     U238:
     - nuSF: 2.0000
@@ -48,25 +47,24 @@ look similar to the example below::
         - LFP38
         type: sf
 
-This example defines 3 transmutations (an ``(n,2n)`` reaction, an ``(n,fission)`` reaction, an
-``(n,gamma``)`` reaction), and a spontaneous fission decay reaction with a very low branching
-ratio. Valid reaction ``type`` values are listed in :py:class:`~armi.nucDirectory.transmutations.Transmutation`
-and :py:class:`~armi.nucDirectory.transmutations.DecayMode`.
+This example defines 3 transmutations (an ``(n,2n)`` reaction, an ``(n,fission)`` reaction, an ``(n,gamma``)``
+reaction), and a spontaneous fission decay reaction with a very low branching ratio. Valid reaction ``type`` values are
+listed in :py:class:`~armi.nucDirectory.transmutations.Transmutation` and
+:py:class:`~armi.nucDirectory.transmutations.DecayMode`.
 
-The ``branch`` entry determines the fraction of the products of a given reaction that will end up
-in a particular product. The branches must never sum up to anything other than 1.0.
+The ``branch`` entry determines the fraction of the products of a given reaction that will end up in a particular
+product. The branches must never sum up to anything other than 1.0.
 
-The ``products`` entry is a list, but only one entry will be the actual product. The list defines
-a preference order. For example, if ``NP239`` is being tracked as an active nuclide in the problem
-it will be the product of the ``nGamma`` reaction above. Otherwise, ``U238`` will transmute directly
-to the alternate product, ``PU239``.
+The ``products`` entry is a list, but only one entry will be the actual product. The list defines a preference order.
+For example, if ``NP239`` is being tracked as an active nuclide in the problem it will be the product of the ``nGamma``
+reaction above. Otherwise, ``U238`` will transmute directly to the alternate product, ``PU239``.
 
-.. warning:: If you track very short-lived decays explicitly then the burn matrix becomes very
-             ill-conditioned and numerical solver issues can result. Specialized matrix
-             exponential solvers (e.g. CRAM [1]) are required to get adequate solutions in these cases [2].
+.. warning:: If you track very short-lived decays explicitly then the burn matrix becomes very ill-conditioned and
+             numerical solver issues can result. Specialized matrix exponential solvers (e.g. CRAM [1]) are required to
+             get adequate solutions in these cases [2].
 
-The example above also defines a ``nuSF`` item, which is how many neutrons are emitted per spontaneous
-fission. This is used for intrinsic source term calculations.
+The example above also defines a ``nuSF`` item, which is how many neutrons are emitted per spontaneous fission. This is
+used for intrinsic source term calculations.
 
 [1] Pusa, Maria, and Jaakko Leppanen. "Computing the matrix exponential in burnup calculations."
     Nuclear science and engineering 164.2 (2010): 140-150.

--- a/armi/nuclearDataIO/cccc/__init__.py
+++ b/armi/nuclearDataIO/cccc/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This subpackage reads and writes CCCC standard interface files for reactor physics codes.
+Read and write CCCC standard interface files for reactor physics codes.
 
 Starting in the late 1960s, the computational nuclear analysis community recognized a need to
 establish some standard file formats to exchange reactor descriptions and reactor physics

--- a/armi/nuclearDataIO/cccc/cccc.py
+++ b/armi/nuclearDataIO/cccc/cccc.py
@@ -616,7 +616,7 @@ class Stream:
         self._stream.close()
 
     def readWrite(self):
-        """This method should be implemented on any sub-classes to specify the order of records."""
+        """Needs to be implemented on any sub-classes to specify the order of records."""
         raise NotImplementedError()
 
     def createRecord(self, hasRecordBoundaries=True):

--- a/armi/nuclearDataIO/cccc/gamiso.py
+++ b/armi/nuclearDataIO/cccc/gamiso.py
@@ -66,7 +66,7 @@ def compareNuclideXS(nuc1, nuc2):
 
 def addDummyNuclidesToLibrary(lib, dummyNuclides):
     """
-    This method adds DUMMY nuclides to the current GAMISO library.
+    Add DUMMY nuclides to the current GAMISO library.
 
     Parameters
     ----------

--- a/armi/nuclearDataIO/cccc/isotxs.py
+++ b/armi/nuclearDataIO/cccc/isotxs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This module reads and writes ISOTXS files.
+Read and write ISOTXS files.
 
 ISOTXS is a binary file that contains multigroup microscopic cross sections.
 ISOTXS stands for  *Isotope Cross Sections*.
@@ -123,7 +123,7 @@ def compareNuclideXS(nuc1, nuc2, tolerance=0.0, verbose=False, nucName=""):
 
 def addDummyNuclidesToLibrary(lib, dummyNuclides):
     """
-    This method adds DUMMY nuclides to the current ISOTXS library.
+    Add DUMMY nuclides to the current ISOTXS library.
 
     Parameters
     ----------

--- a/armi/nuclearDataIO/cccc/pmatrx.py
+++ b/armi/nuclearDataIO/cccc/pmatrx.py
@@ -72,7 +72,7 @@ def compareNuclideXS(nuc1, nuc2):
 
 def addDummyNuclidesToLibrary(lib, dummyNuclides):
     """
-    This method adds DUMMY nuclides to the current PMATRX library.
+    Adds DUMMY nuclides to the current PMATRX library.
 
     Parameters
     ----------

--- a/armi/nuclearDataIO/cccc/rtflux.py
+++ b/armi/nuclearDataIO/cccc/rtflux.py
@@ -166,9 +166,9 @@ class RtfluxStream(cccc.StreamWithDataContainer):
 
 
 class AtfluxStream(RtfluxStream):
-    r"""
-    This is a subclass for the ATFLUX file, which is identical in format to the RTFLUX file except
-    that it contains the adjoint flux and has reversed energy group ordering.
+    """
+    A subclass for the ATFLUX file, which is identical in format to the RTFLUX file except that it contains the adjoint
+    flux and has reversed energy group ordering.
     """
 
     def getEnergyGroupIndex(self, g):
@@ -182,10 +182,7 @@ class AtfluxStream(RtfluxStream):
 
 
 def getFDFluxReader(adjointFlag):
-    r"""
-    Returns the appropriate DIF3D FD flux binary file reader class,
-    either RTFLUX (real) or ATFLUX (adjoint).
-    """
+    """Returns the appropriate DIF3D FD flux binary file reader class, either RTFLUX (real) or ATFLUX (adjoint)."""
     if adjointFlag:
         return AtfluxStream
     else:

--- a/armi/nuclearDataIO/xsNuclides.py
+++ b/armi/nuclearDataIO/xsNuclides.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 r"""
-This module contains cross section nuclides, which are a wrapper around the
-:py:class:`~armi.nucDirectory.nuclideBases.INuclide` objects. The cross section nuclide objects contain cross section
-information from a specific calculation (e.g. neutron, or gamma cross sections).
+Contains cross section nuclides, which are a wrapper around the :py:class:`~armi.nucDirectory.nuclideBases.INuclide`
+objects. The cross section nuclide objects contain cross section information from a specific calculation (e.g. neutron,
+or gamma cross sections).
 
 :py:class:`XSNuclide` objects also contain meta data from the original file, so that another file can be reconstructed.
 
@@ -34,7 +34,7 @@ from armi.utils.plotting import plotScatterMatrix  # noqa: F401
 
 @warn_when_root
 def NuclideLabelDoesNotMatchNuclideLabel(nuclide, label, xsID):
-    return "The label {} (xsID:{}) for nuclide {}, does not match the nucDirectory label.".format(label, xsID, nuclide)
+    return f"The label {label} (xsID:{xsID}) for nuclide {nuclide}, does not match the nucDirectory label."
 
 
 class XSNuclide(nuclideBases.NuclideWrapper):
@@ -69,9 +69,8 @@ class XSNuclide(nuclideBases.NuclideWrapper):
 
         Notes
         -----
-        During instantiation, not everything is available, only they user-supplied nuclide label,
-        i.e. :py:class:`~armi.nucDirectory.nuclideBases.NuclideWrapper.containerKey`.
-        During the read operation,
+        During instantiation, not everything is available, only they user-supplied nuclide label, i.e.
+        :py:class:`~armi.nucDirectory.nuclideBases.NuclideWrapper.containerKey`. During the read operation,
         """
         if self._base is not None:
             return
@@ -94,9 +93,7 @@ class XSNuclide(nuclideBases.NuclideWrapper):
             try:
                 return self.micros[interaction][group]
             except IndexError:
-                raise IndexError(
-                    "Group {0} not found in interaction {1} of nuclide {2}".format(group, interaction, self.name)
-                )
+                raise IndexError(f"Group {group} not found in interaction {interaction} of nuclide {self.name}")
         else:
             return 0
 
@@ -113,15 +110,14 @@ class XSNuclide(nuclideBases.NuclideWrapper):
         """
         Build normalized columns of a scatter matrix.
 
-        the vectors represent all scattering out of each group.
-        The rows of the scatter matrix represent in-scatter and the columns
-        represent out-scatter. So this sums up the columns.
+        the vectors represent all scattering out of each group. The rows of the scatter matrix represent in-scatter and
+        the columns represent out-scatter. So this sums up the columns.
 
         Returns
         -------
         scatterWeights : dict
-            keys are fromG indices, values are sparse matrix columns (size: Gx1)
-            containing normalized columns of the scatter matrix.
+            keys are fromG indices, values are sparse matrix columns (size: Gx1) containing normalized columns of the
+            scatter matrix.
         """
         scatter = self.micros[scatterMatrixKey]
         scatterWeights = {}
@@ -204,8 +200,7 @@ def _mergeAttributes(this, other, attrName):
     attr2 = getattr(other, attrName)
     if attr1 is not None and attr2 is not None:
         raise AttributeError(
-            "Cannot merge {} and {}, the attribute `{}` has been assigned on bothinstances.".format(
-                this, other, attrName
-            )
+            f"Cannot merge {this} and {other}, the attribute `{attrName}` has been assigned on bothinstances."
         )
+
     return attr1 if attr1 is not None else attr2

--- a/armi/operators/snapshots.py
+++ b/armi/operators/snapshots.py
@@ -20,10 +20,10 @@ from armi.operators import operatorMPI
 
 class OperatorSnapshots(operatorMPI.OperatorMPI):
     """
-    This operator just loops over the requested snapshots and computes at them.
+    Loops over the requested snapshots and computes at them.
 
-    These may add CR worth curves, rx coefficients, transient runs etc at these snapshots.
-    This operator can be run as a restart, adding new physics to a previous run.
+    These may add CR worth curves, rx coefficients, transient runs etc at these snapshots. This operator can be run as a
+    restart, adding new physics to a previous run.
     """
 
     def __init__(self, cs):
@@ -53,8 +53,7 @@ class OperatorSnapshots(operatorMPI.OperatorMPI):
         """
         runLog.important("---- Beginning Snapshot (restart) ARMI Operator Loop ------")
 
-        # run things that happen before a calculation.
-        # setups, etc.
+        # run things that happen before a calculation. setups, etc.
         self.interactAllBOL()
 
         # figure out which snapshots to run in. Parse the CCCNNN settings

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This module handles fuel management operations such as shuffling, rotation, and
-fuel processing (in fluid systems).
+Handles fuel management operations such as shuffling, rotation, and fuel processing (in fluid systems).
 
 The :py:class:`FuelHandlerInterface` instantiates a ``FuelHandler``, which is typically a user-defined
 subclass the :py:class:`FuelHandler` object in custom shuffle-logic input files.

--- a/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
+++ b/armi/physics/fuelCycle/hexAssemblyFuelMgmtUtils.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This is a selection of fuel management utilities that seem generally useful enough to keep in ARMI, but they still only
-apply to hex assembly reactors.
+A selection of fuel management utilities that seem generally useful enough to keep in ARMI, but they still only apply to
+hex assembly reactors.
 
 Notes
 -----

--- a/armi/physics/neutronics/crossSectionSettings.py
+++ b/armi/physics/neutronics/crossSectionSettings.py
@@ -631,7 +631,7 @@ class XSModelingOptions:
 
     def setDefaults(self, blockRepresentation, validBlockTypes):
         """
-        This sets the defaults based on some recommended values based on the geometry type.
+        Sets the defaults based on some recommended values based on the geometry type.
 
         Parameters
         ----------

--- a/armi/physics/neutronics/diffIsotxs.py
+++ b/armi/physics/neutronics/diffIsotxs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This script is used to compare ISOTXS files."""
+"""A script used to compare ISOTXS files."""
 
 from armi import runLog
 from armi.cli.entryPoint import EntryPoint

--- a/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
+++ b/armi/physics/neutronics/fissionProductModel/fissionProductModel.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This module contains the implementation of the ``FissionProductModel`` interface.
+The implementation of the ``FissionProductModel`` interface.
 
 
 This ``FissionProductModel`` class implements the management of fission products within

--- a/armi/physics/neutronics/isotopicDepletion/__init__.py
+++ b/armi/physics/neutronics/isotopicDepletion/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This package houses helper tools that allow ARMI to communicate with external isotopic depletion programs."""
+"""Helper tools that allow ARMI to communicate with external isotopic depletion programs."""

--- a/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
+++ b/armi/physics/neutronics/isotopicDepletion/crossSectionTable.py
@@ -31,7 +31,7 @@ from armi.nucDirectory import nucDir
 
 class CrossSectionTable(collections.OrderedDict):
     """
-    This is a set of one group cross sections for use with isotopicDepletion analysis.
+    A set of one group cross sections for use with isotopicDepletion analysis.
 
     It can also double as a reaction rate table.
 

--- a/armi/physics/tests/test_executers.py
+++ b/armi/physics/tests/test_executers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""TProvide tests for the generic Executers."""
+"""Provide tests for the generic Executers."""
 
 import os
 import subprocess

--- a/armi/physics/tests/test_executers.py
+++ b/armi/physics/tests/test_executers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This module provides tests for the generic Executers."""
+"""TProvide tests for the generic Executers."""
 
 import os
 import subprocess
@@ -46,10 +46,7 @@ class MockReactor:
 
 class TestExecutionOptions(unittest.TestCase):
     def test_runningDirectoryPath(self):
-        """
-        Test that the running directory path is set up correctly
-        based on the case title and label provided.
-        """
+        """Test that the running directory path is set up correctly based on the case title and label provided."""
         e = executers.ExecutionOptions(label=None)
         e.setRunDirFromCaseTitle(caseTitle="test")
         self.assertEqual(os.path.basename(e.runDir), "508bc04f-0")

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -681,7 +681,7 @@ class UserPlugin(ArmiPlugin):
 
     def __enforceLimitations(self):
         """
-        This method enforces that UserPlugins are more limited than regular ArmiPlugins.
+        Enforce that UserPlugins are more limited than regular ArmiPlugins.
 
         UserPlugins are different from regular plugins in that they can be defined during a run, and as such, we want to
         limit how flexible they are, so we can correctly corral their side effects during a run.

--- a/armi/reactor/blocks/block.py
+++ b/armi/reactor/blocks/block.py
@@ -1301,21 +1301,20 @@ class Block(composites.Composite):
 
     def getBlocks(self):
         """
-        This method returns all the block(s) included in this block its implemented so that methods
-        could iterate over reactors, assemblies or single blocks without checking to see what the
-        type of the reactor-family object is.
+        Return all the block(s) included in this block its implemented so that methods could iterate over reactors,
+        assemblies or single blocks without checking to see what the type of the reactor-family object is.
         """
         return [self]
 
     def updateComponentDims(self):
         """
-        This method updates all the dimensions of the components.
+        Update all the dimensions of the components.
 
         Notes
         -----
-        This is VERY useful for defining a ThRZ core out of differentialRadialSegements whose
-        dimensions are connected together some of these dimensions are derivative and can be updated
-        by changing dimensions in a Parameter Component or other linked components
+        This is VERY useful for defining a ThRZ core out of differentialRadialSegements whose dimensions are connected
+        together some of these dimensions are derivative and can be updated by changing dimensions in a Parameter
+        Component or other linked components
 
         See Also
         --------

--- a/armi/reactor/blocks/block.py
+++ b/armi/reactor/blocks/block.py
@@ -1301,8 +1301,8 @@ class Block(composites.Composite):
 
     def getBlocks(self):
         """
-        Return all the block(s) included in this block its implemented so that methods could iterate over reactors,
-        assemblies or single blocks without checking to see what the type of the reactor-family object is.
+        Return all the block(s) included in this block it has implemented so that methods could iterate over reactors,
+        assemblies, or single blocks without checking to see what the type of the reactor-family object is.
         """
         return [self]
 

--- a/armi/reactor/blocks/hexBlock.py
+++ b/armi/reactor/blocks/hexBlock.py
@@ -76,6 +76,7 @@ class HexBlock(Block):
             round(y, units.FLOAT_DIMENSION_DECIMALS),
         )
 
+    # TODO: Needs Unit Test
     def createHomogenizedCopy(self, pinSpatialLocators=False):
         """
         Create a new homogenized copy of a block that is less expensive than a full deepcopy.
@@ -229,6 +230,7 @@ class HexBlock(Block):
             else:
                 self.p.linPowByPin = self.p[powerKey]
 
+    # TODO: Needs unit test
     def rotate(self, rad: float):
         """
         Rotates a block's spatially varying parameters by a specified angle in the counter-clockwise direction.
@@ -329,6 +331,7 @@ class HexBlock(Block):
             self.p.displacementX = dispx * math.cos(rad) - dispy * math.sin(rad)
             self.p.displacementY = dispx * math.sin(rad) + dispy * math.cos(rad)
 
+    # TODO: Needs unit test
     def verifyBlockDims(self):
         """Perform some checks on this type of block before it is assembled.
 

--- a/armi/reactor/blocks/hexBlock.py
+++ b/armi/reactor/blocks/hexBlock.py
@@ -76,7 +76,6 @@ class HexBlock(Block):
             round(y, units.FLOAT_DIMENSION_DECIMALS),
         )
 
-    # TODO: Needs Unit Test
     def createHomogenizedCopy(self, pinSpatialLocators=False):
         """
         Create a new homogenized copy of a block that is less expensive than a full deepcopy.
@@ -230,7 +229,6 @@ class HexBlock(Block):
             else:
                 self.p.linPowByPin = self.p[powerKey]
 
-    # TODO: Needs unit test
     def rotate(self, rad: float):
         """
         Rotates a block's spatially varying parameters by a specified angle in the counter-clockwise direction.
@@ -331,7 +329,6 @@ class HexBlock(Block):
             self.p.displacementX = dispx * math.cos(rad) - dispy * math.sin(rad)
             self.p.displacementY = dispx * math.sin(rad) + dispy * math.cos(rad)
 
-    # TODO: Needs unit test
     def verifyBlockDims(self):
         """Perform some checks on this type of block before it is assembled.
 

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -278,15 +278,13 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
     def _prepConstruction(self, cs):
         """
-        This method initializes a bunch of information within a Blueprints object such as assigning
-        assembly and block type numbers, resolving the nuclides in the problem, and pre-populating
-        assemblies.
+        Initialize a bunch of information within a Blueprints object such as assigning assembly and block type numbers,
+        resolving the nuclides in the problem, and pre-populating assemblies.
 
-        Ideally, it would not be necessary at all, but the ``cs`` currently contains a bunch of
-        information necessary to create the applicable model. If it were possible, it would be
-        terrific to override the Yamlizable.from_yaml method to run this code after the instance has
-        been created, but we need additional information in order to build the assemblies that is
-        not within the YAML file.
+        Ideally, it would not be necessary at all, but the ``cs`` currently contains a bunch of information necessary to
+        create the applicable model. If it were possible, it would be terrific to override the Yamlizable.from_yaml
+        method to run this code after the instance has been created, but we need additional information in order to
+        build the assemblies that is not within the YAML file.
 
         This method should not be called directly, but it is used in testing.
         """
@@ -516,7 +514,7 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
 
     @classmethod
     def load(cls, stream, roundTrip=False):
-        """This method is a wrapper around the `yamlize.Object.load()` method."""
+        """A wrapper around the `yamlize.Object.load()` method."""
         # With the release of ruamel.yaml 0.19.1, we began getting the following error:
         # AttributeError: 'RoundTripLoader' object has no attribute 'max_depth'
         # Setting that attribute to `None` solved the issue. However, it would be prudent to rework blueprints loading

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 """
-This module defines the blueprints input object for assemblies.
+Define the blueprints input object for assemblies.
 
-In addition to defining the input format, the ``AssemblyBlueprint`` class is responsible for
-constructing ``Assembly`` objects. An attempt has been made to decouple ``Assembly`` construction
-from the rest of ARMI as much as possible. For example, an assembly does not require a reactor to be
-constructed, or a geometry file (but uses contained Block geometry type as a surrogate).
+In addition to defining the input format, the ``AssemblyBlueprint`` class is responsible for constructing ``Assembly``
+objects. An attempt has been made to decouple ``Assembly`` construction from the rest of ARMI as much as possible. For
+example, an assembly does not require a reactor to be constructed, or a geometry file (but uses contained Block geometry
+type as a surrogate).
 """
 
 import yamlize
@@ -41,10 +41,7 @@ def _configureAssemblyTypes():
 
 
 class Modifications(yamlize.Map):
-    """
-    The names of material modifications and lists of the modification values for each block in the
-    assembly.
-    """
+    """The names of material modifications and lists of the modification values for each block in the assembly."""
 
     key_type = yamlize.Typed(str)
     value_type = yamlize.Sequence

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This module defines the ARMI input for a block definition, and code for constructing an ARMI ``Block``."""
+"""Define the ARMI input for a block definition, and code for constructing an ARMI ``Block``."""
 
 import collections
 from inspect import signature
@@ -64,8 +64,7 @@ class BlockBlueprint(yamlize.KeyedList):
         larger :py:class:`~armi.reactor.blueprints.Blueprints` class.
 
         Includes a ``construct`` method, which instantiates an instance of
-        :py:class:`~armi.reactor.blocks.Block` with the characteristics as specified in the
-        blueprints.
+        :py:class:`~armi.reactor.blocks.Block` with the characteristics as specified in the blueprints.
     """
 
     item_type = componentBlueprint.ComponentBlueprint
@@ -332,8 +331,8 @@ class BlockBlueprint(yamlize.KeyedList):
         """
         Get the appropriate grid design.
 
-        This happens when a lattice input is provided on the block. Otherwise all
-        components are ambiguously defined in the block.
+        This happens when a lattice input is provided on the block. Otherwise all components are ambiguously defined in
+        the block.
         """
         if self.gridName:
             if self.gridName not in blueprint.gridDesigns:

--- a/armi/reactor/blueprints/componentBlueprint.py
+++ b/armi/reactor/blueprints/componentBlueprint.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This module defines the ARMI input for a component definition, and code for constructing an ARMI ``Component``.
+Define the ARMI input for a component definition, and code for constructing an ARMI ``Component``.
 
 Special logic is required for handling component links.
 """
@@ -112,8 +112,8 @@ class ComponentDimension(yamlize.Object):
 
 class ComponentBlueprint(yamlize.Object):
     """
-    This class defines the inputs necessary to build ARMI component objects. It uses ``yamlize`` to enable serialization
-    to and from YAML.
+    Define the inputs necessary to build ARMI component objects. It uses ``yamlize`` to enable serialization to and from
+    YAML.
 
     .. impl:: Construct component from blueprint file.
         :id: I_ARMI_BP_COMP
@@ -303,7 +303,7 @@ class ComponentBlueprint(yamlize.Object):
             )
 
     def _conformKwargs(self, blueprint, matMods):
-        """This method gets the relevant kwargs to construct the component."""
+        """Get the relevant kwargs to construct the component."""
         kwargs = {"mergeWith": self.mergeWith or "", "isotopics": self.isotopics or ""}
 
         for attr in self.attributes:  # yamlize magic

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -14,13 +14,11 @@
 """
 Input definitions for Grids.
 
-Grids are given names which can be referred to on other input structures (like core maps and pin
-maps).
+Grids are given names which can be referred to on other input structures (like core maps and pin maps).
 
 These are in turn interpreted into concrete things at lower levels. For example:
 
-* Core map lattices get turned into :py:mod:`armi.reactor.grids`, which get set to
-  ``core.spatialGrid``.
+* Core map lattices get turned into :py:mod:`armi.reactor.grids`, which get set to ``core.spatialGrid``.
 * Block pin map lattices get applied to the components to provide some subassembly spatial details.
 
 Lattice inputs here are floating in space. Specific dimensions and anchor points are handled by the
@@ -294,8 +292,8 @@ class GridBlueprint(yamlize.Object):
     @property
     def readFromLatticeMap(self):
         """
-        This is implemented as a property, since as a Yamlize object, ``__init__`` is not always
-        called and we have to lazily evaluate its default value.
+        A property because a Yamlize object, ``__init__`` is not always called and we have to lazily evaluate its
+        default value.
         """
         return getattr(self, "_readFromLatticeMap", False)
 
@@ -322,8 +320,8 @@ class GridBlueprint(yamlize.Object):
         runLog.extra(f"Creating the spatial grid {self.name}", single=True)
         if geom in (geometry.RZT, geometry.RZ):
             if self.gridBounds is None:
-                # This check is regrettably late. It would be nice if we could validate that bounds
-                # are provided if R-Theta mesh is being used.
+                # This check is regrettably late. It would be nice if we could validate that bounds are provided if
+                # R-Theta mesh is being used.
                 raise InputError(
                     f"Grid bounds must be provided for `{self.name}` to specify a grid with r-theta components."
                 )

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -292,7 +292,7 @@ class GridBlueprint(yamlize.Object):
     @property
     def readFromLatticeMap(self):
         """
-        A property because a Yamlize object, ``__init__`` is not always called and we have to lazily evaluate its
+        Decorated as a property because a Yamlize object, ``__init__`` is not always called and we have to lazily evaluate its
         default value.
         """
         return getattr(self, "_readFromLatticeMap", False)

--- a/armi/reactor/blueprints/gridBlueprint.py
+++ b/armi/reactor/blueprints/gridBlueprint.py
@@ -292,8 +292,8 @@ class GridBlueprint(yamlize.Object):
     @property
     def readFromLatticeMap(self):
         """
-        Decorated as a property because a Yamlize object, ``__init__`` is not always called and we have to lazily evaluate its
-        default value.
+        Decorated as a property because a Yamlize object, ``__init__`` is not always called and we have to lazily
+        evaluate its default value.
         """
         return getattr(self, "_readFromLatticeMap", False)
 

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -567,8 +567,8 @@ def genDefaultNucFlags():
 
 def autoUpdateNuclideFlags(cs, nuclideFlags, inerts):
     """
-    This function is responsible for examining the fission product model treatment that is selected by the user and
-    adding a set of nuclides to the `nuclideFlags` list.
+    Examine the fission product model treatment that is selected by the user and adding a set of nuclides to the
+    `nuclideFlags` list.
 
     Notes
     -----
@@ -596,8 +596,8 @@ def autoUpdateNuclideFlags(cs, nuclideFlags, inerts):
 
 def getAllNuclideBasesByLibrary(cs):
     """
-    Return a list of nuclide bases available for cross section modeling
-    based on the ``CONF_FISSION_PRODUCT_LIBRARY_NAME`` setting.
+    Return a list of nuclide bases available for cross section modeling based on the
+    ``CONF_FISSION_PRODUCT_LIBRARY_NAME`` setting.
     """
     nbs = []
     if cs[CONF_FP_MODEL] == "explicitFissionProducts":

--- a/armi/reactor/blueprints/tests/test_materialModifications.py
+++ b/armi/reactor/blueprints/tests/test_materialModifications.py
@@ -258,10 +258,9 @@ assemblies:
 
     def test_invalidMatModName(self):
         """
-        This test shows that we can detect invalid material modification
-        names when they are specified on an assembly blueprint. We happen to know
-        that ZR_wt_frac is a valid modification for the UZr material class, so we
-        use that in the first call to prove that things initially work fine.
+        Show that we can detect invalid material modification names when they are specified on an assembly blueprint. We
+        happen to know that ZR_wt_frac is a valid modification for the UZr material class, so we use that in the first
+        call to prove that things initially work fine.
         """
         a = self.loadUZrAssembly(
             """
@@ -300,10 +299,9 @@ assemblies:
 
     def test_invalidMatModType(self):
         """
-        This test shows that we can detect material modifications that are invalid
-        because of their values, not just their names.
-        We happen to know that ZR_wt_frac is a valid modification for UZr, so we
-        use that in the first call to prove that things initially work fine.
+        Show that we can detect material modifications that are invalid because of their values, not just their names.
+        We happen to know that ZR_wt_frac is a valid modification for UZr, so we use that in the first call to prove
+        that things initially work fine.
         """
         a = self.loadUZrAssembly(
             """
@@ -328,10 +326,7 @@ assemblies:
             )
 
     def test_matModsUpTheMRO(self):
-        """
-        Make sure that valid/invalid material modifications are searched up
-        the MRO for a material class.
-        """
+        """Make sure that valid/invalid material modifications are searched up the MRO for a material class."""
         _a = self.loadUZrAssembly(
             """
         material modifications:

--- a/armi/reactor/components/__init__.py
+++ b/armi/reactor/components/__init__.py
@@ -310,17 +310,14 @@ class PositiveOrNegativeVolumeComponent(UnshapedVolumetricComponent):
 
 class DerivedShape(UnshapedComponent):
     """
-    This a component that does have specific dimensions, but they're complicated.
+    A component that does have specific dimensions, but they're complicated.
 
     Notes
     -----
-    - This component type is "derived" through the addition or
-      subtraction of other shaped components (e.g. Coolant)
-    - Because its area and volume are defined by other components,
-      a DerivedShape's area and volume may change as the other
-      components thermally expand. However the DerivedShape cannot
-      drive thermal expansion itself, even if it is a solid component
-      with non-zero thermal expansion coefficient
+    - This component type is "derived" through the addition or subtraction of other shaped components (e.g. Coolant)
+    - Because its area and volume are defined by other components, a DerivedShape's area and volume may change as the
+      other components thermally expand. However the DerivedShape cannot drive thermal expansion itself, even if it is a
+      solid component with non-zero thermal expansion coefficient
     """
 
     def getBoundingCircleOuterDiameter(self, Tc=None, cold=False):

--- a/armi/reactor/components/volumetricShapes.py
+++ b/armi/reactor/components/volumetricShapes.py
@@ -255,13 +255,11 @@ class RadialSegment(ShapedComponent):
 
 class DifferentialRadialSegment(RadialSegment):
     """
-    This component class represents a volume element with thicknesses in the
-    azimuthal, radial and axial directions. Furthermore it has dependent
-    dimensions: (outer theta, outer radius, outer axial) that can be updated
-    depending on the 'differential' in the corresponding directions.
+    Component class representing a volume element with thicknesses in the azimuthal, radial and axial directions.
 
-    This component class is super useful for defining ThRZ reactors and
-    perturbing its dimensions using the optimization modules
+    Furthermore it has dependent dimensions: (outer theta, outer radius, outer axial) that can be updated depending on
+    the 'differential' in the corresponding directions. This component class is super useful for defining ThRZ reactors
+    and perturbing its dimensions using the optimization modules
 
     See Also
     --------
@@ -321,8 +319,8 @@ class DifferentialRadialSegment(RadialSegment):
 
         Notes
         -----
-        Can be used to update any dimension on the component, but outer_radius, outer_axial, and outer_theta are
-        always updated.
+        Can be used to update any dimension on the component, but outer_radius, outer_axial, and outer_theta are always
+        updated.
 
         See Also
         --------

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -13,20 +13,18 @@
 # limitations under the License.
 
 """
-This module contains the basic composite pattern underlying the reactor package.
+The basic composite pattern underlying the reactor package.
 
-This follows the principles of the `Composite Design Pattern
-<https://en.wikipedia.org/wiki/Composite_pattern>`_ to allow the construction of a part/whole
-hierarchy representing a physical nuclear reactor. The composite objects act somewhat like lists:
-they can be indexed, iterated over, appended, extended, inserted, etc. Each member of the hierarchy
-knows its children and its parent, so full access to the hierarchy is available from everywhere.
-This design was chosen because of the close analogy of the model to the physical nature of nuclear
-reactors.
+This follows the principles of the `Composite Design Pattern <https://en.wikipedia.org/wiki/Composite_pattern>`_ to
+allow the construction of a part/whole hierarchy representing a physical nuclear reactor. The composite objects act
+somewhat like lists: they can be indexed, iterated over, appended, extended, inserted, etc. Each member of the hierarchy
+knows its children and its parent, so full access to the hierarchy is available from everywhere. This design was chosen
+because of the close analogy of the model to the physical nature of nuclear reactors.
 
 Warning
 -------
-Because each member of the hierarchy is linked to the entire tree, it is often unsafe to save
-references to individual members; it can cause large and unexpected memory inefficiencies.
+Because each member of the hierarchy is linked to the entire tree, it is often unsafe to save references to individual
+members; it can cause large and unexpected memory inefficiencies.
 
 See Also
 --------

--- a/armi/reactor/converters/blockConverters.py
+++ b/armi/reactor/converters/blockConverters.py
@@ -226,8 +226,7 @@ class ComponentMerger(BlockConverter):
 
     Notes
     -----
-    It is the job of the developer to determine if merging a Block into one Component
-    will yield valid or sane results.
+    It is the job of the developer to determine if merging a Block into one Component will yield valid or sane results.
     """
 
     def __init__(self, sourceBlock, soluteName, solventName):
@@ -315,15 +314,14 @@ class MultipleComponentMerger(BlockConverter):
 class MixedPinComponentMerger(MultipleComponentMerger):
     def __init__(self, sourceBlock, soluteNames, solventName, pin, specifiedMinID=0.0):
         """
-        This BlockConverter handles mixed blocks with multiple pin types.
-        A pin is a list of circular components that share a common spatial locator and thus
-        make up a "pin", which is a physical construct but not a formal ARMI construct.
+        Handles mixed blocks with multiple pin types. A pin is a list of circular components that share a common spatial
+        locator and thus make up a "pin", which is a physical construct but not a formal ARMI construct.
 
-        This class can merge multiple components at a time within a single pin. To perform
-        conversions on multiple pins within a mixed block, a new instance of this class
-        must be constructed for each pin, and then the :py:meth:`convert` method must be called in a
-        waterfall fashion -- that is, the block returned from :py:meth:`convert` should be passed
-        into the constructor of the next instance to perform a chain of component merges.
+        This class can merge multiple components at a time within a single pin. To perform conversions on multiple pins
+        within a mixed block, a new instance of this class must be constructed for each pin, and then the
+        :py:meth:`convert` method must be called in a waterfall fashion -- that is, the block returned from
+        :py:meth:`convert` should be passed into the constructor of the next instance to perform a chain of component
+        merges.
 
         .. impl:: Homogenize multiple components into one in a single pin within a mixed pin assembly.
             :id: I_ARMI_BLOCKCONV2
@@ -404,8 +402,7 @@ class BlockAvgToCylConverter(BlockConverter):
 
     See Also
     --------
-    HexComponentsToCylConverter: This converter is more useful if the pin lattice is in a
-    hex lattice.
+    HexComponentsToCylConverter: This converter is more useful if the pin lattice is in a hex lattice.
     """
 
     def __init__(

--- a/armi/reactor/converters/tests/test_axialExpansionChanger.py
+++ b/armi/reactor/converters/tests/test_axialExpansionChanger.py
@@ -896,7 +896,7 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
     """Verify thermal expansion for process loading of core."""
 
     def setUp(self):
-        """This test uses a different armiRun.yaml than the default."""
+        """Use a different armiRun.yaml than the default."""
         o, r = loadTestReactor(
             os.path.join(TESTING_ROOT, "reactors", "detailedAxialExpansion"),
             customSettings={"inputHeightsConsideredHot": True},
@@ -924,9 +924,8 @@ class TestInputHeightsConsideredHot(unittest.TestCase):
 
         Notes
         -----
-        For R_ARMI_INP_COLD_HEIGHT, the action of axial expansion occurs in setUp() during core
-        construction, specifically in
-        :py:meth:`constructAssem <armi.reactor.blueprints.Blueprints.constructAssem>`
+        For R_ARMI_INP_COLD_HEIGHT, the action of axial expansion occurs in setUp() during core construction,
+        specifically in :py:meth:`constructAssem <armi.reactor.blueprints.Blueprints.constructAssem>`
 
         Two assertions here:
             1. total assembly height should be preserved (through use of top dummy block)
@@ -1120,9 +1119,8 @@ class FakeMatException(FakeMat):
 
     Notes
     -----
-    - the only difference between this and `class FakeMat(HT9)` above is that the thermal expansion
-      factor is higher to ensure that a negative block height is caught in
-      TestExceptions:test_assemblyAxialExpansionException.
+    - the only difference between this and `class FakeMat(HT9)` above is that the thermal expansion factor is higher to
+      ensure that a negative block height is caught in TestExceptions:test_assemblyAxialExpansionException.
     """
 
     def __init__(self):

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -88,15 +88,14 @@ def converterFactory(globalFluxOptions):
 
 class UniformMeshGenerator:
     """
-    This class generates a common axial mesh to for the uniform mesh converter to use. The
-    generation algorithm starts with the simple ``average1DWithinTolerance`` utility function
-    to compute a representative "average" of the assembly meshes in the reactor. It then modifies
-    that mesh to more faithfully represent important material boundaries of fuel and control
-    absorber material.
+    Generate a common axial mesh to for the uniform mesh converter to use. The generation algorithm starts with the
+    simple ``average1DWithinTolerance`` utility function to compute a representative "average" of the assembly meshes in
+    the reactor. It then modifies that mesh to more faithfully represent important material boundaries of fuel and
+    control absorber material.
 
-    The decusping feature is controlled with the case setting ``uniformMeshMinimumSize``. If no
-    value is provided for this setting, the uniform mesh generator will skip the decusping step
-    and just provide the result of ``_computeAverageAxialMesh``.
+    The decusping feature is controlled with the case setting ``uniformMeshMinimumSize``. If no value is provided for
+    this setting, the uniform mesh generator will skip the decusping step and just provide the result of
+    ``_computeAverageAxialMesh``.
     """
 
     def __init__(self, r, minimumMeshSize=None):
@@ -276,8 +275,8 @@ class UniformMeshGenerator:
             When neither mesh point is in the list of ``anchorPoints``, which mesh point is given preference
             ("bottom" or "top")
         warn : bool, optional
-            Whether to log a warning when a mesh is removed. This is true if a
-            control material boundary is removed, but otherwise it is false.
+            Whether to log a warning when a mesh is removed. This is true if a control material boundary is removed, but
+            otherwise it is false.
         """
         if preference == "bottom":
             meshList = sorted(list(set(meshList)))
@@ -308,10 +307,9 @@ class UniformMeshGenerator:
 
                     if warn:
                         runLog.warning(
-                            f"{meshList[i + 1]} is too close to {meshList[i]}! "
-                            f"Difference = {difference} is less than mesh size "
-                            f"tolerance of {minimumMeshSize}. The uniform mesh will "
-                            f"remove {meshList[removeIndex]}."
+                            f"{meshList[i + 1]} is too close to {meshList[i]}! Difference = {difference} is less than "
+                            f"mesh size tolerance of {minimumMeshSize}. The uniform mesh will remove "
+                            f"{meshList[removeIndex]}."
                         )
                     break
             else:
@@ -364,8 +362,7 @@ class UniformMeshGenerator:
 
 class UniformMeshGeometryConverter(GeometryConverter):
     """
-    This geometry converter can be used to change the axial mesh structure of the
-    reactor core.
+    Geometry converter can be used to change the axial mesh structure of the reactor core.
 
     Notes
     -----
@@ -391,10 +388,8 @@ class UniformMeshGeometryConverter(GeometryConverter):
     `setAssemblyStateFromOverlaps` is dependent on the direction in which the mapping
     is being applied to prevent the numerical diffusion problem.
 
-    - "in" is used when mapping parameters into the uniform assembly
-      from the non-uniform assembly.
-    - "out" is used when mapping parameters from the uniform assembly back
-      to the non-uniform assembly.
+    - "in" is used when mapping parameters into the uniform assembly from the non-uniform assembly.
+    - "out" is used when mapping parameters from the uniform assembly back to the non-uniform assembly.
 
     .. warning::
         If a parameter is calculated by a physics solver while the reactor is in its
@@ -592,9 +587,8 @@ class UniformMeshGeometryConverter(GeometryConverter):
         # map the block parameters back to the non-uniform assembly
         self._setParamsToUpdate("out")
 
-        # If we have non-uniform mesh assemblies then we need to apply a
-        # different approach to undo the geometry transformations on an
-        # assembly by assembly basis.
+        # If we have non-uniform mesh assemblies then we need to apply a different approach to undo the geometry
+        # transformations on an assembly by assembly basis.
         if self._hasNonUniformAssems:
             for assem in self._sourceReactor.core.getAssemblies(self._nonUniformMeshFlags):
                 for storedAssem in self._nonUniformAssemStorage:
@@ -617,10 +611,8 @@ class UniformMeshGeometryConverter(GeometryConverter):
                         break
                 else:
                     runLog.error(
-                        f"No assembly matching name {assem.getName()} "
-                        f"was found in the temporary storage list. {assem} "
-                        "will persist as an axially unified assembly. "
-                        "This is likely not intended."
+                        f"No assembly matching name {assem.getName()} was found in the temporary storage list. {assem} "
+                        "will persist as an axially unified assembly. This is likely not intended."
                     )
 
             self._sourceReactor.core.updateAxialMesh()

--- a/armi/reactor/excoreStructure.py
+++ b/armi/reactor/excoreStructure.py
@@ -11,11 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""This module provides the simplest base-class tools for representing reactor objects that are
-outside the reactor core.
+"""Provide the simplest base-class tools for representing reactor objects that are outside the reactor core.
 
-The idea here is that all ex-core objects will be represented first as a spatial grid, and then
-arbitrary ArmiObjects can be added to that grid.
+The idea here is that all ex-core objects will be represented first as a spatial grid, and then arbitrary ArmiObjects
+can be added to that grid.
 """
 
 import copy
@@ -24,7 +23,7 @@ from armi.reactor.composites import Composite
 
 
 class ExcoreStructure(Composite):
-    """This is meant as the simplest baseclass needed to represent an ex-core reactor thing.
+    """The simplest baseclass needed to represent an ex-core reactor thing.
 
     An ex-core structure is expected to:
 
@@ -39,7 +38,7 @@ class ExcoreStructure(Composite):
         self.spatialGrid = None
 
     def __repr__(self):
-        return "<{}: {} id:{}>".format(self.__class__.__name__, self.name, id(self))
+        return f"<{self.__class__.__name__}: {self.name} id:{id(self)}>"
 
     @property
     def r(self):
@@ -146,4 +145,4 @@ class ExcoreCollection(dict):
         return newE
 
     def __repr__(self):
-        return "<{}: {} id:{}>".format(self.__class__.__name__, self.name, id(self))
+        return f"<{self.__class__.__name__}: {self.name} id:{id(self)}>"

--- a/armi/reactor/geometry.py
+++ b/armi/reactor/geometry.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This module contains constants and enumerations that are useful for describing system
-geometry.
-"""
+"""Constants and enumerations that are useful for describing system geometry."""
 
 import enum
 from typing import Optional, Union
@@ -87,9 +84,8 @@ class GeomType(enum.Enum):
         elif canonical == RZ:
             return cls.RZ
 
-        # use the original geomStr with preserved capitalization for better
-        # error-finding.
-        errorMsg = "Unrecognized geometry type {}. Valid geometry options are: ".format(geomStr)
+        # use the original geomStr with preserved capitalization for better error-finding.
+        errorMsg = f"Unrecognized geometry type {geomStr}. Valid geometry options are: "
         errorMsg += ", ".join([f"{geom}" for geom in geomTypes])
         raise ValueError(errorMsg)
 
@@ -134,7 +130,7 @@ class DomainType(enum.Enum):
         elif isinstance(source, str):
             return cls.fromStr(source)
         else:
-            raise TypeError("Expected str or DomainType; got {}".format(type(source)))
+            raise TypeError(f"Expected str or DomainType; got {type(source)}")
 
     @classmethod
     def fromStr(cls, shapeStr: str) -> "DomainType":
@@ -153,7 +149,7 @@ class DomainType(enum.Enum):
         elif canonical == "":
             return cls.NULL
 
-        errorMsg = "{} is not a valid domain option. Valid domain options are:".format(str(canonical))
+        errorMsg = f"{str(canonical)} is not a valid domain option. Valid domain options are:"
         errorMsg += ", ".join([f"{sym}" for sym in domainTypes])
         raise ValueError(errorMsg)
 
@@ -202,7 +198,7 @@ class DomainType(enum.Enum):
         elif self == self.SIXTEENTH_CORE:
             return 16.0
         else:
-            raise ValueError("Could not calculate symmetry factor for domain size {}. update logic.".format(self.label))
+            raise ValueError(f"Could not calculate symmetry factor for domain size {self.label}. update logic.")
 
 
 class BoundaryType(enum.Enum):
@@ -219,7 +215,7 @@ class BoundaryType(enum.Enum):
         elif isinstance(source, str):
             return cls.fromStr(source)
         else:
-            raise TypeError("Expected str or BoundaryType; got {}".format(type(source)))
+            raise TypeError(f"Expected str or BoundaryType; got {type(source)}")
 
     @classmethod
     def fromStr(cls, symmetryStr: str) -> "BoundaryType":
@@ -232,7 +228,7 @@ class BoundaryType(enum.Enum):
         elif canonical == REFLECTIVE:
             return cls.REFLECTIVE
 
-        errorMsg = "{} is not a valid boundary option. Valid boundary options are:".format(str(canonical))
+        errorMsg = f"{str(canonical)} is not a valid boundary option. Valid boundary options are:"
         errorMsg += ", ".join([f"{sym}" for sym in boundaryTypes])
         raise ValueError(errorMsg)
 
@@ -263,10 +259,9 @@ class SymmetryType:
     """
     A wrapper for DomainType and BoundaryType enumerations.
 
-    The goal of this class is to provide simple functions for storing these options
-    in enumerations and using them to check symmetry conditions, while also providing
-    a standard string representation of the options that facilitates interfacing with
-    yaml and/or the database nicely.
+    The goal of this class is to provide simple functions for storing these options in enumerations and using them to
+    check symmetry conditions, while also providing a standard string representation of the options that facilitates
+    interfacing with yaml and/or the database nicely.
     """
 
     VALID_SYMMETRY = {
@@ -300,7 +295,7 @@ class SymmetryType:
         self.isThroughCenterAssembly = throughCenterAssembly
 
         if not self.checkValidSymmetry():
-            errorMsg = "{} is not a valid symmetry option. Valid symmetry options are: ".format(str(self))
+            errorMsg = f"{str(self)} is not a valid symmetry option. Valid symmetry options are: "
             errorMsg += ", ".join([f"{sym}" for sym in self.createValidSymmetryStrings()])
             raise ValueError(errorMsg)
 
@@ -345,7 +340,7 @@ class SymmetryType:
         elif isinstance(source, str):
             return cls.fromStr(source)
         else:
-            raise TypeError("Expected str or SymmetryType; got {}".format(type(source)))
+            raise TypeError(f"Expected str or SymmetryType; got {type(source)}")
 
     def __str__(self):
         """Combined string of domain and boundary symmetry type."""
@@ -395,16 +390,14 @@ def checkValidGeomSymmetryCombo(
     symmetryInput: Union[str, "SymmetryType"],
 ) -> bool:
     """
-    Check if the given combination of GeomType and SymmetryType is valid.
-    Return a boolean indicating the outcome of the check.
+    Check if the given combination of GeomType and SymmetryType is valid. Return a boolean indicating the outcome of the
+    check.
     """
     symmetry = SymmetryType.fromAny(symmetryInput)
     if (symmetry.domain, symmetry.boundary) in VALID_GEOM_SYMMETRY[GeomType.fromAny(geomType)]:
         return True
     else:
-        raise ValueError(
-            "GeomType: {} and SymmetryType: {} is not a valid combination!".format(str(geomType), str(symmetry))
-        )
+        raise ValueError(f"GeomType: {str(geomType)} and SymmetryType: {str(symmetry)} is not a valid combination!")
 
 
 SYSTEMS = "systems"

--- a/armi/reactor/grids/__init__.py
+++ b/armi/reactor/grids/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""
-This contains structured meshes in multiple geometries and spatial locators (i.e. locations).
+Structured meshes in multiple geometries and spatial locators (i.e. locations).
 
 :py:class:`Grids <Grid>` are objects that map indices (i, j, k) to spatial locations
 (x,y,z) or (t,r,z).  They are useful for arranging things in reactors, such as:

--- a/armi/reactor/grids/hexagonal.py
+++ b/armi/reactor/grids/hexagonal.py
@@ -432,7 +432,7 @@ class HexGrid(StructuredGrid):
 
     @staticmethod
     def _getSymmetricIdenticalsThird(indices) -> List[IJType]:
-        """This works by rotating the indices by 120 degrees twice, counterclockwise."""
+        """Rotates the indices by 120 degrees twice, counterclockwise."""
         i, j = indices[:2]
         if i == 0 and j == 0:
             return []

--- a/armi/reactor/parameters/parameterDefinitions.py
+++ b/armi/reactor/parameters/parameterDefinitions.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 r"""
-This module contains the code necessary to represent parameter definitions.
+The code necessary to represent parameter definitions.
 
-``ParameterDefinition``\ s are the metadata that describe specific parameters, and aid in enforcing
-certain rules upon the parameters themselves and the parameter collections that contain them.
+``ParameterDefinition``\ s are the metadata that describe specific parameters, and aid in enforcing certain rules upon
+the parameters themselves and the parameter collections that contain them.
 
-This module also describes the ``ParameterDefinitionCollection`` class, which serves as a
-specialized container to manage related parameter definitions.
+This module also describes the ``ParameterDefinitionCollection`` class, which serves as a specialized container to
+manage related parameter definitions.
 
 See Also
 --------
@@ -346,17 +346,15 @@ class Parameter:
         self._backup = state[0]  # a tuple of 1 element.
 
     def __set__(self, obj, val):
-        """This is a property setter, see Python documentation for "descriptor"."""
         self._setter(obj, val)
 
     def __get__(self, obj, cls=None):
-        """This is a property getter, see Python documentation for "descriptor".
+        """A property getter, see Python documentation for "descriptor".
 
         Notes
         -----
-        We do not check to see if ``cls != None``. This is an optimization choice, that someone may
-        deem unnecessary. As a result, unlike Python's ``property`` class, a subclass cannot
-        override the getter method.
+        We do not check to see if ``cls != None``. This is an optimization choice, that someone may deem unnecessary. As
+        a result, unlike Python's ``property`` class, a subclass cannot override the getter method.
         """
         return self._getter(obj)
 

--- a/armi/reactor/parameters/resolveCollections.py
+++ b/armi/reactor/parameters/resolveCollections.py
@@ -13,53 +13,41 @@
 # limitations under the License.
 
 """
-This module contains the magic that makes the Parameter system and ARMI composite model
-play nicely together.
+The magic that makes the Parameter system and ARMI composite model play nicely together.
 
-The contained metaclass is useful for maintaining a hierarchy of ``ParameterCollection``
-classes, which mimic the hierarchy of ``ArmiObject`` s to which they apply. Some
-``ArmiObject`` subclasses define their own parameters, while others do not, so we do not
-want to blindly create a ``ParameterCollectionClass`` for each ``ArmiObject`` subclass.
-Instead, we want to be able to skip generations when no additional parameters were
-requested for that level. For instance if we have a hierarchy like: ``ArmiObject`` <-
-``A`` <- ``B``, where ``ArmiObject`` and ``B`` define parameters, while ``A`` does not
-define any parameters of its own, we want to have a ``ArmiObjectParameterCollection``
-and a ``BParameterCollection`` (with ``BParameterCollection`` being a subclass of
-``ArmiObjectParameterCollection``).  ``ArmiObject`` and ``A`` will both *share* the
-``ArmiObjectParameterCollection``, while ``B`` will use ``BParameterCollection``.
-``BParameterCollection`` will contain all of the parameters defined in
-``ArmiObjectParameterCollection``, plus whatever additional parameters were defined on
-``B``.
+The contained metaclass is useful for maintaining a hierarchy of ``ParameterCollection`` classes, which mimic the
+hierarchy of ``ArmiObject`` s to which they apply. Some ``ArmiObject`` subclasses define their own parameters, while
+others do not, so we do not want to blindly create a ``ParameterCollectionClass`` for each ``ArmiObject`` subclass.
+Instead, we want to be able to skip generations when no additional parameters were requested for that level. For
+instance if we have a hierarchy like: ``ArmiObject`` <- ``A`` <- ``B``, where ``ArmiObject`` and ``B`` define
+parameters, while ``A`` does not define any parameters of its own, we want to have a ``ArmiObjectParameterCollection``
+and a ``BParameterCollection`` (with ``BParameterCollection`` being a subclass of ``ArmiObjectParameterCollection``).
+``ArmiObject`` and ``A`` will both *share* the ``ArmiObjectParameterCollection``, while ``B`` will use
+``BParameterCollection``. ``BParameterCollection`` will contain all of the parameters defined in
+``ArmiObjectParameterCollection``, plus whatever additional parameters were defined on ``B``.
 
-The above scenario should behave rather intuitively for someone used to classes and
-inheritance, but maintaining this hierarchy by hand would be onerous and error-prone.
-What if one day we decide to add some parameters to ``A``? We need to remember to add a
-new class for its parameters, and make sure to make ``BParameterCollection`` a subclass
-of that new ``ParameterCollection`` class. With the below metaclass, we needn't worry
-ourselves with any of that; it is taken care of automatically.
+The above scenario should behave rather intuitively for someone used to classes and inheritance, but maintaining this
+hierarchy by hand would be onerous and error-prone. What if one day we decide to add some parameters to ``A``? We need
+to remember to add a new class for its parameters, and make sure to make ``BParameterCollection`` a subclass of that new
+``ParameterCollection`` class. With the below metaclass, we needn't worry ourselves with any of that; it is taken care
+of automatically.
 
-If you want to know how the sausage is made, the ``ResolveParametersMeta`` metaclass is
-responsible for forming a hierarchy of ``ParameterCollection`` classes that correspond
-to the related hierarchy of classes inheriting the root ``ArmiObject`` class. It should
-be rare for an ARMI developer not engaged directly with Framework development to need to
-know exactly how this works, but a proficient ARMI developer must keep in mind the
-following rules about how this system behaves in practice:
+If you want to know how the sausage is made, the ``ResolveParametersMeta`` metaclass is responsible for forming a
+hierarchy of ``ParameterCollection`` classes that correspond to the related hierarchy of classes inheriting the root
+``ArmiObject`` class. It should be rare for an ARMI developer not engaged directly with Framework development to need to
+know exactly how this works, but a proficient ARMI developer must keep in mind the following rules about how this system
+behaves in practice:
 
-* When defining subclasses of ``ArmiObject``, defining a class attribute called
-  ``pDefs`` of the ``ParameterDefinitionCollection`` type signals to the system that
-  this is a *Parameter Class*.
-* When defining a *Parameter Class*, it will trigger the creation of a new
-  ``ParameterCollection`` class, which will be derived from the
-  ``ParameterCollection`` class of the most immediate *Parameter Class* ancestor
-  the new class's inheritance tree.
-* All classes derived from ``ArmiObject`` will receive an associated subclass of
-  ``ParameterCollection``, which will ultimately include all of the relevant
-  Parameters for that class. The specific class is the ``ParameterCollection``
-  subclass defined for the most immediate *Parameter Class* in the classes
+* When defining subclasses of ``ArmiObject``, defining a class attribute called ``pDefs`` of the
+  ``ParameterDefinitionCollection`` type signals to the system that this is a *Parameter Class*.
+* When defining a *Parameter Class*, it will trigger the creation of a new ``ParameterCollection`` class, which will be
+  derived from the ``ParameterCollection`` class of the most immediate *Parameter Class* ancestor the new class's
   inheritance tree.
-* Parameter definitions can be added to a *Parameter Class*'s ``pDefs`` until
-  Parameters have been "compiled" for it. After compiling parameters, the ``pDefs``
-  are locked, and any attempts at defining additional parameters will cause an
+* All classes derived from ``ArmiObject`` will receive an associated subclass of ``ParameterCollection``, which will
+  ultimately include all of the relevant Parameters for that class. The specific class is the ``ParameterCollection``
+  subclass defined for the most immediate *Parameter Class* in the classes inheritance tree.
+* Parameter definitions can be added to a *Parameter Class*'s ``pDefs`` until Parameters have been "compiled" for it.
+  After compiling parameters, the ``pDefs`` are locked, and any attempts at defining additional parameters will cause an
   error.
 * ``ArmiObject`` s cannot be instantiated until after parameters have been compiled.
 
@@ -72,31 +60,26 @@ from armi.reactor.parameters.parameterDefinitions import ParameterDefinitionColl
 class ResolveParametersMeta(type):
     """Metaclass for automatically defining associated ParameterCollection classes.
 
-    Any class invoking this metaclass will automatically create an associated sub-class
-    of the ``ParameterCollection`` type, if it has a class attribute called ``pDefs``
-    that is an instance of ``ParameterDefinitionCollection``. This new class will itself
-    be a subclass of the ``ParameterCollection`` class that is associated with the
-    invoking class's parent.
+    Any class invoking this metaclass will automatically create an associated sub-class of the ``ParameterCollection``
+    type, if it has a class attribute called ``pDefs`` that is an instance of ``ParameterDefinitionCollection``. This
+    new class will itself be a subclass of the ``ParameterCollection`` class that is associated with the invoking
+    class's parent.
 
-    If no ``pDefs`` class attribute is present, the invoking class will adopt the
-    ``ParameterCollection`` class associated with it's parent, or ``None`` if it cannot
-    find one.
+    If no ``pDefs`` class attribute is present, the invoking class will adopt the ``ParameterCollection`` class
+    associated with it's parent, or ``None`` if it cannot find one.
 
-    The associated ``ParameterCollection`` will be stored on the new class's
-    ``paramCollectionType`` attribute.
+    The associated ``ParameterCollection`` will be stored on the new class's ``paramCollectionType`` attribute.
 
-    For example, when this metaclass is applied to the ``Block`` class it will create a
-    new class named ``BlockParameterCollection``, and add it as a class attribute called
-    ``Block.paramCollectionType``. The ``BlockParameterCollection`` class will itself be
-    a subclass of ``ArmiObjectParameterCollection``, which it would have found from the
-    ``Composite`` class from which the ``Block`` class inherits. The ``Composite``
-    class, on the other hand, would have obtained the ``ArmiObjectParameterCollection``
-    from it's parent (``ArmiObject``), since it does not have a ``pDefs`` attribute of
-    its own.
+    For example, when this metaclass is applied to the ``Block`` class it will create a new class named
+    ``BlockParameterCollection``, and add it as a class attribute called ``Block.paramCollectionType``. The
+    ``BlockParameterCollection`` class will itself be a subclass of ``ArmiObjectParameterCollection``, which it would
+    have found from the ``Composite`` class from which the ``Block`` class inherits. The ``Composite`` class, on the
+    other hand, would have obtained the ``ArmiObjectParameterCollection`` from it's parent (``ArmiObject``), since it
+    does not have a ``pDefs`` attribute of its own.
     """
 
     def __new__(mcl, name, bases, attrs):
-        assert attrs.get("paramCollectionType") is None, "{} already has parameter collection".format(name)
+        assert attrs.get("paramCollectionType") is None, f"{name} already has parameter collection"
         baseCollections = [b.paramCollectionType for b in bases if hasattr(b, "paramCollectionType")]
         # Make sure that these are what we expect them to be
         assert all([issubclass(c, ParameterCollection) for c in baseCollections if c is not None])
@@ -104,22 +87,19 @@ class ResolveParametersMeta(type):
         # Pull out the one element of the list if it exists
         inferredBaseCollection = next(iter(baseCollections), None)
 
-        # pDefs can be defined in the class definition; if it is, this is is a Parameter
-        # Class!
+        # pDefs can be defined in the class definition; if it is, this is is a Parameter Class!
         pDefs = attrs.get("pDefs")
         makeNewPC = pDefs is not None
         if makeNewPC:
-            # We may have our own parameters, so we need to spin up a new
-            # XParameterCollection class to store them.
+            # We may have our own parameters, so we need to spin up a new XParameterCollection class to store them.
             assert isinstance(pDefs, ParameterDefinitionCollection)
 
             collectionName = name + "ParameterCollection"
             collectionBase = inferredBaseCollection or ParameterCollection
 
-            # Note that we also give a reference to the pDefs to the parameter
-            # collection. This is so that the ParmameterCollection hierarchy can do all
-            # of the parameter definitions work, while plugins can associate definitions
-            # with the ArmiObjects
+            # Note that we also give a reference to the pDefs to the parameter collection. This is so that the
+            # ParmameterCollection hierarchy can do all of the parameter definitions work, while plugins can associate
+            # definitions with the ArmiObjects
             paramCollectionType = type(
                 collectionName,
                 (collectionBase,),
@@ -128,8 +108,8 @@ class ResolveParametersMeta(type):
                 },
             )
         else:
-            # We will not be defining our own parameters, so we will defer to to those
-            # of our parent classes if they have any
+            # We will not be defining our own parameters, so we will defer to to those of our parent classes if they
+            # have any
             paramCollectionType = inferredBaseCollection
 
         attrs["paramCollectionType"] = paramCollectionType

--- a/armi/reactor/parameters/resolveCollections.py
+++ b/armi/reactor/parameters/resolveCollections.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-The magic that makes the Parameter system and ARMI composite model play nicely together.
+Machinery that makes the Parameter system and ARMI composite model play nicely together.
 
 The contained metaclass is useful for maintaining a hierarchy of ``ParameterCollection`` classes, which mimic the
 hierarchy of ``ArmiObject`` s to which they apply. Some ``ArmiObject`` subclasses define their own parameters, while

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -772,19 +772,13 @@ class TestCircle(TestShapedComponent):
         self.assertAlmostEqual(cur, ref)
 
     def test_badComponentName(self):
-        """This shows that resolveLinkedDims cannot support names with periods in them."""
+        """Show that resolveLinkedDims cannot support names with periods in them."""
         nPins = 12
         fuelDims = {"Tinput": 25.0, "Thot": 430.0, "od": 0.9, "id": 0.0, "mult": nPins}
         cladDims = {"Tinput": 25.0, "Thot": 430.0, "od": 1.1, "id": 1.0, "mult": nPins}
         fuel = Circle("fuel", "UZr", **fuelDims)
         clad = Circle("clad_4.2.3", "HT9", **cladDims)
-        gapDims = {
-            "Tinput": 25.0,
-            "Thot": 430.0,
-            "od": "clad_4.2.3.id",
-            "id": "fuel.od",
-            "mult": nPins,
-        }
+        gapDims = {"Tinput": 25.0, "Thot": 430.0, "od": "clad_4.2.3.id", "id": "fuel.od", "mult": nPins}
         gapDims["components"] = {"clad_4.2.3": clad, "fuel": fuel}
         with self.assertRaises(ValueError):
             _gap = Circle("gap", "Void", **gapDims)

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -780,8 +780,8 @@ class TestCompositeTree(unittest.TestCase):
 
     def test_getFuelMass(self):
         """
-        This test creates a dummy assembly and ensures that the assembly, block, and fuel component
-        masses are consistent. `getFuelMass` ensures that the fuel component is used to `getMass`.
+        Create a dummy assembly and ensures that the assembly, block, and fuel component masses are consistent.
+        `getFuelMass` ensures that the fuel component is used to `getMass`.
         """
         cs = settings.Settings()
         assemDesign = assemblyBlueprint.AssemblyBlueprint.load(self.blueprintYaml)

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -72,10 +72,9 @@ class ParameterTests(unittest.TestCase):
 
     def test_writeSomeParamsToDB(self):
         """
-        This tests the ability to specify which parameters should be
-        written to the database. It assumes that the list returned by
-        ParameterDefinitionCollection.toWriteToDB() is used to filter for which
-        parameters to include in the database.
+        Test the ability to specify which parameters should be written to the database. It assumes that the list
+        returned by ParameterDefinitionCollection.toWriteToDB() is used to filter for which parameters to include in the
+        database.
 
         .. test:: Restrict parameters from DB write.
             :id: T_ARMI_PARAM_DB
@@ -102,9 +101,8 @@ class ParameterTests(unittest.TestCase):
 
     def test_serializer_pack_unpack(self):
         """
-        This tests the ability to add a serializer to a parameter instantiation line.
-        It assumes that if this parameter is not None, that the pack and unpack methods
-        will be called during storage to and reading from the database. See
+        Test the ability to add a serializer to a parameter instantiation line. It assumes that if this parameter is not
+        None, that the pack and unpack methods will be called during storage to and reading from the database. See
         database._writeParams for an example use of this functionality.
 
         .. test:: Custom parameter serializer

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -62,7 +62,7 @@ class ReactorTests(unittest.TestCase):
 
 class HexReactorTests(ReactorTests):
     """
-    This is meant to pair with the ``HexReactorReadOnlyTests`` unit test class.
+    Base class meant to pair with the ``HexReactorReadOnlyTests`` unit test class.
 
     The tests in this class all modify the Reactor object, so we need to create a new test reactor for each test.
     """
@@ -114,7 +114,7 @@ class HexReactorTests(ReactorTests):
 
     def test_getSetParameters(self):
         """
-        This test works through multiple levels of the data model hierarchy to test ability to modify parameters.
+        Work through multiple levels of the data model hierarchy to test ability to modify parameters.
 
         .. test:: Parameters are accessible throughout the armi tree.
             :id: T_ARMI_PARAM1
@@ -708,7 +708,7 @@ class HexReactorTests(ReactorTests):
 
 class HexReactorReadOnlyTests(unittest.TestCase):
     """
-    This is meant to pair with the ``HexReactorTests`` unit test class.
+    Testing baseclass meant to pair with the ``HexReactorTests`` unit test class.
 
     The tests in this class only READ, and not WRITE to the Reactor object, so we only have to create one test reactor.
     """
@@ -1075,7 +1075,7 @@ class HexReactorReadOnlyTests(unittest.TestCase):
 
 class HexReactorSoloTests(ReactorTests):
     """
-    This is meant to pair with the ``HexReactorTests`` unit test class.
+    Base class meant to pair with the ``HexReactorTests`` unit test class.
 
     Each test here creates its own, slightly unique, test reactor.
     """
@@ -1096,7 +1096,7 @@ class HexReactorSoloTests(ReactorTests):
 
 class BigHexReactorTests(ReactorTests):
     """
-    This is meant to pair with the ``HexReactorTests`` unit test class.
+    Base class meant to pair with the ``HexReactorTests`` unit test class.
 
     These tests all need a larger test reactor. Ideally, we will migrate these to smaller test reactors one day.
     """

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -708,7 +708,7 @@ class HexReactorTests(ReactorTests):
 
 class HexReactorReadOnlyTests(unittest.TestCase):
     """
-    Testing baseclass meant to pair with the ``HexReactorTests`` unit test class.
+    Testing base class meant to pair with the ``HexReactorTests`` unit test class.
 
     The tests in this class only READ, and not WRITE to the Reactor object, so we only have to create one test reactor.
     """

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -1075,7 +1075,7 @@ class HexReactorReadOnlyTests(unittest.TestCase):
 
 class HexReactorSoloTests(ReactorTests):
     """
-    Base class meant to pair with the ``HexReactorTests`` unit test class.
+    Testing base class meant to pair with the ``HexReactorTests`` unit test class.
 
     Each test here creates its own, slightly unique, test reactor.
     """
@@ -1096,7 +1096,7 @@ class HexReactorSoloTests(ReactorTests):
 
 class BigHexReactorTests(ReactorTests):
     """
-    Base class meant to pair with the ``HexReactorTests`` unit test class.
+    Testing base class meant to pair with the ``HexReactorTests`` unit test class.
 
     These tests all need a larger test reactor. Ideally, we will migrate these to smaller test reactors one day.
     """

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This module handles logging of console during a simulation.
+Handle logging of console during a simulation.
 
 The default way of calling and the global armi logger is to just import it:
 
@@ -69,9 +69,8 @@ class _RunLog:
     """
     Handles all the logging.
 
-    For the parent process, things are allowed to print to stdout and stderr,
-    but the stdout prints are formatted like log statements.
-    For the child processes, everything is piped to log files.
+    For the parent process, things are allowed to print to stdout and stderr, but the stdout prints are formatted like
+    log statements. For the child processes, everything is piped to log files.
     """
 
     STDERR_NAME = "{0}.{1:04d}.stderr"
@@ -84,8 +83,8 @@ class _RunLog:
         Parameters
         ----------
         mpiRank : int
-            If this is zero, we are in the parent process, otherwise child process. This should not
-            be adjusted after instantiation.
+            If this is zero, we are in the parent process, otherwise child process. This should not be adjusted after
+            instantiation.
         """
         self._mpiRank = mpiRank
         self._verbosity = logging.INFO
@@ -110,8 +109,8 @@ class _RunLog:
         Parameters
         ----------
         mpiRank : int
-            If this is zero, we are in the parent process, otherwise child process. This should not
-            be adjusted after instantiation.
+            If this is zero, we are in the parent process, otherwise child process. This should not be adjusted after
+            instantiation.
         """
         rank = "" if mpiRank == 0 else f"-{mpiRank:>03d}"
 
@@ -136,8 +135,8 @@ class _RunLog:
         Parameters
         ----------
         mpiRank : int
-            If this is zero, we are in the parent process, otherwise child process. This should not
-            be adjusted after instantiation.
+            If this is zero, we are in the parent process, otherwise child process. This should not be adjusted after
+            instantiation.
         """
         logLevels = _RunLog.getLogLevels(mpiRank)
         return " " * len(max([ll[1] for ll in logLevels.values()]))
@@ -167,11 +166,11 @@ class _RunLog:
 
     def log(self, msgType, msg, single=False, label=None, **kwargs):
         """
-        This is a wrapper around logger.log() that does most of the work and is used by all message
-        passers (e.g. info, warning, etc.).
+        A wrapper around logger.log() that does most of the work and is used by all message passers (e.g. info, warning,
+        etc.).
 
-        In this situation, we do the mangling needed to get the log level to the correct number.
-        And we do some custom string manipulation so we can handle de-duplicating warnings.
+        In this situation, we do the mangling needed to get the log level to the correct number. And we do some custom
+        string manipulation so we can handle de-duplicating warnings.
         """
         # Determine the log level: users can optionally pass in custom strings ("debug")
         msgLevel = msgType if isinstance(msgType, int) else self.logLevels[msgType][0]
@@ -216,8 +215,7 @@ class _RunLog:
         Parameters
         ----------
         level : int or str
-            The level to set the log output verbosity to.
-            Valid numbers are 0-50 and valid strings are keys of logLevels
+            The level to set the log output verbosity to. Valid numbers are 0-50 and valid strings are keys of logLevels
 
         Examples
         --------
@@ -229,9 +227,9 @@ class _RunLog:
         if isinstance(level, str):
             self._verbosity = self.getLogVerbosityRank(level)
         elif isinstance(level, int):
-            # The logging module does strange things if you set the log level to something other
-            # than DEBUG, INFO, etc. So, if someone tries, we HAVE to set the log level at a
-            # canonical value. Otherwise, nearly all log statements will be silently dropped.
+            # The logging module does strange things if you set the log level to something other than DEBUG, INFO, etc.
+            # So, if someone tries, we HAVE to set the log level at a canonical value. Otherwise, nearly all log
+            # statements will be silently dropped.
             if level in self._logLevelNumbers:
                 self._verbosity = level
             elif level < self._logLevelNumbers[0]:
@@ -286,8 +284,8 @@ class _RunLog:
 
 
 def getLogDir():
-    """This returns a file path for the `logs` directory, first checking if the user set the ARMI_TEMP_ROOT_PATH
-    environment variable.
+    """Return a file path for the `logs` directory, first checking if the user set the ARMI_TEMP_ROOT_PATH environment
+    variable.
     """
     if os.environ.get("ARMI_TEMP_ROOT_PATH"):
         return os.path.join(os.environ["ARMI_TEMP_ROOT_PATH"], "logs")
@@ -325,13 +323,13 @@ def concatenateLogs(logDir=None):
         :id: I_ARMI_LOG_MPI
         :implements: R_ARMI_LOG_MPI
 
-        The log files are plain text files. Since ARMI is frequently run in parallel, the situation
-        arises where each ARMI process generates its own plain text log file. This function combines
-        the separate log files, per process, into one log file.
+        The log files are plain text files. Since ARMI is frequently run in parallel, the situation arises where each
+        ARMI process generates its own plain text log file. This function combines the separate log files, per process,
+        into one log file.
 
-        The files are written in numerical order, with the lead process stdout first then the lead
-        process stderr. Then each other process is written to the combined file, in order, stdout
-        then stderr. Finally, the original stdout and stderr files are deleted.
+        The files are written in numerical order, with the lead process stdout first then the lead process stderr. Then
+        each other process is written to the combined file, in order, stdout then stderr. Finally, the original stdout
+        and stderr files are deleted.
     """
     if logDir is None:
         logDir = getLogDir()
@@ -497,10 +495,10 @@ class RunLogger(logging.Logger):
         :id: I_ARMI_LOG
         :implements: R_ARMI_LOG
 
-        Log statements are any text a user wants to record during a run. For instance, basic
-        notifications of what is happening in the run, simple warnings, or hard errors. Every log
-        message has an associated log level, controlled by the "verbosity" of the logging statement
-        in the code. In the ARMI codebase, you can see many examples of logging:
+        Log statements are any text a user wants to record during a run. For instance, basic notifications of what is
+        happening in the run, simple warnings, or hard errors. Every log message has an associated log level, controlled
+        by the "verbosity" of the logging statement in the code. In the ARMI codebase, you can see many examples of
+        logging:
 
         .. code-block:: python
 
@@ -509,25 +507,24 @@ class RunLogger(logging.Logger):
             runLog.info("This is the usual verbosity.")
             runLog.debug("This is only logged during a debug run.")
 
-        The full list of logging levels is defined in ``_RunLog.getLogLevels()``, and the developer
-        specifies the verbosity of a run via ``_RunLog.setVerbosity()``.
+        The full list of logging levels is defined in ``_RunLog.getLogLevels()``, and the developer specifies the
+        verbosity of a run via ``_RunLog.setVerbosity()``.
 
-        At the end of the ARMI-based simulation, the analyst will have a full record of potentially
-        interesting information they can use to understand their run.
+        At the end of the ARMI-based simulation, the analyst will have a full record of potentially interesting
+        information they can use to understand their run.
 
     .. impl:: Logging is done to the screen and to file.
         :id: I_ARMI_LOG_IO
         :implements: R_ARMI_LOG_IO
 
-        This logger makes it easy for users to add log statements to and ARMI application, and ARMI
-        will control the flow of those log statements. In particular, ARMI overrides the normal
-        Python logging tooling, to allow developers to pipe their log statements to both screen and
-        file. This works for stdout and stderr.
+        This logger makes it easy for users to add log statements to and ARMI application, and ARMI will control the
+        flow of those log statements. In particular, ARMI overrides the normal Python logging tooling, to allow
+        developers to pipe their log statements to both screen and file. This works for stdout and stderr.
 
-        At any place in the ARMI application, developers can interject a plain text logging message,
-        and when that code is hit during an ARMI simulation, the text will be piped to screen and a
-        log file. By default, the ``logging`` module only logs to screen, but ARMI adds a
-        ``FileHandler`` in the ``RunLog`` constructor and in ``_RunLog.startLog``.
+        At any place in the ARMI application, developers can interject a plain text logging message, and when that code
+        is hit during an ARMI simulation, the text will be piped to screen and a log file. By default, the ``logging``
+        module only logs to screen, but ARMI adds a ``FileHandler`` in the ``RunLog`` constructor and in
+        ``_RunLog.startLog``.
     """
 
     FMT = "%(levelname)s%(message)s"
@@ -563,11 +560,11 @@ class RunLogger(logging.Logger):
 
     def log(self, msgType, msg, single=False, label=None, *args, **kwargs):
         """
-        This is a wrapper around logger.log() that does most of the work.
+        A wrapper around logger.log() that does most of the work.
 
-        This is used by all message passers (e.g. info, warning, etc.). In this situation, we do the
-        mangling needed to get the log level to the correct number. And we do some custom string
-        manipulation so we can handle de-duplicating warnings.
+        This is used by all message passers (e.g. info, warning, etc.). In this situation, we do the mangling needed to
+        get the log level to the correct number. And we do some custom string manipulation so we can handle
+        de-duplicating warnings.
         """
         # Determine the log level: users can optionally pass in custom strings ("debug")
         msgLevel = msgType if isinstance(msgType, int) else LOG.logLevels[msgType][0]
@@ -583,8 +580,8 @@ class RunLogger(logging.Logger):
 
         Notes
         -----
-        All of the ``*args`` and ``**kwargs`` logic here are mandatory, as the standard library
-        implementation of this method changed the number of kwargs between Python v3.4 and v3.9.
+        All of the ``*args`` and ``**kwargs`` logic here are mandatory, as the standard library implementation of this
+        method changed the number of kwargs between Python v3.4 and v3.9.
         """
         # we need 'extra' as an output keyword, even if empty
         if "extra" not in kwargs:
@@ -623,7 +620,7 @@ class RunLogger(logging.Logger):
         del self
 
     def getDuplicatesFilter(self):
-        """This object should have a no-duplicates filter. If it exists, find it."""
+        """The RunLogger object should have a no-duplicates filter. If it exists, find it."""
         for f in self.filters:
             if isinstance(f, DeduplicationFilter):
                 return f
@@ -659,7 +656,7 @@ class RunLogger(logging.Logger):
 
 
 class NullLogger(RunLogger):
-    """This is really just a placeholder for logging before or after the span of a normal armi run.
+    """A placeholder for logging before or after the span of a normal armi run.
 
     It will forward all logging to stdout/stderr, as you'd normally expect.
     But it will preserve the formatting and duplication tools of the armi library.

--- a/armi/settings/caseSettings.py
+++ b/armi/settings/caseSettings.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 """
-This defines a Settings object that acts mostly like a dictionary. It
-is meant so that each ARMI run has one-and-only-one Settings object. It records
-user settings like the core power level, the input file names, the number of cycles to
-run, the run type, the environment setup, and hundreds of other things.
+A Settings object that acts mostly like a dictionary. It is meant so that each ARMI run has one-and-only-one Settings
+object. It records user settings like the core power level, the input file names, the number of cycles to run, the run
+type, the environment setup, and hundreds of other things.
 
-A Settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to
-create this settings file, which is then loaded by an ARMI process on the cluster.
+A Settings object can be saved as or loaded from an YAML file. The ARMI GUI is designed to create this settings file,
+which is then loaded by an ARMI process on the cluster.
 """
 
 import io
@@ -53,19 +52,17 @@ class Settings:
         :id: I_ARMI_SETTING0
         :implements: R_ARMI_SETTING
 
-        The Settings object is accessible to most ARMI objects through self.cs
-        (for 'case settings'). It acts largely as a dictionary, and setting values
-        are accessed by keys.
+        The Settings object is accessible to most ARMI objects through self.cs (for 'case settings'). It acts largely as
+        a dictionary, and setting values are accessed by keys.
 
-        The Settings object has a 1-to-1 correspondence with the ARMI settings
-        input file. This file may be created by hand or by a GUI.
+        The Settings object has a 1-to-1 correspondence with the ARMI settings input file. This file may be created by
+        hand or by a GUI.
 
     Notes
     -----
-    While it is possible to modify case settings during the course of a run, this
-    is highly discouraged because there will be no record of this happening in your
-    results or in the database produced from your run. There is no guarantee that
-    doing so will not cause unexpected problems with your calculation.
+    While it is possible to modify case settings during the course of a run, this is highly discouraged because there
+    will be no record of this happening in your results or in the database produced from your run. There is no guarantee
+    that doing so will not cause unexpected problems with your calculation.
     """
 
     defaultCaseTitle = "armi"
@@ -85,11 +82,10 @@ class Settings:
         self._failOnLoad = False
         """This is state information.
 
-        The command line can take settings, which override a value in the current
-        settings file; however, if the settings file is listed after a setting value,
-        the setting from the settings file will be used rather than the one explicitly
-        provided by the user on the command line.  Therefore, _failOnLoad is used to
-        prevent this from happening.
+        The command line can take settings, which override a value in the current settings file; however, if the
+        settings file is listed after a setting value, the setting from the settings file will be used rather than the
+        one explicitly provided by the user on the command line.  Therefore, _failOnLoad is used to prevent this from
+        happening.
         """
         from armi import getApp
 
@@ -118,14 +114,11 @@ class Settings:
             :id: I_ARMI_SETTINGS_META0
             :implements: R_ARMI_SETTINGS_META
 
-            Every Settings object has a "case title"; a string for users to
-            help identify their run. This case title is used in log file
-            names, it is printed during a run, it is frequently used to
-            name the settings file. It is designed to be an easy-to-use
-            and easy-to-understand way to keep track of simulations. The
-            general idea here is that the average analyst that is using
-            ARMI will run many ARMI-based simulations, and there needs
-            to be an easy to identify them all.
+            Every Settings object has a "case title"; a string for users to help identify their run. This case title is
+            used in log file names, it is printed during a run, it is frequently used to name the settings file. It is
+            designed to be an easy-to-use and easy-to-understand way to keep track of simulations. The general idea here
+            is that the average analyst that is using ARMI will run many ARMI-based simulations, and there needs to be
+            an easy to identify them all.
         """
         if not self.path:
             return self.defaultCaseTitle
@@ -150,7 +143,7 @@ class Settings:
         isAltered = lambda s: 1 if s.value != s.default else 0
         altered = sum([isAltered(setting) for setting in self.__settings.values()])
 
-        return "<{} name:{} total:{} altered:{}>".format(self.__class__.__name__, self.caseTitle, total, altered)
+        return f"<{self.__class__.__name__} name:{self.caseTitle} total:{total} altered:{altered}>"
 
     def _directAccessOfSettingAllowed(self, key):
         """
@@ -160,20 +153,19 @@ class Settings:
 
         Notes
         -----
-        Checking the validity of grabbing specific settings at this point, as is done for the
-        SIMPLE_CYCLES_INPUT's, feels a bit intrusive and out of place. In particular, the fact that
-        the check is done every time that a setting is reached for, no matter if it is the setting
-        in question, is quite clunky. In the future, it would be desirable if the settings system
-        were more flexible to control this type of thing at a deeper level.
+        Checking the validity of grabbing specific settings at this point, as is done for the SIMPLE_CYCLES_INPUT's,
+        feels a bit intrusive and out of place. In particular, the fact that the check is done every time that a setting
+        is reached for, no matter if it is the setting in question, is quite clunky. In the future, it would be
+        desirable if the settings system were more flexible to control this type of thing at a deeper level.
         """
         if key not in self.__settings:
             return False, NonexistentSetting(key)
 
         if key in SIMPLE_CYCLES_INPUTS and self.__settings["cycles"].value != []:
             err = ValueError(
-                "Cannot grab simple cycles information from the case settings when detailed cycles "
-                "information is also entered. In general cycles information should be pulled off "
-                "the operator or parsed using the appropriate getter in the utils."
+                "Cannot grab simple cycles information from the case settings when detailed cycles information is also "
+                "entered. In general cycles information should be pulled off the operator or parsed using the "
+                "appropriate getter in the utils."
             )
 
             return False, err
@@ -204,6 +196,8 @@ class Settings:
 
     def __setitem__(self, key, val):
         """
+        Dictionary setter.
+
         Notes
         -----
         This potentially allows for invisible settings mutations.
@@ -217,8 +211,7 @@ class Settings:
         """
         Rebuild schema upon unpickling since schema is unpickleable.
 
-        Pickling happens during mpi broadcasts and also during testing where the test reactor is
-        cached.
+        Pickling happens during mpi broadcasts and also during testing where the test reactor is cached.
 
         See Also
         --------
@@ -255,8 +248,8 @@ class Settings:
         """Return a duplicate copy of this settings object."""
         cs = deepcopy(self)
         cs._failOnLoad = False
-        # It's not really protected access since it is a new Settings object. _failOnLoad is set to
-        # false, because this new settings object should be independent of the command line
+        # It's not really protected access since it is a new Settings object. _failOnLoad is set to false, because this
+        # new settings object should be independent of the command line
         return cs
 
     def revertToDefaults(self):
@@ -265,10 +258,10 @@ class Settings:
             setting.revertToDefault()
 
     def failOnLoad(self):
-        """This method is used to force loading a file to fail.
+        """Force loading a file to fail.
 
-        After command line processing of settings has begun, the settings should be fully defined.
-        If the settings are loaded
+        After command line processing of settings has begun, the settings should be fully defined. If the settings are
+        loaded
         """
         self._failOnLoad = True
 
@@ -276,8 +269,8 @@ class Settings:
         """
         Read in settings from an input YAML file.
 
-        Passes the reader back out in case you want to know something about how the reading went
-        like for knowing if a file contained deprecated settings, etc.
+        Passes the reader back out in case you want to know something about how the reading went like for knowing if a
+        file contained deprecated settings, etc.
         """
         reader, path = self._prepToRead(fName)
         reader.readFromFile(fName, handleInvalids)
@@ -298,9 +291,9 @@ class Settings:
     def _prepToRead(self, fName):
         if self._failOnLoad:
             raise RuntimeError(
-                "Cannot load settings file after processing of command line options begins.\nYou "
-                "may be able to fix this by reordering the command line arguments, and making sure "
-                f"the settings file `{fName}` comes before any modified settings."
+                "Cannot load settings file after processing of command line options begins.\nYou may be able to fix "
+                f"this by reordering the command line arguments, and making sure the settings file `{fName}` comes "
+                "before any modified settings."
             )
         path = pathTools.armiAbsPath(fName)
         return settingsIO.SettingsReader(self), path
@@ -308,13 +301,13 @@ class Settings:
     def loadFromString(self, string, handleInvalids=True):
         """Read in settings from a YAML string.
 
-        Passes the reader back out in case you want to know something about how the reading went
-        like for knowing if a file contained deprecated settings, etc.
+        Passes the reader back out in case you want to know something about how the reading went like for knowing if a
+        file contained deprecated settings, etc.
         """
         if self._failOnLoad:
             raise RuntimeError(
-                "Cannot load settings after processing of command line options begins.\nYou may be "
-                "able to fix this by reordering the command line arguments."
+                "Cannot load settings after processing of command line options begins.\nYou may be able to fix this by "
+                "reordering the command line arguments."
             )
 
         reader = settingsIO.SettingsReader(self)
@@ -336,8 +329,7 @@ class Settings:
 
         Notes
         -----
-        This means that creating a Settings object sets the global logging level of the entire code
-        base.
+        This means that creating a Settings object sets the global logging level of the entire code base.
         """
         if context.MPI_RANK == 0:
             runLog.setVerbosity(self["verbosity"])
@@ -378,8 +370,8 @@ class Settings:
 
     def getSettingsSetByUser(self, fPath):
         """
-        Grabs the list of settings in the user-defined input file so that the settings can be
-        tracked outside of a Settings object.
+        Grabs the list of settings in the user-defined input file so that the settings can be tracked outside of a
+        Settings object.
 
         Parameters
         ----------
@@ -391,8 +383,8 @@ class Settings:
         userSettingsNames : list
             The settings names read in from a yaml settings file
         """
-        # We do not want to load these as settings, but just grab the dictionary straight from the
-        # settings file to know which settings are user-defined.
+        # We do not want to load these as settings, but just grab the dictionary straight from the settings file to know
+        # which settings are user-defined.
         with open(fPath, "r") as stream:
             yaml = YAML()
             yaml.allow_duplicate_keys = False
@@ -424,8 +416,7 @@ class Settings:
         return writer
 
     def updateEnvironmentSettingsFrom(self, otherCs):
-        """Updates the environment settings in this object based on some other cs (from the GUI,
-        most likely).
+        """Updates the environment settings in this object based on some other CS object.
 
         Parameters
         ----------
@@ -456,8 +447,8 @@ class Settings:
         return settings
 
     def setModuleVerbosities(self, force=False):
-        """Attempt to grab the module-level logger verbosities from the settings file,
-        and then set their log levels (verbosities).
+        """Attempt to grab the module-level logger verbosities from the settings file, and then set their log levels
+        (verbosities).
 
         Parameters
         ----------

--- a/armi/settings/fwSettings/__init__.py
+++ b/armi/settings/fwSettings/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This package contains the settings that control the base/framework-level ARMI functionality."""
+"""Settings that control the base/framework-level ARMI functionality."""
 
 from typing import List
 
@@ -22,10 +22,7 @@ from armi.settings.fwSettings import databaseSettings, globalSettings, reportSet
 
 def getFrameworkSettings() -> List[setting.Setting]:
     settings = []
-    for mod in (
-        globalSettings,
-        databaseSettings,
-        reportSettings,
-    ):
+    for mod in (globalSettings, databaseSettings, reportSettings):
         settings.extend(mod.defineSettings())
+
     return settings

--- a/armi/settings/settingsIO.py
+++ b/armi/settings/settingsIO.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This module contains classes and methods for reading and writing
-:py:class:`~armi.settings.caseSettings.Settings`, and the contained
+"""Classes and methods for reading and writing :py:class:`~armi.settings.caseSettings.Settings`, and the contained
 :py:class:`~armi.settings.setting.Setting`.
 """
 
@@ -29,11 +28,7 @@ from ruamel.yaml import YAML
 from armi import context, runLog
 from armi.meta import __version__ as version
 from armi.settings.setting import Setting
-from armi.utils.customExceptions import (
-    InvalidSettingsFileError,
-    InvalidSettingsStopProcess,
-    SettingException,
-)
+from armi.utils.customExceptions import InvalidSettingsFileError, InvalidSettingsStopProcess, SettingException
 
 # Constants defining valid output styles
 WRITE_SHORT = "short"
@@ -52,10 +47,9 @@ class SettingRenamer:
     """
     Utility class to help with setting rename migrations.
 
-    This class stores a cache of renaming maps, derived from the ``Setting.oldNames`` values of the
-    passed ``settings``. Expired renames are retained, so that meaningful warning messages can be
-    generated if one attempts to use one of them. The renaming logic follows the rules described in
-    :py:meth:`renameSetting`.
+    This class stores a cache of renaming maps, derived from the ``Setting.oldNames`` values of the passed ``settings``.
+    Expired renames are retained, so that meaningful warning messages can be generated if one attempts to use one of
+    them. The renaming logic follows the rules described in :py:meth:`renameSetting`.
     """
 
     def __init__(self, settings: Dict[str, Setting]):
@@ -124,9 +118,8 @@ class SettingsReader:
         :id: I_ARMI_SETTINGS_IO_TXT
         :implements: R_ARMI_SETTINGS_IO_TXT
 
-        ARMI uses the YAML standard for settings files. ARMI uses industry-standard ``ruamel.yaml``
-        Python library to read these files. ARMI does not bend or change the YAML file format
-        standard in any way.
+        ARMI uses the YAML standard for settings files. ARMI uses industry-standard ``ruamel.yaml`` Python library to
+        read these files. ARMI does not bend or change the YAML file format standard in any way.
 
     Parameters
     ----------
@@ -141,8 +134,8 @@ class SettingsReader:
         self.settingsAlreadyRead = set()
         self._renamer = SettingRenamer(dict(self.cs.items()))
 
-        # The input version will be overwritten if explicitly stated in input file. Otherwise, it's
-        # assumed to precede the version inclusion change and should be treated as alright.
+        # The input version will be overwritten if explicitly stated in input file. Otherwise, it's assumed to precede
+        # the version inclusion change and should be treated as alright.
         self.inputVersion = version
         self.liveVersion = version
 
@@ -385,8 +378,8 @@ class RunLogPromptCancel(Exception):
 
 class RunLogPromptUnresolvable(Exception):
     """
-    An error that occurs when the current mode enum in armi.__init__ suggests the user cannot be
-    communicated with from the current process.
+    An error that occurs when the current mode enum in armi.__init__ suggests the user cannot be communicated with from
+    the current process.
     """
 
     pass

--- a/armi/settings/settingsValidation.py
+++ b/armi/settings/settingsValidation.py
@@ -130,7 +130,7 @@ class Query:
 
 class Inspector:
     """
-    This manages queries which assert certain states of the data model, generally presenting themselves to the user,
+    Manages queries which assert certain states of the data model, generally presenting themselves to the user,
     offering information on the potential problem, a question and the action to take on an affirmative and negative
     answer from the user.
 
@@ -185,9 +185,9 @@ class Inspector:
         # the following attribute changes will alter what the queries investigate when resolved
         correctionsMade = False
         self.cs = cs or self.cs
-        runLog.debug("{} executing queries.".format(self.__class__.__name__))
+        runLog.debug(f"{self.__class__.__name__} executing queries.")
         if not any(self.queries):
-            runLog.debug("{} found no problems with the current state.".format(self.__class__.__name__))
+            runLog.debug(f"{self.__class__.__name__} found no problems with the current state.")
         else:
             for query in self.queries:
                 query.resolve()
@@ -197,10 +197,9 @@ class Inspector:
             if any(issues):
                 # something isn't resolved or was unresolved by changes
                 raise RuntimeError(
-                    "The input inspection did not resolve all queries, "
-                    "some issues are creating cyclic resolutions: {}".format(issues)
+                    f"The input inspection did not resolve all queries, some are creating cyclic resolutions: {issues}"
                 )
-            runLog.debug("{} has finished querying.".format(self.__class__.__name__))
+            runLog.debug(f"{self.__class__.__name__} has finished querying.")
 
         if correctionsMade:
             # find unused file path to store original settings as to avoid overwrite
@@ -223,7 +222,7 @@ class Inspector:
     def addQuery(self, condition, statement, question, correction):
         """Convenience method, query must be resolved, else run fails."""
         if not callable(correction):
-            raise ValueError('Query for "{}" malformed. Expecting callable.'.format(statement))
+            raise ValueError(f'Query for "{statement}" malformed. Expecting callable.')
         self.queries.append(Query(condition, statement, question, correction))
 
     def addQueryBadLocationWillLikelyFail(self, settingName):
@@ -277,7 +276,7 @@ class Inspector:
 
         self.addQuery(
             lambda: not self._csRelativePathExists(self.cs[CONF_LOADING_FILE]),
-            "Blueprints file {} not found. Run will fail.".format(self.cs[CONF_LOADING_FILE]),
+            f"Blueprints file {self.cs[CONF_LOADING_FILE]} not found. Run will fail.",
             "",
             self.NO_ACTION,
         )
@@ -374,8 +373,7 @@ class Inspector:
             "Starting from cycle 0, and time node 0 was chosen. Restart runs load from "
             "the time node just before the restart. There is no time node to load from "
             "before cycle 0 node 0. Either switch to the snapshot operator, start from "
-            "a different time step or load from inputs rather than database as "
-            "`loadStyle`.",
+            "a different time step or load from inputs rather than database as `loadStyle`.",
             "",
             self.NO_ACTION,
         )

--- a/armi/testing/mockRunLogs.py
+++ b/armi/testing/mockRunLogs.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This module contains subclasses of the armi.runLog._RunLog class that can be used to determine
-whether or not one of the specific methods were called. These should only be used in testing.
+Subclasses of the armi.runLog._RunLog class that can be used to determine whether or not one of the specific methods
+were called. These should only be used in testing.
 """
 
 import io
@@ -26,8 +26,7 @@ from armi import runLog
 class BufferLog(runLog._RunLog):
     """Log which captures the output in attributes instead of emitting them.
 
-    Used mostly in testing to ensure certain things get output, or to prevent any output from
-    showing.
+    Used mostly in testing to ensure certain things get output, or to prevent any output from showing.
     """
 
     def __init__(self, *args, **kwargs):
@@ -51,8 +50,8 @@ class BufferLog(runLog._RunLog):
         """
         Add formatting to a message and handle its singleness, if applicable.
 
-        This is a wrapper around logger.log() that does most of the work and is
-        used by all message passers (e.g. info, warning, etc.).
+        This is a wrapper around logger.log() that does most of the work and is used by all message passers (e.g. info,
+        warning, etc.).
         """
         # the message label is only used to determine unique for single-print warnings
         if label is None:
@@ -89,7 +88,7 @@ class BufferLog(runLog._RunLog):
 
 
 class LogCounter(BufferLog):
-    """This mock log is used to count the number of times a method was called.
+    """A mock log is used to count the number of times a method was called.
 
     It can be used in testing to make sure a warning was issued, without checking the content of the message.
     """

--- a/armi/tests/test_apps.py
+++ b/armi/tests/test_apps.py
@@ -31,7 +31,7 @@ from armi.reactor.flags import Flags
 
 
 class TestPlugin1(plugins.ArmiPlugin):
-    """This should be fine on its own."""
+    """A working solo test."""
 
     @staticmethod
     @plugins.HOOKIMPL
@@ -40,7 +40,7 @@ class TestPlugin1(plugins.ArmiPlugin):
 
 
 class TestPlugin2(plugins.ArmiPlugin):
-    """This should lead to an error if it coexists with Plugin1."""
+    """Coexists with Plugin1, and leads to an error."""
 
     @staticmethod
     @plugins.HOOKIMPL
@@ -49,7 +49,7 @@ class TestPlugin2(plugins.ArmiPlugin):
 
 
 class TestPlugin3(plugins.ArmiPlugin):
-    """This should lead to errors, since it collides with the framework `type` param."""
+    """Leads to errors, since it collides with the framework `type` param."""
 
     @staticmethod
     @plugins.HOOKIMPL
@@ -58,7 +58,7 @@ class TestPlugin3(plugins.ArmiPlugin):
 
 
 class TestPlugin4(plugins.ArmiPlugin):
-    """This should be fine on its own, and safe to merge with TestPlugin1."""
+    """Works on its own, and safe to merge with TestPlugin1."""
 
     @staticmethod
     @plugins.HOOKIMPL

--- a/armi/tests/test_plugins.py
+++ b/armi/tests/test_plugins.py
@@ -270,7 +270,7 @@ class TestPluginBasics(unittest.TestCase):
 
 
 class TestPlugin(unittest.TestCase):
-    """This contains some sanity tests that can be used by implementing plugins."""
+    """Some sanity tests that can be used by implementing plugins."""
 
     plugin: Optional[plugins.ArmiPlugin] = None
 

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -105,7 +105,7 @@ class UserPluginOnProcessCoreLoading(plugins.UserPlugin):
 
 class UpInterface(interfaces.Interface):
     """
-    A mostly meaningless little test interface, just to prove that we can affect the reactor state from an interface
+    Simple test interface to prove that we can affect the reactor state from an interface
     inside a UserPlugin.
     """
 

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -69,7 +69,7 @@ class UserPluginFlags4(plugins.UserPlugin):
 
 
 class UserPluginBadDefinesSettings(plugins.UserPlugin):
-    """This is invalid/bad because it implements defineSettings()."""
+    """Invalid/bad because it implements defineSettings()."""
 
     @staticmethod
     @plugins.HOOKIMPL
@@ -79,7 +79,7 @@ class UserPluginBadDefinesSettings(plugins.UserPlugin):
 
 
 class UserPluginBadDefineParameterRenames(plugins.UserPlugin):
-    """This is invalid/bad because it implements defineParameterRenames()."""
+    """Invalid/bad because it implements defineParameterRenames()."""
 
     @staticmethod
     @plugins.HOOKIMPL
@@ -90,9 +90,8 @@ class UserPluginBadDefineParameterRenames(plugins.UserPlugin):
 
 class UserPluginOnProcessCoreLoading(plugins.UserPlugin):
     """
-    This plugin flex-tests the onProcessCoreLoading() hook,
-    and arbitrarily adds "1" to the height of every block,
-    after the DB is loaded.
+    Flex-test the onProcessCoreLoading() hook, and arbitrarily adds "1" to the height of every block, after the DB is
+    loaded.
     """
 
     @staticmethod
@@ -106,8 +105,8 @@ class UserPluginOnProcessCoreLoading(plugins.UserPlugin):
 
 class UpInterface(interfaces.Interface):
     """
-    A mostly meaningless little test interface, just to prove that we can affect
-    the reactor state from an interface inside a UserPlugin.
+    A mostly meaningless little test interface, just to prove that we can affect the reactor state from an interface
+    inside a UserPlugin.
     """
 
     name = "UpInterface"
@@ -130,8 +129,8 @@ class UserPluginWithInterface(plugins.UserPlugin):
 class TestUserPlugins(unittest.TestCase):
     def setUp(self):
         """
-        Manipulate the standard App. We can't just configure our own, since the
-        pytest environment bleeds between tests.
+        Manipulate the standard App. We can not just configure our own, since the pytest environment bleeds between
+        tests.
         """
         self._backupApp = copy.deepcopy(getApp())
 

--- a/armi/utils/parsing.py
+++ b/armi/utils/parsing.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This file contains tools for common tasks in parsing in python strings into non-string values."""
+"""Tools for common tasks in parsing in python strings into non-string values."""
 
 import ast
 import copy
@@ -27,14 +27,13 @@ def tryLiteralEval(source):
     return source
 
 
-# the following dict helps avoid the need for an eval() statement
-# Is there no better way to go 'bool' -> bool !?
+# The following dict helps avoid the need for an eval() statement. Is there no better way to go 'bool' -> bool !?
 _str_types = {tp.__name__: tp for tp in (type(None), bool, int, complex, float, str, bytes, list, tuple, dict)}
 _type_strs = {v: k for k, v in _str_types.items()}
 
 
-# python's matching truth evaluations of Nones in different primitive types
-# str's and unicodes omitted because parseValue denies their use.
+# python's matching truth evaluations of Nones in different primitive types str's and unicodes omitted because
+# parseValue denies their use.
 _none_types = {
     type(None): None,
     bool: False,

--- a/armi/utils/pathTools.py
+++ b/armi/utils/pathTools.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This module contains commonly used functions relating to directories, files and path
-manipulations.
-"""
+"""Commonly used functions relating to directories, files and path manipulations."""
 
 import importlib
 import os

--- a/armi/utils/plotting.py
+++ b/armi/utils/plotting.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 """
+Generic plottting tools, used throughout ARMI.
+
 This module makes heavy use of matplotlib. Beware that plots generated with matplotlib may not free their memory, even
 after the plot is closed, and excessive use of plotting functions may gobble up all of your machine's memory.
 

--- a/armi/utils/properties.py
+++ b/armi/utils/properties.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This module contains methods for adding properties with custom behaviors to classes."""
+"""Methods for adding properties with custom behaviors to classes."""
 
 import numpy as np
 
@@ -32,11 +32,13 @@ def numpyHackForEqual(val1, val2):
             return False
 
     notEqual = val1 != val2
-    try:  # should work for everything but numpy arrays
+    try:
+        # should work for everything but numpy arrays
         if isinstance(notEqual, np.ndarray) and notEqual.size == 0:
             return True
         return not notEqual.__bool__()
-    except (AttributeError, ValueError):  # from comparing 2 numpy arrays
+    except (AttributeError, ValueError):
+        # from comparing 2 numpy arrays
         return not notEqual.any()
 
 

--- a/armi/utils/textProcessors.py
+++ b/armi/utils/textProcessors.py
@@ -66,10 +66,10 @@ def _processIncludes(
     currentFile="<stream>",
 ):
     """
-    This is the workhorse of ``resolveMarkupInclusions`` and friends.
-
     Recursively inserts the contents of !included YAML files into the output stream,
     keeping track of indentation and a list of included files along the way.
+
+    This is the workhorse of ``resolveMarkupInclusions`` and friends.
     """
 
     def _beginningOfContent(line: str) -> int:

--- a/doc/.static/dochelpers.py
+++ b/doc/.static/dochelpers.py
@@ -36,12 +36,7 @@ def escapeSpecialCharacters(s):
 
 
 def createTable(rst_table, caption=None, label=None, align=None, widths=None, width=None):
-    """
-    This method is available within ``.. exec::``. It allows someone to create a table with a
-    caption.
-
-    The ``rst_table``
-    """
+    """Adds ability to add ``rst_table`` table within ``.. exec::``."""
     rst = [".. table:: {}".format(caption or "")]
     if label:
         rst += ["    :name: {}".format(label)]

--- a/doc/__init__.py
+++ b/doc/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""This is the documentation package: not part of the codebase."""
+"""Only a documentation package: not part of the codebase."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,6 @@ select = ["D", "E", "F", "I", "N801", "SIM", "TID"]
 # D103 - Missing docstring in public function
 # D106 - Missing docstring in public nested class
 # D401 - First line of docstring should be in imperative mood
-# D404 - First word of the docstring should not be "This"
 # SIM102 - Use a single if statement instead of nested if statements
 # SIM105 - Use contextlib.suppress({exception}) instead of try-except-pass
 # SIM108 - Use ternary operator {contents} instead of if-else-block
@@ -199,7 +198,7 @@ select = ["D", "E", "F", "I", "N801", "SIM", "TID"]
 # RUF100 - no unused noqa statements (not consistent enough yet)
 # SIM118 - this does not work where we overload the .keys() method
 #
-ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "D404", "E731", "RUF100", "SIM102", "SIM105", "SIM108", "SIM114", "SIM115", "SIM117", "SIM118"]
+ignore = ["D100", "D101", "D102", "D103", "D105", "D106", "D205", "D401", "E731", "RUF100", "SIM102", "SIM105", "SIM108", "SIM114", "SIM115", "SIM117", "SIM118"]
 
 [tool.ruff.lint.per-file-ignores]
 # D1XX - enforces writing docstrings


### PR DESCRIPTION
## What is the change? Why is it being made?

Here I reinstate the `ruff` rule `D404` that says people can't start every docstring with the word "This". We have done this in other repos and meant to do it here.

I actually did this work months ago, but did not want to cause merge conflicts with all the stuff happening in my big materials PRs. So I pushed it off until now.

I also fixed some docstrings that were near the "This" words that had spelling, language, or line-length problems. Sorry for the extra diff.

close #2368


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: To keep docstring language tight, it is best to not start every description with the word This.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
