### PR TITLE
Documenting that expandTo conserves mass not number of atoms

### DIFF
--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -1292,12 +1292,10 @@ you start changing which nuclides are modeled and which ones deplete.::
 The code will crash if materials used in :ref:`blocks-and-components` contain nuclides not defined in ``nuclide flags``.
 A failure can also occur if the burn chain is missing a nuclide.
 
-.. tip::
-    We plan to upgrade the default behavior of this to inherit from all defined materials in a problem to reduce the
-    user-input burden.
+.. note::
+    If you use the ``expandTo`` feature, ARMI will conserve the total mass, but not the total number of atoms.
 
-.. These following are rst substitutions. They're useful for keeping the plaintext readable while getting subscripted
-   text.
+.. These following are RST substitutions. They're useful for keeping the plain text readable.
 
 .. |Tinput| replace:: T\ :sub:`input`
 .. |Thot| replace:: T\ :sub:`hot`


### PR DESCRIPTION
## What is the change? Why is it being made?

There was some confusion that using the `expandTo` feature in the `nuclide flags` section of the blueprints does not conserve the number of atoms. But that is because it conserves the total mass of the element instead. (And you can only do one.)

Now, this was mentioned in a docstring somewhere, but the request was made to warn people in the documentation. Which is fair, and this PR accomplishes that.

close #1817


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: People should know what kind is conserved when they use the expandTo feature in nuclide flags.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
