### PR TITLE
fix: unpin pypdf dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ docs = [
     "nbsphinx==0.9.6", # Parses Jupyter notebooks
     "pandoc", # Must be in the path (to convert file formats)
     "pylint", # Generates UML diagrams
-    "pypdf==6.15.0", # Generating a single PDF file for the Sphinx documentation
+    "pypdf>=6.15.0", # Generating a single PDF file for the Sphinx documentation
     "setuptools",  # needed for conf.py tooling
     "sphinx-gallery==0.13.0", # Builds an HTML version of a Python script and puts it into a gallery
     "sphinx-needs==4.2.0", # Requirements traceability matrices for QA


### PR DESCRIPTION
## Summary

`pypdf` was pinned to `6.15.0`. The pypdf team marks every minor release as a "security" update, causing Dependabot to open repeated PRs that don't change behavior.

## Change

Unpin to `>=6.15.0` to accept future minor versions without manual intervention.

```toml
# Before
"pypdf==6.15.0",

# After
"pypdf>=6.15.0",
```

Fixes #2633