### PR TITLE
Ignoring negative volume components in mass-weighted averaging

### DIFF
--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -451,8 +451,9 @@ class AverageBlockCollection(BlockCollection):
         weights = np.array([self.getWeight(b) / b.getHeight() for b in blocks])
         weights /= weights.sum()  # normalize by total weight
         components = [sorted(b.getComponents())[compIndex] for b in blocks]
+        masses = [c.getMass() for c in components]
         weightedAvgComponentMass = sum(
-            w * c.getMass() if c.getMass() > 0.0 else 0.0 for w, c in zip(weights, components)
+            w * mass if mass > 0.0 else 0.0 for w, mass in zip(weights, masses)
         )
         if weightedAvgComponentMass == 0.0:
             # if there is no component mass (e.g., gap), do a regular average
@@ -460,7 +461,7 @@ class AverageBlockCollection(BlockCollection):
         else:
             return (
                 weights.dot(
-                    np.array([c.temperatureInC * c.getMass() if c.getMass() > 0.0 else 0.0 for c in components])
+                    np.array([c.temperatureInC * mass if mass > 0.0 else 0.0 for c, mass in zip(components, masses)])
                 )
                 / weightedAvgComponentMass
             )

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -451,13 +451,13 @@ class AverageBlockCollection(BlockCollection):
         weights = np.array([self.getWeight(b) / b.getHeight() for b in blocks])
         weights /= weights.sum()  # normalize by total weight
         components = [sorted(b.getComponents())[compIndex] for b in blocks]
-        weightedAvgComponentMass = sum(w * c.getMass() for w, c in zip(weights, components))
+        weightedAvgComponentMass = sum(w * c.getMass() for w, c in zip(weights, components) if c.getMass() > 0.0)
         if weightedAvgComponentMass == 0.0:
             # if there is no component mass (e.g., gap), do a regular average
             return np.mean(np.array([c.temperatureInC for c in components]))
         else:
             return (
-                weights.dot(np.array([c.temperatureInC * c.getMass() for c in components])) / weightedAvgComponentMass
+                weights.dot(np.array([c.temperatureInC * c.getMass() for c in components if c.getMass() > 0.0])) / weightedAvgComponentMass
             )
 
     def _performAverageByComponent(self):
@@ -844,7 +844,10 @@ class SlabComponentsAverageBlockCollection(BlockCollection):
         densities = np.zeros(len(allNucNames))
         totalWeight = 0.0
         for c, bWeight in zip(components, bWeights):
-            weight = bWeight * c.getArea()
+            compArea = c.getArea()
+            if compArea <= 0.0:
+                continue
+            weight = bWeight * compArea
             totalWeight += weight
             densities += weight * np.array(c.getNuclideNumberDensities(allNucNames))
         if totalWeight > 0.0:

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -451,13 +451,13 @@ class AverageBlockCollection(BlockCollection):
         weights = np.array([self.getWeight(b) / b.getHeight() for b in blocks])
         weights /= weights.sum()  # normalize by total weight
         components = [sorted(b.getComponents())[compIndex] for b in blocks]
-        weightedAvgComponentMass = sum(w * c.getMass() for w, c in zip(weights, components) if c.getMass() > 0.0)
+        weightedAvgComponentMass = sum(w * c.getMass() if c.getMass() > 0.0 else 0.0 for w, c in zip(weights, components))
         if weightedAvgComponentMass == 0.0:
             # if there is no component mass (e.g., gap), do a regular average
             return np.mean(np.array([c.temperatureInC for c in components]))
         else:
             return (
-                weights.dot(np.array([c.temperatureInC * c.getMass() for c in components if c.getMass() > 0.0]))
+                weights.dot(np.array([c.temperatureInC * c.getMass() if c.getMass() > 0.0 else 0.0 for c in components]))
                 / weightedAvgComponentMass
             )
 

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -457,7 +457,8 @@ class AverageBlockCollection(BlockCollection):
             return np.mean(np.array([c.temperatureInC for c in components]))
         else:
             return (
-                weights.dot(np.array([c.temperatureInC * c.getMass() for c in components if c.getMass() > 0.0])) / weightedAvgComponentMass
+                weights.dot(np.array([c.temperatureInC * c.getMass() for c in components if c.getMass() > 0.0]))
+                / weightedAvgComponentMass
             )
 
     def _performAverageByComponent(self):

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -451,18 +451,14 @@ class AverageBlockCollection(BlockCollection):
         weights = np.array([self.getWeight(b) / b.getHeight() for b in blocks])
         weights /= weights.sum()  # normalize by total weight
         components = [sorted(b.getComponents())[compIndex] for b in blocks]
-        masses = [c.getMass() for c in components]
-        weightedAvgComponentMass = sum(
-            w * mass if mass > 0.0 else 0.0 for w, mass in zip(weights, masses)
-        )
+        weightedMass = [w * c.getMass() for w, c in zip(weights, components)]
+        weightedAvgComponentMass = sum(m for m in weightedMass if m > 0.0)
         if weightedAvgComponentMass == 0.0:
             # if there is no component mass (e.g., gap), do a regular average
             return np.mean(np.array([c.temperatureInC for c in components]))
         else:
             return (
-                weights.dot(
-                    np.array([c.temperatureInC * mass if mass > 0.0 else 0.0 for c, mass in zip(components, masses)])
-                )
+                sum([c.temperatureInC * mass if mass > 0.0 else 0.0 for c, mass in zip(components, weightedMass)])
                 / weightedAvgComponentMass
             )
 

--- a/armi/physics/neutronics/crossSectionGroupManager.py
+++ b/armi/physics/neutronics/crossSectionGroupManager.py
@@ -451,13 +451,17 @@ class AverageBlockCollection(BlockCollection):
         weights = np.array([self.getWeight(b) / b.getHeight() for b in blocks])
         weights /= weights.sum()  # normalize by total weight
         components = [sorted(b.getComponents())[compIndex] for b in blocks]
-        weightedAvgComponentMass = sum(w * c.getMass() if c.getMass() > 0.0 else 0.0 for w, c in zip(weights, components))
+        weightedAvgComponentMass = sum(
+            w * c.getMass() if c.getMass() > 0.0 else 0.0 for w, c in zip(weights, components)
+        )
         if weightedAvgComponentMass == 0.0:
             # if there is no component mass (e.g., gap), do a regular average
             return np.mean(np.array([c.temperatureInC for c in components]))
         else:
             return (
-                weights.dot(np.array([c.temperatureInC * c.getMass() if c.getMass() > 0.0 else 0.0 for c in components]))
+                weights.dot(
+                    np.array([c.temperatureInC * c.getMass() if c.getMass() > 0.0 else 0.0 for c in components])
+                )
                 / weightedAvgComponentMass
             )
 

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -594,16 +594,9 @@ class TestBlockCollCompAvg1DCyl(unittest.TestCase):
             :tests: R_ARMI_XSGM_CREATE_REPR_BLOCKS
         """
         xsgm = self.o.getInterface("xsGroups")
-
         xsgm.interactBOL()
 
-        # Check that the correct defaults are propagated after the interactBOL
-        # from the cross section group manager is called.
-        xsOpt = self.o.cs[CONF_CROSS_SECTION]["UA"]
-        self.assertEqual(xsOpt.blockRepresentation, "ComponentAverage1DCylinder")
-
         annularFuel = self.r.core.getAssemblies(Flags.FUEL | Flags.ANNULAR, includeBolAssems=True)[0]
-
         # set temperatures of each gap component before performing average
         # give the gaps some mass (material is arbitrary)
         for i, b in enumerate(annularFuel.getBlocks(Flags.FUEL)):
@@ -622,11 +615,14 @@ class TestBlockCollCompAvg1DCyl(unittest.TestCase):
         reprBlock = xsgm.representativeBlocks["UA"]
         for c in reprBlock.getComponents(Flags.GAP):
             if c.getName() == "gap3":
+                # gap3 temp is 700 C because the 500 C and 600 C components have negative volume
                 self.assertAlmostEqual(c.temperatureInC, 700.0)
             elif c.getName() == "gap4":
+                # gap4 temp is between 500 C and 600 C because the 700C component has negative volume
                 self.assertLess(c.temperatureInC, 600.0)
                 self.assertGreater(c.temperatureInC, 500.0)
             else:
+                # other gap components all have positive volume
                 self.assertAlmostEqual(c.temperatureInC, 600.0)
         outerLiner = reprBlock.getComponent(Flags.LINER | Flags.OUTER)
         self.assertAlmostEqual(outerLiner.temperatureInC, 600.0)

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock
 
 from armi import settings
 from armi.context import PLATFORM, Platform
+from armi.materials.water import Water
 from armi.physics.neutronics import crossSectionGroupManager
 from armi.physics.neutronics.const import CONF_CROSS_SECTION
 from armi.physics.neutronics.crossSectionGroupManager import (
@@ -401,7 +402,6 @@ class TestBlockCollCompAvg(unittest.TestCase):
             ("Assemblies not in the core should still have XS groups, see _getMissingBlueprintBlocks()"),
         )
 
-
 class TestBlockCollCompAvg1DCyl(unittest.TestCase):
     """Test Block collection component averages for 1D cylinder."""
 
@@ -584,6 +584,52 @@ class TestBlockCollCompAvg1DCyl(unittest.TestCase):
                         1.0,
                         f"{nuc} temperature should be different from {compTemp} for component {c}",
                     )
+
+    def test_compAverageNegativeVolume(self):
+        """Test creation of a representative block when negative-volume components are present.
+
+        .. test:: Create representative blocks using a volume-weighted averaging.
+            :id: T_ARMI_XSGM_CREATE_REPR_BLOCKS2
+            :tests: R_ARMI_XSGM_CREATE_REPR_BLOCKS
+        """
+        
+        xsgm = self.o.getInterface("xsGroups")
+
+        xsgm.interactBOL()
+
+        # Check that the correct defaults are propagated after the interactBOL
+        # from the cross section group manager is called.
+        xsOpt = self.o.cs[CONF_CROSS_SECTION]["UA"]
+        self.assertEqual(xsOpt.blockRepresentation, "ComponentAverage1DCylinder")
+
+        annularFuel = self.r.core.getAssemblies(Flags.FUEL | Flags.ANNULAR, includeBolAssems=True)[0]
+
+        # set temperatures of each gap component before performing average
+        # give the gaps some mass (material is arbitrary)
+        for i, b in enumerate(annularFuel.getBlocks(Flags.FUEL)):
+            gaps = b.getComponents(Flags.GAP)
+            for c in gaps:
+                c.temperatureInC = 500.0 + 100.0 * i
+                c.material = Water()
+                c.setNumberDensities({"H": 0.5, "O": 0.25})
+            # make some of the negative-volume gaps have positive volume by adjusting liner temperature
+            liner = b.getComponent(Flags.LINER | Flags.OUTER)
+            liner.setTemperature(500.0 + 100.0 * i)
+
+        xsgm.createRepresentativeBlocks()
+        xsgm.updateNuclideTemperatures()
+
+        reprBlock = xsgm.representativeBlocks["UA"]
+        for c in reprBlock.getComponents(Flags.GAP):
+            if c.getName() == "gap3":
+                self.assertAlmostEqual(c.temperatureInC, 700.0)
+            elif c.getName() == "gap4":
+                self.assertLess(c.temperatureInC, 600.0)
+                self.assertGreater(c.temperatureInC, 500.0)
+            else:
+                self.assertAlmostEqual(c.temperatureInC, 600.0)
+        outerLiner = reprBlock.getComponent(Flags.LINER | Flags.OUTER)
+        self.assertAlmostEqual(outerLiner.temperatureInC, 600.0)
 
     def test_checkComponentConsistency(self):
         xsgm = self.o.getInterface("xsGroups")

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -593,7 +593,6 @@ class TestBlockCollCompAvg1DCyl(unittest.TestCase):
             :id: T_ARMI_XSGM_CREATE_REPR_BLOCKS2
             :tests: R_ARMI_XSGM_CREATE_REPR_BLOCKS
         """
-
         xsgm = self.o.getInterface("xsGroups")
 
         xsgm.interactBOL()

--- a/armi/physics/neutronics/tests/test_crossSectionManager.py
+++ b/armi/physics/neutronics/tests/test_crossSectionManager.py
@@ -402,6 +402,7 @@ class TestBlockCollCompAvg(unittest.TestCase):
             ("Assemblies not in the core should still have XS groups, see _getMissingBlueprintBlocks()"),
         )
 
+
 class TestBlockCollCompAvg1DCyl(unittest.TestCase):
     """Test Block collection component averages for 1D cylinder."""
 
@@ -592,7 +593,7 @@ class TestBlockCollCompAvg1DCyl(unittest.TestCase):
             :id: T_ARMI_XSGM_CREATE_REPR_BLOCKS2
             :tests: R_ARMI_XSGM_CREATE_REPR_BLOCKS
         """
-        
+
         xsgm = self.o.getInterface("xsGroups")
 
         xsgm.interactBOL()


### PR DESCRIPTION
## What is the change? Why is it being made?

**Change**: Ignore any `Component` with negative area when computing a mass-weighted average temperature and composition for a set of components.

**Background**: When building a representative `Block` in the `CrossSectionGroupManager` for a cross section type with the option `averageByComponent: true`, it is necessary to compute an average temperature and composition across all blocks in the `BlockCollection` for each `Component` in the representative `Block`. In normal circumstances, a mass-weighted average is used. However, there are some situations where a `Component` can have negative area/volume and thus negative mass. If some components in the `BlockCollection` have positive mass and others have negative mass, the mass-weighted average temperature of the components can be extremely different than a non-weighted average. In some cases, the resulting temperature could be outside the bounds of defined material properties, which could cause a run to crash.

## SCR Information

Change Type: features

One-Sentence Rationale: This addresses a corner case bug that could cause ARMI apps to crash when there are negative-volume components present.

One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
