### PR TITLE
Moving downstream-imported `test_blocks` machinery to `armi.testing`

### DIFF
--- a/armi/bookkeeping/db/tests/test_database.py
+++ b/armi/bookkeeping/db/tests/test_database.py
@@ -33,12 +33,11 @@ from armi.reactor.excoreStructure import ExcoreCollection, ExcoreStructure
 from armi.reactor.grids import CoordinateLocation, MultiIndexLocation
 from armi.reactor.reactors import Core, Reactor
 from armi.reactor.spentFuelPool import SpentFuelPool
-from armi.reactor.tests.test_blocks import loadTestBlock
 from armi.settings.fwSettings.globalSettings import (
     CONF_GROW_TO_FULL_CORE_AFTER_LOAD,
     CONF_SORT_REACTOR,
 )
-from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
+from armi.testing import TESTING_ROOT, buildComplexHexBlock, loadTestReactor, mockRunLogs
 from armi.utils import getPreviousTimeNode, safeCopy
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
@@ -989,7 +988,7 @@ class TestSimplestDatabaseItems(unittest.TestCase):
 
 class TestStaticDatabaseItems(unittest.TestCase):
     def test_applyComponentNumberDensitiesMigration(self):
-        b = loadTestBlock()
+        b = buildComplexHexBlock()
         comps = [b[0], b[1]]
         unpacked = [
             {"U235": 1.23e-3, "U238": 2.34e-3},

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -40,8 +40,7 @@ from armi.bookkeeping.report.reportingUtils import (
     writeWelcomeHeaders,
 )
 from armi.context import PLATFORM, Platform
-from armi.reactor.tests.test_assemblies import makeTestAssembly
-from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
+from armi.testing import TESTING_ROOT, buildEmptyHexAssembly, loadTestReactor, mockRunLogs
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 SMALLEST_DIR = os.path.join(TESTING_ROOT, "reactors", "smallestTestReactor")
@@ -334,7 +333,7 @@ class TestReportInterface(unittest.TestCase):
             reportInterface.ReportInterface.reportSFP(sfp)
             self.assertEqual(len(mock.getStdout()), 0)
 
-        a = makeTestAssembly(1, 1, r=r)
+        a = buildEmptyHexAssembly(1, 1, r=r)
         sfp.add(a)
 
         with mockRunLogs.BufferLog() as mock:

--- a/armi/physics/fuelPerformance/tests/test_fuelPerformanceUtils.py
+++ b/armi/physics/fuelPerformance/tests/test_fuelPerformanceUtils.py
@@ -17,13 +17,13 @@ import unittest
 
 from armi.physics.fuelPerformance import utils
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_blocks
+from armi.testing import buildComplexHexBlock
 
 
 class TestFuelPerformanceUtils(unittest.TestCase):
     def test_applyFuelDisplacement(self):
         displacement = 0.01
-        block = test_blocks.loadTestBlock()
+        block = buildComplexHexBlock()
         fuel = block.getComponent(Flags.FUEL)
         originalHotODInCm = fuel.getDimension("od")
         utils.applyFuelDisplacement(block, displacement)

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -28,8 +28,7 @@ from armi.physics.neutronics.settings import (
 from armi.reactor import geometry
 from armi.reactor.blocks import HexBlock
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_blocks, test_reactors
-from armi.testing import TESTING_ROOT
+from armi.testing import TESTING_ROOT, applyDummyData, buildComplexHexBlock, loadTestReactor
 from armi.tests import ISOAA_PATH
 
 
@@ -166,9 +165,7 @@ class TestGFI(unittest.TestCase):
         """
         cs = settings.Settings()
         cs["burnSteps"] = 2
-        _o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        _o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
         gfi = MockGlobalFluxInterface(r, cs)
         bocKeff = 1.1
         r.core.p.keffUnc = 1.1
@@ -210,9 +207,7 @@ class TestGFI(unittest.TestCase):
             :tests: R_ARMI_FLUX_CHECK_POWER
         """
         cs = settings.Settings()
-        _o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        _o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
         gfi = MockGlobalFluxInterface(r, cs)
         self.assertEqual(gfi.checkEnergyBalance(), None)
 
@@ -228,9 +223,7 @@ class TestGFIWithExecuters(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.cs = settings.Settings()
-        cls.r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )[1]
+        cls.r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")[1]
 
     def setUp(self):
         self.r.core.p.keff = 1.0
@@ -304,9 +297,7 @@ class TestGFIWithExecutersNonUniform(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cs = settings.Settings()
-        _o, cls.r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        _o, cls.r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
         cls.r.core.p.keff = 1.0
         cls.gfi = MockGlobalFluxWithExecutersNonUniform(cls.r, cs)
 
@@ -349,7 +340,7 @@ class TestGlobalFluxResultMapper(unittest.TestCase):
     def test_mapper(self):
         # Switch to MC2v2 setting to make sure the isotopic/elemental expansions are compatible with
         # actually doing some math using the ISOAA test microscopic library
-        o, r = test_reactors.loadTestReactor(
+        o, r = loadTestReactor(
             TESTING_ROOT,
             customSettings={CONF_XS_KERNEL: "MC2v2"},
             inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml",
@@ -430,8 +421,8 @@ class TestGlobalFluxUtils(unittest.TestCase):
             :id: T_ARMI_FLUX_RX_RATES
             :tests: R_ARMI_FLUX_RX_RATES
         """
-        b = test_blocks.loadTestBlock()
-        test_blocks.applyDummyData(b)
+        b = buildComplexHexBlock()
+        applyDummyData(b)
         self.assertAlmostEqual(b.p.rateAbs, 0.0)
         globalFluxInterface.calcReactionRates(b, 1.01, b.core.lib)
         self.assertGreater(b.p.rateAbs, 0.0)

--- a/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
+++ b/armi/physics/neutronics/latticePhysics/tests/test_latticeInterface.py
@@ -31,8 +31,7 @@ from armi.reactor.assemblies import (
     grids,
 )
 from armi.reactor.reactors import Core, Reactor
-from armi.reactor.tests.test_blocks import buildSimpleFuelBlock
-from armi.testing import mockRunLogs
+from armi.testing import buildSimpleFuelHexBlock, mockRunLogs
 from armi.tests import ISOAA_PATH
 
 
@@ -68,7 +67,7 @@ class TestLatticePhysicsInterfaceBase(unittest.TestCase):
         cls.assembly = HexAssembly("testAssembly")
         cls.assembly.spatialGrid = grids.AxialGrid.fromNCells(1)
         cls.assembly.spatialGrid.armiObject = cls.assembly
-        cls.assembly.add(buildSimpleFuelBlock())
+        cls.assembly.add(buildSimpleFuelHexBlock())
         # init and add interfaces
         cls.xsGroupInterface = CrossSectionGroupManager(cls.o.r, cls.o.cs)
         cls.o.addInterface(cls.xsGroupInterface)

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -44,8 +44,7 @@ from armi.physics.neutronics.settings import (
 )
 from armi.reactor.blocks import HexBlock
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_blocks, test_reactors
-from armi.testing import TESTING_ROOT, mockRunLogs
+from armi.testing import TESTING_ROOT, buildComplexHexBlock, loadTestReactor, mockRunLogs
 from armi.utils import units
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
@@ -149,7 +148,7 @@ class TestBlockCollAvg(unittest.TestCase):
     def test_checkBlockSimilarity(self):
         """Check the block similarity test."""
         self.assertTrue(self.bc._checkBlockSimilarity())
-        self.bc.append(test_blocks.loadTestBlock())
+        self.bc.append(buildComplexHexBlock())
         self.assertFalse(self.bc._checkBlockSimilarity())
 
     def test_createRepresentativeBlock(self):
@@ -182,7 +181,7 @@ class TestBlockCollAvg(unittest.TestCase):
 
     def test_createRepresentativeBlockDissimilar(self):
         """Test creation of a representative block from a collection with dissimilar blocks."""
-        uniqueBlock = test_blocks.loadTestBlock()
+        uniqueBlock = buildComplexHexBlock()
         uniqueBlock.p.percentBu = 50.0
         fpFactory = test_lumpedFissionProduct.getDummyLFPFile()
         uniqueBlock.setLumpedFissionProducts(fpFactory.createLFPsFromFile())
@@ -326,9 +325,7 @@ class TestBlockCollCompAvg(unittest.TestCase):
         Second part of setup builds lists/dictionaries of expected values to compare to.
         has expected values for component isotopic atom density and component area.
         """
-        self.o, self.r = test_reactors.loadTestReactor(
-            os.path.join(TESTING_ROOT, "reactors", "zppr"), inputFileName="zpprTest.yaml"
-        )
+        self.o, self.r = loadTestReactor(os.path.join(TESTING_ROOT, "reactors", "zppr"), inputFileName="zpprTest.yaml")
 
         #                    ndrawer1  lenFuelTypeD1  ndrawer2  lenFuelTypeD2
         EuWeight = float(1 * 60 + 3 * 15)
@@ -415,7 +412,7 @@ class TestBlockCollCompAvg1DCyl(unittest.TestCase):
         has expected values for component isotopic atom density and component area.
         """
         root = os.path.join(TESTING_ROOT, "reactors", "sodiumHexReactor")
-        self.o, self.r = test_reactors.loadTestReactor(root)
+        self.o, self.r = loadTestReactor(root)
 
         sodiumDensity = {"NA23": 0.022166571826233578}
         steelDensity = {
@@ -878,7 +875,7 @@ class TestXSGM(unittest.TestCase):
             :tests: R_ARMI_XSGM_CREATE_XS_GROUPS
         """
         root = os.path.join(TESTING_ROOT, "reactors", "sodiumHexReactor")
-        _o, r = test_reactors.loadTestReactor(root)
+        _o, r = loadTestReactor(root)
         self.csm.r = r
 
         # Assumption: All sodium in fuel blocks for this test is 450 C and this is the expected sodium temperature.
@@ -944,9 +941,7 @@ class TestXSGM(unittest.TestCase):
 
     def _createRepresentativeBlocksUsingExistingBlocks(self, validBlockTypes):
         """Reusable code used in multiple unit tests."""
-        o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
         # set a few random non-default settings on AA to be copied to the new BA group
         o.cs[CONF_CROSS_SECTION].update(
             {
@@ -1104,9 +1099,7 @@ class TestXSGM(unittest.TestCase):
         Tests copying pre-generated cross section and flux files using reactor that is built from a
         case settings file.
         """
-        o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
         # Need to overwrite the relative paths with absolute
         o.cs[CONF_CROSS_SECTION]["XA"].xsFileLocation = [os.path.join(THIS_DIR, "ISOXA")]
         o.cs[CONF_CROSS_SECTION]["YA"].fluxFileLocation = os.path.join(THIS_DIR, "rzmflxYA")
@@ -1218,6 +1211,6 @@ class TestXSNumberConverters(unittest.TestCase):
 
 def makeBlocks(howMany=20):
     root = os.path.join(TESTING_ROOT, "reactors", "sodiumHexReactor")
-    _o, r = test_reactors.loadTestReactor(root)
+    _o, r = loadTestReactor(root)
     # shift y 3 to skip central assemblies 1/3 volume
     return r.core.getBlocks(Flags.FUEL)[3 : howMany + 3]

--- a/armi/physics/neutronics/tests/test_crossSectionTable.py
+++ b/armi/physics/neutronics/tests/test_crossSectionTable.py
@@ -23,9 +23,8 @@ from armi.physics.neutronics.isotopicDepletion import (
     isotopicDepletionInterface as idi,
 )
 from armi.physics.neutronics.latticePhysics import ORDER
-from armi.reactor.tests.test_blocks import loadTestBlock
 from armi.settings import Settings
-from armi.testing import TESTING_ROOT, loadTestReactor
+from armi.testing import TESTING_ROOT, buildComplexHexBlock, loadTestReactor
 from armi.tests import ISOAA_PATH
 
 
@@ -37,7 +36,7 @@ class TestCrossSectionTable(unittest.TestCase):
             :id: T_ARMI_DEPL_TABLES
             :tests: R_ARMI_DEPL_TABLES
         """
-        obj = loadTestBlock()
+        obj = buildComplexHexBlock()
         obj.p.mgFlux = range(33)
         core = obj.parent.parent
         core.lib = isotxs.readBinary(ISOAA_PATH)

--- a/armi/reactor/blueprints/tests/test_blockBlueprints.py
+++ b/armi/reactor/blueprints/tests/test_blockBlueprints.py
@@ -19,7 +19,7 @@ import unittest
 from armi import settings
 from armi.reactor import blueprints
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_blocks
+from armi.testing import buildSimpleFuelHexBlock
 
 FULL_BP = """
 blocks:
@@ -390,8 +390,8 @@ class TestGriddedBlock(unittest.TestCase):
         fuelBlock = a1[0]
         clad = fuelBlock.getComponent(Flags.CLAD)
 
-        # now construct clad programmatically like in test_Blocks
-        programmaticBlock = test_blocks.buildSimpleFuelBlock()
+        # now construct clad programmatically
+        programmaticBlock = buildSimpleFuelHexBlock()
         programaticClad = programmaticBlock.getComponent(Flags.CLAD)
         self.assertAlmostEqual(
             clad.density(),

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -30,7 +30,9 @@ from armi.testing import (
     TESTING_ROOT,
     buildComplexHexBlock,
     buildLinkedFuelHexBlock,
+    buildLinkedFuelHexBlockNegativeArea,
     buildMixedThreePinAssembly,
+    buildSimpleFuelHexBlockNegativeArea,
     loadTestReactor,
 )
 from armi.utils import hexagon
@@ -38,100 +40,6 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
 # TODO: move to testing
-def buildSimpleFuelBlockNegativeArea():
-    """
-    Return a simple block containing fuel, clad, duct, and coolant.
-
-    The block has a negative-area gap between fuel and cladding for testing.
-    """
-    b = blocks.HexBlock("fuel", height=10.0)
-
-    fuelDims = {"Tinput": 25, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
-    cladDims = {"Tinput": 25, "Thot": 600, "od": 0.80, "id": 0.76, "mult": 127.0}
-    ductDims = {"Tinput": 25, "Thot": 600, "op": 16, "ip": 15.3, "mult": 1.0}
-    intercoolantDims = {
-        "Tinput": 400,
-        "Thot": 400,
-        "op": 17.0,
-        "ip": ductDims["op"],
-        "mult": 1.0,
-    }
-    coolDims = {"Tinput": 25.0, "Thot": 400}
-
-    fuel = components.Circle("fuel", "UZr", **fuelDims)
-    clad = components.Circle("clad", "HT9", **cladDims)
-    gapDims = {
-        "Tinput": 25,
-        "Thot": 600,
-        "od": "clad.id",
-        "id": "fuel.od",
-        "mult": 127.0,
-    }
-    gapDims["components"] = {"fuel": fuel, "clad": clad}
-    gap = components.Circle("gap", "Void", **gapDims)
-    duct = components.Hexagon("duct", "HT9", **ductDims)
-    coolant = components.DerivedShape("coolant", "Sodium", **coolDims)
-    intercoolant = components.Hexagon("intercoolant", "Sodium", **intercoolantDims)
-
-    b.add(fuel)
-    b.add(gap)
-    b.add(clad)
-    b.add(duct)
-    b.add(coolant)
-    b.add(intercoolant)
-
-    b.getVolumeFractions()
-
-    return b
-
-
-def buildSimpleFuelBlockNegativeAreaBond():
-    """
-    Return a simple block containing fuel, clad, duct, and coolant.
-
-    The block has a negative-area bond between fuel and cladding for testing.
-    """
-    b = blocks.HexBlock("fuel", height=10.0)
-
-    fuelDims = {"Tinput": 25, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
-    cladDims = {"Tinput": 25, "Thot": 600, "od": 0.80, "id": 0.76, "mult": 127.0}
-    ductDims = {"Tinput": 25, "Thot": 600, "op": 16, "ip": 15.3, "mult": 1.0}
-    intercoolantDims = {
-        "Tinput": 400,
-        "Thot": 400,
-        "op": 17.0,
-        "ip": ductDims["op"],
-        "mult": 1.0,
-    }
-    coolDims = {"Tinput": 25.0, "Thot": 400}
-
-    fuel = components.Circle("fuel", "UZr", **fuelDims)
-    clad = components.Circle("clad", "HT9", **cladDims)
-    bondDims = {
-        "Tinput": 25,
-        "Thot": 600,
-        "od": "clad.id",
-        "id": "fuel.od",
-        "mult": 127.0,
-    }
-    bondDims["components"] = {"fuel": fuel, "clad": clad}
-    bond = components.Circle("bond", "Sodium", **bondDims)
-    duct = components.Hexagon("duct", "HT9", **ductDims)
-    coolant = components.DerivedShape("coolant", "Sodium", **coolDims)
-    intercoolant = components.Hexagon("intercoolant", "Sodium", **intercoolantDims)
-
-    b.add(fuel)
-    b.add(bond)
-    b.add(clad)
-    b.add(duct)
-    b.add(coolant)
-    b.add(intercoolant)
-
-    b.getVolumeFractions()
-
-    return b
-
-
 class TestBlockConverter(unittest.TestCase):
     def setUp(self):
         self.td = TemporaryDirectoryChanger()
@@ -232,17 +140,17 @@ class TestBlockConverter(unittest.TestCase):
 
     def test_dissolveNegativeArea(self):
         """Test dissolving a zero-area gap component into another."""
-        self._test_dissolve(buildSimpleFuelBlockNegativeArea(), "gap", "clad")
+        self._test_dissolve(buildSimpleFuelHexBlockNegativeArea(), "gap", "clad")
 
     def test_dissolveNegativeAreaBond(self):
         """Test dissolving a zero-area non-gap component into another."""
         with self.assertRaises(ValueError):
-            self._test_dissolve(buildSimpleFuelBlockNegativeAreaBond(), "bond", "clad")
+            self._test_dissolve(buildLinkedFuelHexBlockNegativeArea(), "bond", "clad")
 
     def test_dissolveIntoNegativeArea(self):
         """Test dissolving a zero-area component into another."""
         with self.assertRaises(ValueError):
-            self._test_dissolve(buildSimpleFuelBlockNegativeArea(), "clad", "gap")
+            self._test_dissolve(buildSimpleFuelHexBlockNegativeArea(), "clad", "gap")
 
     def _test_dissolve_multi(self, block, soluteNames, solventName):
         converter = blockConverters.MultipleComponentMerger(block, soluteNames, solventName)

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -39,7 +39,6 @@ from armi.utils import hexagon
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
-# TODO: move to testing
 class TestBlockConverter(unittest.TestCase):
     def setUp(self):
         self.td = TemporaryDirectoryChanger()

--- a/armi/reactor/converters/tests/test_blockConverter.py
+++ b/armi/reactor/converters/tests/test_blockConverter.py
@@ -26,12 +26,18 @@ from armi.physics.neutronics.isotopicDepletion.isotopicDepletionInterface import
 from armi.reactor import blocks, components, grids
 from armi.reactor.converters import blockConverters
 from armi.reactor.flags import Flags
-from armi.reactor.tests.test_blocks import buildLinkedFuelBlock, loadTestBlock
-from armi.testing import TESTING_ROOT, buildMixedThreePinAssembly, loadTestReactor
+from armi.testing import (
+    TESTING_ROOT,
+    buildComplexHexBlock,
+    buildLinkedFuelHexBlock,
+    buildMixedThreePinAssembly,
+    loadTestReactor,
+)
 from armi.utils import hexagon
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
+# TODO: move to testing
 def buildSimpleFuelBlockNegativeArea():
     """
     Return a simple block containing fuel, clad, duct, and coolant.
@@ -142,8 +148,8 @@ class TestBlockConverter(unittest.TestCase):
             :id: T_ARMI_BLOCKCONV0
             :tests: R_ARMI_BLOCKCONV
         """
-        self._test_dissolve(loadTestBlock(), "wire", "coolant")
-        hotBlock = loadTestBlock(cold=False)
+        self._test_dissolve(buildComplexHexBlock(), "wire", "coolant")
+        hotBlock = buildComplexHexBlock(cold=False)
         self._test_dissolve(hotBlock, "wire", "coolant")
         hotBlock = self._perturbTemps(hotBlock, "wire", 127, 700)
         self._test_dissolve(hotBlock, "wire", "coolant")
@@ -156,8 +162,8 @@ class TestBlockConverter(unittest.TestCase):
             :id: T_ARMI_BLOCKCONV1
             :tests: R_ARMI_BLOCKCONV
         """
-        self._test_dissolve(loadTestBlock(), "outer liner", "clad")
-        hotBlock = loadTestBlock(cold=False)
+        self._test_dissolve(buildComplexHexBlock(), "outer liner", "clad")
+        hotBlock = buildComplexHexBlock(cold=False)
         self._test_dissolve(hotBlock, "outer liner", "clad")
         hotBlock = self._perturbTemps(hotBlock, "outer liner", 127, 700)
         self._test_dissolve(hotBlock, "outer liner", "clad")
@@ -170,7 +176,7 @@ class TestBlockConverter(unittest.TestCase):
             :id: T_ARMI_BLOCKCONV2
             :tests: R_ARMI_BLOCKCONV
         """
-        self._test_dissolve(buildLinkedFuelBlock(), "bond", "clad")
+        self._test_dissolve(buildLinkedFuelHexBlock(), "bond", "clad")
 
     def _perturbTemps(self, block, cName, tCold, tHot):
         """Give the component different ref and hot temperatures than in test_Blocks."""
@@ -187,8 +193,8 @@ class TestBlockConverter(unittest.TestCase):
 
     def test_dissolveMultiple(self):
         """Test dissolving multiple components into another."""
-        self._test_dissolve_multi(loadTestBlock(), ["wire", "clad"], "coolant")
-        self._test_dissolve_multi(loadTestBlock(), ["inner liner", "outer liner"], "clad")
+        self._test_dissolve_multi(buildComplexHexBlock(), ["wire", "clad"], "coolant")
+        self._test_dissolve_multi(buildComplexHexBlock(), ["inner liner", "outer liner"], "clad")
 
     def test_dissolveMixedAssembly(self):
         """Test dissolving multiple components into another in a mixed assembly."""
@@ -217,12 +223,12 @@ class TestBlockConverter(unittest.TestCase):
 
     def test_dissolveZeroArea(self):
         """Test dissolving a zero-area component into another."""
-        self._test_dissolve(loadTestBlock(), "gap2", "outer liner")
+        self._test_dissolve(buildComplexHexBlock(), "gap2", "outer liner")
 
     def test_dissolveIntoZeroArea(self):
         """Test dissolving a component into a zero-area solvent (raises ValueError)."""
         with self.assertRaises(ValueError):
-            self._test_dissolve(loadTestBlock(), "outer liner", "gap2")
+            self._test_dissolve(buildComplexHexBlock(), "outer liner", "gap2")
 
     def test_dissolveNegativeArea(self):
         """Test dissolving a zero-area gap component into another."""
@@ -256,7 +262,7 @@ class TestBlockConverter(unittest.TestCase):
     def test_build_NthRing(self):
         """Test building of one ring."""
         RING = 6
-        block = loadTestBlock(cold=False)
+        block = buildComplexHexBlock(cold=False)
         block.spatialGrid = grids.HexGrid.fromPitch(1.0)
 
         numPinsInRing = 30
@@ -276,7 +282,7 @@ class TestBlockConverter(unittest.TestCase):
 
     def test_buildInsideDuct(self):
         """Test building inside the duct."""
-        block = loadTestBlock(cold=False)
+        block = buildComplexHexBlock(cold=False)
         block.spatialGrid = grids.HexGrid.fromPitch(1.0)
         converter = blockConverters.HexComponentsToCylConverter(block)
         converter._buildInsideDuct()

--- a/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
+++ b/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
@@ -22,12 +22,12 @@ from armi.reactor.converters.pinTypeBlockConverters import (
     adjustSmearDensity,
 )
 from armi.reactor.flags import Flags
-from armi.reactor.tests.test_blocks import buildSimpleFuelBlock, loadTestBlock
+from armi.testing import buildComplexHexBlock, buildSimpleFuelHexBlock
 
 
 class TestPinTypeConverters(unittest.TestCase):
     def setUp(self):
-        self.block = loadTestBlock()
+        self.block = buildComplexHexBlock()
 
     def test_adjustCladThicknessByOD(self):
         thickness = 0.05
@@ -54,7 +54,7 @@ class MassConservationTests(unittest.TestCase):
     r"""Tests designed to verify mass conservation during thermal expansion."""
 
     def setUp(self):
-        self.b = buildSimpleFuelBlock()
+        self.b = buildSimpleFuelHexBlock()
 
     def test_adjustSmearDensity(self):
         r"""Tests the getting, setting, and getting of smear density functions."""

--- a/armi/reactor/converters/tests/test_uniformMesh.py
+++ b/armi/reactor/converters/tests/test_uniformMesh.py
@@ -26,10 +26,11 @@ from armi.nuclearDataIO.cccc import isotxs
 from armi.physics.neutronics.settings import CONF_XS_KERNEL
 from armi.reactor.converters import uniformMesh
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_blocks
 from armi.settings.fwSettings.globalSettings import CONF_UNIFORM_MESH_MINIMUM_SIZE
 from armi.testing import (
     TESTING_ROOT,
+    applyDummyData,
+    buildComplexHexBlock,
     buildHexAssemblyFiveUZrUTh,
     buildHexAssemblyFourUZrUTh,
     loadTestReactor,
@@ -538,8 +539,8 @@ class TestCalcReationRates(unittest.TestCase):
             :id: T_ARMI_FLUX_RX_RATES_BY_XS_ID
             :tests: R_ARMI_FLUX_RX_RATES
         """
-        b = test_blocks.loadTestBlock()
-        test_blocks.applyDummyData(b)
+        b = buildComplexHexBlock()
+        applyDummyData(b)
         self.assertAlmostEqual(b.p.rateAbs, 0.0)
         blockList = [copy.deepcopy(b) for _i in range(3)]
         xsID = b.getMicroSuffix()

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -29,8 +29,7 @@ from armi.physics.neutronics.settings import CONF_LOADING_FILE, CONF_XS_KERNEL
 from armi.reactor import blocks, blueprints, components, geometry, parameters, reactors
 from armi.reactor.assemblies import Flags, HexAssembly, copy, grids, runLog
 from armi.reactor.parameters import ParamLocation
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT, getEmptyHexReactor, mockRunLogs
+from armi.testing import TESTING_ROOT, buildEmptyHexAssembly, getEmptyHexReactor, loadTestReactor, mockRunLogs
 from armi.utils import directoryChangers, textProcessors
 
 NUM_BLOCKS = 3
@@ -64,15 +63,6 @@ class MaterialInAssembly_TestCase(unittest.TestCase):
         self.assertAlmostEqual(uZrFuel.getMass("U235") / (uZrFuel.getMass("U238") + uZrFuel.getMass("U235")), 0.1)
 
 
-def makeTestAssembly(numBlocks, assemNum, spatialGrid=grids.HexGrid.fromPitch(1.0), r=None):
-    coreGrid = r.core.spatialGrid if r is not None else spatialGrid
-    a = HexAssembly("TestAssem", assemNum=assemNum)
-    a.spatialGrid = grids.AxialGrid.fromNCells(numBlocks)
-    a.spatialGrid.armiObject = a
-    a.spatialLocator = coreGrid[2, 2, 0]
-    return a
-
-
 class AssemblyReadOnlyTests(unittest.TestCase):
     """These tests of Assemblies do not modify the test assembly, which can be created in a setUpClass method."""
 
@@ -88,7 +78,7 @@ class AssemblyReadOnlyTests(unittest.TestCase):
         cls.r = getEmptyHexReactor()
         cls.r.core.symmetry = geometry.SymmetryType(geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC)
 
-        cls.assembly = makeTestAssembly(NUM_BLOCKS, cls.assemNum, r=cls.r)
+        cls.assembly = buildEmptyHexAssembly(NUM_BLOCKS, cls.assemNum, r=cls.r)
 
         # Use these if they are needed
         cls.blockParams = {
@@ -354,7 +344,7 @@ class AssemblyReadOnlyTests(unittest.TestCase):
             :id: T_ARMI_ASSEM_POSI1
             :tests: R_ARMI_ASSEM_POSI
         """
-        a = makeTestAssembly(
+        a = buildEmptyHexAssembly(
             numBlocks=1,
             assemNum=1,
             spatialGrid=grids.CartesianGrid.fromRectangle(1.0, 1.0),
@@ -387,7 +377,7 @@ class AssemblyTests(unittest.TestCase):
         self.r = getEmptyHexReactor()
         self.r.core.symmetry = geometry.SymmetryType(geometry.DomainType.THIRD_CORE, geometry.BoundaryType.PERIODIC)
 
-        self.assembly = makeTestAssembly(NUM_BLOCKS, self.assemNum, r=self.r)
+        self.assembly = buildEmptyHexAssembly(NUM_BLOCKS, self.assemNum, r=self.r)
 
         # Use these if they are needed
         self.blockParams = {
@@ -475,7 +465,7 @@ class AssemblyTests(unittest.TestCase):
             self.assertIs(c.parent, self.assembly)
 
     def test_add(self):
-        a = makeTestAssembly(1, 1)
+        a = buildEmptyHexAssembly(1, 1)
 
         # successfully add some Blocks to an Assembly
         for n in range(3):
@@ -535,7 +525,7 @@ class AssemblyTests(unittest.TestCase):
         # Make a second assembly with 4 times the resolution
         assemNum2 = self.assemNum * 4
         height2 = self.height / 4.0
-        assembly2 = makeTestAssembly(assemNum2, assemNum2)
+        assembly2 = buildEmptyHexAssembly(assemNum2, assemNum2)
 
         # add some blocks with a component
         for _ in range(assemNum2):
@@ -590,7 +580,7 @@ class AssemblyTests(unittest.TestCase):
         # Make a second assembly with 4 times the resolution
         assemNum2 = self.assemNum * 4
         height2 = self.height / 4.0
-        assembly2 = makeTestAssembly(assemNum2, assemNum2)
+        assembly2 = buildEmptyHexAssembly(assemNum2, assemNum2)
 
         # add some blocks with a component
         for _i in range(assemNum2):
@@ -632,7 +622,7 @@ class AssemblyTests(unittest.TestCase):
         self.assertEqual(cur, ref)
 
     def test_updateFromAssembly(self):
-        assembly2 = makeTestAssembly(self.assemNum, self.assemNum)
+        assembly2 = buildEmptyHexAssembly(self.assemNum, self.assemNum)
 
         params = {}
         params["maxPercentBu"] = 30.0
@@ -796,7 +786,7 @@ class AssemblyTests(unittest.TestCase):
 
     def test_calcTotalParam(self):
         # Remake original assembly
-        self.assembly = makeTestAssembly(self.assemNum, self.assemNum)
+        self.assembly = buildEmptyHexAssembly(self.assemNum, self.assemNum)
 
         # add some blocks with a component
         for i in range(self.assemNum):
@@ -837,7 +827,7 @@ class AssemblyTests(unittest.TestCase):
 
     def test_reattach(self):
         # Remake original assembly
-        self.assembly = makeTestAssembly(self.assemNum, self.assemNum)
+        self.assembly = buildEmptyHexAssembly(self.assemNum, self.assemNum)
         self.assertEqual(0, len(self.assembly))
 
         # add some blocks with a component
@@ -923,7 +913,7 @@ class AssemblyTests(unittest.TestCase):
     def test_averagePlenumTemperature(self):
         """Test an assembly's average plenum temperature with a single block outlet."""
         averagePlenumTemp = 42.0
-        plenumBlock = makeTestAssembly(1, 2, grids.CartesianGrid.fromRectangle(1.0, 1.0))
+        plenumBlock = buildEmptyHexAssembly(1, 2, grids.CartesianGrid.fromRectangle(1.0, 1.0))
 
         plenumBlock.setType("plenum", Flags.PLENUM)
         plenumBlock.p.THcoolantOutletT = averagePlenumTemp
@@ -939,7 +929,7 @@ class AssemblyTests(unittest.TestCase):
             :id: T_ARMI_ROTATE_HEX_ASSEM
             :tests: R_ARMI_ROTATE_HEX
         """
-        a = makeTestAssembly(1, 1)
+        a = buildEmptyHexAssembly(1, 1)
         b = blocks.HexBlock("TestBlock")
         b.p.THcornTemp = [400, 450, 500, 550, 600, 650]
         rotTemp = [600, 650, 400, 450, 500, 550]
@@ -1039,7 +1029,7 @@ class AssemblyTests(unittest.TestCase):
 class AssemblyInReactor_TestCase(unittest.TestCase):
     def setUp(self):
         root = os.path.join(TESTING_ROOT, "reactors", "sodiumHexReactor")
-        self.o, self.r = test_reactors.loadTestReactor(root)
+        self.o, self.r = loadTestReactor(root)
 
     def test_snapAxialMesViaBlockIgn(self):
         """Snap axial mesh to a reference mesh should conserve mass based on Block igniter fuel."""

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -32,15 +32,21 @@ from armi.nucDirectory.nuclideBases import NuclideBases
 from armi.nuclearDataIO import xsCollections
 from armi.nuclearDataIO.cccc import isotxs
 from armi.physics.neutronics import GAMMA, NEUTRON
-from armi.physics.neutronics.settings import (
-    CONF_XS_KERNEL,
-)
 from armi.reactor import blocks, blueprints, components, geometry, grids
 from armi.reactor.components import basicShapes, complexShapes
 from armi.reactor.flags import Flags
 from armi.reactor.grids.cartesian import CartesianGrid
 from armi.reactor.tests.test_assemblies import makeTestAssembly
-from armi.testing import TESTING_ROOT, buildMixedPinAssembly, getEmptyCartesianReactor, loadTestReactor, mockRunLogs
+from armi.testing import (
+    TESTING_ROOT,
+    applyDummyData,
+    buildComplexHexBlock,
+    buildMixedPinAssembly,
+    buildSimpleFuelHexBlock,
+    getEmptyCartesianReactor,
+    loadTestReactor,
+    mockRunLogs,
+)
 from armi.tests import ISOAA_PATH
 from armi.utils import densityTools, hexagon, units
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
@@ -52,300 +58,6 @@ from armi.utils.units import (
 )
 
 NUM_PINS_IN_TEST_BLOCK = 217
-
-
-def buildSimpleFuelBlock():
-    """Return a simple hex block containing fuel, clad, duct, and coolant."""
-    b = blocks.HexBlock("fuel", height=10.0)
-
-    fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
-    cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.77, "mult": 127.0}
-    ductDims = {"Tinput": 25.0, "Thot": 400, "op": 16, "ip": 15.3, "mult": 1.0}
-    intercoolantDims = {
-        "Tinput": 400,
-        "Thot": 400,
-        "op": 17.0,
-        "ip": ductDims["op"],
-        "mult": 1.0,
-    }
-    coolDims = {"Tinput": 25.0, "Thot": 400}
-
-    fuel = components.Circle("fuel", "UZr", **fuelDims)
-    clad = components.Circle("clad", "HT9", **cladDims)
-    duct = components.Hexagon("duct", "HT9", **ductDims)
-    coolant = components.DerivedShape("coolant", "Sodium", **coolDims)
-    intercoolant = components.Hexagon("intercoolant", "Sodium", **intercoolantDims)
-
-    b.add(fuel)
-    b.add(clad)
-    b.add(duct)
-    b.add(coolant)
-    b.add(intercoolant)
-
-    return b
-
-
-def buildLinkedFuelBlock():
-    """Return a simple hex block containing linked bond."""
-    b = blocks.HexBlock("fuel", height=10.0)
-
-    fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
-    bondDims = {
-        "Tinput": 25.0,
-        "Thot": 450,
-        "od": "clad.id",
-        "id": "fuel.od",
-        "mult": 127.0,
-    }
-    cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.77, "mult": 127.0}
-    ductDims = {"Tinput": 25.0, "Thot": 400, "op": 16, "ip": 15.3, "mult": 1.0}
-    intercoolantDims = {
-        "Tinput": 400,
-        "Thot": 400,
-        "op": 17.0,
-        "ip": ductDims["op"],
-        "mult": 1.0,
-    }
-    coolDims = {"Tinput": 25.0, "Thot": 400}
-
-    fuel = components.Circle("fuel", "UZr", **fuelDims)
-    clad = components.Circle("clad", "HT9", **cladDims)
-    bondDims["components"] = {"clad": clad, "fuel": fuel}
-    bond = components.Circle("bond", "HT9", **bondDims)
-    duct = components.Hexagon("duct", "HT9", **ductDims)
-    coolant = components.DerivedShape("coolant", "Sodium", **coolDims)
-    intercoolant = components.Hexagon("intercoolant", "Sodium", **intercoolantDims)
-
-    b.add(fuel)
-    b.add(bond)
-    b.add(clad)
-    b.add(duct)
-    b.add(coolant)
-    b.add(intercoolant)
-
-    return b
-
-
-def loadTestBlock(cold=True, depletable=False) -> blocks.HexBlock:
-    """Build an annular test block for evaluating unit tests."""
-    caseSetting = settings.Settings()
-    caseSetting[CONF_XS_KERNEL] = "MC2v2"
-    runLog.setVerbosity("error")
-    caseSetting["nCycles"] = 1
-    r = tests.getEmptyHexReactor()
-
-    assemNum = 3
-    block = blocks.HexBlock("TestHexBlock")
-    block.setType("defaultType")
-    block.p.nPins = NUM_PINS_IN_TEST_BLOCK
-    assembly = makeTestAssembly(assemNum, 1, r=r)
-
-    # NOTE: temperatures are supposed to be in C
-    coldTemp = 25.0
-    hotTempCoolant = 430.0
-    hotTempStructure = 25.0 if cold else hotTempCoolant
-    hotTempFuel = 25.0 if cold else 600.0
-
-    fuelDims = {
-        "Tinput": coldTemp,
-        "Thot": hotTempFuel,
-        "od": 0.84,
-        "id": 0.6,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    fuel = components.Circle("fuel", "UZr", **fuelDims)
-    if depletable:
-        fuel.p.flags = Flags.fromString("fuel depletable")
-
-    bondDims = {
-        "Tinput": coldTemp,
-        "Thot": hotTempCoolant,
-        "od": "fuel.id",
-        "id": 0.3,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    bondDims["components"] = {"fuel": fuel}
-    bond = components.Circle("bond", "Sodium", **bondDims)
-
-    annularVoidDims = {
-        "Tinput": hotTempStructure,
-        "Thot": hotTempStructure,
-        "od": "bond.id",
-        "id": 0.0,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    annularVoidDims["components"] = {"bond": bond}
-    annularVoid = components.Circle("annular void", "Void", **annularVoidDims)
-
-    innerLinerDims = {
-        "Tinput": coldTemp,
-        "Thot": hotTempStructure,
-        "od": 0.90,
-        "id": 0.85,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    innerLiner = components.Circle("inner liner", "Graphite", **innerLinerDims)
-
-    fuelLinerGapDims = {
-        "Tinput": hotTempStructure,
-        "Thot": hotTempStructure,
-        "od": "inner liner.id",
-        "id": "fuel.od",
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    fuelLinerGapDims["components"] = {"inner liner": innerLiner, "fuel": fuel}
-    fuelLinerGap = components.Circle("gap1", "Void", **fuelLinerGapDims)
-
-    outerLinerDims = {
-        "Tinput": coldTemp,
-        "Thot": hotTempStructure,
-        "od": 0.95,
-        "id": 0.90,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    outerLiner = components.Circle("outer liner", "HT9", **outerLinerDims)
-
-    linerLinerGapDims = {
-        "Tinput": hotTempStructure,
-        "Thot": hotTempStructure,
-        "od": "outer liner.id",
-        "id": "inner liner.od",
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    linerLinerGapDims["components"] = {
-        "outer liner": outerLiner,
-        "inner liner": innerLiner,
-    }
-    linerLinerGap = components.Circle("gap2", "Void", **linerLinerGapDims)
-
-    claddingDims = {
-        "Tinput": coldTemp,
-        "Thot": hotTempStructure,
-        "od": 1.05,
-        "id": 0.95,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    cladding = components.Circle("clad", "HT9", **claddingDims)
-    if depletable:
-        cladding.p.flags = Flags.fromString("clad depletable")
-
-    linerCladGapDims = {
-        "Tinput": hotTempStructure,
-        "Thot": hotTempStructure,
-        "od": "clad.id",
-        "id": "outer liner.od",
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    linerCladGapDims["components"] = {"clad": cladding, "outer liner": outerLiner}
-    linerCladGap = components.Circle("gap3", "Void", **linerCladGapDims)
-
-    wireDims = {
-        "Tinput": coldTemp,
-        "Thot": hotTempStructure,
-        "od": 0.1,
-        "id": 0.0,
-        "axialPitch": 30.0,
-        "helixDiameter": 1.1,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
-    }
-    wire = components.Helix("wire", "HT9", **wireDims)
-    if depletable:
-        wire.p.flags = Flags.fromString("wire depletable")
-
-    coolantDims = {"Tinput": hotTempCoolant, "Thot": hotTempCoolant}
-    coolant = components.DerivedShape("coolant", "Sodium", **coolantDims)
-
-    ductDims = {
-        "Tinput": coldTemp,
-        "Thot": hotTempStructure,
-        "ip": 16.6,
-        "op": 17.3,
-        "mult": 1,
-    }
-    duct = components.Hexagon("duct", "HT9", **ductDims)
-    if depletable:
-        duct.p.flags = Flags.fromString("duct depletable")
-
-    interDims = {
-        "Tinput": hotTempCoolant,
-        "Thot": hotTempCoolant,
-        "op": 17.8,
-        "ip": "duct.op",
-        "mult": 1,
-    }
-    interDims["components"] = {"duct": duct}
-    interSodium = components.Hexagon("interCoolant", "Sodium", **interDims)
-
-    block.add(annularVoid)
-    block.add(bond)
-    block.add(fuel)
-    block.add(fuelLinerGap)
-    block.add(innerLiner)
-    block.add(linerLinerGap)
-    block.add(outerLiner)
-    block.add(linerCladGap)
-    block.add(cladding)
-
-    block.add(wire)
-    block.add(coolant)
-    block.add(duct)
-    block.add(interSodium)
-
-    block.setHeight(16.0)
-
-    block.autoCreateSpatialGrids(r.core.spatialGrid)
-    assembly.add(block)
-    r.core.add(assembly)
-    return block
-
-
-def applyDummyData(block):
-    """Add some dummy data to a block for physics-like tests."""
-    # typical SFR-ish flux in 1/cm^2/s
-    flux = [
-        161720716762.12997,
-        2288219224332.647,
-        11068159130271.139,
-        26473095948525.742,
-        45590249703180.945,
-        78780459664094.23,
-        143729928505629.06,
-        224219073208464.06,
-        229677567456769.22,
-        267303906113313.16,
-        220996878365852.22,
-        169895433093246.28,
-        126750484612975.31,
-        143215138794766.53,
-        74813432842005.5,
-        32130372366225.85,
-        21556243034771.582,
-        6297567411518.368,
-        22365198294698.45,
-        12211256796917.86,
-        5236367197121.363,
-        1490736020048.7847,
-        1369603135573.731,
-        285579041041.55945,
-        73955783965.98692,
-        55003146502.73623,
-        18564831886.20426,
-        4955747691.052108,
-        3584030491.076041,
-        884015567.3986057,
-        4298964991.043116,
-        1348809158.0353086,
-        601494405.293505,
-    ]
-    xslib = isotxs.readBinary(ISOAA_PATH)
-    # Slight hack here because the test block was created by hand rather than via blueprints and so
-    # elemental expansion of isotopics did not occur. But, the ISOTXS library being used did go
-    # through an isotopic expansion, so we map nuclides here.
-    xslib._nuclides["NAAA"] = xslib._nuclides["NA23AA"]
-    xslib._nuclides["WAA"] = xslib._nuclides["W184AA"]
-    xslib._nuclides["MNAA"] = xslib._nuclides["MN55AA"]
-    block.p.mgFlux = flux
-    block.core.lib = xslib
 
 
 def getComponentData(component):
@@ -370,7 +82,7 @@ class TestDetailedNDensUpdate(unittest.TestCase):
             self.r = tests.getEmptyHexReactor()
             self.r.blueprints = bps
             a = makeTestAssembly(numBlocks=1, assemNum=0)
-            a.add(buildSimpleFuelBlock())
+            a.add(buildSimpleFuelHexBlock())
             self.r.core.add(a)
 
         # get first block in assembly with 'fuel' key
@@ -424,9 +136,9 @@ class TestValidateSFPSpatialGrids(unittest.TestCase):
 
 class TestBlock(unittest.TestCase):
     def setUp(self):
-        self.block = loadTestBlock()
-        self._hotBlock = loadTestBlock(cold=False)
-        self._deplBlock = loadTestBlock(depletable=True)
+        self.block = buildComplexHexBlock()
+        self._hotBlock = buildComplexHexBlock(cold=False)
+        self._deplBlock = buildComplexHexBlock(depletable=True)
 
     def test_getSmearDensity(self):
         cur = self.block.getSmearDensity()
@@ -812,7 +524,7 @@ class TestBlock(unittest.TestCase):
 
     def test_setZeroHeight(self):
         """Test that demonstrates that a block's height can be set to zero."""
-        b = buildSimpleFuelBlock()
+        b = buildSimpleFuelHexBlock()
 
         # Check for a DerivedShape component
         self.assertEqual(len([c for c in b if c.__class__ is components.DerivedShape]), 1)
@@ -856,7 +568,7 @@ class TestBlock(unittest.TestCase):
 
     def test_getVolumeFractionsWithZeroHeight(self):
         """Tests that the component fractions are the same with a zero height block."""
-        b = buildSimpleFuelBlock()
+        b = buildSimpleFuelHexBlock()
 
         h1 = b.getHeight()
         originalVolFracs = b.getVolumeFractions()
@@ -875,7 +587,7 @@ class TestBlock(unittest.TestCase):
 
     def test_getVolumeFractionWithoutParent(self):
         """Tests that the volume fraction of a block with no parent is zero."""
-        b = buildSimpleFuelBlock()
+        b = buildSimpleFuelHexBlock()
         self.assertIsNone(b.parent)
         with self.assertRaises(ValueError):
             b.getVolumeFraction()
@@ -2157,7 +1869,7 @@ class TestBlock(unittest.TestCase):
     def test_mergeWithBlock(self):
         fuel1 = self.block.getComponent(Flags.FUEL)
         fuel1.setNumberDensity("CM246", 0.0)
-        block2 = loadTestBlock()
+        block2 = buildComplexHexBlock()
         fuel2 = block2.getComponent(Flags.FUEL)
         fuel2.setNumberDensity("CM246", 0.02)
         self.assertEqual(self.block.getNumberDensity("CM246"), 0.0)
@@ -2261,7 +1973,7 @@ class TestBlockInputHeights(unittest.TestCase):
 
     def test_noBlueprints(self):
         """Verify an error is raised if there are no blueprints."""
-        b = buildSimpleFuelBlock()
+        b = buildSimpleFuelHexBlock()
         with self.assertRaisesRegex(AttributeError, "No ancestor.*blueprints"):
             b.getInputHeight()
 
@@ -2275,7 +1987,7 @@ class TestBlockEnergyDepositionConstants(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.block = loadTestBlock()
+        cls.block = buildComplexHexBlock()
 
     def setUp(self):
         self.block.core.lib = MagicMock()
@@ -3486,7 +3198,7 @@ class TestMassConservation(unittest.TestCase):
     """Tests designed to verify mass conservation during thermal expansion."""
 
     def setUp(self):
-        self.b = buildSimpleFuelBlock()
+        self.b = buildSimpleFuelHexBlock()
 
     def test_heightExpansionDifferences(self):
         """The point of this test is to determine if the number densities stay the same with two different heights of

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -36,11 +36,11 @@ from armi.reactor import blocks, blueprints, components, geometry, grids
 from armi.reactor.components import basicShapes, complexShapes
 from armi.reactor.flags import Flags
 from armi.reactor.grids.cartesian import CartesianGrid
-from armi.reactor.tests.test_assemblies import makeTestAssembly
 from armi.testing import (
     TESTING_ROOT,
     applyDummyData,
     buildComplexHexBlock,
+    buildEmptyHexAssembly,
     buildMixedPinAssembly,
     buildSimpleFuelHexBlock,
     getEmptyCartesianReactor,
@@ -81,7 +81,7 @@ class TestDetailedNDensUpdate(unittest.TestCase):
             bps._prepConstruction(cs)
             self.r = tests.getEmptyHexReactor()
             self.r.blueprints = bps
-            a = makeTestAssembly(numBlocks=1, assemNum=0)
+            a = buildEmptyHexAssembly(numBlocks=1, assemNum=0)
             a.add(buildSimpleFuelHexBlock())
             self.r.core.add(a)
 
@@ -1914,7 +1914,7 @@ class TestBlock(unittest.TestCase):
         block.p.xsType = "A"
 
         r = tests.getEmptyHexReactor()
-        assembly = makeTestAssembly(1, 1, r=r)
+        assembly = buildEmptyHexAssembly(1, 1, r=r)
         assembly.add(block)
         r.core.add(assembly)
         r.core.lib = isotxs.readBinary(ISOAA_PATH)
@@ -2096,7 +2096,7 @@ class TestHexBlock(unittest.TestCase):
         self.hexBlock.add(components.DerivedShape("coolant", "Sodium", Tinput=273.0, Thot=273.0))
         self.r = tests.getEmptyHexReactor()
         self.hexBlock.autoCreateSpatialGrids(self.r.core.spatialGrid)
-        a = makeTestAssembly(1, 1)
+        a = buildEmptyHexAssembly(1, 1)
         a.add(self.hexBlock)
         loc1 = self.r.core.spatialGrid[0, 1, 0]
         self.r.core.add(a, loc1)

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -57,8 +57,6 @@ from armi.utils.units import (
     ASCII_LETTER_a,
 )
 
-NUM_PINS_IN_TEST_BLOCK = 217
-
 
 def getComponentData(component):
     density = 0.0

--- a/armi/reactor/tests/test_components.py
+++ b/armi/reactor/tests/test_components.py
@@ -52,7 +52,7 @@ from armi.reactor.components import (
     materials,
 )
 from armi.reactor.reactors import Reactor
-from armi.testing import TESTING_ROOT, loadTestReactor
+from armi.testing import TESTING_ROOT, buildSimpleFuelHexBlock, loadTestReactor
 from armi.utils.units import getTc
 
 
@@ -538,10 +538,8 @@ class TestDerivedShape(TestShapedComponent):
             :id: T_ARMI_COMP_FLUID
             :tests: R_ARMI_COMP_FLUID
         """
-        from armi.reactor.tests.test_blocks import buildSimpleFuelBlock
-
         # Calculate the total volume of the block
-        b = buildSimpleFuelBlock()
+        b = buildSimpleFuelHexBlock()
         totalVolume = b.getVolume()
 
         # calculate the total volume by adding up all the components

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -29,8 +29,7 @@ from armi.reactor import assemblies, components, composites, grids, parameters
 from armi.reactor.blueprints import assemblyBlueprint
 from armi.reactor.components import basicShapes
 from armi.reactor.flags import Flags, TypeSpec
-from armi.reactor.tests.test_blocks import loadTestBlock
-from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
+from armi.testing import TESTING_ROOT, buildComplexHexBlock, loadTestReactor, mockRunLogs
 from armi.tests import ISOAA_PATH
 
 
@@ -526,7 +525,7 @@ class TestCompositePattern(unittest.TestCase):
         self.assertIs(c, c0)
         self.assertIsInstance(c0, composites.Composite)
 
-        b = loadTestBlock()
+        b = buildComplexHexBlock()
         c = b.getComponents()[0]
         c0 = b.getFirstComponent()
         self.assertIs(c, c0)
@@ -673,7 +672,7 @@ class TestCompositeTree(unittest.TestCase):
         """
 
     def setUp(self):
-        self.block = loadTestBlock()
+        self.block = buildComplexHexBlock()
         self.r = self.block.core.r
         self.block.setHeight(100.0)
         self.refDict = {
@@ -999,7 +998,7 @@ class TestMiscMethods(unittest.TestCase):
     """
 
     def setUp(self):
-        self.obj = loadTestBlock()
+        self.obj = buildComplexHexBlock()
 
     def test_setMass(self):
         """Test setting and retrieving mass.
@@ -1020,12 +1019,12 @@ class TestMiscMethods(unittest.TestCase):
         # make sure it works with groups of groups
         group = composites.Composite("group")
         group.add(self.obj)
-        group.add(loadTestBlock())
+        group.add(buildComplexHexBlock())
         group.setMass("U235", 5)
         self.assertAlmostEqual(group.getMass("U235"), 5)
 
         # ad a second block, and confirm it works
-        group.add(loadTestBlock())
+        group.add(buildComplexHexBlock())
         self.assertGreater(group.getMass("U235"), 5)
         self.assertAlmostEqual(group.getMass("U235"), 1364.28376185)
 
@@ -1122,7 +1121,7 @@ class TestMiscMethods(unittest.TestCase):
             self.assertEqual(child.p.percentBu, self.obj.p.percentBu)
 
     def test_copyParamsFrom(self):
-        obj2 = loadTestBlock()
+        obj2 = buildComplexHexBlock()
         obj2.p.percentBu = 15.2
         self.obj.copyParamsFrom(obj2)
         self.assertEqual(obj2.p.percentBu, self.obj.p.percentBu)

--- a/armi/reactor/tests/test_excoreStructures.py
+++ b/armi/reactor/tests/test_excoreStructures.py
@@ -21,7 +21,7 @@ from armi.reactor.composites import Composite
 from armi.reactor.excoreStructure import ExcoreCollection, ExcoreStructure
 from armi.reactor.reactors import Reactor
 from armi.reactor.spentFuelPool import SpentFuelPool
-from armi.reactor.tests.test_assemblies import makeTestAssembly
+from armi.testing import buildEmptyHexAssembly
 
 
 class TestExcoreStructure(TestCase):
@@ -104,12 +104,12 @@ class TestSpentFuelPool(TestCase):
         self.assertEqual(len(self.sfp.getChildren()), 0)
 
         # add one assembly object and validate
-        a0 = makeTestAssembly(1, 987, spatialGrid=self.sfp.spatialGrid)
+        a0 = buildEmptyHexAssembly(1, 987, spatialGrid=self.sfp.spatialGrid)
         self.sfp.add(a0)
         self.assertEqual(len(self.sfp.getChildren()), 1)
 
         # add another assembly object and validate
-        a1 = makeTestAssembly(1, 988, spatialGrid=self.sfp.spatialGrid)
+        a1 = buildEmptyHexAssembly(1, 988, spatialGrid=self.sfp.spatialGrid)
         loc = self.sfp.spatialGrid[(1, -4, 0)]
         self.sfp.add(a1, loc)
         self.assertEqual(len(self.sfp.getChildren()), 2)
@@ -119,7 +119,7 @@ class TestSpentFuelPool(TestCase):
         self.assertEqual(len(self.sfp.getChildren()), 1)
 
     def test_getAssembly(self):
-        a0 = makeTestAssembly(1, 678, spatialGrid=self.sfp.spatialGrid)
+        a0 = buildEmptyHexAssembly(1, 678, spatialGrid=self.sfp.spatialGrid)
         self.sfp.add(a0)
 
         aReturn = self.sfp.getAssembly("A0678")
@@ -140,7 +140,7 @@ class TestSpentFuelPool(TestCase):
         self.assertEqual(loc._k, 0)
 
         # test against a non-empty grid
-        a0 = makeTestAssembly(1, 234, spatialGrid=self.sfp.spatialGrid)
+        a0 = buildEmptyHexAssembly(1, 234, spatialGrid=self.sfp.spatialGrid)
         self.sfp.add(a0)
 
     def test_normalizeNames(self):
@@ -149,7 +149,7 @@ class TestSpentFuelPool(TestCase):
         self.assertEqual(self.sfp.normalizeNames(17), 17)
 
         # test against a non-empty grid
-        a0 = makeTestAssembly(1, 456, spatialGrid=self.sfp.spatialGrid)
+        a0 = buildEmptyHexAssembly(1, 456, spatialGrid=self.sfp.spatialGrid)
         self.sfp.add(a0)
         self.assertEqual(self.sfp.normalizeNames(), 1)
         self.assertEqual(self.sfp.normalizeNames(17), 18)

--- a/armi/reactor/tests/test_hexBlockRotate.py
+++ b/armi/reactor/tests/test_hexBlockRotate.py
@@ -18,11 +18,11 @@ import math
 import unittest
 
 import numpy as np
+from testing import NUM_PINS_IN_TEST_BLOCK, buildComplexHexBlock
 
 from armi.reactor.blocks import HexBlock
 from armi.reactor.components import Component
 from armi.reactor.grids import CoordinateLocation, HexGrid, IndexLocation, MultiIndexLocation
-from armi.reactor.tests.test_blocks import NUM_PINS_IN_TEST_BLOCK, loadTestBlock
 from armi.utils import iterables
 
 
@@ -48,7 +48,7 @@ class HexBlockRotateTests(unittest.TestCase):
     PIN_DATA = np.arange(NUM_PINS_IN_TEST_BLOCK, dtype=float)
 
     def setUp(self):
-        self.baseBlock = loadTestBlock()
+        self.baseBlock = buildComplexHexBlock()
         self._assignParamData(self.BOUNDARY_PARAMS, self.BOUNDARY_DATA)
         self._assignParamData(self.PIN_PARAMS, self.PIN_DATA)
 

--- a/armi/reactor/tests/test_hexBlockRotate.py
+++ b/armi/reactor/tests/test_hexBlockRotate.py
@@ -18,11 +18,11 @@ import math
 import unittest
 
 import numpy as np
-from testing import NUM_PINS_IN_COMPLEX_HEX_BLOCK, buildComplexHexBlock
 
 from armi.reactor.blocks import HexBlock
 from armi.reactor.components import Component
 from armi.reactor.grids import CoordinateLocation, HexGrid, IndexLocation, MultiIndexLocation
+from armi.testing import NUM_PINS_IN_COMPLEX_HEX_BLOCK, buildComplexHexBlock
 from armi.utils import iterables
 
 

--- a/armi/reactor/tests/test_hexBlockRotate.py
+++ b/armi/reactor/tests/test_hexBlockRotate.py
@@ -18,7 +18,7 @@ import math
 import unittest
 
 import numpy as np
-from testing import NUM_PINS_IN_TEST_BLOCK, buildComplexHexBlock
+from testing import NUM_PINS_IN_COMPLEX_HEX_BLOCK, buildComplexHexBlock
 
 from armi.reactor.blocks import HexBlock
 from armi.reactor.components import Component
@@ -45,7 +45,7 @@ class HexBlockRotateTests(unittest.TestCase):
         "linPowByPin",
     ]
 
-    PIN_DATA = np.arange(NUM_PINS_IN_TEST_BLOCK, dtype=float)
+    PIN_DATA = np.arange(NUM_PINS_IN_COMPLEX_HEX_BLOCK, dtype=float)
 
     def setUp(self):
         self.baseBlock = buildComplexHexBlock()

--- a/armi/testing/__init__.py
+++ b/armi/testing/__init__.py
@@ -34,6 +34,7 @@ from armi.testing.singleAssemblies import (  # noqa: F401
     BLOCK_DEFINITIONS_3PIN,
     GRID_DEFINITION,
     REGULAR_ASSEMBLY_DEF,
+    buildEmptyHexAssembly,
     buildHexAssemblyFiveUZrUTh,
     buildHexAssemblyFourUZrUTh,
     buildHexAssemblySingleUZr,

--- a/armi/testing/__init__.py
+++ b/armi/testing/__init__.py
@@ -41,6 +41,13 @@ from armi.testing.singleAssemblies import (  # noqa: F401
     buildMixedPinAssembly,
     buildMixedThreePinAssembly,
 )
+from armi.testing.singleBlocks import (  # noqa: F401
+    NUM_PINS_IN_TEST_BLOCK,
+    applyDummyData,
+    buildComplexHexBlock,
+    buildLinkedFuelHexBlock,
+    buildSimpleFuelHexBlock,
+)
 
 TEST_ROOT = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "tests"))
 TESTING_ROOT = os.path.dirname(os.path.abspath(__file__))

--- a/armi/testing/__init__.py
+++ b/armi/testing/__init__.py
@@ -43,7 +43,7 @@ from armi.testing.singleAssemblies import (  # noqa: F401
     buildMixedThreePinAssembly,
 )
 from armi.testing.singleBlocks import (  # noqa: F401
-    NUM_PINS_IN_TEST_BLOCK,
+    NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     applyDummyData,
     buildComplexHexBlock,
     buildLinkedFuelHexBlock,

--- a/armi/testing/__init__.py
+++ b/armi/testing/__init__.py
@@ -47,7 +47,9 @@ from armi.testing.singleBlocks import (  # noqa: F401
     applyDummyData,
     buildComplexHexBlock,
     buildLinkedFuelHexBlock,
+    buildLinkedFuelHexBlockNegativeArea,
     buildSimpleFuelHexBlock,
+    buildSimpleFuelHexBlockNegativeArea,
 )
 
 TEST_ROOT = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "tests"))

--- a/armi/testing/singleAssemblies.py
+++ b/armi/testing/singleAssemblies.py
@@ -564,6 +564,33 @@ grids:
 """
 
 
+# Formerly makeTestAssembly
+def buildEmptyHexAssembly(numBlocks, assemNum, spatialGrid=grids.HexGrid.fromPitch(1.0), r=None):
+    """Builds an empty hex assembly.
+
+    Parameters
+    ----------
+    numBlocks : int
+        Number of blocks
+    assemNum : int
+        Assembly ID
+    spatialGrid : ...
+    r : armi.reactor
+
+    Returns
+    -------
+    ...
+    """
+    from armi.reactor.assemblies import HexAssembly
+
+    coreGrid = r.core.spatialGrid if r is not None else spatialGrid
+    a = HexAssembly("TestAssem", assemNum=assemNum)
+    a.spatialGrid = grids.AxialGrid.fromNCells(numBlocks)
+    a.spatialGrid.armiObject = a
+    a.spatialLocator = coreGrid[2, 2, 0]
+    return a
+
+
 def buildMixedPinAssembly(
     blockDefs: str = BLOCK_DEFINITIONS_2PIN,
     assemDef: str = REGULAR_ASSEMBLY_DEF,

--- a/armi/testing/singleAssemblies.py
+++ b/armi/testing/singleAssemblies.py
@@ -574,11 +574,15 @@ def buildEmptyHexAssembly(numBlocks, assemNum, spatialGrid=grids.HexGrid.fromPit
         Number of blocks
     assemNum : int
         Assembly ID
-    spatialGrid : ...
-    r : armi.reactor
+    spatialGrid : :py:class:`armi.reactors.grids.HexGrid`
+        HexGrid used for assembly.
+    r : :py:class:`armi.reactors.Reactor`
+        Optional reactor object that may be passed. This objects `self.core.spatialGrid` is used instead of the
+        `spatialGrid` argument.
 
     Returns
     -------
+    a : :py:class:`armi.reactor.assemblies.HexAssembly`
     ...
     """
     from armi.reactor.assemblies import HexAssembly

--- a/armi/testing/singleAssemblies.py
+++ b/armi/testing/singleAssemblies.py
@@ -564,7 +564,6 @@ grids:
 """
 
 
-# Formerly makeTestAssembly
 def buildEmptyHexAssembly(numBlocks, assemNum, spatialGrid=grids.HexGrid.fromPitch(1.0), r=None):
     """Builds an empty hex assembly.
 
@@ -583,7 +582,6 @@ def buildEmptyHexAssembly(numBlocks, assemNum, spatialGrid=grids.HexGrid.fromPit
     Returns
     -------
     a : :py:class:`armi.reactor.assemblies.HexAssembly`
-    ...
     """
     from armi.reactor.assemblies import HexAssembly
 

--- a/armi/testing/singleBlocks.py
+++ b/armi/testing/singleBlocks.py
@@ -28,8 +28,6 @@ from armi.reactor import blocks
 from armi.reactor.components import Circle, DerivedShape, Helix, Hexagon
 from armi.reactor.flags import Flags
 
-NUM_PINS_IN_TEST_BLOCK = 217
-
 
 def _buildSimpleFuelHexBlockHelper(linkedBond=False):
     """Returns a simple hex block containing fuel, clad, duct, and coolant, with an optional
@@ -92,32 +90,34 @@ def _buildSimpleFuelHexBlockHelper(linkedBond=False):
     return b
 
 
-# formerly buildSimpleFuelBlock
 def buildSimpleFuelHexBlock():
     """Return a simple hex block containing fuel, clad, duct, and coolant."""
     return _buildSimpleFuelHexBlockHelper()
 
 
-# formerly buildLinkedFuelBlock
 def buildLinkedFuelHexBlock():
     """Return a simple hex block containing containing fuel, clad, duct, linked bond, and coolant."""
     return _buildSimpleFuelHexBlockHelper(linkedBond=True)
 
 
-## formerly loadTestBlock
+NUM_PINS_IN_COMPLEX_HEX_BLOCK = 217
+
+
 def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
-    """Build an annular test block for evaluating unit tests.
+    """Build an annular hex block representing a more realistic SFR fuel pin structure, including an anulus and
+    voids/gaps between fuel, liner, and cladding. Use for evaluating unit tests.
 
     Parameters
     ----------
     cold : bool
-        ...
-    depeltable : bool
-        ...
+        Whether or not the block is cold.
+    depeletable : bool
+        Whether or not the block is depletable.
 
     Returns
     -------
-    block :
+    block : :py:class:`armi.reactor.blocks.HexBlock`
+        Annular hex block.
 
     """
     from armi.testing import buildEmptyHexAssembly, getEmptyHexReactor
@@ -129,9 +129,10 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
     r = getEmptyHexReactor()
 
     assemNum = 3
-    block = blocks.HexBlock("TestHexBlock")
+    # name was formerly TestHexBlock
+    block = blocks.HexBlock("ComplexHexBlock")
     block.setType("defaultType")
-    block.p.nPins = NUM_PINS_IN_TEST_BLOCK
+    block.p.nPins = NUM_PINS_IN_COMPLEX_HEX_BLOCK
     assembly = buildEmptyHexAssembly(assemNum, 1, r=r)
 
     # NOTE: temperatures are supposed to be in C
@@ -145,7 +146,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "Thot": hotTempFuel,
         "od": 0.84,
         "id": 0.6,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     fuel = Circle("fuel", "UZr", **fuelDims)
     if depletable:
@@ -156,7 +157,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "Thot": hotTempCoolant,
         "od": "fuel.id",
         "id": 0.3,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     bondDims["components"] = {"fuel": fuel}
     bond = Circle("bond", "Sodium", **bondDims)
@@ -166,7 +167,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "Thot": hotTempStructure,
         "od": "bond.id",
         "id": 0.0,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     annularVoidDims["components"] = {"bond": bond}
     annularVoid = Circle("annular void", "Void", **annularVoidDims)
@@ -176,7 +177,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "Thot": hotTempStructure,
         "od": 0.90,
         "id": 0.85,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     innerLiner = Circle("inner liner", "Graphite", **innerLinerDims)
 
@@ -185,7 +186,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "Thot": hotTempStructure,
         "od": "inner liner.id",
         "id": "fuel.od",
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     fuelLinerGapDims["components"] = {"inner liner": innerLiner, "fuel": fuel}
     fuelLinerGap = Circle("gap1", "Void", **fuelLinerGapDims)
@@ -195,7 +196,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "Thot": hotTempStructure,
         "od": 0.95,
         "id": 0.90,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     outerLiner = Circle("outer liner", "HT9", **outerLinerDims)
 
@@ -204,7 +205,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "Thot": hotTempStructure,
         "od": "outer liner.id",
         "id": "inner liner.od",
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     linerLinerGapDims["components"] = {
         "outer liner": outerLiner,
@@ -217,7 +218,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "Thot": hotTempStructure,
         "od": 1.05,
         "id": 0.95,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     cladding = Circle("clad", "HT9", **claddingDims)
     if depletable:
@@ -228,7 +229,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "Thot": hotTempStructure,
         "od": "clad.id",
         "id": "outer liner.od",
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     linerCladGapDims["components"] = {"clad": cladding, "outer liner": outerLiner}
     linerCladGap = Circle("gap3", "Void", **linerCladGapDims)
@@ -240,7 +241,7 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
         "id": 0.0,
         "axialPitch": 30.0,
         "helixDiameter": 1.1,
-        "mult": NUM_PINS_IN_TEST_BLOCK,
+        "mult": NUM_PINS_IN_COMPLEX_HEX_BLOCK,
     }
     wire = Helix("wire", "HT9", **wireDims)
     if depletable:

--- a/armi/testing/singleBlocks.py
+++ b/armi/testing/singleBlocks.py
@@ -47,7 +47,6 @@ def _buildSimpleFuelHexBlockHelper(linkedBond=False):
         name = "simple-fuel-linked"
     else:
         name = "simple-fuel"
-    # name was formerly "fuel"
     b = blocks.HexBlock(name, height=10.0)
 
     fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}

--- a/armi/testing/singleBlocks.py
+++ b/armi/testing/singleBlocks.py
@@ -51,6 +51,7 @@ def _buildSimpleFuelHexBlockHelper(linkedBond=False):
     b = blocks.HexBlock(name, height=10.0)
 
     fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
+    # only used if linkedBond is True
     bondDims = {
         "Tinput": 25.0,
         "Thot": 450,
@@ -88,6 +89,94 @@ def _buildSimpleFuelHexBlockHelper(linkedBond=False):
     b.add(coolant)
     b.add(intercoolant)
     return b
+
+
+def _buildSimpleFuelHexBlockNegativeAreaHelper(linkedBond=False):
+    """Returns a simple hex block containing fuel, clad, duct, and coolant, with an optional
+    linked bond.
+
+    If linkedBond is True, the block has a negative-area bond between fuel and cladding for testing. Otherwise the block
+    has a negative-area gap between fuel and cladding for testing.
+
+    Parameters
+    ----------
+    linkedBond : bool
+        Whether or not to include the linked bond in the returned block.
+
+    Returns
+    -------
+    b : :py:class:`armi.reactor.blocks.HexBlock`
+        The simple fuel hex block.
+    """
+    if linkedBond:
+        name = "simple-fuel-negative-linked"
+    else:
+        name = "simple-fuel-negative"
+
+    # name was formerly "fuel"
+    b = blocks.HexBlock(name, height=10.0)
+
+    fuelDims = {"Tinput": 25, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
+    cladDims = {"Tinput": 25, "Thot": 600, "od": 0.80, "id": 0.76, "mult": 127.0}
+    ductDims = {"Tinput": 25, "Thot": 600, "op": 16, "ip": 15.3, "mult": 1.0}
+    intercoolantDims = {
+        "Tinput": 400,
+        "Thot": 400,
+        "op": 17.0,
+        "ip": ductDims["op"],
+        "mult": 1.0,
+    }
+    coolDims = {"Tinput": 25.0, "Thot": 400}
+
+    fuel = Circle("fuel", "UZr", **fuelDims)
+    clad = Circle("clad", "HT9", **cladDims)
+    negativeDims = {
+        "Tinput": 25,
+        "Thot": 600,
+        "od": "clad.id",
+        "id": "fuel.od",
+        "mult": 127.0,
+    }
+    negativeDims["components"] = {"fuel": fuel, "clad": clad}
+    if linkedBond:
+        bond = Circle("bond", "Sodium", **negativeDims)
+    else:
+        gap = Circle("gap", "Void", **negativeDims)
+    duct = Hexagon("duct", "HT9", **ductDims)
+    coolant = DerivedShape("coolant", "Sodium", **coolDims)
+    intercoolant = Hexagon("intercoolant", "Sodium", **intercoolantDims)
+
+    b.add(fuel)
+    if linkedBond:
+        b.add(bond)
+    else:
+        b.add(gap)
+    b.add(clad)
+    b.add(duct)
+    b.add(coolant)
+    b.add(intercoolant)
+
+    b.getVolumeFractions()
+
+    return b
+
+
+def buildSimpleFuelHexBlockNegativeArea():
+    """
+    Return a simple block containing fuel, clad, duct, and coolant.
+
+    The block has a negative-area gap between fuel and cladding for testing.
+    """
+    return _buildSimpleFuelHexBlockNegativeAreaHelper()
+
+
+def buildLinkedFuelHexBlockNegativeArea():
+    """
+    Return a simple block containing fuel, clad, duct, and coolant.
+
+    The block has a negative-area bond between fuel and cladding for testing.
+    """
+    return _buildSimpleFuelHexBlockNegativeAreaHelper(linkedBond=True)
 
 
 def buildSimpleFuelHexBlock():

--- a/armi/testing/singleBlocks.py
+++ b/armi/testing/singleBlocks.py
@@ -113,7 +113,6 @@ def _buildSimpleFuelHexBlockNegativeAreaHelper(linkedBond=False):
     else:
         name = "simple-fuel-negative"
 
-    # name was formerly "fuel"
     b = blocks.HexBlock(name, height=10.0)
 
     fuelDims = {"Tinput": 25, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
@@ -207,7 +206,6 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
     -------
     block : :py:class:`armi.reactor.blocks.HexBlock`
         Annular hex block.
-
     """
     from armi.testing import buildEmptyHexAssembly, getEmptyHexReactor
 
@@ -218,7 +216,6 @@ def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
     r = getEmptyHexReactor()
 
     assemNum = 3
-    # name was formerly TestHexBlock
     block = blocks.HexBlock("ComplexHexBlock")
     block.setType("defaultType")
     block.p.nPins = NUM_PINS_IN_COMPLEX_HEX_BLOCK

--- a/armi/testing/singleBlocks.py
+++ b/armi/testing/singleBlocks.py
@@ -1,0 +1,345 @@
+# Copyright 2026 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Importable testing utilities for block-related machinery.
+
+This is a very limited set of ARMI block testing tools, meant to be importable as part of the ARMI API. The goal is to
+provide a small set of high quality block-related tools to help downstream ARMI developers write tests.
+
+Notes
+-----
+This will not be a catch-all for random unit test functions. Be very sparing here.
+"""
+
+from armi import runLog, settings
+from armi.physics.neutronics.settings import CONF_XS_KERNEL
+from armi.reactor import blocks
+from armi.reactor.components import Circle, DerivedShape, Helix, Hexagon
+from armi.reactor.flags import Flags
+
+NUM_PINS_IN_TEST_BLOCK = 217
+
+
+def _buildSimpleFuelHexBlockHelper(linkedBond=False):
+    """Returns a simple hex block containing fuel, clad, duct, and coolant, with an optional
+    linked bond.
+
+    Parameters
+    ----------
+    linkedBond : bool
+        Whether or not to include the linked bond in the returned block.
+
+    Returns
+    -------
+    b : :py:class:`armi.reactor.blocks.HexBlock`
+        The simple fuel hex block.
+    """
+    if linkedBond:
+        name = "simple-fuel-linked"
+    else:
+        name = "simple-fuel"
+    # name was formerly "fuel"
+    b = blocks.HexBlock(name, height=10.0)
+
+    fuelDims = {"Tinput": 25.0, "Thot": 600, "od": 0.76, "id": 0.00, "mult": 127.0}
+    bondDims = {
+        "Tinput": 25.0,
+        "Thot": 450,
+        "od": "clad.id",
+        "id": "fuel.od",
+        "mult": 127.0,
+    }
+    cladDims = {"Tinput": 25.0, "Thot": 450, "od": 0.80, "id": 0.77, "mult": 127.0}
+    ductDims = {"Tinput": 25.0, "Thot": 400, "op": 16, "ip": 15.3, "mult": 1.0}
+    intercoolantDims = {
+        "Tinput": 400,
+        "Thot": 400,
+        "op": 17.0,
+        "ip": ductDims["op"],
+        "mult": 1.0,
+    }
+    coolDims = {"Tinput": 25.0, "Thot": 400}
+
+    fuel = Circle("fuel", "UZr", **fuelDims)
+    clad = Circle("clad", "HT9", **cladDims)
+
+    if linkedBond:
+        bondDims["components"] = {"clad": clad, "fuel": fuel}
+        bond = Circle("bond", "HT9", **bondDims)
+    duct = Hexagon("duct", "HT9", **ductDims)
+
+    coolant = DerivedShape("coolant", "Sodium", **coolDims)
+    intercoolant = Hexagon("intercoolant", "Sodium", **intercoolantDims)
+
+    b.add(fuel)
+    if linkedBond:
+        b.add(bond)
+    b.add(clad)
+    b.add(duct)
+    b.add(coolant)
+    b.add(intercoolant)
+    return b
+
+
+# formerly buildSimpleFuelBlock
+def buildSimpleFuelHexBlock():
+    """Return a simple hex block containing fuel, clad, duct, and coolant."""
+    return _buildSimpleFuelHexBlockHelper()
+
+
+# formerly buildLinkedFuelBlock
+def buildLinkedFuelHexBlock():
+    """Return a simple hex block containing containing fuel, clad, duct, linked bond, and coolant."""
+    return _buildSimpleFuelHexBlockHelper(linkedBond=True)
+
+
+## formerly loadTestBlock
+def buildComplexHexBlock(cold=True, depletable=False) -> blocks.HexBlock:
+    """Build an annular test block for evaluating unit tests.
+
+    Parameters
+    ----------
+    cold : bool
+        ...
+    depeltable : bool
+        ...
+
+    Returns
+    -------
+    block :
+
+    """
+    from armi.testing import buildEmptyHexAssembly, getEmptyHexReactor
+
+    caseSetting = settings.Settings()
+    caseSetting[CONF_XS_KERNEL] = "MC2v2"
+    runLog.setVerbosity("error")
+    caseSetting["nCycles"] = 1
+    r = getEmptyHexReactor()
+
+    assemNum = 3
+    block = blocks.HexBlock("TestHexBlock")
+    block.setType("defaultType")
+    block.p.nPins = NUM_PINS_IN_TEST_BLOCK
+    assembly = buildEmptyHexAssembly(assemNum, 1, r=r)
+
+    # NOTE: temperatures are supposed to be in C
+    coldTemp = 25.0
+    hotTempCoolant = 430.0
+    hotTempStructure = 25.0 if cold else hotTempCoolant
+    hotTempFuel = 25.0 if cold else 600.0
+
+    fuelDims = {
+        "Tinput": coldTemp,
+        "Thot": hotTempFuel,
+        "od": 0.84,
+        "id": 0.6,
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    fuel = Circle("fuel", "UZr", **fuelDims)
+    if depletable:
+        fuel.p.flags = Flags.fromString("fuel depletable")
+
+    bondDims = {
+        "Tinput": coldTemp,
+        "Thot": hotTempCoolant,
+        "od": "fuel.id",
+        "id": 0.3,
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    bondDims["components"] = {"fuel": fuel}
+    bond = Circle("bond", "Sodium", **bondDims)
+
+    annularVoidDims = {
+        "Tinput": hotTempStructure,
+        "Thot": hotTempStructure,
+        "od": "bond.id",
+        "id": 0.0,
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    annularVoidDims["components"] = {"bond": bond}
+    annularVoid = Circle("annular void", "Void", **annularVoidDims)
+
+    innerLinerDims = {
+        "Tinput": coldTemp,
+        "Thot": hotTempStructure,
+        "od": 0.90,
+        "id": 0.85,
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    innerLiner = Circle("inner liner", "Graphite", **innerLinerDims)
+
+    fuelLinerGapDims = {
+        "Tinput": hotTempStructure,
+        "Thot": hotTempStructure,
+        "od": "inner liner.id",
+        "id": "fuel.od",
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    fuelLinerGapDims["components"] = {"inner liner": innerLiner, "fuel": fuel}
+    fuelLinerGap = Circle("gap1", "Void", **fuelLinerGapDims)
+
+    outerLinerDims = {
+        "Tinput": coldTemp,
+        "Thot": hotTempStructure,
+        "od": 0.95,
+        "id": 0.90,
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    outerLiner = Circle("outer liner", "HT9", **outerLinerDims)
+
+    linerLinerGapDims = {
+        "Tinput": hotTempStructure,
+        "Thot": hotTempStructure,
+        "od": "outer liner.id",
+        "id": "inner liner.od",
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    linerLinerGapDims["components"] = {
+        "outer liner": outerLiner,
+        "inner liner": innerLiner,
+    }
+    linerLinerGap = Circle("gap2", "Void", **linerLinerGapDims)
+
+    claddingDims = {
+        "Tinput": coldTemp,
+        "Thot": hotTempStructure,
+        "od": 1.05,
+        "id": 0.95,
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    cladding = Circle("clad", "HT9", **claddingDims)
+    if depletable:
+        cladding.p.flags = Flags.fromString("clad depletable")
+
+    linerCladGapDims = {
+        "Tinput": hotTempStructure,
+        "Thot": hotTempStructure,
+        "od": "clad.id",
+        "id": "outer liner.od",
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    linerCladGapDims["components"] = {"clad": cladding, "outer liner": outerLiner}
+    linerCladGap = Circle("gap3", "Void", **linerCladGapDims)
+
+    wireDims = {
+        "Tinput": coldTemp,
+        "Thot": hotTempStructure,
+        "od": 0.1,
+        "id": 0.0,
+        "axialPitch": 30.0,
+        "helixDiameter": 1.1,
+        "mult": NUM_PINS_IN_TEST_BLOCK,
+    }
+    wire = Helix("wire", "HT9", **wireDims)
+    if depletable:
+        wire.p.flags = Flags.fromString("wire depletable")
+
+    coolantDims = {"Tinput": hotTempCoolant, "Thot": hotTempCoolant}
+    coolant = DerivedShape("coolant", "Sodium", **coolantDims)
+
+    ductDims = {
+        "Tinput": coldTemp,
+        "Thot": hotTempStructure,
+        "ip": 16.6,
+        "op": 17.3,
+        "mult": 1,
+    }
+    duct = Hexagon("duct", "HT9", **ductDims)
+    if depletable:
+        duct.p.flags = Flags.fromString("duct depletable")
+
+    interDims = {
+        "Tinput": hotTempCoolant,
+        "Thot": hotTempCoolant,
+        "op": 17.8,
+        "ip": "duct.op",
+        "mult": 1,
+    }
+    interDims["components"] = {"duct": duct}
+    interSodium = Hexagon("interCoolant", "Sodium", **interDims)
+
+    block.add(annularVoid)
+    block.add(bond)
+    block.add(fuel)
+    block.add(fuelLinerGap)
+    block.add(innerLiner)
+    block.add(linerLinerGap)
+    block.add(outerLiner)
+    block.add(linerCladGap)
+    block.add(cladding)
+
+    block.add(wire)
+    block.add(coolant)
+    block.add(duct)
+    block.add(interSodium)
+
+    block.setHeight(16.0)
+
+    block.autoCreateSpatialGrids(r.core.spatialGrid)
+    assembly.add(block)
+    r.core.add(assembly)
+    return block
+
+
+def applyDummyData(block):
+    """Add some dummy data to a block for physics-like tests."""
+    from armi.nuclearDataIO.cccc import isotxs
+    from armi.tests import ISOAA_PATH
+
+    # typical SFR-ish flux in 1/cm^2/s
+    flux = [
+        161720716762.12997,
+        2288219224332.647,
+        11068159130271.139,
+        26473095948525.742,
+        45590249703180.945,
+        78780459664094.23,
+        143729928505629.06,
+        224219073208464.06,
+        229677567456769.22,
+        267303906113313.16,
+        220996878365852.22,
+        169895433093246.28,
+        126750484612975.31,
+        143215138794766.53,
+        74813432842005.5,
+        32130372366225.85,
+        21556243034771.582,
+        6297567411518.368,
+        22365198294698.45,
+        12211256796917.86,
+        5236367197121.363,
+        1490736020048.7847,
+        1369603135573.731,
+        285579041041.55945,
+        73955783965.98692,
+        55003146502.73623,
+        18564831886.20426,
+        4955747691.052108,
+        3584030491.076041,
+        884015567.3986057,
+        4298964991.043116,
+        1348809158.0353086,
+        601494405.293505,
+    ]
+    xslib = isotxs.readBinary(ISOAA_PATH)
+    # Slight hack here because the test block was created by hand rather than via blueprints and so
+    # elemental expansion of isotopics did not occur. But, the ISOTXS library being used did go
+    # through an isotopic expansion, so we map nuclides here.
+    xslib._nuclides["NAAA"] = xslib._nuclides["NA23AA"]
+    xslib._nuclides["WAA"] = xslib._nuclides["W184AA"]
+    xslib._nuclides["MNAA"] = xslib._nuclides["MN55AA"]
+    block.p.mgFlux = flux
+    block.core.lib = xslib


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
This PR moves and renames the following functions and variables, previously stored in `armi.reactors.tests.test_blocks`, to `armi.testing.singleBlocks`:
* `test_blocks.buildSimpleFuelBlock()` ->
  `testing.buildSimpleFuelHexBlock()`
* `test_blocks.buildLinkedFuelBlock()` ->
  `testing.buildLinkedFuelHexblock()`
* `test_blocks.loadTestBlock()` -> `testing.buildComplexHexBlock()`
* `test_blocks.NUM_PINS_IN_TEST_BLOCK` -> `testing.NUM_PINS_IN_COMPLEX_HEX_BLOCK`

 This is done to prevent downstream plugins from importing directly from the ARMI testing suite.

There are some additional pieces of machinery from around ARMI's test suite moved to `armi.testing` for consistency.
* `test_blocks.applyDummyData()` -> `testing.applyDummyData()`
* `test_assemblies.makeTestAssembly()` -> `testing.buildEmptyHexAssembly()`
* `test_blockConverter.buildSimpleFuelBlockNegativeArea()` -> `testing.buildSimpleFuelHexBlockNegativeArea()`
* `test_blockConverter.buildSimpleFuelBlockNegativeAreaBond()` ->`testing.buildLinkedFuelBlockNegativeArea()`

Any feedback and suggested improvements on this design choice would be appreciated.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Improving testing suite makes downstream code more resilient.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
