### PR TITLE
Getting ARMI docs building correctly

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -87,6 +87,7 @@ jobs:
           name: html-docs
           path: doc/_build/html
           retention-days: 5
+          include-hidden-files: true
       - name: Archive PDF Docs
         uses: actions/upload-artifact@v7
         with:

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -611,7 +611,7 @@ class ThoriumTests(AbstractMaterialTest, unittest.TestCase):
         Test default mass fractions.
 
         .. test:: The materials generate nuclide mass fractions.
-            :id: T_ARMI_MAT_FRACS0
+            :id: T_ARMI_MAT_FRACS6
             :tests: R_ARMI_MAT_FRACS
         """
         self.mat.setDefaultMassFracs()

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -260,7 +260,7 @@ class ArmiPlugin:
         It is only meant to be run one time. Because ``db.load()`` may be run several times in the same script, it is
         strongly recommended that developers implement the following pattern when adding this hook to any plugin:
 
-        .. code::
+        .. code-block::
             from armi.utils import onlyRunOnce
 
             @staticmethod
@@ -274,7 +274,7 @@ class ArmiPlugin:
         with potentially different materials libraries in the same python instance, they may reset the ``onlyRunOnce``
         decorator with the following:
 
-        .. code::
+        .. code-block::
             from <somewhere> import <PLUGIN>
 
             <PLUGIN>.beforeReactorConstruction.reset_onlyRunOnce()
@@ -340,7 +340,7 @@ class ArmiPlugin:
 
         Example
         -------
-        .. code::
+        .. code-block::
 
             [
                 (HexBlock, HexAssembly),
@@ -622,7 +622,7 @@ class ArmiPlugin:
             Dictionary that maps a grid type from the input file (e.g., ``"core"``)
             to a function responsible for building a grid of that type, e.g.,
 
-            .. code::
+            .. code-block::
 
                 {
                     "core": armi.reactor.reactors.Core,

--- a/armi/plugins.py
+++ b/armi/plugins.py
@@ -261,6 +261,7 @@ class ArmiPlugin:
         strongly recommended that developers implement the following pattern when adding this hook to any plugin:
 
         .. code-block::
+
             from armi.utils import onlyRunOnce
 
             @staticmethod
@@ -275,6 +276,7 @@ class ArmiPlugin:
         decorator with the following:
 
         .. code-block::
+
             from <somewhere> import <PLUGIN>
 
             <PLUGIN>.beforeReactorConstruction.reset_onlyRunOnce()

--- a/armi/runLog.py
+++ b/armi/runLog.py
@@ -17,21 +17,21 @@ Handle logging of console during a simulation.
 
 The default way of calling and the global armi logger is to just import it:
 
-.. code::
+.. code-block::
 
     from armi import runLog
 
 You may want a logger specific to a single module, say to provide debug logging for only one module.
 That functionality is provided by a global override of logging imports:
 
-.. code::
+.. code-block::
 
     import logging
     runLog = logging.getLogger(__name__)
 
 In either case, you can then log things the same way:
 
-.. code::
+.. code-block::
 
     runLog.info('information here')
     runLog.error('extra error info here')
@@ -39,7 +39,7 @@ In either case, you can then log things the same way:
 
 Or change the log level the same way:
 
-.. code::
+.. code-block::
 
     runLog.setVerbosity('debug')
 """

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -465,7 +465,7 @@ sphinx_gallery_conf = {
     "default_thumb_file": os.path.join(STATIC_DIR, "TerraPowerLogo.png"),
 }
 
-suppress_warnings = ["autoapi.python_import_resolution", "config.cache"]
+suppress_warnings = ["autoapi.python_import_resolution", "config.cache", "autosectionlabel.*"]
 
 # Filter out this warning which shows up in sphinx-gallery builds. This is suggested in the sphinx-gallery example but
 # doesn't actually work?

--- a/doc/developer/testing.rst
+++ b/doc/developer/testing.rst
@@ -14,7 +14,7 @@ Use Case: Test code that prints to stdout
 
 While there are some other mocking examples in ARMI, none are as heavily used as ``mockRunLogs``. ``mockRunLogs.BufferLog()`` is used to capture the ``runLog`` output instead of printing it.
 
-In `test_comparedb3.py <https://github.com/terrapower/armi/blob/49f357b2a92aaffaf883642f7b86fbe21b0e0272/armi/bookkeeping/db/tests/test_comparedb3.py>`_, there is a (simplified here) use case. A portion of the test for ``_diffSpecialData`` wants to confirm the below printout has happened, so it uses the ``getStdout()`` method to check that the expected printout exists.
+In ``test_comparedb3.py`` (``armi/bookkeeping/db/tests/test_comparedb3.py``), there is a (simplified here) use case. A portion of the test for ``_diffSpecialData`` wants to confirm the below printout has happened, so it uses the ``getStdout()`` method to check that the expected printout exists.
 
 Example of ``mockRunLogs``:
 
@@ -49,7 +49,7 @@ Use Case: Automatically cleans up tests that create files:
 
 Two main uses of this class in testing:
 
-1. Standalone test that calls code that creates something (`test_operators.py <https://github.com/terrapower/armi/blob/2bcb03689954ae39f3044f18a9a77c1fb7a0e63b/armi/operators/tests/test_operators.py#L237-L242>`_):
+1. Standalone test that calls code that creates something, like ``test_operators.py`` (``armi/operators/tests/test_operators.py``):
 
 .. code-block:: python
 
@@ -60,7 +60,7 @@ Two main uses of this class in testing:
                  self.o.snapshotRequest(0, 1) 
                  self.assertIn("ISOTXS-c0", mock.getStdout()) 
 
-2. Setup and teardown of a testing class, where all/most of the tests create something (`test_comparedb3.py <https://github.com/terrapower/armi/blob/2bcb03689954ae39f3044f18a9a77c1fb7a0e63b/armi/bookkeeping/db/tests/test_comparedb3.py#L36-L52>`_):
+2. Setup and teardown of a testing class, where all/most of the tests create something, like ``test_comparedb3.py`` (``armi/bookkeeping/db/tests/test_comparedb3.py``):
 
 .. code-block:: python
 

--- a/doc/developer/testing.rst
+++ b/doc/developer/testing.rst
@@ -151,6 +151,6 @@ Use Case: Your unit test needs some ARMI objects, but not a full test reactor.
 ARMI provides several helpful tools for generating simple blocks and assemblies for unit tests:
 
 * ``from armi.reactor.tests.test_assemblies import buildTestAssemblies`` - Two hex blocks.
-* ``from armi.reactor.tests.test_blocks import buildSimpleFuelBlock`` - A simple hex block containing fuel, clad, duct, and coolant.
-* ``from armi.reactor.tests.test_blocks import loadTestBlock`` - An annular test block.
+* ``from armi.testing import buildSimpleFuelHexBlock`` - A simple hex block containing fuel, clad, duct, and coolant.
+* ``from armi.testing import buildComplexHexBlock`` - An annular test block.
 

--- a/doc/gallery-src/framework/run_blockVolumeFractions.py
+++ b/doc/gallery-src/framework/run_blockVolumeFractions.py
@@ -35,7 +35,7 @@ from armi import configure
 configure(permissive=True)
 
 from armi.reactor.flags import Flags
-from armi.reactor.tests.test_blocks import buildSimpleFuelBlock
+from armi.testing import buildSimpleFuelHexBlock
 from armi.utils import tabulate
 
 
@@ -84,7 +84,7 @@ def plotVolFracsWithComponentTemps(b, uniformTemps):
 
 
 uniformTempsInC = [300.0, 400.0, 500.0, 600.0, 700.0]
-b = buildSimpleFuelBlock()
+b = buildSimpleFuelHexBlock()
 
 writeInitialVolumeFractions(b)
 plotVolFracsWithComponentTemps(b, uniformTempsInC)

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Plot a reactor facemap.
-=======================
+Plot a reactor facemap
+======================
 
-Load a test reactor from the test suite and plot a dummy
-power distribution from it. You can plot any block parameter.
+Load a test reactor from the test suite and plot a dummy power distribution from it. You can plot any block parameter.
 """
 
 from armi import configure

--- a/doc/gallery-src/framework/run_reactorFacemap.py
+++ b/doc/gallery-src/framework/run_reactorFacemap.py
@@ -20,7 +20,7 @@ power distribution from it. You can plot any block parameter.
 """
 
 from armi import configure
-from armi.testng import loadTestReactor
+from armi.testing import loadTestReactor
 from armi.utils import plotting
 
 # configure ARMI

--- a/doc/tutorials/param_sweep.nblink
+++ b/doc/tutorials/param_sweep.nblink
@@ -1,9 +1,9 @@
 {
 	"path": "../../armi/tests/tutorials/param_sweep.ipynb",
 	  "extra-media": [
-        "../armi/testing/reactors/anl-afci-177/anl-afci-177-blueprints.yaml",
-        "../armi/testing/reactors/anl-afci-177/anl-afci-177.yaml",
-        "../armi/testing/reactors/anl-afci-177/anl-afci-177-coreMap.yaml",
-        "../armi/testing/reactors/anl-afci-177/anl-afci-177-fuelManagement.py"
+        "../../armi/testing/reactors/anl-afci-177/anl-afci-177-blueprints.yaml",
+        "../../armi/testing/reactors/anl-afci-177/anl-afci-177.yaml",
+        "../../armi/testing/reactors/anl-afci-177/anl-afci-177-coreMap.yaml",
+        "../../armi/testing/reactors/anl-afci-177/anl-afci-177-fuelManagement.py"
       ]
 }

--- a/doc/user/grids.rst
+++ b/doc/user/grids.rst
@@ -238,7 +238,7 @@ The other version is the corners up lattice. Notice how the ``-`` placeholders a
 
 and a larger example
 
-.. clode-block:: yaml
+.. code-block:: yaml
 
     geom: hex_corners_up
     symmetry: full

--- a/doc/user/grids.rst
+++ b/doc/user/grids.rst
@@ -274,7 +274,7 @@ and a larger example
 Placeholders and Whitespace
 """""""""""""""""""""""""""
 In lattice maps whitespace is used to separate symbols. The exact count of spaces is not strictly speaking important;
-one space is as good as five. The following to lattice maps yield the same result, though obviously one is easier to
+one space is as good as five. The following two lattice maps yield the same result, though obviously one is easier to
 read than the other
 
 .. code-block:: yaml

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -458,7 +458,7 @@ through the :attr:`~armi.reactor.cores.Core.zones` attribute on the core. See al
 Users can define these zones with the ``zonesFile`` setting. It must point to YAML file that contains the high-level key
 ``customZonesMap`` containing a map of ``location: zone`` maps.
 
-.. code:: yaml
+.. code-block:: yaml
 
     customZonesMap:
       001-001: primary control
@@ -480,7 +480,7 @@ This example would produce four zones:
 An alternative method is with the ``zoneDefinitions`` setting in the primary settings file. This contains a list of
 zone names and the assemblies that make up that zone. The following would create an identical zone structure as above.
 
-.. code:: yaml
+.. code-block:: yaml
 
     settings:
       zoneDefinitions:

--- a/doc/user/spatial_block_data.rst
+++ b/doc/user/spatial_block_data.rst
@@ -22,7 +22,7 @@ In your blueprints file, you likely have a core grid that defines where assembli
 are assigned to locations on that grid according to their ``specifier`` blueprint attribute. Below is an example
 of a "flats up" hexagonal core grid of fuel assemblies with 1/3 symmetry.
 
-.. code:: yaml
+.. code-block:: yaml
 
     grids:
       core:
@@ -37,7 +37,7 @@ of a "flats up" hexagonal core grid of fuel assemblies with 1/3 symmetry.
 
 We can similarly define a grid for the block with a similar entry in the ``grids`` portion of the blueprints.
 
-.. code:: yaml
+.. code-block:: yaml
 
     pins:
       geom: hex_corners_up

--- a/doc/user/symmetry_handling.rst
+++ b/doc/user/symmetry_handling.rst
@@ -9,7 +9,7 @@ Introduction
 
 A partial core may be specified in the blueprints file using the ``symmetry`` attribute, as shown below.
 
-.. code:: yaml
+.. code-block:: yaml
 
     grids:
       core:


### PR DESCRIPTION
## What is the change? Why is it being made?

There were several things going on in the ARMI docs. I tried to fix them all to get the docs building correctly again.

1. The ARMI docs API is currently not being built due to some pathing changes made in this PR: https://github.com/terrapower/armi/pull/2608 Essentially, this path:

```python
from armi.reactor.tests.test_blocks import buildSimpleFuelBlock
```

became this path:

```python
from armi.testing import buildSimpleFuelHexBlock
```

And that was fixed everywhere but the docs.

2. Also, there was a broken import in the docs (spelling of the word "testing"):

```python
from armi.testng import loadTestReactor
```

3. And, just because I'm looking at the Sphinx log, I cleaned up some other Sphinx warnings I found.

4. And there was a duplicate unit test tag that I fixed.

5. And there was a typo where the `code-block` directive was spelled `clode-block`.

close #2621
close #2620


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: The docs depend on a working API.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
