### PR TITLE
Removing `Composite.containsHeavyMetal()`

### DIFF
--- a/armi/reactor/composites.py
+++ b/armi/reactor/composites.py
@@ -1838,10 +1838,6 @@ class ArmiObject(metaclass=CompositeModelType):
         """True if this is a fuel block."""
         return self.hasFlags(Flags.FUEL)
 
-    def containsHeavyMetal(self):
-        """True if this has HM."""
-        return any(nucDir.isHeavyMetal(nucName) for nucName in self.getNuclides())
-
     def getNuclides(self):
         """
         Determine which nuclides are present in this armi object.

--- a/armi/reactor/tests/test_composites.py
+++ b/armi/reactor/tests/test_composites.py
@@ -1111,9 +1111,6 @@ class TestMiscMethods(unittest.TestCase):
         weight = self.obj.getAtomicWeight()
         self.assertTrue(50 < weight < 100)
 
-    def test_containsHeavyMetal(self):
-        self.assertTrue(self.obj.containsHeavyMetal())
-
     def test_copyParamsToChildren(self):
         self.obj.p.percentBu = 5
         self.obj.copyParamsToChildren(["percentBu"])


### PR DESCRIPTION
## What is the change? Why is it being made?

<!-- MANDATORY: Describe the change -->
The `Composite.containsHeavyMeta()` function appears to be unused in ARMI, and in downstream repositories. It is also not particularly useful. This PR removes this function.

## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: trivial

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Unused/stale code should be deleted.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

<!--
    The pull request author should check the box if the condition is met OR if it does not apply.
-->

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
