### PR TITLE
Removing numMoves parameter

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -249,7 +249,6 @@ class FuelHandler:
         else:
             numMoved = 0
 
-        self.o.r.core.p.numMoves = numMoved
         self.o.r.core.setBlockMassParams()
 
         runLog.important("Fuel handler performed {0} assembly shuffles.".format(numMoved))
@@ -984,7 +983,6 @@ class FuelHandler:
             return
 
         # add assemblies into the moved location
-        # keep it unique so we don't get artificially inflated numMoves
         for a in [incoming, outgoing]:
             if a not in self.moved:
                 self.moved.append(a)

--- a/armi/reactor/assemblies.py
+++ b/armi/reactor/assemblies.py
@@ -237,7 +237,6 @@ class Assembly(composites.Composite):
         oldSymmetryFactor = self.getSymmetryFactor()
         composites.Composite.moveTo(self, locator)
         if self.lastLocationLabel != self.DATABASE:
-            self.p.numMoves += 1
             self.p.daysSinceLastMove = 0.0
         self.parent.childrenByLocator[locator] = self
         # symmetry may have changed (either moving on or off of symmetry line)

--- a/armi/reactor/assemblyParameters.py
+++ b/armi/reactor/assemblyParameters.py
@@ -107,8 +107,6 @@ def getAssemblyParameterDefinitions():
 
         pb.defParam("maxPercentBu", units=units.PERCENT, description="maxPercentBu")
 
-        pb.defParam("numMoves", units=units.UNITLESS, description="numMoves")
-
         pb.defParam("timeToLimit", units=units.DAYS, description="timeToLimit", default=1e6)
 
         pb.defParam(

--- a/armi/reactor/cores.py
+++ b/armi/reactor/cores.py
@@ -93,7 +93,6 @@ class Core(composites.Composite):
         self.numRings = 0
         self.spatialGrid = None
         self.xsIndex = {}
-        self.p.numMoves = 0
         self._lib = None  # placeholder for ISOTXS object
         self.locParams = {}  # location-based parameters
         # overridden in case.py to include pre-reactor time.

--- a/armi/reactor/reactorParameters.py
+++ b/armi/reactor/reactorParameters.py
@@ -95,8 +95,6 @@ def defineCoreParameters():
             default=0,
         )
 
-        pb.defParam("numMoves", units=units.UNITLESS, description="numMoves", default=0)
-
     with pDefs.createBuilder() as pb:
         pb.defParam(
             "axialMesh",

--- a/armi/reactor/tests/test_assemblies.py
+++ b/armi/reactor/tests/test_assemblies.py
@@ -646,7 +646,6 @@ class TestAssembly(unittest.TestCase):
 
         params = {}
         params["maxPercentBu"] = 30.0
-        params["numMoves"] = 5.0
         params["maxPercentBu"] = 0
         params["timeToLimit"] = 2.7e5
         params["arealPd"] = 110.0

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -96,7 +96,6 @@ def plotReactorPerformance(reactor, dbi, buGroups, extension=None, history=None)
         ymin=1.0,
         extension=extension,
     )
-    movesVsCycle(reactor.name, scalars, extension=extension)
 
 
 def valueVsTime(name, x, y, key, yaxis, title, ymin=None, extension=None):
@@ -191,54 +190,6 @@ def keffVsTime(name, time, keff, keffUnc=None, ymin=None, extension=None):
     plt.close(1)
 
     report.setData("K-Eff", os.path.abspath(figName), report.KEFF_PLOT)
-
-
-def movesVsCycle(name, scalars, extension=None):
-    """
-    Make a bar chart showing the number of moves per cycle in the full core.
-
-    A move is defined as an assembly being picked up, moved, and put down. So if
-    two assemblies are swapped, that is 2 moves. Note that it does not count
-    temporary storage for such swaps. This is an approximation because in a chain of moves,
-    only one out of the chain would have to be temporarily stored. So as the chains get longer,
-    this approximation gets more accurate.
-
-    Parameters
-    ----------
-    name : str
-        reactor.name
-    extension : str, optional
-        The file extension for saving the figure
-
-    See Also
-    --------
-    FuelHandler.outage : sets the number of moves in each cycle
-    """
-    extension = extension or settings.Settings()["outputFileExtension"]
-
-    cycles = []
-    yvals = []
-    for moves, cycle in zip(scalars["numMoves"], scalars["cycle"]):
-        if moves is None:
-            moves = 0.0
-        if cycle not in cycles:  # only one move per cycle
-            # use the cycles scalar val in case burnSteps is dynamic
-            cycles.append(cycle)
-            yvals.append(moves)
-
-    plt.figure(figsize=(12, 6))  # make it wide and short
-    plt.bar(cycles, yvals, align="center")
-    if len(cycles) > 1:
-        plt.xticks(cycles)
-    plt.grid(color="0.70")
-    plt.xlabel("Cycle")
-    plt.ylabel("Number of Moves")
-    plt.title("Fuel management rate for " + name)
-    figName = name + ".moves." + extension
-    plt.savefig(figName)
-    plt.close(1)
-
-    report.setData("Moves Plot", os.path.abspath(figName), report.MOVES_PLOT)
 
 
 def plotCoreOverviewRadar(reactors, reactorNames=None):

--- a/armi/utils/reportPlotting.py
+++ b/armi/utils/reportPlotting.py
@@ -75,7 +75,6 @@ def plotReactorPerformance(reactor, dbi, buGroups, extension=None, history=None)
                     "maxBuI",
                     "maxBuF",
                     "maxDPA",
-                    "numMoves",
                 ],
             )
         )

--- a/armi/utils/tests/test_reportPlotting.py
+++ b/armi/utils/tests/test_reportPlotting.py
@@ -136,7 +136,6 @@ class TestRadar(unittest.TestCase):
             "maxBuF": [6, 7, 8, 9],
             "maxBuI": [6, 7, 8, 9],
             "maxDPA": [6, 7, 8, 9],
-            "numMoves": [2, 2, 2, 2],
             "time": [1, 2, 3, 4],
         }
         figName = name + ".moves.png"

--- a/armi/utils/tests/test_reportPlotting.py
+++ b/armi/utils/tests/test_reportPlotting.py
@@ -26,7 +26,6 @@ from armi.utils.reportPlotting import (
     _getPhysicalVals,
     createPlotMetaData,
     keffVsTime,
-    movesVsCycle,
     plotAxialProfile,
     plotCoreOverviewRadar,
     valueVsTime,
@@ -128,17 +127,3 @@ class TestRadar(unittest.TestCase):
         valueVsTime(self.r.name, t, t, "val", "yaxis", "title", extension=ext)
         self.assertTrue(os.path.exists("R-armiRunSmallest.val.png"))
         self.assertGreater(os.path.getsize("R-armiRunSmallest.val.png"), 0)
-
-    def test_movesVsCycle(self):
-        name = "movesVsCycle"
-        scalars = {
-            "cycle": [1, 2, 3, 4],
-            "maxBuF": [6, 7, 8, 9],
-            "maxBuI": [6, 7, 8, 9],
-            "maxDPA": [6, 7, 8, 9],
-            "time": [1, 2, 3, 4],
-        }
-        figName = name + ".moves.png"
-        movesVsCycle(name, scalars, "png")
-        self.assertTrue(os.path.exists(figName))
-        self.assertGreater(os.path.getsize(figName), 0)


### PR DESCRIPTION
## What is the change? Why is it being made?

There are some real concerns about the correctness of `numMoves` in parallel runs. It seems like it is being updated from a class attribute that can change during asynchronous operations.

And that would all be very difficult to fix... Luckily, Arrielle points out that this `Parameter` is not actually used in ARMI or anywhere we can find downstream. So we're just going to remove this `Parameter` that is hard to make correct anyway.

Thanks @opotowsky for the solution!

close #1590


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: We should not have Parameters around if we cannot validate their correctness.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
