### PR TITLE
Fixing Materia.getProperty for matProps properties

### DIFF
--- a/armi/materials/material.py
+++ b/armi/materials/material.py
@@ -529,8 +529,16 @@ class Material(MatPropsMaterial):
             # only use cached value if the temperature at which it is cached is the same.
             return cached[1]
         else:
-            # go look it up from material properties.
-            val = getattr(self, propName)(Tk=Tk, **kwargs)
+            # go look it up from material properties
+            try:
+                # If this is an armi.materials.Material property.
+                val = getattr(self, propName)(Tk=Tk, **kwargs)
+            except KeyError:
+                # This is an armi.matProps.MatPropsMaterial property.
+                if Tc is None:
+                    Tc = getTc(Tc, Tk)
+                val = getattr(self, propName)(T=Tc, **kwargs)
+
             # cache only one value for each property. Prevents unbounded cache explosion.
             self._setCache(propName, (Tk, val))
             return val

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -89,12 +89,24 @@ class AbstractMaterialTest:
         self.assertEqual(val, "Noether")
 
 
-class TestMaterialConstruction(unittest.TestCase):
+class TestMaterialBasics(unittest.TestCase):
     def test_matInit(self):
         """Make sure all materials can be instantiated without error."""
         for matClass in materials.iterAllMaterialClassesInNamespace(materials):
             m = matClass()
             self.assertIsInstance(m, materials.Material)
+
+    def test_getProperty(self):
+        mat = materials.Cs()
+
+        # use Material.getProperty on something simple; that has a direction function in the Material class
+        self.assertAlmostEqual(mat.density(Tc=500), 1.843)
+        self.assertAlmostEqual(mat.getProperty("density", Tc=500), 1.843)
+        self.assertAlmostEqual(mat.getProperty("density", Tk=units.getTk(Tc=500)), 1.843)
+
+        # use Material.getProperty on a matProps-only property name
+        self.assertAlmostEqual(mat.getProperty("T_melt", Tc=500), 111)
+        self.assertAlmostEqual(mat.getProperty("T_melt", Tk=600), 222)
 
 
 class TestMaterialFinding(unittest.TestCase):

--- a/armi/materials/tests/test_materials.py
+++ b/armi/materials/tests/test_materials.py
@@ -105,8 +105,8 @@ class TestMaterialBasics(unittest.TestCase):
         self.assertAlmostEqual(mat.getProperty("density", Tk=units.getTk(Tc=500)), 1.843)
 
         # use Material.getProperty on a matProps-only property name
-        self.assertAlmostEqual(mat.getProperty("T_melt", Tc=500), 111)
-        self.assertAlmostEqual(mat.getProperty("T_melt", Tk=600), 222)
+        self.assertAlmostEqual(mat.getProperty("T_melt", Tc=500), 28.55)
+        self.assertAlmostEqual(mat.getProperty("T_melt", Tk=600), 28.55)
 
 
 class TestMaterialFinding(unittest.TestCase):


### PR DESCRIPTION
## What is the change? Why is it being made?

The method `armi.materials.Material.getProperty()` has not been used much. And it was also not unit tested at all. 

And hence there was a bug in the method. If someone asked for a material property from the matProps side of things, this method would fail. (Due to a temperature conversion issue.)

This little PR fixes that issue.

close #2643


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Material.getProperty is not heavily used, but if it exists it should work correctly.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
