### PR TITLE
Cleaning up `test_reactors` imports

### DIFF
--- a/armi/bookkeeping/db/tests/test_comparedb3.py
+++ b/armi/bookkeeping/db/tests/test_comparedb3.py
@@ -31,8 +31,7 @@ from armi.bookkeeping.db.compareDB3 import (
     compareDatabases,
 )
 from armi.bookkeeping.db.databaseInterface import DatabaseInterface
-from armi.reactor.tests import test_reactors
-from armi.testing import mockRunLogs
+from armi.testing import loadTestReactor, mockRunLogs
 from armi.tests import TESTING_ROOT
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
@@ -100,7 +99,7 @@ class TestCompareDB3(unittest.TestCase):
     def test_compareDatabaseDuplicate(self):
         """End-to-end test of compareDatabases() on a photocopy database."""
         # build two super-simple H5 files for testing
-        o, r = test_reactors.loadTestReactor(
+        o, r = loadTestReactor(
             TESTING_ROOT,
             customSettings={"reloadDBName": "reloadingDB.h5"},
             inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml",
@@ -131,7 +130,7 @@ class TestCompareDB3(unittest.TestCase):
     def test_compareDatabaseSim(self):
         """End-to-end test of compareDatabases() on very similar databases."""
         # build two super-simple H5 files for testing
-        o, r = test_reactors.loadTestReactor(
+        o, r = loadTestReactor(
             TESTING_ROOT,
             customSettings={"reloadDBName": "reloadingDB.h5"},
             inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml",

--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -24,13 +24,12 @@ from armi.bookkeeping.memoryProfiler import (
     getCurrentMemoryUsage,
     getTotalJobMemory,
 )
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT, mockRunLogs
+from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
 
 
 class TestMemoryProfiler(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor(
+        self.o, self.r = loadTestReactor(
             TESTING_ROOT,
             {"debugMem": True},
             inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml",

--- a/armi/bookkeeping/visualization/tests/test_vis.py
+++ b/armi/bookkeeping/visualization/tests/test_vis.py
@@ -23,8 +23,7 @@ from armi import settings
 from armi.bookkeeping.db import Database
 from armi.bookkeeping.visualization import utils, vtk, xdmf
 from armi.reactor import blocks, components
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT
+from armi.testing import TESTING_ROOT, loadTestReactor
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
@@ -64,9 +63,7 @@ class TestVisDump(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         caseSetting = settings.Settings()
-        _, cls.r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        _, cls.r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
 
         cls.hexBlock = next(cls.r.core.iterBlocks())
 

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -25,8 +25,7 @@ from armi import cases, context, getApp, interfaces, plugins, runLog, settings
 from armi.bookkeeping.db.databaseInterface import DatabaseInterface
 from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
 from armi.reactor import blueprints
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT, mockRunLogs
+from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
 from armi.tests import ARMI_RUN_PATH
 from armi.utils import directoryChangers
 
@@ -412,7 +411,7 @@ class TestCaseSuiteComparison(unittest.TestCase):
     def test_compareNoDiffs(self):
         """As a baseline, this test should always reveal zero diffs."""
         # build two super-simple H5 files for testing
-        o, r = test_reactors.loadTestReactor(
+        o, r = loadTestReactor(
             TESTING_ROOT,
             customSettings={"reloadDBName": "reloadingDB.h5"},
             inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml",

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -30,7 +30,6 @@ from armi.physics.neutronics.globalFlux.globalFluxInterface import (
     GlobalFluxInterfaceUsingExecuters,
 )
 from armi.reactor.reactors import Core, Reactor
-from armi.reactor.tests import test_reactors
 from armi.settings.caseSettings import Settings
 from armi.settings.fwSettings.globalSettings import (
     CONF_CYCLES_SKIP_TIGHT_COUPLING_INTERACTION,
@@ -40,7 +39,7 @@ from armi.settings.fwSettings.globalSettings import (
     CONF_TIGHT_COUPLING,
     CONF_TIGHT_COUPLING_SETTINGS,
 )
-from armi.testing import TESTING_ROOT, mockRunLogs
+from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
 from armi.utils import directoryChangers
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
@@ -64,7 +63,7 @@ class InterfaceC(Interface):
 
 class OperatorTests(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor(
+        self.o, self.r = loadTestReactor(
             TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
         )
         self.activeInterfaces = [ii for ii in self.o.interfaces if ii.enabled()]
@@ -173,9 +172,7 @@ class OperatorTests(unittest.TestCase):
         self.assertEqual(self.o.getInterface("Third"), interfaceC)
 
     def test_interfaceIsActive(self):
-        self.o, _r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        self.o, _r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
         self.assertTrue(self.o.interfaceIsActive("main"))
         self.assertFalse(self.o.interfaceIsActive("Fake-o"))
 
@@ -552,7 +549,7 @@ settings:
 class TestInterfaceAndEventHeaders(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.o, cls.r = test_reactors.loadTestReactor(
+        cls.o, cls.r = loadTestReactor(
             TESTING_ROOT,
             inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml",
             customSettings={CONF_TIGHT_COUPLING: True},
@@ -600,7 +597,7 @@ class OperatorRestartTests(unittest.TestCase):
     def setUpClass(cls):
         cls.START_CYCLE = 4
         cls.START_NODE = 2
-        cls.o, cls.r = test_reactors.loadTestReactor(
+        cls.o, cls.r = loadTestReactor(
             TESTING_ROOT,
             inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml",
             customSettings={

--- a/armi/physics/fuelCycle/tests/test_assemblyRotationAlgorithms.py
+++ b/armi/physics/fuelCycle/tests/test_assemblyRotationAlgorithms.py
@@ -37,7 +37,7 @@ from armi.physics.fuelCycle.settings import CONF_ASSEM_ROTATION_STATIONARY
 from armi.reactor.assemblies import HexAssembly
 from armi.reactor.blocks import HexBlock
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
+from armi.testing import loadTestReactor
 
 
 class MockFuelHandler(fuelHandlers.FuelHandler):
@@ -75,7 +75,7 @@ class ShuffleAndRotateTestHelper(TestCase):
     N_PINS = 169
 
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor()
+        self.o, self.r = loadTestReactor()
         self.r.core.locateAllAssemblies()
 
     @staticmethod

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -43,11 +43,10 @@ from armi.physics.neutronics.latticePhysics.latticePhysicsInterface import (
 from armi.reactor import assemblies, blocks, components, grids
 from armi.reactor.flags import Flags
 from armi.reactor.parameters import ParamLocation
-from armi.reactor.tests import test_reactors
 from armi.reactor.zones import Zone
 from armi.settings import caseSettings
 from armi.settings.fwSettings.globalSettings import CONF_TRACK_ASSEMS
-from armi.testing import TESTING_ROOT, mockRunLogs
+from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
 from armi.tests import ArmiTestHelper
 from armi.utils import directoryChangers
 from armi.utils.customExceptions import InputError
@@ -176,7 +175,7 @@ class FuelHandlerTestHelper(ArmiTestHelper):
 
         There are some igniters and feeds but none of these have any number densities.
         """
-        self.o, self.r = test_reactors.loadTestReactor(
+        self.o, self.r = loadTestReactor(
             self.directoryChanger.destination,
             customSettings={"nCycles": 4, "trackAssems": True},
         )

--- a/armi/reactor/tests/test_cores.py
+++ b/armi/reactor/tests/test_cores.py
@@ -22,8 +22,7 @@ from armi.nuclearDataIO.xsLibraries import IsotxsLibrary
 from armi.reactor.assemblies import HexAssembly
 from armi.reactor.blocks import Block
 from armi.reactor.flags import Flags
-from armi.reactor.tests.test_reactors import loadTestReactor
-from armi.testing import TESTING_ROOT
+from armi.testing import TESTING_ROOT, loadTestReactor
 from armi.tests import ISOAA_PATH
 
 

--- a/armi/tests/test_cartesian.py
+++ b/armi/tests/test_cartesian.py
@@ -19,13 +19,13 @@ import unittest
 
 from armi.reactor import geometry
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
+from armi.testing import loadTestReactor
 from armi.tests import TESTING_ROOT
 
 
 class CartesianReactorTests(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor(
+        self.o, self.r = loadTestReactor(
             os.path.join(TESTING_ROOT, "reactors", "smallCartesian"),
             inputFileName="refTestCartesian.yaml",
         )

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -19,8 +19,7 @@ from logging import WARNING
 
 from armi import runLog
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT, mockRunLogs
+from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
 from armi.utils import directoryChangers
 
 TEST_INPUT_TITLE = "c5g7-settings.yaml"
@@ -46,7 +45,7 @@ class C5G7ReactorTests(unittest.TestCase):
             runLog.LOG.setVerbosity(WARNING)
 
             # load the reactor
-            _o, r = test_reactors.loadTestReactor(
+            _o, r = loadTestReactor(
                 os.path.join(TESTING_ROOT, "reactors", "c5g7"),
                 inputFileName=TEST_INPUT_TITLE,
             )

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -27,8 +27,7 @@ from armi.mpiActions import (
     runActions,
     runBatchedActions,
 )
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT, mockRunLogs
+from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
 from armi.utils import iterables
 
 
@@ -162,9 +161,7 @@ class MpiIterTests(unittest.TestCase):
     @patch("armi.context.MPI_COMM", MockMpiComm())
     @patch("armi.context.MPI_SIZE", 4)
     def test_runActionsDistributionAction(self):
-        o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
 
         act = DistributionAction([self.action])
         results = runActions(o, r, o.cs, [act])
@@ -180,9 +177,7 @@ class MpiIterTests(unittest.TestCase):
     @patch("armi.context.MPI_NODENAMES", ["node0", "node0", "node1", "node1"])
     @patch("armi.context.MPI_DISTRIBUTABLE", True)
     def test_runBatchedActions(self):
-        o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
 
         actionsByNode = {
             "node0": [MockMpiAction(invokeResult=1)],
@@ -209,9 +204,7 @@ class MpiIterTests(unittest.TestCase):
     @patch("armi.context.MPI_DISTRIBUTABLE", True)
     def test_runBatchedActionsOverload(self):
         """Test that an error is thrown if the number of tasks exceeds number of ranks."""
-        o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
 
         actionsByNode = {
             "node0": [MockMpiAction()],
@@ -227,9 +220,7 @@ class MpiIterTests(unittest.TestCase):
     @patch("armi.context.MPI_COMM", MockMpiComm())
     @patch("armi.context.MPI_SIZE", 4)
     def test_runActionsDistributeStateAction(self):
-        o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
 
         act = DistributeStateAction([self.action])
         results = runActions(o, r, o.cs, [act])
@@ -240,9 +231,7 @@ class MpiIterTests(unittest.TestCase):
     @patch("armi.context.MPI_SIZE", 4)
     @patch("armi.context.MPI_DISTRIBUTABLE", True)
     def test_runActionsDistStateActionParallel(self):
-        o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
 
         act = DistributeStateAction([self.action])
         results = runActions(o, r, o.cs, [act])

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -37,8 +37,7 @@ from armi.operators import OperatorMPI
 from armi.physics.neutronics.const import CONF_CROSS_SECTION
 from armi.reactor import blueprints, reactors
 from armi.reactor.parameters import parameterDefinitions
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT, mockRunLogs
+from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
 from armi.tests import ARMI_RUN_PATH
 from armi.utils import pathTools
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
@@ -100,7 +99,7 @@ class MpiOperatorTests(unittest.TestCase):
     """Testing the MPI parallelization operator."""
 
     def setUp(self):
-        self.old_op, self.r = test_reactors.loadTestReactor(
+        self.old_op, self.r = loadTestReactor(
             TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
         )
         self.o = OperatorMPI(cs=self.old_op.cs)

--- a/armi/tests/test_user_plugins.py
+++ b/armi/tests/test_user_plugins.py
@@ -19,9 +19,8 @@ import unittest
 
 from armi import context, getApp, interfaces, plugins, utils
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
 from armi.settings import caseSettings
-from armi.testing import TESTING_ROOT
+from armi.testing import TESTING_ROOT, loadTestReactor
 from armi.utils import directoryChangers
 
 
@@ -236,9 +235,7 @@ class TestUserPlugins(unittest.TestCase):
         plug0 = [p[1] for p in pluginz if p[0] == name][0]
 
         # load a reactor and grab the fuel assemblies
-        o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
         fuels = r.core.getBlocks(Flags.FUEL)
 
         # prove that our plugin affects the core in the desired way
@@ -263,9 +260,7 @@ class TestUserPlugins(unittest.TestCase):
         self.assertIn("UserPluginWithInterface", pluginNames)
 
         # load a reactor and grab the fuel assemblieapps
-        o, r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
         _fuels = r.core.getAssemblies(Flags.FUEL)
 
         # This is here because we have multiple tests altering the App()

--- a/armi/utils/tests/test_plotting.py
+++ b/armi/utils/tests/test_plotting.py
@@ -27,8 +27,7 @@ from armi import settings
 from armi.nuclearDataIO.cccc import isotxs
 from armi.reactor import blueprints, reactors
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT
+from armi.testing import TESTING_ROOT, loadTestReactor
 from armi.tests import ISOAA_PATH, getEmptyHexReactor
 from armi.utils import plotting
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
@@ -46,9 +45,7 @@ class TestPlotting(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.o, cls.r = test_reactors.loadTestReactor(
-            TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
-        )
+        cls.o, cls.r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")
 
     def test_plotDepthMap(self):
         """Indirectly tests plot face map."""
@@ -223,7 +220,7 @@ class TestPatches(unittest.TestCase):
             f.write(txt)
 
         # this one is flats-up with many assemblies in the core
-        _, rHexFlatsUp = test_reactors.loadTestReactor(inputFilePath=".", inputFileName="armiRunSmallest.yaml")
+        _, rHexFlatsUp = loadTestReactor(inputFilePath=".", inputFileName="armiRunSmallest.yaml")
 
         nAssems = len(rHexFlatsUp.core)
         self.assertEqual(nAssems, 1)
@@ -242,7 +239,7 @@ class TestPatches(unittest.TestCase):
         self.assertAlmostEqual(vertices[0][1], 0)
 
         # this one is corners-up, with only a single assembly
-        _, rHexCornersUp = test_reactors.loadTestReactor(
+        _, rHexCornersUp = loadTestReactor(
             TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
         )
 
@@ -257,7 +254,7 @@ class TestPatches(unittest.TestCase):
         self.assertAlmostEqual(vertices[0][0], 0)
 
         # this one is cartestian, with many assemblies in the core
-        _, rCartesian = test_reactors.loadTestReactor(
+        _, rCartesian = loadTestReactor(
             os.path.join(TESTING_ROOT, "reactors", "smallCartesian"), inputFileName="refTestCartesian.yaml"
         )
 

--- a/armi/utils/tests/test_reportPlotting.py
+++ b/armi/utils/tests/test_reportPlotting.py
@@ -20,8 +20,7 @@ import unittest
 import numpy as np
 
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT
+from armi.testing import TESTING_ROOT, loadTestReactor
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 from armi.utils.reportPlotting import (
     _getPhysicalVals,
@@ -36,7 +35,7 @@ from armi.utils.reportPlotting import (
 
 class TestRadar(unittest.TestCase):
     def setUp(self):
-        self.o, self.r = test_reactors.loadTestReactor(
+        self.o, self.r = loadTestReactor(
             TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
         )
         self.td = TemporaryDirectoryChanger()

--- a/doc/developer/testing.rst
+++ b/doc/developer/testing.rst
@@ -108,7 +108,7 @@ To get the standard ARMI test reactor, import this:
 
 .. code-block:: python
 
-    from armi.reactor.tests.test_reactors import loadTestReactor
+    from armi.testing import loadTestReactor
 
 This function will return a reactor object. And it takes various input arguments to allow you to customize that reactor:
 

--- a/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
+++ b/doc/gallery-src/analysis/run_blockMcnpMaterialCard.py
@@ -23,13 +23,13 @@ materials cards is so pervasive that it made it into the framework
 
 from armi import configure
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
+from armi.testing import loadTestReactor
 from armi.utils.densityTools import formatMaterialCard
 
 # configure ARMI
 configure(permissive=True)
 
-_o, r = test_reactors.loadTestReactor()
+_o, r = loadTestReactor()
 
 bFuel = r.core.getBlocks(Flags.FUEL)[0]
 

--- a/doc/gallery-src/analysis/run_hexBlockToRZConversion.py
+++ b/doc/gallery-src/analysis/run_hexBlockToRZConversion.py
@@ -44,12 +44,12 @@ efficient analysis.
 from armi import configure
 from armi.reactor.converters import blockConverters
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
+from armi.testing import loadTestReactor
 
 # configure ARMI
 configure(permissive=True)
 
-_o, r = test_reactors.loadTestReactor()
+_o, r = loadTestReactor()
 
 # fully heterogeneous
 bFuel = r.core.getBlocks(Flags.FUEL)[0]

--- a/doc/gallery-src/analysis/run_hexReactorToRZ.py
+++ b/doc/gallery-src/analysis/run_hexReactorToRZ.py
@@ -30,13 +30,13 @@ import matplotlib.pyplot as plt
 
 from armi import configure
 from armi.reactor.converters import geometryConverters
-from armi.reactor.tests import test_reactors
+from armi.testing import loadTestReactor
 from armi.utils import plotting
 
 # configure ARMI
 configure(permissive=True)
 
-o, r = test_reactors.loadTestReactor()
+o, r = loadTestReactor()
 kgFis = [a.getHMMass() for a in r.core]
 plotting.plotFaceMap(r.core, data=kgFis, labelFmt="{:.1e}")
 

--- a/doc/gallery-src/framework/run_fuelManagement.py
+++ b/doc/gallery-src/framework/run_fuelManagement.py
@@ -34,14 +34,13 @@ import os
 from armi import configure
 from armi.physics.fuelCycle import fuelHandlers
 from armi.reactor.flags import Flags
-from armi.reactor.tests import test_reactors
-from armi.testing import TESTING_ROOT
+from armi.testing import TESTING_ROOT, loadTestReactor
 from armi.utils import plotting
 
 # configure ARMI
 configure(permissive=True)
 
-o, reactor = test_reactors.loadTestReactor(
+o, reactor = loadTestReactor(
     os.path.join(TESTING_ROOT, "reactors", "smallCartesian"), inputFileName="refTestCartesian.yaml"
 )
 

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -20,13 +20,13 @@ power distribution from it. You can plot any block parameter.
 """
 
 from armi import configure
-from armi.reactor.tests import test_reactors
+from armi.testng import loadTestReactor
 from armi.utils import plotting
 
 # configure ARMI
 configure(permissive=True)
 
-operator, reactor = test_reactors.loadTestReactor()
+operator, reactor = loadTestReactor()
 reactor.core.growToFullCore(None)
 # set dummy power
 for b in reactor.core.getBlocks():


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
This is a follow up to #2585 that removes internal imports of `armi.reactors.tests.test_reactors.loadTestReactor` replacing them with imports of `armi.testing.loadTestReactor` to reflect the actual origin of that function.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: ARMI should import functions from where they actually exist.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
