### PR TITLE
Adding and enforcing test function and class naming standards

### DIFF
--- a/armi/bookkeeping/tests/test_memoryProfiler.py
+++ b/armi/bookkeeping/tests/test_memoryProfiler.py
@@ -205,7 +205,7 @@ class TestMemoryProfiler(unittest.TestCase):
         ]
 
 
-class KlassCounterTests(unittest.TestCase):
+class TestKlassCounter(unittest.TestCase):
     def get_containers(self):
         container1 = [1, 2, 3, 4, 5, 6, 7, 2.0]
         container2 = ("a", "b", container1, None)

--- a/armi/matProps/tests/test_property.py
+++ b/armi/matProps/tests/test_property.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Program that runs all of the tests contained in PropertyTests class."""
+"""Tests for the matProps.Property class."""
 
 import os
 import unittest
@@ -22,7 +22,7 @@ from armi.matProps import loadMaterial
 from armi.matProps.prop import defProp, properties
 
 
-class PropertyTests(unittest.TestCase):
+class TestProperty(unittest.TestCase):
     """Class which contains tests for the matProps Property class."""
 
     @classmethod

--- a/armi/materials/tests/test__init__.py
+++ b/armi/materials/tests/test__init__.py
@@ -38,7 +38,7 @@ def betterSubClassCheck(item, superClass):
         return False
 
 
-class TestMaterials__init__(unittest.TestCase):
+class TestMaterialsInit(unittest.TestCase):
     def test_canAccessClassesFromPackage(self):
         klasses = [kk for _, kk in vars(materials).items() if betterSubClassCheck(kk, materials.material.Material)]
         self.assertGreater(len(klasses), 10)

--- a/armi/materials/tests/test__init__.py
+++ b/armi/materials/tests/test__init__.py
@@ -82,7 +82,7 @@ class TestMaterialBaseClassHook(unittest.TestCase):
         self.assertIsInstance(mat, TestMaterial)
 
 
-class YamlMaterialTests(unittest.TestCase):
+class TestYamlMaterial(unittest.TestCase):
     def setUp(self):
         self._monkeypatch = MonkeyPatch()
         origNamespace = materials._MATERIAL_NAMESPACE_ORDER

--- a/armi/materials/tests/test__init__.py
+++ b/armi/materials/tests/test__init__.py
@@ -38,7 +38,7 @@ def betterSubClassCheck(item, superClass):
         return False
 
 
-class Materials__init__Tests(unittest.TestCase):
+class TestMaterials__init__(unittest.TestCase):
     def test_canAccessClassesFromPackage(self):
         klasses = [kk for _, kk in vars(materials).items() if betterSubClassCheck(kk, materials.material.Material)]
         self.assertGreater(len(klasses), 10)

--- a/armi/materials/tests/test_b4c.py
+++ b/armi/materials/tests/test_b4c.py
@@ -16,14 +16,14 @@
 import unittest
 
 from armi.materials.b4c import B4C
-from armi.materials.tests.test_materials import AbstractMaterialTest
+from armi.materials.tests.test_materials import TestAbstractMaterial
 
 
-class TestB4C(AbstractMaterialTest, unittest.TestCase):
+class TestB4C(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = B4C
 
     def setUp(self):
-        AbstractMaterialTest.setUp(self)
+        TestAbstractMaterial.setUp(self)
         self.mat = B4C()
 
         self.B4C_TD_frac = B4C()

--- a/armi/materials/tests/test_b4c.py
+++ b/armi/materials/tests/test_b4c.py
@@ -19,7 +19,7 @@ from armi.materials.b4c import B4C
 from armi.materials.tests.test_materials import AbstractMaterialTest
 
 
-class B4C_TestCase(AbstractMaterialTest, unittest.TestCase):
+class TestB4C(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = B4C
 
     def setUp(self):

--- a/armi/materials/tests/test_b4c.py
+++ b/armi/materials/tests/test_b4c.py
@@ -16,14 +16,14 @@
 import unittest
 
 from armi.materials.b4c import B4C
-from armi.materials.tests.test_materials import TestAbstractMaterial
+from armi.materials.tests.test_materials import AbstractMaterialTest
 
 
-class TestB4C(TestAbstractMaterial, unittest.TestCase):
+class TestB4C(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = B4C
 
     def setUp(self):
-        TestAbstractMaterial.setUp(self)
+        AbstractMaterialTest.setUp(self)
         self.mat = B4C()
 
         self.B4C_TD_frac = B4C()

--- a/armi/materials/tests/test_be9.py
+++ b/armi/materials/tests/test_be9.py
@@ -16,10 +16,10 @@
 import unittest
 
 from armi.materials import Be9
-from armi.materials.tests.test_materials import AbstractMaterialTest
+from armi.materials.tests.test_materials import TestAbstractMaterial
 
 
-class Be9Tests(AbstractMaterialTest, unittest.TestCase):
+class Be9Tests(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = Be9
 
     def test_pseudoDensity(self):

--- a/armi/materials/tests/test_be9.py
+++ b/armi/materials/tests/test_be9.py
@@ -16,10 +16,10 @@
 import unittest
 
 from armi.materials import Be9
-from armi.materials.tests.test_materials import TestAbstractMaterial
+from armi.materials.tests.test_materials import AbstractMaterialTest
 
 
-class Be9Tests(TestAbstractMaterial, unittest.TestCase):
+class Be9Tests(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = Be9
 
     def test_pseudoDensity(self):

--- a/armi/materials/tests/test_graphite.py
+++ b/armi/materials/tests/test_graphite.py
@@ -19,7 +19,7 @@ import unittest
 from armi.materials import Graphite
 
 
-class Graphite_TestCase(unittest.TestCase):
+class TestGraphite(unittest.TestCase):
     MAT_CLASS = Graphite
 
     def setUp(self):

--- a/armi/materials/tests/test_lithium.py
+++ b/armi/materials/tests/test_lithium.py
@@ -16,14 +16,14 @@
 import unittest
 
 from armi.materials import Lithium
-from armi.materials.tests.test_materials import TestAbstractMaterial
+from armi.materials.tests.test_materials import AbstractMaterialTest
 
 
-class TestLithium(TestAbstractMaterial, unittest.TestCase):
+class TestLithium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = Lithium
 
     def setUp(self):
-        TestAbstractMaterial.setUp(self)
+        AbstractMaterialTest.setUp(self)
         self.mat = Lithium()
 
     def test_liAbundance(self):

--- a/armi/materials/tests/test_lithium.py
+++ b/armi/materials/tests/test_lithium.py
@@ -16,14 +16,14 @@
 import unittest
 
 from armi.materials import Lithium
-from armi.materials.tests.test_materials import AbstractMaterialTest
+from armi.materials.tests.test_materials import TestAbstractMaterial
 
 
-class TestLithium(AbstractMaterialTest, unittest.TestCase):
+class TestLithium(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = Lithium
 
     def setUp(self):
-        AbstractMaterialTest.setUp(self)
+        TestAbstractMaterial.setUp(self)
         self.mat = Lithium()
 
     def test_liAbundance(self):

--- a/armi/materials/tests/test_lithium.py
+++ b/armi/materials/tests/test_lithium.py
@@ -19,7 +19,7 @@ from armi.materials import Lithium
 from armi.materials.tests.test_materials import AbstractMaterialTest
 
 
-class LithiumTests(AbstractMaterialTest, unittest.TestCase):
+class TestLithium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = Lithium
 
     def setUp(self):

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -33,7 +33,7 @@ from armi.utils import units
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
-class TestAbstractMaterial:
+class AbstractMaterialTest:
     """Base for material tests."""
 
     MAT_CLASS = None
@@ -185,7 +185,7 @@ class TestMaterialFinding(unittest.TestCase):
             self.assertGreater(mat.rho(T=400), 500)
 
 
-class TestCalifornium(TestAbstractMaterial, unittest.TestCase):
+class TestCalifornium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Californium
 
     def test_pseudoDensity(self):
@@ -203,7 +203,7 @@ class TestCalifornium(TestAbstractMaterial, unittest.TestCase):
         self.assertEqual(self.mat.gasPorosity, 0.0)
 
 
-class TestCesium(TestAbstractMaterial, unittest.TestCase):
+class TestCesium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Cs
 
     def test_pseudoDensity(self):
@@ -216,7 +216,7 @@ class TestCesium(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=ref * 0.05)
 
 
-class TestMagnesium(TestAbstractMaterial, unittest.TestCase):
+class TestMagnesium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Magnesium
     VALID_TEMP_K = 1000
 
@@ -232,7 +232,7 @@ class TestMagnesium(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
 
-class TestMagnesiumOxide(TestAbstractMaterial, unittest.TestCase):
+class TestMagnesiumOxide(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.MgO
 
     def test_pseudoDensity(self):
@@ -256,7 +256,7 @@ class TestMagnesiumOxide(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class TestMOX(TestAbstractMaterial, unittest.TestCase):
+class TestMOX(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.MOX
 
     def test_density(self):
@@ -300,7 +300,7 @@ class TestMOX(TestAbstractMaterial, unittest.TestCase):
         self.assertEqual(len(self.mat.massFrac), 0)
 
 
-class TestNaCl(TestAbstractMaterial, unittest.TestCase):
+class TestNaCl(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.NaCl
 
     def test_density(self):
@@ -313,7 +313,7 @@ class TestNaCl(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class TestPotassium(TestAbstractMaterial, unittest.TestCase):
+class TestPotassium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Potassium
 
     def test_pseudoDensity(self):
@@ -343,7 +343,7 @@ class TestPotassium(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
 
-class TestScandiumOxide(TestAbstractMaterial, unittest.TestCase):
+class TestScandiumOxide(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Sc2O3
 
     def test_pseudoDensity(self):
@@ -361,7 +361,7 @@ class TestScandiumOxide(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class TestSodium(TestAbstractMaterial, unittest.TestCase):
+class TestSodium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Sodium
 
     def test_pseudoDensity(self):
@@ -398,7 +398,7 @@ class TestSodium(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
 
-class TestThoriumUraniumMetal(TestAbstractMaterial, unittest.TestCase):
+class TestThoriumUraniumMetal(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.ThU
 
     def test_pseudoDensity(self):
@@ -429,7 +429,7 @@ class TestThoriumUraniumMetal(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class TestUranium(TestAbstractMaterial, unittest.TestCase):
+class TestUranium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Uranium
 
     def test_applyInputParams(self):
@@ -478,7 +478,7 @@ class TestUranium(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class TestUraniumOxide(TestAbstractMaterial, unittest.TestCase):
+class TestUraniumOxide(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.UraniumOxide
 
     def test_adjustMassEnrichment(self):
@@ -603,7 +603,7 @@ class TestUraniumOxide(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(ratio, 0.1)
 
 
-class TestThorium(TestAbstractMaterial, unittest.TestCase):
+class TestThorium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Thorium
 
     def test_setDefaultMassFracs(self):
@@ -638,7 +638,7 @@ class TestThorium(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, accuracy)
 
 
-class TestThoriumOxide(TestAbstractMaterial, unittest.TestCase):
+class TestThoriumOxide(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.ThoriumOxide
 
     def test_density(self):
@@ -662,7 +662,7 @@ class TestThoriumOxide(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, 4)
 
 
-class TestVoid(TestAbstractMaterial, unittest.TestCase):
+class TestVoid(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Void
 
     def test_pseudoDensity(self):
@@ -688,7 +688,7 @@ class TestVoid(TestAbstractMaterial, unittest.TestCase):
         self.assertEqual(cur, ref)
 
 
-class TestLead(TestAbstractMaterial, unittest.TestCase):
+class TestLead(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Lead
     VALID_TEMP_K = 600
 
@@ -734,7 +734,7 @@ class TestLead(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
 
-class TestLeadBismuth(TestAbstractMaterial, unittest.TestCase):
+class TestLeadBismuth(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.LeadBismuth
 
     def test_setDefaultMassFracs(self):
@@ -783,7 +783,7 @@ class TestLeadBismuth(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=ref * 0.001)
 
 
-class TestCopper(TestAbstractMaterial, unittest.TestCase):
+class TestCopper(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Cu
 
     def test_setDefaultMassFracs(self):
@@ -810,7 +810,7 @@ class TestCopper(TestAbstractMaterial, unittest.TestCase):
         self.assertEqual(len(self.mat.getChildrenWithFlags("anything")), 0)
 
 
-class TestZr(TestAbstractMaterial, unittest.TestCase):
+class TestZr(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Zr
 
     def test_thermalConductivity(self):
@@ -908,7 +908,7 @@ class TestZr(TestAbstractMaterial, unittest.TestCase):
             self.assertAlmostEqual(self.mat.pseudoDensity(Tk=Tk), expectedValues[i], msg=str(Tk))
 
 
-class TestInconel(TestAbstractMaterial, unittest.TestCase):
+class TestInconel(AbstractMaterialTest, unittest.TestCase):
     def setUp(self):
         self.Inconel = materials.Inconel()
         self.Inconel800 = materials.Inconel800()
@@ -952,7 +952,7 @@ class TestInconel(TestAbstractMaterial, unittest.TestCase):
             self.assertAlmostEqual(cur, ref, delta=10e-7, msg=str(Tc))
 
 
-class TestInconel600(TestAbstractMaterial, unittest.TestCase):
+class TestInconel600(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Inconel600
 
     def test_setDefaultMassFracs(self):
@@ -1024,7 +1024,7 @@ class TestInconel600(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=cur * 0.001)
 
 
-class TestInconel625(TestAbstractMaterial, unittest.TestCase):
+class TestInconel625(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Inconel625
 
     def test_setDefaultMassFracs(self):
@@ -1115,7 +1115,7 @@ class TestInconel625(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=cur * 0.001)
 
 
-class TestInconelX750(TestAbstractMaterial, unittest.TestCase):
+class TestInconelX750(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.InconelX750
 
     def test_setDefaultMassFracs(self):
@@ -1200,7 +1200,7 @@ class TestInconelX750(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=cur * 0.001)
 
 
-class TestAlloy200(TestAbstractMaterial, unittest.TestCase):
+class TestAlloy200(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Alloy200
 
     def test_nickleContent(self):
@@ -1218,7 +1218,7 @@ class TestAlloy200(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
 
-class TestCaH2(TestAbstractMaterial, unittest.TestCase):
+class TestCaH2(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.CaH2
 
     def test_pseudoDensity(self):
@@ -1230,7 +1230,7 @@ class TestCaH2(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, ref * 0.01)
 
 
-class TestHafnium(TestAbstractMaterial, unittest.TestCase):
+class TestHafnium(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Hafnium
 
     def test_pseudoDensity(self):
@@ -1242,7 +1242,7 @@ class TestHafnium(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, ref * 0.01)
 
 
-class TestHT9(TestAbstractMaterial, unittest.TestCase):
+class TestHT9(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.HT9
 
     def test_feContent(self):
@@ -1259,7 +1259,7 @@ class TestHT9(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
 
-class TestHastelloyN(TestAbstractMaterial, unittest.TestCase):
+class TestHastelloyN(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.HastelloyN
 
     def test_thermalConductivity(self):
@@ -1313,7 +1313,7 @@ class TestHastelloyN(TestAbstractMaterial, unittest.TestCase):
             self.assertAlmostEqual(cur, ref, delta=10e-7, msg=str(Tc))
 
 
-class TestTZM(TestAbstractMaterial, unittest.TestCase):
+class TestTZM(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.TZM
 
     def test_applyInputParams(self):
@@ -1340,7 +1340,7 @@ class TestTZM(TestAbstractMaterial, unittest.TestCase):
             self.assertAlmostEqual(cur, ref, delta=10e-3, msg=str(Tc))
 
 
-class TestYttriumOxide(TestAbstractMaterial, unittest.TestCase):
+class TestYttriumOxide(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.Y2O3
 
     def test_pseudoDensity(self):
@@ -1358,7 +1358,7 @@ class TestYttriumOxide(TestAbstractMaterial, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
 
-class TestZincOxide(TestAbstractMaterial, unittest.TestCase):
+class TestZincOxide(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = materials.ZnO
 
     def test_density(self):
@@ -1418,7 +1418,7 @@ assemblies:
 """
 
     def loadAssembly(self, materialModifications):
-        # Prevent circular import. Not all uses of TestAbstractMaterial will have a configured app.
+        # Prevent circular import. Not all uses of AbstractMaterialTest will have a configured app.
         from armi.reactor import blueprints
 
         yamlString = self.baseInput + "\n" + materialModifications

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -33,7 +33,7 @@ from armi.utils import units
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
-class AbstractMaterialTest:
+class TestAbstractMaterial:
     """Base for material tests."""
 
     MAT_CLASS = None
@@ -89,7 +89,7 @@ class AbstractMaterialTest:
         self.assertEqual(val, "Noether")
 
 
-class MaterialConstructionTests(unittest.TestCase):
+class TestMaterialConstruction(unittest.TestCase):
     def test_matInit(self):
         """Make sure all materials can be instantiated without error."""
         for matClass in materials.iterAllMaterialClassesInNamespace(materials):
@@ -97,7 +97,7 @@ class MaterialConstructionTests(unittest.TestCase):
             self.assertIsInstance(m, materials.Material)
 
 
-class MaterialFindingTests(unittest.TestCase):
+class TestMaterialFinding(unittest.TestCase):
     """Make sure materials are discoverable as designed."""
 
     def test_findMaterial(self):
@@ -185,7 +185,7 @@ class MaterialFindingTests(unittest.TestCase):
             self.assertGreater(mat.rho(T=400), 500)
 
 
-class CaliforniumTests(AbstractMaterialTest, unittest.TestCase):
+class TestCalifornium(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Californium
 
     def test_pseudoDensity(self):
@@ -203,7 +203,7 @@ class CaliforniumTests(AbstractMaterialTest, unittest.TestCase):
         self.assertEqual(self.mat.gasPorosity, 0.0)
 
 
-class CesiumTests(AbstractMaterialTest, unittest.TestCase):
+class TestCesium(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Cs
 
     def test_pseudoDensity(self):
@@ -216,7 +216,7 @@ class CesiumTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=ref * 0.05)
 
 
-class MagnesiumTests(AbstractMaterialTest, unittest.TestCase):
+class TestMagnesium(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Magnesium
     VALID_TEMP_K = 1000
 
@@ -232,7 +232,7 @@ class MagnesiumTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
 
-class MagnesiumOxideTests(AbstractMaterialTest, unittest.TestCase):
+class TestMagnesiumOxide(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.MgO
 
     def test_pseudoDensity(self):
@@ -256,7 +256,7 @@ class MagnesiumOxideTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class MOXTests(AbstractMaterialTest, unittest.TestCase):
+class TestMOX(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.MOX
 
     def test_density(self):
@@ -300,7 +300,7 @@ class MOXTests(AbstractMaterialTest, unittest.TestCase):
         self.assertEqual(len(self.mat.massFrac), 0)
 
 
-class NaClTests(AbstractMaterialTest, unittest.TestCase):
+class TestNaCl(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.NaCl
 
     def test_density(self):
@@ -313,7 +313,7 @@ class NaClTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class PotassiumTests(AbstractMaterialTest, unittest.TestCase):
+class TestPotassium(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Potassium
 
     def test_pseudoDensity(self):
@@ -343,7 +343,7 @@ class PotassiumTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
 
-class ScandiumOxideTests(AbstractMaterialTest, unittest.TestCase):
+class TestScandiumOxide(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Sc2O3
 
     def test_pseudoDensity(self):
@@ -361,7 +361,7 @@ class ScandiumOxideTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class SodiumTests(AbstractMaterialTest, unittest.TestCase):
+class TestSodium(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Sodium
 
     def test_pseudoDensity(self):
@@ -398,7 +398,7 @@ class SodiumTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
 
-class ThoriumUraniumMetalTests(AbstractMaterialTest, unittest.TestCase):
+class TestThoriumUraniumMetal(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.ThU
 
     def test_pseudoDensity(self):
@@ -429,7 +429,7 @@ class ThoriumUraniumMetalTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class UraniumTests(AbstractMaterialTest, unittest.TestCase):
+class TestUranium(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Uranium
 
     def test_applyInputParams(self):
@@ -478,7 +478,7 @@ class UraniumTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=abs(ref * 0.001))
 
 
-class UraniumOxideTests(AbstractMaterialTest, unittest.TestCase):
+class TestUraniumOxide(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.UraniumOxide
 
     def test_adjustMassEnrichment(self):
@@ -603,7 +603,7 @@ class UraniumOxideTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(ratio, 0.1)
 
 
-class ThoriumTests(AbstractMaterialTest, unittest.TestCase):
+class TestThorium(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Thorium
 
     def test_setDefaultMassFracs(self):
@@ -638,7 +638,7 @@ class ThoriumTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, accuracy)
 
 
-class ThoriumOxideTests(AbstractMaterialTest, unittest.TestCase):
+class TestThoriumOxide(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.ThoriumOxide
 
     def test_density(self):
@@ -662,7 +662,7 @@ class ThoriumOxideTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, 4)
 
 
-class VoidTests(AbstractMaterialTest, unittest.TestCase):
+class TestVoid(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Void
 
     def test_pseudoDensity(self):
@@ -688,7 +688,7 @@ class VoidTests(AbstractMaterialTest, unittest.TestCase):
         self.assertEqual(cur, ref)
 
 
-class LeadTests(AbstractMaterialTest, unittest.TestCase):
+class TestLead(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Lead
     VALID_TEMP_K = 600
 
@@ -734,7 +734,7 @@ class LeadTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, delta=delta)
 
 
-class LeadBismuthTests(AbstractMaterialTest, unittest.TestCase):
+class TestLeadBismuth(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.LeadBismuth
 
     def test_setDefaultMassFracs(self):
@@ -783,7 +783,7 @@ class LeadBismuthTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=ref * 0.001)
 
 
-class CopperTests(AbstractMaterialTest, unittest.TestCase):
+class TestCopper(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Cu
 
     def test_setDefaultMassFracs(self):
@@ -810,7 +810,7 @@ class CopperTests(AbstractMaterialTest, unittest.TestCase):
         self.assertEqual(len(self.mat.getChildrenWithFlags("anything")), 0)
 
 
-class ZrTests(AbstractMaterialTest, unittest.TestCase):
+class TestZr(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Zr
 
     def test_thermalConductivity(self):
@@ -908,7 +908,7 @@ class ZrTests(AbstractMaterialTest, unittest.TestCase):
             self.assertAlmostEqual(self.mat.pseudoDensity(Tk=Tk), expectedValues[i], msg=str(Tk))
 
 
-class InconelTests(AbstractMaterialTest, unittest.TestCase):
+class TestInconel(TestAbstractMaterial, unittest.TestCase):
     def setUp(self):
         self.Inconel = materials.Inconel()
         self.Inconel800 = materials.Inconel800()
@@ -952,7 +952,7 @@ class InconelTests(AbstractMaterialTest, unittest.TestCase):
             self.assertAlmostEqual(cur, ref, delta=10e-7, msg=str(Tc))
 
 
-class Inconel600Tests(AbstractMaterialTest, unittest.TestCase):
+class TestInconel600(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Inconel600
 
     def test_setDefaultMassFracs(self):
@@ -1024,7 +1024,7 @@ class Inconel600Tests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=cur * 0.001)
 
 
-class Inconel625Tests(AbstractMaterialTest, unittest.TestCase):
+class TestInconel625(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Inconel625
 
     def test_setDefaultMassFracs(self):
@@ -1115,7 +1115,7 @@ class Inconel625Tests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=cur * 0.001)
 
 
-class InconelX750Tests(AbstractMaterialTest, unittest.TestCase):
+class TestInconelX750(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.InconelX750
 
     def test_setDefaultMassFracs(self):
@@ -1200,7 +1200,7 @@ class InconelX750Tests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=cur * 0.001)
 
 
-class Alloy200Tests(AbstractMaterialTest, unittest.TestCase):
+class TestAlloy200(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Alloy200
 
     def test_nickleContent(self):
@@ -1218,7 +1218,7 @@ class Alloy200Tests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
 
-class CaH2Tests(AbstractMaterialTest, unittest.TestCase):
+class TestCaH2(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.CaH2
 
     def test_pseudoDensity(self):
@@ -1230,7 +1230,7 @@ class CaH2Tests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, ref * 0.01)
 
 
-class HafniumTests(AbstractMaterialTest, unittest.TestCase):
+class TestHafnium(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Hafnium
 
     def test_pseudoDensity(self):
@@ -1242,7 +1242,7 @@ class HafniumTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(cur, ref, ref * 0.01)
 
 
-class HT9Tests(AbstractMaterialTest, unittest.TestCase):
+class TestHT9(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.HT9
 
     def test_feContent(self):
@@ -1259,7 +1259,7 @@ class HT9Tests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
 
-class HastelloyNTests(AbstractMaterialTest, unittest.TestCase):
+class TestHastelloyN(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.HastelloyN
 
     def test_thermalConductivity(self):
@@ -1313,7 +1313,7 @@ class HastelloyNTests(AbstractMaterialTest, unittest.TestCase):
             self.assertAlmostEqual(cur, ref, delta=10e-7, msg=str(Tc))
 
 
-class TZMTests(AbstractMaterialTest, unittest.TestCase):
+class TestTZM(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.TZM
 
     def test_applyInputParams(self):
@@ -1340,7 +1340,7 @@ class TZMTests(AbstractMaterialTest, unittest.TestCase):
             self.assertAlmostEqual(cur, ref, delta=10e-3, msg=str(Tc))
 
 
-class YttriumOxideTests(AbstractMaterialTest, unittest.TestCase):
+class TestYttriumOxide(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.Y2O3
 
     def test_pseudoDensity(self):
@@ -1358,7 +1358,7 @@ class YttriumOxideTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
 
-class ZincOxideTests(AbstractMaterialTest, unittest.TestCase):
+class TestZincOxide(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = materials.ZnO
 
     def test_density(self):
@@ -1376,7 +1376,7 @@ class ZincOxideTests(AbstractMaterialTest, unittest.TestCase):
         self.assertAlmostEqual(ref, cur, delta=abs(ref * 0.001))
 
 
-class FuelMaterialTests(unittest.TestCase):
+class TestFuelMaterial(unittest.TestCase):
     baseInput = r"""
 nuclide flags:
     U: {burn: false, xs: true}
@@ -1418,7 +1418,7 @@ assemblies:
 """
 
     def loadAssembly(self, materialModifications):
-        # Prevent circular import. Not all uses of AbstractMaterialTest will have a configured app.
+        # Prevent circular import. Not all uses of TestAbstractMaterial will have a configured app.
         from armi.reactor import blueprints
 
         yamlString = self.baseInput + "\n" + materialModifications
@@ -1427,7 +1427,7 @@ assemblies:
         return design.assemblies["fuel a"]
 
 
-class PickledMaterialsTests(unittest.TestCase):
+class TestPickledMaterials(unittest.TestCase):
     def test_simpleReload(self):
         """Prove that the material pickling works, creating reasonable copies of the matProps material."""
         refDens = 7.709686132722035

--- a/armi/materials/tests/test_thoriumOxide.py
+++ b/armi/materials/tests/test_thoriumOxide.py
@@ -16,14 +16,14 @@
 import unittest
 
 from armi.materials import ThoriumOxide
-from armi.materials.tests.test_materials import AbstractMaterialTest
+from armi.materials.tests.test_materials import TestAbstractMaterial
 
 
-class TestThoriumOxide(AbstractMaterialTest, unittest.TestCase):
+class TestThoriumOxide(TestAbstractMaterial, unittest.TestCase):
     MAT_CLASS = ThoriumOxide
 
     def setUp(self):
-        AbstractMaterialTest.setUp(self)
+        TestAbstractMaterial.setUp(self)
         self.mat = ThoriumOxide()
 
         self.ThoriumOxide_TD_frac = ThoriumOxide()

--- a/armi/materials/tests/test_thoriumOxide.py
+++ b/armi/materials/tests/test_thoriumOxide.py
@@ -19,7 +19,7 @@ from armi.materials import ThoriumOxide
 from armi.materials.tests.test_materials import AbstractMaterialTest
 
 
-class ThoriumOxideTests(AbstractMaterialTest, unittest.TestCase):
+class TestThoriumOxide(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = ThoriumOxide
 
     def setUp(self):

--- a/armi/materials/tests/test_thoriumOxide.py
+++ b/armi/materials/tests/test_thoriumOxide.py
@@ -16,14 +16,14 @@
 import unittest
 
 from armi.materials import ThoriumOxide
-from armi.materials.tests.test_materials import TestAbstractMaterial
+from armi.materials.tests.test_materials import AbstractMaterialTest
 
 
-class TestThoriumOxide(TestAbstractMaterial, unittest.TestCase):
+class TestThoriumOxide(AbstractMaterialTest, unittest.TestCase):
     MAT_CLASS = ThoriumOxide
 
     def setUp(self):
-        TestAbstractMaterial.setUp(self)
+        AbstractMaterialTest.setUp(self)
         self.mat = ThoriumOxide()
 
         self.ThoriumOxide_TD_frac = ThoriumOxide()

--- a/armi/materials/tests/test_uZr.py
+++ b/armi/materials/tests/test_uZr.py
@@ -20,7 +20,7 @@ from unittest import TestCase
 from armi.materials.uZr import UZr
 
 
-class UZR_TestCase(TestCase):
+class TestUZR(TestCase):
     MAT_CLASS = UZr
 
     def setUp(self):

--- a/armi/nucDirectory/tests/test_transmutations.py
+++ b/armi/nucDirectory/tests/test_transmutations.py
@@ -26,7 +26,7 @@ def randomString(length):
     return "".join(random.choice(string.ascii_lowercase) for _ in range(length))
 
 
-class TransmutationTests(unittest.TestCase):
+class TestTransmutation(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.nuclideBases = NuclideBases()
@@ -58,7 +58,7 @@ class TransmutationTests(unittest.TestCase):
         self.assertGreater(errorCount, 2)
 
 
-class DecayModeTests(unittest.TestCase):
+class TestDecayMode(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.nuclideBases = NuclideBases()

--- a/armi/nuclearDataIO/cccc/tests/test_cccc.py
+++ b/armi/nuclearDataIO/cccc/tests/test_cccc.py
@@ -19,7 +19,7 @@ import unittest
 from armi.nuclearDataIO import cccc
 
 
-class CcccIOStreamTests(unittest.TestCase):
+class TestCcccIOStream(unittest.TestCase):
     def test_initWithFileMode(self):
         self.assertIsInstance(cccc.Stream("some-file", "rb"), cccc.Stream)
         self.assertIsInstance(cccc.Stream("some-file", "wb"), cccc.Stream)
@@ -29,7 +29,7 @@ class CcccIOStreamTests(unittest.TestCase):
             cccc.Stream("some-file", "bacon")
 
 
-class CcccBinaryRecordTests(unittest.TestCase):
+class TestCcccBinaryRecord(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.writerClass = cccc.BinaryRecordWriter
@@ -97,8 +97,8 @@ class CcccBinaryRecordTests(unittest.TestCase):
                 self.assertEqual(4, reader.rwInt(None))
 
 
-class CcccAsciiRecordTests(CcccBinaryRecordTests):
-    """Runs the same tests as CcccBinaryRecordTests, but using ASCII readers and writers."""
+class TestCcccAsciiRecord(TestCcccBinaryRecord):
+    """Runs the same tests as TestCcccBinaryRecord, but using ASCII readers and writers."""
 
     @classmethod
     def setUpClass(cls):

--- a/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_dlayxs.py
@@ -26,7 +26,7 @@ from armi.testing import mockRunLogs
 from armi.utils.directoryChangers import TemporaryDirectoryChanger
 
 
-class DlayxsTests(unittest.TestCase):
+class TestDlayxs(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.dlayxs3 = dlayxs.readBinary(test_xsLibraries.DLAYXS_MCC3)

--- a/armi/nuclearDataIO/cccc/tests/test_isotxs.py
+++ b/armi/nuclearDataIO/cccc/tests/test_isotxs.py
@@ -174,7 +174,7 @@ class TestIsotxs(unittest.TestCase):
             nuclearDataIO.getExpectedGAMISOFileName(cycle=10, xsID="AA")
 
 
-class Isotxs_merge_Tests(unittest.TestCase):
+class TestIsotxsMerge(unittest.TestCase):
     def test_mergeMccV2FilesRemovesTheFileWideChi(self):
         """Test merging ISOTXS files.
 

--- a/armi/nuclearDataIO/tests/test_xsNuclides.py
+++ b/armi/nuclearDataIO/tests/test_xsNuclides.py
@@ -23,7 +23,7 @@ from armi.testing import mockRunLogs
 from armi.tests import ISOAA_PATH
 
 
-class NuclideTests(unittest.TestCase):
+class TestNuclide(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.lib = isotxs.readBinary(ISOAA_PATH)
@@ -46,7 +46,7 @@ class NuclideTests(unittest.TestCase):
         self.assertEqual("AA", nrAA.xsId)
         self.assertFalse(hasattr(nuc, "xsId"))
 
-    def test_odifyingNucAttrUpdatesIsotxs(self):
+    def test_modifyingNucAttrUpdatesIsotxs(self):
         """Modifying nuclide attribute updates the ISOTXS nuclide data."""
         lib = xsLibraries.IsotxsLibrary()
         nuc = copy(self.nuclideBases.byName["FE"])

--- a/armi/operators/tests/test_operators.py
+++ b/armi/operators/tests/test_operators.py
@@ -61,7 +61,7 @@ class InterfaceC(Interface):
     name = "Third"
 
 
-class OperatorTests(unittest.TestCase):
+class TestOperator(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(
             TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml"
@@ -414,7 +414,7 @@ class TestTightCoupling(unittest.TestCase):
         )
 
 
-class CyclesSettingsTests(unittest.TestCase):
+class TestCyclesSettings(unittest.TestCase):
     """Check that we can correctly access the various cycle settings from the operator."""
 
     detailedCyclesSettings = """
@@ -590,8 +590,8 @@ class TestInterfaceAndEventHeaders(unittest.TestCase):
         )
 
 
-class OperatorRestartTests(unittest.TestCase):
-    """Tests on the behavior of the interactAllRestart hook."""
+class TestOperatorRestart(unittest.TestCase):
+    """Test the behavior of the interactAllRestart hook."""
 
     @classmethod
     def setUpClass(cls):

--- a/armi/physics/fuelCycle/tests/test_assemblyRotationAlgorithms.py
+++ b/armi/physics/fuelCycle/tests/test_assemblyRotationAlgorithms.py
@@ -317,7 +317,7 @@ class TestFuelHandlerMgmtTools(ShuffleAndRotateTestHelper):
         third.rotate.assert_not_called()
 
 
-class SimpleRotationTests(ShuffleAndRotateTestHelper):
+class TestSimpleRotation(ShuffleAndRotateTestHelper):
     """Test the simple rotation where assemblies are rotated a fixed amount."""
 
     def test_simpleAssemblyRotation(self):

--- a/armi/physics/fuelCycle/tests/test_fuelHandlerFactory.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlerFactory.py
@@ -33,7 +33,7 @@ class _DummyOperator:
         self.cs = settings
 
 
-class FuelHandlerFactoryTests(unittest.TestCase):
+class TestFuelHandlerFactory(unittest.TestCase):
     """Exercise the custom module import logic."""
 
     def setUp(self):

--- a/armi/physics/fuelCycle/tests/test_utils.py
+++ b/armi/physics/fuelCycle/tests/test_utils.py
@@ -24,7 +24,7 @@ from armi.reactor.flags import Flags
 from armi.reactor.grids import IndexLocation, MultiIndexLocation
 
 
-class FuelCycleUtilsTests(TestCase):
+class TestFuelCycleUtils(TestCase):
     """Tests for geometry indifferent fuel cycle routines."""
 
     N_PINS = 169

--- a/armi/physics/neutronics/tests/test_neutronicsPlugin.py
+++ b/armi/physics/neutronics/tests/test_neutronicsPlugin.py
@@ -94,7 +94,7 @@ class TestNeutronicsPlugin(TestPlugin):
         self.assertIn(CONF_NEUTRONICS_KERNEL, cs)
 
 
-class NeutronicsReactorTests(unittest.TestCase):
+class TestNeutronicsReactor(unittest.TestCase):
     @staticmethod
     def __getModifiedSettings(customSettings):
         cs = settings.Settings()

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -853,14 +853,14 @@ class ArmiObject(metaclass=CompositeModelType):
 
         See Also
         --------
-        test_block.Block_TestCase.test_consistentAreaWithOverlappingComponents
+        test_block.TestBlock.test_consistentAreaWithOverlappingComponents
 
         Notes
         -----
         void areas can be negative in gaps between fuel/clad/liner(s), but these
         negative areas are intended to account for overlapping positive areas to insure
         the total area of components inside the clad is accurate. See
-        test_block.Block_TestCase.test_consistentAreaWithOverlappingComponents
+        test_block.TestBlock.test_consistentAreaWithOverlappingComponents
         """
         children = self.getChildren()
         numerator = [c.getVolume() for c in children]

--- a/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
+++ b/armi/reactor/converters/tests/test_pinTypeBlockConverters.py
@@ -50,7 +50,7 @@ class TestPinTypeConverters(unittest.TestCase):
         self.assertAlmostEqual(curThickness, thickness)
 
 
-class MassConservationTests(unittest.TestCase):
+class TestMassConservation(unittest.TestCase):
     r"""Tests designed to verify mass conservation during thermal expansion."""
 
     def setUp(self):

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -35,7 +35,7 @@ from armi.utils import directoryChangers, textProcessors
 NUM_BLOCKS = 3
 
 
-class MaterialInAssembly_TestCase(unittest.TestCase):
+class TestMaterialInAssembly(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.assembly = testing.buildHexAssemblySingleUZrUTh()
@@ -1026,7 +1026,7 @@ class TestAssembly(unittest.TestCase):
             self.assertEqual(bIndex, math.ceil(zIndex / 2) if zIndex < 5 else -1)
 
 
-class AssemblyInReactor_TestCase(unittest.TestCase):
+class TestAssemblyInReactor(unittest.TestCase):
     def setUp(self):
         root = os.path.join(TESTING_ROOT, "reactors", "sodiumHexReactor")
         self.o, self.r = loadTestReactor(root)
@@ -1244,7 +1244,7 @@ class AssemblyInReactor_TestCase(unittest.TestCase):
         self.assertAlmostEqual(shieldPlenumMass, shieldPlenumMassAfterShrink, 7)
 
 
-class AnnularFuelTestCase(unittest.TestCase):
+class TestAnnularFuel(unittest.TestCase):
     """Test fuel with a whole in the center."""
 
     def setUp(self):

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -63,7 +63,7 @@ class MaterialInAssembly_TestCase(unittest.TestCase):
         self.assertAlmostEqual(uZrFuel.getMass("U235") / (uZrFuel.getMass("U238") + uZrFuel.getMass("U235")), 0.1)
 
 
-class AssemblyReadOnlyTests(unittest.TestCase):
+class TestAssemblyReadOnly(unittest.TestCase):
     """These tests of Assemblies do not modify the test assembly, which can be created in a setUpClass method."""
 
     @classmethod
@@ -363,7 +363,7 @@ class AssemblyReadOnlyTests(unittest.TestCase):
         self.assertEqual(elevations, [0.0, 10.0, 10.0, 20.0, 20.0, 30.0])
 
 
-class AssemblyTests(unittest.TestCase):
+class TestAssembly(unittest.TestCase):
     """These tests of Assemblies modify the test assembly, so each unit tests needs a fresh test assembly."""
 
     def setUp(self):

--- a/armi/reactor/tests/test_blocks.py
+++ b/armi/reactor/tests/test_blocks.py
@@ -3074,7 +3074,7 @@ class TestCartesianBlock(unittest.TestCase):
         # block/assembly. The inner dimensions is defined by whatever thickness is necessary to have the desired area
         # fraction. The second way is to define all physical material components as unshaped, and add an additional
         # infinitely thin Void component (no area) that defines pitch. See second part of
-        # HexBlock_TestCase.test_getPitchHomogeneousBlock for demonstration.
+        # TestHexBlock.test_getPitchHomogeneousBlock for demonstration.
         cartBlock = blocks.CartesianBlock("TestCartBlock")
 
         hexComponentArea = areaFractions[0] * rectTotalArea

--- a/armi/reactor/tests/test_cores.py
+++ b/armi/reactor/tests/test_cores.py
@@ -26,7 +26,7 @@ from armi.testing import TESTING_ROOT, loadTestReactor
 from armi.tests import ISOAA_PATH
 
 
-class HexCoreTests(unittest.TestCase):
+class TestHexCore(unittest.TestCase):
     """Tests on a hex reactor core."""
 
     @classmethod

--- a/armi/reactor/tests/test_hexBlockRotate.py
+++ b/armi/reactor/tests/test_hexBlockRotate.py
@@ -26,7 +26,7 @@ from armi.testing import NUM_PINS_IN_COMPLEX_HEX_BLOCK, buildComplexHexBlock
 from armi.utils import iterables
 
 
-class HexBlockRotateTests(unittest.TestCase):
+class TestHexBlockRotate(unittest.TestCase):
     """Tests for various rotation aspects of a hex block."""
 
     BOUNDARY_PARAMS = [

--- a/armi/reactor/tests/test_parameters.py
+++ b/armi/reactor/tests/test_parameters.py
@@ -43,7 +43,7 @@ class MockCompositeChild(MockCompositeParent):
     pass
 
 
-class ParameterTests(unittest.TestCase):
+class TestParameter(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.defs = parameters.ALL_DEFINITIONS._paramDefs

--- a/armi/reactor/tests/test_reactors.py
+++ b/armi/reactor/tests/test_reactors.py
@@ -48,7 +48,7 @@ from armi.utils import directoryChangers
 _THIS_DIR = os.path.dirname(__file__)
 
 
-class ReactorTests(unittest.TestCase):
+class TestReactor(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Prepare the input files. This is important so the unit tests run from wherever they need to run from.
@@ -60,9 +60,9 @@ class ReactorTests(unittest.TestCase):
         cls.td.__exit__(None, None, None)
 
 
-class HexReactorTests(ReactorTests):
+class TestHexReactor(TestReactor):
     """
-    Base class meant to pair with the ``HexReactorReadOnlyTests`` unit test class.
+    Base class meant to pair with the ``TestHexReactorReadOnly`` unit test class.
 
     The tests in this class all modify the Reactor object, so we need to create a new test reactor for each test.
     """
@@ -706,9 +706,9 @@ class HexReactorTests(ReactorTests):
         self.assertEqual(self.r.core.getNumRings(), 3)
 
 
-class HexReactorReadOnlyTests(unittest.TestCase):
+class TestHexReactorReadOnly(unittest.TestCase):
     """
-    Testing base class meant to pair with the ``HexReactorTests`` unit test class.
+    Testing base class meant to pair with the ``TestHexReactor`` unit test class.
 
     The tests in this class only READ, and not WRITE to the Reactor object, so we only have to create one test reactor.
     """
@@ -1073,9 +1073,9 @@ class HexReactorReadOnlyTests(unittest.TestCase):
                     self.assertAlmostEqual(p, coldHeightP)
 
 
-class HexReactorSoloTests(ReactorTests):
+class TestHexReactorSolo(TestReactor):
     """
-    Testing base class meant to pair with the ``HexReactorTests`` unit test class.
+    Testing base class meant to pair with the ``TestHexReactor`` unit test class.
 
     Each test here creates its own, slightly unique, test reactor.
     """
@@ -1094,9 +1094,9 @@ class HexReactorSoloTests(ReactorTests):
         self.assertEqual(originalHeights, heights)
 
 
-class BigHexReactorTests(ReactorTests):
+class TestBigHexReactor(TestReactor):
     """
-    Testing base class meant to pair with the ``HexReactorTests`` unit test class.
+    Testing base class meant to pair with the ``TestHexReactor`` unit test class.
 
     These tests all need a larger test reactor. Ideally, we will migrate these to smaller test reactors one day.
     """
@@ -1210,7 +1210,7 @@ class BigHexReactorTests(ReactorTests):
         self.assertEqual(locs, [(3, 2), (3, 3), (3, 4), (2, 3), (1, 1), (2, 1)])
 
 
-class CartesianReactorTests(ReactorTests):
+class TestCartesianReactor(TestReactor):
     def setUp(self):
         self.o = buildOperatorOfEmptyCartesianBlocks()
         self.r = self.o.r
@@ -1253,7 +1253,7 @@ class CartesianReactorTests(ReactorTests):
         self.assertIn("Structure", messages)
 
 
-class CartesianReactorNeighborTests(ReactorTests):
+class TestCartesianReactorNeighbor(TestReactor):
     def setUp(self):
         self.r = loadTestReactor(os.path.join(TESTING_ROOT, "reactors", "zppr"), inputFileName="zpprTest.yaml")[1]
 

--- a/armi/settings/tests/test_settingsIO.py
+++ b/armi/settings/tests/test_settingsIO.py
@@ -30,7 +30,7 @@ from armi.utils.customExceptions import (
 )
 
 
-class SettingsFailureTests(unittest.TestCase):
+class TestSettingsFailure(unittest.TestCase):
     def test_settingsObjSetting(self):
         sets = settings.Settings()
         with self.assertRaises(NonexistentSetting):
@@ -50,7 +50,7 @@ class SettingsFailureTests(unittest.TestCase):
             reader.readFromStream(io.StringIO("useless:\n    should_fail"))
 
 
-class SettingsReaderTests(unittest.TestCase):
+class TestSettingsReader(unittest.TestCase):
     def setUp(self):
         self.cs = settings.caseSettings.Settings()
 
@@ -84,7 +84,7 @@ class SettingsReaderTests(unittest.TestCase):
                 settings.caseSettings.Settings(outPath)
 
 
-class SettingsRenameTests(unittest.TestCase):
+class TestSettingsRename(unittest.TestCase):
     testSettings = [
         setting.Setting(
             "testSetting1",
@@ -136,7 +136,7 @@ class SettingsRenameTests(unittest.TestCase):
             _ = settingsIO.SettingRenamer(settings)
 
 
-class SettingsWriterTests(unittest.TestCase):
+class TestSettingsWriter(unittest.TestCase):
     def setUp(self):
         self.td = directoryChangers.TemporaryDirectoryChanger()
         self.td.__enter__()
@@ -195,7 +195,7 @@ class MockEntryPoint(entryPoint.EntryPoint):
     name = "dummy"
 
 
-class SettingArgsTests(unittest.TestCase):
+class TestSettingArgs(unittest.TestCase):
     def setUp(self):
         self.cs = None
 

--- a/armi/tests/test_cartesian.py
+++ b/armi/tests/test_cartesian.py
@@ -23,7 +23,7 @@ from armi.testing import loadTestReactor
 from armi.tests import TESTING_ROOT
 
 
-class CartesianReactorTests(unittest.TestCase):
+class TestCartesianReactor(unittest.TestCase):
     def setUp(self):
         self.o, self.r = loadTestReactor(
             os.path.join(TESTING_ROOT, "reactors", "smallCartesian"),

--- a/armi/tests/test_lwrInputs.py
+++ b/armi/tests/test_lwrInputs.py
@@ -25,7 +25,7 @@ from armi.utils import directoryChangers
 TEST_INPUT_TITLE = "c5g7-settings.yaml"
 
 
-class C5G7ReactorTests(unittest.TestCase):
+class TestC5G7Reactor(unittest.TestCase):
     def setUp(self):
         self.td = directoryChangers.TemporaryDirectoryChanger()
         self.td.__enter__()

--- a/armi/tests/test_mpiActions.py
+++ b/armi/tests/test_mpiActions.py
@@ -70,7 +70,7 @@ class MockMpiAction(MpiAction):
 
 
 @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")
-class MpiIterTests(unittest.TestCase):
+class TestMpiIter(unittest.TestCase):
     def setUp(self):
         """Save MPI size on entry."""
         self._mpiSize = context.MPI_SIZE
@@ -243,7 +243,7 @@ class MpiIterTests(unittest.TestCase):
         self.assertEqual(7, MockMpiAction.invokeAsMaster(1, 2, 3))
 
 
-class QueueActionsTests(unittest.TestCase):
+class TestQueueActions(unittest.TestCase):
     def test_disableForExclusiveTasks(self):
         num = 5
         actionsThisRound = [MpiAction() for _ in range(num - 1)]

--- a/armi/tests/test_mpiFeatures.py
+++ b/armi/tests/test_mpiFeatures.py
@@ -95,7 +95,7 @@ class MockInterface(Interface):
         pass
 
 
-class MpiOperatorTests(unittest.TestCase):
+class TestMpiOperator(unittest.TestCase):
     """Testing the MPI parallelization operator."""
 
     def setUp(self):
@@ -196,7 +196,7 @@ class BcastAction2(mpiActions.MpiAction):
             return []
 
 
-class MpiDistributeStateTests(unittest.TestCase):
+class TestMpiDistributeState(unittest.TestCase):
     def setUp(self):
         self.cs = settings.Settings(fName=ARMI_RUN_PATH)
         bp = blueprints.loadFromCs(self.cs)
@@ -292,7 +292,7 @@ class MpiDistributeStateTests(unittest.TestCase):
         self.assertEqual(results1, results2)
 
 
-class MpiPathToolsTests(unittest.TestCase):
+class TestMpiPathTools(unittest.TestCase):
     @unittest.skipIf(context.MPI_SIZE <= 1 or MPI_EXE is None, "Parallel test only")
     def test_cleanPathMpi(self):
         """Simple tests of cleanPath(), in the MPI scenario."""

--- a/armi/tests/test_mpiParameters.py
+++ b/armi/tests/test_mpiParameters.py
@@ -42,7 +42,7 @@ def makeComp(name):
     return c
 
 
-class SynchronizationTests(unittest.TestCase):
+class TestSynchronization(unittest.TestCase):
     """Some tests that must be run with mpirun instead of the standard unittest system."""
 
     def setUp(self):

--- a/armi/utils/tests/test_custom_exceptions.py
+++ b/armi/utils/tests/test_custom_exceptions.py
@@ -19,7 +19,7 @@ from armi.testing import mockRunLogs
 from armi.utils.customExceptions import important, info, warn, warn_when_root
 
 
-class CustomExceptionTests(unittest.TestCase):
+class TestCustomException(unittest.TestCase):
     @info
     def exampleInfoMessage(self):
         return "output message"

--- a/armi/utils/tests/test_densityTools.py
+++ b/armi/utils/tests/test_densityTools.py
@@ -27,7 +27,7 @@ class UraniumOxide(Material):
     """A test material that needs to be stored in a different namespace.
 
     This is a duplicate (by name only) of :py:class:`armi.materials.UraniumOxide` and is used for testing in
-    :py:meth:`armi.materials.tests.test_materials.MaterialFindingTests.test_namespacing`
+    :py:meth:`armi.materials.tests.test_materials.TestMaterialFinding.test_namespacing`
     """
 
     def pseudoDensity(self, Tk=None, Tc=None):

--- a/armi/utils/tests/test_pathTools.py
+++ b/armi/utils/tests/test_pathTools.py
@@ -27,7 +27,7 @@ from armi.utils.directoryChangers import TemporaryDirectoryChanger
 THIS_DIR = os.path.dirname(__file__)
 
 
-class PathToolsTests(unittest.TestCase):
+class TestPathTools(unittest.TestCase):
     def test_copyOrWarnFile(self):
         with TemporaryDirectoryChanger():
             # Test a successful copy
@@ -98,7 +98,7 @@ class PathToolsTests(unittest.TestCase):
         self.assertFalse(pathTools.moduleAndAttributeExist(thisFile))
         self.assertFalse(pathTools.moduleAndAttributeExist(thisFile + ":doesntExist"))
         self.assertTrue(pathTools.moduleAndAttributeExist(thisFile + ":THIS_DIR"))
-        self.assertTrue(pathTools.moduleAndAttributeExist(thisFile + ":PathToolsTests"))
+        self.assertTrue(pathTools.moduleAndAttributeExist(thisFile + ":TestPathTools"))
 
     @unittest.skipUnless(context.MPI_RANK == 0, "test only on root node")
     def test_cleanPathNoMpi(self):

--- a/armi/utils/tests/test_properties.py
+++ b/armi/utils/tests/test_properties.py
@@ -29,7 +29,7 @@ class ImmutableClass:
             properties.lockImmutableProperties(self)
 
 
-class ImmutablePropertyTests(unittest.TestCase):
+class TestImmutableProperty(unittest.TestCase):
     def test_retreivingUnassignedValue(self):
         """Attempting to retreive an unassigned value should raise an error."""
         ic = ImmutableClass()

--- a/armi/utils/tests/test_textProcessors.py
+++ b/armi/utils/tests/test_textProcessors.py
@@ -102,7 +102,7 @@ class YamlIncludeTest(unittest.TestCase):
         self.assertEqual(len(includes), 2)
 
 
-class SequentialReaderTests(unittest.TestCase):
+class TestSequentialReader(unittest.TestCase):
     textStream = """This is an example test stream.
 This has multiple lines in it and below it contains a set of data that
 can be found using a regular expression pattern.

--- a/armi/utils/tests/test_utils.py
+++ b/armi/utils/tests/test_utils.py
@@ -308,7 +308,7 @@ class TestGeneralUtils(unittest.TestCase):
         self.assertIs(wrapped.__wrapped__, f)
 
 
-class CyclesSettingsTests(unittest.TestCase):
+class TestCyclesSettings(unittest.TestCase):
     """
     Check reading of the various cycle history settings for both the detailed
     and simple input options.

--- a/doc/developer/standards_and_practices.rst
+++ b/doc/developer/standards_and_practices.rst
@@ -136,6 +136,9 @@ class attribute, instance attribute and method names
     Use ``camelCase``. If the method is only intended to be used within that module, prefix it with a single
     leading underscore to indicate it is "class protected."
 
+test class and test function names
+    See :ref:`unit-tests` for test function and class naming conventions.
+
 Naming quick-reference
 ----------------------
 
@@ -208,6 +211,8 @@ Public methods should have docstrings
 Always create the `proper docstrings <https://numpydoc.readthedocs.io/en/latest/example.html>`_ for all public
 functions and public classes.
 
+.. _unit-tests:
+
 Unit tests
 ==========
 All ARMI developers are required to write unit tests.
@@ -222,6 +227,7 @@ ARMI uses the ``pytest`` library to drive tests, therefore tests need to be runn
 * All unit tests should be placed into a separate module from production code that is prefixed with ``test_``.
 * All unit tests should be written in object-oriented fashion, inheriting from ``unittest.TestCase``.
 * All test method names should start with ``test_``.
+* All test clases should be of the form ``TestXYZ``.
 * All test method names should be descriptive. If the test method is not descriptive enough, add a docstring.
 * Unit tests should have at least one assertion.
 


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
This PR adds style rules for test function and class naming to the ARMI developer docs, as well as actually implementing those changes.

closes #2570 and https://github.com/terrapower/armi/issues/2603
## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
<!-- Change Type: fixes -->
<!-- Change Type: trivial -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: ARMI test and class names should be named consistently

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
