### PR TITLE
Making `_geomOptions` `None` by default

### DIFF
--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -74,7 +74,7 @@ class BlockBlueprint(yamlize.KeyedList):
     gridName = yamlize.Attribute(key="grid name", type=str, default=None)
     flags = yamlize.Attribute(type=str, default=None)
     axialExpTargetComponent = yamlize.Attribute(key="axial expansion target component", type=str, default=None)
-    _geomOptions = _configureGeomOptions()
+    _geomOptions = None
 
     def _getBlockClass(self, outerComponent):
         """
@@ -85,6 +85,9 @@ class BlockBlueprint(yamlize.KeyedList):
         outerComponent : Component
             Largest component in block.
         """
+        if BlockBlueprint._geomOptions is None:
+            BlockBlueprint._configureGeomOptions()
+
         for compCls, blockCls in self._geomOptions.items():
             if isinstance(outerComponent, compCls):
                 return blockCls

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -85,8 +85,8 @@ class BlockBlueprint(yamlize.KeyedList):
         outerComponent : Component
             Largest component in block.
         """
-        if BlockBlueprint._geomOptions is None:
-            BlockBlueprint._configureGeomOptions()
+        if self._geomOptions is None:
+            self._configureGeomOptions()
 
         for compCls, blockCls in self._geomOptions.items():
             if isinstance(outerComponent, compCls):

--- a/armi/reactor/blueprints/blockBlueprint.py
+++ b/armi/reactor/blueprints/blockBlueprint.py
@@ -85,8 +85,8 @@ class BlockBlueprint(yamlize.KeyedList):
         outerComponent : Component
             Largest component in block.
         """
-        if self._geomOptions is None:
-            self._configureGeomOptions()
+        if BlockBlueprint._geomOptions is None:
+            BlockBlueprint._geomOptions = _configureGeomOptions()
 
         for compCls, blockCls in self._geomOptions.items():
             if isinstance(outerComponent, compCls):


### PR DESCRIPTION
## What is the change? Why is it being made?

@john-science discovered some pathological behavior in #2596 where importing `singleMixedAssembly` in `armi/testing/__init__.py` (now called `singleAssemblies.py` in that PR) causes the `BlockBlueprint` class to be initialized _before_ an ARMI `App` class is instantiated. The specific issue is that the class variable `_geomOptions` gets called but requires an ARMI `App` to be instantiated.

To avoid this, we force `_geomOptions` to be `None` by default and only instantiate it when `getBlockClass()` is called for the first time.

## SCR Information

Change Type: trivial

One-Sentence Rationale: ARMI should be resilient and unit testable everywhere without relying on statefulness if possible.

One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
