### PR TITLE
Removing incorrect summarizePowerPeaking

### DIFF
--- a/armi/bookkeeping/report/reportInterface.py
+++ b/armi/bookkeeping/report/reportInterface.py
@@ -62,9 +62,8 @@ class ReportInterface(interfaces.Interface):
 
     def interactEveryNode(self, cycle, node):
         self.r.core.calcBlockMaxes()
-        reportingUtils.summarizePowerPeaking(self.r.core)
 
-        runLog.important("Cycle {}, node {} Summary: ".format(cycle, node))
+        runLog.important(f"Cycle {cycle}, node {node} Summary: ")
         runLog.important(
             "  time= {0:8.2f} years, keff= {1:.12f} maxPD= {2:-8.2f} MW/m^2, maxBuI= {3:-8.4f} maxBuF= {4:8.4f}".format(
                 self.r.p.time,

--- a/armi/bookkeeping/report/reportingUtils.py
+++ b/armi/bookkeeping/report/reportingUtils.py
@@ -706,36 +706,6 @@ def summarizePinDesign(core):
         runLog.warning(f"Pin summarization failed to work: {error}")
 
 
-def summarizePowerPeaking(core):
-    """Prints reactor Fz, Fxy, Fq.
-
-    Parameters
-    ----------
-    core : armi.reactor.reactors.Core
-    """
-    # Fz is the axial peaking of the highest power assembly
-    _maxPow, maxPowBlock = core.getMaxParam("power", returnObj=True, generationNum=2)
-    maxPowAssem = maxPowBlock.parent
-    avgPDens = maxPowAssem.calcAvgParam("pdens")
-    peakPDens = maxPowAssem.getMaxParam("pdens")
-    if not avgPDens:
-        # protect against divide-by-zero. Peaking doesn't make sense if there is no power
-        return
-    axPeakF = peakPDens / avgPDens
-
-    # Fxy is the radial peaking factor, looking at ALL assemblies with axially integrated powers.
-    power = 0.0
-    n = 0
-    for n, a in enumerate(core):
-        power += a.calcTotalParam("power", typeSpec=Flags.FUEL)
-    avgPow = power / (n + 1)
-    radPeakF = maxPowAssem.calcTotalParam("power", typeSpec=Flags.FUEL) / avgPow
-
-    runLog.important(
-        "Power Peaking: Fz= {0:.3f} Fxy= {1:.3f} Fq= {2:.3f}".format(axPeakF, radPeakF, axPeakF * radPeakF)
-    )
-
-
 def makeCoreDesignReport(core, cs):
     """Builds report to summarize core design inputs.
 

--- a/armi/bookkeeping/report/tests/test_report.py
+++ b/armi/bookkeeping/report/tests/test_report.py
@@ -34,7 +34,6 @@ from armi.bookkeeping.report.reportingUtils import (
     makeCoreDesignReport,
     setNeutronBalancesReport,
     summarizePinDesign,
-    summarizePowerPeaking,
     writeAssemblyMassSummary,
     writeCycleSummary,
     writeWelcomeHeaders,
@@ -224,10 +223,6 @@ class TestReport(unittest.TestCase):
             makeBlockDesignReport(r)
             self.assertEqual(len(mock.getStdout()), 0)
             mock.emptyStdout()
-
-            # this report won't do much for the test reactor - improve test reactor
-            summarizePowerPeaking(r.core)
-            self.assertEqual(len(mock.getStdout()), 0)
 
     def test_writeWelcomeHeaders(self):
         o, r = loadTestReactor(TESTING_ROOT, inputFileName="reactors/smallestTestReactor/armiRunSmallest.yaml")


### PR DESCRIPTION
## What is the change? Why is it being made?

Removing the `summarizePowerPeaking` report. It is not correct, and the team said to ditch it.


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: fixes

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: Inaccurate reports in the run logs are counterproductive.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
