### PR TITLE
Banning AM242 from nuclide flags

### DIFF
--- a/armi/migration/__init__.py
+++ b/armi/migration/__init__.py
@@ -15,30 +15,26 @@
 """
 Migrate input/output from one version of ARMI to another.
 
-Users want to be able to upgrade to the latest version of the code without having to
-invest a bunch of time in updating their previous input and output files. Users have up
-to thousands of inputs that they want to keep working. Even more serious, follow-on
-analysts who got an output database (including associated inputs) from an ARMI
-user strongly prefer to be able to migrate old cases. Oftentimes, an output
-database can be many GB large and be the result of many CPU-weeks, so there's monetary
-and temporal value to be preserved.
+Users want to be able to upgrade to the latest version of the code without having to invest a bunch of time in updating
+their previous input and output files. Users have up to thousands of inputs that they want to keep working. Even more
+serious, follow-on analysts who got an output database (including associated inputs) from an ARMI user strongly prefer
+to be able to migrate old cases. Oftentimes, an output database can be many GB large and be the result of many
+CPU-weeks, so there's monetary and temporal value to be preserved.
 
-Meanwhile, developers want to be able to make upgrades to the input and/or output to fix
-bugs, ease the training and cognitive burden of new users, and so on.
+Meanwhile, developers want to be able to make upgrades to the input and/or output to fix bugs, ease the training and
+cognitive burden of new users, and so on.
 
 Migrations are key to getting both of these big needs.
 
-Migrations should generally happen in the background from the user's perspective, just
-like happens in mainstream applications like word processors and spreadsheets.
+Migrations should generally happen in the background from the user's perspective, just like happens in mainstream
+applications like word processors and spreadsheets.
 """
 
-from armi.migration import (
-    m0_1_3,
-    m0_1_6,
-)
+from armi.migration import m0_1_3, m0_1_6, m0_7_0
 
 ACTIVE_MIGRATIONS = [
     m0_1_3.RemoveCentersFromBlueprints,
     m0_1_3.UpdateElementalNuclides,
     m0_1_6.ConvertAlphanumLocationSettingsToNum,
+    m0_7_0.UpdateAmericium242,
 ]

--- a/armi/migration/__init__.py
+++ b/armi/migration/__init__.py
@@ -33,7 +33,6 @@ applications like word processors and spreadsheets.
 from armi.migration import m0_1_3, m0_1_6, m0_7_0
 
 ACTIVE_MIGRATIONS = [
-    m0_1_3.RemoveCentersFromBlueprints,
     m0_1_3.UpdateElementalNuclides,
     m0_1_6.ConvertAlphanumLocationSettingsToNum,
     m0_7_0.UpdateAmericium242,

--- a/armi/migration/base.py
+++ b/armi/migration/base.py
@@ -81,7 +81,7 @@ class Migration(abc.ABC):
         skip = False
         # Compare self.toVersion to the version of the DB.
         if version is not None and version != "uncontrolled":
-            if versionToNumber(version) >= versionToNumber(self.toVersion):
+            if versionToNumber(version) > versionToNumber(self.toVersion):
                 # this migration is not necessary, because the DB is newer than that.
                 skip = True
 

--- a/armi/migration/m0_1_3.py
+++ b/armi/migration/m0_1_3.py
@@ -16,30 +16,7 @@
 import io
 import re
 
-from armi import runLog
 from armi.migration.base import BlueprintsMigration
-
-
-class RemoveCentersFromBlueprints(BlueprintsMigration):
-    """Removes now-invalid `centers:` lines from auto-generated component inputs."""
-
-    @property
-    def fromVersion(self):
-        return "0.1.2"
-
-    @property
-    def toVersion(self):
-        return "0.1.3"
-
-    def _applyToStream(self):
-        runLog.info("Removing `centers:` sections.")
-        migrated = []
-        for line in self.stream.read().split("\n"):
-            if re.search(r"^\s*centers:\s*$", line):
-                continue
-            migrated.append(line)
-        result = "\n".join(migrated)
-        return io.StringIO(result)
 
 
 class UpdateElementalNuclides(BlueprintsMigration):

--- a/armi/migration/m0_7_0.py
+++ b/armi/migration/m0_7_0.py
@@ -1,4 +1,4 @@
-# Copyright 2019 TerraPower, LLC
+# Copyright 2026 TerraPower, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/armi/migration/m0_7_0.py
+++ b/armi/migration/m0_7_0.py
@@ -43,7 +43,6 @@ class UpdateAmericium242(BlueprintsMigration):
         Custom isotopics: `        AM242: 0.0015135`
         Nuclide flags: `    AM242M: {burn: false, xs: true}`
         """
-        print("xxxxxxxxxxx")
         migrated = []
         swapFrom, swapTo = self.swap
         for line in self.stream.read().split("\n"):

--- a/armi/migration/m0_7_0.py
+++ b/armi/migration/m0_7_0.py
@@ -1,0 +1,54 @@
+# Copyright 2019 TerraPower, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Complete the migration from AM242 to AM242M."""
+
+import io
+import re
+
+from armi.migration.base import BlueprintsMigration
+
+
+class UpdateAmericium242(BlueprintsMigration):
+    """The current ARMI nuclide modeling uses AM242M as the default metastable isomer of AM242.
+
+    The reason for this little oddity is that AM242M is by a wide margin the most stable isomer, with a half-life in the
+    neighborhood of 141 years. Many of the other meta-stable states have half lives in the range of hours or even
+    milliseconds.
+    """
+
+    swap = ("AM242", "AM242M")
+
+    @property
+    def fromVersion(self):
+        return "0.6.4"
+
+    @property
+    def toVersion(self):
+        return "0.7.0"
+
+    def _applyToStream(self):
+        """Change both nuclide flags as well as custom isotopics.
+
+        Custom isotopics: `        AM242: 0.0015135`
+        Nuclide flags: `    AM242M: {burn: false, xs: true}`
+        """
+        print("xxxxxxxxxxx")
+        migrated = []
+        swapFrom, swapTo = self.swap
+        for line in self.stream.read().split("\n"):
+            line = re.sub(r"^(\s+)({0})(:.+)".format(swapFrom), r"\1{0}\3".format(swapTo), line)
+            migrated.append(line)
+
+        result = "\n".join(migrated)
+        return io.StringIO(result)

--- a/armi/migration/tests/test_m0_1_6.py
+++ b/armi/migration/tests/test_m0_1_6.py
@@ -16,7 +16,9 @@
 import io
 import unittest
 
+from armi.migration.m0_1_3 import RemoveCentersFromBlueprints, UpdateElementalNuclides
 from armi.migration.m0_1_6 import ConvertAlphanumLocationSettingsToNum
+from armi.migration.m0_7_0 import UpdateAmericium242
 from armi.settings import caseSettings
 from armi.settings.settingsIO import SettingsReader, SettingsWriter
 
@@ -43,8 +45,8 @@ class TestMigration(unittest.TestCase):
         """
         Ensure that no migration happens if the version of the DB is newer than the migration 'toVersion'.
 
-        This test checks the specific case of `ConvertAlphanumLocationSettingsToNum`, which should only
-        be applied until v0.1.7.
+        This test checks the specific case of `ConvertAlphanumLocationSettingsToNum`, which should only be applied until
+        v0.1.7.
         """
         cs = caseSettings.Settings()
         newSettings = {"detailAssemLocationsBOL": ["B1012"]}
@@ -60,3 +62,36 @@ class TestMigration(unittest.TestCase):
         reader = SettingsReader(newCs)
         reader.readFromStream(converter.apply(version="0.6.4"))
         self.assertEqual(newCs["detailAssemLocationsBOL"][0], "B1012")
+
+    def test_removeCentersFromBlueprints(self):
+        # RemoveCentersFromBlueprints
+        pass
+
+    def test_updateElementalNuclides(self):
+        # UpdateElementalNuclides
+        pass
+
+    def test_updateAmericium242(self):
+        # mock up a partial blueprint
+        bpText = """
+nulide flags:
+  CM244: {burn: false, xs: true, expandTo: []}
+  CM242: {burn: false, xs: true, expandTo: []}
+  AM242: {burn: false, xs: true, expandTo: []}
+  CM245: {burn: false, xs: true, expandTo: []}
+  CM243: {burn: false, xs: true, expandTo: []}
+"""
+        # run the UpdateAmericium242 migration
+        stream = io.StringIO(bpText)
+        converter = UpdateAmericium242(stream=stream)
+        newStream = converter.apply(version="0.7.0")
+        outText = newStream.read()
+
+        print(outText)
+
+        # validate migration
+        self.assertIn("AM242M:", outText)
+        self.assertNotIn("AM242:", outText)
+        self.assertIn("CM244:", outText)
+        self.assertIn("CM243:", outText)
+        

--- a/armi/migration/tests/test_migrations.py
+++ b/armi/migration/tests/test_migrations.py
@@ -11,19 +11,51 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test Locationlabel migration."""
+"""Basic tests of the migrations that come packaged with ARMI."""
 
 import io
 import unittest
 
-from armi.migration.m0_1_3 import RemoveCentersFromBlueprints, UpdateElementalNuclides
+from armi.migration.m0_1_3 import UpdateElementalNuclides
 from armi.migration.m0_1_6 import ConvertAlphanumLocationSettingsToNum
 from armi.migration.m0_7_0 import UpdateAmericium242
 from armi.settings import caseSettings
 from armi.settings.settingsIO import SettingsReader, SettingsWriter
 
 
-class TestMigration(unittest.TestCase):
+class TestMigration013(unittest.TestCase):
+    def test_updateElementalNuclides(self):
+        # mock up a partial blueprint
+        bpText = """
+nulide flags:
+  MN55: {burn: false, xs: true, expandTo: []}
+  CM242: {burn: false, xs: true, expandTo: []}
+  W182: {burn: false, xs: true, expandTo: []}
+  CM245: {burn: false, xs: true, expandTo: []}
+  AL27: {burn: false, xs: true, expandTo: []}
+"""
+        # run the UpdateElementalNuclides migration
+        stream = io.StringIO(bpText)
+        converter = UpdateElementalNuclides(stream=stream)
+        newStream = converter.apply(version="0.1.3")
+        outText = newStream.read()
+
+        # validate migration: old versions removed
+        self.assertNotIn("MN55:", outText)
+        self.assertNotIn("W182:", outText)
+        self.assertNotIn("AL27:", outText)
+
+        # validate migration: new versions added
+        self.assertIn("MN:", outText)
+        self.assertIn("W:", outText)
+        self.assertIn("AL:", outText)
+
+        # validate migration: unrelated things unaffected
+        self.assertIn("CM242:", outText)
+        self.assertIn("CM245:", outText)
+
+
+class TestMigration016(unittest.TestCase):
     def test_locationLabelMigration(self):
         """Make a setting with an old value and make sure it migrates to expected new value."""
         cs = caseSettings.Settings()
@@ -63,14 +95,8 @@ class TestMigration(unittest.TestCase):
         reader.readFromStream(converter.apply(version="0.6.4"))
         self.assertEqual(newCs["detailAssemLocationsBOL"][0], "B1012")
 
-    def test_removeCentersFromBlueprints(self):
-        # RemoveCentersFromBlueprints
-        pass
 
-    def test_updateElementalNuclides(self):
-        # UpdateElementalNuclides
-        pass
-
+class TestMigration070(unittest.TestCase):
     def test_updateAmericium242(self):
         # mock up a partial blueprint
         bpText = """
@@ -87,11 +113,8 @@ nulide flags:
         newStream = converter.apply(version="0.7.0")
         outText = newStream.read()
 
-        print(outText)
-
         # validate migration
         self.assertIn("AM242M:", outText)
         self.assertNotIn("AM242:", outText)
         self.assertIn("CM244:", outText)
         self.assertIn("CM243:", outText)
-        

--- a/armi/nucDirectory/nucDir.py
+++ b/armi/nucDirectory/nucDir.py
@@ -137,8 +137,8 @@ def getMc2Label(name):
     'FE'
     >>> nucDir.getMc2Label("IRON")
     'FE'
-    >>> nucDir.getMc2Label("AM242")
-    A242
+    >>> nucDir.getMc2Label("AM242M")
+    A242M
 
     """
     # First translate to the proper nuclide. CARB->C

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -616,8 +616,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
             # Am242 has special rules
             if self.state != 1:
                 # MCNP uses base state for the common metastable state AM242M, so AM242M is just 95242
-                # AM242 base state is called 95642 (+400) in mcnp.
-                # see https://mcnp.lanl.gov/pdf_files/la-ur-08-1999.pdf
+                # AM242 base state is called 95642 (+400) in mcnp. see https://mcnp.lanl.gov/pdf_files/la-ur-08-1999.pdf
                 # New ACE-Formatted Neutron and Proton Libraries Based on ENDF/B-VII.0
                 a += 300 + 100 * max(self.state, 1)
         elif self.state > 0:

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -616,7 +616,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
             # Am242 has special rules
             if self.state != 1:
                 # MCNP uses base state for the common metastable state AM242M, so AM242M is just 95242
-                # AM242 base state is called 95642 (+400) in mcnp. see https://mcnp.lanl.gov/pdf_files/la-ur-08-1999.pdf
+                # AM242 base state is called 95642 (+400) in mcnp.
                 # New ACE-Formatted Neutron and Proton Libraries Based on ENDF/B-VII.0
                 a += 300 + 100 * max(self.state, 1)
         elif self.state > 0:

--- a/armi/nucDirectory/nuclideBases.py
+++ b/armi/nucDirectory/nuclideBases.py
@@ -617,7 +617,7 @@ class NuclideBase(INuclide, IMcnpNuclide):
             if self.state != 1:
                 # MCNP uses base state for the common metastable state AM242M, so AM242M is just 95242
                 # AM242 base state is called 95642 (+400) in mcnp.
-                # New ACE-Formatted Neutron and Proton Libraries Based on ENDF/B-VII.0
+                # See LA-UR-08-1999, New ACE-Formatted Neutron and Proton Libraries Based on ENDF/B-VII.0
                 a += 300 + 100 * max(self.state, 1)
         elif self.state > 0:
             # in general mcnp adds 300 + 100*m to the Z number for metastables. see above source

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -98,8 +98,6 @@ class NuclideFlag(yamlize.Object):
         if value not in nuclideBases.byName and value not in elements.bySymbol:
             allowedKeys = set(nuclideBases.byName.keys()).update(set(elements.bySymbol.keys()))
             raise ValueError(f"`{value}` is not a valid nuclide name, must be one of: {allowedKeys}")
-        elif value == "AM242":
-            raise ValueError("AM242 is not currently a valid nuclide in ARMI, you want to use AM242M.")
 
     burn = yamlize.Attribute(type=bool)
     xs = yamlize.Attribute(type=bool)

--- a/armi/reactor/blueprints/isotopicOptions.py
+++ b/armi/reactor/blueprints/isotopicOptions.py
@@ -98,6 +98,8 @@ class NuclideFlag(yamlize.Object):
         if value not in nuclideBases.byName and value not in elements.bySymbol:
             allowedKeys = set(nuclideBases.byName.keys()).update(set(elements.bySymbol.keys()))
             raise ValueError(f"`{value}` is not a valid nuclide name, must be one of: {allowedKeys}")
+        elif value == "AM242":
+            raise ValueError("AM242 is not currently a valid nuclide in ARMI, you want to use AM242M.")
 
     burn = yamlize.Attribute(type=bool)
     xs = yamlize.Attribute(type=bool)
@@ -412,13 +414,16 @@ def getDefaultNuclideFlags():
         "U": [234, 235, 236, 238],
         "NP": [237, 238],
         "PU": [236] + list(range(238, 243)),
-        "AM": range(241, 244),
+        "AM": [241, 243],
         "CM": range(242, 248),
     }
 
     for el, masses in actinides.items():
         for mass in masses:
             nuclideFlags[f"{el}{mass}"] = {"burn": True, "xs": True, "expandTo": None}
+
+    # handle special case: AM242M
+    nuclideFlags["AM242M"] = {"burn": True, "xs": True, "expandTo": None}
 
     for fp in [35, 38, 39, 40, 41]:
         nuclideFlags[f"LFP{fp}"] = {"burn": True, "xs": True, "expandTo": None}

--- a/armi/reactor/blueprints/tests/test_blueprints.py
+++ b/armi/reactor/blueprints/tests/test_blueprints.py
@@ -585,7 +585,7 @@ nuclide flags:
     AM243: {burn: true, xs: true}
     CM244: {burn: true, xs: true}
     CM242: {burn: true, xs: true}
-    AM242: {burn: true, xs: true}
+    AM242M: {burn: true, xs: true}
     PU240: {burn: true, xs: true}
     CM245: {burn: true, xs: true}
     NP238: {burn: true, xs: true}

--- a/armi/reactor/blueprints/tests/test_customIsotopics.py
+++ b/armi/reactor/blueprints/tests/test_customIsotopics.py
@@ -65,7 +65,7 @@ nuclide flags:
     AM243: {burn: true, xs: true}
     CM244: {burn: true, xs: true}
     CM242: {burn: true, xs: true}
-    AM242: {burn: true, xs: true}
+    AM242M: {burn: true, xs: true}
     CM245: {burn: true, xs: true}
     NP238: {burn: true, xs: true}
     CM243: {burn: true, xs: true}
@@ -593,7 +593,6 @@ blocks:
         clad:
             shape: Hexagon
             material: Custom
-            #isotopics: sodium custom isotopics
             Tinput: 25.0
             Thot: 600.0
             ip: 0.0

--- a/armi/testing/reactors/godiva/godiva-blueprints.yaml
+++ b/armi/testing/reactors/godiva/godiva-blueprints.yaml
@@ -35,7 +35,7 @@ nuclide flags:
   PA231: {burn: false, xs: true, expandTo: []}
   CM244: {burn: false, xs: true, expandTo: []}
   CM242: {burn: false, xs: true, expandTo: []}
-  AM242: {burn: false, xs: true, expandTo: []}
+  AM242M: {burn: false, xs: true, expandTo: []}
   CM245: {burn: false, xs: true, expandTo: []}
   CM243: {burn: false, xs: true, expandTo: []}
   CM246: {burn: false, xs: true, expandTo: []}

--- a/armi/testing/reactors/smallHexReactor/smallHexReactor-bp.yaml
+++ b/armi/testing/reactors/smallHexReactor/smallHexReactor-bp.yaml
@@ -52,7 +52,7 @@ nuclide flags:
     burn: true
     xs: true
     expandTo:
-  AM242:
+  AM242M:
     burn: true
     xs: true
     expandTo:

--- a/armi/testing/reactors/thirdSmallHexReactor/thirdSmallHexReactor-bp.yaml
+++ b/armi/testing/reactors/thirdSmallHexReactor/thirdSmallHexReactor-bp.yaml
@@ -52,7 +52,7 @@ nuclide flags:
     burn: true
     xs: true
     expandTo:
-  AM242:
+  AM242M:
     burn: true
     xs: true
     expandTo:


### PR DESCRIPTION
## What is the change? Why is it being made?

Currently, the nuclide modeling in ARMI breaks `AM242` into `AM242M` and `AM242G` where the user should use `AM242M` instead of `AM242`.

The end result is that if the users puts `AM242M` in the "nuclides flags" in their blueprints they will be fine. So this PR enforces that by raising an error if the user puts straight `AM242` into their "nuclide flags".

close #1757


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Since AM242 does not work in the nuclide flags, ARMI should raise an error if a user tries.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
