### PR TITLE
Removing inefficiencies in Assembly initialization

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -209,12 +209,9 @@ class Assembly(composites.Composite):
             :id: I_ARMI_ASSEM_BLOCKS_2
             :implements: R_ARMI_ASSEM_BLOCKS
 
-            Builds an assembly from a stack of Blocks. The spatialLocator
-            of the Assembly is updated. In ``reestablishBlockOrder``, the
-            Assembly spatialGrid is reinitialized and Block-wise
-            spatialLocator and name objects are updated. The axial mesh
-            and other Block geometry parameters are updated in
-            ``calculateZCoords``.
+            Builds an Assembly from a stack of Blocks. The spatialLocator of the Assembly is updated. In
+            ``reestablishBlockOrder``, the Assembly spatialGrid is reinitialized and Block-wise spatialLocator and name
+            objects are updated. The axial mesh and other Block geometry parameters are updated in ``calculateZCoords``.
         """
         # replace grid with one that has the right number of locations
         self.removeAll()

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -202,7 +202,20 @@ class Assembly(composites.Composite):
         self.calculateZCoords()
 
     def setBlockStack(self, blockStack: list[blocks.Block]):
-        """Re-initialize this assembly based on a provided stack of blocks."""
+        """
+        Re-initialize this assembly based on a provided stack of blocks.
+
+        .. impl:: Assemblies are made up of type Block.
+            :id: I_ARMI_ASSEM_BLOCKS_2
+            :implements: R_ARMI_ASSEM_BLOCKS
+
+            Builds an assembly from a stack of Blocks. The spatialLocator
+            of the Assembly is updated. In ``reestablishBlockOrder``, the
+            Assembly spatialGrid is reinitialized and Block-wise
+            spatialLocator and name objects are updated. The axial mesh
+            and other Block geometry parameters are updated in
+            ``calculateZCoords``.
+        """
         # replace grid with one that has the right number of locations
         self.removeAll()
         self.spatialGrid = grids.AxialGrid.fromNCells(len(blockStack))

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -201,6 +201,21 @@ class Assembly(composites.Composite):
         self.reestablishBlockOrder()
         self.calculateZCoords()
 
+    def setBlockStack(self, blockStack: list[blocks.Block]):
+        """Re-initialize this assembly based on a provided stack of blocks."""
+        # replace grid with one that has the right number of locations
+        self.removeAll()
+        self.spatialGrid = grids.AxialGrid.fromNCells(len(blockStack))
+        self.spatialGrid.armiObject = self
+        for i, obj in enumerate(blockStack):
+            self._checkPotentialChild(obj, "add")
+            composites.Composite.add(self, obj)
+            obj.spatialLocator = self.spatialGrid[0, 0, i]
+
+        # more work is needed, make a new mesh
+        self.reestablishBlockOrder()
+        self.calculateZCoords()
+
     def insert(self, index, obj):
         """Insert an object at a given index position with the assembly."""
         self._checkPotentialChild(obj, "insert")
@@ -375,9 +390,7 @@ class Assembly(composites.Composite):
 
         self.removeAll()
         self.spatialGrid = grids.AxialGrid.fromNCells(len(newBlockStack))
-        for b in newBlockStack:
-            self.add(b)
-        self.reestablishBlockOrder()
+        self.setBlockStack(newBlockStack)
 
     def getAxialMesh(self, centers=False, zeroAtFuel=False):
         """

--- a/armi/reactor/blueprints/assemblyBlueprint.py
+++ b/armi/reactor/blueprints/assemblyBlueprint.py
@@ -203,9 +203,11 @@ class AssemblyBlueprint(yamlize.Object):
         a.p.AziMesh = aziMeshPoints
 
         # Loop a second time because we needed all the blocks before choosing the assembly class.
+        blockStack = []
         for axialIndex, b in enumerate(blocks):
             b.name = b.makeName(a.p.assemNum, axialIndex)
-            a.add(b)
+            blockStack.append(b)
+        a.setBlockStack(blockStack)
 
         # Assign values for the parameters if they are defined on the blueprints
         for paramDef in a.p.paramDefs.inCategory(parameters.Category.assignInBlueprints):

--- a/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
+++ b/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
@@ -257,16 +257,16 @@ class AssemblyAxialLinkage:
         lstLinkedC = AxialLink(lowerC, upperC)
         self.linkedComponents[c] = lstLinkedC
 
-        if self.linkedBlocks[b].lower is None and lstLinkedC.lower is None:
-            runLog.debug(
-                f"Assembly {self.a}, Block {b}, Component {c} has nothing linked below it!",
-                single=True,
-            )
-        if self.linkedBlocks[b].upper is None and lstLinkedC.upper is None:
-            runLog.debug(
-                f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
-                single=True,
-            )
+        # if self.linkedBlocks[b].lower is None and lstLinkedC.lower is None:
+        #     runLog.debug(
+        #         f"Assembly {self.a}, Block {b}, Component {c} has nothing linked below it!",
+        #         single=True,
+        #     )
+        # if self.linkedBlocks[b].upper is None and lstLinkedC.upper is None:
+        #     runLog.debug(
+        #         f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
+        #         single=True,
+        #     )
 
     @staticmethod
     def areAxiallyLinked(componentA: Component, componentB: Component) -> bool:

--- a/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
+++ b/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
@@ -258,16 +258,16 @@ class AssemblyAxialLinkage:
         lstLinkedC = AxialLink(lowerC, upperC)
         self.linkedComponents[c] = lstLinkedC
 
-        # if self.linkedBlocks[b].lower is None and lstLinkedC.lower is None:
-        #     runLog.debug(
-        #         f"Assembly {self.a}, Block {b}, Component {c} has nothing linked below it!",
-        #         single=True,
-        #     )
-        # if self.linkedBlocks[b].upper is None and lstLinkedC.upper is None:
-        #     runLog.debug(
-        #         f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
-        #         single=True,
-        #     )
+        if self.linkedBlocks[b].lower is None and lstLinkedC.lower is None:
+            runLog.debug(
+                f"Assembly {self.a}, Block {b}, Component {c} has nothing linked below it!",
+                single=True,
+            )
+        if self.linkedBlocks[b].upper is None and lstLinkedC.upper is None:
+            runLog.debug(
+                f"Assembly {self.a}, Block {b}, Component {c} has nothing linked above it!",
+                single=True,
+            )
 
     @staticmethod
     def areAxiallyLinked(componentA: Component, componentB: Component) -> bool:

--- a/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
+++ b/armi/reactor/converters/axialExpansionChanger/assemblyAxialLinkage.py
@@ -60,29 +60,30 @@ def areAxiallyLinked(componentA: Component, componentB: Component) -> bool:
     ## Cases 4
     linked = False
 
-    if isinstance(componentA, type(componentB)) and (
-        componentA.containsSolidMaterial() and componentB.containsSolidMaterial()
-    ):
-        if isinstance(componentA, UnshapedComponent):
-            ## Case 1
-            runLog.warning(
-                f"Components {componentA} and {componentB} are UnshapedComponents "
-                "and do not have 'getCircleInnerDiameter' or getBoundingCircleOuterDiameter methods; "
-                "nor is it physical to do so. Instead of crashing and raising an error, "
-                "they are going to be assumed to not be linked.",
-                single=True,
-            )
-        elif isinstance(componentA.spatialLocator, MultiIndexLocation) and isinstance(
-            componentB.spatialLocator, MultiIndexLocation
+    if componentA.getDimension("mult") == componentB.getDimension("mult"):
+        if isinstance(componentA, type(componentB)) and (
+            componentA.containsSolidMaterial() and componentB.containsSolidMaterial()
         ):
-            ## Case 2
-            fromA = set(tuple(index) for index in componentA.spatialLocator.indices)
-            fromB = set(tuple(index) for index in componentB.spatialLocator.indices)
-            if fromA == fromB:
+            if isinstance(componentA, UnshapedComponent):
+                ## Case 1
+                runLog.warning(
+                    f"Components {componentA} and {componentB} are UnshapedComponents "
+                    "and do not have 'getCircleInnerDiameter' or getBoundingCircleOuterDiameter methods; "
+                    "nor is it physical to do so. Instead of crashing and raising an error, "
+                    "they are going to be assumed to not be linked.",
+                    single=True,
+                )
+            elif isinstance(componentA.spatialLocator, MultiIndexLocation) and isinstance(
+                componentB.spatialLocator, MultiIndexLocation
+            ):
+                ## Case 2
+                fromA = set(tuple(index) for index in componentA.spatialLocator.indices)
+                fromB = set(tuple(index) for index in componentB.spatialLocator.indices)
+                if fromA == fromB:
+                    linked = _checkOverlap(componentA, componentB)
+            else:
+                ## Case 3
                 linked = _checkOverlap(componentA, componentB)
-        elif componentA.getDimension("mult") == componentB.getDimension("mult"):
-            ## Case 3
-            linked = _checkOverlap(componentA, componentB)
 
     return linked
 

--- a/armi/reactor/converters/axialExpansionChanger/redistributeMass.py
+++ b/armi/reactor/converters/axialExpansionChanger/redistributeMass.py
@@ -131,10 +131,13 @@ class RedistributeMass:
         # calculate the mass of each nuclide and then the ndens for the new mass
         newNDens: dict[str, float] = {}
         nucs = self._getAllNucs(self.toComp.getNuclides(), self.fromComp.getNuclides())
+        toVolume = self.toCompVolume
+        fromVolume = self.fromCompVolume
+        newVolume = toVolume + fromVolume
         for nuc in nucs:
-            massByNucFrom = densityTools.getMassInGrams(nuc, self.fromCompVolume, self.fromComp.getNumberDensity(nuc))
-            massByNucTo = densityTools.getMassInGrams(nuc, self.toCompVolume, self.toComp.getNumberDensity(nuc))
-            newNDens[nuc] = densityTools.calculateNumberDensity(nuc, massByNucFrom + massByNucTo, self.newVolume)
+            massByNucFrom = densityTools.getMassInGrams(nuc, fromVolume, self.fromComp.getNumberDensity(nuc))
+            massByNucTo = densityTools.getMassInGrams(nuc, toVolume, self.toComp.getNumberDensity(nuc))
+            newNDens[nuc] = densityTools.calculateNumberDensity(nuc, massByNucFrom + massByNucTo, newVolume)
             self.massFrom += massByNucFrom
             self.massTo += massByNucTo
 

--- a/armi/reactor/converters/uniformMesh.py
+++ b/armi/reactor/converters/uniformMesh.py
@@ -678,6 +678,7 @@ class UniformMeshGeometryConverter(GeometryConverter):
         """
         newAssem = UniformMeshGeometryConverter._createNewAssembly(sourceAssem)
         newAssem.p.assemNum = sourceAssem.p.assemNum
+        newBlockStack = []
         runLog.debug(f"Creating a uniform mesh of {newAssem}")
         bottom = 0.0
 
@@ -743,11 +744,10 @@ class UniformMeshGeometryConverter(GeometryConverter):
             block.p.xsType = xsType
             block.setHeight(topMeshPoint - bottom)
             block.p.axMesh = 1
-            newAssem.add(block)
+            newBlockStack.append(block)
             bottom = topMeshPoint
 
-        newAssem.reestablishBlockOrder()
-        newAssem.calculateZCoords()
+        newAssem.setBlockStack(newBlockStack)
 
         UniformMeshGeometryConverter.setAssemblyStateFromOverlaps(
             sourceAssem,

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -482,16 +482,15 @@ class TestAssembly(unittest.TestCase):
     def test_setBlockStack(self):
         a = buildEmptyHexAssembly(1, 1)
 
-        # successfully add some Blocks to an Assembly
-        blockStack = a.getBlocks()
-        nBlocks = len(blockStack)
-        for n in range(3):
-            self.assertEqual(len(a), n)
+        # successfully add a stack of Blocks to an Assembly
+        blockStack = []
+        nBlocks = 3
+        for _n in range(nBlocks):
             b = blocks.HexBlock("TestBlock")
             blockStack.append(b)
 
         a.setBlockStack(blockStack)
-        self.assertEqual(len(a), nBlocks + n)
+        self.assertEqual(len(a), nBlocks)
         for b in blockStack:
             self.assertIn(b, a)
             self.assertEqual(b.parent, a)

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -479,6 +479,27 @@ class TestAssembly(unittest.TestCase):
         with self.assertRaises(TypeError):
             a.add(blocks.CartesianBlock("Test Cart Block"))
 
+    def test_setBlockStack(self):
+        a = buildEmptyHexAssembly(1, 1)
+
+        # successfully add some Blocks to an Assembly
+        blockStack = a.getBlocks()
+        nBlocks = len(blockStack)
+        for n in range(3):
+            self.assertEqual(len(a), n)
+            b = blocks.HexBlock("TestBlock")
+            blockStack.append(b)
+
+        a.setBlockStack(blockStack)
+        self.assertEqual(len(a), nBlocks + n)
+        for b in blockStack:
+            self.assertIn(b, a)
+            self.assertEqual(b.parent, a)
+
+        with self.assertRaises(TypeError):
+            blockStack.append(blocks.CartesianBlock("Test Cart Block"))
+            a.setBlockStack(blockStack)
+
     def test_moveTo(self):
         ref = self.r.core.spatialGrid.getLocatorFromRingAndPos(3, 10)
         i, j = grids.HexGrid.getIndicesFromRingAndPos(3, 10)


### PR DESCRIPTION
## What is the change? Why is it being made?

Remove some inefficiencies in assembly initialization, to speed up reactor creation from blueprints and  uniform mesh conversion. Three inefficiencies are addressed:

1. When performing axial expansion on an `Assembly`, the `RedistributeMass` class would repeatedly call the properties `toCompVolume`, `fromCompVolume`, and `newVolume` on the same components. Each time, a call would be made to `Component.getArea()`, which can be expensive. This routine is changed to call each property once, store the value, and use the stored value in the loop over nuclides. With this update, I observed a speedup of **approximately 20x** (107 s down to 5.4 s) for the axial expansion.
2. When performing axial expansion, the axial linkages need to be determined for each `Component`. The logic was refactored to perform lower-cost checks first (Component multiplicity), which allows the higher-cost check (all spatial locator indices are identical) to be skipped in some cases. In the test case I ran, I observed a speedup of 2.3x (38 s down to 16.3 s).
3. Reduce number of calls to `reestablishBlockOrder` and `calculateZCoords` when building an assembly from the number of blocks down to 1. Each call iterates over all blocks in the assembly, so this reduces the iteration from `O(n^2)` to `O(n)`. In my testing, I observed a drop in time spent adding blocks to assemblies from 7.9 s to 0.4 s -- about 20x speedup, albeit on a small piece of the pie.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: This speeds up initialization of a reactor object and other operations that involve building assemblies, such as uniform mesh conversion.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: New implementation tag `I_ARMI_ASSEM_BLOCKS_2` for requirement `R_ARMI_ASSEM_BLOCKS`.

---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
