### PR TITLE
Ensuring migrations are not applied when they are not needed

### DIFF
--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -429,7 +429,8 @@ class Database:
             return None
 
         stream = io.StringIO(bpString)
-        stream = Blueprints.migrate(stream)
+        version = self.version if self.version != "uncontrolled" else None
+        stream = Blueprints.migrate(stream, version)
         return Blueprints.load(stream)
 
     def writeInputsToDB(self, cs, csString=None, bpString=None):

--- a/armi/migration/base.py
+++ b/armi/migration/base.py
@@ -20,6 +20,7 @@ migration class defined here chooses this behavior based on whether the ``stream
 the constructor.
 """
 
+import io
 import os
 import shutil
 
@@ -58,19 +59,28 @@ class Migration:
         version : str
             Optional DB version string, for example: 1.2.3
         """
-        # TODO: Compare self.toVersion to version of DB or whatever...
+        skip = False
+        # Compare self.toVersion to the version of the DB.
         if version is not None:
-            if versionToNumber(self.toVersion) >= versionToNumber(version):
+            if versionToNumber(version) >= versionToNumber(self.toVersion):
                 # this migration is not necessary, because the DB is newer than that.
-                return
+                skip = True
 
-        runLog.info(f"Applying {self}")
+        if not skip:
+            runLog.info(f"Applying {self}")
+
         if self.path:
             self._loadStreamFromPath()
-        newStream = self._applyToStream()
-        if self.path:
-            self._backupOriginal()
-            self._writeNewFile(newStream)
+
+        if not skip:
+            newStream = self._applyToStream()
+
+            if self.path:
+                self._backupOriginal()
+                self._writeNewFile(newStream)
+        else:
+            newStream = io.StringIO(self.stream.read())
+
         return newStream
 
     def _loadStreamFromPath(self):

--- a/armi/migration/base.py
+++ b/armi/migration/base.py
@@ -14,12 +14,10 @@
 """
 Base migration classes.
 
-A classic migration takes a file name, read the files, migrates the
-data, and re-writes the file. Some migrations need to happen live
-on a stream. For example, if an old/invalid input file is being read
-in from an old database. The migration class defined here
-chooses this behavior based on whether the ``stream`` or ``path``
-variables are given in the constructor.
+A classic migration takes a file name, read the files, migrates the data, and re-writes the file. Some migrations need
+to happen live on a stream. For example, if an old/invalid input file is being read in from an old database. The
+migration class defined here chooses this behavior based on whether the ``stream`` or ``path`` variables are given in
+the constructor.
 """
 
 import os
@@ -27,13 +25,13 @@ import shutil
 
 from armi import runLog
 from armi.settings import caseSettings
+from armi.settings.settingsValidation import versionToNumber
 
 
 class Migration:
     """Generic migration.
 
-    To implement a concrete Migration, one must often only
-    implement the ``_applyToStream`` method.
+    To implement a concrete Migration, one must often only implement the ``_applyToStream`` method.
     """
 
     fromVersion = "x.x.x"
@@ -49,12 +47,23 @@ class Migration:
     def __repr__(self):
         return f"<Migration from {self.fromVersion}: {self.__doc__[:40]}..."
 
-    def apply(self):
+    def apply(self, version: str = None):
         """
         Apply migration.
 
         This is generally called from a subclass.
+
+        Parameters
+        ----------
+        version : str
+            Optional DB version string, for example: 1.2.3
         """
+        # TODO: Compare self.toVersion to version of DB or whatever...
+        if version is not None:
+            if versionToNumber(self.toVersion) >= versionToNumber(version):
+                # this migration is not necessary, because the DB is newer than that.
+                return
+
         runLog.info(f"Applying {self}")
         if self.path:
             self._loadStreamFromPath()

--- a/armi/migration/base.py
+++ b/armi/migration/base.py
@@ -61,7 +61,7 @@ class Migration:
         """
         skip = False
         # Compare self.toVersion to the version of the DB.
-        if version is not None:
+        if version is not None or version != "uncontrolled":
             if versionToNumber(version) >= versionToNumber(self.toVersion):
                 # this migration is not necessary, because the DB is newer than that.
                 skip = True

--- a/armi/migration/base.py
+++ b/armi/migration/base.py
@@ -68,13 +68,11 @@ class Migration:
                 # this migration is not necessary, because the DB is newer than that.
                 skip = True
 
-        if not skip:
-            runLog.info(f"Applying {self}")
-
         if self.path:
             self._loadStreamFromPath()
 
         if not skip:
+            runLog.info(f"Applying {self}")
             newStream = self._applyToStream()
 
             if self.path:

--- a/armi/migration/base.py
+++ b/armi/migration/base.py
@@ -61,7 +61,7 @@ class Migration:
         """
         skip = False
         # Compare self.toVersion to the version of the DB.
-        if version is not None or version != "uncontrolled":
+        if version is not None and version != "uncontrolled":
             if versionToNumber(version) >= versionToNumber(self.toVersion):
                 # this migration is not necessary, because the DB is newer than that.
                 skip = True

--- a/armi/migration/base.py
+++ b/armi/migration/base.py
@@ -32,15 +32,17 @@ from armi.settings.settingsValidation import versionToNumber
 class Migration:
     """Generic migration.
 
-    To implement a concrete Migration, one must often only implement the ``_applyToStream`` method.
+    To implement a concrete Migration, you must implement the ``_applyToStream`` method. You must also over-write the
+    class variables ``fromVersion`` and ``toVersion``. These are the ARMI versions you are migrating from and to. The
+    ``toVersion`` must be higher than the ``fromVersion``.
     """
 
+    # Any subclass MUST over-write these ARMI versions; "toVersion" MUST be higher than "fromVersion".
     fromVersion = "x.x.x"
     toVersion = "x.x.x"
 
     def __init__(self, stream=None, path=None):
-        if not (bool(stream) ^ bool(path)):
-            # XOR
+        if not (bool(stream) ^ bool(path)):  # XOR
             raise RuntimeError("Stream and path inputs to migration aremutually exclusive. Choose one or the other.")
         self.stream = stream
         self.path = path

--- a/armi/migration/base.py
+++ b/armi/migration/base.py
@@ -20,6 +20,7 @@ migration class defined here chooses this behavior based on whether the ``stream
 the constructor.
 """
 
+import abc
 import io
 import os
 import shutil
@@ -32,20 +33,36 @@ from armi.settings.settingsValidation import versionToNumber
 class Migration:
     """Generic migration.
 
-    To implement a concrete Migration, you must implement the ``_applyToStream`` method. You must also over-write the
-    class variables ``fromVersion`` and ``toVersion``. These are the ARMI versions you are migrating from and to. The
-    ``toVersion`` must be higher than the ``fromVersion``.
+    To implement a concrete Migration, you must implement the ``_applyToStream`` method. You must also define the
+    abstract properties ``fromVersion`` and ``toVersion``. These are the ARMI versions you are migrating from and to.
+    The ``toVersion`` must be higher than the ``fromVersion``.
     """
 
-    # Any subclass MUST over-write these ARMI versions; "toVersion" MUST be higher than "fromVersion".
-    fromVersion = "x.x.x"
-    toVersion = "x.x.x"
+    __metaclass__ = abc.ABCMeta
 
     def __init__(self, stream=None, path=None):
         if not (bool(stream) ^ bool(path)):  # XOR
-            raise RuntimeError("Stream and path inputs to migration aremutually exclusive. Choose one or the other.")
+            raise RuntimeError("Only a stream or a path may be used as migration input. Choose exactly one.")
+        elif versionToNumber(self.toVersion) <= versionToNumber(self.fromVersion):
+            raise ValueError(f"{self.toVersion} is not higher than {self.fromVersion}.")
+
         self.stream = stream
         self.path = path
+
+    @abc.abstractproperty
+    def fromVersion(self):
+        """ARMI version string, must be smaller than toVersion."""
+        pass
+
+    @abc.abstractproperty
+    def toVersion(self):
+        """ARMI version string, must be larger than fromVersion."""
+        pass
+
+    @abc.abstractmethod
+    def _applyToStream(self):
+        """Add actual migration code here in a subclass."""
+        pass
 
     def __repr__(self):
         return f"<Migration from {self.fromVersion}: {self.__doc__[:40]}..."
@@ -91,10 +108,6 @@ class Migration:
         if not os.path.exists(self.path):
             raise ValueError(f"File {self.path} does not exist")
 
-    def _applyToStream(self):
-        """Add actual migration code here in a subclass."""
-        raise NotImplementedError()
-
     def _backupOriginal(self):
         # must be called after _loadStreamFromPath
         self.stream.close()
@@ -103,7 +116,7 @@ class Migration:
     def _writeNewFile(self, newStream):
         i = 0
         while os.path.exists(self.path):
-            # don't overwrite files (could be blueprints)
+            # Do not overwrite files (they could be blueprints).
             name, ext = os.path.splitext(self.path)
             self.path = name + f"{i}" + ext
             i += 1
@@ -118,7 +131,7 @@ class BlueprintsMigration(Migration):
     def _loadStreamFromPath(self):
         from armi.physics.neutronics.settings import CONF_LOADING_FILE
 
-        Migration._loadStreamFromPath(self)
+        super()._loadStreamFromPath()
         cs = caseSettings.Settings(fName=self.path)
         self.path = cs[CONF_LOADING_FILE]
         self.stream = open(self.path)
@@ -128,7 +141,7 @@ class SettingsMigration(Migration):
     """Migration for settings input."""
 
     def _loadStreamFromPath(self):
-        Migration._loadStreamFromPath(self)
+        super()._loadStreamFromPath()
         self.stream = open(self.path)
 
 

--- a/armi/migration/base.py
+++ b/armi/migration/base.py
@@ -30,7 +30,7 @@ from armi.settings import caseSettings
 from armi.settings.settingsValidation import versionToNumber
 
 
-class Migration:
+class Migration(abc.ABC):
     """Generic migration.
 
     To implement a concrete Migration, you must implement the ``_applyToStream`` method. You must also define the

--- a/armi/migration/m0_1_3.py
+++ b/armi/migration/m0_1_3.py
@@ -23,8 +23,13 @@ from armi.migration.base import BlueprintsMigration
 class RemoveCentersFromBlueprints(BlueprintsMigration):
     """Removes now-invalid `centers:` lines from auto-generated component inputs."""
 
-    fromVersion = "0.1.2"
-    toVersion = "0.1.3"
+    @property
+    def fromVersion(self):
+        return "0.1.2"
+
+    @property
+    def toVersion(self):
+        return "0.1.3"
 
     def _applyToStream(self):
         runLog.info("Removing `centers:` sections.")
@@ -40,9 +45,6 @@ class RemoveCentersFromBlueprints(BlueprintsMigration):
 class UpdateElementalNuclides(BlueprintsMigration):
     """Update elemental nuclide flags."""
 
-    fromVersion = "0.1.2"
-    toVersion = "0.1.3"
-
     swaps = (
         ("NA23", "NA"),
         ("MN55", "MN"),
@@ -54,6 +56,14 @@ class UpdateElementalNuclides(BlueprintsMigration):
     )
     # these get absorbed into W
     deletions = ("W183", "W184", "W186")
+
+    @property
+    def fromVersion(self):
+        return "0.1.2"
+
+    @property
+    def toVersion(self):
+        return "0.1.3"
 
     def _applyToStream(self):
         # Change both nuclide flags as well as custom isotopics

--- a/armi/migration/m0_1_6.py
+++ b/armi/migration/m0_1_6.py
@@ -35,8 +35,13 @@ AXIAL_CHARS = [
 class ConvertAlphanumLocationSettingsToNum(SettingsMigration):
     """Convert old location label values to new style."""
 
-    fromVersion = "0.1.6"
-    toVersion = "0.1.7"
+    @property
+    def fromVersion(self):
+        return "0.1.6"
+
+    @property
+    def toVersion(self):
+        return "0.1.7"
 
     def _applyToStream(self):
         cs = caseSettings.Settings()

--- a/armi/migration/m0_1_6.py
+++ b/armi/migration/m0_1_6.py
@@ -79,8 +79,7 @@ def getIndicesFromDIF3DStyleLocatorLabel(label):
     """Convert a ring-based label like A2003B into 1-based ring, location indices."""
     locMatch = re.search(r"([A-Z]\d)(\d\d\d)([A-Z]?)", label)
     if locMatch:
-        # we have a valid location label. Process it and set parameters
-        # convert A4 to 04, B2 to 12, etc.
+        # we have a valid location label. Process it and set parameters convert A4 to 04, B2 to 12, etc.
         ring = locMatch.group(1)
         posLabel = locMatch.group(2)
         axLabel = locMatch.group(3)
@@ -88,7 +87,7 @@ def getIndicesFromDIF3DStyleLocatorLabel(label):
         if firstDigit < 10:
             i = int("{0}{1}".format(firstDigit, ring[1]))
         else:
-            raise RuntimeError("invalid label {0}. 1st character too large.".format(label))
+            raise RuntimeError(f"invalid label {label}. 1st character too large.")
         j = int(posLabel)
         if axLabel:
             k = AXIAL_CHARS.index(axLabel)
@@ -96,4 +95,4 @@ def getIndicesFromDIF3DStyleLocatorLabel(label):
             k = None
         return i, j, k
 
-    raise RuntimeError("No Indices found for DIF3D-style label: {0}".format(label))
+    raise RuntimeError(f"No Indices found for DIF3D-style label: {label}")

--- a/armi/migration/tests/test_m0_1_6.py
+++ b/armi/migration/tests/test_m0_1_6.py
@@ -42,7 +42,7 @@ class TestMigration(unittest.TestCase):
     def test_noMigrationIfVersion(self):
         """
         Ensure that no migration happens if the version of the DB is newer than the migration 'toVersion'.
-        
+
         This test checks the specific case of `ConvertAlphanumLocationSettingsToNum`, which should only
         be applied until v0.1.7.
         """

--- a/armi/migration/tests/test_m0_1_6.py
+++ b/armi/migration/tests/test_m0_1_6.py
@@ -38,3 +38,20 @@ class TestMigration(unittest.TestCase):
         reader = SettingsReader(newCs)
         reader.readFromStream(converter.apply())
         self.assertEqual(newCs["detailAssemLocationsBOL"][0], "011-012")
+
+    def test_noMigrationIfVersion(self):
+        """Ensure that no migration happens if the version of the DB is new than the migration 'toVersion'."""
+        cs = caseSettings.Settings()
+        newSettings = {"detailAssemLocationsBOL": ["B1012"]}
+        cs = cs.modified(newSettings=newSettings)
+
+        writer = SettingsWriter(cs)
+        stream = io.StringIO()
+        writer.writeYaml(stream)
+        stream.seek(0)
+
+        converter = ConvertAlphanumLocationSettingsToNum(stream=stream)
+        newCs = caseSettings.Settings()
+        reader = SettingsReader(newCs)
+        reader.readFromStream(converter.apply(version="0.6.4"))
+        self.assertEqual(newCs["detailAssemLocationsBOL"][0], "B1012")

--- a/armi/migration/tests/test_m0_1_6.py
+++ b/armi/migration/tests/test_m0_1_6.py
@@ -40,7 +40,12 @@ class TestMigration(unittest.TestCase):
         self.assertEqual(newCs["detailAssemLocationsBOL"][0], "011-012")
 
     def test_noMigrationIfVersion(self):
-        """Ensure that no migration happens if the version of the DB is new than the migration 'toVersion'."""
+        """
+        Ensure that no migration happens if the version of the DB is newer than the migration 'toVersion'.
+        
+        This test checks the specific case of `ConvertAlphanumLocationSettingsToNum`, which should only
+        be applied until v0.1.7.
+        """
         cs = caseSettings.Settings()
         newSettings = {"detailAssemLocationsBOL": ["B1012"]}
         cs = cs.modified(newSettings=newSettings)

--- a/armi/migration/tests/test_migration_base.py
+++ b/armi/migration/tests/test_migration_base.py
@@ -65,13 +65,6 @@ class BrokenDatabaseMigration1(DatabaseMigration):
         pass
 
 
-class BrokenBlueprintsMigration1(DatabaseMigration):
-    """For testing purposes only, fromVersion and toVersion are missing."""
-
-    def _applyToStream(self):
-        pass
-
-
 class TestMigrationBases(unittest.TestCase):
     def test_basicValidation(self):
         with self.assertRaises(RuntimeError):
@@ -85,16 +78,8 @@ class TestMigrationBases(unittest.TestCase):
         with self.assertRaises(ValueError):
             m._loadStreamFromPath()
 
-    def test_abstractClass(self):
-        """Some basic testing of the abstract base class."""
-        with self.assertRaises(AttributeError):
-            _m = Migration(None, "fake_path")
-
         with self.assertRaises(ValueError):
             _m = BrokenDatabaseMigration1(None, "fake_path")
-
-        with self.assertRaises(AttributeError):
-            _m = BrokenBlueprintsMigration1(None, "fake_path")
 
 
 class TestSettingsMigration(unittest.TestCase):

--- a/armi/migration/tests/test_migration_base.py
+++ b/armi/migration/tests/test_migration_base.py
@@ -16,27 +16,90 @@
 import os
 import unittest
 
-from armi.migration.base import Migration, SettingsMigration
+from armi.migration.base import DatabaseMigration, Migration, SettingsMigration
 from armi.testing import TESTING_ROOT
 
 
+class MockMigration1(Migration):
+    """Migration defined for unit tests only."""
+
+    @property
+    def fromVersion(self):
+        return "0.2.3"
+
+    @property
+    def toVersion(self):
+        return "0.6.4"
+
+    def _applyToStream(self):
+        pass
+
+
+class MockSettingsMigration1(SettingsMigration):
+    """SettingsMigration defined for unit tests only."""
+
+    @property
+    def fromVersion(self):
+        return "0.1.2"
+
+    @property
+    def toVersion(self):
+        return "0.3.4"
+
+    def _applyToStream(self):
+        pass
+
+
+class BrokenDatabaseMigration1(DatabaseMigration):
+    """For testing purposes only, fromVersion and toVersion are invalid."""
+
+    @property
+    def fromVersion(self):
+        return "0.7.0"
+
+    @property
+    def toVersion(self):
+        return "0.6.4"
+
+    def _applyToStream(self):
+        pass
+
+
+class BrokenBlueprintsMigration1(DatabaseMigration):
+    """For testing purposes only, fromVersion and toVersion are missing."""
+
+    def _applyToStream(self):
+        pass
+
+
 class TestMigrationBases(unittest.TestCase):
-    def test_basic_validation(self):
+    def test_basicValidation(self):
         with self.assertRaises(RuntimeError):
-            _m = Migration(None, None)
+            _m = MockMigration1(None, None)
 
         with self.assertRaises(RuntimeError):
-            _m = Migration("fake_stream", "fake_path")
+            _m = MockMigration1("fake_stream", "fake_path")
 
-        Migration("fake_stream", None)
-        m = Migration(None, "fake_path")
+        MockMigration1("fake_stream", None)
+        m = MockMigration1(None, "fake_path")
         with self.assertRaises(ValueError):
             m._loadStreamFromPath()
+
+    def test_abstractClass(self):
+        """Some basic testing of the abstract base class."""
+        with self.assertRaises(AttributeError):
+            _m = Migration(None, "fake_path")
+
+        with self.assertRaises(ValueError):
+            _m = BrokenDatabaseMigration1(None, "fake_path")
+
+        with self.assertRaises(AttributeError):
+            _m = BrokenBlueprintsMigration1(None, "fake_path")
 
 
 class TestSettingsMigration(unittest.TestCase):
     def test_loadStreamFromPath(self):
         file_path = os.path.join(TESTING_ROOT, "reactors", "sodiumHexReactor", "armiRun.yaml")
-        m = SettingsMigration(None, file_path)
+        m = MockSettingsMigration1(None, file_path)
         m._loadStreamFromPath()
         self.assertIsNotNone(m.stream)

--- a/armi/reactor/blueprints/__init__.py
+++ b/armi/reactor/blueprints/__init__.py
@@ -497,18 +497,21 @@ class Blueprints(yamlize.Object, metaclass=_BlueprintsPluginCollector):
                     )
 
     @classmethod
-    def migrate(cls, inp: typing.TextIO):
+    def migrate(cls, inp: typing.TextIO, version: str = None):
         """Given a stream representation of a blueprints file, migrate it.
 
         Parameters
         ----------
         inp : typing.TextIO
             Input stream to migrate.
+        version : str
+            Optional DB version string, for example: 1.2.3
         """
         for migI in migration.ACTIVE_MIGRATIONS:
             if issubclass(migI, migration.base.BlueprintsMigration):
                 mig = migI(stream=inp)
-                inp = mig.apply()
+                inp = mig.apply(version)
+
         return inp
 
     @classmethod

--- a/armi/settings/settingsValidation.py
+++ b/armi/settings/settingsValidation.py
@@ -672,6 +672,14 @@ def versionToNumber(version: str):
     """Convert an ARMI version string to an arbitrary number, so we can compare ARMI version strings.
 
     The expected format for versions strings is "1.2.3". Other formats are not supported.
+
+    The actual numerical value returned is not particularly interesting on its own, it is just meant to support
+    comparing version strings (which is greater, etc).
+
+    Parameters
+    ----------
+    versionThis: str
+        ARMI-style version string, typically of the form 1.2.3.
     """
     versionBits = version.split(".")
     num = 1e6 * int(versionBits[0]) + 1e3 * int(versionBits[1])

--- a/armi/settings/settingsValidation.py
+++ b/armi/settings/settingsValidation.py
@@ -685,5 +685,6 @@ def versionToNumber(version: str):
     num = 1e6 * int(versionBits[0]) + 1e3 * int(versionBits[1])
     if len(versionBits) >= 3:
         num += int(versionBits[2])
+        # We are quietly ignoring longer versions strings, like 1.2.3.dev0
 
     return num

--- a/armi/settings/settingsValidation.py
+++ b/armi/settings/settingsValidation.py
@@ -665,4 +665,17 @@ def validateVersion(versionThis: str, versionRequired: str) -> bool:
     elif re.search(minV, versionRequired) is not None:
         return versionThis.split(".")[0] == versionRequired
     else:
-        raise ValueError("The required version is not a valid format: {}".format(versionRequired))
+        raise ValueError(f"The required version is not a valid format: {versionRequired}")
+
+
+def versionToNumber(version: str):
+    """Convert an ARMI version string to an arbitrary number, so we can compare ARMI version strings.
+
+    The expected format for versions strings is "1.2.3". Other formats are not supported.
+    """
+    versionBits = version.split(".")
+    num = 1e6 * int(versionBits[0]) + 1e3 * int(versionBits[1])
+    if len(versionBits) >= 3:
+        num += int(versionBits[2])
+
+    return num

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -28,9 +28,8 @@ from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
 from armi.physics.neutronics.settings import CONF_NEUTRONICS_KERNEL
 from armi.reactor.flags import Flags
 from armi.settings import caseSettings, setting
-from armi.settings.settingsValidation import Inspector, validateVersion
-from armi.testing import TESTING_ROOT, mockRunLogs
-from armi.tests import ARMI_RUN_PATH
+from armi.settings.settingsValidation import Inspector, validateVersion, versionToNumber
+from armi.testing import ARMI_RUN_PATH, TESTING_ROOT, mockRunLogs
 from armi.utils import directoryChangers
 from armi.utils.customExceptions import NonexistentSetting
 
@@ -508,7 +507,7 @@ class TestFlagListSetting(unittest.TestCase):
             fs.value = "DUCT"
 
 
-class TestSettingsValidationUtils(unittest.TestCase):
+class TestSettingsVersionUtils(unittest.TestCase):
     def test_validateVersion(self):
         # controlled version, and true
         self.assertTrue(validateVersion("1.22.3", "1.22.3"))
@@ -535,3 +534,24 @@ class TestSettingsValidationUtils(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             validateVersion("1.2.3", "zzz")
+
+    def test_versionToNumber(self):
+        # the standard use-case
+        self.assertEqual(versionToNumber("0.0.7"), 7)
+        self.assertEqual(versionToNumber("0.1.0"), 1000)
+        self.assertEqual(versionToNumber("1.0.0"), 1e6)
+        self.assertEqual(versionToNumber("1.2.3"), 1002003)
+
+        # an edge case we support
+        self.assertEqual(versionToNumber("0.1"), 1000)
+        self.assertEqual(versionToNumber("3.2"), 3002000)
+
+        # an edge case we do not support
+        self.assertEqual(versionToNumber("1.3.5"), versionToNumber("1.3.5.dev0"))
+
+        # invalid put values
+        with self.assertRaises(AttributeError):
+            versionToNumber(123)
+
+        with self.assertRaises(IndexError):
+            versionToNumber("1")


### PR DESCRIPTION
## What is the change? Why is it being made?

The original concern was `N14` was disappearing. The problem was that a database migration was wiping out N14 as an input nuclide. This should not have been happening though, because the new database did not need the ancient DB migration applied to it.

Also, per reviewer comments, I have altered the base `Migration` class to use some abstract methods now.

close #2431


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Applying redundant migrations can incorrectly modify databases.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
