### PR TITLE
Unpinning PyPDF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ docs = [
     "nbsphinx==0.9.6", # Parses Jupyter notebooks
     "pandoc", # Must be in the path (to convert file formats)
     "pylint", # Generates UML diagrams
-    "pypdf==6.15.0", # Generating a single PDF file for the Sphinx documentation
+    "pypdf", # Generating a single PDF file for the Sphinx documentation
     "setuptools",  # needed for conf.py tooling
     "sphinx-gallery==0.13.0", # Builds an HTML version of a Python script and puts it into a gallery
     "sphinx-needs==4.2.0", # Requirements traceability matrices for QA


### PR DESCRIPTION
## What is the change? Why is it being made?

In this PR I am unpinning the docs-only dependency `pypdf`. The [discussion](https://github.com/terrapower/armi/issues/2633) here leads me to think this is probably a safe option. The `pypdf` team is probably falsely marking every one of their releases as a "security" update, and that's the source of the problem. And that's a real problem, but it's out of our hands.

If, in the future, we have problems with `pypdf` making breaking changes that wreck our docs, then I think we will be left with no other option that to find a replacement library. But, until that happens, this seems like a fine solution.

close #2633


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: We want to stop the constant stream of Dependabot PRs due to pypdf.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
