### PR TITLE
Increasing ARMI HTML and PDF documentation TOC depth

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -370,7 +370,7 @@ html_theme_options = {
     # Toc options
     "collapse_navigation": True,
     "includehidden": True,
-    "navigation_depth": 4,
+    "navigation_depth": -1,
     "sticky_navigation": True,
     "titles_only": False,
 }
@@ -410,6 +410,8 @@ latex_elements = {
     "preamble": r"""\usepackage{amsmath}
 
 \usepackage{wasysym}
+\setcounter{tocdepth}{5}
+\setcounter{secnumdepth}{5}
 """,
 }
 

--- a/doc/developer/index.rst
+++ b/doc/developer/index.rst
@@ -11,7 +11,7 @@ into their workflow and/or enhance ARMI for the community.
 -------------
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 5
    :numbered:
    :glob:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@ ARMI
 
 .. toctree::
    :hidden:
-   :maxdepth: 2
+   :maxdepth: 5
 
    readme
    installation

--- a/doc/qa_docs/index.rst
+++ b/doc/qa_docs/index.rst
@@ -9,7 +9,7 @@ Software Design and Implementation Document (SDID), and the Software Test Report
 -------------
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 5
    :numbered:
    
    srsd

--- a/doc/qa_docs/scr/index.rst
+++ b/doc/qa_docs/scr/index.rst
@@ -6,7 +6,7 @@ You can find a Software Change Request (SCR) for each releases below.
 ----------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 5
    :glob:
    :reversed:
 

--- a/doc/tutorials/index.rst
+++ b/doc/tutorials/index.rst
@@ -10,7 +10,7 @@ interact with ARMI.
 --------------
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 5
     :numbered:
 
     nuclide_demo.ipynb

--- a/doc/user/index.rst
+++ b/doc/user/index.rst
@@ -8,7 +8,7 @@ ARMI input files, running various kinds of ARMI runs, analyzing ARMI output file
 --------------
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 5
    :numbered:
 
    inputs


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
This PR extends the TOC depth for both ARMI's HTML and PDF docpages. This is done in several places.
- The `:maxdepth:` option in the `.. toctree:` directive was changed from 5 everywhere.
- `html_theme_options['navigation_depth']` in `conf.py` was set to `-1`, allowing unlimited depth.
- The following was added to `latex_elements["preamble"]` in `conf.py`:
  ```
   \setcounter{tocdepth}{5}
   \setcounter{secnumdepth}{5}
  ```

closes #2414

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: The ARMI documentation should be easily navigable.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
