### PR TITLE
Making Composite.changeNDensByFactor safe for Components

### DIFF
--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1505,11 +1505,13 @@ class ArmiObject(metaclass=CompositeModelType):
         """Change the number density of all nuclides within the object by a multiplicative factor."""
         densitiesScaled = {nuc: val * factor for nuc, val in self.getNumberDensities().items()}
         self.setNumberDensities(densitiesScaled)
+
         # Update detailedNDens
-        if self.p.detailedNDens is not None:
+        if self.p.get("detailedNDens", None) is not None:
             self.p.detailedNDens *= factor
+
         # Update pinNDens
-        if self.p.pinNDens is not None:
+        if self.p.get("pinNDens", None) is not None:
             self.p.pinNDens *= factor
 
     def clearNumberDensities(self):

--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1506,11 +1506,11 @@ class ArmiObject(metaclass=CompositeModelType):
         densitiesScaled = {nuc: val * factor for nuc, val in self.getNumberDensities().items()}
         self.setNumberDensities(densitiesScaled)
 
-        # Update detailedNDens
+        # Update detailedNDens if it exists (Components only)
         if self.p.get("detailedNDens", None) is not None:
             self.p.detailedNDens *= factor
 
-        # Update pinNDens
+        # Update pinNDens if it exists (Components only)
         if self.p.get("pinNDens", None) is not None:
             self.p.pinNDens *= factor
 


### PR DESCRIPTION
## What is the change? Why is it being made?

The method `Composite.changeNDensByFactor()` is also called from Components, which do not have the same set of Parameters as Composites.

So, there were two options available to me:

1. Copy the method over to Components, and alter it, or
2. Make the method safe from within.

I dislike code duplication, and if we did (1) we would be heavily relying on docstrings in each method to point to the other method, if there were updates made to one of the methods. So (2) seems like a safer option, not only does it result in there being less code, but the method is not intrinsically safe.

close #2628


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: While this problem has not occurred yet, it is very easy to safeguard against.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
