### PR TITLE
Fixing Database.mergeHistory for EOL and error time steps

### DIFF
--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -515,10 +515,8 @@ class Database:
         for time, h5ts in zip(inputDB.genTimeSteps(), inputDB.genTimeStepGroups()):
             cyc = time[0]
             tn = time[1]
-            print("TODO", cyc, tn)
             if cyc == startCycle and tn == startNode:
                 # all data up to current state are merged
-                print("    TODO", cyc, tn)
                 return
             self.h5db.copy(h5ts, h5ts.name)
 

--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -495,10 +495,7 @@ class Database:
         self.h5db["inputs/blueprints"] = bpString
 
     def readInputsFromDB(self):
-        return (
-            self.h5db["inputs/settings"].asstr()[()],
-            self.h5db["inputs/blueprints"].asstr()[()],
-        )
+        return (self.h5db["inputs/settings"].asstr()[()], self.h5db["inputs/blueprints"].asstr()[()])
 
     def mergeHistory(self, inputDB, startCycle, startNode):
         """
@@ -517,8 +514,10 @@ class Database:
         # iterate over the top level H5Groups and copy
         for time, h5ts in zip(inputDB.genTimeSteps(), inputDB.genTimeStepGroups()):
             cyc, tn = time
+            print("TODO", cyc, tn)
             if cyc == startCycle and tn == startNode:
                 # all data up to current state are merged
+                print("    TODO", cyc, tn)
                 return
             self.h5db.copy(h5ts, h5ts.name)
 

--- a/armi/bookkeeping/db/database.py
+++ b/armi/bookkeeping/db/database.py
@@ -513,7 +513,8 @@ class Database:
 
         # iterate over the top level H5Groups and copy
         for time, h5ts in zip(inputDB.genTimeSteps(), inputDB.genTimeStepGroups()):
-            cyc, tn = time
+            cyc = time[0]
+            tn = time[1]
             print("TODO", cyc, tn)
             if cyc == startCycle and tn == startNode:
                 # all data up to current state are merged

--- a/armi/bookkeeping/db/tests/test_database.py
+++ b/armi/bookkeeping/db/tests/test_database.py
@@ -1055,7 +1055,7 @@ class TestSimplestDatabaseItems(unittest.TestCase):
                 self.timeSteps = timeSteps
 
             def genTimeStepGroups(self):
-                return [FakeHDF5(i) for i in range(len(self.timeSteps))]
+                return [FakeHDF5(t) for t in self.timeSteps]
 
             def genTimeSteps(self):
                 return self.timeSteps
@@ -1063,11 +1063,11 @@ class TestSimplestDatabaseItems(unittest.TestCase):
         db.h5db = FakeHDF5(123)
         db.mergeHistory(MockDB([(0, 0), (0, 1)]), 0, 1)
 
-        self.assertListEqual(results, [0])
+        self.assertListEqual(results, [(0, 0)])
 
         results = []
         db.mergeHistory(MockDB([(0, 0), (0, 0, "error"), (0, 1)]), 0, 1)
-        self.assertListEqual(results, [0])
+        self.assertListEqual(results, [(0, 0), (0, 0, "error")])
 
         # remove the fake H5 file or the DB cleanup in ARMI's context.py will panic
         db.h5db = None

--- a/armi/bookkeeping/db/tests/test_database.py
+++ b/armi/bookkeeping/db/tests/test_database.py
@@ -1033,14 +1033,21 @@ class TestSimplestDatabaseItems(unittest.TestCase):
         db.h5db = None
 
     def test_mergeHistory(self):
+        """Test some edge cases of Database.mergeHistory.
+
+        This test uses some mock database and H5 file tooling, so we can more easily test edge cases in the ........
+        """
         # mock up a test DB
         dbPath = "test_mergeHistory.h5"
         db = Database(dbPath, "w")
         db.close()
 
+        # Optimization: We use this "results" list so we do not need to write to a real H5 file for this tests.
         results = []
 
         class FakeHDF5:
+            """As an optimization, and simplification, a stand-in for a H5 group."""
+
             name = "fake"
 
             def __init__(self, x):
@@ -1050,6 +1057,8 @@ class TestSimplestDatabaseItems(unittest.TestCase):
                 return results.append(a.x)
 
         class MockDB:
+            """As an optimization, and simplification, a stand-in for needing a second ARMI DB file in the tests."""
+
             def __init__(self, timeSteps):
                 self.versionMajor = 3
                 self.timeSteps = timeSteps
@@ -1060,14 +1069,25 @@ class TestSimplestDatabaseItems(unittest.TestCase):
             def genTimeSteps(self):
                 return self.timeSteps
 
+        # test 0: should just grab the first time node
         db.h5db = FakeHDF5(123)
         db.mergeHistory(MockDB([(0, 0), (0, 1)]), 0, 1)
-
         self.assertListEqual(results, [(0, 0)])
 
+        # test 1: should grab the first 4 of 6 time nodes
+        results = []
+        db.mergeHistory(MockDB([(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)]), 2, 0)
+        self.assertListEqual(results, [(0, 0), (0, 1), (1, 0), (1, 1)])
+
+        # test 2: should grab the first time node and the error time node
         results = []
         db.mergeHistory(MockDB([(0, 0), (0, 0, "error"), (0, 1)]), 0, 1)
         self.assertListEqual(results, [(0, 0), (0, 0, "error")])
+
+        # test 3: should grab all 5 time nodes, including the EOL
+        results = []
+        db.mergeHistory(MockDB([(0, 0), (0, 1), (1, 0), (1, 1), (1, 1, "EOL")]), 2, 4)
+        self.assertListEqual(results, [(0, 0), (0, 1), (1, 0), (1, 1), (1, 1, "EOL")])
 
         # remove the fake H5 file or the DB cleanup in ARMI's context.py will panic
         db.h5db = None
@@ -1077,10 +1097,7 @@ class TestStaticDatabaseItems(unittest.TestCase):
     def test_applyComponentNumberDensitiesMigration(self):
         b = buildComplexHexBlock()
         comps = [b[0], b[1]]
-        unpacked = [
-            {"U235": 1.23e-3, "U238": 2.34e-3},
-            {"PU239": 5.6e-4, "PU240": 7.8e-4},
-        ]
+        unpacked = [{"U235": 1.23e-3, "U238": 2.34e-3}, {"PU239": 5.6e-4, "PU240": 7.8e-4}]
 
         Database._applyComponentNumberDensitiesMigration(comps, unpacked)
 

--- a/armi/bookkeeping/db/tests/test_database.py
+++ b/armi/bookkeeping/db/tests/test_database.py
@@ -1035,7 +1035,7 @@ class TestSimplestDatabaseItems(unittest.TestCase):
     def test_mergeHistory(self):
         """Test some edge cases of Database.mergeHistory.
 
-        This test uses some mock database and H5 file tooling, so we can more easily test edge cases in the ........
+        This test uses some mock database and H5 file tooling, so we can more easily test edge cases.
         """
         # mock up a test DB
         dbPath = "test_mergeHistory.h5"

--- a/armi/bookkeeping/db/tests/test_database.py
+++ b/armi/bookkeeping/db/tests/test_database.py
@@ -1032,6 +1032,46 @@ class TestSimplestDatabaseItems(unittest.TestCase):
         # remove the fake H5 file or the DB cleanup in ARMI's context.py will panic
         db.h5db = None
 
+    def test_mergeHistory(self):
+        # mock up a test DB
+        dbPath = "test_mergeHistory.h5"
+        db = Database(dbPath, "w")
+        db.close()
+
+        results = []
+
+        class FakeHDF5:
+            name = "fake"
+
+            def __init__(self, x):
+                self.x = x
+
+            def copy(self, a, b):
+                return results.append(a.x)
+
+        class MockDB:
+            def __init__(self, timeSteps):
+                self.versionMajor = 3
+                self.timeSteps = timeSteps
+
+            def genTimeStepGroups(self):
+                return [FakeHDF5(i) for i in range(len(self.timeSteps))]
+
+            def genTimeSteps(self):
+                return self.timeSteps
+
+        db.h5db = FakeHDF5(123)
+        db.mergeHistory(MockDB([(0, 0), (0, 1)]), 0, 1)
+
+        self.assertListEqual(results, [0])
+
+        results = []
+        db.mergeHistory(MockDB([(0, 0), (0, 0, "error"), (0, 1)]), 0, 1)
+        self.assertListEqual(results, [0])
+
+        # remove the fake H5 file or the DB cleanup in ARMI's context.py will panic
+        db.h5db = None
+
 
 class TestStaticDatabaseItems(unittest.TestCase):
     def test_applyComponentNumberDensitiesMigration(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

This is a follow up to https://github.com/terrapower/armi/pull/2607. That solution solve the problem, but opened up another problem in `Database.mergeHistory()`, which also needs to support "error" and "EOL" time nodes.

**NOTE**: I also went through all the rest of the uses of `Database.genTimeSteps()` in ARMI, and they are not similarly broken.

close https://github.com/terrapower/armi/issues/1960


## SCR Information

 Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: MergeHistory should not fail if there are special error or EOL time steps in the DB.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
