### PR TITLE
Improving warnings on negative DPA calculations

### DIFF
--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -832,7 +832,7 @@ class GlobalFluxResultMapper(interfaces.OutputReader):
                 a.p.kInf = totalSrc / totalAbs  # assembly average k-inf.
 
 
-def computeDpaRate(mgFlux, dpaXs):
+def computeDpaRate(mgFlux, dpaXs, block=None):
     r"""
     Compute the DPA rate incurred by exposure of a certain flux spectrum.
 
@@ -840,8 +840,8 @@ def computeDpaRate(mgFlux, dpaXs):
         :id: I_ARMI_FLUX_DPA
         :implements: R_ARMI_FLUX_DPA
 
-        This method calculates DPA rates using the inputted multigroup flux and DPA cross sections.
-        Displacements calculated by displacement cross-section:
+        Calculate DPA rates using a provided multi-group flux and DPA cross sections. Displacements are calculated by
+        displacement cross-section:
 
         .. math::
             :nowrap:
@@ -865,48 +865,49 @@ def computeDpaRate(mgFlux, dpaXs):
 
             \frac{\text{dpa}}{s}  = \frac{\phi N \sigma}{N} = \phi * \sigma
 
-        the number density of the structural material cancels out. It's in the macroscopic
-        cross-section and in the original number of atoms.
+        the number density of the structural material cancels out. It is in the macroscopic cross-section and in the
+        original number of atoms.
 
     Parameters
     ----------
     mgFlux : list
-        multigroup neutron flux in #/cm^2/s
-
+        multi-group neutron flux in #/cm^2/s
     dpaXs : list
         DPA cross section in barns to convolute with flux to determine DPA rate
+    block : Block
+        Optional parameter, used purely for logging.
 
     Returns
     -------
     dpaPerSecond : float
-        The dpa/s in this material due to this flux
+        The DPA/s in this material due to this flux
 
     Raises
     ------
     RuntimeError
        Negative dpa rate.
     """
-    displacements = 0.0
     if len(mgFlux) != len(dpaXs):
         runLog.warning(
-            "Multigroup flux of length {} is incompatible with dpa cross section of length {};"
-            "dpa rate will be set do 0.0".format(len(mgFlux), len(dpaXs)),
+            f"Multigroup flux of length {len(mgFlux)} is incompatible with DPA cross section of length {len(dpaXs)}; "
+            "DPA rate will be set do 0.0",
             single=True,
         )
-        return displacements
+        return 0.0
+
+    displacements = 0.0
     for flux, barns in zip(mgFlux, dpaXs):
         displacements += flux * barns
-    dpaPerSecond = displacements * units.CM2_PER_BARN
 
+    dpaPerSecond = displacements * units.CM2_PER_BARN
     if dpaPerSecond < 0:
-        runLog.warning(
-            "Negative DPA rate calculated at {}".format(dpaPerSecond),
-            single=True,
-            label="negativeDpaPerSecond",
-        )
+        forBlock = f" for block {block}" if block else ""
+        runLog.warning(f"Negative DPA rate calculated to be {dpaPerSecond}{forBlock}, setting to zero.")
         # ensure physical meaning of dpaPerSecond, it is likely just slightly negative
         if dpaPerSecond < -1.0e-10:
-            raise RuntimeError("Calculated DPA rate is substantially negative at {}".format(dpaPerSecond))
+            msg = f"Calculated DPA rate is substantially negative at {dpaPerSecond}{forBlock}."
+            runLog.error(msg)
+            raise RuntimeError(msg)
         dpaPerSecond = 0.0
 
     return dpaPerSecond

--- a/armi/physics/neutronics/globalFlux/globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/globalFluxInterface.py
@@ -840,7 +840,7 @@ def computeDpaRate(mgFlux, dpaXs, block=None):
         :id: I_ARMI_FLUX_DPA
         :implements: R_ARMI_FLUX_DPA
 
-        Calculate DPA rates using a provided multi-group flux and DPA cross sections. Displacements are calculated by
+        Calculate DPA rates using a provided multi-group flux and DPA cross section. Displacements are calculated by
         displacement cross-section:
 
         .. math::

--- a/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
+++ b/armi/physics/neutronics/globalFlux/tests/test_globalFluxInterface.py
@@ -28,7 +28,7 @@ from armi.physics.neutronics.settings import (
 from armi.reactor import geometry
 from armi.reactor.blocks import HexBlock
 from armi.reactor.flags import Flags
-from armi.testing import TESTING_ROOT, applyDummyData, buildComplexHexBlock, loadTestReactor
+from armi.testing import TESTING_ROOT, applyDummyData, buildComplexHexBlock, loadTestReactor, mockRunLogs
 from armi.tests import ISOAA_PATH
 
 
@@ -152,10 +152,36 @@ class TestGFI(unittest.TestCase):
             :id: T_ARMI_FLUX_DPA
             :tests: R_ARMI_FLUX_DPA
         """
-        xs = [1, 2, 3]
-        flx = [0.5, 0.75, 2]
-        res = globalFluxInterface.computeDpaRate(flx, xs)
-        self.assertEqual(res, 10**-24 * (0.5 + 1.5 + 6))
+        with mockRunLogs.BufferLog() as mock:
+            # test basic math
+            xs = [1, 2, 3]
+            flx = [0.5, 0.75, 2]
+            res = globalFluxInterface.computeDpaRate(flx, xs)
+            self.assertEqual(res, 10**-24 * (0.5 + 1.5 + 6))
+
+            # test mismatched input data, including logging
+            xs = [1, 2, 3, 4, 5]
+            flx = [1, 2, 3]
+            self.assertNotIn("will be set do 0.0", mock.getStdout())
+            self.assertEqual(globalFluxInterface.computeDpaRate(flx, xs), 0.0)
+            self.assertIn("will be set do 0.0", mock.getStdout())
+
+            # test slightly negative value, including logging
+            xs = [-2, 1, 1]
+            flx = [1.0 + 1e-12, 1.0, 1.0]
+            mock.emptyStdout()
+            self.assertNotIn("setting to zero", mock.getStdout())
+            self.assertEqual(globalFluxInterface.computeDpaRate(flx, xs), 0.0)
+            self.assertIn("setting to zero", mock.getStdout())
+
+            # test very negative value, including logging
+            xs = [-2e14, 1, 1]
+            flx = [1, 1, 1]
+            mock.emptyStdout()
+            self.assertNotIn("substantially negative", mock.getStdout())
+            with self.assertRaises(RuntimeError):
+                globalFluxInterface.computeDpaRate(flx, xs)
+            self.assertIn("substantially negative", mock.getStdout())
 
     def test_interaction(self):
         """


### PR DESCRIPTION
## What is the change? Why is it being made?

@keckler raised the concern, and @andrewryh agreed, that the warnings for negative DPA calculations were not helpful. They request that the actual `Block` in question be listed in the warning, and we stop trying to silence these warnings if they reappear.

To make this happen, I had to optionally pass in the `Block` in question, for logging. (I can't make this mandatory, because of downstream users.)

Also, I added a bunch of testing to the method `computeDpaRate().

close #2629 


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Our users wanted better fidelity on these warnings.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
