### PR TITLE
Supporting Blueprint.dump without streams

### DIFF
--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -75,7 +75,7 @@ import h5py
 import ordered_set
 import yamlize
 import yamlize.objects
-from ruamel.yaml import RoundTripLoader
+from ruamel.yaml import RoundTripDumper, RoundTripLoader
 
 from armi import (
     context,
@@ -512,19 +512,50 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
         return inp
 
     @classmethod
-    def dump(cls, data, stream) -> None:
-        """A wrapper around the yamlize.Object.dump.
+    def dump(cls, data, stream=None, Dumper=RoundTripDumper):
+        """A modification of yamlize.Object.dump.
 
         With the release of ruamel.yaml 0.19.1, we began to get an error where lists that include only empty and 0.0
         values incorrectly for the zero values to zero strings: '0.0'.
         """
-        super().dump(data, stream=stream)
+        convertToYaml = stream is None
+        stream = stream or io.StringIO()
+        dumper = Dumper(stream)
 
-        if stream is None or isinstance(stream, io.TextIOWrapper):
-            return
+        try:
+            dumper._serializer.open()
+            root_node = cls.to_yaml(dumper, data)
+            dumper.serialize(root_node)
+            dumper._serializer.close()
+        finally:
+            try:
+                dumper._emitter.dispose()
+            except AttributeError:
+                raise
+                dumper.dispose()  # cyaml
 
-        # Loop through the entire text file, to attempt to do the cleaning
-        stream.seek(0)  # must rewind to be able to read the entire stream
+        try:
+            Blueprints.streamCleaner(stream)
+        except io.UnsupportedOperation:
+            # Not all streams are writable.
+            pass
+
+        if convertToYaml:
+            return stream.getvalue()
+
+        return None
+
+    @classmethod
+    def streamCleaner(cls, stream) -> None:
+        """Clean the zero strings into zero floats.
+
+        With the release of ruamel.yaml 0.19.1, we began to get an error where lists that include only empty and 0.0
+        values incorrectly for the zero values to zero strings: '0.0'.
+        """
+        # must rewind to be able to read the entire stream
+        stream.seek(0)
+
+        # build the replacement string
         txt = stream.read()
         txt = txt.replace("'0.0'", "0.0")
         txt = txt.replace('"0.0"', "0.0")

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -196,9 +196,10 @@ class TestRuamelYamlBug(unittest.TestCase):
             self.assertEqual(modFracs[2], 0.0)
             self.assertEqual(modFracs[3], 0.0)
 
-            # test an edge case: mandatory stream argument
-            with self.assertRaises(TypeError):
-                bp.dump(bp)
+            txt = bp.dump(bp)
+            self.assertIn("0.0, 0.0, 0.0", txt)
+            self.assertNotIn('"0.0"', txt)
+            self.assertNotIn('"0.0"', txt)
 
 
 class TestBlueprintsSchema(unittest.TestCase):


### PR DESCRIPTION
## What is the change? Why is it being made?

In a [recent PR](https://github.com/terrapower/armi/pull/2604) I attempted to fix a [bug](https://github.com/terrapower/armi/issues/2600) with `Blueprints.dump()`.

I convinced @drewj-tp  that no one was using the returned string from this method. And so I had a quicker fix.

But @yardasol found a downstream use-case where someone WAS using the retuned string. So I need another version.

Essentially, this is a rewrite of the [same method in yamlizable](https://github.com/SimplyKnownAsG/yamlize/blob/master/yamlize/yamlizable.py#L58), but with a "stream cleaner" added to fix this zeros. I tested downstream where Olek found the problem, and that passes now.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
 Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Blueprints.dump needs to be able to return a string sometimes.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
