### PR TITLE
Improving flexibility of CaseSuite.discover

### DIFF
--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 r"""
-The ``CaseSuite`` object is responsible for running, and executing a set of user inputs.  Many
-entry points redirect into ``CaseSuite`` methods, such as ``clone``, ``compare``, and ``submit``.
+The ``CaseSuite`` object is responsible for running, and executing a set of user inputs. Many entry points redirect into
+``CaseSuite`` methods, such as ``clone``, ``compare``, and ``submit``.
 
-Used in conjunction with the :py:class:`~armi.cases.case.Case` object, ``CaseSuite`` can be used to
-collect a series of cases and submit them to a cluster for execution. Furthermore, a ``CaseSuite``
-can be used to gather executed cases for post-analysis.
+Used in conjunction with the :py:class:`~armi.cases.case.Case` object, ``CaseSuite`` can be used to collect a series of
+cases and submit them to a cluster for execution. Furthermore, a ``CaseSuite`` can be used to gather executed cases for
+post-analysis.
 
-``CaseSuite``\ s should allow ``Cases`` to be added from totally separate directories. This is
-useful for plugin-informed testing as well as other things.
+``CaseSuite``\ s should allow ``Cases`` to be added from totally separate directories. This is useful for plugin-
+informed testing as well as other things.
 
 See Also
 --------
@@ -45,12 +45,10 @@ class CaseSuite:
         :id: I_ARMI_CASE_SUITE
         :implements: R_ARMI_CASE_SUITE
 
-        The CaseSuite object allows multiple, often related,
-        :py:class:`~armi.cases.case.Case` objects to be run sequentially. A CaseSuite
-        is intended to be both a pre-processing or a post-processing tool to facilitate
-        case generation and analysis. Under most circumstances one may wish to subclass
-        a CaseSuite to meet the needs of a specific calculation. A CaseSuite is a
-        collection that is keyed off Case titles.
+        The CaseSuite object allows multiple, often related, :py:class:`~armi.cases.case.Case` objects to be run
+        sequentially. A CaseSuite is intended to be both a pre-processing or a post-processing tool to facilitate case
+        generation and analysis. Under most circumstances one may wish to subclass a CaseSuite to meet the needs of a
+        specific calculation. A CaseSuite is a collection that is keyed off Case titles.
     """
 
     def __init__(self, cs):
@@ -88,8 +86,8 @@ class CaseSuite:
     def discover(
         self,
         rootDir=None,
-        patterns=None,
-        ignorePatterns=None,
+        patterns=[],
+        ignorePatterns=[],
         recursive=True,
         skipInspection=False,
     ):
@@ -111,6 +109,22 @@ class CaseSuite:
         skipInspection : bool, optional
             if True, skip running the check inputs
         """
+        assert not isinstance(patterns, str), "Bare string passed as patterns. Make sure to pass a list"
+        assert not isinstance(ignorePatterns, str), "Bare string passed as ignore patterns. Make sure to pass a list"
+
+        # handle the case where someone gives just a string (input), but they meant to add an asterisk (input*)
+        regexChars = [".", "^", "$", "*", "+", "?", "{", "}", "[", "]", "|", "(", ")"]
+        for i in range(len(patterns)):
+            pat = patterns[i]
+            foundRegex = False
+            for rChar in regexChars:
+                if rChar in pat:
+                    foundRegex = True
+                    break
+            if not foundRegex:
+                patterns[i] = pat = pat + "*"
+
+        # find all settings files that match the root dir and patterns provided
         csFiles = settings.recursivelyLoadSettingsFiles(
             rootDir or os.path.abspath(os.getcwd()),
             patterns or ["*.yaml"],
@@ -119,6 +133,7 @@ class CaseSuite:
             handleInvalids=False,
         )
 
+        # load cases from the found files
         for cs in csFiles:
             case = armicase.Case(cs=cs, caseSuite=self)
             if not skipInspection:
@@ -131,11 +146,10 @@ class CaseSuite:
 
         Notes
         -----
-        Some of these printouts won't make sense for all users, and may make sense to
-        be delegated to the plugins/app.
+        Some of these printouts won't make sense for all users, and may make sense to be delegated to the plugins/app.
         """
         for setting in self.cs.environmentSettings:
-            runLog.important("{}: {}".format(self.cs.getSetting(setting).label, self.cs[setting]))
+            runLog.important(f"{self.cs.getSetting(setting).label}: {self.cs[setting]}")
 
         runLog.important("Test inputs will be taken from test case results when they have finished")
         runLog.important(
@@ -157,30 +171,25 @@ class CaseSuite:
         """
         Clone a CaseSuite to a new place.
 
-        Creates a clone for each case within a CaseSuite. If ``oldRoot`` is not
-        specified, then each case clone is made in a directory with the title of the
-        case. If ``oldRoot`` is specified, then a relative path from ``oldRoot`` will
-        be used to determine a new relative path to the current directory ``oldRoot``.
+        Creates a clone for each case within a CaseSuite. If ``oldRoot`` is not specified, then each case clone is made
+        in a directory with the title of the case. If ``oldRoot`` is specified, then a relative path from ``oldRoot``
+        will be used to determine a new relative path to the current directory ``oldRoot``.
 
         Parameters
         ----------
         oldRoot : str (optional)
-            root directory of original case suite used to help filter when a suite
-            contains one or more cases with the same case title.
+            root directory of original case suite used to help filter when a suite contains one or more cases with the
+            same case title.
         writeStyle : str (optional)
-            Writing style for which settings get written back to the settings files
-            (short, medium, or full).
+            Writing style for which settings get written back to the settings files (short, medium, or full).
 
         Notes
         -----
-        By design, a CaseSuite has no location dependence; this allows any set of cases
-        to compose a CaseSuite. The thought is that the post-analysis capabilities
-        without restricting a root directory could be beneficial. For example, this
-        allows one to perform analysis on cases analyzed by Person A and Person B, even
-        if the analyses were performed in completely different locations. As a
-        consequence, when you want to clone, we need to infer a "root" of the original
-        cases to attempt to mirror whatever existing directory structure there may have
-        been.
+        By design, a CaseSuite has no location dependence; this allows any set of cases to compose a CaseSuite. The
+        thought is that the post-analysis capabilities without restricting a root directory could be beneficial. For
+        example, this allows one to perform analysis on cases analyzed by Person A and Person B, even if the analyses
+        were performed in completely different locations. As a consequence, when you want to clone, we need to infer a
+        "root" of the original cases to attempt to mirror whatever existing directory structure there may have been.
         """
         clone = CaseSuite(self.cs.duplicate())
 
@@ -200,8 +209,8 @@ class CaseSuite:
 
         Warning
         -------
-        Suite running may not work yet if the cases have interdependencies. We typically run on a
-        HPC but are still working on a platform independent way of handling HPCs.
+        Suite running may not work yet if the cases have interdependencies. We typically run on a HPC but are still
+        working on a platform independent way of handling HPCs.
         """
         for ci, case in enumerate(self):
             runLog.important(f"Running case {ci + 1}/{len(self)}: {case}")
@@ -247,12 +256,10 @@ class CaseSuite:
                 caseStatus.append(status)
             refFile, userFile = caseStatus
             if any(stat != "Found" for stat in caseStatus):
-                # Case was not run, or failed to produce a database.
-                # In either case, this is an issue.
-                # It could possibly be a new test, but there is no way to tell this
-                # versus a reference file being missing so when a new test is made
-                # it will be an issue. After the first push with the new tests the files
-                # will be copied over and future tests will be fine.
+                # Case was not run, or failed to produce a database. In either case, this is an issue. It could possibly
+                # be a new test, but there is no way to tell this versus a reference file being missing so when a new
+                # test is made it will be an issue. After the first push with the new tests the files will be copied
+                # over and future tests will be fine.
                 caseIssues = 1
                 suiteHasMissingFiles = False
             else:
@@ -276,8 +283,7 @@ class CaseSuite:
         Write inputs for all cases in the suite.
 
         writeStyle : str (optional)
-            Writing style for which settings get written back to the settings files
-            (short, medium, or full).
+            Writing style for which settings get written back to the settings files (short, medium, or full).
 
         See Also
         --------
@@ -309,7 +315,7 @@ class CaseSuite:
             totalDiffs += caseIssues
 
         print(tabulate.tabulate(data, header, tableFmt=fmt))
-        print(tabulate.tabulate([["Total number of differences: {}".format(totalDiffs)]], tableFmt=fmt))
+        print(tabulate.tabulate([[f"Total number of differences: {totalDiffs}"]], tableFmt=fmt))
 
 
 UNMISSABLE_FAILURE = '''

--- a/armi/cases/suite.py
+++ b/armi/cases/suite.py
@@ -94,8 +94,7 @@ class CaseSuite:
         skipInspection=False,
     ):
         """
-        Finds case objects by searching for a pattern of file paths, and adds them to
-        the suite.
+        Finds case objects by searching for a pattern of file paths, and adds them to the suite.
 
         This searches for Settings input files and loads them to create Case objects.
 

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -397,6 +397,9 @@ class TestCaseSuiteDependencies(unittest.TestCase):
         self.c1.title = "new_bob"
         self.assertEqual(self.c1.title, "new_bob")
 
+    def test_discover(self):
+        pass
+
 
 class TestCaseSuiteComparison(unittest.TestCase):
     """CaseSuite.compare() tests."""

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -25,6 +25,7 @@ from armi import cases, context, getApp, interfaces, plugins, runLog, settings
 from armi.bookkeeping.db.databaseInterface import DatabaseInterface
 from armi.physics.fuelCycle.settings import CONF_SHUFFLE_LOGIC
 from armi.reactor import blueprints
+from armi.settings import caseSettings
 from armi.testing import TESTING_ROOT, loadTestReactor, mockRunLogs
 from armi.tests import ARMI_RUN_PATH
 from armi.utils import directoryChangers
@@ -397,8 +398,76 @@ class TestCaseSuiteDependencies(unittest.TestCase):
         self.c1.title = "new_bob"
         self.assertEqual(self.c1.title, "new_bob")
 
+
+class TestCaseSuiteDiscovery(unittest.TestCase):
+    def setUp(self):
+        """
+        Write arbitrary settings to files in the following file structure.
+
+        .. code-block::
+
+            tmpDir/
+            ├── settings1.yaml
+            ├── settings2.yaml
+            ├── notSettings.yaml
+            └── subdir/
+                ├── settings3.yaml
+                └── skipSettings.yaml
+
+        """
+        self.dc = directoryChangers.TemporaryDirectoryChanger()
+        self.dc.__enter__()
+
+        cs = caseSettings.Settings()
+        cs.writeToYamlFile("settings1.yaml")
+        cs.writeToYamlFile("settings2.yaml")
+        with open("notSettings.yaml", "w") as f:
+            f.write("some: other\nyaml: file\n")
+        os.mkdir("subdir")
+        cs.writeToYamlFile("subdir/settings3.yaml")
+        cs.writeToYamlFile("subdir/skipSettings.yaml")
+
+    def tearDown(self):
+        self.dc.__exit__(None, None, None)
+
     def test_discover(self):
-        pass
+        """Test CaseSuit.discover().
+
+        Notes
+        -----
+        All of these examples have ``skipInspection=True``, because these are just dumb test settings.
+        """
+        cs = settings.Settings()
+
+        # find all YAML files, recursively in the test dir, fully explicity inputs
+        suite = cases.CaseSuite(cs)
+        self.assertEqual(len(suite), 0)
+        suite.discover(rootDir=".", patterns=["*.yaml"], ignorePatterns=["skip*"], recursive=True, skipInspection=True)
+        self.assertEqual(len(suite), 3)
+
+        # find all YAML files, recursively in the test dir, implicit file ending
+        suite = cases.CaseSuite(cs)
+        self.assertEqual(len(suite), 0)
+        suite.discover(rootDir=".", ignorePatterns=["skip*"], recursive=True, skipInspection=True)
+        self.assertEqual(len(suite), 3)
+
+        # find all YAML files in the subdir, recursively in the test dir, implicit file ending
+        suite = cases.CaseSuite(cs)
+        self.assertEqual(len(suite), 0)
+        suite.discover(rootDir="subdir", skipInspection=True)
+        self.assertEqual(len(suite), 2)
+
+        # find all YAML files starting with "settings*", not recursively, implicit file ending
+        suite = cases.CaseSuite(cs)
+        self.assertEqual(len(suite), 0)
+        suite.discover(rootDir=".", patterns=["settings*"], recursive=False, skipInspection=True)
+        self.assertEqual(len(suite), 2)
+
+        # find all YAML files starting with "settings", not recursively, implicit file ending
+        suite = cases.CaseSuite(cs)
+        self.assertEqual(len(suite), 0)
+        suite.discover(rootDir=".", patterns=["settings"], recursive=False, skipInspection=True)
+        self.assertEqual(len(suite), 2)
 
 
 class TestCaseSuiteComparison(unittest.TestCase):

--- a/armi/settings/__init__.py
+++ b/armi/settings/__init__.py
@@ -15,10 +15,9 @@
 """
 Settings are various key-value pairs that determine a bunch of modeling and simulation behaviors.
 
-They are one of the key inputs to an ARMI run. They say which modules to run and which
-modeling approximations to apply and how many cycles to run and at what power and
-availability fraction and things like that. The ARMI Framework itself has many settings
-of its own, and plugins typically register some of their own settings as well.
+They are one of the key inputs to an ARMI run. They say which modules to run and which modeling approximations to apply
+and how many cycles to run and at what power and availability fraction and things like that. The ARMI Framework itself
+has many settings of its own, and plugins typically register some of their own settings as well.
 """
 
 import fnmatch
@@ -75,11 +74,10 @@ def recursivelyLoadSettingsFiles(
         list of :py:class:`~armi.settings.caseSettings.Settings` objects.
     """
     assert not isinstance(ignorePatterns, str), "Bare string passed as ignorePatterns. Make sure to pass a list"
-
     assert not isinstance(patterns, str), "Bare string passed as patterns. Make sure to pass a list"
 
     possibleSettings = []
-    runLog.info("Finding potential settings files matching {}.".format(patterns))
+    runLog.info(f"Finding potential settings files matching {patterns}.")
     if recursive:
         for directory, _list, files in os.walk(rootDir):
             matches = set()
@@ -97,19 +95,17 @@ def recursivelyLoadSettingsFiles(
     runLog.info("Checking for valid settings files.")
     for possibleSettingsFile in possibleSettings:
         if os.path.getsize(possibleSettingsFile) > 1e6:
-            runLog.extra("skipping {} -- looks too big".format(possibleSettingsFile))
+            runLog.extra(f"skipping {possibleSettingsFile} -- looks too big")
             continue
         try:
             cs = Settings()
             cs.loadFromInputFile(possibleSettingsFile, handleInvalids=handleInvalids)
             csFiles.append(cs)
-            runLog.extra("loaded {}".format(possibleSettingsFile))
+            runLog.extra(f"loaded {possibleSettingsFile}")
         except InvalidSettingsFileError as ee:
-            runLog.extra("skipping {}\n    {}".format(possibleSettingsFile, ee))
+            runLog.extra(f"skipping {possibleSettingsFile}\n    {ee}")
         except yaml.composer.ComposerError as ee:
-            runLog.extra(
-                "skipping {}; it appears to be an incomplete YAML snippet\n    {}".format(possibleSettingsFile, ee)
-            )
+            runLog.extra(f"skipping {possibleSettingsFile}; it appears to be an incomplete YAML snippet\n    {ee}")
         except Exception as ee:
             runLog.error(
                 "Failed to parse {}.\nIt looked like a settings file but gave this exception:\n{}: {}".format(
@@ -117,6 +113,7 @@ def recursivelyLoadSettingsFiles(
                 )
             )
             raise
+
     csFiles.sort(key=lambda csFile: csFile.caseTitle)
     return csFiles
 
@@ -139,7 +136,7 @@ def promptForSettingsFile(choice=None):
 
     if choice is None:
         for i, pathToFile in enumerate(files):
-            runLog.info("[{0}] - {1}".format(i, os.path.split(pathToFile)[-1]))
+            runLog.info(f"[{i}] - {os.path.split(pathToFile)[-1]}")
         choice = int(input("Enter choice: "))
 
     return files[choice]

--- a/armi/settings/tests/test_settings.py
+++ b/armi/settings/tests/test_settings.py
@@ -445,11 +445,23 @@ class TestSettingsUtils(unittest.TestCase):
     """Tests for utility functions."""
 
     def setUp(self):
+        """
+        Write arbitrary settings to files in the following file structure.
+
+        .. code-block::
+
+            tmpDir/
+            ├── settings1.yaml
+            ├── settings2.yaml
+            ├── notSettings.yaml
+            └── subdir/
+                ├── settings3.yaml
+                └── skipSettings.yaml
+
+        """
         self.dc = directoryChangers.TemporaryDirectoryChanger()
         self.dc.__enter__()
 
-        # Create a little case suite on the fly. Whipping it up from defaults should be
-        # more evergreen than committing settings files as a test resource
         cs = caseSettings.Settings()
         cs.writeToYamlFile("settings1.yaml")
         cs.writeToYamlFile("settings2.yaml")
@@ -462,14 +474,15 @@ class TestSettingsUtils(unittest.TestCase):
     def tearDown(self):
         self.dc.__exit__(None, None, None)
 
-    def test_recursiveScan(self):
-        loadedSettings = settings.recursivelyLoadSettingsFiles(".", ["*.yaml"], ignorePatterns=["skip*"])
-        names = {cs.caseTitle for cs in loadedSettings}
-        self.assertIn("settings1", names)
-        self.assertIn("settings2", names)
-        self.assertIn("settings3", names)
-        self.assertNotIn("skipSettings", names)
+    def test_recursivelyLoadSettingsFiles(self):
+        # test basic error handling
+        with self.assertRaises(AssertionError):
+            settings.recursivelyLoadSettingsFiles(".", "*.yaml")
 
+        with self.assertRaises(AssertionError):
+            settings.recursivelyLoadSettingsFiles(".", ["*.yaml"], ignorePatterns="skip*")
+
+        # find files non-recursively via *.yaml with an ignore pattern skip*
         loadedSettings = settings.recursivelyLoadSettingsFiles(
             ".", ["*.yaml"], recursive=False, ignorePatterns=["skip*"]
         )
@@ -477,6 +490,15 @@ class TestSettingsUtils(unittest.TestCase):
         self.assertIn("settings1", names)
         self.assertIn("settings2", names)
         self.assertNotIn("settings3", names)
+        self.assertNotIn("skipSettings", names)
+
+        # find files recursively via *.yaml with an ignore pattern skip*
+        loadedSettings = settings.recursivelyLoadSettingsFiles(".", ["*.yaml"], ignorePatterns=["skip*"])
+        names = {cs.caseTitle for cs in loadedSettings}
+        self.assertIn("settings1", names)
+        self.assertIn("settings2", names)
+        self.assertIn("settings3", names)
+        self.assertNotIn("skipSettings", names)
 
     def test_prompt(self):
         selection = settings.promptForSettingsFile(1)


### PR DESCRIPTION
## What is the change? Why is it being made?

Here I beef up `CaseSuite.discover()` so that it supports `discover(pattern="input")` not just `discover(pattern="input*")`. This required some improvements to `recursivelyLoadSettingsFiles()` as well.

Also, `CaseSuite.discover()` didn't have any unit tests and `recursivelyLoadSettingsFiles()` didn't have enough testing.

close #2181


## SCR Information

<!-- MANDATORY: uncomment one-and-only-one of these -->
Change Type: features

<!-- MANDATORY: Describe why this change is needed, in one sentence -->
One-Sentence Rationale: The user base requested this feature should be more flexible and easier to use.

<!-- MANDATORY: Describe any impact on the requirements, all on one line -->
One-line Impact on Requirements: NA


---

## Checklist

- [x] This PR has only [one purpose or idea](https://terrapower.github.io/armi/developer/tooling.html#one-idea-one-pr).
- [x] [Tests](https://terrapower.github.io/armi/developer/tooling.html#test-it) have been added/updated to verify any new/changed code.
- [x] The [documentation](https://terrapower.github.io/armi/developer/tooling.html#document-it) is still up-to-date in the `doc` folder.
- [x] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [x] The dependencies are still up-to-date in `pyproject.toml`.
