### PR TITLE
Fixing hung GitHub Docs CI build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,8 +26,6 @@ jobs:
         with:
           python-version: 3.13
           persist-credentials: false
-      - name: Update package index
-        run: sudo apt-get update
       - name: Install apt-get libs
         run: sudo apt-get -y install texlive-xetex=2021.20220204-1 texlive-latex-base=2021.20220204-1 texlive-full=2021.20220204-1 pandoc libopenmpi-dev
       - name: Setup Graphviz


### PR DESCRIPTION
## What is the change? Why is it being made?

Today, like sometimes, the ARMI Docs build on CI is hung up on the `apt-get update` stage of the bulid.

I am just going to try to remove this line and see if the docs still build correctly.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: docs

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: CI should be consistent and fast.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
