### PR TITLE
Removing unnecessary r-strings

### DIFF
--- a/armi/bookkeeping/memoryProfiler.py
+++ b/armi/bookkeeping/memoryProfiler.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
+"""
 Interface to help diagnose memory issues during debugging/development.
 
 There are many approaches to memory profiling.
@@ -146,7 +146,7 @@ class MemoryProfiler(interfaces.Interface):
         )
 
     def displayMemoryUsage(self, timeDescription):
-        r"""
+        """
         Print out some information to stdout about the memory usage of ARMI.
 
         Useful when the debugMem setting is set to True.
@@ -299,8 +299,8 @@ class KlassCounter:
         """
         Recursively find objects inside arbitrarily-deeply-nested containers.
 
-        This is designed to work with the garbage collector, so it focuses on
-        objects potentially being held in dict, tuple, list, or sets.
+        This is designed to work with the garbage collector, so it focuses on objects potentially being held in dict,
+        tuple, list, or sets.
         """
         counter = self[type(ao)]
         if counter.add(ao):

--- a/armi/materials/b4c.py
+++ b/armi/materials/b4c.py
@@ -50,7 +50,7 @@ class B4C(material.Material):
         self.clearCache()
 
     def setNewMassFracsFromMassEnrich(self, massEnrichment):
-        r"""
+        """
         Calculate the mass fractions for a given  mass enrichment and set it on any parent.
 
         Parameters
@@ -111,7 +111,7 @@ class B4C(material.Material):
         return boron10MassGrams, boron11MassGrams, carbonMassGrams
 
     def setDefaultMassFracs(self) -> None:
-        r"""B4C mass fractions. Using Natural B4C. 19.9% B-10/ 80.1% B-11
+        """B4C mass fractions. Using Natural B4C. 19.9% B-10/ 80.1% B-11
         Boron: 10.811 g/mol
         Carbon:  12.0107 g/mol.
 

--- a/armi/nuclearDataIO/cccc/nhflux.py
+++ b/armi/nuclearDataIO/cccc/nhflux.py
@@ -413,10 +413,9 @@ class NhfluxStream(cccc.StreamWithDataContainer):
 
             numExternalSurfaces = self._getNumOuterSurfacesHex()
 
-            # Initialize np arrays to store all node ordering (and node surface ordering)
-            # data. We don't actually use incomingPointersToAllAssemblies (basically
-            # equivalent to nearest neighbors indices), but it's here in case someone
-            # needs it in the future.
+            # Initialize np arrays to store all node ordering (and node surface ordering) data. We don't actually use
+            # incomingPointersToAllAssemblies (basically equivalent to nearest neighbors indices), but it's here in case
+            # someone needs it in the future.
 
             # Initialize data size when reading
             if self._data.incomingPointersToAllAssemblies.size == 0:
@@ -450,7 +449,7 @@ class NhfluxStream(cccc.StreamWithDataContainer):
                 self._data.ingoingPCSymSecPointers = record.rwList(self._data.ingoingPCSymSecPointers, "int", npcsto)
 
     def _rwFluxMoments3D(self, contents):
-        r"""
+        """
         Read/write multigroup flux moments from the NHFLUX 3D block.
 
         This reads/writes the planar moments for each DIF3D node on ONE x,y plane. The
@@ -485,7 +484,7 @@ class NhfluxStream(cccc.StreamWithDataContainer):
         return contents
 
     def _rwHexPartialCurrents4D(self, surfCurrents, externalSurfCurrents):
-        r"""
+        """
         Read/write multigroup lateral partial OUTGOING currents from the NHFLUX 4D block.
 
         This reads all OUTGOING partial currents for all assembly block lateral surfaces

--- a/armi/nuclearDataIO/cccc/rtflux.py
+++ b/armi/nuclearDataIO/cccc/rtflux.py
@@ -83,9 +83,7 @@ class RtfluxStream(cccc.StreamWithDataContainer):
     fileName: str
         path to RTFLUX file
     fileMode: str
-        string indicating if ``fileName`` is being read or written, and
-        in ascii or binary format
-
+        string indicating if ``fileName`` is being read or written, and in ascii or binary format
     """
 
     @staticmethod
@@ -109,8 +107,7 @@ class RtfluxStream(cccc.StreamWithDataContainer):
 
         Notes
         -----
-        The username, version, etc are embedded in this string but it's
-        usually blank.
+        The username, version, etc are embedded in this string but it's usually blank.
         """
         with self.createRecord() as record:
             self._metadata["label"] = record.rwString(self._metadata["label"], 28)
@@ -156,7 +153,7 @@ class RtfluxStream(cccc.StreamWithDataContainer):
                         )
 
     def getEnergyGroupIndex(self, g):
-        r"""
+        """
         Real fluxes stored in RTFLUX have "normal" (or "forward") energy groups.
         Also see the subclass method ATFLUX.getEnergyGroupIndex().
 
@@ -172,7 +169,7 @@ class AtfluxStream(RtfluxStream):
     """
 
     def getEnergyGroupIndex(self, g):
-        r"""
+        """
         Adjoint fluxes stored in ATFLUX have "reversed" (or "backward") energy groups.
 
         0 based, so if NG=33 and you want the third group (g=2), this returns 30.

--- a/armi/reactor/__init__.py
+++ b/armi/reactor/__init__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
-The reactor package houses the data model used in ARMI to represent the reactor during its
-simulation. It contains definitions of the reactor, assemblies, blocks, components, etc.
+"""
+The reactor package houses the data model used in ARMI to represent the reactor during its simulation. It contains
+definitions of the reactor, assemblies, blocks, components, etc.
 
 See :doc:`/developer/index`.
 """

--- a/armi/utils/hexagon.py
+++ b/armi/utils/hexagon.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""
+"""
 Generic hexagon math.
 
 Hexagons are fundamental to advanced reactors.


### PR DESCRIPTION
## What is the change? Why is it being made?

There were a bunch of r-string declarations on docstrings that didn't need to be r-strings. (They contained no backslashes.)

I saw one of these in a recent PR that Olek was working on, and thought "Hey, we should just fix all of those."


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: This is an example of removing unused code, albeit just trivially in docstrings.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
