### PR TITLE
Updating Assembly detailed number density when Core pitch changes

### DIFF
--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1250,7 +1250,7 @@ class Assembly(composites.Composite):
 
             N = \frac{\sum_c\left(N_c * V_c\right)}{\sum_cV_c}
 
-        If no detailed number densities are found, sets parameter to ``None``
+        If no detailed number densities are found, sets parameter to ``None``.
         """
         totalVolume = 0.0
         onAssembly = None
@@ -1274,7 +1274,7 @@ class Assembly(composites.Composite):
         Parameters
         ----------
         pitchInCm
-            Requested pitch of this assembly. Means different things for
+           Requested pitch of this assembly. Means different things for
            different assemblies (e.g., hex vs. cartesian). But the child blocks
            also know what to do with this.
 

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1268,6 +1268,30 @@ class Assembly(composites.Composite):
         else:
             self.p.detailedNDens = None
 
+    def setPitch(self, pitchInCm: float):
+        """Adjust the assembly to alight with a uniform pitch.
+
+        Parameters
+        ----------
+        pitchInCm
+            Requested pitch of this assembly. Means different things for
+           different assemblies (e.g., hex vs. cartesian). But the child blocks
+           also know what to do with this.
+
+        See Also
+        --------
+        :meth:`armi.reactor.cores.Core.setPitchUniform`
+        :meth:`armi.reactor.blocks.Block.setPitch`
+
+        :meth:`assignConsistentDetailedNDens` will be called if ``detailedNDens`` is set
+        because the child volumes may have been adjusted
+        """
+        for block in self:
+            block.setPitch(pitchInCm)
+
+        if self.p.detailedNDens is not None:
+            self.assignConsistentDetailedNDens()
+
 
 class HexAssembly(Assembly):
     """An assembly that is hexagonal in cross-section."""

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -1241,6 +1241,33 @@ class Assembly(composites.Composite):
             if b.spatialGrid is not None:
                 b.assignPinIndices()
 
+    def assignConsistentDetailedNDens(self):
+        r"""Update ``self.p.detailedNDens`` to be consistent with child components.
+
+        Sets the parameter equal to the sum of detailed atoms
+
+        .. math::
+
+            N = \frac{\sum_c\left(N_c * V_c\right)}{\sum_cV_c}
+
+        If no detailed number densities are found, sets parameter to ``None``
+        """
+        totalVolume = 0.0
+        onAssembly = None
+        for c in self.iterComponents():
+            vol = c.getVolume()
+            totalVolume += vol
+            if (onChild := c.p.detailedNDens) is not None:
+                if onAssembly is not None:
+                    onAssembly += onChild * vol
+                else:
+                    onAssembly = onChild * vol
+        if onAssembly is not None:
+            onAssembly /= totalVolume
+            self.p.detailedNDens = onAssembly
+        else:
+            self.p.detailedNDens = None
+
 
 class HexAssembly(Assembly):
     """An assembly that is hexagonal in cross-section."""

--- a/armi/reactor/blocks/block.py
+++ b/armi/reactor/blocks/block.py
@@ -1316,6 +1316,9 @@ class Block(composites.Composite):
         if updateBolParams:
             self.completeInitialLoading()
 
+        # Area may have changed which means volume may have changed
+        self.clearCache()
+
     def getMfp(self, gamma=False):
         r"""
         Calculate the mean free path for neutron or gammas in this block.

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -2084,10 +2084,10 @@ class Core(composites.Composite):
 
         return converter
 
-    def setPitchUniform(self, pitchInCm):
-        """Set the pitch in all blocks."""
-        for b in self.iterBlocks():
-            b.setPitch(pitchInCm)
+    def setPitchUniform(self, pitchInCm: float):
+        """Set the pitch in all contained assemblies."""
+        for a in self:
+            a.setPitch(pitchInCm)
 
         # have to update the 2-D reactor mesh too.
         self.spatialGrid.changePitch(pitchInCm)

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1070,6 +1070,15 @@ class TestAssembly(unittest.TestCase):
                 expected += c.p.detailedNDens * vol
         np.testing.assert_allclose(self.assembly.p.detailedNDens, expected / totalVol)
 
+    def test_assemblyDetailedNDensNoOperation(self):
+        """If the assembly has no children with detailed number density, nothing happens."""
+        # Arbitrary non-None initial data
+        self.assembly.p.detailedNDens = np.random.default_rng().uniform(low=0, high=1e-2, size=(73,))
+        for c in self.assembly.iterComponents():
+            c.p.detailedNDens = None
+
+        self.assembly.assignConsistentDetailedNDens()
+        self.assertIsNone(self.assembly.p.detailedNDens)
 
 
 class TestAssemblyInReactor(unittest.TestCase):

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -1045,6 +1045,32 @@ class TestAssembly(unittest.TestCase):
             bIndex = self.assembly.getBIndexFromZIndex(zIndex * 0.5)
             self.assertEqual(bIndex, math.ceil(zIndex / 2) if zIndex < 5 else -1)
 
+    def test_assemblyDetailedNDens(self):
+        """Ensure assembly and component number densities are consistent."""
+        # Set Up
+        numDetailedNucs = 100  # arbitrary
+        didUpdate = False
+        # Use random densities, we just need to show consistency
+        rng = np.random.default_rng()
+        for c in self.assembly.iterComponents(Flags.FUEL):
+            c.p.detailedNDens = rng.uniform(low=0, high=1e-2, size=(numDetailedNucs,))
+            didUpdate = True
+        self.assertTrue(didUpdate, msg="No components updated!")
+        self.assembly.p.detailedNDens = None
+        # Now the real test
+        self.assembly.assignConsistentDetailedNDens()
+        self.assertIsNotNone(self.assembly.p.detailedNDens)
+        # Recalculate and compare
+        expected = np.zeros(numDetailedNucs)
+        totalVol = 0
+        for c in self.assembly.iterComponents():
+            vol = c.getVolume()
+            totalVol += vol
+            if c.p.detailedNDens is not None:
+                expected += c.p.detailedNDens * vol
+        np.testing.assert_allclose(self.assembly.p.detailedNDens, expected / totalVol)
+
+
 
 class TestAssemblyInReactor(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->

When the `Core` pitch changes via `Core.setPitchUniform`, the pitch of each `Block` in the `Core` changes to match the uniform pitch. For hex assemblies / hex blocks, this is functionally changes the outer flat-to-flat pitch of the largest hex `Component` in each `Block`. As such, the `Block` and `Assembly` volume can change as a result of this operation.

Changing an `Assembly` volume impacts the `Assembly` detailed number density `Parameter`. We'd like this to be consistent with the volume-weighted average of the child components. See #2613

This PR does two related things.

1. Introduce `Assembly.assignConsistentDetailedNDens` to set the `a.p.detailedNDens` as this volume-weighted average, and
2. Use `Assembly.assignConsistentDetailedNDens` when `Core.setPitchUniform` is called.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
<!-- Change Type: features -->
Change Type: fixes
<!-- Change Type: trivial -->
<!-- Change Type: docs -->

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Keep assembly detailed number density consistent through changing core pitch

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
